### PR TITLE
Feature 137 - mongoose history

### DIFF
--- a/docs/content/pages/docs/database.jade
+++ b/docs/content/pages/docs/database.jade
@@ -127,7 +127,7 @@ block content
 					td Prevents deletion of items from the list through the Keystone Admin UI
                 tr
                     td <code>saveHistory</code> <code class="data-type">Boolean</code>
-                    td Determines whether or not the item's state is history is saved. ie - saves item's history for updates, removes, and inserts into mongo.
+                    td Determines whether or not the item's state history is saved. ie - saves item's history for updates, removes, and inserts into mongo.
 
 			
 			a(name='lists-plugins')

--- a/docs/content/pages/docs/database.jade
+++ b/docs/content/pages/docs/database.jade
@@ -125,6 +125,10 @@ block content
 				tr
 					td <code>nodelete</code> <code class="data-type">Boolean</code>
 					td Prevents deletion of items from the list through the Keystone Admin UI
+                tr
+                    td <code>saveHistory</code> <code class="data-type">Boolean</code>
+                    td Determines whether or not the item's state is history is saved. ie - saves item's history for updates, removes, and inserts into mongo.
+
 			
 			a(name='lists-plugins')
 			h3 Schema Plugins

--- a/lib/list.js
+++ b/lib/list.js
@@ -30,6 +30,7 @@ function List(key, options) {
 		autocreate: false,
 		sortable: false,
 		hidden: false,
+        saveHistory: false,
 		searchFields: '__name__',
 		defaultSort: '__default__',
 		defaultColumns: '__name__'
@@ -38,8 +39,14 @@ function List(key, options) {
 	this.key = key;
 	this.path = this.get('path') || utils.keyToPath(key, true);
 	this.schema = new keystone.mongoose.Schema();
-    this.schema.plugin(mongooseHistory);
-	this.uiElements = [];
+
+    //use the saveHistory option to set if List should save the history of updates, deletes, and inserts. Defaults to
+    //false
+    if(this.options.saveHistory==true){
+        this.schema.plugin(mongooseHistory);
+    }
+
+    this.uiElements = [];
 	this.underscoreMethods = {};
 	this.fields = {};
 	this.relationships = {};

--- a/lib/list.js
+++ b/lib/list.js
@@ -42,7 +42,7 @@ function List(key, options) {
 
     //use the saveHistory option to set if List should save the history of updates, deletes, and inserts. Defaults to
     //false
-    if(this.options.saveHistory==true){
+    if(this.options.saveHistory===true){
         this.schema.plugin(mongooseHistory);
     }
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -2,6 +2,7 @@ var _ = require('underscore'),
 	async = require('async'),
 	moment = require('moment'),
 	keystone = require('../'),
+    mongooseHistory = require('mongoose-history'),
 	schemaPlugins = require('./schemaPlugins'),
 	utils = require('keystone-utils'),
 	Field = require('./field'),
@@ -37,6 +38,7 @@ function List(key, options) {
 	this.key = key;
 	this.path = this.get('path') || utils.keyToPath(key, true);
 	this.schema = new keystone.mongoose.Schema();
+    this.schema.plugin(mongooseHistory);
 	this.uiElements = [];
 	this.underscoreMethods = {};
 	this.fields = {};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "keystone-utils": "~0.1.7",
     "express": "~3.3.8",
     "mongoose": "~3.8.8",
-    "mongoose-history": "git+https://github.com/britztopher/mongoose-history.git#minus-id-false",
+    "mongoose-history": "latest",
     "less-middleware": "~0.1.15",
     "connect-flash": "~0.1.1",
     "jade": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "keystone-utils": "~0.1.7",
     "express": "~3.3.8",
     "mongoose": "~3.8.8",
-    "mongoose-history": "~0.1.0",
+    "mongoose-history": "latest",
     "less-middleware": "~0.1.15",
     "connect-flash": "~0.1.1",
     "jade": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "keystone-utils": "~0.1.7",
     "express": "~3.3.8",
     "mongoose": "~3.8.8",
+    "mongoose-history": "~0.1.0",
     "less-middleware": "~0.1.15",
     "connect-flash": "~0.1.1",
     "jade": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "keystone-utils": "~0.1.7",
     "express": "~3.3.8",
     "mongoose": "~3.8.8",
-    "mongoose-history": "latest",
+    "mongoose-history": "git+https://github.com/britztopher/mongoose-history.git#minus-id-false",
     "less-middleware": "~0.1.15",
     "connect-flash": "~0.1.1",
     "jade": "~1.3.0",


### PR DESCRIPTION
Added ability to use mongoose history (https://github.com/rossan/mongoose-history).  There is an option named saveHistory that defaults to false meaning no history will be saved on the list.  There are a few concerns i have and they are as follows:

1. I added a conditional statement in list.js within the constructor to check if option saveHistory === true then use mongoose-history plugin for that list, however, there probably is a more elegant way to accomplish this same task, but I could not find where you enforce options on the list.

I also updated the docs with the new option and information needed to use the history option