### PR TITLE
Added descriptions to list items and updated docs.

### DIFF
--- a/docs/content/pages/docs/database.jade
+++ b/docs/content/pages/docs/database.jade
@@ -7,47 +7,47 @@ block intro
 		.container
 			h1 Database
 			p.lead Setting up and using Data Models
-	
+
 block content
 	.container: .row
-		
+
 		.col-sm-3
 			+docsnav(docssection)
-		
+
 		.col-sm-9: .docs-content
-			
+
 			h2
 				a(name='concepts')
 				| Concepts
 			p In KeystoneJS, your data schema and models are controlled by <strong>Lists</strong>, and documents in your database are often called <strong>Items</strong>.
-			
-			p To define a data model, you create a <code>new keystone.List</code>, and pass it <a href="#lists-options">list options</a>. 
-			
+
+			p To define a data model, you create a <code>new keystone.List</code>, and pass it <a href="#lists-options">list options</a>.
+
 			p You then <code>add</code> fields to the list. Behind the scenes, a Keystone List will create a <a href="http://mongoosejs.com/docs/guide.html" target="_blank">mongoose schema</a>, and add the appropriate paths to it for the fields you define.
-			
+
 			p The <code>schema</code> is accessible, allowing you to plug in other mongoose functionality like virtuals, methods and pre / post hooks.
-			
+
 			p When you have finished setting up your List, call <code>list.register()</code> to initialise it and register it with Keystone.
-			
+
 			p To query your data, you use the <code>list.model</code> (which is a <a href="http://mongoosejs.com/docs/models.html" target="_blank">mongoose model</a>).
-			
+
 			p List Items are <a href="http://mongoosejs.com/docs/documents.html" target"_blank">mongoose documents</a>. To create new items, use <code>new list.model()</code> and when you're ready to save it (or to save changes to an existing Item), call <code>item.save()</code>.
-			
+
 			a(name='lists')
 			h2 Lists
-			
+
 			a(name='lists-usage')
 			h3 Usage
-			
+
 			p The syntax for creating a <strong>Keystone List</strong> is very similar to the syntax for creating a Mongoose Schema, with the exception of the constructor, which is <code>var MyList = new keystone.List(key, options)</code>.
 			p Once you have created a new List, add fields to it using <code>MyList.add(fields)</code>, where fields is an object of keys (for field paths) and values (for field types, or options).
 			p Fields are defined by an object with a <code>type</code> property, which must be a valid Field Type or basic data type. Using the object syntax you can specify additional options for the field. Common field options and field-type-specific options are detailed in the fields documentation.
 			p When all the fields and options have been set on the list, call <code>MyList.register()</code> to register the list with Keystone and finalise its configuration.
-			
+
 			a(name='lists-example')
 			h3 Example
 			p A simple Post model for a blog might look like this:
-			
+
 			.code-header: h4 Post.js
 			pre: code.language-javascript
 				| var keystone = require('keystone'),
@@ -71,22 +71,25 @@ block content
 				| });
 				| Post.defaultColumns = 'title, state|20%, author, publishedAt|15%'
 				| Post.register();
-			
+
 			p.note This example implements the optional <code>map</code>, <code>autokey</code> and <code>defaultSort</code> options, described below.
 			p.note It also specifies <code>title</code>, <code>state</code>, <code>author</code> and <code>publishedAt</code> as the default columns to display in the Admin UI, with state and publishedAt being given column widths.
 			p.note The <code>author</code> field is a relationship with the <code>User</code> model, as described in the <a href="/guide#models_users">getting started guide</a>.
-			
+
 			a(name='lists-options')
 			h3 Options
-			
+
 			p Lists support the following options:
-			
+
 			table.table
 				col(width=210)
 				col
 				tr
 					td <code>drilldown</code> <code class="data-type">String</code>
 					td A space-delimited list of relationships to display as drilldown in the Admin UI
+				tr
+					td <code>description</code> <code class="data-type">String</code>
+					td A general description of the model, that will appear above every list item in the Admin UI
 				tr
 					td <code>sortable</code> <code class="data-type">Boolean</code>
 					td Adds a hidden field <code>sortOrder</code> to the schema, and enables drag and drop sorting in the Admin UI
@@ -125,43 +128,43 @@ block content
 				tr
 					td <code>nodelete</code> <code class="data-type">Boolean</code>
 					td Prevents deletion of items from the list through the Keystone Admin UI
-			
+
 			a(name='lists-plugins')
 			h3 Schema Plugins
-			
+
 			p You can specify <a href="http://mongoosejs.com/docs/guide.html" target="_blank"><strong>virtuals</strong>, <strong>methods</strong>, <strong>statics</strong></a> as well as <a href="http://mongoosejs.com/docs/middleware.html" target="_blank"><strong>pre</strong> and <strong>post</strong> hooks</a> for your <strong>Lists</strong> using the <code>schema</code>. You can also use <a href="http://mongoosejs.com/docs/plugins.html" target="_blank">mongoose plugins</a> from the <a href="http://plugins.mongoosejs.com" target="_blank">plugins website</a>.
-			
+
 			p For example, in our <strong>Post</strong> list above, we might want to automatically set the <code>publishedAt</code> value when the <code>state</code> is changed to <code>published</code> (but only if it hasn't already been set).
-			
+
 			p We might also want to add a method to check whether the post is published, rather than checking the <code>state</code> field value directly.
-			
+
 			p Before calling <code>Post.register()</code>, we would add the following code:
-			
+
 			pre: code.language-javascript
 				| Post.schema.methods.isPublished = function() {
 				|     return this.state == 'published';
 				| }
-				| 
+				|
 				| Post.schema.pre('save', function(next) {
 				|     if (this.isModified('state') &amp;&amp; this.isPublished() &amp;&amp; !this.publishedAt) {
 				|         this.publishedAt = new Date();
 				|     }
 				|     next();
 				| });
-			
-			
+
+
 			a(name='lists-querying')
 			h3 Querying Data
-			
+
 			p To query data, you can use any of the <a href="http://mongoosejs.com/docs/queries.html" target="_blank">mongoose query</a> methods on the <code>list.model</code>.
-			
+
 			p <strong>For example:</strong> to load the last 5 <code>posts</code> with the state <code>published</code>, populating the linked <code>author</code>, sorted by reverse published date:
-			
+
 			.code-header: h4 Loading Posts
 			pre: code.language-javascript
 				| var keystone = require('keystone'),
 				|     Post = keystone.list('Post');
-				| 
+				|
 				| Post.model.find()
 				|     .where('state', 'published')
 				|     .populate('author')
@@ -170,62 +173,62 @@ block content
 				|     .exec(function(err, posts) {
 				|         // do something with posts
 				|     });
-			
+
 			a(name='lists-creating')
 			h3 Creating Items
-			
+
 			p To create new items, again use the <a href="http://mongoosejs.com/docs/models.html" target"_blank">mongoose model</a>:
-			
+
 			.code-header: h4 Creating Posts
 			pre: code.language-javascript
 				| var keystone = require('keystone'),
 				|     Post = keystone.list('Post');
-				| 
+				|
 				| var newPost = new Post.model({
 				|     title: 'New Post'
 				| });
-				| 
+				|
 				| if (shouldBePublished) {
 				|     newPost.state = 'published';
 				| }
-				| 
+				|
 				| newPost.save(function(err) {
-				|     // post has been saved	
+				|     // post has been saved
 				| });
-			
+
 			.contextual-note
 				h4 Automatic keys
 				p Because we set the <code>autokey</code> option on our <code>Post</code> list, it will have generated a unique key based on the <code>title</code> before it was saved to the database.
 				pre
 					| newPost.slug == 'new-post';
-			
+
 			a(name='lists-deleting')
 			h3 Deleting Items
-			
+
 			p To delete items, first load the data, then use the <code>remove</code> method:
-			
+
 			.code-header: h4 Deleting a Post
 			pre: code.language-javascript
 				| var keystone = require('keystone'),
 				|     Post = keystone.list('Post');
-				| 
+				|
 				| Post.model.findById(postId)
 				|     .remove(function(err) {
 				|         // post has been deleted
 				|     });
-			
+
 			// TODO: Documentation for Schema features (virtuals, methods, statics and hooks)
-			
+
 			// TODO: Documentation for Update Handler
-			
+
 			a(name='fields')
 			h2 Fields
-			
+
 			p When adding <strong>fields</strong> to <strong>Lists</strong>, you can either specify basic data types or Keystone Field Types.
-			
+
 			a(name='fields-overview')
 			h3 Overview
-			
+
 			p <strong>Keystone Fields</strong> allow you to easily add rich, functional fields to your application's models. They are designed to describe not just the <em>structure</em> of your data, but also the <em>intention</em> of your data. They provide:
 			ul
 				li Rich controls in Keystone's Admin UI
@@ -234,9 +237,9 @@ block content
 				li Additional virtual properties; e.g. the <code>name</code> field provides a <code>name.full</code> virtual which concatenates the stored <code>name.first</code> and <code>name.last</code>
 				li Underscore methods; e.g. the <code>password</code> field provides a <code>password.compare</code> method for testing against the encrypted hash
 				li Metadata about how fields relate to each other; e.g. which fields depend on certain values in other fields
-			
+
 			p Basic data types are mapped to their corresponding Keystone field types:
-			
+
 			table.table(style="width:200px")
 				col
 				col
@@ -255,18 +258,18 @@ block content
 				tr
 					td: code.data-type Boolean
 					td: code.data-type Boolean
-			
+
 			a(name='fields-options')
 			h3 Field Options
-			
+
 			p All field types support several common options, which can specify database settings (such as <code>index</code> and <code>default</code>), or can provide information for Keystone's Admin UI (such as <code>label</code>).
-			
+
 			p.note Fields can be nested inside objects, as in mongoose schemas.
-			
+
 			p.note All <a href="http://mongoosejs.com/docs/schematypes.html" target="_blank">mongoose schema type options</a> are passed to the <a href="http://mongoosejs.com/docs/guide.html" target="_blank">mongoose schema</a>, so you can also use any options mongoose supports.
-			
+
 			p Common field options include:
-			
+
 			table.table
 				col(width=210)
 				col
@@ -291,165 +294,165 @@ block content
 				tr
 					td <code>dependsOn</code> <code class="data-type">Object</code>
 					td Hides the field in the admin UI unless the specified conditions (other field values) are met.
-			
+
 			//- TODO: Documentation for field methods
-			
+
 			a(name="fields-underscoremethods")
 			h3 Underscore Methods
-			
+
 			p Some field types include helpful <strong>underscore methods</strong>, which are available on the item at the field's path preceded by an underscore.
 			p <strong>For example</strong>: use the <code>format</code> underscore method of the <code>createdAt</code> <code class="data-type">DateTime</code> field of the Posts List (above) like this
-			
+
 			pre: code.language-javascript
 				| var keystone = require('keystone'),
 				|     Post = keystone.list('Post');
-				| 
+				|
 				| Post.model.findById(postId).exec(function(err, post) {
 				|    console.log(post._.createdAt.format('Do MMMM YYYY')); // 25th August 2013
 				| });
-			
-			
+
+
 			a(name="relationships")
 			h2 Relationships
-			
+
 			p Keystone enhances MongoDB's ability to store the ObjectIDs of related documents in a field (or many related ObjectIDs in an Array) with support for Relationship fields and Definitions in Models.
-			
+
 			a(name="relationship-fields")
 			h3 Relationship Fields
-			
+
 			h4 <code class="data-type">ObjectId</code> or <code class="data-type">Array</code> &mdash; Displayed as an auto-suggest field in the Admin UI
-			
+
 			p Stores references to ObjectIDs from another Model in an ObjectID field or array to create one-many or many-many relationships.
-			
+
 			p Specify the related Model using the <code>ref</code> option. For a many-many relationship, set the <code>many</code> option to <code class="default-value">true</code>.
-			
+
 			p For example, if you wanted to link a <strong>Post</strong> model to a single <strong>Author</strong> and many <strong>PostCategories</strong>, you would do it like this:
-			
+
 			pre: code.language-javascript
 				| Post.add({
 				|     author: { type: Types.Relationship, ref: 'User' },
 				|     categories: { type: Types.Relationship, ref: 'PostCategory', many: true }
 				| });
-			
+
 			h5 Populating related data in queries
-			
+
 			p You can populate related data for relationship fields thanks to <a href="http://mongoosejs.com/docs/populate.html" target="_blank">Mongoose's populate functionality</a>. To populate the author and category documents when loading a Post from the example above, you would do this:
-			
+
 			pre: code.language-javascript
 				| Post.model.findOne().populate('author categories').exec(function(err, post) {
 				|     // the author is a fully populated User document
 				|     console.log(post.author.name);
 				| });
-			
+
 			p.note Note that if no ObjectId is stored, or an invalid ObjectId is stored (e.g. a document has been deleted), <code>author</code> will be <code class="data-type">undefined</code> in the example above.
-			
+
 			a(name="relationship-definitions")
 			h3 Relationship Definitions
-			
+
 			p What if, in the example above, you wanted to see a list of the Posts by each Author? Because the relationship field is on the Post, you need to tell the Author (and the PostCategory) Model that it is being referred to. Doing so allows the Admin UI to represent the relationship from both sides.
-			
+
 			p You do this by calling the <code>relationship</code> method on the <code>Model</code> like this:
-			
+
 			pre: code.language-javascript
 				| User.relationship({ path: 'posts', ref: 'Post', refPath: 'author' });
-			
+
 			.options
-				
+
 				h5 Options
 				p <code>path</code> <code class="data-type">String</code> - the path of the relationship reference on the Model
 				p <code>ref</code> <code class="data-type">String</code> - the key of the referred Model (the one that has the relationship field)
 				p <code>refPath</code> <code class="data-type">String</code> - the path of the relationship being referred to in the referred Model
-			
+
 			p As you can see, the options provided to the <code>relationship</code> method mirror those of the relationship field it refers to.
-			
+
 			p.note Relationship definitions are optional; if you leave them out, the relationships simply won't be displayed in the Admin UI from the other side of the relationship. The relationship field will still work as expected.
-			
+
 			a(name="relationship-queries")
 			h3 Loading related items
-			
+
 			p Filtering one-to-many related items is easy; simply specify the ID of the item you wish to filter on like any other value:
-			
+
 			pre: code.language-javascript
 				| Post.model.find().where('author', author.id).exec(function(err, posts) {
 				|     // ...
 				| });
-				
+
 			p To filter many-to-many related items, use an <code>in</code> condition and specify one (or more) ids as an array:
-			
+
 			pre: code.language-javascript
 				| Post.model.find().where('categories').in([category.id]).exec(function(err, posts) {
 				|     // ...
 				| });
-			
-			
+
+
 			a(name="fieldtypes")
 			h2 Field Types
-			
-			
+
+
 			a(name="fieldtypes-boolean")
 			h3 <code>Boolean</code>
 			h4 <code class="data-type">Boolean</code> &mdash; Displayed as a checkbox in the Admin UI
 			pre: code.language-javascript { type: Types.Boolean }
-			
-			
+
+
 			a(name="fieldtypes-text")
 			h3 <code>Text</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a text field in the Admin UI
 			pre: code.language-javascript { type: Types.Text }
-			
-			
+
+
 			a(name="fieldtypes-textarea")
 			h3 <code>Textarea</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a textarea field in the Admin UI
 			pre: code.language-javascript { type: Types.Textarea }
 			.options
-				
+
 				h5 Options
 				p <code>height</code> <code class="data-type">Number</code> - the height of the field (in pixels)
-			
-			
+
+
 			a(name="fieldtypes-email")
 			h3 <code>Email</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a text field in the Admin UI
 			p.note Input must look like a valid email address (can be blank unless field is required)
 			pre: code.language-javascript { type: Types.Email, displayGravatar: true }
 			.options
-				
+
 				h5 Options
 				p <code>displayGravatar</code> <code class="data-type">Boolean</code> - whether to display a gravatar image in the Admin UI
-				
+
 				h5 Underscore methods:
 				p <code>gravatarUrl(input, size, defaultImage, rating)</code> - generates a gravatar image request url
 				pre: code.language-javascript
 					| item.email = "demo@keystonejs.com";
 					| item._.email.gravatarUrl(); // "//www.gravatar.com/avatar/74a0071e5f3a7107b570b7d4a1a7619d?s=80&d=identicon&r=g"
 					| item._.email.gravatarUrl(200,'mm','r'); // "//www.gravatar.com/avatar/74a0071e5f3a7107b570b7d4a1a7619d?s=200&d=mm&r=r"
-			
-			
+
+
 			a(name="fieldtypes-url")
 			h3 <code>Url</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a text field in the Admin UI.
 			pre: code.language-javascript { type: Types.Url }
 			.options
-				
+
 				h5 Underscore methods:
 				p <code>format()</code> - formats the stored value by stripping the leading protocol (if any)
 				pre: code.language-javascript
 					| item.url = "http://keystonejs.com";
 					| item._.url.format(); // "keystonejs.com"
-			
-			
+
+
 			a(name="fieldtypes-html")
 			h3 <code>Html</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a text field or WYSIWYG Editor in the Admin UI.
 			pre: code.language-javascript { type: Types.Html, wysiwyg: true }
 			.options
-				
+
 				h5 Options
 				p <code>wysiwyg</code> <code class="data-type">Boolean</code> - whether to display a WYSIWYG editor in the Admin UI
 				p <code>height</code> <code class="data-type">Number</code> - the height of the field (in pixels)
-			
-			
+
+
 			a(name="fieldtypes-date")
 			h3 <code>Date</code>
 			h4 <code class="data-type">Date</code> &mdash; Displayed as a date picker in the Admin UI
@@ -457,11 +460,11 @@ block content
 			p.note To default Date fields to the current time, set the <code>default</code> option to <code class="default-value">Date.now</code>
 			pre: code.language-javascript { type: Types.Date }
 			.options
-				
+
 				h5 Options
 				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">Do MMM YYYY</code>
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
-				
+
 				h5 Underscore methods
 				p <code>format(string)</code> - formats the stored value using <a href="http://momentjs.com" target="_blank">momentjs</a>
 				p <code>moment()</code> - returns a <a href="http://momentjs.com" target="_blank">momentjs</a> object initialised with the value of the field
@@ -472,7 +475,7 @@ block content
 					| item._.createdDate.format(); // returns today's date using the default format string
 					| item._.createdDate.parse('2013-12-04'); // returns a moment object with the parsed date
 					| item._.createdDate.format('YYYY-MM-DD'); // returns '2013-12-04'
-			
+
 			a(name="fieldtypes-datetime")
 			h3 <code>Datetime</code>
 			h4 <code class="data-type">Datetime</code> &mdash; Displayed as a date and time picker in the Admin UI
@@ -480,59 +483,59 @@ block content
 			p.note To default Date fields to the current time, set the <code>default</code> option to <code>Date.now</code>
 			pre: code.language-javascript { type: Types.Datetime, default: Date.now }
 			.options
-				
+
 				h5 Options:
 				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">Do MMM YYYY hh:mm:ss a</code>
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
-				
+
 				h5 Underscore methods:
 				p <code>format(string)</code> - formats the stored value using <a href="http://momentjs.com" target="_blank">momentjs</a>
 				p <code>moment()</code> - returns a <a href="http://momentjs.com" target="_blank">momentjs</a> object initialised with the value of the field
 				p <code>parse(input, format, ...)</code> - parses input using <a href="http://momentjs.com" target="_blank">momentjs</a>, sets the field value and returns the moment object
 				p See the <a href="http://momentjs.com/docs/#/parsing/" target="_blank">momentjs parse docs</a> for information on the supported formats and options for the <code>parse</code> method.
-			
-			
+
+
 			a(name="fieldtypes-key")
 			h3 <code>Key</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a text field in the Admin UI
 			p Automatically converts input to a valid key (no spaces or special characters). White space is replaced with a separator.
 			pre: code.language-javascript { type: Types.Key }
 			.options
-				
+
 				h5 Options
 				p <code>separator</code> <code class="data-type">String</code> - the separator to use when replace white space in the input; defaults to <code class="default-value">-</code>
-			
-			
+
+
 			a(name="fieldtypes-number")
 			h3 <code>Number</code>
 			h4 <code class="data-type">Number</code> &mdash; Displayed as a number field in the Admin UI
 			p Input should either be a valid <strong>Number</strong>, or a string that can be converted to a number (can be blank unless field is required)
 			pre: code.language-javascript { type: Types.Number }
 			.options
-				
+
 				h5 Underscore methods
 				p <code>format(string)</code> - formats the stored value using <a href="http://numeraljs.com" target="_blank">numeraljs</a>.
 				p Format string defaults to <code class="default-value">0,0[.][000000000000]</code>
-			
-			
+
+
 			a(name="fieldtypes-money")
 			h3 <code>Money</code>
 			h4 <code class="data-type">Number</code> &mdash; Displayed as a number field in the Admin UI
 			p Input should either be a valid <strong>Number</strong>, or a string that can be converted to a number (leading symbols are allowed; can be blank unless field is required). Money fields do not understand currency.
 			pre: code.language-javascript { type: Types.Money }
 			.options
-				
+
 				h5 Underscore methods
 				p <code>format(string)</code> - formats the stored value using <a href="http://numeraljs.com" target="_blank">numeraljs</a>.
 				p Format string defaults to <code class="default-value">$0,0.00</code>
-			
-			
+
+
 			a(name="fieldtypes-select")
 			h3 <code>Select</code>
 			h4 <code class="data-type">String</code> or <code class="data-type">Number</code> &mdash; Displayed as a select field in the Admin UI
 			pre: code.language-javascript { type: Types.Select, options: 'first, second, third' }
 			.options
-				
+
 				h5 Options
 				p <code>numeric</code> <code class="data-type">Boolean</code> when <code class="default-value">true</code>, causes the value of the field to be stored as a <code class="data-type">Number</code> instead of a <code class="data-type">String</code>
 				pre: code.language-javascript { type: Types.Select, numeric: true, options: [{ value: 1, label: 'One' }, { value: 2, label: 'Two' }] }
@@ -550,26 +553,26 @@ block content
 					|     { value: 'first', label: 'The first option', custom: 'value' },
 					|     { value: 'second', label: 'Second' }
 					| ]}
-				
+
 				h5 Properties
 				p <code>ops</code> <code class="data-type">Array</code> - the field <strong>options</strong> array
 				p <code>values</code> <code class="data-type">Array</code> - all <code>option.value</code> properties
 				p <code>labels</code> <code class="data-type">Object</code> - app <code>option.label</code> properties, keyed by <code>option.value</code>
 				p <code>map</code> <code class="data-type">Object</code> - map of options, keyed by <code>option.value</code>
-				
+
 				h5 Schema
 				p The value of the current option will be stored at <code>{path}</code>. In addition, these virtuals are provided:
 				p <code>pathLabel</code> <code class="data-type">String</code> - the label of the currently selected <strong>option</strong>
 				p <code>pathData</code> <code class="data-type">Object</code> - the currently selected <strong>option</strong>, including any custom properties
 				p <code>pathOptions</code> <code class="data-type">Array</code> - the field <strong>options</strong> array
 				p <code>pathOptionsMap</code> <code class="data-type">Object</code> - map of options, keyed by <code>option.value</code>
-				
+
 				h5 Underscore methods:
 				p <code>pluck(property, default)</code> - returns <code>property</code> value of the currently selected <strong>option</strong>, or <code>default</code>. Useful in conjunction with custom properties for options.
-				
+
 				pre: code.language-javascript
 					| MyList.add({ state: { type: Types.Select, options: 'draft, published, archived', default: 'draft' });
-					| 
+					|
 					| MyList.fields.state.values == 'draft,published,archived';
 					| MyList.fields.state.labels == { draft: 'Draft', published: 'Published', archived: 'Archived' };
 					| MyList.fields.state.ops == [
@@ -582,72 +585,72 @@ block content
 					|     published: { value: 'published', label: 'Published' },
 					|     archived: { value: 'archived', label: 'Archived' }
 					| };
-					| 
+					|
 					| var item = new MyList.model();
 					| item.state == 'draft';
 					| item.stateLabel == 'Draft';
 					| item.stateData == { value: 'draft', label: 'Draft' };
 					| item.stateOptions == MyList.fields.state.ops;
 					| item.stateOptionsMap == MyList.fields.state.map;
-			
-			
+
+
 			a(name="fieldtypes-markdown")
 			h3 <code>Markdown</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as a textarea field in the Admin UI
 			pre: code.language-javascript { type: Types.Markdown }
 			.options
-				
+
 				h5 Schema
 				p The markdown field will automatically convert markdown to html when the <code>md</code> property is changed, via a setter on the <code>md</code> path.
 				p <code>md</code> <code class="data-type">String</code> - source markdown text
 				p <code>html</code> <code class="data-type">String</code> - generated html code
 				pre: code.language-javascript
 					| Page.add({ content: Types.Markdown });
-					| 
+					|
 					| var page = new Page.model();
 					| page.content.md = "# Hello World";
 					| page.content.html == "&lt;h1&gt;Hello World&lt;/h1&gt;";
-					| 
+					|
 					| // or...
-					| 
+					|
 					| Page.fields.content.updateItem(page, "* list item");
 					| page.fields.content.format(page) == "&lt;ul&gt;&lt;li&gt;list item&lt;/ul&gt;&lt;/li&gt;";
-			
+
 			a(name="fieldtypes-name")
 			h3 <code>Name</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as <strong>firstname</strong> <strong>lastname</strong> fields in the Admin UI
 			pre: code.language-javascript { type: Types.Name }
 			.options
-				
+
 				h5 Schema
 				p The name field adds <code>first</code> and <code>last</code> <code class="data-type">String</code> paths to the schema, as well as a <code>full</code> virtual getter and setter.
 				p <code>first</code> <code class="data-type">String</code> - first name
 				p <code>last</code> <code class="data-type">String</code> - last name
-				
+
 				h5 Virtuals
 				p <code>full</code> <code class="data-type">String</code> - first and last name, concatenated with a space (if both have a value)
 				p The <code>name.full</code> setter splits input at the first space.
-			
-			
+
+
 			a(name="fieldtypes-password")
 			h3 <code>Password</code>
 			h4 <code class="data-type">String</code> &mdash; Displayed as a password field in the Admin UI, with a 'change' button.
-			
+
 			p Passwords are automatically encrypted with bcrypt, and expose a method to compare a string to the encrypted hash.
 			p.note The encryption happens with a <strong>pre-save hook</strong> added to the <strong>schema</strong>, so passwords set will not be encrypted until an item has been saved to the database.
 			pre: code.language-javascript { type: Types.Password }
 			.options
-				
+
 				h5 Options
 				p <code>workFactor</code> <code class="data-type">Number</code> - the bcrypt workfactor to use when generating the hash, higher numbers are slower but more secure (defaults to <code class="default-value">10</code>)
-				
+
 				h5 Underscore methods
 				p <code>compare(input)</code> <code class="data-type">Boolean</code> - compares the input against the encrypted hash, returns <code class="default-value">true</code> if they match or <code class="default-value">false</code> if they don't
-				
+
 				h5 Special paths
 				p <code>{path}_compare</code> - when provided to the <strong>updateHandler</strong>, it will be checked against <code>{path}</code> and validation will fail if they don't match.
-			
-			
+
+
 			a(name="fieldtypes-location")
 			h3 <code>Location</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as a combination of fields in the Admin UI
@@ -657,7 +660,7 @@ block content
 			pre: code.language-javascript { type: Types.Location }
 			p.note Note: the schema paths are based on Australian address formats, and should be updated to be more appropriate for other international formats. If you have feedback on how the structure should be internationalised, please open a ticket.
 			.options
-				
+
 				h5 Schema
 				p <code>name</code> <code class="data-type">String</code> - building name
 				p <code>number</code> <code class="data-type">String</code> - unit or shop number
@@ -669,18 +672,18 @@ block content
 				p <code>country</code> <code class="data-type">String</code>
 				p <code>geo</code> <code class="data-type">Array</code> <code class="default-value">longitude, latitude</code>
 				p.note <strong>Important</strong>: as per the MongoDB convention, the order for the <strong>geo</strong> array must be <code class="default-value">lng, lat</code> which is the opposite of the order used by Google's API.
-				
+
 				h5 Underscore methods
 				p <code>googleLookup(region, update, callback)</code> - autodetect the full address and lng, lat from the stored value.
 				ul
 					li <code>region</code> <code class="data-type">String</code> is passed to the Places API for regional biasing and filtering.
 					li <code>update</code> <code class="data-type">String</code> passing <code class="default-value">"overwrite"</code> will completely overwrite existing data with the result. <code class="default-value">true</code> will set blank properties on the field with the result.
 					li <code>callback(err, location, result)</code> - is passed the parsed <strong>location</strong> object, and the raw <strong>result</strong> from Google.
-				
+
 				p Internal status codes mimic the Google API status codes. See <a href="https://developers.google.com/maps/documentation/geocoding/" target="_blank">https://developers.google.com/maps/documentation/geocoding/</a> for more information.
 				p Use of the Google Geocoding API is subject to a query limit of 2,500 geolocation requests per day, except with an enterprise license.
 				p The Geocoding API may only be used in conjunction with a Google map; geocoding results without displaying them on a map is prohibited. Please make sure your Keystone app complies with the Google Maps API License.
-			
+
 			a(name="fieldtypes-cloudinaryimage")
 			h3 <code>CloudinaryImage</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as an image upload field in the Admin UI
@@ -688,7 +691,7 @@ block content
 			p See the <a href="/docs/configuration#services-cloudinary">Cloudinary configuration documentation</a> for details on how to set up Cloudinary in KeystoneJS.
 			pre: code.language-javascript { type: Types.CloudinaryImage }
 			.options
-				
+
 				h5 Schema
 				p <code>public_id</code> <code class="data-type">String</code>
 				p <code>version</code> <code class="data-type">Number</code>
@@ -699,14 +702,14 @@ block content
 				p <code>width</code> <code class="data-type">Number</code>
 				p <code>height</code> <code class="data-type">Number</code>
 				p <code>secure_url</code> <code class="data-type">String</code>
-				
+
 				h5 Virtuals
 				<code>exists</code> <code class="data-type">Boolean</code> - whether there is a stored image
-				
+
 				h5 Special paths
 				p <code>{path}_upload</code> - when a <code class="data-type">file</code> is provided to the <strong>updateHandler</strong>, it will be uploaded to cloudinary and the details will be stored in the field.
 				//- TODO: Document {path}_action
-				
+
 				h5 Underscore methods
 				p <code>src(options)</code> <code class="data-type">String</code> - returns the url of the image, accepts all options cloudinary supports
 				p <code>tag(options)</code> <code class="data-type">String</code> - returns an <code class="default-value">&lt;img&gt;</code> tag
@@ -721,15 +724,15 @@ block content
 				p <code>thumbnail(width, height, options)</code> <code class="data-type">String</code> - crops the image to fill the specified width and height
 				p In all methods, <code class="default-value">options</code> is an optional <code class="data-type">Object</code>. See <a href="http://cloudinary.com/documentation/image_transformations" target="_blank">Cloudinary's Transformation Documentation</a> for more information on the supported options and transformations.
 				//- TODO: Usage Examples
-			
+
 			a(name="fieldtypes-cloudinaryimages")
 			h3 <code>CloudinaryImages</code>
 			h4 <code class="data-type">Array</code> &mdash; Displayed as a series of images, and an upload field in the Admin UI
 			p Stores multiple images in a array as a nested <code class="data-type">Schema</code>, each of which expose the same methods as the <code class="data-type">cloudinaryimage</code> field.
 			pre: code.language-javascript { type: Types.CloudinaryImages }
 			//- TODO: Usage Examples
-			
-			
+
+
 			a(name="fieldtypes-localfile")
 			h3 <code>LocalFile</code>
 			.alert.alert-warning This field type is not compatible with PAAS Hosts like Heroku because it relies on the local file system
@@ -737,51 +740,51 @@ block content
 			p Stores files on the local file system.
 			pre: code.language-javascript { type: Types.LocalFile }
 			.options
-				
+
 				h5 Schema
 				p <code>filename</code> <code class="data-type">String</code>
 				p <code>path</code> <code class="data-type">String</code>
 				p <code>size</code> <code class="data-type">Number</code>
 				p <code>filetype</code> <code class="data-type">String</code>
-				
+
 				h5 Virtuals
 				<code>exists</code> <code class="data-type">Boolean</code> - whether there is a file path stored
-			
+
 				h5 Underscore methods
 				p <code>uploadFile(file, update, callback)</code> - uploads a file to the local storage, stores the details in the field and provides the file data to the callback.
 				ul
 					li <code>file</code> <code class="data-type">File</code> should be a file as provided by express when a file is uploaded, i.e. <code class="default-value">req.files.path</code>
 					li <code>update</code> <code class="data-type">Boolean</code> whether to update the field with the details of the file after upload completes
 					li <code>callback(err, fileData)</code> - is passed the object that will be stored in the field (see schema above)
-			
+
 			//- TODO: document pre/post move hooks for LocalFile
-			
-			
+
+
 			a(name="fieldtypes-s3file")
 			h3 <code>S3 File</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as an file upload field in the Admin UI
 			p Automatically manages files stored in <a href="http://aws.amazon.com/s3" target="_blank">Amazon S3</a>, including uploading and deleting.
 			pre: code.language-javascript { type: Types.S3File }
 			.options
-				
+
 				h5 Options
 				p <code>s3path</code> <code class="data-type">String</code> - the path to store uploaded files under in the S3 bucket
 				p <code>datePrefix</code> <code class="data-type">String</code> - if set, prefixes the file name with the current date in this format (see <a href="http://momentjs.com" target="_blank">moment.js</a> for format options)
 				p <code>allowedTypes</code> <code class="data-type">Array</code> of <code class="data-type">String</code> - optional white-list of allowed mime types for uploaded files
-				
+
 				h5 Schema
 				p <code>filename</code> <code class="data-type">String</code>
 				p <code>type</code> <code class="data-type">String</code>
 				p <code>filesize</code> <code class="data-type">Number</code>
 				p <code>url</code> <code class="data-type">String</code>
-				
+
 				h5 Virtuals
 				<code>exists</code> <code class="data-type">Boolean</code> - whether there is a stored file
-				
+
 				h5 Special paths
 				p <code>{path}_upload</code> - when a <code class="data-type">file</code> is provided to the <strong>updateHandler</strong>, it will be uploaded to s3 and the details will be stored in the field.
 				//- TODO: Document {path}_action
-			
+
 				h5 Underscore methods
 				p <code>uploadFile(file, update, callback)</code> - uploads a file to the s3 bucket, stores the details in the field and provides the file data to the callback.
 				ul
@@ -796,7 +799,7 @@ block content
 			p Automatically manages files stored in <a href="http://www.windowsazure.com/" target="_blank">Windows Azure Storage</a>, including uploading and deleting.
 			pre: code.language-javascript { type: Types.AzureFile }
 			.options
-				
+
 				h5 Options
 				p <code>filenameFormatter</code> <code class="data-type">Callback</code> - function with arguments current model and client file name to return the new filename to upload.
 				pre: code.language-javascript { type: Types.AzureFile, filenameFormatter: function(item, filename) {
@@ -806,25 +809,25 @@ block content
 				pre: code.language-javascript { type: Types.AzureFile, containerFormatter: containerFormatter: function(item, filename) {
 					|	return item.modelProperty;
 					|} }
-				
+
 				h5 Schema
 				p <code>filename</code> <code class="data-type">String</code>
 				p <code>type</code> <code class="data-type">String</code>
 				p <code>filesize</code> <code class="data-type">Number</code>
 				p <code>url</code> <code class="data-type">String</code>
 				p <code>etag</code> <code class="data-type">String</code>
-				
+
 				h5 Virtuals
 				<code>exists</code> <code class="data-type">Boolean</code> - whether there is a stored file
-				
+
 				h5 Underscore methods
 				p <code>uploadFile(file, update, callback)</code> - uploads a file to the Azure Storage Account, stores the details in the field and provides the file data to the callback.
 				ul
 					li <code>file</code> <code class="data-type">File</code> should be a file as provided by express when a file is uploaded, i.e. <code class="default-value">req.files.path</code>
 					li <code>update</code> <code class="data-type">Boolean</code> whether to update the field with the details of the file after upload completes
 					li <code>callback(err, fileData)</code> - is passed the object that will be stored in the field (see schema above)
-						
-			
+
+
 			a(name="fieldtypes-embedly")
 			h3 <code>Embedly</code>
 			h4 <code class="data-type">Object</code> &mdash; Displayed as read-only data in the Admin UI
@@ -834,12 +837,12 @@ block content
 			p See the <a href="/docs/configuration#services-embedly">Embed.ly configuration documentation</a> for details on how to set up Embed.ly in KeystoneJS.
 			pre: code.language-javascript { type: Types.Embedly, from: 'path' }
 			.options
-				
+
 				h5 Options
 				p <code>from</code> <code class="data-type">String</code> - the path of another field in the Schema that will be passed to the Embedly API. The other field must contain a <code class="data-type">String</code> value.
 				p <code>options</code> <code class="data-type">Object</code> (optional) - passed as arguments to the embedly API along with the <code>from</code> field value
 				p See <a href="http://embed.ly/docs/embed/api/endpoints/1/oembed" target="_blank">Embedly's oEmbed API documentation</a> for more information on options and returned data.
-				
+
 				h5 Schema
 				p <code>exists</code> <code class="data-type">Boolean</code>
 				p <code>type</code> <code class="data-type">String</code>
@@ -857,6 +860,6 @@ block content
 				p <code>thumbnailUrl</code> <code class="data-type">String</code>
 				p <code>thumbnailWidth</code> <code class="data-type">Number</code>
 				p <code>thumbnailHeight</code> <code class="data-type">Number</code>
-			
+
 			h2 More examples
 			p See the <a href="/examples">Examples</a> page for projects that demonstrate real-world usage of the various list options and field types.

--- a/templates/views/item.jade
+++ b/templates/views/item.jade
@@ -40,9 +40,9 @@ block intro
 							each di, i in d.items
 								a(href=di.href, title=d.list.singular, data-toggle='tooltip', data-placement='top')= di.label
 								if i < d.items.length - 1
-									span , 
+									span ,
 						if d.more
-							li: span  ... 
+							li: span  ...
 					else
 						li: a(href=d.href, title=d.list.singular, data-toggle='tooltip', data-placement='top') #{d.label}
 			li
@@ -56,14 +56,17 @@ block intro
 				.btn-group.visible-md.visible-lg.pull-right(style='margin-left:20px')
 					a.btn.btn-default.btn-xs(href='/keystone/#{list.path}?new') new #{list.singular.toLowerCase()}
 					//- a.btn.btn-default.btn-xs(href='/keystone/#{list.path}/#{item.id}?duplicate') duplicate
-			
+
 block content
+	if list.get('description')
+		h4 Description:
+		p #{list.get("description")}
 	form(method='post', enctype='multipart/form-data').item-details
-		
+
 		input(type='hidden', name='action', value='updateItem')
-		
+
 		- var nameField = list.nameField, nameIsEditable = list.nameIsEditable;
-		
+
 		.field.item-name: .col-sm-12
 			if nameIsEditable
 				input(type='text', name=list.nameField.path, value=item.get(list.nameField.path)).form-control.input-lg
@@ -71,7 +74,7 @@ block content
 				h2.form-heading.name-value= list.nameField.format(item) || '(no name)'
 			else
 				h2.form-heading.name-value= item.get(list.namePath) || '(no name)'
-		
+
 		each el in list.uiElements
 			if el.type == 'field'
 				if (el.field.type != 'text' || el.field != nameField) && !el.field.hidden
@@ -82,14 +85,14 @@ block content
 				| <div class="form-indent">
 			else if el.type == 'outdent'
 				| </div>
-		
+
 		.toolbar.toolbar-fixed
 			if !list.get('noedit')
 				button(type='submit').btn.btn-default.btn-save Save
 				a(href='/keystone/' + list.path + '/' + item.id, data-confirm='Are you sure you want to reset your changes?').btn.btn-link.btn-cancel reset changes
 			if !list.get('nodelete')
 				a(href='/keystone/' + list.path + '?delete=' + item.id, data-confirm='Are you sure you want to delete this ' + list.singular.toLowerCase() + '?').btn.btn-link.btn-cancel delete #{list.singular.toLowerCase()}
-	
+
 	if showRelationships
 		h2.relationship-heading.form-heading Relationships
 			each rel in relationships


### PR DESCRIPTION
Hey, 

I had a usecase where I wanted to give some general info about the model in its item view, and I found the field notes a bit clunky for that. So I added the option to give a model a description and it will show up in the Admin list item view of the model.
I also updated your docs with the description of this (see database page).

Some screens of what I'm talking about:
without description (same as now):
![without_desc](https://cloud.githubusercontent.com/assets/1830626/2789142/82d35690-cba8-11e3-8666-29e994712c7f.jpg)

with description:
![with_desc](https://cloud.githubusercontent.com/assets/1830626/2789141/77f06506-cba8-11e3-9f8d-fb8169d874d4.jpg)

EDIT: I'm really not sure why you can't just automerge this, should be just something like 4-6 new lines altogether
