### PR TITLE
Restish

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,17 +425,17 @@ Keystone.prototype.routes = function(app) {
 	}
 	
 	// Generic Lists API
-	app.post('/keystone/api/:list', initList(), function(req, res) {
+	app.post('/keystone/restish_api/:list', initList(), function(req, res) {
 		req.params.action = 'create';
 		require('./routes/api/list')(req, res);
 	});
 
-	app.get('/keystone/api/:list', initList(), function(req, res) {
+	app.get('/keystone/restish_api/:list', initList(), function(req, res) {
 		req.params.action = 'get';
 		require('./routes/api/list')(req, res);
 	});
 
-	app.delete('/keystone/api/:list', initList(), function(req, res) {
+	app.delete('/keystone/restish_api/:list', initList(), function(req, res) {
 		req.params.action = 'delete';
 		require('./routes/api/list')(req, res);
 	});

--- a/index.js
+++ b/index.js
@@ -431,12 +431,19 @@ Keystone.prototype.routes = function(app) {
 	});
 
 	app.get('/keystone/restish_api/:list', initList(), function(req, res) {
-		req.params.action = 'get';
+		req.params.action = 'getAll';
 		require('./routes/api/list')(req, res);
 	});
 
-	app.delete('/keystone/restish_api/:list', initList(), function(req, res) {
+	app.get('/keystone/restish_api/:list/:id', initList(), function(req, res) {
+		req.params.action = 'get';
+		req.query.id = req.params.id;
+		require('./routes/api/list')(req, res);
+	});
+
+	app.delete('/keystone/restish_api/:list/:id', initList(), function(req, res) {
 		req.params.action = 'delete';
+		req.query.id = req.params.id;
 		require('./routes/api/list')(req, res);
 	});
 

--- a/index.js
+++ b/index.js
@@ -425,6 +425,21 @@ Keystone.prototype.routes = function(app) {
 	}
 	
 	// Generic Lists API
+	app.post('/keystone/api/:list', initList(), function(req, res) {
+		req.params.action = 'create';
+		require('./routes/api/list')(req, res);
+	});
+
+	app.get('/keystone/api/:list', initList(), function(req, res) {
+		req.params.action = 'get';
+		require('./routes/api/list')(req, res);
+	});
+
+	app.delete('/keystone/api/:list', initList(), function(req, res) {
+		req.params.action = 'delete';
+		require('./routes/api/list')(req, res);
+	});
+
 	app.all('/keystone/api/:list/:action', initList(), require('./routes/api/list'));
 	
 	// Generic Lists Download Route

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -102,7 +102,15 @@ exports = module.exports = function(req, res) {
 				}
 			}
 
-			req.list.model.find(null, null, opts).exec(function(err, item) {
+			if (req.query.filter) {
+				var filter = {};
+				req.query.filter.split(',').map(function(param) {
+					var elems = param.split(':');
+					filter[elems[0]] = elems[1];
+				});
+			};
+
+			req.list.model.find(filter || null, null, opts).exec(function(err, item) {
 
 				if(err) return sendError('database error', err);
 				if (!item) return sendResponse({ name: req.query.id, id: req.query.id });

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -89,6 +89,27 @@ exports = module.exports = function(req, res) {
 
 
 		break;
+		
+		case 'getAll':
+
+			req.list.model.find().exec(function(err, item) {
+
+				if (err) return sendError('database error', err);
+				if (!item) return sendResponse({ name: req.query.id, id: req.query.id });
+
+				switch (req.query.dataset) {
+					case 'simple':
+						return sendResponse({
+							name: req.list.getDocumentName(item, true),
+							id: item.id
+						});
+					break;
+					default:
+						return sendResponse(item);
+				}
+			});
+
+		break;
 
 		case 'get':
 

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -99,7 +99,7 @@ exports = module.exports = function(req, res) {
 				opts = {
 					skip: per_page * (page - 1),
 					limit: per_page * (page - 1)
-				}
+				};
 			}
 
 			if (req.query.filter) {
@@ -108,7 +108,7 @@ exports = module.exports = function(req, res) {
 					var elems = param.split(':');
 					filter[elems[0]] = elems[1];
 				});
-			};
+			}
 
 			req.list.model.find(filter || null, null, opts).exec(function(err, item) {
 

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -92,9 +92,19 @@ exports = module.exports = function(req, res) {
 		
 		case 'getAll':
 
-			req.list.model.find().exec(function(err, item) {
+			var opts = {};
+			if(req.query.page || req.query.per_page) {
+				var page = parseInt(req.query.page) || 1;
+				var per_page = parseInt(req.query.per_page) || 10;
+				opts = {
+					skip: per_page * (page - 1),
+					limit: per_page * (page - 1)
+				}
+			}
 
-				if (err) return sendError('database error', err);
+			req.list.model.find(null, null, opts).exec(function(err, item) {
+
+				if(err) return sendError('database error', err);
 				if (!item) return sendResponse({ name: req.query.id, id: req.query.id });
 
 				switch (req.query.dataset) {


### PR DESCRIPTION
I think this is now at the point where it warrants discussion. The point of this PR is to get an out-of-the-box generic list API from Keystone that works with [AngularJS' resource service](https://docs.angularjs.org/api/ngResource/service/$resource) and is generally rest-y.

The main things I've done are:

  1. add a new getAll method to the generic list api
  1. add a new endpoint at /keystone/restish_api

The new getAll method does what it says on the tin. Returns all members of a list. The obvious threat here is that maybe that list is gigantic. If so, I think the onus is on the app developer to add their own API routes. I think the happy path is to have it Just Work out of the box, and once you've got enough data for that to be a problem you can deal with it in whatever way makes sense for your app.

It would have been super-nice to be able to overload the /keystone/api endpoint so that it was compatible with angular, but I couldn't see a way to do it without also intercepting the old-style API calls to that endpoint. In order to not break backwards compatibility, I've namespaced these changes.

I think it's worth asking the question about backwards compatibility with this API, though. To my mind, the closer we get to the common conception of RESTfulness, the better. Even if you're not using Angular, this should work with most things that expect a rails-style REST API. Anyone that's used that kind of API in the past should be able to get up to speed pretty quickly without needing to read the docs.