### PR TITLE
Formating option fixture

### DIFF
--- a/lib/fieldTypes/localfiles.js
+++ b/lib/fieldTypes/localfiles.js
@@ -204,13 +204,26 @@ localfiles.prototype.addToSchema = function() {
 /**
  * Formats the field value
  *
+ * Delegates to the options.format function if it exists.
  * @api public
  */
 
 localfiles.prototype.format = function(item) {
-	return path.join(item.get(this.paths.path), item.get(this.paths.filename));
+	if(this.hasFormatter())
+		return this.options.format(item, item[this.path]);
+	return path.join(this.href(item),'?dim=160x160');
 };
 
+
+/**
+ * Detects the field have formatter function
+ *
+ * @api public
+ */
+
+localfiles.prototype.hasFormatter = function(){
+	return this.options.format !== undefined;
+}
 
 /**
  * Detects whether the field has been modified


### PR DESCRIPTION
Example:
images: {
type: Types.LocalFiles,
dest: './public/assets',
format:function(file){
	return 'img src="/assets/'+file.filename+'?dim=160x160"&gt;'
}
}