### PR TITLE
Adding Support for sub directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var Keystone = function() {
 		'auto update': false,
 		'model prefix': null,
 		'webroot': '/',
-		'cmsdirectory': 'keystone',
+		'cmsdir': 'keystone',
 	};
 	this._pre = {
 		routes: [],
@@ -302,7 +302,8 @@ Keystone.prototype.render = function(req, res, view, ext) {
 			menubar: keystone.get('wysiwyg menubar')
 		},
 		webroot: keystone.get('webroot'),
-		cmsdirectory: keystone.get('cmsdirectory'),
+		cmsdir: keystone.get('cmsdir'),
+		cmsroot: keystone.get('webroot') + keystone.get('cmsdir'),
 	};
 	
 	// optional extensions to the local scope

--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ var Keystone = function() {
 		'headless': false,
 		'logger': 'dev',
 		'auto update': false,
-		'model prefix': null
+		'model prefix': null,
+		'webroot': '/',
+		'cmsdirectory': 'keystone',
 	};
 	this._pre = {
 		routes: [],
@@ -298,7 +300,9 @@ Keystone.prototype.render = function(req, res, view, ext) {
 			overrideToolbar: keystone.get('wysiwyg override toolbar'),
 			skin: keystone.get('wysiwyg skin') || 'keystone',
 			menubar: keystone.get('wysiwyg menubar')
-		}
+		},
+		webroot: keystone.get('webroot'),
+		cmsdirectory: keystone.get('cmsdirectory'),
 	};
 	
 	// optional extensions to the local scope

--- a/lib/core/bindEmailTestRoutes.js
+++ b/lib/core/bindEmailTestRoutes.js
@@ -3,7 +3,8 @@ var _ = require('underscore');
 function bindEmailTestRoutes(app, emails) {
 	
 	var keystone = this;
-	
+	var cmsroot = keystone.get('webroot') + keystone.get("cmsdir");
+
 	var handleError = function(req, res, err) {
 		if (res.err) {
 			res.err(err);
@@ -27,7 +28,7 @@ function bindEmailTestRoutes(app, emails) {
 			});
 		};
 		
-		app.get('/keystone/test-email/' + key, function(req, res) {
+		app.get(cmsroot + '/test-email/' + key, function(req, res) {
 			if ('function' === typeof vars) {
 				vars(req, res, function(err, locals) {
 					render(err, req, res, locals);

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -205,6 +205,7 @@ function mount(mountPath, parentApp, events) {
 	
 	if (mountPath) {
 		//fix root-relative keystone urls for assets (gets around having to re-write all the keystone templates)
+		//This won't do anything if you are using the new webroot, and cmsdir variables. However we will leave this for backward compatability.
 		parentApp.all(/^\/keystone($|\/*)/, function(req, res, next) {
 			req.url = mountPath + req.url;
 			next();

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -16,7 +16,7 @@ function routes(app) {
 	
 	this.app = app;
 	var keystone = this;
-	var cmsroot = keystone.get('webroot') + this.get("cmsdir");
+	var cmsroot = keystone.get('webroot') + keystone.get("cmsdir");
 
 	// ensure keystone nav has been initialised
 	if (!this.nav) {

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -16,7 +16,8 @@ function routes(app) {
 	
 	this.app = app;
 	var keystone = this;
-	
+	var keystoneroot = keystone.get('webroot') + keystone.get('cmsdirectory');
+
 	// ensure keystone nav has been initialised
 	if (!this.nav) {
 		this.nav = this.initNav();
@@ -31,22 +32,22 @@ function routes(app) {
 	if (this.get('auth') === true) {
 		
 		if (!this.get('signout url')) {
-			this.set('signout url', '/keystone/signout');
+			this.set('signout url', keystoneroot + '/signout');
 		}
 		if (!this.get('signin url')) {
-			this.set('signin url', '/keystone/signin');
+			this.set('signin url', keystoneroot + '/signin');
 		}
 		
 		if (!this.nativeApp || !this.get('session')) {
-			app.all('/keystone*', this.session.persist);
+			app.all(keystoneroot + '*', this.session.persist);
 		}
 		
-		app.all('/keystone/signin', require('../../routes/views/signin'));
-		app.all('/keystone/signout', require('../../routes/views/signout'));
-		app.all('/keystone*', this.session.keystoneAuth);
+		app.all(keystoneroot + '/signin', require('../../routes/views/signin'));
+		app.all(keystoneroot + '/signout', require('../../routes/views/signout'));
+		app.all(keystoneroot + '*', this.session.keystoneAuth);
 		
 	} else if ('function' === typeof this.get('auth')) {
-		app.all('/keystone*', this.get('auth'));
+		app.all(keystoneroot + '*', this.get('auth'));
 	}
 	
 	var initList = function(protect) {
@@ -54,14 +55,14 @@ function routes(app) {
 			req.list = keystone.list(req.params.list);
 			if (!req.list || (protect && req.list.get('hidden'))) {
 				req.flash('error', 'List ' + req.params.list + ' could not be found.');
-				return res.redirect('/keystone');
+				return res.redirect(keystoneroot);
 			}
 			next();
 		};
 	};
 	
 	// Keystone Admin Route
-	app.all('/keystone', require('../../routes/views/home'));
+	app.all(keystoneroot, require('../../routes/views/home'));
 	
 	// Email test routes
 	if (this.get('email tests')) {
@@ -73,24 +74,24 @@ function routes(app) {
 		if (!keystone.get('cloudinary config')) {
 			throw new Error('KeystoneJS Initialisaton Error:\n\nTo use wysiwyg cloudinary images, the \'cloudinary config\' setting must be configured.\n\n');
 		}
-		app.post('/keystone/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
+		app.post(keystoneroot + '/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
 	}
 	
 	// Cloudinary API for selecting an existing image from the cloud
 	if (keystone.get('cloudinary config')) {
-		app.get('/keystone/api/cloudinary/get', require('../../routes/api/cloudinary').get);
-		app.get('/keystone/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
+		app.get(keystoneroot + '/api/cloudinary/get', require('../../routes/api/cloudinary').get);
+		app.get(keystoneroot + '/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
 	}
 
 	// Generic Lists API
-	app.all('/keystone/api/:list/:action', initList(), require('../../routes/api/list'));
+	app.all(keystoneroot + '/api/:list/:action', initList(), require('../../routes/api/list'));
 	
 	// Generic Lists Download Route
-	app.all('/keystone/download/:list', initList(), require('../../routes/download/list'));
+	app.all(keystoneroot + '/download/:list', initList(), require('../../routes/download/list'));
 	
 	// List and Item Details Admin Routes
-	app.all('/keystone/:list/:page([0-9]{1,5})?', initList(true), require('../../routes/views/list'));
-	app.all('/keystone/:list/:item', initList(true), require('../../routes/views/item'));
+	app.all(keystoneroot + '/:list/:page([0-9]{1,5})?', initList(true), require('../../routes/views/list'));
+	app.all(keystoneroot + '/:list/:item', initList(true), require('../../routes/views/item'));
 	
 	return this;
 	

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -16,7 +16,7 @@ function routes(app) {
 	
 	this.app = app;
 	var keystone = this;
-	var keystoneroot = keystone.get('webroot') + keystone.get('cmsdirectory');
+	var cmsroot = keystone.get('webroot') + this.get("cmsdir");
 
 	// ensure keystone nav has been initialised
 	if (!this.nav) {
@@ -32,22 +32,22 @@ function routes(app) {
 	if (this.get('auth') === true) {
 		
 		if (!this.get('signout url')) {
-			this.set('signout url', keystoneroot + '/signout');
+			this.set('signout url', cmsroot + '/signout');
 		}
 		if (!this.get('signin url')) {
-			this.set('signin url', keystoneroot + '/signin');
+			this.set('signin url', cmsroot + '/signin');
 		}
 		
 		if (!this.nativeApp || !this.get('session')) {
-			app.all(keystoneroot + '*', this.session.persist);
+			app.all(cmsroot + '*', this.session.persist);
 		}
 		
-		app.all(keystoneroot + '/signin', require('../../routes/views/signin'));
-		app.all(keystoneroot + '/signout', require('../../routes/views/signout'));
-		app.all(keystoneroot + '*', this.session.keystoneAuth);
+		app.all(cmsroot + '/signin', require('../../routes/views/signin'));
+		app.all(cmsroot + '/signout', require('../../routes/views/signout'));
+		app.all(cmsroot + '*', this.session.keystoneAuth);
 		
 	} else if ('function' === typeof this.get('auth')) {
-		app.all(keystoneroot + '*', this.get('auth'));
+		app.all(cmsroot + '*', this.get('auth'));
 	}
 	
 	var initList = function(protect) {
@@ -55,14 +55,14 @@ function routes(app) {
 			req.list = keystone.list(req.params.list);
 			if (!req.list || (protect && req.list.get('hidden'))) {
 				req.flash('error', 'List ' + req.params.list + ' could not be found.');
-				return res.redirect(keystoneroot);
+				return res.redirect(cmsroot);
 			}
 			next();
 		};
 	};
 	
 	// Keystone Admin Route
-	app.all(keystoneroot, require('../../routes/views/home'));
+	app.all(cmsroot, require('../../routes/views/home'));
 	
 	// Email test routes
 	if (this.get('email tests')) {
@@ -74,24 +74,24 @@ function routes(app) {
 		if (!keystone.get('cloudinary config')) {
 			throw new Error('KeystoneJS Initialisaton Error:\n\nTo use wysiwyg cloudinary images, the \'cloudinary config\' setting must be configured.\n\n');
 		}
-		app.post(keystoneroot + '/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
+		app.post(cmsroot + '/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
 	}
 	
 	// Cloudinary API for selecting an existing image from the cloud
 	if (keystone.get('cloudinary config')) {
-		app.get(keystoneroot + '/api/cloudinary/get', require('../../routes/api/cloudinary').get);
-		app.get(keystoneroot + '/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
+		app.get(cmsroot + '/api/cloudinary/get', require('../../routes/api/cloudinary').get);
+		app.get(cmsroot + '/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
 	}
 
 	// Generic Lists API
-	app.all(keystoneroot + '/api/:list/:action', initList(), require('../../routes/api/list'));
+	app.all(cmsroot + '/api/:list/:action', initList(), require('../../routes/api/list'));
 	
 	// Generic Lists Download Route
-	app.all(keystoneroot + '/download/:list', initList(), require('../../routes/download/list'));
+	app.all(cmsroot + '/download/:list', initList(), require('../../routes/download/list'));
 	
 	// List and Item Details Admin Routes
-	app.all(keystoneroot + '/:list/:page([0-9]{1,5})?', initList(true), require('../../routes/views/list'));
-	app.all(keystoneroot + '/:list/:item', initList(true), require('../../routes/views/item'));
+	app.all(cmsroot + '/:list/:page([0-9]{1,5})?', initList(true), require('../../routes/views/list'));
+	app.all(cmsroot + '/:list/:item', initList(true), require('../../routes/views/item'));
 	
 	return this;
 	

--- a/lib/core/static.js
+++ b/lib/core/static.js
@@ -11,9 +11,9 @@ var path = require('path'),
  */
 
 function static(app) {
-	
-	app.use('/keystone', require('less-middleware')(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
-	app.use('/keystone', express.static(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
+
+	app.use(this.get("webroot") + this.get("cmsdirectory"), require('less-middleware')(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
+	app.use(this.get("webroot") + this.get("cmsdirectory"), express.static(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
 	
 	return this;
 	

--- a/lib/core/static.js
+++ b/lib/core/static.js
@@ -12,8 +12,8 @@ var path = require('path'),
 
 function static(app) {
 
-	app.use(this.get("webroot") + this.get("cmsdirectory"), require('less-middleware')(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
-	app.use(this.get("webroot") + this.get("cmsdirectory"), express.static(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
+	app.use(this.get("webroot") + this.get("cmsdir"), require('less-middleware')(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
+	app.use(this.get("webroot") + this.get("cmsdir"), express.static(__dirname + path.sep + '..' + path.sep + '..' + path.sep + 'public'));
 	
 	return this;
 	

--- a/lib/core/wrapHTMLError.js
+++ b/lib/core/wrapHTMLError.js
@@ -5,8 +5,10 @@
  */
 
 function wrapHTMLError(title, err) {
+	var cmsroot = this.get('webroot') + this.get("cmsdir");
+
 	return '<html><head><meta charset=\'utf-8\'><title>Error</title>' +
-	'<link rel=\'stylesheet\' href=\'/keystone/styles/error.css\'>' +
+	'<link rel=\'stylesheet\' href=\'' + cmsroot + '/styles/error.css\'>' +
 	'</head><body><div class=\'error\'><h1 class=\'error-title\'>' + title + '</h1>' +
 	'<div class="error-message">' + (err || '') + '</div></div></body></html>';
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -161,9 +161,11 @@ exports.persist = function(req, res, next) {
  */
 
 exports.keystoneAuth = function(req, res, next) {
+	var cmsroot = keystone.get('webroot') + keystone.get("cmsdir");
+	cmsroot = cmsroot.replace(/\//g, '\/');
 
 	if (!req.user || !req.user.canAccessKeystone) {
-		var from = new RegExp('^\/keystone\/?$', 'i').test(req.url) ? '' : '?from=' + req.url;
+		var from = new RegExp('^' + cmsroot + '\/?$', 'i').test(req.url) ? '' : '?from=' + req.url;
 		return res.redirect(keystone.get('signin url') + from);
 	}
 

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -234,7 +234,7 @@ exports = module.exports = function(req, res) {
 							}
 						}
 						params = querystring.stringify(_.defaults(params, queryParams));
-						return '/keystone/' + req.list.path + (p ? '/' + p : '') + (params ? '?' + params : '');
+						return keystone.get('webroot') + keystone.get('cmsdir') + '/' + req.list.path + (p ? '/' + p : '') + (params ? '?' + params : '');
 					};
 
 				var query = req.list.model.find(queryFilters).sort(req.query.sort).skip(skip).limit(1),

--- a/routes/views/item.js
+++ b/routes/views/item.js
@@ -4,6 +4,8 @@ var keystone = require('../../'),
 
 exports = module.exports = function(req, res) {
 	
+	var cmsroot = keystone.get('webroot') + keystone.get("cmsdir");
+	
 	var itemQuery = req.list.model.findById(req.params.item);
 	
 	if (req.list.tracking && req.list.tracking.createdBy) {
@@ -18,7 +20,7 @@ exports = module.exports = function(req, res) {
 		
 		if (!item) {
 			req.flash('error', 'Item ' + req.params.item + ' could not be found.');
-			return res.redirect('/keystone/' + req.list.path);
+			return res.redirect(cmsroot + '/' + req.list.path);
 		}
 		
 		var viewLocals = {
@@ -75,7 +77,7 @@ exports = module.exports = function(req, res) {
 									list: refList,
 									items: _.map(results, function(i) { return {
 										label: refList.getDocumentName(i),
-										href: '/keystone/' + refList.path + '/' + i.id
+										href: cmsroot + '/' + refList.path + '/' + i.id
 									};}),
 									more: (more) ? true : false
 								});
@@ -92,7 +94,7 @@ exports = module.exports = function(req, res) {
 								drilldown.items.push({
 									list: refList,
 									label: refList.getDocumentName(result),
-									href: '/keystone/' + refList.path + '/' + result.id
+									href: cmsroot + '/' + refList.path + '/' + result.id
 								});
 							}
 							done();
@@ -180,7 +182,7 @@ exports = module.exports = function(req, res) {
 					return renderView();
 				}
 				req.flash('success', 'Your changes have been saved.');
-				return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+				return res.redirect(cmsroot + '/' + req.list.path + '/' + item.id);
 			});
 			
 			

--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -5,6 +5,8 @@ var keystone = require('../../'),
 
 exports = module.exports = function(req, res) {
 	
+	var cmsroot = keystone.get('webroot') + keystone.get("cmsdir");
+
 	var viewLocals = {
 		validationErrors: {},
 		showCreateForm: _.has(req.query, 'new')
@@ -71,7 +73,7 @@ exports = module.exports = function(req, res) {
 				}
 			}
 			params = querystring.stringify(_.defaults(params, queryParams));
-			return '/keystone/' + req.list.path + (p ? '/' + p : '') + (params ? '?' + params : '');
+			return cmsroot + '/' + req.list.path + (p ? '/' + p : '') + (params ? '?' + params : '');
 		};
 		
 		query.exec(function(err, items) {
@@ -83,15 +85,15 @@ exports = module.exports = function(req, res) {
 			
 			// if there were results but not on this page, reset the page
 			if (req.params.page && items.total && !items.results.length) {
-				return res.redirect('/keystone/' + req.list.path);
+				return res.redirect(cmsroot + '/' + req.list.path);
 			}
 			
 			// go straight to the result if there was a search, and only one result
 			if (req.query.search && items.total === 1 && items.results.length === 1) {
-				return res.redirect('/keystone/' + req.list.path + '/' + items.results[0].id);
+				return res.redirect(cmsroot + '/' + req.list.path + '/' + items.results[0].id);
 			}
 			
-			var download_link = '/keystone/download/' + req.list.path,
+			var download_link = cmsroot + '/download/' + req.list.path,
 				downloadParams = {};
 				
 			if (req.query.q) {
@@ -167,7 +169,7 @@ exports = module.exports = function(req, res) {
 				} else {
 					req.flash('success', 'All ' + req.list.plural + ' updated successfully.');
 				}
-				res.redirect('/keystone/' + req.list.path);
+				res.redirect(cmsroot + '/' + req.list.path);
 			});
 		})();
 		
@@ -181,7 +183,7 @@ exports = module.exports = function(req, res) {
 		}
 		
 		req.list.model.findById(req.query['delete']).exec(function (err, item) {
-			if (err || !item) return res.redirect('/keystone/' + req.list.path);
+			if (err || !item) return res.redirect(cmsroot + '/' + req.list.path);
 			
 			item.remove(function (err) {
 				if (err) {
@@ -191,7 +193,7 @@ exports = module.exports = function(req, res) {
 				} else {
 					req.flash('success', req.list.singular + ' deleted successfully.');
 				}
-				res.redirect('/keystone/' + req.list.path);
+				res.redirect(cmsroot + '/' + req.list.path);
 			});
 		});
 		
@@ -211,7 +213,7 @@ exports = module.exports = function(req, res) {
 				renderView();
 			} else {
 				req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
-				return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+				return res.redirect(cmsroot + '/' + req.list.path + '/' + item.id);
 			}
 			
 		});
@@ -241,7 +243,7 @@ exports = module.exports = function(req, res) {
 				return renderView();
 			}
 			req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
-			return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+			return res.redirect(cmsroot + '/' + req.list.path + '/' + item.id);
 		});
 		
 	} else {

--- a/routes/views/signin.js
+++ b/routes/views/signin.js
@@ -33,7 +33,7 @@ exports = module.exports = function(req, res) {
 			} else if ('function' === typeof keystone.get('signin redirect')) {
 				keystone.get('signin redirect')(user, req, res);
 			} else {
-				res.redirect('/keystone');
+				res.redirect(keystone.get('webroot') + keystone.get('cmsdir'));
 			}
 
 		};

--- a/routes/views/signout.js
+++ b/routes/views/signout.js
@@ -10,7 +10,7 @@ exports = module.exports = function(req, res) {
 		} else if ('function' === typeof keystone.get('signout redirect')) {
 			return keystone.get('signout redirect')(req, res);
 		} else {
-			return res.redirect('/keystone');
+			return res.redirect(keystone.get('webroot') + keystone.get('cmsdir'));
 		}
 
 		keystone.render(req, res, 'signout', {

--- a/templates/fields/boolean/form.jade
+++ b/templates/fields/boolean/form.jade
@@ -2,9 +2,9 @@
 	.field-ui(class=field.indent ? 'field-indented' : false)
 		if field.noedit
 			if item.get(field.path)
-				img(src='/keystone/images/icons/16/checkbox-checked.png', width=16, height=16).checked
+				img(src='#{cmsroot}/images/icons/16/checkbox-checked.png', width=16, height=16).checked
 			else
-				img(src='/keystone/images/icons/16/checkbox-unchecked.png', width=16, height=16).unchecked
+				img(src='#{cmsroot}/images/icons/16/checkbox-unchecked.png', width=16, height=16).unchecked
 			span= field.label
 		else
 			label(for=field.path).checkbox

--- a/templates/fields/relationship/form.jade
+++ b/templates/fields/relationship/form.jade
@@ -8,10 +8,10 @@ else
 			.field-message
 			if field.noedit
 				if !field.many && item.get(field.path)
-					a(href='/keystone/' + refList.path + '/' + item.get(field.path), data-ref-path=refList.path).ui-related-item= item.get(field.path)
+					a(href='#{cmsroot}/' + refList.path + '/' + item.get(field.path), data-ref-path=refList.path).ui-related-item= item.get(field.path)
 				else if field.many && item.get(field.path).length
 					each value in item.get(field.path)
-						a(href='/keystone/' + refList.path + '/' + value, data-ref-path=refList.path).ui-related-item= value
+						a(href='#{cmsroot}/' + refList.path + '/' + value, data-ref-path=refList.path).ui-related-item= value
 				else
 					.help-block (not set)
 			else
@@ -25,6 +25,6 @@ else
 					data-ref-singular=refList.singular,
 					data-ref-plural=refList.plural).ui-select2-ref
 				if !field.many
-					a(href='/keystone/' + refList.path + '/' + item.get(field.path), style='margin-left: 10px;' + (!item.get(field.path) ? 'display: none' : '')).btn.btn-link.btn-goto-linked-item view #{refList.singular.toLowerCase()}
+					a(href='#{cmsroot}/' + refList.path + '/' + item.get(field.path), style='margin-left: 10px;' + (!item.get(field.path) ? 'display: none' : '')).btn.btn-link.btn-goto-linked-item view #{refList.singular.toLowerCase()}
 			if field.note
 				.field-note!= field.note

--- a/templates/includes/auth-brand.jade
+++ b/templates/includes/auth-brand.jade
@@ -4,4 +4,4 @@
 	else if logo
 		a(href='/').auth-box-logo: img(src=logo, alt=brand)
 	else
-		a(href='/').auth-box-logo: img(src='/keystone/images/logo.png', width=205, height=68, alt=brand)
+		a(href='/').auth-box-logo: img(src='#{cmsroot}/images/logo.png', width=205, height=68, alt=brand)

--- a/templates/layout/auth.jade
+++ b/templates/layout/auth.jade
@@ -6,8 +6,8 @@ html
 		meta(charset="utf-8")
 		meta(name="viewport", content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width")
 		title Sign into #{brand ? brand : 'Keystone'}
-		link(rel="stylesheet", href="/keystone/styles/auth.min.css")
-		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
+		link(rel="stylesheet", href="#{cmsroot}/styles/auth.min.css")
+		link(rel="shortcut icon", href="#{webroot}favicon.ico", type="image/x-icon")
 		block css
 			
 	body: .auth-wrapper

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -9,14 +9,14 @@ html
 		title= title
 
 		//- Component Stylesheets
-		link(rel="stylesheet", href="/keystone/js/lib/select2/select2-3.3.2.css")
-		link(rel="stylesheet", href="/keystone/js/lib/pikaday/pikaday-1.1.0.css")
+		link(rel="stylesheet", href="#{cmsroot}/js/lib/select2/select2-3.3.2.css")
+		link(rel="stylesheet", href="#{cmsroot}/js/lib/pikaday/pikaday-1.1.0.css")
 
 		//- Keystone Stylesheet
-		link(rel="stylesheet", href="/keystone/styles/keystone.min.css")
+		link(rel="stylesheet", href="#{cmsroot}/styles/keystone.min.css")
 		block css
 
-		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
+		link(rel="shortcut icon", href="#{webroot}/favicon.ico", type="image/x-icon")
 		block head
 
 	body(id='page-' + page)
@@ -31,9 +31,9 @@ html
 						span.icon-bar
 						span.icon-bar
 					if section.lists && section.lists.length > 1
-						a(href='/keystone', class=(section == 'home' ? 'active' : null)).navbar-brand= brand
+						a(href='#{cmsroot}', class=(section == 'home' ? 'active' : null)).navbar-brand= brand
 					else
-						a(href='/keystone', class=(section == 'home' ? 'active' : null)).navbar-brand= brand
+						a(href='#{cmsroot}', class=(section == 'home' ? 'active' : null)).navbar-brand= brand
 				.collapse.navbar-collapse.navbar-headernav-collapse
 					if signout
 						ul.nav.navbar-nav.navbar-right
@@ -41,7 +41,7 @@ html
 							li: a(href=signout).signout Sign Out
 					ul.nav.navbar-nav
 						each navSection in nav.sections
-							li(class=section.key == navSection.key ? 'active' : null): a(href='/keystone/' + navSection.lists[0].path)= navSection.label
+							li(class=section.key == navSection.key ? 'active' : null): a(href='#{cmsroot}/' + navSection.lists[0].path)= navSection.label
 			if section.lists && section.lists.length > 1
 				nav(role='navigation')#section-nav.navbar.navbar-default.navbar-static-top: .container
 					.navbar-header
@@ -57,7 +57,7 @@ html
 					.collapse.navbar-collapse.navbar-sectionnav-collapse
 						ul.nav.navbar-nav
 							each navList in section.lists
-								li(class=navList.key == list.key ? 'active' : null): a(href='/keystone/' + navList.path)= navList.label
+								li(class=navList.key == list.key ? 'active' : null): a(href='#{cmsroot}/' + navList.path)= navList.label
 			#body: .container
 				block intro
 				+flash-messages(messages)
@@ -67,28 +67,28 @@ html
 			p Powered by <a href="http://keystonejs.com" target="_blank">KeystoneJS</a> version #{version}.
 				if User && user
 					|  Signed in as 
-					a(href='/keystone/' + User.path + '/' + user.id)= User.getDocumentName(user)
+					a(href='#{cmsroot}/' + User.path + '/' + user.id)= User.getDocumentName(user)
 					| .
 
 		//- Common
-		script(src="/keystone/js/lib/underscore/underscore-1.5.1.min.js")
-		script(src="/keystone/js/lib/jquery/jquery-1.10.2.min.js")
-		script(src="/keystone/js/lib/async/async.js")
+		script(src="#{cmsroot}/js/lib/underscore/underscore-1.5.1.min.js")
+		script(src="#{cmsroot}/js/lib/jquery/jquery-1.10.2.min.js")
+		script(src="#{cmsroot}/js/lib/async/async.js")
 
 		//- Bootstrap Components
-		script(src='/keystone/js/lib/bootstrap/collapse.js')
-		script(src='/keystone/js/lib/bootstrap/dropdown.js')
-		script(src='/keystone/js/lib/bootstrap/tooltip.js')
-		script(src='/keystone/js/lib/bootstrap/button.js')
+		script(src='#{cmsroot}/js/lib/bootstrap/collapse.js')
+		script(src='#{cmsroot}/js/lib/bootstrap/dropdown.js')
+		script(src='#{cmsroot}/js/lib/bootstrap/tooltip.js')
+		script(src='#{cmsroot}/js/lib/bootstrap/button.js')
 
 		//- Other Components
-		script(src="/keystone/js/lib/bootstrap-colorpicker/bootstrap-colorpicker.min.js")
-		script(src="/keystone/js/lib/moment/moment-1.7.2.min.js")
-		script(src="/keystone/js/lib/move/move-0.1.1.min.js")
-		script(src="/keystone/js/lib/select2/select2-3.3.2.min.js")
-		script(src="/keystone/js/lib/pikaday/pikaday-1.1.0.js")
-		script(src="/keystone/js/lib/pikaday/pikaday.jquery-1.1.0.js")
-		script(src="/keystone/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
+		script(src="#{cmsroot}/js/lib/bootstrap-colorpicker/bootstrap-colorpicker.min.js")
+		script(src="#{cmsroot}/js/lib/moment/moment-1.7.2.min.js")
+		script(src="#{cmsroot}/js/lib/move/move-0.1.1.min.js")
+		script(src="#{cmsroot}/js/lib/select2/select2-3.3.2.min.js")
+		script(src="#{cmsroot}/js/lib/pikaday/pikaday-1.1.0.js")
+		script(src="#{cmsroot}/js/lib/pikaday/pikaday.jquery-1.1.0.js")
+		script(src="#{cmsroot}/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
 
 		//- App
 		script.
@@ -101,10 +101,10 @@ html
 			Keystone.csrf.key = "#{csrf_token_key}";
 			Keystone.csrf.value = "#{csrf_token_value}";
 		if cloudinary
-			script(src='/keystone/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
-			script(src='/keystone/js/lib/jqueryfileupload/jquery.iframe-transport.js')
-			script(src='/keystone/js/lib/jqueryfileupload/jquery.fileupload.js')
-			script(src='/keystone/js/lib/cloudinary/jquery.cloudinary.js')
+			script(src='#{cmsroot}/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
+			script(src='#{cmsroot}/js/lib/jqueryfileupload/jquery.iframe-transport.js')
+			script(src='#{cmsroot}/js/lib/jqueryfileupload/jquery.fileupload.js')
+			script(src='#{cmsroot}/js/lib/cloudinary/jquery.cloudinary.js')
 			| !{cloudinary_js_config}
 			script.
 				Keystone.cloudinary = {
@@ -115,12 +115,12 @@ html
 				}
 
 		//- Keystone UI
-		script(src="/keystone/js/common/plugins.js")
-		script(src="/keystone/js/common/ui.js")
-		script(src="/keystone/js/common/ui-alt-text.js")
-		script(src="/keystone/js/common/ui-color.js")
-		script(src="/keystone/js/common/ui-sortable.js")
-		script(src="/keystone/js/common/ui-multivalue.js")
+		script(src="#{cmsroot}/js/common/plugins.js")
+		script(src="#{cmsroot}/js/common/ui.js")
+		script(src="#{cmsroot}/js/common/ui-alt-text.js")
+		script(src="#{cmsroot}/js/common/ui-color.js")
+		script(src="#{cmsroot}/js/common/ui-sortable.js")
+		script(src="#{cmsroot}/js/common/ui-multivalue.js")
 		
 		//- Page Scripts
 		block js

--- a/templates/mixins/columns.jade
+++ b/templates/mixins/columns.jade
@@ -15,7 +15,7 @@ mixin column(list, col, item)
 			else
 				- var value = col.subField ? col.subField.format(refData) : refData[col.refPath]
 				if col.refList && refData && refData.id
-					+column_link(value, '/keystone/' + col.refList.path + '/' + refData.id)
+					+column_link(value, cmsroot + '/' + col.refList.path + '/' + refData.id)
 				else
 					+column_basic(value)
 	else if col.type == 'markdown'
@@ -25,7 +25,7 @@ mixin column(list, col, item)
 	else
 		- var value = col.field ? col.field.format(item) : item.get(col.path)
 		if col.isName
-			+column_link(value || '(no name)', '/keystone/' + list.path + '/' + item.id)
+			+column_link(value || '(no name)', cmsroot + '/' + list.path + '/' + item.id)
 		else if col.type == 'email'
 			if value && col.field.options.displayGravatar
 				+column_gravatar(col.field.gravatarUrl(item,35))
@@ -46,9 +46,9 @@ mixin column_gravatar(src)
 
 mixin column_boolean(value)
 	if (value)
-		img(src='/keystone/images/icons/16/checkbox-checked.png', width=16, height=16)
+		img(src='#{cmsroot}/images/icons/16/checkbox-checked.png', width=16, height=16)
 	else
-		img(src='/keystone/images/icons/16/checkbox-unchecked.png', width=16, height=16)
+		img(src='#{cmsroot}/images/icons/16/checkbox-unchecked.png', width=16, height=16)
 
 mixin column_html(value)
 	div.col-value!= value

--- a/templates/mixins/rows.jade
+++ b/templates/mixins/rows.jade
@@ -3,7 +3,7 @@ include columns
 mixin row(list, colums, item)
   tr(id=item.id)
     if !list.get('nodelete') && item.id !== user.id
-      td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
+      td.control: a(href= cmsroot + '/' + list.path + '?delete=' + item.id + csrf_query).control-delete
     else if !list.get('nodelete')
       td.control
     if sortable

--- a/templates/views/home.jade
+++ b/templates/views/home.jade
@@ -9,15 +9,15 @@ block content
 		if nav.flat
 			each list in lists
 				if (!list.get('hidden'))
-					h3: a(href='/keystone/' + list.path)= list.label
+					h3: a(href='#{cmsroot}/' + list.path)= list.label
 		else
 			each navSection in nav.sections
 				.nav-section
 					h4= navSection.label
 					ul: each list in navSection.lists
-						li: a(href='/keystone/' + list.path)= list.label
+						li: a(href='#{cmsroot}/' + list.path)= list.label
 			if orphanedLists.length
 				.nav-section
 					h4 Other
 					ul: each list in orphanedLists
-						li: a(href='/keystone/' + list.path)= list.label
+						li: a(href='#{cmsroot}/' + list.path)= list.label

--- a/templates/views/item.jade
+++ b/templates/views/item.jade
@@ -3,44 +3,44 @@ extends ../layout/base
 include ../mixins/columns
 
 block css
-	link(rel="stylesheet", href="/keystone/js/lib/fancybox/jquery.fancybox.css")
+	link(rel="stylesheet", href="#{cmsroot}/js/lib/fancybox/jquery.fancybox.css")
 	if list.fieldTypes.markdown
-		link(rel="stylesheet", href="/keystone/js/lib/bootstrap-markdown/css/bootstrap-markdown.css")
+		link(rel="stylesheet", href="#{cmsroot}/js/lib/bootstrap-markdown/css/bootstrap-markdown.css")
 	if list.fieldTypes.code
-		link(rel="stylesheet", href="/keystone/js/lib/codemirror/codemirror.css")
+		link(rel="stylesheet", href="#{cmsroot}/js/lib/codemirror/codemirror.css")
 
 block js
-	script(src="/keystone/js/common/ui-fixed-toolbar.js")
-	script(src="/keystone/js/lib/joseph-myers/md5.js")
-	script(src="/keystone/js/lib/fancybox/jquery.fancybox.pack.js")
-	script(src="/keystone/js/lib/html5sortable/jquery.sortable.js")
+	script(src="#{cmsroot}/js/common/ui-fixed-toolbar.js")
+	script(src="#{cmsroot}/js/lib/joseph-myers/md5.js")
+	script(src="#{cmsroot}/js/lib/fancybox/jquery.fancybox.pack.js")
+	script(src="#{cmsroot}/js/lib/html5sortable/jquery.sortable.js")
 	if list.fieldTypes.location
-		script(src="/keystone/js/common/ui-location.js")
+		script(src="#{cmsroot}/js/common/ui-location.js")
 	if list.fieldTypes.cloudinaryimage
-		script(src="/keystone/js/common/ui-cloudinaryimage.js")
+		script(src="#{cmsroot}/js/common/ui-cloudinaryimage.js")
 	if list.fieldTypes.cloudinaryimages
-		script(src="/keystone/js/common/ui-cloudinaryimages.js")
+		script(src="#{cmsroot}/js/common/ui-cloudinaryimages.js")
 	if list.fieldTypes.s3file
-		script(src="/keystone/js/common/ui-s3file.js")
+		script(src="#{cmsroot}/js/common/ui-s3file.js")
 	if list.fieldTypes.azurefile
-		script(src="/keystone/js/common/ui-azurefile.js")
+		script(src="#{cmsroot}/js/common/ui-azurefile.js")
 	if list.fieldTypes.localfile
-		script(src="/keystone/js/common/ui-localfile.js")
+		script(src="#{cmsroot}/js/common/ui-localfile.js")
 	if list.fieldTypes.localfiles
-		script(src="/keystone/js/common/ui-localfiles.js")
+		script(src="#{cmsroot}/js/common/ui-localfiles.js")
 	if list.fieldTypes.markdown
-		script(src='/keystone/js/lib/marked/marked.js')
-		script(src='/keystone/js/lib/bootstrap-markdown/js/bootstrap-markdown.js')
-		script(src="/keystone/js/common/ui-markdown.js")
+		script(src='#{cmsroot}/js/lib/marked/marked.js')
+		script(src='#{cmsroot}/js/lib/bootstrap-markdown/js/bootstrap-markdown.js')
+		script(src="#{cmsroot}/js/common/ui-markdown.js")
 	if list.fieldTypes.code
-		script(src="/keystone/js/common/ui-code.js")
-		script(src='/keystone/js/lib/codemirror/codemirror-compressed.js')
+		script(src="#{cmsroot}/js/common/ui-code.js")
+		script(src='#{cmsroot}/js/lib/codemirror/codemirror-compressed.js')
 	if list.fieldTypes.wysiwyg
-		script(src='/keystone/js/lib/tinymce/tinymce.min.js')
-		script(src='/keystone/js/lib/tinymce/jquery.tinymce.min.js')
-		script(src="/keystone/js/common/ui-wysiwyg.js")
+		script(src='#{cmsroot}/js/lib/tinymce/tinymce.min.js')
+		script(src='#{cmsroot}/js/lib/tinymce/jquery.tinymce.min.js')
+		script(src="#{cmsroot}/js/common/ui-wysiwyg.js")
 	
-	script(src='/keystone/js/views/item.js')
+	script(src='#{cmsroot}/js/views/item.js')
 	script.
 		Keystone.list = { path: "#{list.path}" };
 		Keystone.item = { id: "#{item.id}" };
@@ -63,13 +63,13 @@ block intro
 					else
 						li: a(href=d.href, title=d.list.singular) #{d.label}
 				li
-					a(href='/keystone/' + list.path, title='Back to ' + list.plural) #{list.label}
+					a(href='#{cmsroot}/' + list.path, title='Back to ' + list.plural) #{list.label}
 			else
-				li: a(href='/keystone/' + list.path, title='Back to ' + list.plural)
+				li: a(href='#{cmsroot}/' + list.path, title='Back to ' + list.plural)
 					span.mr-5.ion-arrow-left-c
 					= list.plural
 		.searchbox
-			form(method='get', action='/keystone/' + list.path).form-inline.searchbox-form
+			form(method='get', action='#{cmsroot}/' + list.path).form-inline.searchbox-form
 				.searchbox-field: input(type='search', name='search', placeholder='Search #{list.plural}').form-control.searchbox-input
 				.searchbox-button: button(type='submit').btn.btn-default.searchbox-submit Search
 				button(type='button').btn.btn-link.btn-cancel.js-itemsearch-close Cancel
@@ -79,7 +79,7 @@ block intro
 			else
 				li id: #{item.id}
 			if !list.options.nocreate
-				li: a(href='/keystone/#{list.path}?new' + csrf_query)
+				li: a(href='#{cmsroot}/#{list.path}?new' + csrf_query)
 					span.mr-5.ion-plus
 					| New #{list.singular}
 			
@@ -115,7 +115,7 @@ block content
 					if meta_createdBy
 						.item-details-meta-item
 							span.item-details-meta-label= meta_createdAt ? 'by' : 'Created by'
-							span.item-details-meta-info: a(href='/keystone/' + User.path + '/' + meta_createdBy.id)= User.getDocumentName(meta_createdBy)
+							span.item-details-meta-info: a(href='#{cmsroot}/' + User.path + '/' + meta_createdBy.id)= User.getDocumentName(meta_createdBy)
 				if list.tracking.updatedAt
 					- meta_updatedAt = item.get(list.tracking.updatedAt)
 					if meta_updatedAt && (!meta_createdAt || meta_createdAt.getTime() !== meta_updatedAt.getTime())
@@ -129,7 +129,7 @@ block content
 					if meta_updatedBy && (!meta_createdBy || meta_createdBy.id !== meta_updatedBy.id || meta_updatedAt)
 						.item-details-meta-item
 							span.item-details-meta-label= meta_updatedAt ? 'by' : 'Updated by'
-							span.item-details-meta-info: a(href='/keystone/' + User.path + '/' + meta_updatedBy.id)= User.getDocumentName(meta_updatedBy)
+							span.item-details-meta-info: a(href='#{cmsroot}/' + User.path + '/' + meta_updatedBy.id)= User.getDocumentName(meta_updatedBy)
 		
 		
 		each el in list.uiElements
@@ -147,16 +147,16 @@ block content
 		.toolbar.toolbar-fixed
 			if !list.get('noedit')
 				button(type='submit').btn.btn-default.btn-save Save
-				a(href='/keystone/' + list.path + '/' + item.id, data-confirm='Are you sure you want to reset your changes?').btn.btn-link.btn-cancel reset changes
+				a(href='#{cmsroot}/' + list.path + '/' + item.id, data-confirm='Are you sure you want to reset your changes?').btn.btn-link.btn-cancel reset changes
 			if !list.get('nodelete')  && item.id !== user.id
-				a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query, data-confirm='Are you sure you want to delete this ' + list.singular.toLowerCase() + '?').btn.btn-link.btn-cancel delete #{list.singular.toLowerCase()}
+				a(href='#{cmsroot}/' + list.path + '?delete=' + item.id + csrf_query, data-confirm='Are you sure you want to delete this ' + list.singular.toLowerCase() + '?').btn.btn-link.btn-cancel delete #{list.singular.toLowerCase()}
 	
 	
 	if showRelationships
 		h2.relationship-heading.form-heading Relationships
 			each rel in relationships
 				if rel.items.results.length
-					h3.form-heading.relationship-heading: a(href='/keystone/' + rel.list.path)= (rel.label) ? rel.label : rel.list.label
+					h3.form-heading.relationship-heading: a(href='#{cmsroot}/' + rel.list.path)= (rel.label) ? rel.label : rel.list.label
 					if rel.note
 						.field-note= rel.note
 					- var firstColspan = 1

--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -5,22 +5,22 @@ include ../mixins/pagination
 
 block css
 	if list.fieldTypes.markdown
-		link(rel="stylesheet", href="/keystone/js/lib/bootstrap-markdown/css/bootstrap-markdown.css")
+		link(rel="stylesheet", href="#{cmsroot}/js/lib/bootstrap-markdown/css/bootstrap-markdown.css")
 
 block js
 	if list.fieldTypes.location
-		script(src="/keystone/js/common/ui-location.js")
+		script(src="#{cmsroot}/js/common/ui-location.js")
 	if list.fieldTypes.markdown
-		script(src='/keystone/js/lib/marked/marked.js')
-		script(src='/keystone/js/lib/bootstrap-markdown/js/bootstrap-markdown.js')
-		script(src="/keystone/js/common/ui-markdown.js")
+		script(src='#{cmsroot}/js/lib/marked/marked.js')
+		script(src='#{cmsroot}/js/lib/bootstrap-markdown/js/bootstrap-markdown.js')
+		script(src="#{cmsroot}/js/common/ui-markdown.js")
 	if list.fieldTypes.wysiwyg
-		script(src='/keystone/js/lib/tinymce/tinymce.min.js')
-		script(src='/keystone/js/lib/tinymce/jquery.tinymce.min.js')
-		script(src="/keystone/js/common/ui-wysiwyg.js")
-	script(src='/keystone/js/views/list.js')
-	script(src='/keystone/js/lib/browserified/querystring.js')
-	script(src='/keystone/js/lib/browserified/queryfilter.js')
+		script(src='#{cmsroot}/js/lib/tinymce/tinymce.min.js')
+		script(src='#{cmsroot}/js/lib/tinymce/jquery.tinymce.min.js')
+		script(src="#{cmsroot}/js/common/ui-wysiwyg.js")
+	script(src='#{cmsroot}/js/views/list.js')
+	script(src='#{cmsroot}/js/lib/browserified/querystring.js')
+	script(src='#{cmsroot}/js/lib/browserified/queryfilter.js')
 	script.
 		Keystone.list = { path: "#{list.path}", label: "#{list.label}", singular: "#{list.singular}", plural: "#{list.plural}", cols: !{JSON.stringify(colPaths)}, perPage: !{ Number(list.perPage) || 50 } };
 		Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
@@ -43,7 +43,7 @@ block content
 						span.ion-plus-round
 						|  Create #{list.singular}
 			else
-				form(method='post', action='/keystone/' + list.path)
+				form(method='post', action='#{cmsroot}/' + list.path)
 					input(type='hidden', name='action', value='create')
 					input(type='hidden', name=csrf_token_key, value=csrf_token_value)
 					.form
@@ -201,7 +201,7 @@ block content
 								.searchbox-field
 									input(type='search', name='search', placeholder='Search #{list.plural.toLowerCase()}', value=search).form-control.js-search-list.searchbox-input
 									if search
-										a(href='/keystone/#{list.path}', title='Clear search').search-list-clear &times;
+										a(href='#{cmsroot}/#{list.path}', title='Clear search').search-list-clear &times;
 								.searchbox-button: button(type='submit').btn.btn-default.btn-search.searchbox-submit
 									span.visible-xs Go
 									span.hidden-xs Search
@@ -414,7 +414,7 @@ block content
 								
 				.list-filters-action
 					button(type='submit').btn.btn-default.btn-filter Search
-					a(href='/keystone/#{list.path}').btn.btn-link.btn-cancel clear filters
+					a(href='#{cmsroot}/#{list.path}').btn.btn-link.btn-cancel clear filters
 			
 	if items.results.length
 		//-

--- a/templates/views/signin.jade
+++ b/templates/views/signin.jade
@@ -12,8 +12,8 @@ block content
 				p.lead You're already signed in.
 				.toolbar
 					if user.isAdmin
-						a(href='/keystone').btn.btn-primary Open Keystone
-					a(href='/keystone/signout').btn.btn-cancel Sign out
+						a(href='#{cmsroot}').btn.btn-primary Open Keystone
+					a(href='#{cmsroot}/signout').btn.btn-cancel Sign out
 			
 			else
 				form(method="post", novalidate).auth-form

--- a/templates/views/signout.jade
+++ b/templates/views/signout.jade
@@ -8,5 +8,5 @@ block content
 			
 		.auth-box-col
 			p.lead You have been signed out
-			a(href='/').btn.btn-primary Home
-			a(href='/keystone/signin').btn.btn-link Sign in again
+			a(href='#{webroot}').btn.btn-primary Home
+			a(href='#{cmsroot}/signin').btn.btn-link Sign in again


### PR DESCRIPTION
I have added two new options that allow for keystone to be better integrated with existing sites. The options are "webroot" and "cmsdir".

Webroot allows you to change the base location of where keystone is hosted. Previously you always needed to host the public files at your web root. This makes for sloppy integration with existing sites. This also makes it so you do not need to use the mount command to achieve this setup. 

Cmsdir allows you to change the name of the keystone directory. This allows you to host your admin panel in a custom directory, which can allow for easier to remember urls or allow for additional security by making the location of the admin panel not easily predictable. 

If you want to host the site your site where "http://www.mysite.com/blog" is the cms frontend and the backend is hosted at "http://www.mysite.com/blog/admin" you would do the following in your init call:

keystone.init({
'name': 'Keystone',
'brand': 'Keystone Co.',

'less': 'public',
'static': 'public',
'favicon': 'public/favicon.ico',
'views': 'templates/views',
'view engine': 'jade',

'emails': 'templates/emails',

'auto update': true,
'session': true,
'auth': true,
'user model': 'User',
'cookie secret': 'lasdjhfalsdkjfhalsdjkfhasldkjfhasldjfahsdlfasjkdhf',

'webroot': '/blog/',
'cmsdir': 'admin',
});
