### PR TITLE
Filter line and paragraph separators

### DIFF
--- a/lib/fieldTypes/text.js
+++ b/lib/fieldTypes/text.js
@@ -36,6 +36,26 @@ text.prototype.crop = function(item, length, append, preserveWords) {
 };
 
 
+/**
+* Updates the value for this field in the item from a data object
+* Ensures that the string doesn't contain line separators
+*
+* @api public
+*/
+
+text.prototype.updateItem = function(item, data) {
+
+	var newValue = data[this.path];
+
+	var newValue = newValue.replace("\u2028", "").replace("\u2029", "");
+
+	if (this.path in data && newValue !== item.get(this.path)) {
+		item.set(this.path, newValue);
+	}
+
+};
+
+
 /*!
  * Export class
  */

--- a/lib/fieldTypes/text.js
+++ b/lib/fieldTypes/text.js
@@ -45,14 +45,11 @@ text.prototype.crop = function(item, length, append, preserveWords) {
 
 text.prototype.updateItem = function(item, data) {
 
-	if (!(this.path in data))
-		return;
-		
-	var newValue = data[this.path];
+	var newValue = this.getValueFromData(data);
 
 	var newValue = newValue.replace("\u2028", "").replace("\u2029", "");
 
-	if (this.path in data && newValue !== item.get(this.path)) {
+	if (newValue !== item.get(this.path)) {
 		item.set(this.path, newValue);
 	}
 

--- a/lib/fieldTypes/text.js
+++ b/lib/fieldTypes/text.js
@@ -45,6 +45,9 @@ text.prototype.crop = function(item, length, append, preserveWords) {
 
 text.prototype.updateItem = function(item, data) {
 
+	if (!(this.path in data))
+		return;
+		
 	var newValue = data[this.path];
 
 	var newValue = newValue.replace("\u2028", "").replace("\u2029", "");

--- a/lib/fieldTypes/textarea.js
+++ b/lib/fieldTypes/textarea.js
@@ -48,6 +48,26 @@ textarea.prototype.crop = function(item, length, append, preserveWords) {
 };
 
 
+/**
+* Updates the value for this field in the item from a data object
+* Ensures that the string doesn't contain line separators
+*
+* @api public
+*/
+
+textarea.prototype.updateItem = function(item, data) {
+
+	var newValue = data[this.path];
+
+	var newValue = newValue.replace("\u2028", "").replace("\u2029", "");
+
+	if (this.path in data && newValue !== item.get(this.path)) {
+		item.set(this.path, newValue);
+	}
+
+};
+
+
 /*!
  * Export class
  */

--- a/lib/fieldTypes/textarea.js
+++ b/lib/fieldTypes/textarea.js
@@ -57,6 +57,9 @@ textarea.prototype.crop = function(item, length, append, preserveWords) {
 
 textarea.prototype.updateItem = function(item, data) {
 
+	if (!(this.path in data))
+		return;
+
 	var newValue = data[this.path];
 
 	var newValue = newValue.replace("\u2028", "").replace("\u2029", "");


### PR DESCRIPTION
After pasting some text into a Types.Input field I realised that the search and filtering no longer worked because the text contained a line separator. I found that whereas JSON can contain line and paragraph separators, JavaScript strings cannot. This patch strips the line and paragraph separators from the Types.Input and Types.Textarea fields.