### PR TITLE
Use jsxhint instead of jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,6 @@
   "nonbsp": true,
   "nonew": true,
   "plusplus": false, /* custom */
-  "quotmark": true,
   "undef": true,
   "unused": false, /* enable for checking unused varaibles, disabled by default because it's noisy */
   "strict": false, /* enable later */

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPORTER = progress
 ISTANBUL_CMD = node_modules/istanbul/lib/cli.js cover
-JSHINT_CMD = node_modules/jshint/bin/jshint
+JSXHINT_CMD = node_modules/jsxhint/cli.js
 MOCHA_CMD = node_modules/mocha/bin/_mocha
 JSHINT_REPORTER = node_modules/jshint-stylish/stylish.js
 TESTS = test/*.js
@@ -14,7 +14,7 @@ test: lint
 		--reporter $(REPORTER)
 
 lint:
-	@$(JSHINT_CMD) --reporter $(JSHINT_REPORTER) .; true
+	@$(JSXHINT_CMD) --reporter $(JSHINT_REPORTER) .; true
 
 test-cov: clean
 	@$(ISTANBUL_CMD) $(MOCHA_CMD) -- --reporter $(REPORTER)

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-uglify": "~1.0.2",
     "gulp-util": "~3.0.1",
     "gulp-watch": "~1.2.0",
-    "jshint": "~2.5.11",
+    "jsxhint": "^0.9.0",
     "jshint-stylish": "~1.0.0",
     "istanbul": "^0.3.5",
     "mocha": "2.1.0",


### PR DESCRIPTION
Closes #847

Also removes `quotmark` jshint option since the react transform uses double quotes instead of single.