### PR TITLE
Log mongoose validation errors generated during createItems

### DIFF
--- a/lib/updates.js
+++ b/lib/updates.js
@@ -71,7 +71,10 @@ exports.apply = function(callback) {
 					update(function(err) {
 						if (err) {
 							console.log(_dashes_ + '\nUpdate ' + file + ' (background mode) failed with error:');
-							console.log(err);
+							console.error(err);
+							if ('stack' in err) {
+								console.trace(err.stack);
+							}
 						} else {
 							console.log(_dashes_ + '\nSuccessfully applied update ' + file + ' (in background).');
 							if (update.__commit__ !== false) {
@@ -84,7 +87,10 @@ exports.apply = function(callback) {
 					update(function(err) {
 						if (err) {
 							console.log(_dashes_ + '\nUpdate ' + file + ' failed with error:');
-							console.log(err);
+							console.error(err);
+							if ('stack' in err) {
+								console.trace(err.stack);
+							}
 							done(err);
 						} else {
 							updateCount++;


### PR DESCRIPTION
Addresses #868 

Without the changes and if there is a mongoose validation error I get the following:

    ------------------------------------------------
    An error occurred applying updates, bailing on Keystone init.

    Error details:

With the changes and if there is a mongoose validation error I get something like the following, which is a huge help in troubleshooting:

    { [ValidationError: Validation failed]
      message: 'Validation failed',
      name: 'ValidationError',
      errors:
       { startTime:
          { [ValidatorError: Path `startTime` is required.]
            message: 'Path `startTime` is required.',
            name: 'ValidatorError',
            path: 'startTime',
            type: 'required',
            value: undefined } },
      model: 'Event',
      data:
       { name: 'Test Booking 1',
         status: 'pending',
         endTime:
          { _isAMomentObject: true,
            _isUTC: false,
            _pf: [Object],
            _locale: [Object],
            _d: Tue Jan 06 2015 19:09:37 GMT-0500 (Eastern Standard Time) },
         __ref: 'Event_1',
         __doc:
          { endTime: Tue Jan 06 2015 19:09:37 GMT-0500 (Eastern Standard Time),
            name: 'Test Booking 1',
            type: 'none',
            repeat: 'none',
            status: 'pending',
            guests: [],
            allDay: false,
            listName: 'Event',
            _id: 54ac7943a2751ad02b12ed57 } } }