### PR TITLE
makes connect-redis work

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -150,10 +150,8 @@ function mount(mountPath, parentApp, events) {
 			case 'redis':
 				// default session store for using Redis
 				sessionStore = 'connect-redis';
-				// TODO: are there default options that should be applied here?
 				break;
 			case 'connect-redis':
-				// TODO: are there default options that should be applied here?
 				break;
 
 			default:
@@ -168,8 +166,13 @@ function mount(mountPath, parentApp, events) {
 
 		// Initialize the session store
 		try {
-			
-			var SessionStore = require(sessionStore)(express);
+      var SessionStore = {};
+			if (sessionStore === 'connect-redis') {
+				var expressSession = require('express-session');
+				SessionStore = require(sessionStore)(expressSession);
+			} else {
+				SessionStore = require(sessionStore)(express);
+			}
 			
 			if (waitForSessionStore) {
 				sessionStorePromise = new P(function(resolve) {
@@ -183,9 +186,16 @@ function mount(mountPath, parentApp, events) {
 			
 			if (e.code === 'MODULE_NOT_FOUND') {
 				
-				// connect-redis must be explicitly installed @1.4.7, so we special-case it here
-				var installName = (sessionStore === 'connect-redis') ? sessionStore + '@1.4.7' : sessionStore;
-				
+				// connect-redis must be installed, as well as express-session,
+				// with keystone having access to it,
+				// so we special-case it here.
+        var installName = '';
+				if (sessionStore === 'connect-redis') {
+					installName = sessionStore + '@2.1.0 express-session@1.10.0';
+				} else {
+					installName = sessionStore;
+				}
+        
 				console.error(
 					'\nERROR: ' + sessionStore + ' not found.\n' +
 					'\nPlease install ' + sessionStore + ' from npm to use it as a `session store` option.' +

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -166,7 +166,7 @@ function mount(mountPath, parentApp, events) {
 
 		// Initialize the session store
 		try {
-      var SessionStore = {};
+			var SessionStore = {};
 			if (sessionStore === 'connect-redis') {
 				var expressSession = require('express-session');
 				SessionStore = require(sessionStore)(expressSession);
@@ -189,13 +189,13 @@ function mount(mountPath, parentApp, events) {
 				// connect-redis must be installed, as well as express-session,
 				// with keystone having access to it,
 				// so we special-case it here.
-        var installName = '';
+				var installName = '';
 				if (sessionStore === 'connect-redis') {
 					installName = sessionStore + '@2.1.0 express-session@1.10.0';
 				} else {
 					installName = sessionStore;
 				}
-        
+				
 				console.error(
 					'\nERROR: ' + sessionStore + ' not found.\n' +
 					'\nPlease install ' + sessionStore + ' from npm to use it as a `session store` option.' +


### PR DESCRIPTION
Connect redis does not work, in any environment that I've tried, with the default options. There is always an error thrown within the interior code of connect-redis itself that propagates through and crashes keystone, at booting.

Here is an example of such a stack trace:
```
/home/greg/site/node_modules/keystone/lib/core/mount.js:197
                                throw e;
                                      ^
TypeError: Cannot read property 'prototype' of undefined
  at module.exports (/home/site/node_modules/connect-redis/lib/connect-redis.js:123:21)
  at [object Object].mount (/home/site/node_modules/keystone/lib/core/mount.js:172:44)
  at [object Object].start (/home/site/node_modules/keystone/lib/core/start.js:235:7)
  at Object.<anonymous> (/home/site/keystone_serve.js:3:13)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:906:3
```
Tracing it back in keystone leads to this line:
https://github.com/keystonejs/keystone/blob/0.2.x/lib/core/mount.js#L172

Which, then, takes us to this line here:
https://github.com/tj/connect-redis/blob/master/lib/connect-redis.js#L128

The connect redis docs claim that you can use it with express if you install 1.4.7. I have not found this to be the case with keystone, as I get the same exact error when I use 1.4.7 as when I use 1.5.0, and 2.1.0. I do not know why this is the case, but, simply, it is. 

So, I have rewritten the relevant parts of mount.js to fix this.