### PR TITLE
Log mongoose validation errors generated during createItems(improvement)

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -295,6 +295,10 @@ function createItems(data, ops, callback) {
 	], function(err) {
 
 		if (err) {
+			console.error(err);
+			if ('stack' in err) {
+				console.trace(err.stack);
+			}
 			return callback && callback(err);
 		}
 

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -26,6 +26,14 @@ exports.apply = function(callback) {
 
 	var updatesPath = keystone.getPath('updates', 'updates');
 
+	// logError is used to log errors before the process exits since it is more synchronous than console.error.  Using 
+	// console.error gets into race condition issues with process.exit, which has higher priority.
+	var logError = function() {
+		for (var i = 0, len = arguments.length; i < len; ++i) {
+			process.stderr.write(arguments[i] + '\n');
+		}
+	};
+
 	var applyUpdate = function(file, done) {
 		Update.findOne({ key: file }, function(err, updateRecord) {
 			if (err) {
@@ -43,10 +51,30 @@ exports.apply = function(callback) {
 				if (_.isObject(update.create)) {
 					var items = update.create,
 						ops = update.options || {};
+					var background_mode = update.__background__ ? ' (background mode) ' : '';
+					
 					update = function(done) {
 						keystone.createItems(items, ops, function(err, stats) {
-							stats && console.log(stats.message);
-							done(err);
+							if (!err) {
+								var statsMsg = stats ? stats.message : '';
+
+								console.log('\n' + _dashes_,
+									'\n' + keystone.get('name') + ': Successfully applied update ' + file + background_mode + '.',
+									'\n' + statsMsg,
+									'\n');
+								done(null);
+							}
+							else {
+								logError('\n' + _dashes_,
+									'\n' + keystone.get('name') + ': Update ' + file + background_mode + ' failed with errors:',
+									'\n' + err,
+									'\n');
+
+								// give the logging some time to finish
+								process.nextTick(function() {
+									done(err);
+								});
+							}
 						});
 					};
 				}
@@ -69,14 +97,7 @@ exports.apply = function(callback) {
 				if (update.__background__) {
 					updateCount++;
 					update(function(err) {
-						if (err) {
-							console.log(_dashes_ + '\nUpdate ' + file + ' (background mode) failed with error:');
-							console.error(err);
-							if ('stack' in err) {
-								console.trace(err.stack);
-							}
-						} else {
-							console.log(_dashes_ + '\nSuccessfully applied update ' + file + ' (in background).');
+						if (!err) {
 							if (update.__commit__ !== false) {
 								new Update({key: file}).save();
 							}
@@ -85,16 +106,8 @@ exports.apply = function(callback) {
 					done();
 				} else {
 					update(function(err) {
-						if (err) {
-							console.log(_dashes_ + '\nUpdate ' + file + ' failed with error:');
-							console.error(err);
-							if ('stack' in err) {
-								console.trace(err.stack);
-							}
-							done(err);
-						} else {
+						if (!err) {
 							updateCount++;
-							console.log(_dashes_ + '\nSuccessfully applied update ' + file + '.');
 							if (update.__commit__ === false) {
 								done();
 							} else {
@@ -156,11 +169,8 @@ exports.apply = function(callback) {
 			if (!(updateCount || deferCount || skipCount)) {
 				errmsg = _dashes_ + '\n' + errmsg;
 			}
-			console.error(errmsg);
-			console.error(err);
-			if ('stack' in err) {
-				console.trace(err.stack);
-			}
+			logError(errmsg);
+			logError(err);
 			// wait till nextTick to exit so the trace completes.
 			process.nextTick(function() {
 				process.exit(1);


### PR DESCRIPTION
At least, on windows keystone has issues generating mongoose validation errors when they happen during createItems.  To address this issue createItems errors need to be logged very early on within its own module and not back in the updates module where the process.exit() happens since it has higher priority than logging and thus most times preempts any logging that may still be queued up.  The code arrangement provided by this PR ensures the best consistent results.

With the updated changes, if a validation or other error or occurs createItems will log an error.  For example:

    { [ValidationError: Validation failed]
      message: 'Validation failed',
      name: 'ValidationError',
      errors:
       { startTime:
          { [ValidatorError: Path `startTime` is required.]
            message: 'Path `startTime` is required.',
            name: 'ValidatorError',
            path: 'startTime',
            type: 'required',
            value: undefined } },
      model: 'Event',
      data:
       { name: 'Test Booking 1',
         status: 'pending',
         endTime:
          { _isAMomentObject: true,
            _isUTC: false,
            _pf: [Object],
            _locale: [Object],
            _d: Thu Jan 08 2015 21:29:37 GMT-0500 (Eastern Standard Time) },
         __ref: 'Event_1',
         __doc:
          { endTime: Thu Jan 08 2015 21:29:37 GMT-0500 (Eastern Standard Time),
            name: 'Test Booking 1',
            type: 'none',
            repeat: 'none',
            status: 'pending',
            guests: [],
            allDay: false,
            listName: 'Event',
            _id: 54af3d139844182c0ff75cea } } }
    Trace: ValidationError: Path `startTime` is required.
        at model.Document.invalidate (c:\reDist\node_modules\keystone\node_modules\mongoose\lib\document.js:1021:32)
        at c:\reDist\node_modules\keystone\node_modules\mongoose\lib\document.js:970:16
        at validate (c:\reDist\node_modules\keystone\node_modules\mongoose\lib\schematype.js:610:7)
        at c:\reDist\node_modules\keystone\node_modules\mongoose\lib\schematype.js:627:9
        at Array.forEach (native)
        at SchemaDate.SchemaType.doValidate (c:\reDist\node_modules\keystone\node_modules\mongoose\lib\schematype.js:614:19)
        at c:\reDist\node_modules\keystone\node_modules\mongoose\lib\document.js:968:9
        at process._tickCallback (node.js:419:13)
        at c:\reDist\node_modules\keystone\lib\core\createItems.js:295:13
        at c:\avp\node_modules\async\lib\async.js:544:30
        at c:\avp\node_modules\async\lib\async.js:151:21
        at c:\avp\node_modules\async\lib\async.js:151:21
        at c:\reDist\node_modules\keystone\lib\core\createItems.js:120:7
        at handleError (c:\reDist\node_modules\keystone\node_modules\mongoose\node_modules\hooks\hooks.js:92:18)
        at _next (c:\reDist\node_modules\keystone\node_modules\mongoose\node_modules\hooks\hooks.js:34:22)
        at fnWrapper (c:\reDist\node_modules\keystone\node_modules\mongoose\node_modules\hooks\hooks.js:159:8)
        at complete (c:\reDist\node_modules\keystone\node_modules\mongoose\lib\document.js:986:5)
        at c:\reDist\node_modules\keystone\node_modules\mongoose\lib\document.js:977:20




With the updated changes, if a createItems error occurs the updates module will log a final error.  For example:

    ------------------------------------------------

    avp: Update 0.0.1-avp failed with errors:

    ValidationError: Path `startTime` is required.



If createItems succeeds then you get the usual.  For example:

    ------------------------------------------------
    avp: Successfully applied update 0.0.1-avp.

    Successfully created:

    *   2 Users
    *   8 Events