### PR TITLE
Fix many jscs warnings

### DIFF
--- a/lib/asyncdi.js
+++ b/lib/asyncdi.js
@@ -9,10 +9,9 @@ var _ = require('underscore'),
 // Thanks to Angular for the regex
 var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 
-
 /**
  * Calling the module directly returns a new Wrapper instance
- * 
+ *
  * @param  {Function} fn
  * @return {Wrapper}
  */
@@ -22,35 +21,35 @@ exports = module.exports = function(fn) {
 
 /**
  * Wrapper Class
- * 
+ *
  * @param {Function} fn
  * @param {Object} context
  */
 var Wrapper = exports.Wrapper = function Wrapper(fn, context) {
-	
+
 	// Ensure a new instance has been created.
 	// Calling Wrapper as a function will return a new instance instead.
 	if (!(this instanceof Wrapper)) {
 		return new Wrapper(fn, context);
 	}
-	
+
 	// Ensure a function has actually been provided.
 	if (!_.isFunction(fn)) {
 		throw new Error('AsyncDI Wrapper must be initialised with a function');
 	}
-	
+
 	// Save the function
 	this.fn = fn;
-	
+
 	// Detect the dependencies using the regex
 	this.deps = fn.toString().match(FN_ARGS)[1].split(',').map(function(i) { return i.trim(); });
-	
+
 	// Create a map of dependency names for easy presence detection
 	this.requires = {};
 	this.deps.forEach(function(i) {
 		this.requires[i] = true;
 	}, this);
-	
+
 	// If the last argument is named 'callback', the function is async.
 	// The callback is removed from the dependencies so it doesn't get considered
 	// when this.provides() is called
@@ -58,22 +57,22 @@ var Wrapper = exports.Wrapper = function Wrapper(fn, context) {
 		this.isAsync = true;
 		this.deps.pop();
 	}
-	
+
 	// Save the context (may be changed later)
 	this._context = context;
-	
+
 	// The internal provides object maps dependencies that can be provided if
 	// requested by the function
 	this._provides = {};
-	
+
 	// The internal arguments array contains the provided deps mapped to the
 	// arguments requested, and is ready to be applied to the function
 	this._arguments = [];
-	
+
 };
 
 _.extend(Wrapper.prototype, {
-	
+
 	/**
 	 * Registers dependencies that can be provided to the function
 	 * @param  {Object} provides map of key: value pairs
@@ -86,7 +85,7 @@ _.extend(Wrapper.prototype, {
 		}, this);
 		return this;
 	},
-	
+
 	/**
 	 * Changes the context of the function to the object provided
 	 * @param  {Object} context
@@ -96,12 +95,12 @@ _.extend(Wrapper.prototype, {
 		this._context = context;
 		return this;
 	},
-	
+
 	/**
 	 * Calls the function
-	 * 
+	 *
 	 * Will return the result if not async and no callback is provided
-	 * 
+	 *
 	 * @param  {Object} context (optional)
 	 * @param  {Function} callback
 	 */
@@ -129,12 +128,12 @@ _.extend(Wrapper.prototype, {
 			}
 		}
 	},
-	
+
 	/**
 	 * Applies the function iterator to each item in arr, in parallel.
-	 * 
+	 *
 	 * The context of the function will be the current item in the array.
-	 * 
+	 *
 	 * @param  {Array} arr
 	 * @param  {Function} callback
 	 */
@@ -151,12 +150,12 @@ _.extend(Wrapper.prototype, {
 			if (callback) { callback(); }
 		}
 	},
-	
+
 	/**
 	 * Returns the results of interating the function on each item in an array.
-	 * 
+	 *
 	 * The context of the function will be the current item in the array.
-	 * 
+	 *
 	 * @param  {Array} arr
 	 * @param  {Function} callback
 	 * @return {Array}
@@ -173,5 +172,5 @@ _.extend(Wrapper.prototype, {
 			}));
 		}
 	}
-	
+
 });

--- a/lib/email.js
+++ b/lib/email.js
@@ -114,13 +114,13 @@ var objToMandrillVars = function (_var) {
 var templateCSSMethods = {
 	shadeColor: function(color, percent) {
 		/* jshint ignore:start */
-		var num = parseInt(color.slice(1),16), amt = Math.round(2.55 * percent), R = (num >> 16) + amt, G = (num >> 8 & 0x00FF) + amt, B = (num & 0x0000FF) + amt;
-		return '#' + (0x1000000 + (R<255?R<1?0:R:255)*0x10000 + (G<255?G<1?0:G:255)*0x100 + (B<255?B<1?0:B:255)).toString(16).slice(1);
+		var num = parseInt(color.slice(1), 16), amt = Math.round(2.55 * percent), R = (num >> 16) + amt, G = (num >> 8 & 0x00FF) + amt, B = (num & 0x0000FF) + amt;
+		return '#' + (0x1000000 + (R < 255 ? R < 1 ? 0:R:255) * 0x10000 +
+			(G < 255 ? G < 1 ? 0:G:255) * 0x100 +
+			(B < 255 ? B < 1 ? 0:B:255)).toString(16).slice(1);
 		/* jshint ignore:end */
 	}
 };
-
-
 
 /**
  * Email Class
@@ -143,7 +143,7 @@ var templateCSSMethods = {
 var Email = function(options) {
 
 	// Passing a string will use Email.defaults for everything but template name
-	if ('string' === typeof(options)) {
+	if (typeof options === 'string') {
 		options = {
 			templateName: options
 		};
@@ -178,13 +178,13 @@ var Email = function(options) {
 
 Email.prototype.render = function(locals, callback) {
 
-	if ('function' === typeof locals && !callback) {
+	if (typeof locals === 'function' && !callback) {
 		callback = locals;
 		locals = {};
 	}
 
-	locals = ('object' === typeof locals) ? locals : {};
-	callback = ('function' === typeof callback) ? callback : function() {};
+	locals = (typeof locals === 'object') ? locals : {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	if (keystone.get('email locals')) {
 		_.defaults(locals, keystone.get('email locals'));
@@ -215,7 +215,7 @@ Email.prototype.render = function(locals, callback) {
 
 		// ensure extended characters are replaced
 		html = html.replace(/[\u007f-\uffff]/g, function(c) {
-			return '&#x'+('0000'+c.charCodeAt(0).toString(16)).slice(-4)+';';
+			return '&#x' + ('0000' + c.charCodeAt(0).toString(16)).slice(-4) + ';';
 		});
 
 		// process email rules
@@ -233,7 +233,7 @@ Email.prototype.render = function(locals, callback) {
 					var find = rule.find,
 						replace = rule.replace;
 
-					if ('string' === typeof find) {
+					if (typeof find === 'string') {
 						find = new RegExp(find, 'gi');
 					}
 
@@ -252,7 +252,6 @@ Email.prototype.render = function(locals, callback) {
 
 };
 
-
 /**
  * Loads the template. Looks for `templateName.templateExt`, followed by `templateName/email.templateExt`
  *
@@ -263,7 +262,7 @@ Email.prototype.render = function(locals, callback) {
 
 Email.prototype.loadTemplate = function(callback) {
 
-	callback = ('function' === typeof callback) ? callback : function() {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	var fsTemplatePath = path.join(Email.getEmailsPath(), this.templateName + '.' + this.templateExt);
 
@@ -299,7 +298,7 @@ Email.prototype.loadTemplate = function(callback) {
 
 Email.prototype.compileTemplate = function(callback) {
 
-	callback = ('function' === typeof callback) ? callback : function() {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	if (keystone.get('env') === 'production' && templateCache[this.templateName]) {
 		return process.nextTick(callback);
@@ -336,12 +335,12 @@ Email.prototype.prepare = function(options, callback) {
 		options = arguments[1] || arguments[0];
 	}
 
-	callback = ('function' === typeof callback) ? callback : function() {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	// Renders an email via Keystone (default behavior)
 	if (!this.templateMandrillName || this.templateForceHtml) {
 
-		this.render(locals, function(err, email){
+		this.render(locals, function(err, email) {
 
 			_.extend(options, email);
 			this.buildOptions.call(this, err, options, callback);
@@ -364,7 +363,7 @@ Email.prototype.prepare = function(options, callback) {
  */
 Email.prototype.buildOptions = function(err, options, callback) {
 
-	callback = ('function' === typeof callback) ? callback : function() {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	if (err) {
 		return callback(err);
@@ -378,7 +377,7 @@ Email.prototype.buildOptions = function(err, options, callback) {
 		});
 	}
 
-	if ('string' === typeof options.from) {
+	if (typeof options.from === 'string') {
 		options.fromName = options.from;
 		options.fromEmail = options.from;
 	} else if (utils.isObject(options.from)) {
@@ -426,9 +425,9 @@ Email.prototype.buildOptions = function(err, options, callback) {
 
 	for (var i = 0; i < options.to.length; i++) {
 
-		if ('string' === typeof options.to[i]) {
+		if (typeof options.to[i] === 'string') {
 			options.to[i] = { email: options.to[i] };
-		} else if ('object' === typeof options.to[i] && options.to[i] !== null) {
+		} else if (typeof options.to[i] === 'object' && options.to[i] !== null) {
 
 			if (!options.to[i].email) {
 				return callback({
@@ -451,10 +450,10 @@ Email.prototype.buildOptions = function(err, options, callback) {
 		var recipient = { email: options.to[i].email },
 			vars = [{ name: 'email', content: recipient.email }];
 
-		if ('string' === typeof options.to[i].name) {
+		if (typeof options.to[i].name === 'string') {
 			recipient.name = options.to[i].name;
 			vars.push({ name: 'name', content: options.to[i].name });
-		} else if ('object' === typeof options.to[i].name) {
+		} else if (typeof options.to[i].name === 'object') {
 			recipient.name = options.to[i].name.full || '';
 			vars.push({ name: 'name', content: options.to[i].name.full || '' });
 			vars.push({ name: 'first_name', content: options.to[i].name.first || '' });
@@ -539,36 +538,35 @@ Email.prototype.buildOptions = function(err, options, callback) {
  * @param {Function} callback(err, info)
  *
  * @api private
- */ 
+ */
 
 Email.prototype.send = function(options, callback) {
 
-	var locals = options;
+	var locals = options,
+		prepareOptions = [locals];
 
-	var prepareOptions = [locals];
-
-	if (arguments.length === 3 ) {
+	if (arguments.length === 3) {
 		// we expect locals, options, callback
 		if (_.isObject(arguments[1])) {
 			prepareOptions.push(arguments[1]);
 		}
 		callback = arguments[2];
-		
+
 	} else if (arguments.length === 2 && !utils.isFunction(callback)) {
 		// no callback so we expect locals, options
 		if (_.isObject(arguments[1])) {
 			prepareOptions.push(arguments[1]);
 		}
-		callback = function(err,info) {
+		callback = function(err, info) {
 			if (err) console.log(err);
 		};
-		
+
 	} else if (arguments.length === 1) {
 		// we expect options here and it is pushed already
-		callback = function(err,info){
+		callback = function(err, info) {
 			if (err) console.log(err);
 		};
-	}  
+	}
 
 	prepareOptions.push(function(err, toSend) {
 
@@ -621,7 +619,7 @@ Email.prototype.renderMandrill = function(options, callback) {
 		prepareOptions.push(options);
 	}
 
-	callback = ('function' === typeof callback) ? callback : function() {};
+	callback = (typeof callback === 'function') ? callback : function() {};
 
 	prepareOptions.push(function(err, toSend) {
 

--- a/lib/email.js
+++ b/lib/email.js
@@ -26,11 +26,11 @@ var defaultConfig = {
 
 /** Custom Errors */
 
-// TOTO: Uses arguments.callee for the stack trace, which prevents optimisation.
+// TODO: Uses arguments.callee for the stack trace, which prevents optimisation.
 // I've marked these to be ignored by jshint but we should find a better way.
 
 var ErrorNoEmailTemplateName = function() {
- 	Error.apply(this, arguments);
+	Error.apply(this, arguments);
 	Error.captureStackTrace(this, arguments.callee); // jshint ignore:line
 	this.message = 'No email templateName specified.';
 	this.name = 'ErrorNoEmailTemplateName';
@@ -97,9 +97,9 @@ var flattenObject = function(obj, delim) {
  * @param  {Mixed}  _var Object to parse
  * @return {Array}       An array of vars
  */
-var objToMandrillVars = function (_var) {
+var objToMandrillVars = function(_var) {
 	var _new = [];
-	if ('object' === typeof _var) {
+	if (typeof _var === 'object') {
 		var _flat = flattenObject(_var, '_');
 		_.each(_flat, function(value, key) {
 			_new.push({name: key, content: value });
@@ -115,9 +115,9 @@ var templateCSSMethods = {
 	shadeColor: function(color, percent) {
 		/* jshint ignore:start */
 		var num = parseInt(color.slice(1), 16), amt = Math.round(2.55 * percent), R = (num >> 16) + amt, G = (num >> 8 & 0x00FF) + amt, B = (num & 0x0000FF) + amt;
-		return '#' + (0x1000000 + (R < 255 ? R < 1 ? 0:R:255) * 0x10000 +
-			(G < 255 ? G < 1 ? 0:G:255) * 0x100 +
-			(B < 255 ? B < 1 ? 0:B:255)).toString(16).slice(1);
+		return '#' + (0x1000000 + (R < 255 ? R < 1 ? 0 : R : 255) * 0x10000 +
+			(G < 255 ? G < 1 ? 0 : G : 255) * 0x100 +
+			(B < 255 ? B < 1 ? 0 : B : 255)).toString(16).slice(1);
 		/* jshint ignore:end */
 	}
 };

--- a/lib/field.js
+++ b/lib/field.js
@@ -12,7 +12,6 @@ var _ = require('underscore'),
 	utils = require('keystone-utils'),
 	compiledTemplates = {};
 
-
 /**
  * Field Constructor
  * =================
@@ -80,11 +79,11 @@ function Field(list, path, options) {
  */
 
 Field.prototype.getOptions = function() {
-	
+
 	if (!this.__options) {
-		
+
 		this.__options = {};
-		
+
 		var optionKeys = [
 				'path',
 				'paths',
@@ -104,11 +103,11 @@ Field.prototype.getOptions = function() {
 				'collapse',
 				'dependsOn'
 			];
-		
+
 		if (_.isArray(this._properties)) {
 			optionKeys = optionKeys.concat(this._properties);
 		}
-		
+
 		optionKeys.forEach(function(key) {
 			if (this[key]) {
 				this.__options[key] = this[key];
@@ -118,11 +117,11 @@ Field.prototype.getOptions = function() {
 		if (this.getProperties) {
 			_.extend(this.__options, this.getProperties());
 		}
-	
+
 	}
-	
+
 	return this.__options;
-	
+
 };
 
 /**
@@ -210,7 +209,6 @@ Field.prototype.getPreSaveWatcher = function() {
 
 exports = module.exports = Field;
 
-
 /** Getter properties for the Field prototype */
 
 Object.defineProperty(Field.prototype, 'size', { get: function() { return this.getSize(); } });
@@ -225,7 +223,6 @@ Object.defineProperty(Field.prototype, 'nofilter', { get: function() { return th
 Object.defineProperty(Field.prototype, 'collapse', { get: function() { return this.options.collapse || false; } });
 Object.defineProperty(Field.prototype, 'hidden', { get: function() { return this.options.hidden || false; } });
 Object.defineProperty(Field.prototype, 'dependsOn', { get: function() { return this.options.dependsOn || false; } });
-
 
 
 /**
@@ -253,10 +250,10 @@ Field.prototype.bindUnderscoreMethods = function(methods) {
 	// always include the 'update' method
 
 	(this._underscoreMethods || []).concat({ fn: 'updateItem', as: 'update' }, (methods || [])).forEach(function(method) {
-		if ('string' === typeof method) {
+		if (typeof method === 'string') {
 			method = { fn: method, as: method };
 		}
-		if ('function' !== typeof field[method.fn]) {
+		if (typeof field[method.fn] !== 'function') {
 			throw new Error('Invalid underscore method (' + method.fn + ') applied to ' + field.list.key + '.' + field.path + ' (' + field.type + ')');
 		}
 		field.underscoreMethod(method.as, function() {
@@ -266,7 +263,6 @@ Field.prototype.bindUnderscoreMethods = function(methods) {
 	});
 
 };
-
 
 /**
  * Adds a method to the underscoreMethods collection on the field's list,
@@ -281,7 +277,6 @@ Field.prototype.underscoreMethod = function(path, fn) {
 	});
 };
 
-
 /**
  * Default method to format the field value for display
  * Overridden by some fieldType Classes
@@ -292,7 +287,6 @@ Field.prototype.underscoreMethod = function(path, fn) {
 Field.prototype.format = function(item) {
 	return item.get(this.path);
 };
-
 
 /**
  * Default method to detect whether the field has been modified in an item
@@ -305,7 +299,6 @@ Field.prototype.isModified = function(item) {
 	return item.isModified(this.path);
 };
 
-
 /**
  * Validates that a value for this field has been provided in a data object
  * Overridden by some fieldType Classes
@@ -316,13 +309,12 @@ Field.prototype.isModified = function(item) {
 Field.prototype.validateInput = function(data, required, item) {
 	if (!required) return true;
 	if (!(this.path in data) && item && item.get(this.path)) return true;
-	if ('string' === typeof data[this.path]) {
+	if (typeof data[this.path] === 'string') {
 		return (data[this.path].trim()) ? true : false;
 	} else {
 		return (data[this.path]) ? true : false;
 	}
 };
-
 
 /**
  * Updates the value for this field in the item from a data object
@@ -332,19 +324,19 @@ Field.prototype.validateInput = function(data, required, item) {
  */
 
 Field.prototype.updateItem = function(item, data) {
-	
+
 	var value = this.getValueFromData(data);
-	
+
 	// This is a deliberate type coercion so that numbers from forms play nice
 	if (value !== undefined && value != item.get(this.path)) { // jshint ignore:line
 		item.set(this.path, value);
 	}
-	
+
 };
 
 /**
  * Retrieves the value from an object, whether the path is nested or flattened
- * 
+ *
  * @api public
  */
 
@@ -364,7 +356,7 @@ Field.prototype.compile = function(type, callback) {
 
 	if (!compiledTemplates[templatePath]) {
 		fs.readFile(templatePath, 'utf8', function(err, file) {
-			if (!err){
+			if (!err) {
 				compiledTemplates[templatePath] = jade.compile(file, {
 					filename: templatePath,
 					pretty: keystone.get('env') !== 'production'

--- a/lib/list.js
+++ b/lib/list.js
@@ -268,7 +268,9 @@ List.prototype.add = function() {
 					'Did you misspell the field type?\n');
 			}
 
-			if (utils.isObject(obj[key]) && (!obj[key].constructor || 'Object' === obj[key].constructor.name) && (!obj[key].type || obj[key].type.type)) {
+			if (utils.isObject(obj[key]) &&
+			    (!obj[key].constructor || obj[key].constructor.name === 'Object') &&
+			    (!obj[key].type || obj[key].type.type)) {
 				if (Object.keys(obj[key]).length) {
 					// nested object, e.g. { last: { name: String }}
 					// matches logic in mongoose/Schema:add
@@ -293,7 +295,7 @@ List.prototype.add = function() {
 
 	_.each(arguments, function(def) {
 
-		if ('string' === typeof def) {
+		if (typeof def === 'string') {
 			if (def === '>>>') {
 				this.uiElements.push({
 					type: 'indent'
@@ -310,7 +312,7 @@ List.prototype.add = function() {
 				});
 			}
 		} else {
-			if (def.heading && 'string' === typeof def.heading) {
+			if (def.heading && typeof def.heading === 'string') {
 				this.uiElements.push({
 					type: 'heading',
 					heading: def.heading,
@@ -327,7 +329,6 @@ List.prototype.add = function() {
 
 };
 
-
 /**
  * Creates a new field at the specified path, with the provided options.
  * If no options are provides, returns the field at the specified path.
@@ -341,7 +342,7 @@ List.prototype.field = function(path, options) {
 		return this.fields[path];
 	}
 
-	if ('function' === typeof options) {
+	if (typeof options === 'function') {
 		options = { type: options };
 	}
 
@@ -353,7 +354,7 @@ List.prototype.field = function(path, options) {
 		options.note = this.get('notes')[path];
 	}
 
-	if ('function' !== typeof options.type) {
+	if (typeof options.type !== 'function') {
 		throw new Error('Fields must be specified with a type function');
 	}
 
@@ -389,7 +390,6 @@ List.prototype.field = function(path, options) {
 
 };
 
-
 /**
  * Adds a method to the underscoreMethods collection on the list, which is then
  * added to the schema before the list is registered with mongoose.
@@ -414,7 +414,6 @@ List.prototype.underscoreMethod = function(path, fn) {
 
 };
 
-
 /**
  * Default Sort Field
  *
@@ -436,7 +435,6 @@ Object.defineProperty(List.prototype, 'defaultSort', {
 	}
 
 });
-
 
 /**
  * Expands a comma-separated string or array of columns into valid column objects.
@@ -570,7 +568,6 @@ List.prototype.expandColumns = function(cols) {
 
 };
 
-
 /**
  * Specified select and populate options for a query based the provided columns.
  *
@@ -600,13 +597,12 @@ List.prototype.selectColumns = function(q, cols) {
 	q.select(select.join(' '));
 
 	for (path in populate) {
-		if ( populate.hasOwnProperty(path) ) {
+		if (populate.hasOwnProperty(path)) {
 			q.populate(path, populate[path].join(' '));
 		}
 	}
 
 };
-
 
 /**
  * Default Column Fields
@@ -633,7 +629,6 @@ Object.defineProperty(List.prototype, 'defaultColumns', {
 
 });
 
-
 /**
  * Registers relationships to this list defined on others
  *
@@ -647,7 +642,7 @@ List.prototype.relationship = function(def) {
 		return this;
 	}
 
-	if ('string' === typeof def) {
+	if (typeof def === 'string') {
 		def = { ref: def };
 	}
 
@@ -681,7 +676,6 @@ List.prototype.relationship = function(def) {
 
 };
 
-
 /**
  * Registers the Schema with Mongoose, and the List with Keystone
  *
@@ -694,7 +688,7 @@ List.prototype.register = function() {
 
 	var list = this;
 
-	this.schema.virtual('list').get(function () {
+	this.schema.virtual('list').get(function() {
 		return list;
 	});
 
@@ -735,7 +729,6 @@ List.prototype.register = function() {
 	return this;
 };
 
-
 /**
  * Gets the name of the provided document from the correct path
  *
@@ -753,7 +746,6 @@ List.prototype.getDocumentName = function(doc, escape) {
 	return (escape) ? utils.encodeHTMLEntities(name) : name;
 };
 
-
 /**
  * Processes a filter string into a filters object
  *
@@ -762,16 +754,15 @@ List.prototype.getDocumentName = function(doc, escape) {
  */
 
 List.prototype.processFilters = function(q) {
-	var list = this;
-	var filters = {};
-	queryfilterlib.QueryFilters.create(q).getFilters().forEach(function(filter){
+	var list = this,
+		filters = {};
+	queryfilterlib.QueryFilters.create(q).getFilters().forEach(function(filter) {
 		filter.path = filter.key; // alias for b/c
 		filter.field = list.fields[filter.key];
 		filters[filter.path] = filter;
 	});
 	return filters;
 };
-
 
 /**
  * Gets filters for a Mongoose query that will search for the provided string,
@@ -804,7 +795,7 @@ List.prototype.getSearchFilters = function(search, add) {
 			searchFilters = [],
 			searchIdField = utils.isValidObjectId(search);
 
-		if ('string' === typeof searchFields) {
+		if (typeof searchFields === 'string') {
 			searchFields = searchFields.split(',');
 		}
 
@@ -862,7 +853,7 @@ List.prototype.getSearchFilters = function(search, add) {
 	if (add) {
 		_.each(add, function(filter) {
 			var cond, path = filter.key, value = filter.value;
-			
+
 			switch (filter.field.type) {
 
 				case 'boolean':
@@ -871,7 +862,7 @@ List.prototype.getSearchFilters = function(search, add) {
 					} else {
 						filters[path] = true;
 					}
-					break;
+				break;
 
 				case 'localfile':
 				case 'cloudinaryimage':
@@ -880,16 +871,16 @@ List.prototype.getSearchFilters = function(search, add) {
 				case 'name':
 				case 'password':
 					// TODO
-					break;
+				break;
 
 				case 'location':
-					_.each(['street1','suburb','state','postcode','country'], function(pathKey, i) {
+					_.each(['street1', 'suburb', 'state', 'postcode', 'country'], function(pathKey, i) {
 						var value = filter.value[i];
 						if (value) {
 							filters[filter.field.paths[pathKey]] = new RegExp(utils.escapeRegExp(value), 'i');
 						}
 					});
-					break;
+				break;
 
 				case 'relationship':
 					if (value) {
@@ -908,7 +899,7 @@ List.prototype.getSearchFilters = function(search, add) {
 					// TODO: Searching on "not linked to" (null) values seems to return all results.
 					// console.log(filter.field.path + ':');
 					// console.log(filters[filter.field.path]);
-					break;
+				break;
 
 				case 'select':
 					if (filter.value) {
@@ -916,7 +907,7 @@ List.prototype.getSearchFilters = function(search, add) {
 					} else {
 						filters[path] = (filter.inverse) ? { $nin: ['', null] } : { $in: ['', null] };
 					}
-					break;
+				break;
 
 				case 'number':
 				case 'money':
@@ -925,7 +916,7 @@ List.prototype.getSearchFilters = function(search, add) {
 							utils.number(value[0]),
 							utils.number(value[1])
 						];
-						if ( !isNaN(value[0]) && !isNaN(value[1]) ) {
+						if (!isNaN(value[0]) && !isNaN(value[1])) {
 							filters[path] = {
 								$gte: value[0],
 								$lte: value[1]
@@ -937,7 +928,7 @@ List.prototype.getSearchFilters = function(search, add) {
 					}
 					else {
 						value = utils.number(value);
-						if ( !isNaN(value) ) {
+						if (!isNaN(value)) {
 							if (filter.operator === 'gt') {
 								filters[path] = { $gt: value};
 							}
@@ -961,7 +952,7 @@ List.prototype.getSearchFilters = function(search, add) {
 							moment(value[0]),
 							moment(value[1])
 						];
-						if ( (value[0] && value[0].isValid()) && (value[1] && value[0].isValid()) ) {
+						if ((value[0] && value[0].isValid()) && (value[1] && value[0].isValid())) {
 							filters[path] = {
 								$gte: moment(value[0]).startOf('day').toDate(),
 								$lte: moment(value[1]).endOf('day').toDate()
@@ -982,7 +973,7 @@ List.prototype.getSearchFilters = function(search, add) {
 							}
 						}
 					}
-					break;
+				break;
 
 				case 'text':
 				case 'textarea':
@@ -1005,7 +996,7 @@ List.prototype.getSearchFilters = function(search, add) {
 						cond = new RegExp(utils.escapeRegExp(value), 'i');
 						filters[path] = filter.inverse ? { $not: cond } : cond;
 					}
-					break;
+				break;
 
 			}
 		});
@@ -1016,7 +1007,6 @@ List.prototype.getSearchFilters = function(search, add) {
 	return filters;
 
 };
-
 
 /**
  * Updates every document in a List,
@@ -1029,7 +1019,7 @@ List.prototype.getSearchFilters = function(search, add) {
 
 List.prototype.updateAll = function(data, callback) {
 
-	if ('function' === typeof data) {
+	if (typeof data === 'function') {
 		callback = data;
 		data = null;
 	}
@@ -1054,7 +1044,6 @@ List.prototype.updateAll = function(data, callback) {
 	});
 
 };
-
 
 /**
  * Gets a unique value from a generator method by checking for documents with the same value.
@@ -1126,29 +1115,29 @@ List.prototype.getUniqueValue = function(path, generator, limit, callback) {
  * @api public
  */
 List.prototype.getPages = function(options, maxPages) {
-		var surround = Math.floor(maxPages / 2),
-			firstPage = maxPages ? Math.max(1, options.currentPage - surround) : 1,
-			padRight = Math.max(((options.currentPage - surround) - 1) * -1, 0),
-			lastPage = maxPages ? Math.min(options.totalPages, options.currentPage + surround + padRight) : options.totalPages,
-			padLeft = Math.max(((options.currentPage + surround) - lastPage), 0);
+	var surround = Math.floor(maxPages / 2),
+		firstPage = maxPages ? Math.max(1, options.currentPage - surround) : 1,
+		padRight = Math.max(((options.currentPage - surround) - 1) * -1, 0),
+		lastPage = maxPages ? Math.min(options.totalPages, options.currentPage + surround + padRight) : options.totalPages,
+		padLeft = Math.max(((options.currentPage + surround) - lastPage), 0);
 
-		options.pages = [];
+	options.pages = [];
 
-		firstPage = Math.max(Math.min(firstPage, firstPage - padLeft), 1);
+	firstPage = Math.max(Math.min(firstPage, firstPage - padLeft), 1);
 
-		for (var i = firstPage; i <= lastPage; i++) {
-			options.pages.push(i);
-		}
+	for (var i = firstPage; i <= lastPage; i++) {
+		options.pages.push(i);
+	}
 
-		if (firstPage !== 1) {
-			options.pages.shift();
-			options.pages.unshift('...');
-		}
+	if (firstPage !== 1) {
+		options.pages.shift();
+		options.pages.unshift('...');
+	}
 
-		if (lastPage !== Number(options.totalPages)) {
-			options.pages.pop();
-			options.pages.push('...');
-		}
+	if (lastPage !== Number(options.totalPages)) {
+		options.pages.pop();
+		options.pages.push('...');
+	}
 };
 
 /**
@@ -1251,7 +1240,6 @@ List.prototype.paginate = function(options, callback) {
 		return query;
 	}
 };
-
 
 /*!
  * Export class

--- a/lib/list.js
+++ b/lib/list.js
@@ -8,7 +8,6 @@ var _ = require('underscore'),
 	UpdateHandler = require('./updateHandler'),
 	queryfilterlib = require('queryfilter');
 
-
 /**
  * List Class
  *
@@ -95,10 +94,9 @@ function List(key, options) {
 
 }
 
-
 /**
  * Gets the options for the List, as used by the React components
- * 
+ *
  * @api public
  */
 
@@ -128,7 +126,7 @@ List.prototype.getOptions = function() {
 		autokey: this.autokey,
 		fields: {},
 		uiElements: [],
-		initialFields: _.pluck(this.initialFields, 'path'),
+		initialFields: _.pluck(this.initialFields, 'path')
 	};
 	_.each(this.uiElements, function(el) {
 		switch (el.type) {
@@ -158,7 +156,6 @@ List.prototype.getOptions = function() {
 	return ops;
 };
 
-
 /**
  * Gets the data from an Item ready to be serialised for client-side use, as
  * used by the React components
@@ -181,7 +178,6 @@ List.prototype.getData = function(item) {
 	return data;
 };
 
-
 /**
  * Sets list options
  *
@@ -202,7 +198,6 @@ List.prototype.set = function(key, value) {
 	return value;
 };
 
-
 /**
  * Gets list options
  *
@@ -217,7 +212,6 @@ List.prototype.set = function(key, value) {
 
 List.prototype.get = List.prototype.set;
 
-
 /**
  * Maps a built-in field (e.g. name) to a specific path
  *
@@ -231,7 +225,6 @@ List.prototype.map = function(field, path) {
 	return this.mappings[field];
 };
 
-
 /**
  * Checks to see if a field path matches a currently unmapped path, and
  * if so, adds a mapping for it.
@@ -244,7 +237,6 @@ List.prototype.automap = function(field) {
 		this.map(field.path, field.path);
 	}
 };
-
 
 /**
  * Adds one or more fields to the List
@@ -264,13 +256,14 @@ List.prototype.add = function() {
 			var key = keys[i];
 
 			if (!obj[key]) {
-				throw new Error('Invalid value for schema path `'+ prefix + key +'` in `' + this.key + '`.\n' +
+				throw new Error('Invalid value for schema path `' +
+					prefix + key + '` in `' + this.key + '`.\n' +
 					'Did you misspell the field type?\n');
 			}
 
 			if (utils.isObject(obj[key]) &&
-			    (!obj[key].constructor || obj[key].constructor.name === 'Object') &&
-			    (!obj[key].type || obj[key].type.type)) {
+				(!obj[key].constructor || obj[key].constructor.name === 'Object') &&
+				(!obj[key].type || obj[key].type.type)) {
 				if (Object.keys(obj[key]).length) {
 					// nested object, e.g. { last: { name: String }}
 					// matches logic in mongoose/Schema:add
@@ -962,8 +955,8 @@ List.prototype.getSearchFilters = function(search, add) {
 					else {
 						value = moment(value);
 						if (value && value.isValid()) {
-							var start = moment(value).startOf('day').toDate();
-							var end = moment(value).endOf('day').toDate();
+							var start = moment(value).startOf('day').toDate(),
+								end = moment(value).endOf('day').toDate();
 							if (filter.operator === 'gt') {
 								filters[path] = { $gt: end };
 							} else if (filter.operator === 'lt') {

--- a/lib/path.js
+++ b/lib/path.js
@@ -14,11 +14,11 @@ exports = module.exports = function Path(str) {
 
 	this.original = str;
 
-	var parts = this.parts = str.split('.');
-	var last = this.last = this.parts[this.parts.length-1];
-	var exceptLast = [];
+	var parts = this.parts = str.split('.'),
+	last = this.last = this.parts[this.parts.length - 1],
+	exceptLast = [];
 
-	for (var i = 0; i < parts.length-1; i++) {
+	for (var i = 0; i < parts.length - 1; i++) {
 		exceptLast.push(parts[i]);
 	}
 

--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -2,10 +2,9 @@ var keystone = require('../'),
 	Types = require('./fieldTypes'),
 	_ = require('underscore'),
 	async = require('async'),
-	utils = require('keystone-utils');
-
-var methods = module.exports.methods = {};
-var options = module.exports.options = {};
+	utils = require('keystone-utils'),
+	methods = module.exports.methods = {},
+	options = module.exports.options = {};
 
 exports.sortable = function() {
 
@@ -16,7 +15,7 @@ exports.sortable = function() {
 	});
 
 	this.schema.pre('save', function(next) {
-		
+
 		var sortOrderType = this.schema.path('sortOrder');
 		if (typeof sortOrderType !== 'undefined' && sortOrderType instanceof keystone.mongoose.Schema.Types.Number) {
 			return next();
@@ -47,7 +46,7 @@ exports.autokey = function() {
 		throw new Error(pathMsg);
 	}
 
-	if ('string' === typeof autokey.from) {
+	if (typeof autokey.from === 'string') {
 		autokey.from = autokey.from.split(' ');
 	}
 
@@ -60,7 +59,7 @@ exports.autokey = function() {
 		type: String,
 		index: true
 	};
-	
+
 	if (autokey.unique) {
 		def[autokey.path].index = { unique: true };
 	}
@@ -142,34 +141,34 @@ exports.autokey = function() {
 /**
  * List track option
  *
- * When enabled, it tracks when a document are created/updated, 
+ * When enabled, it tracks when a document are created/updated,
  * as well as the user who created/updated it.
  */
 exports.track = function() {
-	
+
 	var list = this,
 		options = list.get('track'),
 		userModel = keystone.get('user model'),
-		defaultOptions = { 
-			createdAt: false, 
+		defaultOptions = {
+			createdAt: false,
 			createdBy: false,
 			updatedAt: false,
 			updatedBy: false
 		},
 		fields = {};
-	
+
 	// ensure track is a boolean or an object
-	if (!_.isBoolean(options) && !_.isObject(options) ) {
+	if (!_.isBoolean(options) && !_.isObject(options)) {
 		throw new Error('Invalid List "track" option for ' + list.key + '\n' +
 			'"track" must be a boolean or an object.\n\n' +
-			'See http://keystonejs.com/docs/database/#lists-options for more information.');				
+			'See http://keystonejs.com/docs/database/#lists-options for more information.');
 	}
 
 	if (_.isBoolean(options)) {
 		// shorthand: { track: true } sets all tracked fields to true
 		if (options) {
-			options = { 
-				createdAt: true, 
+			options = {
+				createdAt: true,
 				createdBy: true,
 				updatedAt: true,
 				updatedBy: true
@@ -190,9 +189,9 @@ exports.track = function() {
 
 	// validate option fields
 	_.each(options, function(value, key) {
-		
+
 		var fieldName;
-		
+
 		// make sure the key isn't already defined as a field
 		if (_.has(list.fields, key)) {
 			throw new Error('Invalid List "track" option for ' + list.key + '\n' +
@@ -201,7 +200,7 @@ exports.track = function() {
 
 		// make sure it's a valid track option field
 		if (_.has(defaultOptions, key)) {
-			
+
 			// make sure the option field value is either a boolean or a string
 			if (!_.isBoolean(value) && !_.isString(value)) {
 				throw new Error('Invalid List "track" option for ' + list.key + '\n' +
@@ -210,12 +209,12 @@ exports.track = function() {
 			}
 
 			if (value) {
-				// determine 
+				// determine
 				fieldName = value === true ? key : value;
 				options[key] = fieldName;
 				list.map(key, fieldName);
 
-				switch(key) {
+				switch (key) {
 					case 'createdAt':
 					case 'updatedAt':
 						fields[fieldName] = { type: Date, hidden: true, index: true };
@@ -230,19 +229,19 @@ exports.track = function() {
 		} else {
 			throw new Error('Invalid List "track" option for ' + list.key + '\n' +
 				'valid field options are "createdAt", "createdBy", "updatedAt", an "updatedBy".\n\n' +
-				'See http://keystonejs.com/docs/database/#lists-options for more information.');				
+				'See http://keystonejs.com/docs/database/#lists-options for more information.');
 		}
 
 	});
 
 	// add track fields to schema
 	list.add(fields);
-	
+
 	list.tracking = options;
 
 	// add the pre-save schema plugin
-	list.schema.pre('save', function (next) {
-		
+	list.schema.pre('save', function(next) {
+
 		var now = new Date();
 
 		// set createdAt/createdBy on new docs
@@ -266,7 +265,7 @@ exports.track = function() {
 		}
 
 		next();
-		
+
 	});
 
 };
@@ -277,13 +276,13 @@ methods.getRelated = function(paths, callback, nocollapse) {
 		list = this.list,
 		queue = {};
 
-	if ('function' !== typeof callback) {
+	if (typeof callback !== 'function') {
 		throw new Error('List.getRelated(paths, callback, nocollapse) requires a callback function.');
 	}
 
-	if ('string' === typeof paths) {
-		var pathsArr = paths.split(' ');
-		var lastPath = '';
+	if (typeof paths === 'string') {
+		var pathsArr = paths.split(' '),
+			lastPath = '';
 		paths = [];
 		for (var i = 0; i < pathsArr.length; i++) {
 			lastPath += (lastPath.length ? ' ' : '') + pathsArr[i];
@@ -298,10 +297,10 @@ methods.getRelated = function(paths, callback, nocollapse) {
 
 		var populateString = '';
 
-		if ('string' === typeof options) {
+		if (typeof options === 'string') {
 			if (options.indexOf('[') > 0) {
 				populateString = options.substring(options.indexOf('[') + 1, options.indexOf(']'));
-				options = options.substr(0,options.indexOf('['));
+				options = options.substr(0, options.indexOf('['));
 			}
 			options = { path: options };
 		}
@@ -384,7 +383,7 @@ methods.populateRelated = function(rel, callback) {
 
 	var item = this;
 
-	if ('function' !== typeof callback) {
+	if (typeof callback !== 'function') {
 		throw new Error('List.populateRelated(rel, callback) requires a callback function.');
 	}
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -46,7 +46,7 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			onSuccess(user);
 		});
 	};
-	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
+	if (typeof lookup.email === 'string' && typeof lookup.password === 'string') {
 		// match email address and password
 		User.model.findOne({ email: lookup.email }).exec(function(err, user) {
 			if (user) {

--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -223,10 +223,10 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			case 'azurefile':
 			case 's3file':
 				actionQueue.push(field.getRequestHandler(this.item, this.req, options.paths, function(err) {
-				if (err && options.flashErrors) {
-					this.req.flash('error', field.label + ' upload failed - ' + err.message);
-				}
-				progress(err);
+					if (err && options.flashErrors) {
+						this.req.flash('error', field.label + ' upload failed - ' + err.message);
+					}
+					progress(err);
 				}.bind(this)));
 			break;
 

--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -33,7 +33,6 @@ function UpdateHandler(list, item, req, res, options) {
 
 }
 
-
 /**
  * Adds a custom validation method for a given path
  *
@@ -46,7 +45,6 @@ UpdateHandler.prototype.validate = function(path, fn) {
 	this.validationMethods[path] = fn;
 	return this;
 };
-
 
 /**
  * Adds a validationError to the updateHandler; can be used before
@@ -69,7 +67,6 @@ UpdateHandler.prototype.addValidationError = function(path, msg, type) {
 	return this;
 };
 
-
 /**
  * Processes data from req.body, req.query, or any data source.
  *
@@ -86,47 +83,47 @@ UpdateHandler.prototype.addValidationError = function(path, msg, type) {
  */
 
 UpdateHandler.prototype.process = function(data, options, callback) {
-	
+
 	var usingDefaultFields = false;
-	
-	if ('function' === typeof options) {
+
+	if (typeof options === 'function') {
 		callback = options;
 		options = null;
 	}
 
-	if ('function' !== typeof callback) {
+	if (typeof callback !== 'function') {
 		callback = function() {};
 	}
-	
+
 	// Initialise options
-	
+
 	if (!options) {
 		options = {};
-	} else if ('string' === typeof options) {
+	} else if (typeof options === 'string') {
 		options = { fields: options };
 	}
-	
+
 	if (!options.fields) {
 		options.fields = _.keys(this.list.fields);
 		usingDefaultFields = true;
-	} else if ('string' === typeof options.fields) {
+	} else if (typeof options.fields === 'string') {
 		options.fields = options.fields.split(',').map(function(i) { return i.trim(); });
 	}
-	
+
 	options.required = options.required || {};
 	options.errorMessage = options.errorMessage || this.options.errorMessage;
 	options.invalidMessages = options.invalidMessages || {};
 	options.requiredMessages = options.requiredMessages || {};
-	
+
 	// Parse a string of required fields into field paths
-	if ('string' === typeof options.required) {
+	if (typeof options.required === 'string') {
 		var requiredFields = options.required.split(',').map(function(i) { return i.trim(); });
 		options.required = {};
 		requiredFields.forEach(function(path) {
 			options.required[path] = true;
 		});
 	}
-	
+
 	// Make sure fields with the required option set are included in the required paths
 	options.fields.forEach(function(path) {
 		var field = (path instanceof keystone.Field) ? path : this.list.field(path);
@@ -134,13 +131,12 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			options.required[field.path] = true;
 		}
 	}, this);
-	
-	// TODO: The whole progress queue management code could be a lot neater...
-	
+
+// TODO: The whole progress queue management code could be a lot neater
 	var actionQueue = [],
 		addValidationError = this.addValidationError.bind(this),
 		validationErrors = this.validationErrors;
-	
+
 	var progress = function(err) {
 		if (err) {
 			if (options.logErrors) {
@@ -168,12 +164,12 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			saveItem();
 		}
 	}.bind(this);
-	
+
 	var saveItem = function() {
-		
+
 		// Make current user available to pre/post save events
 		this.item._req_user = this.user;
-		
+
 		this.item.save(function(err) {
 			if (err) {
 				if (err.name === 'ValidationError') {
@@ -198,28 +194,28 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			return callback(err, this.item, this);
 		}.bind(this));
 	}.bind(this);
-	
+
 	options.fields.forEach(function(path) {
-		
+
 		// console.log('Processing field ' + path);
 		var message;
-		
+
 		var field = (path instanceof keystone.Field) ? path : this.list.field(path),
 			invalidated = false;
-		
+
 		if (!field) {
 			throw new Error('UpdateHandler.process called with invalid field path: ' + path);
 		}
-		
+
 		// skip uneditable fields
 		if (usingDefaultFields && field.noedit && !options.ignoreNoedit) {
 			// console.log('Skipping field ' + path + ' (noedit: true)');
 			return;
 		}
-		
+
 		// Some field types have custom behaviours for queueing or validation
 		switch (field.type) {
-			
+
 			case 'localfile':
 			case 'localfiles':
 			case 'cloudinaryimage':
@@ -227,13 +223,13 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			case 'azurefile':
 			case 's3file':
 				actionQueue.push(field.getRequestHandler(this.item, this.req, options.paths, function(err) {
-				    if (err && options.flashErrors) {
-				        this.req.flash('error', field.label + ' upload failed - ' + err.message);
-				    }
-				    progress(err);
+				if (err && options.flashErrors) {
+					this.req.flash('error', field.label + ' upload failed - ' + err.message);
+				}
+				progress(err);
 				}.bind(this)));
 			break;
-			
+
 			case 'location':
 				actionQueue.push(field.getRequestHandler(this.item, this.req, options.paths, function(err) {
 					if (err && options.flashErrors) {
@@ -242,7 +238,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 					progress(err);
 				}.bind(this)));
 			break;
-			
+
 			case 'password':
 				// passwords should only be set if a value is provided.
 				// if no value is provided, as long as the field isn't required or empty, bail.
@@ -256,9 +252,9 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 					invalidated = true;
 				}
 			break;
-			
+
 		}
-		
+
 		// validate field input, unless it's already been invalidated by field-specific behaviour
 		if (!invalidated && !field.validateInput(data)) {
 			// console.log('Field ' + field.path + ' is invalid');
@@ -266,7 +262,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			addValidationError(field.path, message);
 			invalidated = true;
 		}
-		
+
 		// validate required fields, unless they've already been invalidated by field-specific behaviour
 		if (!invalidated && options.required[field.path] && !field.validateInput(data, true, this.item)) {
 			// console.log('Field ' + field.path + ' is required, but not provided.');
@@ -274,7 +270,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			addValidationError(field.path, message);
 			invalidated = true;
 		}
-		
+
 		// check for a custom validation rule at the path, and run it (unless the field is already invalid)
 		if (!invalidated && this.validationMethods[field.path]) {
 			message = this.validationMethods[field.path](data);
@@ -283,15 +279,14 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			}
 			invalidated = true;
 		}
-		
-		field.updateItem(this.item, data);
-		
-	}, this);
-	
-	progress();
-	
-};
 
+		field.updateItem(this.item, data);
+
+	}, this);
+
+	progress();
+
+};
 
 /*!
  * Export class

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -26,8 +26,9 @@ exports.apply = function(callback) {
 
 	var updatesPath = keystone.getPath('updates', 'updates');
 
-	// logError is used to log errors before the process exits since it is more synchronous than console.error.  Using 
-	// console.error gets into race condition issues with process.exit, which has higher priority.
+	// logError is used to log errors before the process exits since it is
+	// more synchronous than console.error. Using console.error gets into
+	// race condition issues with process.exit, which has higher priority.
 	var logError = function() {
 		for (var i = 0, len = arguments.length; i < len; ++i) {
 			process.stderr.write(arguments[i] + '\n');
@@ -51,22 +52,22 @@ exports.apply = function(callback) {
 				if (_.isObject(update.create)) {
 					var items = update.create,
 						ops = update.options || {};
-					var background_mode = update.__background__ ? ' (background mode) ' : '';
-					
+					var BACKGROUND_MODE = update.__background__ ? ' (background mode) ' : '';
+
 					update = function(done) {
 						keystone.createItems(items, ops, function(err, stats) {
 							if (!err) {
 								var statsMsg = stats ? stats.message : '';
 
 								console.log('\n' + _dashes_,
-									'\n' + keystone.get('name') + ': Successfully applied update ' + file + background_mode + '.',
+									'\n' + keystone.get('name') + ': Successfully applied update ' + file + BACKGROUND_MODE + '.',
 									'\n' + statsMsg,
 									'\n');
 								done(null);
 							}
 							else {
 								logError('\n' + _dashes_,
-									'\n' + keystone.get('name') + ': Update ' + file + background_mode + ' failed with errors:',
+									'\n' + keystone.get('name') + ': Update ' + file + BACKGROUND_MODE + ' failed with errors:',
 									'\n' + err,
 									'\n');
 

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -52,7 +52,7 @@ exports.apply = function(callback) {
 				if (_.isObject(update.create)) {
 					var items = update.create,
 						ops = update.options || {};
-					var BACKGROUND_MODE = update.__background__ ? ' (background mode) ' : '';
+					var background_mode = update.__background__ ? ' (background mode) ' : '';
 
 					update = function(done) {
 						keystone.createItems(items, ops, function(err, stats) {
@@ -60,14 +60,14 @@ exports.apply = function(callback) {
 								var statsMsg = stats ? stats.message : '';
 
 								console.log('\n' + _dashes_,
-									'\n' + keystone.get('name') + ': Successfully applied update ' + file + BACKGROUND_MODE + '.',
+									'\n' + keystone.get('name') + ': Successfully applied update ' + file + background_mode + '.',
 									'\n' + statsMsg,
 									'\n');
 								done(null);
 							}
 							else {
 								logError('\n' + _dashes_,
-									'\n' + keystone.get('name') + ': Update ' + file + BACKGROUND_MODE + ' failed with errors:',
+									'\n' + keystone.get('name') + ': Update ' + file + background_mode + ' failed with errors:',
 									'\n' + err,
 									'\n');
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -38,7 +38,6 @@ function View(req, res) {
 
 module.exports = exports = View;
 
-
 /**
  * Adds a method (or array of methods) to be executed in parallel
  * to the `init`, `action` or `render` queue.
@@ -47,18 +46,18 @@ module.exports = exports = View;
  */
 
 View.prototype.on = function(on) {
-	
+
 	var req = this.req,
 		callback = arguments[1],
 		values;
-	
-	if ('function' === typeof on) {
-		
+
+	if (typeof on === 'function') {
+
 		/* If the first argument is a function that returns truthy then add the second
 		 * argument to the action queue
-		 * 
+		 *
 		 * Example:
-		 * 
+		 *
 		 *     view.on(function() {
 		 *             var thing = true;
 		 *             return thing;
@@ -69,23 +68,23 @@ View.prototype.on = function(on) {
 		 *         }
 		 *     );
 		 */
-		
+
 		if (on()) {
 			this.actionQueue.push(callback);
 		}
 
 	} else if (utils.isObject(on)) {
-		
+
 		/* Do certain actions depending on information in the response object.
-		 * 
+		 *
 		 * Example:
-		 * 
+		 *
 		 *     view.on({ 'user.name.first': 'Admin' }, function(next) {
 		 *         console.log('Hello Admin!');
 		 *         next();
 		 *     });
 		 */
-		
+
 		var check = function(value, path) {
 
 			var ctx = req,
@@ -97,9 +96,9 @@ View.prototype.on = function(on) {
 				}
 				ctx = ctx[parts[i]];
 			}
-			
+
 			path = _.last(parts);
-			
+
 			return (value === true && path in ctx) ? true : (ctx[path] === value);
 
 		};
@@ -107,89 +106,88 @@ View.prototype.on = function(on) {
 		if (_.every(on, check)) {
 			this.actionQueue.push(callback);
 		}
-		
+
 	} else if (on === 'get' || on === 'post' || on === 'put' || on === 'delete') {
-		
+
 		/* Handle HTTP verbs
-		 * 
+		 *
 		 * Example:
 		 *     view.on('get', function(next) {
 		 *         console.log('GOT!');
 		 *         next();
 		 *     });
 		 */
-		
+
 		if (req.method !== on.toUpperCase()) {
 			return;
 		}
-		
+
 		if (arguments.length === 3) {
-			
+
 			/* on a POST and PUT requests search the req.body for a matching value
 			 * on every other request search the query.
-			 * 
+			 *
 			 * Example:
 			 *     view.on('post', { action: 'theAction' }, function(next) {
 			 *         // respond to the action
 			 *         next();
 			 *     });
-			 *     
+			 *
 			 * Example:
 			 *     view.on('get', { page: 2 }, function(next) {
 			 *         // do something specifically on ?page=2
 			 *         next();
 			 *     });
 			 */
-			
+
 			if (utils.isString(arguments[1])) {
 				values = {};
 				values[arguments[1]] = true;
 			} else {
 				values = arguments[1];
 			}
-			
+
 			callback = arguments[2];
-			
+
 			var ctx = (on === 'post' || on === 'put') ? req.body : req.query;
-			
+
 			if (_.every(values || {}, function(value, path) {
 				return (value === true && path in ctx) ? true : (ctx[path] === value);
 			})) {
 				this.actionQueue.push(callback);
 			}
-			
+
 		} else {
 			this.actionQueue.push(callback);
 		}
 
 	} else if (on === 'init') {
-		
+
 		/* Init events are always fired in series, before any other actions
-		 * 
+		 *
 		 * Example:
 		 *     view.on('init', function (next) {
 		 *         // do something before any actions or queries have run
 		 *     });
 		 */
-		
+
 		this.initQueue.push(callback);
-		
+
 	} else if (on === 'render') {
-		
+
 		/* Render events are always fired last in parallel, after any other actions
-		 *  
+		 *
 		 * Example:
 		 *     view.on('render', function (next) {
 		 *         // do something after init, action and query middleware has run
 		 *     });
 		 */
-		
+
 		this.renderQueue.push(callback);
-		
+
 	}
 
 	return this;
-	
 };
 
 var QueryCallbacks = function(options) {
@@ -205,11 +203,21 @@ var QueryCallbacks = function(options) {
 	return this;
 };
 
-QueryCallbacks.prototype.has = function(fn) { return (fn in this.callbacks); };
-QueryCallbacks.prototype.err = function(fn) { this.callbacks.err = fn; return this; };
-QueryCallbacks.prototype.none = function(fn) { this.callbacks.none = fn; return this; };
-QueryCallbacks.prototype.then = function(fn) { this.callbacks.then = fn; return this; };
-
+QueryCallbacks.prototype.has = function(fn) {
+	return (fn in this.callbacks);
+};
+QueryCallbacks.prototype.err = function(fn) {
+	this.callbacks.err = fn;
+	return this;
+};
+QueryCallbacks.prototype.none = function(fn) {
+	this.callbacks.none = fn;
+	return this;
+};
+QueryCallbacks.prototype.then = function(fn) {
+	this.callbacks.then = fn;
+	return this;
+};
 
 /**
  * Queues a mongoose query for execution before the view is rendered.
@@ -220,22 +228,22 @@ QueryCallbacks.prototype.then = function(fn) { this.callbacks.then = fn; return 
  * The third argument `then` can be a method to call after the query is completed
  * like function(err, results, callback), or a `populatedRelated` definition
  * (string or array).
- * 
+ *
  * Examples:
- * 
+ *
  * view.query('books', keystone.list('Book').model.find());
- * 
+ *
  *     an array of books from the database will be added to locals.books. You can
  *     also nest properties on the locals variable.
- * 
+ *
  * view.query(
  *     'admin.books',
  *      keystone.list('Book').model.find().where('user', 'Admin')
  * );
- * 
+ *
  *     locals.admin.books will be the result of the query
  *     views.query().then is always called if it is available
- * 
+ *
  * view.query('books', keystone.list('Book').model.find())
  *     .then(function (err, results, next) {
  *         if (err) return next(err);
@@ -251,7 +259,7 @@ View.prototype.query = function(key, query, options) {
 	var locals = this.res.locals,
 		parts = key.split('.'),
 		chain = new QueryCallbacks(options);
-    key = parts.pop();
+	key = parts.pop();
 
 	for (var i = 0; i < parts.length; i++) {
 		if (!locals[parts[i]]) {
@@ -269,7 +277,7 @@ View.prototype.query = function(key, query, options) {
 			if (err) {
 				if ('err' in callbacks) {
 					/* Will pass errors into the err callback
-					 * 
+					 *
 					 * Example:
 					 *     view.query('books', keystone.list('Book'))
 					 *         .err(function (err, next) {
@@ -282,7 +290,7 @@ View.prototype.query = function(key, query, options) {
 			} else {
 				if ((!results || (utils.isArray(results) && !results.length)) && 'none' in callbacks) {
 					/* If there are no results view.query().none will be called
-					 * 
+					 *
 					 * Example:
 					 *     view.query('books', keystone.list('Book').model.find())
 					 *         .none(function (next) {
@@ -308,7 +316,6 @@ View.prototype.query = function(key, query, options) {
 	return chain;
 };
 
-
 /**
  * Executes the current queue of init and action methods in series, and
  * then executes the render function. If renderFn is a string, it is provided
@@ -327,17 +334,17 @@ View.prototype.render = function(renderFn, locals, callback) {
 	var req = this.req,
 		res = this.res;
 
-	if ('string' === typeof renderFn) {
+	if (typeof renderFn === 'string') {
 		var viewPath = renderFn;
 		renderFn = function() {
-			if ('function' === typeof locals) {
+			if (typeof locals === 'function') {
 				locals = locals();
 			}
 			this.res.render(viewPath, locals, callback);
 		}.bind(this);
 	}
 
-	if ('function' !== typeof renderFn) {
+	if (typeof renderFn !== 'function') {
 		throw new Error('Keystone.View.render() renderFn must be a templatePath (string) or a function.');
 	}
 
@@ -361,7 +368,7 @@ View.prototype.render = function(renderFn, locals, callback) {
 		if (Array.isArray(i)) {
 			// process nested arrays in parallel
 			async.parallel(i, next);
-		} else if ('function' === typeof i) {
+		} else if (typeof i === 'function') {
 			// process single methods in series
 			i(next);
 		} else {

--- a/test/_req_user.test.js
+++ b/test/_req_user.test.js
@@ -36,7 +36,7 @@ describe('List schema pre/post save hooks', function() {
 
 	describe('when using UpdateHandler()', function() {
 
-		it('should receive ._req_user', function (done) {
+		it('should receive ._req_user', function(done) {
 			pre = undefined;
 			post = undefined;
 
@@ -57,7 +57,7 @@ describe('List schema pre/post save hooks', function() {
 				.post('/using-update-handler')
 				.send({ name: 'test' })
 				.expect('GOOD')
-				.end(function(err, res){
+				.end(function(err, res) {
 					if (err) return done(err);
 					demand(pre).be(dummyUser);
 					demand(post).be(dummyUser);
@@ -70,7 +70,7 @@ describe('List schema pre/post save hooks', function() {
 
 	describe('when using .save()', function() {
 
-		it('should not receive ._req_user', function (done) {
+		it('should not receive ._req_user', function(done) {
 			pre = undefined;
 			post = undefined;
 
@@ -90,7 +90,7 @@ describe('List schema pre/post save hooks', function() {
 				.post('/using-save')
 				.send({ name: 'test' })
 				.expect('GOOD')
-				.end(function(err, res){
+				.end(function(err, res) {
 					if (err) return done(err);
 					demand(pre).be.undefined();
 					demand(post).be.undefined();

--- a/test/fields.js
+++ b/test/fields.js
@@ -1,23 +1,19 @@
-var demand = require('must');
-
-var keystone = require('../').init(),
-	Types = keystone.Field.Types;
-
-/** Test List and Fields */
-
+var demand = require('must'),
+	keystone = require('../').init(),
+	Types = keystone.Field.Types,
 // use nocreate to allow required fields without tripping `initial` validation
-var Test = keystone.List('Test', { nocreate: true }),
+	Test = keystone.List('Test', { nocreate: true }),
 	testItem;
 
 before(function() {
-	
+
 	// Create a Test List with all the field types that will be tested
 	Test.add({
 		text: Types.Text,
 		bool: Types.Boolean,
 		nested: {
 			text: String,
-			bool: Boolean,
+			bool: Boolean
 		},
 		date: Types.Date,
 		datetime: Types.Datetime,
@@ -27,19 +23,19 @@ before(function() {
 		}
 	});
 	Test.register();
-	
+
 	// Create a new Test Item to run tests against
 	testItem = new Test.model();
-	
+
 });
 
 /** Tests */
 
 describe('Fields', function() {
-	
+
 	/** FieldType: Text (String) */
 	describe('Text', function() {
-		
+
 		it('should update top level fields', function() {
 			Test.fields.text.updateItem(testItem, {
 				text: 'value'
@@ -47,7 +43,7 @@ describe('Fields', function() {
 			demand(testItem.text).be('value');
 			testItem.text = undefined;
 		});
-		
+
 		it('should update nested fields', function() {
 			Test.fields['nested.text'].updateItem(testItem, {
 				nested: {
@@ -57,7 +53,7 @@ describe('Fields', function() {
 			demand(testItem.nested.text).be('value');
 			testItem.nested.text = undefined;
 		});
-		
+
 		it('should update nested fields with flat paths', function() {
 			Test.fields['nested.text'].updateItem(testItem, {
 				'nested.text': 'value'
@@ -65,12 +61,12 @@ describe('Fields', function() {
 			demand(testItem.nested.text).be('value');
 			testItem.nested.text = undefined;
 		});
-		
+
 	});
-	
+
 	/** FieldType: Boolean */
 	describe('Boolean', function() {
-		
+
 		it('should be true when passed the boolean true', function() {
 			Test.fields.bool.updateItem(testItem, {
 				bool: true
@@ -78,7 +74,7 @@ describe('Fields', function() {
 			demand(testItem.bool).be.true();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should be true when passed the string "true"', function() {
 			Test.fields.bool.updateItem(testItem, {
 				bool: 'true'
@@ -86,7 +82,7 @@ describe('Fields', function() {
 			demand(testItem.bool).be.true();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should be false when passed the boolean false', function() {
 			Test.fields.bool.updateItem(testItem, {
 				bool: false
@@ -94,7 +90,7 @@ describe('Fields', function() {
 			demand(testItem.bool).be.false();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should be false when passed the string "false"', function() {
 			Test.fields.bool.updateItem(testItem, {
 				bool: 'false'
@@ -102,13 +98,13 @@ describe('Fields', function() {
 			demand(testItem.bool).be.false();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should be false when passed undefined', function() {
 			Test.fields.bool.updateItem(testItem, {});
 			demand(testItem.bool).be.false();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should be false when passed an empty string', function() {
 			Test.fields.bool.updateItem(testItem, {
 				bool: ''
@@ -116,7 +112,7 @@ describe('Fields', function() {
 			demand(testItem.bool).be.false();
 			testItem.bool = undefined;
 		});
-		
+
 		it('should update nested fields', function() {
 			Test.fields['nested.bool'].updateItem(testItem, {
 				nested: {
@@ -126,7 +122,7 @@ describe('Fields', function() {
 			demand(testItem.nested.bool).be.true();
 			testItem.nested.bool = undefined;
 		});
-		
+
 		it('should update nested fields with flat paths', function() {
 			Test.fields['nested.bool'].updateItem(testItem, {
 				'nested.bool': true
@@ -134,32 +130,30 @@ describe('Fields', function() {
 			demand(testItem.nested.bool).be.true();
 			testItem.nested.bool = undefined;
 		});
-		
+
 	});
-	
+
 	/** FieldType: Date */
 	describe('Date', function() {
-		
+
 		it('should parse without error via underscore date', function() {
 			testItem._.date.parse('20131204', 'YYYYMMDD');
 		});
-		
+
 		it('should be the date we expect', function() {
 			testItem.date = new Date(2013, 11, 4);
 			demand(testItem._.date.format()).to.equal('4th Dec 2013');
 			demand(testItem._.date.format('YYYYMMDD')).to.equal('20131204');
 		});
-		
+
 		it('should be a moment object', function() {
 			testItem.date = new Date(2013, 11, 4);
 			demand(testItem._.date.moment()._isAMomentObject);
 		});
-		
 	});
-	
+
 	/** FieldType: Location */
 	describe('Location', function() {
-		
 		var emptyLocationValues = {
 			number: '',
 			name: '',
@@ -170,14 +164,13 @@ describe('Fields', function() {
 			postcode: '',
 			country: '',
 			geo: []
-		};
-		
-		var resetLocationValues = function() {
+		},
+                resetLocationValues = function() {
 			testItem.set('location.basic', emptyLocationValues);
 			testItem.set('location.required', emptyLocationValues);
 			testItem.set('location.customRequired', emptyLocationValues);
-		}
-		
+		};
+
 		it('should update its value from flat paths', function() {
 			resetLocationValues();
 			Test.fields['location.basic'].updateItem(testItem, {
@@ -204,7 +197,7 @@ describe('Fields', function() {
 			demand(testItem.location.basic.geo[0]).be(151.2099);
 			demand(testItem.location.basic.geo[1]).be(-33.865143);
 		});
-		
+
 		it('should update its value from nested paths', function() {
 			resetLocationValues();
 			Test.fields['location.basic'].updateItem(testItem, {
@@ -234,7 +227,7 @@ describe('Fields', function() {
 			demand(testItem.location.basic.geo[0]).be(151.2099);
 			demand(testItem.location.basic.geo[1]).be(-33.865143);
 		});
-		
+
 		it('should remove the location.geo path without valid values', function() {
 			resetLocationValues();
 			Test.fields['location.basic'].updateItem(testItem, {
@@ -248,7 +241,7 @@ describe('Fields', function() {
 			});
 			demand(testItem.location.basic.geo).be.undefined();
 		});
-		
+
 		it('should validate required fields', function() {
 			Test.fields['location.basic'].validateInput({}, true, testItem).must.be.false();
 			Test.fields['location.basic'].validateInput({
@@ -274,6 +267,5 @@ describe('Fields', function() {
 				'location.customRequired.country': 'country'
 			}, true, testItem).must.be.true();
 		});
-		
 	});
 });

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -6,7 +6,7 @@ var keystone = require('../index.js'),
 	getExpressApp = require('./helpers/getExpressApp'),
 	removeModel = require('./helpers/removeModel');
 
-describe('List "track" option', function () {
+describe('List "track" option', function() {
 	var app = getExpressApp(),
 		userModelName = 'User',
 		testModelName = 'Test',
@@ -97,8 +97,8 @@ describe('List "track" option', function () {
 		});
 
 		tasks.push(function(done) {
-			dummyUser1 = new User.model({ 
-				'name': 'John Doe'
+			dummyUser1 = new User.model({
+				name: 'John Doe'
 			}).save(function(err, data) {
 				if (err) {
 					throw new err;
@@ -109,8 +109,8 @@ describe('List "track" option', function () {
 		});
 
 		tasks.push(function(done) {
-			dummyUser2 = new User.model({ 
-				'name': 'Jane Doe'
+			dummyUser2 = new User.model({
+				name: 'Jane Doe'
 			}).save(function(err, data) {
 				if (err) {
 					throw new err;
@@ -128,13 +128,12 @@ describe('List "track" option', function () {
 		});
 	});
 
-	describe('when "track" option is not valid', function () {
-		
+	describe('when "track" option is not valid', function() {
 		afterEach(function() {
 			removeModel(testModelName);
 		});
 
-		it('should throw an error if "track" is not a boolean or an object', function () {
+		it('should throw an error if "track" is not a boolean or an object', function() {
 			function badList() {
 				Test = keystone.List(testModelName, { track: 'bad setting' });
 				Test.add({ name: { type: String } });
@@ -143,7 +142,7 @@ describe('List "track" option', function () {
 			badList.must.throw(/"track" must be a boolean or an object/);
 		});
 
-		it('should throw an error if "track" fields are not booleans or strings', function () {
+		it('should throw an error if "track" fields are not booleans or strings', function() {
 			function badList() {
 				Test = keystone.List(testModelName, { track: { createdBy: 5 } });
 				Test.add({ name: { type: String } });
@@ -152,7 +151,7 @@ describe('List "track" option', function () {
 			badList.must.throw(/must be a boolean or a string/);
 		});
 
-		it('should throw an error if "track" has an invalid field name', function () {
+		it('should throw an error if "track" has an invalid field name', function() {
 			function badList() {
 				Test = keystone.List(testModelName, { track: { createdAt: true, badfield: true } });
 				Test.add({ name: { type: String } });
@@ -162,7 +161,7 @@ describe('List "track" option', function () {
 		});
 
 		it('should not register the plugin if all fields are false', function() {
-			Test = keystone.List(testModelName, { 
+			Test = keystone.List(testModelName, {
 				track: { createdAt: false, createdBy: false, updatedAt: false, updatedBy: false }
 			});
 			Test.add({ name: { type: String } });
@@ -178,7 +177,7 @@ describe('List "track" option', function () {
 
 	describe('when "track" option is set to true', function() {
 
-		describe('using updateHandler()', function () {
+		describe('using updateHandler()', function() {
 
 			before(function() {
 				Test = keystone.List(testModelName, { track: true });
@@ -202,7 +201,7 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should have all the default fields', function () {
+			it('should have all the default fields', function() {
 				demand(Test.field('createdAt')).be.an.object();
 				demand(Test.field('createdBy')).be.an.object();
 				demand(Test.field('updatedAt')).be.an.object();
@@ -218,7 +217,7 @@ describe('List "track" option', function () {
 					.post('/using-update-handler')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -239,7 +238,7 @@ describe('List "track" option', function () {
 					.post('/using-update-handler/' + post.get('id'))
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -254,10 +253,9 @@ describe('List "track" option', function () {
 						done();
 					});
 			});
-			
 		});
 
-		describe('using .save()', function () {
+		describe('using .save()', function() {
 
 			before(function() {
 				Test = keystone.List(testModelName, { track: true });
@@ -281,7 +279,7 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should have all the default fields', function () {
+			it('should have all the default fields', function() {
 				demand(Test.field('createdAt')).be.an.object();
 				demand(Test.field('createdBy')).be.an.object();
 				demand(Test.field('updatedAt')).be.an.object();
@@ -299,7 +297,7 @@ describe('List "track" option', function () {
 					.post('/using-save')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -322,7 +320,7 @@ describe('List "track" option', function () {
 					.post('/using-save/' + post._id)
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -338,7 +336,6 @@ describe('List "track" option', function () {
 					});
 
 			});
-			
 		});
 
 	});
@@ -349,7 +346,7 @@ describe('List "track" option', function () {
 		describe('using updateHandler()', function() {
 
 			before(function() {
-				Test = keystone.List(testModelName, { 
+				Test = keystone.List(testModelName, {
 					track: { updatedAt: true, updatedBy: true }
 				});
 				Test.add({ name: { type: String } });
@@ -372,7 +369,7 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should have all the default fields', function () {
+			it('should have all the default fields', function() {
 				demand(Test.field('createdAt')).be.undefined();
 				demand(Test.field('createdBy')).be.undefined();
 				demand(Test.field('updatedAt')).be.an.object();
@@ -387,7 +384,7 @@ describe('List "track" option', function () {
 					.post('/using-update-handler')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -404,7 +401,7 @@ describe('List "track" option', function () {
 					.post('/using-update-handler/' + post._id)
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -422,7 +419,7 @@ describe('List "track" option', function () {
 		describe('using .save()', function() {
 
 			before(function() {
-				Test = keystone.List(testModelName, { 
+				Test = keystone.List(testModelName, {
 					track: { updatedAt: true, updatedBy: true }
 				});
 				Test.add({ name: { type: String } });
@@ -445,7 +442,7 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should have all the default fields', function () {
+			it('should have all the default fields', function() {
 				demand(Test.field('createdAt')).be.undefined();
 				demand(Test.field('createdBy')).be.undefined();
 				demand(Test.field('updatedAt')).be.an.object();
@@ -460,7 +457,7 @@ describe('List "track" option', function () {
 					.post('/using-save')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -477,7 +474,7 @@ describe('List "track" option', function () {
 					.post('/using-save/' + post._id)
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
@@ -489,22 +486,21 @@ describe('List "track" option', function () {
 						done();
 					});
 			});
-			
 		});
 
 	});
 
-	describe('when "track" option has custom field names', function () {
+	describe('when "track" option has custom field names', function() {
 		var previousUpdatedAt;
 
 		describe('using updateHandler()', function() {
 
 			before(function() {
-				Test = keystone.List(testModelName, { 
-					track: { 
+				Test = keystone.List(testModelName, {
+					track: {
 						createdAt: 'customCreatedAt',
 						createdBy: 'customCreatedBy',
-						updatedAt: 'customUpdatedAt', 
+						updatedAt: 'customUpdatedAt',
 						updatedBy: 'customUpdatedBy'
 					}
 				});
@@ -528,14 +524,14 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should no have any of the default fields', function () {
+			it('should no have any of the default fields', function() {
 				demand(Test.field('createdAt')).be.undefined();
 				demand(Test.field('createdBy')).be.undefined();
 				demand(Test.field('updatedAt')).be.undefined();
 				demand(Test.field('updatedBy')).be.undefined();
 			});
 
-			it('should have all the custom fields', function () {
+			it('should have all the custom fields', function() {
 				demand(Test.field('customCreatedAt')).be.an.object();
 				demand(Test.field('customCreatedBy')).be.an.object();
 				demand(Test.field('customUpdatedAt')).be.an.object();
@@ -552,18 +548,18 @@ describe('List "track" option', function () {
 					.post('/using-update-handler')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
 						demand(post.get('name')).be('test1');
-						demand(post['customCreatedBy'].toString()).be(dummyUser1.get('id'));
-						demand(post['customUpdatedBy'].toString()).be(dummyUser1.get('id'));
+						demand(post.customCreatedBy.toString()).be(dummyUser1.get('id'));
+						demand(post.customUpdatedBy.toString()).be(dummyUser1.get('id'));
 
-						post['customCreatedAt'].must.be.a.date();
-						post['customUpdatedAt'].must.be.a.date();
+						post.customCreatedAt.must.be.a.date();
+						post.customUpdatedAt.must.be.a.date();
 
-						demand(post['customCreatedAt']).equal(post['customUpdatedAt']);
+						demand(post.customCreatedAt).equal(post.customUpdatedAt);
 						done();
 					});
 			});
@@ -573,29 +569,29 @@ describe('List "track" option', function () {
 					.post('/using-update-handler/' + post._id)
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
 						demand(post.get('name')).be('test2');
-						demand(post['customUpdatedBy'].toString()).be(dummyUser2.get('id'));
-						post['customUpdatedAt'].must.be.a.date();
+						demand(post.customUpdatedBy.toString()).be(dummyUser2.get('id'));
+						post.customUpdatedAt.must.be.a.date();
 
-						demand(post['customUpdatedAt']).be.after(post['customCreatedAt']);
+						demand(post.customUpdatedAt).be.after(post.customCreatedAt);
 						done();
 					});
 			});
 
 		});
-		
+
 		describe('using save()', function() {
 
 			before(function() {
-				Test = keystone.List(testModelName, { 
-					track: { 
+				Test = keystone.List(testModelName, {
+					track: {
 						createdAt: 'customCreatedAt',
 						createdBy: 'customCreatedBy',
-						updatedAt: 'customUpdatedAt', 
+						updatedAt: 'customUpdatedAt',
 						updatedBy: 'customUpdatedBy'
 					}
 				});
@@ -619,14 +615,14 @@ describe('List "track" option', function () {
 				});
 			});
 
-			it('should no have any of the default fields', function () {
+			it('should no have any of the default fields', function() {
 				demand(Test.field('createdAt')).be.undefined();
 				demand(Test.field('createdBy')).be.undefined();
 				demand(Test.field('updatedAt')).be.undefined();
 				demand(Test.field('updatedBy')).be.undefined();
 			});
 
-			it('should have all the custom fields', function () {
+			it('should have all the custom fields', function() {
 				demand(Test.field('customCreatedAt')).be.an.object();
 				demand(Test.field('customCreatedBy')).be.an.object();
 				demand(Test.field('customUpdatedAt')).be.an.object();
@@ -643,18 +639,18 @@ describe('List "track" option', function () {
 					.post('/using-save')
 					.send({ name: 'test1' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
 						demand(post.get('name')).be('test1');
-						demand(post['customCreatedBy'].toString()).be(dummyUser1.get('id'));
-						demand(post['customUpdatedBy'].toString()).be(dummyUser1.get('id'));
+						demand(post.customCreatedBy.toString()).be(dummyUser1.get('id'));
+						demand(post.customUpdatedBy.toString()).be(dummyUser1.get('id'));
 
-						post['customCreatedAt'].must.be.a.date();
-						post['customUpdatedAt'].must.be.a.date();
+						post.customCreatedAt.must.be.a.date();
+						post.customUpdatedAt.must.be.a.date();
 
-						demand(post['customCreatedAt']).equal(post['customUpdatedAt']);
+						demand(post.customCreatedAt).equal(post.customUpdatedAt);
 						done();
 					});
 			});
@@ -664,21 +660,19 @@ describe('List "track" option', function () {
 					.post('/using-save/' + post._id)
 					.send({ name: 'test2' })
 					.expect('GOOD')
-					.end(function(err, res){
+					.end(function(err, res) {
 						if (err) {
 							return done(err);
 						}
 						demand(post.get('name')).be('test2');
-						demand(post['customUpdatedBy'].toString()).be(dummyUser2.get('id'));
-						post['customUpdatedAt'].must.be.a.date();
+						demand(post.customUpdatedBy.toString()).be(dummyUser2.get('id'));
+						post.customUpdatedAt.must.be.a.date();
 
-						demand(post['customUpdatedAt']).be.after(post['customCreatedAt']);
+						demand(post.customUpdatedAt).be.after(post.customCreatedAt);
 						done();
 					});
 			});
 
 		});
-		
 	});
-	
 });

--- a/test/track.test.js
+++ b/test/track.test.js
@@ -90,7 +90,7 @@ describe('List "track" option', function() {
 		tasks.push(function(done) {
 			User.model.remove({}, function(err) {
 				if (err) {
-					throw new err;
+					throw err;
 				}
 				done();
 			});
@@ -101,7 +101,7 @@ describe('List "track" option', function() {
 				name: 'John Doe'
 			}).save(function(err, data) {
 				if (err) {
-					throw new err;
+					throw err;
 				}
 				dummyUser1 = data;
 				done();
@@ -113,7 +113,7 @@ describe('List "track" option', function() {
 				name: 'Jane Doe'
 			}).save(function(err, data) {
 				if (err) {
-					throw new err;
+					throw err;
 				}
 				dummyUser2 = data;
 				done();
@@ -122,7 +122,7 @@ describe('List "track" option', function() {
 
 		async.series(tasks, function(err) {
 			if (err) {
-				throw new err;
+				throw err;
 			}
 			done();
 		});
@@ -194,7 +194,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();
@@ -272,7 +272,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();
@@ -362,7 +362,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();
@@ -435,7 +435,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();
@@ -517,7 +517,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();
@@ -608,7 +608,7 @@ describe('List "track" option', function() {
 				// post test cleanup
 				Test.model.remove({}, function(err) {
 					if (err) {
-						throw new err;
+						throw err;
 					}
 					removeModel(testModelName);
 					done();


### PR DESCRIPTION
This is a big one. Here I reworded all `yoda conditionals`, trailing whitespace and random other things. The test suite is not complaining and I tried my best to make only changes that I think wont cause any breakage to keystone deployments. Down 627 warnings to 145.