### PR TITLE
add missing files to lint and jshint

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,7 +1,7 @@
 docs
-public
+public/js/lib
+public/build/js/app.js
 node_modules
-test
 coverage
 fields/types/markdown/lib/bootstrap-markdown.js
 fields/types/color/lib/bootstrap-colorpicker.js

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,10 @@ ISTANBUL_CMD = node_modules/istanbul/lib/cli.js cover
 JSXHINT_CMD = node_modules/jsxhint/cli.js
 JSCS_CMD = node_modules/.bin/jscs
 JSCS_REPORTER = console
-JSCS_FILES = ./**/*.js
+JSCS_FILES = `find . -path "*.js" ! -path "./node_modules/*" \
+		! -path "./public/js/lib/*" \
+		! -path "./docs/*" \
+		! -path "./coverage/*"`
 MOCHA_CMD = node_modules/mocha/bin/_mocha
 JSHINT_REPORTER = node_modules/jshint-stylish/stylish.js
 TESTS = test/*.js

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,19 @@ TESTS = test/*.js
 
 default: test
 
-test: lint
+test: jshint jscs
+	@echo "\nRunning Test Suite ..."
 	@NODE_ENV=test $(MOCHA_CMD) \
 		--require should \
 		--growl \
 		--reporter $(REPORTER)
 
-lint:
+jshint:
+	@echo "\nRunning JSHint ..."
 	@$(JSXHINT_CMD) --reporter $(JSHINT_REPORTER) .; true
+
+jscs:
+	@echo "\nRunning JSCS ..."
 	@$(JSCS_CMD) $(JSCS_FILES) --reporter=$(JSCS_REPORTER); true
 
 test-cov: clean
@@ -30,7 +35,6 @@ test-travis: test-spec
 	if test -n "$$CODECLIMATE_REPO_TOKEN"; then codeclimate < coverage/lcov.info; fi
 
 # TODO explore generating documentation from a makefile task
-# TODO explore using jscoverage over istanbul for coverage reports
 
 clean:
 	rm -rf coverage


### PR DESCRIPTION
turns out makefiles don't handle recursion like gulp, grunt or npm. Added call out to 'find' to grab all project files.