### PR TITLE
Passing relevant options from Types.Relationship to schema.path so mongo...

### DIFF
--- a/lib/fieldTypes/relationship.js
+++ b/lib/fieldTypes/relationship.js
@@ -65,7 +65,10 @@ relationship.prototype.addToSchema = function() {
 
 	var def = {
 		type: this._nativeType,
-		ref: this.options.ref
+		ref: this.options.ref,
+		index: (this.options.index ? true : false),
+		required: (this.options.required ? true : false),
+		unique: (this.options.unique ? true : false)
 	};
 
 	schema.path(this.path, this.many ? [def] : def);


### PR DESCRIPTION
It looks like the trouble I was having with ```Types.Relationship``` fields' required-ness and uniqueness in my Lists relates to the overridden ```addToSchema``` not passing along options specified during List creation.  By checking for those and passing them along in the call to ```schema.path```, the relevant field options seem to be recognized.  Thanks @snowkeeper for the help and filing #869 on behalf of this Issue. 