### PR TITLE
Mongo session store in production env fix

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -190,7 +190,8 @@ function mount(mountPath, parentApp, events) {
 			
 			if (waitForSessionStore) {
 				sessionStorePromise = new P(function(resolve) {
-					sessionOptions.store = new SessionStore(sessionStoreOptions, resolve);
+					sessionOptions.store = new SessionStore(sessionStoreOptions);
+					resolve(sessionOptions.store);
 				});
 			} else {
 				sessionOptions.store = new SessionStore(sessionStoreOptions);


### PR DESCRIPTION
When NODE_ENV=production and session store is set to mongo, there's a bug - neverending waiting for SessionStore due to never resolved sessionStorePromise 