### PR TITLE
Add support for cross-referencing relationships across update files

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -7,7 +7,7 @@ var _ = require('underscore'),
 	async = require('async'),
 	utils = require('keystone-utils');
 
-function createItems(data, ops, callback) {
+function createItems(data, refs, ops, callback) {
 	
 	var keystone = this;
 	
@@ -31,7 +31,6 @@ function createItems(data, ops, callback) {
 	}
 	
 	var lists = _.keys(data),
-		refs = {},
 		stats = {};
 
 	// logger function
@@ -62,7 +61,8 @@ function createItems(data, ops, callback) {
 					return doneList();
 				}
 				
-				refs[list.key] = {};
+				if (!refs[list.key]) refs[list.key] = {};
+				
 				stats[list.key] = {
 					singular: list.singular,
 					plural: list.plural,

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -22,7 +22,8 @@ exports.apply = function(callback) {
 	var Update = mongoose.model('App_Update'),
 		updateCount = 0,
 		deferCount = 0,
-		skipCount = 0;
+		skipCount = 0,
+		refs = {};
 
 	var updatesPath = keystone.getPath('updates', 'updates');
 
@@ -54,7 +55,7 @@ exports.apply = function(callback) {
 					var background_mode = update.__background__ ? ' (background mode) ' : '';
 					
 					update = function(done) {
-						keystone.createItems(items, ops, function(err, stats) {
+						keystone.createItems(items, refs, ops, function(err, stats) {
 							if (!err) {
 								var statsMsg = stats ? stats.message : '';
 


### PR DESCRIPTION
This is useful when you want to stack updates across different files.  For example, setup a base updates file and have custom updates files reference base list items.