### PR TITLE
A convenient way to add additional classes to the wysiwyg editor

### DIFF
--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -80,7 +80,8 @@ function render(req, res, view, ext) {
 			additionalOptions: keystone.get('wysiwyg additional options') || {},
 			overrideToolbar: keystone.get('wysiwyg override toolbar'),
 			skin: keystone.get('wysiwyg skin') || 'keystone',
-			menubar: keystone.get('wysiwyg menubar')
+			menubar: keystone.get('wysiwyg menubar'),
+			importcss: keystone.get('wysiwyg importcss') || ''
 		}
 	};
 	

--- a/lib/fieldTypes/s3file.js
+++ b/lib/fieldTypes/s3file.js
@@ -247,8 +247,8 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 		prefix = field.options.datePrefix ? moment().format(field.options.datePrefix) + '-' : '',
 		name = prefix + file.name;
 
-	if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, file.mimetype)){
-		return callback(new Error('Unsupported File Type: '+file.mimetype));
+	if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, file.type)){
+		return callback(new Error('Unsupported File Type: '+file.type));
 	}
 
 	if ('function' === typeof update) {
@@ -263,7 +263,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 		}
 
 		knox.createClient(field.s3config).putFile(file.path, path + name, {
-			'Content-Type': file.mimetype,
+			'Content-Type': file.type,
 			'x-amz-acl': 'public-read'
 		}, function(err, res) {
 
@@ -277,7 +277,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 				filename: name,
 				path: path,
 				size: file.size,
-				filetype: file.mimetype,
+				filetype: file.type,
 				url: url
 			};
 
@@ -302,7 +302,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 	var client = s3.createClient(keystone.get('s3 config'));
 
 	var headers = {
-		'Content-Type': file.mimetype,
+		'Content-Type': file.type,
 		'x-amz-acl': 'public-read'
 	};
 
@@ -321,7 +321,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 		item.set(field.path, {
 			filename: file.name,
 			size: file.size,
-			filetype: file.mimetype,
+			filetype: file.type,
 			url: url
 		});
 		callback();

--- a/public/js/common/ui-wysiwyg.js
+++ b/public/js/common/ui-wysiwyg.js
@@ -30,6 +30,15 @@ jQuery(function($) {
 			plugins.push(additionalPlugins[i]);
 		}
 	}
+	if (Keystone.wysiwyg.options.importcss) {
+		plugins.push('importcss');
+		var importcssOptions = {
+			content_css: Keystone.wysiwyg.options.importcss,
+			importcss_append: true,
+			importcss_merge_classes: true
+		};
+		$.extend(Keystone.wysiwyg.options.additionalOptions,importcssOptions);
+	}
 	toolbar += ' | code';
 
 	//init editable wysiwygs


### PR DESCRIPTION
I know, it is possible to achieve this with the existing options, but this is a shortcut to add new classes to the wysiwyg editor. The syntax is the same as with the current wysiwyg options. Just add

keystone.init({
	...
	'wysiwyg importcss': '/path/to/classes.css',
	....
});

All classes from the css file will be added to the Format > Formats menu entry.