### PR TITLE
A convenient way to add additional classes to the wysiwyg editor

### DIFF
--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -80,7 +80,8 @@ function render(req, res, view, ext) {
 			additionalOptions: keystone.get('wysiwyg additional options') || {},
 			overrideToolbar: keystone.get('wysiwyg override toolbar'),
 			skin: keystone.get('wysiwyg skin') || 'keystone',
-			menubar: keystone.get('wysiwyg menubar')
+			menubar: keystone.get('wysiwyg menubar'),
+			importcss: keystone.get('wysiwyg importcss') || ''
 		}
 	};
 	

--- a/public/js/common/ui-wysiwyg.js
+++ b/public/js/common/ui-wysiwyg.js
@@ -30,6 +30,15 @@ jQuery(function($) {
 			plugins.push(additionalPlugins[i]);
 		}
 	}
+	if (Keystone.wysiwyg.options.importcss) {
+		plugins.push('importcss');
+		var importcssOptions = {
+			content_css: Keystone.wysiwyg.options.importcss,
+			importcss_append: true,
+			importcss_merge_classes: true
+		};
+		$.extend(Keystone.wysiwyg.options.additionalOptions,importcssOptions);
+	}
 	toolbar += ' | code';
 
 	//init editable wysiwygs


### PR DESCRIPTION
I know, it is possible to achieve this with the existing options, but this is a shortcut to add new classes to the wysiwyg editor. The syntax is the same as with the current wysiwyg options. Just add
```
keystone.init({
...
'wysiwyg importcss': '/path/to/classes.css',
....
});
```
All classes from the css file will be added to the Format > Formats menu entry.