### PR TITLE
Use filename without suffix as default publicID for cloudinary

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -396,6 +396,8 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 				uploadOptions.tags.push(tp + 'dev');
 			}
 
+			uploadOptions.public_id = req.files[paths.upload].name.substring(0, req.files[paths.upload].name.lastIndexOf('.'));
+
 			if (field.options.publicID) {
 				var publicIdValue = item.get(field.options.publicID);
 				if (publicIdValue) {

--- a/routes/api/cloudinary.js
+++ b/routes/api/cloudinary.js
@@ -18,6 +18,8 @@ exports = module.exports = {
 				} else {
 					res.send('{"image":{"url":"' + result.url + '"}}');
 				}
+			}, {
+				public_id: req.files.file.name.substring(0, req.files.file.name.lastIndexOf('.'))
 			});
 		} else {
 			res.send('{"error":{"message":"No image selected"}}');


### PR DESCRIPTION
When I upload a picture to cloudinary using the built-in field type or via the wysiwyg editor plugin, the image gets by default the file name of the tmp file as its publicID, which is normally a very cryptic string. My suggestion would be to use the original file name of the image without the suffix as the default publicID?