### PR TITLE
Adding visual anchor links to headings/subheadings in docs (#945)

### DIFF
--- a/docs/content/common/templates/layout/base.jade
+++ b/docs/content/common/templates/layout/base.jade
@@ -89,6 +89,7 @@ html(lang=language)
 		script(src='/js/lib/bootstrap/collapse.js')
 		//- script(src='/js/lib/bootstrap/dropdown.js')
 		script(src='/js/lib/prism/prism.min.js')
+		script(src='/js/anchor-links.js')
 			
 		//- Twitter
 		script.

--- a/docs/public/js/anchor-links.js
+++ b/docs/public/js/anchor-links.js
@@ -1,0 +1,18 @@
+/*
+ * Add visual anchor links to docs-content
+ * Solution for issue #945 - https://github.com/keystonejs/keystone/issues/945
+ */
+$(function() {
+	// for all anchor tags with name props
+	$(".docs-content a[name]").each(function() {
+		var $anchor = $(this),
+			name = $anchor.attr("name"),
+			$link = $('<a class="anchor" href="#' + name + '"><i class="entypo entypo-link"></i></a>'),
+			$next = $anchor.next();
+
+		// only append links to H2/H3 tags
+		if ($next.prop("tagName") === "H2" || $next.prop("tagName") === "H3") {
+			$next().append($link);
+		}
+	});
+});

--- a/docs/public/js/anchor-links.js
+++ b/docs/public/js/anchor-links.js
@@ -1,6 +1,5 @@
 /*
  * Add visual anchor links to docs-content
- * Solution for issue #945 - https://github.com/keystonejs/keystone/issues/945
  */
 $(function() {
 	// for all anchor tags with name props

--- a/docs/public/styles/entypo.less
+++ b/docs/public/styles/entypo.less
@@ -49,7 +49,7 @@
 	font-size: 2.5em;
 	
 	/* offset font-size */
-	line-height: .5em;
+	line-height: 0;
 	
 	// because of the altered font-size/line-height
 	text-decoration: none;

--- a/docs/public/styles/site/docs.less
+++ b/docs/public/styles/site/docs.less
@@ -61,8 +61,28 @@ h2:first-child {
 	margin-top: 0;
 }
 
+// ANCHOR LINKS
+// ------------------------------
 
-
+.docs-content {
+	.anchor {
+		display: inline-block;
+		vertical-align: text-top;
+		padding-right: 15px;
+		padding-left: 15px;
+		i {
+			display: none;
+			font-size: 1.5em;
+		}
+	}
+	h2, h3 {
+		&:hover {
+			.anchor i {
+				display: inline-block;
+			}
+		}	
+	}
+}
 
 // LISTS
 // ------------------------------

--- a/docs/public/styles/site/intro.less
+++ b/docs/public/styles/site/intro.less
@@ -168,7 +168,6 @@
 	.entypo, .entypo-social {
 		font-size: 48px;
 		margin-right: 6px;
-		vertical-align: middle;
 	}
 }
 


### PR DESCRIPTION
Adding feature suggested by @morenoh149 in #945, which I thought was a pretty good idea.

The anchor links appear when hovering over any heading/subheading in the docs. Tested in both the English and Chinese version of the docs.

This feature programmatically adds the visual links when it finds an `a` tag with a `name` attribute, followed by an `h2` or `h3` tag.

For example it would find code like this:

```html
<a name="routesviews-settingup"></a>
<h3>Setting up your Routes and Middleware</h3>
````

and turn it into this:

```html
<a name="routesviews-settingup"></a>
<h3>Setting up your Routes and Middleware<a class="anchor" href="#routesviews-settingup'"><i class="entypo entypo-link"></i></a></h3>
````

The other two commits fixed the alignment of entypo icons on the language selection bar and the home page. It had been bugging me for a few days. @JedWatson, if you prefer a separate PR for these last two commits just let me know.
