### PR TITLE
stops server.listen() from being called more than once, so cluster works

### DIFF
--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -172,10 +172,10 @@ function start(events) {
 				var httpsReadyMsg = (ssl === 'only') ? keystone.get('name') + ' (SSL) is ready on ' : 'SSL Server is ready on ';
 				
 				if (sslHost) {
-					httpsStarted(httpsReadyMsg + 'https://' + sslHost + ':' + sslPort);
+					keystone.httpsServer.listen(sslPort, sslHost, httpsStarted(httpsReadyMsg + 'https://' + sslHost + ':' + sslPort));
 				} else {
 					var httpsPortMsg = (keystone.get('ssl port')) ? 'port: ' + keystone.get('ssl port') : 'default port 3001';
-					httpsStarted(httpsReadyMsg + httpsPortMsg);
+					keystone.httpsServer.listen(sslPort, httpsStarted(httpsReadyMsg + httpsPortMsg));
 				}
 				
 			}

--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -99,13 +99,22 @@ function start(events) {
 			port = keystone.get('port'),
 			listen = keystone.get('listen'),
 			ssl = keystone.get('ssl');
-
-		keystone.httpServer = app.listen(port || 3000);
-		events.onHttpServerCreated && events.onHttpServerCreated();
-			
-		// start the http server unless we're in ssl-only mode
 		
 		if (ssl !== 'only') {
+			var httpReadyMsg = keystone.get('name') + ' is ready on ';
+			
+			if (host) {
+				httpReadyMsg += 'http://' + host;
+				if (port) {
+					httpReadyMsg += ':' + port;
+				} else {
+					httpReadyMsg += ':3000';
+				}
+			} else if (port){
+				httpReadyMsg += 'port ' + port;
+			} else {
+				httpReadyMsg += 'port 3000';
+			}
 			
 			var httpStarted = function(msg) {
 				return function() {
@@ -113,49 +122,16 @@ function start(events) {
 					serverStarted();
 				};
 			};
-				
-			if (port || port === 0) {
-				
-				app.set('port', port);
-				
-				var httpReadyMsg = keystone.get('name') + ' is ready';
-				
-				if (host) {
-					httpReadyMsg += ' on http://' + host;
-					if (port) {
-						httpReadyMsg += ':' + port;
-					}
-					// start listening on the specified host and port
-					keystone.httpServer.listen(port, host, httpStarted(httpReadyMsg));
-				} else {
-					if (port) {
-						httpReadyMsg += ' on port ' + port;
-					}
-					// start listening on any IPv4 address (INADDR_ANY) and the specified port
-					keystone.httpServer.listen(port, httpStarted(httpReadyMsg));
-				}
-				
-			} else if (host) {
-				// start listening on a specific host address and default port 3000
-				app.set('port', 3000);
-				keystone.httpServer.listen(3000, host, httpStarted(keystone.get('name') + ' is ready on ' + host + ':3000'));
-			} else if (listen) {
-				// start listening to a unix socket
-				keystone.httpServer.listen(listen, httpStarted(keystone.get('name') + ' is ready' + (('string' === typeof listen) ? ' on ' + listen : '')));
-			} else {
-				// default: start listening on any IPv4 address (INADDR_ANY) and default port 3000
-				app.set('port', 3000);
-				keystone.httpServer.listen(3000, httpStarted(keystone.get('name') + ' is ready on default port 3000'));
-			}
 			
+			keystone.httpServer = app.listen(port || 3000, httpStarted(httpReadyMsg));
+			events.onHttpServerCreated && events.onHttpServerCreated();
 		} else {
 			waitForServers--;
 		}
 		
-		
 		if (ssl) {
 			
-		  debug('start the ssl server');
+			debug('start the ssl server');
 			var sslOpts = {};
 			
 			if (keystone.get('ssl cert') && fs.existsSync(keystone.getPath('ssl cert'))) {
@@ -184,22 +160,22 @@ function start(events) {
 					return function() {
 						startupMessages.push(msg);
 						serverStarted();
-						};
 					};
-					
+				};
+				
 				keystone.httpsServer = https.createServer(sslOpts, app);
 				events.onHttpsServerCreated && events.onHttpsServerCreated();
 				
 				var sslHost = keystone.get('ssl host') || host,
 					sslPort = keystone.get('ssl port') || 3001;
-					
+				
 				var httpsReadyMsg = (ssl === 'only') ? keystone.get('name') + ' (SSL) is ready on ' : 'SSL Server is ready on ';
 				
 				if (sslHost) {
-					keystone.httpsServer.listen(sslPort, sslHost, httpsStarted(httpsReadyMsg + 'https://' + sslHost + ':' + sslPort));
+					httpsStarted(httpsReadyMsg + 'https://' + sslHost + ':' + sslPort);
 				} else {
 					var httpsPortMsg = (keystone.get('ssl port')) ? 'port: ' + keystone.get('ssl port') : 'default port 3001';
-					keystone.httpsServer.listen(sslPort, httpsStarted(httpsReadyMsg + httpsPortMsg));
+					httpsStarted(httpsReadyMsg + httpsPortMsg);
 				}
 				
 			}


### PR DESCRIPTION
Node cluster would error out, because app.listen() was called multiple times with the same port. The first time this happens, with the first node in the cluster, it wouldn't error out. However, the second time it happened, the server would error out.

So, I cleaned up start.js to call it only once. It also consolidated the message creation for the http server.

A small note: When I linted it, there were some errors. They were almost all, either, in parts of the code that I did not touch, or for trailing whitespace. Generally, if there were errors, I attempted to keep them consistent.