### PR TITLE
Adding "module root" setting (#652)

### DIFF
--- a/docs/content/en/pages/docs/configuration.jade
+++ b/docs/content/en/pages/docs/configuration.jade
@@ -47,6 +47,14 @@ block content
 					td <code>brand</code> <code class="data-type">String</code>
 					td Displayed in the top left hand corner of the Admin UI
 				tr
+					td <code>module root</code> <code class="data-type">String</code>
+					td
+						p This setting tells Keystone the root path of your app. By default, <code>module root</code> points to the path of the first script that required Keystone within your app. This default may be undesireable at times.
+						p Setting <code>module root</code> allows you to specify a custom root path for your app. Overriding the default <code>module root</code> may be useful, for example, when unit testing your app.
+						p <code>module root</code> is used by Keystone's <code>.getPath()</code> method to resolve/expand the paths of the <code>views</code>, <code>favicon</code>, <code>extensions</code>, <code>ssl cert</code>, <code>ssl key</code>, <code>ssl ca</code>, <code>emails</code>, and <code>updates</code> settings.
+						p When setting a custom <code>module root</code> you may use either an absolute or a relative path.
+						p.note If a relative path is used, it will be considered relative to the location of the script from which the setting was made.
+				tr
 					td <code>nav</code> <code class="data-type">Object</code>
 					td
 						p An object that specifies the navigation structure for the Admin UI. Create a key for each section that should be visible in the primary navigation. Each key's value can be a single list path (as is seen in the URL when you view a list) or an array of list paths. When an array is used, secondary navigation is rendered in the Admin UI.

--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ var Keystone = function() {
 		'headless': false,
 		'logger': 'dev',
 		'auto update': false,
-		'model prefix': null
+		'model prefix': null,
+		'module root': moduleRoot
 	};
 	this._pre = {
 		routes: [],
@@ -103,7 +104,7 @@ var Keystone = function() {
 	
 };
 
-_.extend(Keystone.prototype, require('./lib/core/options')(moduleRoot));
+_.extend(Keystone.prototype, require('./lib/core/options')());
 
 
 /**
@@ -191,7 +192,7 @@ keystone.security = {
 
 Keystone.prototype.import = function(dirname) {
 	
-	var initialPath = path.join(moduleRoot, dirname);
+	var initialPath = path.join(this.get('module root'), dirname);
 	
 	var doImport = function(fromPath) {
 		

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -4,9 +4,10 @@ var path = require('path'),
 	debug = require('debug')('keystone:core:options'),
 	cloudinary = require('cloudinary'),
 	mandrillapi = require('mandrill-api'),
+	callerId = require('caller-id'),
 	utils = require('keystone-utils');
 
-function options(moduleRoot) {
+function options() {
 	
 	var exports = {};
 
@@ -20,6 +21,11 @@ function options(moduleRoot) {
 		'signin success': 'signin redirect',
 		'signout': 'signout url'
 	};
+
+	// Determines if path is absolute or relative
+	function isAbsolutePath(value) {
+		return path.resolve(value) === path.normalize(value).replace(RegExp(path.sep+'$'), '');
+	}
 
 	/**
 	 * Sets keystone options
@@ -91,6 +97,13 @@ function options(moduleRoot) {
 						console.error('\nInvalid Configuration:\nThe `mongo` option must be a mongodb connection string, e.g. mongodb://localhost/db_name\n');
 						process.exit(1);
 					}
+				}
+			break;
+			case 'module root':
+				// if relative path is used, resolve it based on the caller's path
+				if (!isAbsolutePath(value)) {
+					var caller = callerId.getData();
+					value = path.resolve(path.dirname(caller.filePath), value);
 				}
 			break;
 		}
@@ -166,7 +179,7 @@ function options(moduleRoot) {
 
 	exports.expandPath = function(pathValue) {
 		pathValue = ('string' === typeof pathValue && pathValue.substr(0,1) !== path.sep && pathValue.substr(1,2) !== ':\\')
-			? path.join(moduleRoot, pathValue)
+			? path.join(this.get('module root'), pathValue)
 			: pathValue;
 		return pathValue;
 	};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bluebird": "~2.4.2",
     "body-parser": "~1.10.0",
     "bytes": "^1.0.0",
+    "caller-id": "^0.1.0",
     "classnames": "^1.0.0",
     "cloudinary": "~1.1.0",
     "codemirror": "^4.8.0",

--- a/test/module.root.test.js
+++ b/test/module.root.test.js
@@ -1,0 +1,61 @@
+var keystone = require('../'),
+	demand = require('must'),
+	path = require('path'),
+	getExpressApp = require('./helpers/getExpressApp');
+
+describe('Keystone "module root" setting', function () {
+
+	before(function() {
+		getExpressApp();
+	});
+
+	describe('default', function() {
+
+		it('should be set to the path where keystone was required', function() {
+			demand(keystone.get('module root')).to.be(__dirname);
+		});
+
+		it('should be used by keystone.getPath()', function() {
+			var viewsPath = 'relative/path/to/views'
+			keystone.set('views', viewsPath);
+			demand(keystone.getPath('views')).to.be(path.resolve(__dirname, viewsPath));
+		});
+
+	});
+
+	describe('custom with relative path', function() {
+		var customPath = '../..';
+
+		before(function() {
+			keystone.set('module root', customPath);
+		});
+
+		it('should return the custom configured path', function() {
+			demand(keystone.get('module root')).to.be(path.resolve(__dirname, customPath));
+		});
+
+		it('should be used by keystone.getPath() to resolve relative paths', function() {
+			var viewsPath = 'relative/path/to/views'
+			keystone.set('views', viewsPath);
+			demand(keystone.getPath('views')).to.be(path.resolve(__dirname, customPath, viewsPath));
+		});
+	});
+
+	describe('custom with absolute path', function() {
+		var customPath = path.resolve(__dirname, '../..');
+
+		before(function() {
+			keystone.set('module root', customPath);
+		});
+
+		it('should return the custom configured path', function() {
+			demand(keystone.get('module root')).to.be(customPath);
+		});
+
+		it('should be used by keystone.getPath() to resolve relative paths', function() {
+			var viewsPath = 'relative/path/to/views'
+			keystone.set('views', viewsPath);
+			demand(keystone.getPath('views')).to.be(path.resolve(customPath, viewsPath));
+		});
+	});
+});


### PR DESCRIPTION
As was pointed out in issue #652 by @indexzero, Keystone is sensitive to the apps module root path. This "sensitivity" is by design. Keystone utilizes the module root path to resolve the location of a number of files, the path of which is typically specified relative to the module root.

By default, Keystone uses as its root path the location of the first script that required it. While this is not an issue in most circumstances, there are instances in which it may be undesirable. Unit testing your app is one of these circumstances, as explained by @alanshaw in #943.

While we cannot eliminate this "sensitivity", we can provide a means to allow developers to specify a custom root path. That is purpose of this PR, which introduces the new `module root` setting.

The PR includes docs (so I won't bore you with those details here), as well as unit tests for the new feature. It is backwards compatible and does not introduce any breaking changes (AFAICT ... so, please let me know if you find any issues).

I typical don't like to add dependencies to Keystone in my PRs, but I felt that it was merited here. I added as a dependency a module called [caller-id](https://www.npmjs.com/package/caller-id), which I used to determine the path of the calling script, so that we could allow specifying a `module root` relative to the caller.

@indexzero and @alanshaw, please let me know if this works for you.

As always, comments, suggestions and constructive criticism is more than welcome.