### PR TITLE
Add support for starting app with unix socket

### DIFF
--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -79,7 +79,7 @@ function start(events) {
 		onMount && onMount();
 		
 		var startupMessages = ['KeystoneJS Started:'],
-			waitForServers = 2;
+			waitForServers = 3;
 			
 		// Log the startup messages and calls the onStart method
 		
@@ -98,9 +98,10 @@ function start(events) {
 		var host = keystone.get('host'),
 			port = keystone.get('port'),
 			listen = keystone.get('listen'),
-			ssl = keystone.get('ssl');
+			ssl = keystone.get('ssl'),
+			unixSocket = keystone.get('unix socket');
 		
-		if (ssl !== 'only') {
+		if (ssl !== 'only' && !unixSocket) {
 			var httpReadyMsg = keystone.get('name') + ' is ready on ';
 			
 			if (host) {
@@ -129,7 +130,7 @@ function start(events) {
 			waitForServers--;
 		}
 		
-		if (ssl) {
+		if (ssl && !unixSocket) {
 			
 			debug('start the ssl server');
 			var sslOpts = {};
@@ -179,6 +180,27 @@ function start(events) {
 				}
 				
 			}
+			
+		} else {
+			waitForServers--;
+		}
+		
+		if(unixSocket) {
+			var unixSocketStarted = function(msg) {
+				return function() {
+					startupMessages.push(msg);
+					serverStarted();
+				};
+			};
+			var httpReadyMsg = keystone.get('name') + ' is ready on ' + unixSocket;
+			fs.unlink(unixSocket, function(err) {
+				keystone.httpServer = app.listen(unixSocket, unixSocketStarted(httpReadyMsg));
+				events.onSocketServerCreated && events.onSocketServerCreated();
+				fs.chmod(unixSocket,0x777,function(){
+					// set permissions
+				});
+			});
+
 			
 		} else {
 			waitForServers--;

--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -186,21 +186,23 @@ function start(events) {
 		}
 		
 		if(unixSocket) {
+			
 			var unixSocketStarted = function(msg) {
 				return function() {
 					startupMessages.push(msg);
 					serverStarted();
 				};
 			};
+			
 			var httpReadyMsg = keystone.get('name') + ' is ready on ' + unixSocket;
+			
 			fs.unlink(unixSocket, function(err) {
 				keystone.httpServer = app.listen(unixSocket, unixSocketStarted(httpReadyMsg));
 				events.onSocketServerCreated && events.onSocketServerCreated();
-				fs.chmod(unixSocket,0x777,function(){
+				fs.chmod(unixSocket, 0x777, function(){
 					// set permissions
 				});
 			});
-
 			
 		} else {
 			waitForServers--;


### PR DESCRIPTION
Adds option `keystone.set('unix socket','/path/app.socket')` refrenced in #958 

When set, http and https are ignored and the app is started listening to the socket. 

Will add docs if approved.

Should this be 0.3.0 only or ported to 0.2.x?