### PR TITLE
expose express session

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -198,9 +198,11 @@ function mount(mountPath, parentApp, events) {
 		}
 	}
 
-	// expose initialised session options
+	// expose initialised session and options
 	
 	this.set('session options', sessionOptions);
+	this.set('express session', session(sessionOptions)); 
+	
 	
 	// wrangle arguments
 	
@@ -366,7 +368,7 @@ function mount(mountPath, parentApp, events) {
 	app.use(bodyParser.urlencoded({ extended: true }));
 	app.use(methodOverride());
 	app.use(sessionOptions.cookieParser);
-	app.use(session(sessionOptions));
+	app.use(this.get('express session'));
 	app.use(multer({
 		includeEmptyFields: true
 	}));


### PR DESCRIPTION
Adds 
`keystone.set('express session', session(sessionOptions))` 
and updates
`app.use(session(sessionOptions));`
to
`app.use(this.get('express session'));`

Allows use of sessions for sockets, etc.
```
var sharedsession = require("express-socket.io-session");
var sock = require('socket.io')();

var io = sock.attach(keystone.httpServer);

/* set up session middleware */
io.use(sharedsession(keystone.get('express session'), keystone.get('session options').cookieParser));

```