### PR TITLE
set admin page title to project name

### DIFF
--- a/routes/views/home.js
+++ b/routes/views/home.js
@@ -1,10 +1,11 @@
 var keystone = require('../../');
 
 exports = module.exports = function(req, res) {
-
+	
 	keystone.render(req, res, 'home', {
 		section: 'home',
 		page: 'home',
+		title: keystone.get('name') || 'Keystone',
 		orphanedLists: keystone.getOrphanedLists()
 	});
 

--- a/routes/views/item.js
+++ b/routes/views/item.js
@@ -147,9 +147,11 @@ exports = module.exports = function(req, res) {
 					return rel.items.results.length;
 				});
 				
+				var appName = keystone.get('name') || 'Keystone';
+				
 				keystone.render(req, res, 'item', _.extend(viewLocals, {
 					section: keystone.nav.by.list[req.list.key] || {},
-					title: 'Keystone: ' + req.list.singular + ': ' + req.list.getDocumentName(item),
+					title: appName + ': ' + req.list.singular + ': ' + req.list.getDocumentName(item),
 					page: 'item',
 					list: req.list,
 					item: item,

--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -110,9 +110,11 @@ exports = module.exports = function(req, res) {
 				download_link += '?' + downloadParams;
 			}
 			
+			var appName = keystone.get('name') || 'Keystone';
+			
 			keystone.render(req, res, 'list', _.extend(viewLocals, {
 				section: keystone.nav.by.list[req.list.key] || {},
-				title: 'Keystone: ' + req.list.plural,
+				title: appName + ': ' + req.list.plural,
 				page: 'list',
 				link_to: link_to,
 				download_link: download_link,


### PR DESCRIPTION
A small change until we move to a complete SPA.  Sets the Admin UI page title to the project name if available.