### PR TITLE
Update ui-cloudinaryimage.js

### DIFF
--- a/public/js/common/ui-cloudinaryimage.js
+++ b/public/js/common/ui-cloudinaryimage.js
@@ -31,7 +31,7 @@ jQuery(function($) {
 		var action = false;
 		
 		var imageFieldHTML = '<div class="image-preview new">' +
-				'<div class="img-thumbnail placeholder-wrap"><img class="placeholder' + ( !window.FileReader ? ' no-preview' : '' ) + '" /><div class="ion-upload upload-pending"></div></div></div>'
+				'<div class="img-thumbnail placeholder-wrap"><img class="placeholder' + ( !window.FileReader ? ' no-preview' : '' ) + '" /><div class="ion-upload upload-pending"></div></div></div>' +
 			'</div>';
 		
 		var removeNewImage = function() {


### PR DESCRIPTION
The missing "+" to join the strings on this line was giving me errors in Chrome in production and prevented the rest of the script from running (and therefore could not upload to Cloudinary). Adding the "+" fixes it....