### PR TITLE
allow dependsOn to check for numeric value

### DIFF
--- a/fields/types/select/SelectField.js
+++ b/fields/types/select/SelectField.js
@@ -14,7 +14,7 @@ module.exports = Field.create({
 	valueChanged: function(newValue) {
 		this.props.onChange({
 			path: this.props.path,
-			value: newValue
+			value: (this.props.numeric) ? Number(newValue) : newValue
 		});
 	},
 	


### PR DESCRIPTION
 `{ dependsOn: { sortBy: 2 } }` fails since the value is always a string.

This checks if `this.props.numeric` is set and saves the prop as a Number on `this.props.onChange`