### PR TITLE
fixed typical example of a connection string

### DIFF
--- a/docs/content/en/pages/docs/configuration.jade
+++ b/docs/content/en/pages/docs/configuration.jade
@@ -212,7 +212,7 @@ block content
 					td <code>mongo</code> <code class="data-type">String</code>
 					td
 						p The url for your MongoDB connection.
-						p You should typically set this to <code class="default-value">"mongodb://localhost/your-db" || process.env.MONGO_URI</code>
+						p You should typically set this to <code class="default-value">process.env.MONGO_URI || "mongodb://localhost/your-db"</code>
 				tr
 					td <code>model prefix</code> <code class="data-type">String</code>
 					td

--- a/docs/content/zh/pages/docs/configuration.jade
+++ b/docs/content/zh/pages/docs/configuration.jade
@@ -213,7 +213,7 @@ block content
 					td <code>mongo</code> <code class="data-type">String</code>
 					td
 						p MongoDB连接的url。
-						p 一般应该设为<code class="default-value">"mongodb://localhost/your-db" || process.env.MONGO_URI</code>
+						p 一般应该设为<code class="default-value">process.env.MONGO_URI || "mongodb://localhost/your-db"</code>
 				tr
 					td <code>model prefix</code> <code class="data-type">String</code>
 					td


### PR DESCRIPTION

In the docs, the typical example of a connection string for the mongo option will crash the app 
if used as written when deploying to a platform such as heroku.

the localhost connection string should always be the last value assigned to the mongo option (as done
in the mount function when the mongo option is not set).  

