### PR TITLE
factor out style task from lint task. Ignore project directories that co...

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,8 @@
 {
-  "excludeFiles": ["coverage", "fields", "admin", "docs", "test", "node_modules", "public/build", "public/js/lib", "public/js/build"],
+	"excludeFiles": [
+		"coverage", "docs", "admin/src/components/", "admin/src/views/",
+		"node_modules", "public/build", "public/js/lib", "public/js/build", "fields"
+	],
 	"preset": "yandex",
 	"disallowMultipleVarDecl": null,
 	"disallowMultipleLineBreaks": null,

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ lint:
 	@echo "Running JSHint ..."
 	@$(JSXHINT_CMD) --reporter $(JSHINT_REPORTER) .
 
+style:
 	@echo "\nRunning JSCS ..."
 	@$(JSCS_CMD) .
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "gulp-uglify": "^1.1.0",
     "jade": "~1.9.2",
     "jquery": "~2.1.3",
+    "jscs": "^1.11.3",
     "keystone-utils": "~0.1.13",
     "knox": "~0.9.2",
     "less-middleware": "~1.0.4",


### PR DESCRIPTION
factor out style task from lint task. Ignore project directories that contain jsx files.

We should also investigate using the `--esprima=esprima-fb` option http://jscs.info/overview.html#-esprima- For handling jsx in js files.