### PR TITLE
throw error to user if Amazon doesn't save a file correctly

### DIFF
--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -269,8 +269,14 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 			'x-amz-acl': 'public-read'
 		}, function(err, res) {
 
-			if (res) res.resume();
 			if (err) return callback(err);
+			if (res) {
+				if (res.statusCode !== 200) {
+					return callback(new Error('Amazon returned Http Code: ' + res.statusCode));
+				} else {
+					res.resume();
+				}
+			}
 
 			var protocol = (field.s3config.protocol && field.s3config.protocol + ':') || '',
 				url = res.req.url.replace(/^https?:/i, protocol);


### PR DESCRIPTION
This will show the user an error if the file failed for whatever reason.
![screenshot 2015-02-11 19 04 53](https://cloud.githubusercontent.com/assets/587438/6161110/e7b586a0-b220-11e4-92b4-fd8e87094786.png)
