### PR TITLE
Fixing relationship field dup key test

### DIFF
--- a/fields/types/relationship/test/server.js
+++ b/fields/types/relationship/test/server.js
@@ -40,7 +40,7 @@ exports.testFieldType = function(List) {
 			text: 'value',
 			testRelationship: testItem._id
 		}).save(function(err, data) {
-			err.err.must.match(/insertDocument :: caused by :: 11000 E11000 duplicate key error.*testRelationship_1/);
+			demand(err.code).equal(11000);
 			done();
 		});
 	});


### PR DESCRIPTION
Change to check `err.code` (which is always `11000` for dup key errors) instead of `err.err`, because the actual message sometimes differs from platform to platform.