### PR TITLE
fixed missing dot in regex for keystone urls

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -221,7 +221,7 @@ function mount(mountPath, parentApp, events) {
 	
 	if (mountPath) {
 		//fix root-relative keystone urls for assets (gets around having to re-write all the keystone templates)
-		parentApp.all(/^\/keystone($|\/*)/, function(req, res, next) {
+		parentApp.all(/^\/keystone($|\/.*)/, function(req, res, next) {
 			req.url = mountPath + req.url;
 			next();
 		});


### PR DESCRIPTION
The current regex: /^\/keystone($|\/*)/

Without the missing dot in the regex, paths like /keystoneaaaa will match the regex in addition 
to all /keystone/* urls. 

