### PR TITLE
fixed undefined keystone variable

### DIFF
--- a/lib/core/connect.js
+++ b/lib/core/connect.js
@@ -19,7 +19,7 @@ function connect() {
 		'Due to changes in Express 4, "keystone.connect()" no longer works as expected.\n\n'
 		'See http://localhost:8080/docs/configuration#options-project for more information.'
 
-	keystone.console.err('Deprecation Warning', warningMsg);
+	this.console.err('Deprecation Warning', warningMsg);
 
 	// detect type of each argument
 	for (var i = 0; i < arguments.length; i++) {


### PR DESCRIPTION

Throws an error when starting the app since keystone is not defined in connect.js.

