### PR TITLE
Check for existence req.user on DELETE action, otherwise it will fail wh...

### DIFF
--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -176,7 +176,7 @@ exports = module.exports = function(req, res) {
 
 			var id = req.body.id || req.query.id;
 			
-			if (id === req.user.id) {
+			if (req.user && id === req.user.id) {
 				return sendError('You can not delete yourself');
 			}
 			


### PR DESCRIPTION
Was doing a check for `id === req.user.id` on delete action, which returns an error if you have `keystone.auth` disabled. Added a check to make sure that `req.user` exists. :+1: