### PR TITLE
relationship field should update when order, but not contents, has changed

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -157,14 +157,10 @@ relationship.prototype.updateItem = function(item, data) {
 
 		_new = _.compact(_new);
 
-		// remove ids
-		_.difference(_old, _new).forEach(function(val) {
-			arr.pull(val);
-		});
-		// add new ids
-		_.difference(_new, _old).forEach(function(val) {
-			arr.push(val);
-		});
+		// Only update if the lists aren't the same
+		if (!_.isEqual(_old, _new)) {
+			item.set(this.path, _new);
+		}
 
 	} else {
 		if (data[this.path]) {


### PR DESCRIPTION
Prior to this change the relationship field wasn't being updated when only the order was changed. The only potential gotcha that I'm aware of is that this no longer updates the array in-place. I don't see why this would be necessary, especially since everything is moving to React, but I could be mistaken.