### PR TITLE
 Adding Keystone "frame guard" option (0.2.x)

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ var Keystone = function() {
 		'headless': false,
 		'logger': 'dev',
 		'auto update': false,
-		'model prefix': null
+		'model prefix': null,
+		'frame guard': 'sameorigin'
 	};
 	this._pre = {
 		routes: [],

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -357,6 +357,13 @@ function mount(mountPath, parentApp, events) {
 		app.use(this.get('session'));
 	}
 	
+	// Add 'X-Frame-Options' to response header for ClickJacking protection
+
+	if(this.get('frame guard')) {
+		debug('enabling frame guard');
+		app.use(require('../security/frameGuard')(this));
+	}
+
 	// Process 'X-Forwarded-For' request header
 	
 	if (this.get('trust proxy') === true) {

--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -77,6 +77,21 @@ function options(moduleRoot) {
 					}
 				}
 			break;
+			case 'frame guard':
+				var validFrameGuardOptions = ['deny', 'sameorigin'];
+
+				if (value === true) {
+					value = 'deny';
+				}
+				if (utils.isString(value)) {
+					value = value.toLowerCase();
+					if (validFrameGuardOptions.indexOf(value) < 0) {
+						value = false;
+					}
+				} else if ('boolean' !== typeof value) {
+					value = false;
+				}
+			break;
 		}
 		
 		this._options[key] = value;

--- a/lib/security/frameGuard.js
+++ b/lib/security/frameGuard.js
@@ -1,0 +1,24 @@
+/**
+ * Adds iframe protection headers to the response
+ *
+ * ####Example:
+ *
+ *     app.use(keystone.security.frameGuard(keystone));
+ *
+ * @param {app.request} req
+ * @param {app.response} res
+ * @param {function} next
+ * @api public
+ */
+
+exports = module.exports = function(keystone) {
+	return function frameGuard(req, res, next) {
+		var options = keystone.get('frame guard');
+
+		if (options) {
+			res.header('x-frame-options', options);
+		}
+		
+		next();
+	};
+};

--- a/test/lib/security/frameGuard-test.js
+++ b/test/lib/security/frameGuard-test.js
@@ -1,0 +1,100 @@
+var keystone = require('../../..'),
+	demand = require('must'),
+	request = require('supertest'),
+	demand = require('must'),
+	getExpressApp = require('../../helpers/getExpressApp'),
+	app = getExpressApp(),
+	frameGuard = require('../../../lib/security/frameGuard');
+
+describe('Keystone "frame guard" setting', function () {
+	before(function() {
+		app.use(frameGuard(keystone));
+		app.get('/', function(req, res) {
+			res.send('OK');
+		});
+	});
+
+	describe('default setting', function() {
+
+		it('should be "sameorigin"', function() {
+			demand(keystone.get('frame guard')).to.be('sameorigin');
+		});
+
+	});
+
+	describe('keystone.set("frame guard")', function() {
+
+		it('should allow setting to "sameorigin"', function() {
+			keystone.set('frame guard', 'sameorigin');
+			demand(keystone.get('frame guard')).to.be('sameorigin');
+		});
+
+		it('should allow setting to "deny"', function() {
+			keystone.set('frame guard', 'deny');
+			demand(keystone.get('frame guard')).to.be('deny');
+		});
+
+		it('should allow setting to TRUE, converts to "deny"', function() {
+			keystone.set('frame guard', true);
+			demand(keystone.get('frame guard')).to.be('deny');
+		});
+
+		it('should allow setting to FALSE', function() {
+			keystone.set('frame guard', false);
+			demand(keystone.get('frame guard')).to.be(false);
+		});
+
+		it('should translate invalid options to FALSE', function() {
+			keystone.set('frame guard', 'xxx');
+			demand(keystone.get('frame guard')).to.be(false);
+			keystone.set('frame guard', 999);
+			demand(keystone.get('frame guard')).to.be(false);
+			keystone.set('frame guard', []);
+			demand(keystone.get('frame guard')).to.be(false);
+			keystone.set('frame guard', {});
+			demand(keystone.get('frame guard')).to.be(false);
+		});
+
+	});
+
+	describe('X-Frame-Options header', function() {
+
+		it('should be set to "deny" when "frame guard" is "deny"', function(done) {
+			keystone.set('frame guard', 'deny');
+			request(app)
+				.get('/')
+				.expect('x-frame-options', 'deny')
+				.expect(200, done);
+		});
+
+		it('should be set to "sameorigin" when "frame guard" is "sameorigin"', function(done) {
+			keystone.set('frame guard', 'sameorigin');
+			request(app)
+				.get('/')
+				.expect('x-frame-options', 'sameorigin')
+				.expect(200, done);
+		});
+
+		it('should be set to "deny" when "frame guard" is TRUE', function(done) {
+			keystone.set('frame guard', true);
+			request(app)
+				.get('/')
+				.expect('x-frame-options', 'deny')
+				.expect(200, done);
+		});
+
+		it('should not be set when "frame guard" is FALSE', function(done) {
+			keystone.set('frame guard', false);
+			request(app)
+				.get('/')
+				.expect(function(res) {
+					if (res.headers['x-frame-options']) {
+						return 'X-Frame-Options key exists';
+					}
+				})
+				.expect(200, done);
+		});
+
+	});
+
+});


### PR DESCRIPTION
Added new Keystone frame guard option and tests to `0.2.x` branch.

Intended as a fix for #1086.