### PR TITLE
Removing unnecessary debug

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -360,7 +360,6 @@ function mount(mountPath, parentApp, events) {
 	// Add 'X-Frame-Options' to response header for ClickJacking protection
 
 	if(this.get('frame guard')) {
-		debug('enabling frame guard');
 		app.use(require('../security/frameGuard')(this));
 	}
 


### PR DESCRIPTION
I thought we had introduced the use of `debug()` on `0.2.x` ... I was wrong. ... Sorry about that! :-(