### PR TITLE
Fixing issue when deploying Keystone app to OpenShift

### DIFF
--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -125,7 +125,11 @@ function start(events) {
 				};
 			};
 			
-			keystone.httpServer = app.listen(port || 3000, httpStarted(httpReadyMsg));
+			if (host) {
+				keystone.httpServer = app.listen(port || 3000, host, httpStarted(httpReadyMsg));
+			} else {
+				keystone.httpServer = app.listen(port || 3000, httpStarted(httpReadyMsg));
+			}
 			events.onHttpServerCreated && events.onHttpServerCreated();
 		} else {
 			waitForServers--;


### PR DESCRIPTION
Fixing issue #1118.

OpenShift requires that the `host/ip` argument be explicitly passed when calling `app.listen()`. When available, Keystone uses `process.env.OPENSHIFT_NODEJS_IP` to set the `host` option. This PR passes the value of the `host` option to `app.listen()` ONLY when it is set, effectively correcting the issue when deploying to OpenShift, while maintaining backwards compatibility.