### PR TITLE
Temporary fix for linking non-editable relationship fields with multiple...

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -143,19 +143,15 @@ module.exports = Field.create({
 		if (!this.state.ready) {
 			return this.renderLoadingUI();
 		}
-		// TODO expand IDs
-		if (this.props.many) {
-			// a(href='/keystone/' + refList.path + '/' + item.get(field.path), data-ref-path=refList.path).ui-related-item= item.get(field.path)
-			return <div className='field-value'>{this.props.value}</div>;
-		} else if (this.props.many && this.props.value.length) {
-			// var body = [];
-			// 
-			// _.each(this.props.value, function (value) {
-			// 	body.push(<a href={'/keystone/' + this.props.refList.path + '/' + value} className='ui-related-item'>{value}</a>);
-			// }, this);
-			// 
-			// return value;
-			return <div className='field-value'>{this.props.value}</div>;
+		// Todo: this is only a temporary fix, remodel
+		if (this.state.expandedValues && this.state.expandedValues.length) {
+			var body = [];
+			
+			_.each(this.state.expandedValues, function (item) {
+				body.push(<a href={'/keystone/' + this.props.refList.path + '/' + item.value} className='ui-related-item'>{item.label}</a>);
+			}, this);
+			
+			return body;
 		} else {
 			return <div className='field-value'>(not set)</div>;
 		}


### PR DESCRIPTION
... values to their respective resources.

ATM if you set a relationship field to `{noedit:true, many:true}` it is rendered as a sequence of `<span>`s, i.e. they're all shown inline, which is just horrible. Also, no links to the respective resources are created.

As a temporary fix I uncommented the relevant lines starting from https://github.com/keystonejs/keystone/blob/master/fields/types/relationship/RelationshipField.js#L151 (and also fixed some errors), but saw that this would revert commit e5905fbcf2277f29406c53dd5e2fa5c4142c3c57. @jossmac do you remember what the error was, and why you chose for this solution?? TBH I think the only thing wrong with the previous code (i.e. the one you commented) was that it returned an undeclared `value` variable instead of `body` which it should have.

Just to be clear: this PR **DEFINITELY** needs to be reviewed, I really don't know the first thing about how the fields are rendered, my changes are a result of trial-and-error in an existing project, but I have NO IDEA of its impact on the relationship field at large.