### PR TITLE
Localfile enhancements

### DIFF
--- a/docs/content/en/pages/docs/database.jade
+++ b/docs/content/en/pages/docs/database.jade
@@ -1105,7 +1105,16 @@ block content
 				p <code>prefix</code> <code class="data-type">String</code> - the path prefix in browser, if it different with <code>dest</code>
 				p <code>datePrefix</code> <code class="data-type">String</code> - if set, prefixes the file name with the current date in this format (see <a href="http://momentjs.com" target="_blank">moment.js</a> for format options)
 				p <code>allowedTypes</code> <code class="data-type">Array</code> of <code class="data-type">String</code> - optional white-list of allowed mime types for uploaded file
-				p <code>filename</code> <code class="data-type">Function</code> - function with arguments current model and client file name to return the new filename to upload.
+				p <code>filename</code> <code class="data-type">Function</code> - function with two arguments: current model and file object to return the new filename to upload.
+					pre: code.language-javascript.
+						{
+							type: Types.LocalFile,
+							dest: '/data/files',
+							prefix: '/files/',
+							filename: function(item, file){
+								return item.id + '.' + file.extension
+							}
+						}
 				p <code>format</code> <code class="data-type">Function</code> - function with two arguments: current model and file object to return representation of this file in Admin UI.
 					pre: code.language-javascript.
 						{

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -116,6 +116,7 @@ localfile.prototype.addToSchema = function() {
 	var paths = this.paths = {
 		// fields
 		filename:		this._path.append('.filename'),
+		originalname:		this._path.append('.originalname'),
 		path:			this._path.append('.path'),
 		size:			this._path.append('.size'),
 		filetype:		this._path.append('.filetype'),
@@ -128,6 +129,7 @@ localfile.prototype.addToSchema = function() {
 	
 	var schemaPaths = this._path.addTo({}, {
 		filename:		String,
+		originalname :		String,
 		path:			String,
 		size:			Number,
 		filetype:		String
@@ -288,7 +290,6 @@ localfile.prototype.updateItem = function(item, data) {
  */
 
 localfile.prototype.uploadFile = function(item, file, update, callback) {
-
 	var field = this,
 		prefix = field.options.datePrefix ? moment().format(field.options.datePrefix) + '-' : '',
 		filename = prefix + file.name,
@@ -315,6 +316,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 
 			var fileData = {
 				filename: filename,
+				originalname: file.originalname,
 				path: field.options.dest,
 				size: file.size,
 				filetype: filetype

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -307,7 +307,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 	var doMove = function(callback) {
 		
 		if ('function' === typeof field.options.filename) {
-			filename = field.options.filename(item, filename);
+			filename = field.options.filename(item, file);
 		}
 
 		fs.move(file.path, path.join(field.options.dest, filename), { clobber: field.options.overwrite }, function(err) {


### PR DESCRIPTION
A few minor tweaks to the localfile field type. With this the original filename is automatically saved to the DB as well. This is necessary to allow more advanced custom collision resolutions. Also, the full file object is passed to the `options.filename` function, in symmetry with `options.format` and to allow more complex file name generators. I updated the docs at once as well.
If anything else needs to be done, let me know.