### PR TITLE
Bugs with rendering of document name on EditForm

### DIFF
--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -60,15 +60,9 @@ var EditForm = React.createClass({
 				React.createElement(Fields[nameField.type], nameFieldProps)
 			);
 			
-		} else if (nameField && nameField.type == 'name') {
-			var nameValue = this.props.data.fields[nameField.path] || {};
-			nameValue = _.compact([nameValue.first, nameValue.last]).join(' ');
-			return wrapNameField(
-				<h2 className="form-heading name-value">{nameValue || '(no name)'}</h2>
-			);
 		} else {
 			return wrapNameField(
-				<h2 className="form-heading name-value">{this.props.data.fields[namePath] || '(no name)'}</h2>
+				<h2 className="form-heading name-value">{this.props.data.name || '(no name)'}</h2>
 			);
 		}
 	},


### PR DESCRIPTION
AFAICT [EditForm#renderNameField](https://github.com/keystonejs/keystone/blob/5211a34f19104e9b7f130fe9d2bcb49725bab4df/admin/src/components/EditForm.js#L36) can be simplified a lot, since `this.props.data` already contains a `name` field with the (constructed, if so necessary) name value. Also, if `this.props.data.name` would be used instead of constructing the name on the fly like it is ATM a number of bugs would be solved:

1.  "(No name)" is shown if the name should be constructed from a field with `{hidden:true}`
1.  "(No name)" is shown if the name should be constructed from a field starting with a `_` (underscore)
1.  "(No name)" is shown if the name should be constructed from a virtual field

These bugs occur since none of the hidden fields and virtuals are passed to the EditForm#renderNameField.

However, I have no idea whatsoever where `this.props.data.name` gets its value from. I've tested it with several models, with several kinds of name mappings and it _seems_ to be correctly populated all of the times, but since I don't know where it comes from I can't be sure and could use some guidance from someone who does know.