### PR TITLE
Markdown fields don't honor collapse config

### DIFF
--- a/fields/types/markdown/MarkdownField.js
+++ b/fields/types/markdown/MarkdownField.js
@@ -9,6 +9,10 @@ module.exports = Field.create({
 	
 	displayName: 'MarkdownField',
 	
+	shouldCollapse : function() {
+		return this.props.collapse && !this.props.value.md;
+	},
+	
 	componentDidMount: function() {
 		var markdownOptions = {
 			autofocus: false,


### PR DESCRIPTION
Since the `this.props.value` for a markdown field is an object the default `!this.props.value` check in `shouldCollapse()` always returns `true`. That's... not helpful. This PR provides an overridden implementation that comprehends the object version of `this.props.value` and uses the `md` field as the conditional.

You can repro the original issue by creating a model with the following config. When rendered by the Admin UI it will never be shown in the collapsed state.

```js
var Model = new keystone.List("Model");

Model.add({
    markdown : {
        type : keystone.types.Markdown,
        collapse : true
    }
});
```

I haven't written any tests for this because this change only affects client rendering and I don't see any existing tests for that.

**Note:** #1071 applies here as well, when you click the "Add" link and it renders the markdown field it doesn't have any wysiwyg controls. I'm looking into the causes of that and will hopefully send a separate PR for that.
