### PR TITLE
Markdown respects height config

### DIFF
--- a/fields/types/markdown/MarkdownField.js
+++ b/fields/types/markdown/MarkdownField.js
@@ -46,6 +46,8 @@ var renderMarkdown = function (component) {
 		autofocus: false,
 		savable: false,
 		resize: 'vertical',
+		height: component.props.height,
+		hiddenButtons: component.props.toolbarOptions.hiddenButtons,
 
 		// Heading buttons
 		additionalButtons: [{
@@ -94,18 +96,24 @@ module.exports = Field.create({
 	
 	// only have access to `refs` once component is mounted
 	componentDidMount: function() {
-		renderMarkdown(this);
+		if(this.props.wysiwyg) {
+			renderMarkdown(this);
+		}
 	},
 
 	// only have access to `refs` once component is mounted
 	componentDidUpdate : function() {
-		renderMarkdown(this);
+		if(this.props.wysiwyg) {
+			renderMarkdown(this);
+		}
 	},
 	
 	renderField: function() {
 		var styles = {
-			padding: 8
+			padding: 8,
+			height: this.props.height
 		};
+		
 		return (
 			<div className="md-editor">
 				<textarea name={this.props.paths.md} style={styles} defaultValue={this.props.value.md} ref="markdownTextarea" className="form-control markdown code"></textarea>

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -21,6 +21,12 @@ function markdown(list, path, options) {
 
 	this.toolbarOptions = options.toolbarOptions || {};
 	this.height = options.height || 90;
+
+	// since wysiwyg option can be falsey this needs to use `in` instead of ||
+	this.wysiwyg = ("wysiwyg" in options) ? options.wysiwyg : true;
+
+	this._properties = [ 'wysiwyg', 'height', 'toolbarOptions' ];
+
 	markdown.super_.call(this, list, path, options);
 
 }


### PR DESCRIPTION
Told markdown it should respect the `height` option that was already being managed on the server but not sent to the client. Then passed it through to the markdown editor so it'd respect it.

Also taught markdown fields how not to be `wysiwyg` but kept existing behavior of defaulting to `wysiwyg`. Doing this required slightly more work than a usual option (because of backcompat & falsiness) but isn't super-scary or anything. Height is also maintained when `wysiwyg` is disabled.

Also sending `toolbarOptions` down to the client. It was in the docs but as far as I can tell it wasn't plumbed through in the React component for markdown fields. Only supporting `toolbarOptions.hiddenButtons` for now since that is all that is in the docs.

MarkdownField.js has no client tests, so I haven't written any.