### PR TITLE
Allow asynchronous callbacks for `value` methods in fields

### DIFF
--- a/docs/content/en/pages/docs/database.jade
+++ b/docs/content/en/pages/docs/database.jade
@@ -498,15 +498,22 @@ block content
 				tr
 					td <code>value</code> <code class="data-type">Function</code>
 					td
-						p The function to generate the field value when a watched path is changed. Must return the new value.
+						p The function to generate the field value when a watched path is changed. Must return the new value, or accept a node-style <code>callback</code> argument, which can be called to set the field value asynchronously.
 						p The <code>this</code> context of the function will be the item being saved.
-						.code-header: h4 Example
+						.code-header: h4 Example (synchronous)
 						pre: code.language-javascript
 							| function () {
 							|     return this.total<=this.totalreceived ? true:false;
 							| }
-			
-			//- TODO: Documentation for field methods
+						.code-header: h4 Example (asynchronous)
+						pre: code.language-javascript
+							| function (callback) { // BEWARE: MUST be called "callback" to allow asynchronous execution
+							|	list.model.findById(this.createdBy).exec(function(err, user){
+							|		callback(err, user.name + "-" + Date.now());
+							|	});
+							| }
+
+	//- TODO: Documentation for field methods
 			
 			a(name="fields-underscoremethods")
 			h3 Underscore Methods

--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -10,6 +10,7 @@ var _ = require('underscore'),
 	fs = require('fs'),
 	keystone = require('../../'),
 	utils = require('keystone-utils'),
+	di = require("../../lib/asyncdi"),
 	compiledTemplates = {};
 
 
@@ -202,8 +203,15 @@ Field.prototype.getPreSaveWatcher = function() {
 		if (!applyValue(this)) {
 			return next();
 		}
-		this.set(field.path, field.options.value.call(this));
-		next();
+		di(field.options.value).call(this, function(err, val){
+			if(err){
+				console.error('\nError: ' +
+				'Watch set with value method for ' + field.list.key + '.' + field.path + ' (' + field.type + ') throws error:' + err);
+			}else{
+				this.set(field.path, val);
+			}
+			next();
+		}.bind(this));
 	};
 
 };


### PR DESCRIPTION
If I declare a field to watch a relationship field it only receives the `id` of the selected relationship, however in most cases you'd want to use the `name` field or another field value. Unfortunately since the  result of the `value` option is used synchronously you can't use the passed in id to look up the relevant document either.

E.g.:

```js
//file: models/representations.js
var Representation = new keystone.List( "Representation", {
  track : true
} );
Representation.add({
  name : {
    type     : String,
    watch    : "assessment",
    value    : function(){
        //I'd like to do this, but this.assessment is an id
        return this.assessment.name + " - " + Date.now();
    }
  },

  assessment : {
    type     : Types.Relationship,
    ref      : "Assessment"
  }
});
```

Not sure what the best solution would be. One possibility would be to modify [this line](https://github.com/keystonejs/keystone/blob/2ffbbbfefafbd9b92b0e9e5f93ea5d3d1ea95e2f/fields/types/Type.js#L205) to an asynchronous one, e.g.

```js
//file: fields/types/Type.js
field.options.value.call(this, function(value){
  this.set(field.path, value);
}.bind(this));
```

In which case the `value` field option is responsible for calling the callback:

```js
//file: models/representations.js
    value    : function(callback){
        //retrieve the assessment document using this.assessment
        callback(results);
    }
```

