### PR TITLE
Tasks as NPM scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: ["0.11", "0.10"]
-script: "make test-travis"
+script: "npm run test-cov && make test-travis"
 
 notifications:
   email: ["jed@keystonejs.com"]

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,4 @@
-ISTANBUL_CMD = node_modules/istanbul/lib/cli.js cover
-JSXHINT_CMD = node_modules/jsxhint/cli.js
-JSCS_CMD = node_modules/.bin/jscs
-JSCS_REPORTER = console
-MOCHA_CMD = node_modules/mocha/bin/_mocha
-JSHINT_REPORTER = node_modules/jshint-stylish/stylish.js
-
-default: test
-
-test:
-	$(MOCHA_CMD)
-
-lint:
-	@echo "Running JSHint ..."
-	@$(JSXHINT_CMD) --reporter $(JSHINT_REPORTER) .
-
-style:
-	@echo "\nRunning JSCS ..."
-	@$(JSCS_CMD) .
-
-test-cov: clean
-	@$(ISTANBUL_CMD) $(MOCHA_CMD) --
-
-test-travis: test-cov
+test-travis:
 	if test -n "$$CODECLIMATE_REPO_TOKEN"; then codeclimate < coverage/lcov.info; fi
 
-clean:
-	rm -rf coverage
-
-.PHONY: default lint test test-cov test-travis clean
+.PHONY: test-travis

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "mocha": "2.1.0",
     "must": ">= 0.12 < 1",
     "reactify": "~1.0.0",
+    "rimraf": "^2.3.1",
     "should": "^5.0.1",
     "sinon": "~1.12.2",
     "supertest": "~0.15.0",
@@ -116,7 +117,11 @@
     "url": "https://github.com/keystonejs/keystone/issues"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "jsxhint --reporter=node_modules/jshint-stylish/stylish.js .",
+    "style": "jscs .",
+    "test-cov": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha",
+    "clean": "rimraf ./coverage"
   },
   "engines": {
     "node": ">= 0.10.28",


### PR DESCRIPTION
Because Makefiles are prejudiced against windows users. Reqired adding rimraf as a devDependency but that's not the worst thing in the world.

Travis config file changes are somewhat speculative at this point, but I can tweak once Travis blows up.