### PR TITLE
Asyncdi minor tweaks and fixes

### DIFF
--- a/lib/asyncdi.js
+++ b/lib/asyncdi.js
@@ -16,8 +16,8 @@ var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
  * @param  {Function} fn
  * @return {Wrapper}
  */
-exports = module.exports = function(fn) {
-	return new Wrapper(fn);
+exports = module.exports = function(fn, context) {
+	return new Wrapper(fn, context);
 };
 
 /**

--- a/lib/asyncdi.js
+++ b/lib/asyncdi.js
@@ -122,7 +122,11 @@ _.extend(Wrapper.prototype, {
 			if (callback) {
 				// If a callback is provided, it must use the error-first arguments pattern.
 				// The return value of the function will be the second argument.
-				callback(null, this.fn.apply(context, this._arguments));
+				try {
+					callback(null, this.fn.apply(context, this._arguments));
+				} catch(e) {
+					callback(e);
+				}
 			} else {
 				// If no callback is provided simply return the result of the function
 				return this.fn.apply(context, this._arguments);

--- a/test/lib/asyncdi_test.js
+++ b/test/lib/asyncdi_test.js
@@ -4,6 +4,8 @@ var demand = require('must'),
 var fn_basic = function() { return true; };
 var fn_async = function(callback) { callback(null, true) };
 var fn_one = function(one) { return true; };
+var fn_scope = function(){ return this; };
+var scope = {};
 
 describe('AsyncDI', function() {
 	describe('new Wrapper', function() {
@@ -59,4 +61,20 @@ describe('AsyncDI', function() {
 			demand(di(fn_one).requires.two).be.undefined();
 		});
 	});
-})
+	describe('(fn_scope).call(scope, callback)', function(){
+		it('must return scope', function(done){
+			di(fn_scope).call(scope, function(err, val){
+				demand(val).equal(scope);
+				done();
+			});
+		});
+	});
+	describe('(fn_scope, scope).call(callback)', function(){
+		it('must return scope', function(done){
+			di(fn_scope, scope).call(function(err, val){
+				demand(val).equal(scope);
+				done();
+			});
+		});
+	});
+});

--- a/test/lib/asyncdi_test.js
+++ b/test/lib/asyncdi_test.js
@@ -1,10 +1,13 @@
 var demand = require('must'),
 	di = require('../../lib/asyncdi');
 
+var thrownErr = new Error("Should've been caught by asyncdi");
+
 var fn_basic = function() { return true; };
-var fn_async = function(callback) { callback(null, true) };
+var fn_async = function(callback) { setTimeout(callback, 500, null, true) };
 var fn_one = function(one) { return true; };
 var fn_scope = function(){ return this; };
+var fn_error = function() { throw thrownErr };
 var scope = {};
 
 describe('AsyncDI', function() {
@@ -73,6 +76,14 @@ describe('AsyncDI', function() {
 		it('must return scope', function(done){
 			di(fn_scope, scope).call(function(err, val){
 				demand(val).equal(scope);
+				done();
+			});
+		});
+	});
+	describe('(fn_error).call(callback)', function(){
+		it('must return thrownErr', function(done){
+			di(fn_error).call(function(err, val){
+				demand(err).equal(thrownErr);
 				done();
 			});
 		});

--- a/test/lib/asyncdi_test.js
+++ b/test/lib/asyncdi_test.js
@@ -9,6 +9,7 @@ var fn_one = function(one) { return true; };
 var fn_scope = function(){ return this; };
 var fn_error = function() { throw thrownErr };
 var scope = {};
+var notAFunction = {};
 
 describe('AsyncDI', function() {
 	describe('new Wrapper', function() {
@@ -19,6 +20,13 @@ describe('AsyncDI', function() {
 	describe('()', function() {
 		it('must be an instance of Wrapper', function() {
 			di(fn_basic).must.be.an.instanceof(di.Wrapper);
+		});
+	});
+	describe('(notAFunction)', function(){
+		it('must throw an error', function(){
+			demand(function(){
+				di(notAFunction);
+			}).to.throw(/function/i);
 		});
 	});
 	describe('fn_basic.isAsync', function() {


### PR DESCRIPTION
ATM the context parameter is not passed to Wrapper from the module function in asyncdi.
For instance: you'd expect the callback to be called inside `context`, but it isn't.

```js
var di = require('./lib/asyncdi');
di(fn_scope, scope).call(function(err, val){
	demand(val).equal(scope); //fails
	done();
});
```

Fix and tests coming in a few secs.