### PR TITLE
Fix for validationErrors beeing overwritten

### DIFF
--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -136,11 +136,10 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 	}, this);
 	
 	// TODO: The whole progress queue management code could be a lot neater...
-	
 	var actionQueue = [],
 		addValidationError = this.addValidationError.bind(this),
 		validationErrors = this.validationErrors;
-	
+
 	var progress = function(err) {
 		if (err) {
 			if (options.logErrors) {
@@ -268,7 +267,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 		}
 		
 		// validate required fields, unless they've already been invalidated by field-specific behaviour
-		if (!invalidated && options.required[field.path] && !field.validateInput(data, true, this.item)) {
+		if (!invalidated && options.required[field.path] && !field.validateInput(data, true, this.item) && !validationErrors[field.path]) {
 			// console.log('Field ' + field.path + ' is required, but not provided.');
 			message = options.requiredMessages[field.path] || field.options.requiredMessage || field.label + ' is required';
 			addValidationError(field.path, message);
@@ -287,7 +286,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 		field.updateItem(this.item, data);
 		
 	}, this);
-	
+
 	progress();
 	
 };


### PR DESCRIPTION
When a validation error is added with UpdateHandler.prototype.addValidationError it will be overwritten here https://github.com/keystonejs/keystone/blob/master/lib/updateHandler.js#L274 unless we check if it's already in validationErrors[field.path]

Hope I did not oversee anything