### PR TITLE
Fix "Many" Relationships not collapsing

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -9,6 +9,16 @@ module.exports = Field.create({
 	
 	displayName: 'RelationshipField',
 	
+	shouldCollapse: function() {
+		// many:true relationships have an Array for a value
+		// so need to check length instead
+		if(this.props.many) {
+			return this.props.collapse && !this.props.value.length;
+		}
+		
+		return this.props.collapse && !this.props.value;
+	},
+	
 	getInitialState: function() {
 		return {
 			ready: this.props.value ? false : true,
@@ -72,7 +82,7 @@ module.exports = Field.create({
 		
 		_.each(this.props.filters, function(value, key) {
 			if(_.isString(value) && value[0] == ':') {
-				fieldName = value.slice(1);
+				var fieldName = value.slice(1);
 
 				var val = this.props.values[fieldName];
 				if (val) {
@@ -94,13 +104,16 @@ module.exports = Field.create({
 		
 		_.each(filters, function (val, key) {
 			parts.push('filters[' + key + ']=' + encodeURIComponent(val));
-		})
+		});
 		
 		return parts.join('&');
 	},
 
 	buildOptionQuery: function (input) {
-		return 'context=relationship&q=' + input + '&list=' + Keystone.list.path + '&field=' + this.props.path + '&' + this.buildFilters()
+		return  'context=relationship&q=' + input +
+				'&list=' + Keystone.list.path +
+				'&field=' + this.props.path +
+				'&' + this.buildFilters();
 	},
 
 	getOptions: function(input, callback) {


### PR DESCRIPTION
Because a many relationship field doesn't have a simple value (it's an array) the default `shouldCollapse()` in `Field.js` returns a bogus value. I have overriden `shouldCollapse()` in `RelationshipField.js` so that it now can fork its response based on a single/many relationship. The single relationship path is the same, while a many relationship will use the `.length` of value instead.

Also fixed a few JSHint errors in generally non-scary ways (add a `var` on line 79, some semicolons).

Fixes #101