### PR TITLE
Allow wysiwyg option to be an object of options

### DIFF
--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -68,40 +68,46 @@ module.exports = Field.create({
 
 	getOptions: function() {
   		var plugins = [ 'code', 'link' ],
-  			toolbar = Keystone.wysiwyg.options.overrideToolbar ? '' : 'bold italic | alignleft aligncenter alignright | bullist numlist | outdent indent | link';
+  			options = _.defaults(
+             	_.isObject(this.props.wysiwyg) ? this.props.wysiwyg : {},
+             	Keystone.wysiwyg.options
+         	),
+  			toolbar = options.overrideToolbar ? '' : 'bold italic | alignleft aligncenter alignright | bullist numlist | outdent indent | link';
 
-		if (Keystone.wysiwyg.options.enableImages) {
+		if (options.enableImages) {
 			plugins.push('image');
 			toolbar += ' | image';
 		}
 
-		if (Keystone.wysiwyg.options.enableCloudinaryUploads) {
+		if (options.enableCloudinaryUploads) {
 			plugins.push('uploadimage');
-			toolbar += Keystone.wysiwyg.options.enableImages ? ' uploadimage' : ' | uploadimage';
+			toolbar += options.enableImages ? ' uploadimage' : ' | uploadimage';
 		}
 
-		if (Keystone.wysiwyg.options.additionalButtons) {
-			var additionalButtons = Keystone.wysiwyg.options.additionalButtons.split(',');
+		if (options.additionalButtons) {
+			var additionalButtons = options.additionalButtons.split(',');
 			for (var i = 0; i < additionalButtons.length; i++) {
 				toolbar += (' | ' + additionalButtons[i]);
 			}
 		}
-		if (Keystone.wysiwyg.options.additionalPlugins) {
-			var additionalPlugins = Keystone.wysiwyg.options.additionalPlugins.split(',');
+		if (options.additionalPlugins) {
+			var additionalPlugins = options.additionalPlugins.split(',');
 			for (var i = 0; i < additionalPlugins.length; i++) {
 				plugins.push(additionalPlugins[i]);
 			}
 		}
-		if (Keystone.wysiwyg.options.importcss) {
+		if (options.importcss) {
 			plugins.push('importcss');
 			var importcssOptions = {
-				content_css: Keystone.wysiwyg.options.importcss,
+				content_css: options.importcss,
 				importcss_append: true,
 				importcss_merge_classes: true
 			};
-			$.extend(Keystone.wysiwyg.options.additionalOptions,importcssOptions);
+			
+			$.extend(options.additionalOptions, importcssOptions);
 		}
-		if (!Keystone.wysiwyg.options.overrideToolbar) {
+		
+		if (!options.overrideToolbar) {
 			toolbar += ' | code';
 		}
 
@@ -109,8 +115,8 @@ module.exports = Field.create({
 			selector: '#' + this.state.id,
 			toolbar:  toolbar,
 			plugins:  plugins,
-			menubar:  Keystone.wysiwyg.options.menubar || false,
-			skin:     Keystone.wysiwyg.options.skin || 'keystone'
+			menubar:  options.menubar || false,
+			skin:     options.skin || 'keystone'
 		};
 
 		if (this.shouldRenderField()) {
@@ -125,8 +131,8 @@ module.exports = Field.create({
 			});
 		}
 
-		if (Keystone.wysiwyg.options.additionalOptions){
-			_.extend(opts, Keystone.wysiwyg.options.additionalOptions);
+		if (options.additionalOptions){
+			_.extend(opts, options.additionalOptions);
 		}
 
 		return opts;

--- a/fields/types/html/HtmlType.js
+++ b/fields/types/html/HtmlType.js
@@ -18,13 +18,12 @@ function html(list, path, options) {
 
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
-	this.wysiwyg = (options.wysiwyg) ? true : false;
+	this.wysiwyg = options.wysiwyg || false;
 	this.height = options.height || 180;
 	
 	this._properties = ['wysiwyg', 'height'];
 
 	html.super_.call(this, list, path, options);
-
 }
 
 /*!


### PR DESCRIPTION
By making this change it allows you to specify editor config options on a per-field basis. Since even an empty object is truthy none of the code around checking for field validity needs to change and we can simply pass the value through. The React component does have to do an `_isObject` check now but it's a small change.

Had to rework the `getOptions` function to take the `wysiwyg` object option into account (via `_.defaults`) and then changed references to the merged result throughout the function. Very little else actually needed to change though.

I've tested against global options, fields wit no options, and fields with customized options all in the same model to try and rule out any pass-by-reference issues and don't see anything. If someone can think of a sufficiently-complicated test-case I could use that this breaks on I'd love to see it. This change has me a bit paranoid.