### PR TITLE
Example says .set() but code says .options()

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -139,7 +139,7 @@ function options() {
 	 *
 	 * ####Example:
 	 *
-	 *     keystone.set({test: value}) // sets the 'test' option to `value`
+	 *     keystone.options({test: value}) // sets the 'test' option to `value`
 	 *
 	 * @param {Object} options
 	 * @api public


### PR DESCRIPTION
So I made the example match the code.