### PR TITLE
Override shouldCollapse in ArrayField.js

### DIFF
--- a/fields/mixins/ArrayField.js
+++ b/fields/mixins/ArrayField.js
@@ -72,5 +72,10 @@ module.exports = {
 				<button type="button" className='btn btn-xs btn-default' onClick={this.addItem}>Add item</button>
 			</div>
 		);
+	},
+	
+	// Override shouldCollapse to check for array length
+	shouldCollapse: function () {
+		return this.props.collapse && !this.props.value.length;
 	}
 };


### PR DESCRIPTION
This lets `collapse: true` do the right thing for any *Array fields. Using the default `shouldCollapse` implementation in Field.js doesn't work when the value is an array.

Starting to think I should make `shouldCollapse` in Field.js a little bit smarter so it can handle Arrays & Simple values. Thoughts? The override in markdown makes sense because it's pretty uncommon and you have to know the right object property to check, but doing `Array.isArray` on `this.props.value` and then forking the logic on that in the base implementation might be useful.

Fixes #1111