### PR TITLE
Implements parseFormat and parseStrict options

### DIFF
--- a/docs/content/en/pages/docs/database.jade
+++ b/docs/content/en/pages/docs/database.jade
@@ -666,7 +666,8 @@ block content
 			.options
 				
 				h5 Options
-				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">Do MMM YYYY</code>
+				p <code>format</code> <code class="data-type">string</code> - the default format pattern to show the date, defaults to <code class="default-value">Do MMM YYYY</code>
+				p <code>parseFormat</code> <code class="data-type">string</code> - the default format pattern to parse the date, optional
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
 				
 				h5 Underscore methods
@@ -690,7 +691,8 @@ block content
 			.options
 				
 				h5 Options:
-				p <code>format</code> <code class="data-type">string</code> - the default format pattern to use, defaults to <code class="default-value">Do MMM YYYY hh:mm:ss a</code>
+				p <code>format</code> <code class="data-type">string</code> - the default format pattern to show the date, defaults to <code class="default-value">Do MMM YYYY</code>
+				p <code>parseFormat</code> <code class="data-type">string</code> - the default format pattern to parse the date, optional
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
 				
 				h5 Underscore methods:

--- a/docs/content/en/pages/docs/database.jade
+++ b/docs/content/en/pages/docs/database.jade
@@ -667,7 +667,7 @@ block content
 				
 				h5 Options
 				p <code>format</code> <code class="data-type">string</code> - the default format pattern to show the date, defaults to <code class="default-value">Do MMM YYYY</code>
-				p <code>parseFormat</code> <code class="data-type">string</code> - the default format pattern to parse the date, optional
+				p <code>parseFormat</code> <code class="data-type">string</code> - the default format pattern to parse the date, a comma-separated string, optional
 				p See the <a href="http://momentjs.com/docs/#/displaying/format/" target="_blank">momentjs format docs</a> for information on the supported formats and options.
 				
 				h5 Underscore methods

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -22,7 +22,7 @@ function datetime(list, path, options) {
 	this._properties = ['formatString'];
 	
 	this.typeDescription = 'date and time';
-	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY h:m a');
+	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY hh:mm:ss a');
 	
 	if (this.formatString && 'string' !== typeof this.formatString) {
 		throw new Error('FieldType.DateTime: options.format must be a string.');


### PR DESCRIPTION
This pull request adds two new options for `DateType` and `DatetimeType`. The new options are `parseFormat` and `parseStrict`.

With these options, user can define a custom input format for dates. If `parseStrict`is used, only the given format will be used, otherwise the default options are also used. If `parseFormat`is given without `parseStrict`, the given format will be tried before the default formats.

The format can be a comma-separated string or an array of strings.

Because the Admin UI doesn't know anything about these new options, `parseStrict` should be not be used if the Admin UI is in use. For this reason, `parseStrict` defaults to false.

Implements #1156 
