### PR TITLE
Use filename without suffix as default publicID for cloudinary

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -402,6 +402,8 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 				if (publicIdValue) {
 					uploadOptions.public_id = publicIdValue;
 				}
+			} else if (field.options.filenameAsPublicID) {
+				uploadOptions.public_id = req.files[paths.upload].originalname.substring(0, req.files[paths.upload].originalname.lastIndexOf('.'));
 			}
 
 			if (field.options.autoCleanup && item.get(field.paths.exists)) {

--- a/routes/api/cloudinary.js
+++ b/routes/api/cloudinary.js
@@ -1,4 +1,5 @@
-var cloudinary = require('cloudinary');
+var cloudinary = require('cloudinary'),
+	keystone = require('../../');
 
 exports = module.exports = {
 
@@ -11,14 +12,20 @@ exports = module.exports = {
 	 */
 	upload: function(req, res) {
 		if(req.files && req.files.file){
-			cloudinary.uploader.upload(req.files.file.path, function(result) { 
+			var options = {};
+
+			if (keystone.get('wysiwyg cloudinary images filenameAsPublicID')) {
+				options.public_id = req.files.file.originalname.substring(0, req.files.file.originalname.lastIndexOf('.'));
+			}
+
+			cloudinary.uploader.upload(req.files.file.path, function(result) {
 
 				if (result.error) {
 					res.send('{"error":{"message":"' + result.error.message + '"}}');
 				} else {
 					res.send('{"image":{"url":"' + result.url + '"}}');
 				}
-			});
+			}, options);
 		} else {
 			res.send('{"error":{"message":"No image selected"}}');
 		}


### PR DESCRIPTION
This is a continuation from #925 as I made the changes for 0.3 now.

There are two options you can set:

_ 'wysiwyg cloudinary images filenameAsPublicID': This will change the publicID to the filename if you use the cloudinary image upload within the wysiwyg editor.

_ filenameAsPublicID for a cloudinary image field: This will change the publicID to the filename if set to true for a cloudinary image field. The publicID option takes precedence for backwards compatibility.