### PR TITLE
Adding node 0.12 to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: ["0.11", "0.10"]
+node_js: ["0.12", "0.11", "0.10"]
 script: "npm run test-cov && make test-travis"
 
 notifications:


### PR DESCRIPTION
@JedWatson, I know this may seem like a ridiculously silly PR, but would it be okay if we configure Travis to build/check Keystone on Node `0.12` as well?