### PR TITLE
Refactor "doSignin()" and expose as "keystone.session.signinWithUser()"

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -30,24 +30,19 @@ var hash = function(str) {
 
 exports.signinWithUser = function signinWithUser(user, req, res, onSuccess) {
 	if (arguments.length < 4) {
-		console.error('\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
-		process.exit(1);
+		throw new Error('keystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.');
 	}
 	if ('object' !== typeof user) {
-		console.error('\nkeystone.sesson.signinWithUser requires user to be an object.\n');
-		process.exit(1);
+		throw new Error('keystone.sesson.signinWithUser requires user to be an object.');
 	}
 	if ('object' !== typeof req) {
-		console.error('\nkeystone.sesson.signinWithUser requires req to be an object.\n');
-		process.exit(1);
+		throw new Error('keystone.sesson.signinWithUser requires req to be an object.');
 	}
 	if ('object' !== typeof res) {
-		console.error('\nkeystone.sesson.signinWithUser requires res to be an object.\n');
-		process.exit(1);
+		throw new Error('keystone.sesson.signinWithUser requires res to be an object.');
 	}
 	if ('function' !== typeof onSuccess) {
-		console.error('\nkeystone.sesson.signinWithUser requires onSuccess to be a function.\n');
-		process.exit(1);
+		throw new Error('keystone.sesson.signinWithUser requires onSuccess to be a function.');
 	}
 	
 	req.session.regenerate(function() {

--- a/lib/session.js
+++ b/lib/session.js
@@ -20,6 +20,49 @@ var hash = function(str) {
 };
 
 /**
+ * Signs in a user using user obejct
+ *
+ * @param {Object} user - user object
+ * @param {Object} req - express request object
+ * @param {Object} res - express response object
+ * @param {function()} onSuccess callback, is passed the User instance
+ */
+
+exports.doSignin = function doSignin(user, req, res, onSuccess) {
+	if (arguments.length < 4) {
+		console.error('\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+		process.exit(1);
+	}
+	if ('object' !== typeof user) {
+		console.error('\nkeystone.sesson.doSignin requires user to be an object.\n');
+		process.exit(1);
+	}
+	if ('object' !== typeof req) {
+		console.error('\nkeystone.sesson.doSignin requires req to be an object.\n');
+		process.exit(1);
+	}
+	if ('object' !== typeof res) {
+		console.error('\nkeystone.sesson.doSignin requires res to be an object.\n');
+		process.exit(1);
+	}
+	if ('function' !== typeof onSuccess) {
+		console.error('\nkeystone.sesson.doSignin requires onSuccess to be a function.\n');
+		process.exit(1);
+	}
+	
+	req.session.regenerate(function() {
+		req.user = user;
+		req.session.userId = user.id;
+		// if the user has a password set, store a persistence cookie to resume sessions
+		if (keystone.get('cookie signin') && user.password) {
+			var userToken = user.id + ':' + hash(user.password);
+			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true });
+		}
+		onSuccess(user);
+	});
+};
+
+/**
  * Signs in a user user matching the lookup filters
  *
  * @param {Object} lookup - must contain email and password
@@ -34,25 +77,13 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 		return onFail(new Error('session.signin requires a User ID or Object as the first argument'));
 	}
 	var User = keystone.list(keystone.get('user model'));
-	var doSignin = function(user) {
-		req.session.regenerate(function() {
-			req.user = user;
-			req.session.userId = user.id;
-			// if the user has a password set, store a persistence cookie to resume sessions
-			if (keystone.get('cookie signin') && user.password) {
-				var userToken = user.id + ':' + hash(user.password);
-				res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true });
-			}
-			onSuccess(user);
-		});
-	};
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
 		// match email address and password
 		User.model.findOne({ email: lookup.email }).exec(function(err, user) {
 			if (user) {
 				user._.password.compare(lookup.password, function(err, isMatch) {
 					if (!err && isMatch) {
-						doSignin(user);
+						doSignin(user, req, res, onSuccess);
 					}
 					else {
 						onFail(err);
@@ -69,7 +100,7 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			passwordCheck = (lookup.indexOf(':') > 0) ? lookup.substr(lookup.indexOf(':') + 1) : false;
 		User.model.findById(userId).exec(function(err, user) {
 			if (user && (!passwordCheck || scmp(passwordCheck, hash(user.password)))) {
-				doSignin(user);
+				doSignin(user, req, res, onSuccess);
 			} else {
 				onFail(err);
 			}

--- a/lib/session.js
+++ b/lib/session.js
@@ -28,25 +28,25 @@ var hash = function(str) {
  * @param {function()} onSuccess callback, is passed the User instance
  */
 
-exports.doSignin = function doSignin(user, req, res, onSuccess) {
+exports.signinWithUser = function signinWithUser(user, req, res, onSuccess) {
 	if (arguments.length < 4) {
-		console.error('\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+		console.error('\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
 		process.exit(1);
 	}
 	if ('object' !== typeof user) {
-		console.error('\nkeystone.sesson.doSignin requires user to be an object.\n');
+		console.error('\nkeystone.sesson.signinWithUser requires user to be an object.\n');
 		process.exit(1);
 	}
 	if ('object' !== typeof req) {
-		console.error('\nkeystone.sesson.doSignin requires req to be an object.\n');
+		console.error('\nkeystone.sesson.signinWithUser requires req to be an object.\n');
 		process.exit(1);
 	}
 	if ('object' !== typeof res) {
-		console.error('\nkeystone.sesson.doSignin requires res to be an object.\n');
+		console.error('\nkeystone.sesson.signinWithUser requires res to be an object.\n');
 		process.exit(1);
 	}
 	if ('function' !== typeof onSuccess) {
-		console.error('\nkeystone.sesson.doSignin requires onSuccess to be a function.\n');
+		console.error('\nkeystone.sesson.signinWithUser requires onSuccess to be a function.\n');
 		process.exit(1);
 	}
 	
@@ -83,7 +83,7 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			if (user) {
 				user._.password.compare(lookup.password, function(err, isMatch) {
 					if (!err && isMatch) {
-						doSignin(user, req, res, onSuccess);
+						signinWithUser(user, req, res, onSuccess);
 					}
 					else {
 						onFail(err);
@@ -100,7 +100,7 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			passwordCheck = (lookup.indexOf(':') > 0) ? lookup.substr(lookup.indexOf(':') + 1) : false;
 		User.model.findById(userId).exec(function(err, user) {
 			if (user && (!passwordCheck || scmp(passwordCheck, hash(user.password)))) {
-				doSignin(user, req, res, onSuccess);
+				signinWithUser(user, req, res, onSuccess);
 			} else {
 				onFail(err);
 			}

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -1,5 +1,4 @@
 var keystone = require('../..'),
-	demand = require('must'),
 	sinon = require('sinon');
 
 describe('Keystone.session', function() {

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -1,0 +1,213 @@
+var keystone = require('../..'),
+	demand = require('must'),
+	sinon = require('sinon');
+
+describe('Keystone.session', function() {
+
+	describe('keystone.session.doSignin()', function() {
+		// mock args for doSignin(user, req, res, onSuccess)
+		var res = {
+				cookie: sinon.stub()
+			},
+			onSuccess = sinon.stub(),
+			user,
+			req;
+
+		function resetMocks() {
+			user = {
+				id: 'USERID',
+				password: 'PASSWORD'
+			};
+			req = {
+				user: null,
+				session: {
+					userId: null,
+					regenerate: function(callback) {
+						callback();
+					}
+				}
+			};
+		}
+
+		before(function() {
+			keystone.get('cookie secret', 'SECRET');
+			keystone.set('user model', 'User');
+		});
+
+		beforeEach(function() {
+			resetMocks();
+			sinon.spy(req.session, 'regenerate');
+		});
+
+		afterEach(function() {
+			req.session.regenerate.reset();
+			res.cookie.reset();
+			onSuccess.reset();
+		});
+
+		describe('with valid args, "cookie signin" on', function() {
+
+			it('should regenerate session, set user, session.userId, and res.cookie', function() {
+				keystone.set('cookie signin', true);
+				keystone.session.doSignin(user, req, res, onSuccess);
+
+				sinon.assert.calledOnce(req.session.regenerate);
+
+				req.user.must.equal(user);
+				req.session.userId.must.equal(user.id);				
+
+				sinon.assert.calledOnce(res.cookie);
+				sinon.assert.calledWith(res.cookie, 'keystone.uid');
+
+				sinon.assert.calledOnce(onSuccess);
+				sinon.assert.calledWithExactly(onSuccess, user);
+			});
+
+		});
+
+		describe('with valid args, "cookie signin" off', function() {
+
+			it('should regenerate session, set user, session.userId', function() {
+				keystone.set('cookie signin', false);
+				keystone.session.doSignin(user, req, res, onSuccess);
+
+				sinon.assert.calledOnce(req.session.regenerate);
+
+				req.user.must.equal(user);
+				req.session.userId.must.equal(user.id);				
+
+				sinon.assert.callCount(res.cookie, 0);
+
+				sinon.assert.calledOnce(onSuccess);
+				sinon.assert.calledWithExactly(onSuccess, user);
+			});
+
+		});
+
+		describe('with invalid args', function() {
+			beforeEach(function() {
+				sinon.stub(console, 'error');
+				sinon.stub(process, 'exit').throws('ProcessExit');
+			});
+
+			afterEach(function() {
+				console.error.restore();
+				process.exit.restore();				
+			});
+
+			it('should error when called less then 4 args', function() {
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin();
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+
+				console.error.reset();
+				process.exit.reset();				
+
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+
+				console.error.reset();
+				process.exit.reset();				
+
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user, req);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+
+				console.error.reset();
+				process.exit.reset();				
+
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user, req, onSuccess);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+			});
+
+			it('should error when user arg is not an object', function() {
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin('user', req, res, onSuccess);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user to be an object.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+			});
+
+			it('should error when req arg is not an object', function() {
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user, 'req', res, onSuccess);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires req to be an object.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+			});
+
+			it('should error when res arg is not an object', function() {
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user, req, 'res', onSuccess);
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires res to be an object.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+			});
+
+			it('should error when onSuccess arg is not a function', function() {
+				try {
+					keystone.set('cookie signin', true);
+					keystone.session.doSignin(user, req, res, 'onSuccess');
+				} catch(e) {
+					sinon.assert.calledOnce(console.error);
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires onSuccess to be a function.\n');
+					sinon.assert.calledOnce(process.exit);
+					sinon.assert.calledWithExactly(process.exit, 1);
+				}
+			});
+
+		});
+
+	});
+
+	// TODO: test keystone.session.signin()
+	// describe('keystone.session.signin()');
+
+	// TODO: test keystone.session.signout()
+	// describe('keystone.session.signout()');
+
+	// TODO: test keystone.session.persist()
+	// describe('keystone.session.persist()');
+
+	// TODO: test keystone.session.keystoneAuth()
+	// describe('keystone.session.keystoneAuth()');
+
+});

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -4,8 +4,8 @@ var keystone = require('../..'),
 
 describe('Keystone.session', function() {
 
-	describe('keystone.session.doSignin()', function() {
-		// mock args for doSignin(user, req, res, onSuccess)
+	describe('keystone.session.signinWithUser()', function() {
+		// mock args for signinWithUser(user, req, res, onSuccess)
 		var res = {
 				cookie: sinon.stub()
 			},
@@ -49,7 +49,7 @@ describe('Keystone.session', function() {
 
 			it('should regenerate session, set user, session.userId, and res.cookie', function() {
 				keystone.set('cookie signin', true);
-				keystone.session.doSignin(user, req, res, onSuccess);
+				keystone.session.signinWithUser(user, req, res, onSuccess);
 
 				sinon.assert.calledOnce(req.session.regenerate);
 
@@ -69,7 +69,7 @@ describe('Keystone.session', function() {
 
 			it('should regenerate session, set user, session.userId', function() {
 				keystone.set('cookie signin', false);
-				keystone.session.doSignin(user, req, res, onSuccess);
+				keystone.session.signinWithUser(user, req, res, onSuccess);
 
 				sinon.assert.calledOnce(req.session.regenerate);
 
@@ -98,10 +98,10 @@ describe('Keystone.session', function() {
 			it('should error when called less then 4 args', function() {
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin();
+					keystone.session.signinWithUser();
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -111,10 +111,10 @@ describe('Keystone.session', function() {
 
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user);
+					keystone.session.signinWithUser(user);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -124,10 +124,10 @@ describe('Keystone.session', function() {
 
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user, req);
+					keystone.session.signinWithUser(user, req);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -137,10 +137,10 @@ describe('Keystone.session', function() {
 
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user, req, onSuccess);
+					keystone.session.signinWithUser(user, req, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user, req and res objects, and an onSuccess callback.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -149,10 +149,10 @@ describe('Keystone.session', function() {
 			it('should error when user arg is not an object', function() {
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin('user', req, res, onSuccess);
+					keystone.session.signinWithUser('user', req, res, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires user to be an object.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user to be an object.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -161,10 +161,10 @@ describe('Keystone.session', function() {
 			it('should error when req arg is not an object', function() {
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user, 'req', res, onSuccess);
+					keystone.session.signinWithUser(user, 'req', res, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires req to be an object.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires req to be an object.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -173,10 +173,10 @@ describe('Keystone.session', function() {
 			it('should error when res arg is not an object', function() {
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user, req, 'res', onSuccess);
+					keystone.session.signinWithUser(user, req, 'res', onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires res to be an object.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires res to be an object.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}
@@ -185,10 +185,10 @@ describe('Keystone.session', function() {
 			it('should error when onSuccess arg is not a function', function() {
 				try {
 					keystone.set('cookie signin', true);
-					keystone.session.doSignin(user, req, res, 'onSuccess');
+					keystone.session.signinWithUser(user, req, res, 'onSuccess');
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.doSignin requires onSuccess to be a function.\n');
+					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires onSuccess to be a function.\n');
 					sinon.assert.calledOnce(process.exit);
 					sinon.assert.calledWithExactly(process.exit, 1);
 				}

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -96,7 +96,6 @@ describe('Keystone.session', function() {
 
 			it('should error when called less then 4 args', function() {
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser();
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -109,7 +108,6 @@ describe('Keystone.session', function() {
 				process.exit.reset();				
 
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -122,7 +120,6 @@ describe('Keystone.session', function() {
 				process.exit.reset();				
 
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user, req);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -135,7 +132,6 @@ describe('Keystone.session', function() {
 				process.exit.reset();				
 
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user, req, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -147,7 +143,6 @@ describe('Keystone.session', function() {
 
 			it('should error when user arg is not an object', function() {
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser('user', req, res, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -159,7 +154,6 @@ describe('Keystone.session', function() {
 
 			it('should error when req arg is not an object', function() {
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user, 'req', res, onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -171,7 +165,6 @@ describe('Keystone.session', function() {
 
 			it('should error when res arg is not an object', function() {
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user, req, 'res', onSuccess);
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);
@@ -183,7 +176,6 @@ describe('Keystone.session', function() {
 
 			it('should error when onSuccess arg is not a function', function() {
 				try {
-					keystone.set('cookie signin', true);
 					keystone.session.signinWithUser(user, req, res, 'onSuccess');
 				} catch(e) {
 					sinon.assert.calledOnce(console.error);

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -84,105 +84,54 @@ describe('Keystone.session', function() {
 		});
 
 		describe('with invalid args', function() {
-			beforeEach(function() {
-				sinon.stub(console, 'error');
-				sinon.stub(process, 'exit').throws('ProcessExit');
-			});
-
-			afterEach(function() {
-				console.error.restore();
-				process.exit.restore();				
-			});
-
 			it('should error when called less then 4 args', function() {
-				try {
+				function callWithNoArgs() {
 					keystone.session.signinWithUser();
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
 				}
+				callWithNoArgs.must.throw('keystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.');
 
-				console.error.reset();
-				process.exit.reset();				
-
-				try {
+				function callWithOneArg() {
 					keystone.session.signinWithUser(user);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
 				}
+				callWithOneArg.must.throw('keystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.');
 
-				console.error.reset();
-				process.exit.reset();				
-
-				try {
+				function callWithTwoArgs() {
 					keystone.session.signinWithUser(user, req);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
 				}
+				callWithOneArg.must.throw('keystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.');
 
-				console.error.reset();
-				process.exit.reset();				
-
-				try {
-					keystone.session.signinWithUser(user, req, onSuccess);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
+				function callWithThreeArgs() {
+					keystone.session.signinWithUser(user, req, res);
 				}
+				callWithOneArg.must.throw('keystone.sesson.signinWithUser requires user, req and res objects, and an onSuccess callback.');
 			});
 
 			it('should error when user arg is not an object', function() {
-				try {
+				function callWithInvalidUser() {
 					keystone.session.signinWithUser('user', req, res, onSuccess);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires user to be an object.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
-				}
+				}				
+				callWithInvalidUser.must.throw('keystone.sesson.signinWithUser requires user to be an object.');
 			});
 
 			it('should error when req arg is not an object', function() {
-				try {
+				function callWithInvalidReq() {
 					keystone.session.signinWithUser(user, 'req', res, onSuccess);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires req to be an object.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
-				}
+				}				
+				callWithInvalidReq.must.throw('keystone.sesson.signinWithUser requires req to be an object.');
 			});
 
 			it('should error when res arg is not an object', function() {
-				try {
+				function callWithInvalidRes() {
 					keystone.session.signinWithUser(user, req, 'res', onSuccess);
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires res to be an object.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
-				}
+				}				
+				callWithInvalidRes.must.throw('keystone.sesson.signinWithUser requires res to be an object.');
 			});
 
 			it('should error when onSuccess arg is not a function', function() {
-				try {
+				function callWithInvalidCallback() {
 					keystone.session.signinWithUser(user, req, res, 'onSuccess');
-				} catch(e) {
-					sinon.assert.calledOnce(console.error);
-					sinon.assert.calledWithExactly(console.error, '\nkeystone.sesson.signinWithUser requires onSuccess to be a function.\n');
-					sinon.assert.calledOnce(process.exit);
-					sinon.assert.calledWithExactly(process.exit, 1);
-				}
+				}				
+				callWithInvalidCallback.must.throw('keystone.sesson.signinWithUser requires onSuccess to be a function.');
 			});
 
 		});


### PR DESCRIPTION
Factored `doSignin()` out of `keystone.session.signin()`. This allows for reusability (in support features like the ones mentioned in keystonejs/generator-keystone#10)  and better testability.

Renamed and exposed the new method as `keystone.session.signinWithUser()`.

Tests for <del>`keystone.session.doSignin()`</del> `keystone.session.signinWithUser()` already included. I intend to add the rest of the tests for the `keystone.session` module as time permits.