### PR TITLE
Extract pre & post hooking functionality to separate module

### DIFF
--- a/fields/types/azurefile/AzureFileType.js
+++ b/fields/types/azurefile/AzureFileType.js
@@ -5,10 +5,10 @@
 var _ = require('underscore'),
 	moment = require('moment'),
 	keystone = require('../../../'),
-	async = require('async'),
 	util = require('util'),
 	azure = require('azure'),
 	utils = require('keystone-utils'),
+	prepost = require("../../../lib/prepost"),
 	super_ = require('../Type');
 
 
@@ -19,14 +19,11 @@ var _ = require('underscore'),
  */
 
 function azurefile(list, path, options) {
+	prepost.mixin(this)
+		.register("pre:upload");
 
 	this._underscoreMethods = ['format', 'uploadFile'];
 	this._fixedSize = 'full';
-
-	// event queues
-	this._pre = {
-		upload: []
-	};
 
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
@@ -56,7 +53,7 @@ function azurefile(list, path, options) {
 
 	// Could be more pre- hooks, just upload for now
 	if (options.pre && options.pre.upload) {
-		this._pre.upload = this._pre.upload.concat(options.pre.upload);
+		this.pre("upload", options.pre.upload);
 	}
 
 }
@@ -74,22 +71,6 @@ util.inherits(azurefile, super_);
 Object.defineProperty(azurefile.prototype, 'azurefileconfig', { get: function() {
 	return this.options.azurefileconfig || keystone.get('azurefile config');
 }});
-
-
-/**
- * Allows you to add pre middleware after the field has been initialised
- *
- * @api public
- */
-
-azurefile.prototype.pre = function(event, fn) {
-	if (!this._pre[event]) {
-		throw new Error('AzureFile (' + this.list.key + '.' + this.path + ') error: azurefile.pre()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._pre[event].push(fn);
-	return this;
-};
 
 
 /**
@@ -287,7 +268,7 @@ azurefile.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	async.eachSeries(this._pre.upload, function(fn, next) {
+	this.hooks("pre:upload", function(fn, next) {
 		fn(item, file, next);
 	}, function(err) {
 		if (err) return callback(err);

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -6,7 +6,7 @@ var fs = require('fs-extra'),
 	path = require('path'),
 	_ = require('underscore'),
 	moment = require('moment'),
-	async = require('async'),
+	prepost = require('../../../lib/prepost'),
 	util = require('util'),
 	utils = require('keystone-utils'),
 	super_ = require('../Type');
@@ -18,19 +18,11 @@ var fs = require('fs-extra'),
  */
 
 function localfile(list, path, options) {
-	
+	prepost.mixin(this)
+		.register("pre:move", "post:move");
 	this._underscoreMethods = ['format', 'uploadFile'];
 	this._fixedSize = 'full';
 
-	// event queues
-	this._pre = {
-		move: [] // Before file is moved into final destination
-	};
-
-	this._post = {
-		move: [] // After file is moved into final destination
-	};
-	
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
 	
@@ -51,14 +43,13 @@ function localfile(list, path, options) {
 		throw new Error('Invalid Configuration\n\n' +
 			'localfile fields (' + list.key + '.' + path + ') require the "dest" option to be set.');
 	}
-	
 	// Allow hook into before and after
 	if (options.pre && options.pre.move) {
-		this._pre.move = this._pre.move.concat(options.pre.move);
+		this.pre("move", options.pre.move);
 	}
 	
 	if (options.post && options.post.move) {
-		this._post.move = this._post.move.concat(options.post.move);
+		this.post("move", options.post.move);
 	}
 	
 }
@@ -69,37 +60,6 @@ function localfile(list, path, options) {
 
 util.inherits(localfile, super_);
 
-
-/**
- * Allows you to add pre middleware after the field has been initialised
- *
- * @api public
- */
-
-localfile.prototype.pre = function(event, fn) {
-	if (!this._pre[event]) {
-		throw new Error('localfile (' + this.list.key + '.' + this.path + ') error: localfile.pre()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._pre[event].push(fn);
-	return this;
-};
-
-
-/**
- * Allows you to add post middleware after the field has been initialised
- *
- * @api public
- */
-
-localfile.prototype.post = function(event, fn) {
-	if (!this._post[event]) {
-		throw new Error('localfile (' + this.list.key + '.' + this.path + ') error: localfile.post()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._post[event].push(fn);
-	return this;
-};
 
 
 /**
@@ -331,7 +291,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	async.eachSeries(this._pre.move, function(fn, next) {
+	field.hooks("pre:move", function(fn, next) {
 		fn(item, file, next);
 	}, function(err) {
 		
@@ -340,7 +300,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 		doMove(function(err, fileData) {
 			if (err) return callback(err);
 
-			async.eachSeries(field._post.move, function(fn, next) {
+			field.hooks("post:move", function(fn, next) {
 				fn(item, file, fileData, next);
 			}, function(err) {
 				if (err) return callback(err);

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -10,7 +10,8 @@ var fs = require('fs-extra'),
 	util = require('util'),
 	utils = require('keystone-utils'),
 	super_ = require('../Type'),
-	async = require('async');
+	async = require('async'),
+	prepost = require('../../../lib/prepost');
 
 /**
  * localfiles FieldType Constructor
@@ -19,18 +20,10 @@ var fs = require('fs-extra'),
  */
 
 function localfiles(list, path, options) {
-	
+	prepost.mixin(this)
+		.register("pre:move", "post:move");
 	this._underscoreMethods = ['format', 'uploadFiles'];
 	this._fixedSize = 'full';
-
-	// event queues
-	this._pre = {
-		move: [] // Before file is moved into final destination
-	};
-
-	this._post = {
-		move: [] // After file is moved into final destination
-	};
 
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
@@ -55,11 +48,11 @@ function localfiles(list, path, options) {
 
 	// Allow hook into before and after
 	if (options.pre && options.pre.move) {
-		this._pre.move = this._pre.move.concat(options.pre.move);
+		this.pre("move", options.pre.move);
 	}
 
 	if (options.post && options.post.move) {
-		this._post.move = this._post.move.concat(options.post.move);
+		this.post("move", options.post.move);
 	}
 	
 }
@@ -69,38 +62,6 @@ function localfiles(list, path, options) {
  */
 
 util.inherits(localfiles, super_);
-
-
-/**
- * Allows you to add pre middleware after the field has been initialised
- *
- * @api public
- */
-
-localfiles.prototype.pre = function(event, fn) {
-	if (!this._pre[event]) {
-		throw new Error('localfiles (' + this.list.key + '.' + this.path + ') error: localfiles.pre()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._pre[event].push(fn);
-	return this;
-};
-
-
-/**
- * Allows you to add post middleware after the field has been initialised
- *
- * @api public
- */
-
-localfiles.prototype.post = function(event, fn) {
-	if (!this._post[event]) {
-		throw new Error('localfiles (' + this.list.key + '.' + this.path + ') error: localfiles.post()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._post[event].push(fn);
-	return this;
-};
 
 
 /**
@@ -354,7 +315,7 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 			
 		};
 		
-		async.eachSeries(field._pre.move, function(fn, next) {
+		field.hooks("pre:move", function(fn, next) {
 			fn(item, file, next);
 		}, function(err) {
 			if (err) return processedFile(err);
@@ -362,7 +323,7 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 			doMove(function(err, fileData) {
 				if (err) return processedFile(err);
 				
-				async.eachSeries(field._post.move, function(fn, next) {
+				field.hooks("post:move", function(fn, next) {
 					fn(item, file, fileData, next);
 				}, function(err) {
 					return processedFile(err, fileData);

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -5,11 +5,11 @@
 var _ = require('underscore'),
 	moment = require('moment'),
 	keystone = require('../../../'),
-	async = require('async'),
 	util = require('util'),
 	knox = require('knox'),
 	// s3 = require('s3'),
 	utils = require('keystone-utils'),
+	prepost = require('../../../lib/prepost'),
 	super_ = require('../Type');
 
 /**
@@ -19,14 +19,10 @@ var _ = require('underscore'),
  */
 
 function s3file(list, path, options) {
-
+	prepost.mixin(this)
+		.register("pre:upload");
 	this._underscoreMethods = ['format', 'uploadFile'];
 	this._fixedSize = 'full';
-
-	// event queues
-	this._pre = {
-		upload: []
-	};
 
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
@@ -48,7 +44,7 @@ function s3file(list, path, options) {
 
 	// Could be more pre- hooks, just upload for now
 	if (options.pre && options.pre.upload) {
-		this._pre.upload = this._pre.upload.concat(options.pre.upload);
+		this.pre("upload", options.pre.upload);
 	}
 
 }
@@ -66,22 +62,6 @@ util.inherits(s3file, super_);
 Object.defineProperty(s3file.prototype, 's3config', { get: function() {
 	return this.options.s3config || keystone.get('s3 config');
 }});
-
-
-/**
- * Allows you to add pre middleware after the field has been initialised
- *
- * @api public
- */
-
-s3file.prototype.pre = function(event, fn) {
-	if (!this._pre[event]) {
-		throw new Error('S3File (' + this.list.key + '.' + this.path + ') error: s3field.pre()\n\n' +
-			'Event ' + event + ' is not supported.\n');
-	}
-	this._pre[event].push(fn);
-	return this;
-};
 
 
 /**
@@ -298,7 +278,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	async.eachSeries(this._pre.upload, function(fn, next) {
+	this.hooks("pre:upload", function(fn, next) {
 		fn(item, file, next);
 	}, function(err) {
 		if (err) return callback(err);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var fs = require('fs'),
 	moment = require('moment'),
 	numeral = require('numeral'),
 	cloudinary = require('cloudinary'),
-	utils = require('keystone-utils');
+	utils = require('keystone-utils'),
+	prepost = require('./lib/prepost');
 
 var templateCache = {};
 
@@ -31,7 +32,8 @@ var moduleRoot = (function(_rootPath) {
  */
 
 var Keystone = function() {
-	
+	prepost.mixin(this)
+		.register("pre:routes", "pre:render");
 	this.lists = {};
 	this.paths = {};
 	this._options = {
@@ -44,10 +46,6 @@ var Keystone = function() {
 		'model prefix': null,
 		'module root': moduleRoot,
 		'frame guard': 'sameorigin'
-	};
-	this._pre = {
-		routes: [],
-		render: []
 	};
 	this._redirects = {};
 	
@@ -106,26 +104,6 @@ var Keystone = function() {
 };
 
 _.extend(Keystone.prototype, require('./lib/core/options')());
-
-
-/**
- * Registers a pre-event handler.
- *
- * Valid events include:
- * - `routes` - calls the function before any routes are matched, after all other middleware
- *
- * @param {String} event
- * @param {Function} function to call
- * @api public
- */
-
-Keystone.prototype.pre = function(event, fn) {
-	if (!this._pre[event]) {
-		throw new Error('keystone.pre() Error: event ' + event + ' does not exist.');
-	}
-	this._pre[event].push(fn);
-	return this;
-};
 
 
 Keystone.prototype.prefixModel = function (key) {

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -59,13 +59,13 @@ var _ = require('underscore'),
 	multer = require('multer'),
 	bodyParser = require('body-parser'),
 	cookieParser = require('cookie-parser'),
+	prepost = require('../prepost'),
 	compression = require('compression');
 
 var dashes = '\n------------------------------------------------\n';
 
 function mount(mountPath, parentApp, events) {
   debug('mounting');
-
 	// Validate the express app instance
 	
 	if (!this.app) {
@@ -416,7 +416,7 @@ function mount(mountPath, parentApp, events) {
 	
 	// Pre-route middleware
 	
-	this._pre.routes.forEach(function(fn) {
+	this.hooks("pre:routes", function(fn, next) {
 		try {
 			debug('adding pre-route middlewares');
 			app.use(fn);
@@ -427,6 +427,7 @@ function mount(mountPath, parentApp, events) {
 			}
 			throw e;
 		}
+		next();
 	});
 	
 	// Headless mode means don't bind the Keystone routes

--- a/lib/prepost.js
+++ b/lib/prepost.js
@@ -1,0 +1,77 @@
+"use strict";
+
+var _ = require( "underscore" ),
+	async = require("async");
+
+function init(){
+    this.__prepost = {
+        pre  : {},
+        post : {}
+    };
+}
+
+function addEventListener(context, type, args){
+	var event = args.shift(),
+		fn = _.flatten(args);
+	if( !context.__prepost[type][event] ){
+     throw new Error('Event ' + event + ' is not supported.');
+	 }
+	var handlers = context.__prepost[type]; 
+	handlers[event] = handlers[event].concat(fn);
+}
+var methods = {
+	/**
+	 * Registers a pre-event handler.
+	 *
+	 * Valid events include:
+	 * - `routes` - calls the function before any routes are matched, after all other middleware
+	 *
+	 * @param {String} event
+	 * @param {Function} fn function to call
+	 * @api public
+	 */
+	
+    pre: function( event,
+                         fn ){
+		addEventListener(this, "pre", _.toArray(arguments));
+        return this;
+    },
+    post: function( event,
+                         fn ){
+		addEventListener(this, "post", _.toArray(arguments));
+        return this;
+    },
+    register : function( types ){
+		var args = _.flatten(_.toArray(arguments));
+		_.each(args, function(event){
+			var temp = event.split(":"),
+				type = temp[0],
+				eventName = temp[1];
+			if( !this.__prepost[ type ] ){
+			   throw new Error( "Only 'pre' and 'post' types are allowed, not '"+type+"'" );
+		   }
+				this.__prepost[type][eventName] = [];
+		}, this);
+    },
+	hooks : function(event, iterator, done){
+		var temp = event.split(":"),
+			type = temp[0],
+			eventName = temp[1];
+		async.eachSeries(this.__prepost[type][eventName], iterator, done);
+	}
+};
+
+function mixin( instance ){
+    init.call( instance );
+    _.extend( instance, methods );
+    return instance;
+}
+
+function create(){
+    return mixin( {} );
+}
+
+module.exports = {
+    mixin  : mixin,
+    create : create
+};

--- a/lib/view.js
+++ b/lib/view.js
@@ -348,10 +348,11 @@ View.prototype.render = function(renderFn, locals, callback) {
 	var preRenderQueue = [];
 
 	// Add Keystone's global pre('render') queue
-	keystone._pre.render.forEach(function(fn) {
+	keystone.hooks("pre:render", function(fn, next) {
 		preRenderQueue.push(function(next) {
 			fn(req, res, next);
 		});
+		next();
 	});
 
 	this.initQueue.push(preRenderQueue);


### PR DESCRIPTION
I saw the 'pre' and 'post' hook functionality was re-implemented at several places, so I extracted it to a separate module. This is related to #1152 since I'll need some kind of mechanism to hook into the application life cycle, i.e. I'll be adding some more `pre` and `post` dispatching to keystone.

Some remarks:

- I use a mixin mechanism to add the methods to an existing instance, if you prefer a different approach @JedWatson let me know
- It would be best to extract the `prepost` module to an external module IMO, as you did with `asyncdi`