### PR TITLE
Add format option to Url type to prevent stripping http/https PR/Question

### DIFF
--- a/docs/content/en/pages/docs/database.jade
+++ b/docs/content/en/pages/docs/database.jade
@@ -957,6 +957,9 @@ block content
 			pre: code.language-javascript { type: Types.Url }
 			.options
 				
+				h5 Options
+				p <code>format</code> <code class="data-type">Function</code> - process URL before its printed in the href/text of Admin UI cell. Defaults to <code class="default-value">removeProtocolPrefix</code>
+
 				h5 Underscore methods:
 				p <code>format()</code> - formats the stored value by stripping the leading protocol (if any)
 				pre: code.language-javascript

--- a/fields/types/url/UrlType.js
+++ b/fields/types/url/UrlType.js
@@ -14,7 +14,8 @@ var util = require('util'),
 function url(list, path, options) {
 	this._nativeType = String;
 	this._underscoreMethods = ['format'];
-	this.formatUrl = options.format;
+	this._formatUrl = options.format || removeProtocolPrefix;
+
 	url.super_.call(this, list, path, options);
 }
 
@@ -26,19 +27,25 @@ util.inherits(url, super_);
 
 
 /**
- * Formats the field value
- *
- * Strips the leading protocol from the value for simpler display
+ * Formats the field value using either a supplied format function or default
+ * which strips the leading protocol from the value for simpler display
  *
  * @api public
  */
 
 url.prototype.format = function(item) {
 	var url = (item.get(this.path) || '');
-
-	return this.formatUrl ? this.formatUrl(url) : url.replace(/^[a-zA-Z]+\:\/\//, '');
+	return this._formatUrl(url);
 };
 
+/**
+ * Remove the protocol prefix from url
+ *
+ * @api private
+ */
+function removeProtocolPrefix(url) {
+	return url.replace(/^[a-zA-Z]+\:\/\//, '');
+}
 
 // TODO: Proper url validation
 

--- a/fields/types/url/UrlType.js
+++ b/fields/types/url/UrlType.js
@@ -14,6 +14,7 @@ var util = require('util'),
 function url(list, path, options) {
 	this._nativeType = String;
 	this._underscoreMethods = ['format'];
+	this.formatUrl = options.format;
 	url.super_.call(this, list, path, options);
 }
 
@@ -33,7 +34,9 @@ util.inherits(url, super_);
  */
 
 url.prototype.format = function(item) {
-	return (item.get(this.path) || '').replace(/^[a-zA-Z]+\:\/\//, '');
+	var url = (item.get(this.path) || '');
+
+	return this.formatUrl ? this.formatUrl(url) : url.replace(/^[a-zA-Z]+\:\/\//, '');
 };
 
 


### PR DESCRIPTION
Hi,

This PR is just a question/suggestion. If you think that this is a sensible patch, I'll add the docs/integrate any other suggestions. 

It seems that the column_link mixin for Url type inside columns.jade always executes ```url.prototype.format```
method for the anchor href and preview, which strips the http & https prefix from the url, causing columns with Url type to be relative to the site. 

```
var value = col.field ? col.field.format(item) : item.get(col.path)
...
else if col.type == 'url'
    +column_link(value, value, true)
...
```

E.g. if I want to have a column with youtube urls, pressing on a record on the admin UI will point the user back to ```http://localhost:3000/keystone/img.youtube.com/vi/s2nlrpudHIM/hqdefault.jpg``` instead of ```https://img.youtube.com/vi/s2nlrpudHIM/hqdefault.jpg```

To overcome that I've added option to provide custom format for the Url, so that in your model you can do this:
```
thumb: { type: Types.Url, initial: false,
             watch: 'video',
             format: function(url) { return url; },
             value: function() { return getThumbnailUrl(this.video)} }
```

What do you think? Is there an alternative to doing this?

Thanks.