### PR TITLE
Don't use HTML entities in JSON response

### DIFF
--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -84,7 +84,7 @@ exports = module.exports = function(req, res) {
 				switch (req.query.dataset) {
 					case 'simple':
 						return sendResponse({
-							name: req.list.getDocumentName(item, true),
+							name: req.list.getDocumentName(item, false),
 							id: item.id
 						});
 					default:
@@ -156,7 +156,7 @@ exports = module.exports = function(req, res) {
 				} else {
 					return sendResponse({
 						success: true,
-						name: req.list.getDocumentName(item, true),
+						name: req.list.getDocumentName(item, false),
 						id: item.id
 					});
 				}

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -61,7 +61,7 @@ exports = module.exports = function(req, res) {
 						total: total,
 						items: items.map(function(i) {
 							return {
-								name: req.list.getDocumentName(i, true) || '(' + i.id + ')',
+								name: req.list.getDocumentName(i, false) || '(' + i.id + ')',
 								id: i.id
 							};
 						})


### PR DESCRIPTION
In JSON responses, there should be raw data and not HTML entities. It should be client-side responsibility to avoid any injections.

Because the data contains HTML entities, Admin UI's autocomplete feature currently shows items like `Hyvink&auml;&auml;`.