### PR TITLE
Add exclude option to UpdateHandler

### DIFF
--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -75,7 +75,8 @@ UpdateHandler.prototype.addValidationError = function(path, msg, type) {
  * Processes data from req.body, req.query, or any data source.
  *
  * Options:
- * - fields (comma-delimited list or array of field paths)
+ * - fields (comma-delimited list or array of field paths to include)
+ * - exclude (comme-delimited list or array of field paths to exclude)
  * - flashErrors (boolean, default false; whether to push validation errors to req.flash)
  * - ignoreNoedit (boolean, default false; whether to ignore noedit settings on fields)
  * - validationErrors (object; validation errors from previous form handling that should be included)
@@ -104,7 +105,12 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 	if (!options) {
 		options = {};
 	} else if ('string' === typeof options) {
-		options = { fields: options };
+		// If the field list starts with a hyphen, exclude fields
+		if (options.trim()[0] === '-') {
+			options = { exclude: options };
+		} else {
+			options = { fields: options };
+		}
 	}
 	
 	if (!options.fields) {
@@ -114,6 +120,15 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 		options.fields = options.fields.split(',').map(function(i) { return i.trim(); });
 	}
 	
+	if (!options.exclude) {
+		options.exclude = [];
+	} else if ('string' === typeof options.exclude) {
+		options.exclude = options.exclude.split(',').map(function(i) {
+			// Remove possible hyphens
+			return i.trim().replace(/^-/, '');
+		});
+	}
+
 	options.required = options.required || {};
 	options.errorMessage = options.errorMessage || this.options.errorMessage;
 	options.invalidMessages = options.invalidMessages || {};
@@ -217,6 +232,12 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			return;
 		}
 		
+		// skip excluded fields
+		if (options.exclude.indexOf(path) > -1) {
+			// console.log('Skipping field ' + path + ' (excluded)');
+			return;
+		}
+
 		// Some field types have custom behaviours for queueing or validation
 		switch (field.type) {
 			


### PR DESCRIPTION
The main reason for this PR is to make `UpdateHandler` more usable in own code. If there are many fields in the model, blacklisting fields may be easier than whitelisting the wanted fields. This PR adds a new option `exclude` to achieve this.

There are two ways to use the option:

```javascript
updater.process(newData, {exclude: 'user, createdAt'}, function(err) {
```

```javascript
updater.process(newData, '-user, -createdAt', function(err) {
```

If a string is passed instead of an object and the string starts with a hyphen, the string is considered as the list of fields to be excluded.

This PR partially implements #1216. This was the easier part of that and the new field-level option still requires comments and ideas.
