### PR TITLE
Tabbed field support

### DIFF
--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -152,7 +152,7 @@ var EditForm = React.createClass({
 
 				var tabs = Object.keys(el.tabs).map(function(name) {
 					return (
-						<Tabs.Panel title={name}>
+						<Tabs.Panel title={name} key={name}>
 							{this.renderFormElements(el.tabs[name])}
 						</Tabs.Panel>
 			        );

--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -14,8 +14,7 @@ var EditForm = React.createClass({
 	
 	getInitialState: function() {
 		return {
-			values: _.clone(this.props.data.fields),
-			tabs: {}
+			values: _.clone(this.props.data.fields)
 		};
 	},
 	
@@ -149,8 +148,6 @@ var EditForm = React.createClass({
 				elements['h-' + headings] = React.createElement(FormHeading, el);
 				
 			} else if (el.type === 'tabs') {
-				var key = 'tabs' + idx;
-
 				var tabs = Object.keys(el.tabs).map(function(name) {
 					return (
 						<Tab key={name}>
@@ -217,10 +214,6 @@ var EditForm = React.createClass({
 				{this.renderToolbar()}
 			</form>
 		);
-	},
-
-	onTabChange: function(key, index) {
-		this.state.tabs[key] = index;
 	}
 	
 });

--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -4,7 +4,8 @@ var _ = require('underscore'),
 	Fields = require('../fields'),
 	FormHeading = require('./FormHeading'),
 	Toolbar = require('./Toolbar'),
-	InvalidFieldType = require('./InvalidFieldType');
+	InvalidFieldType = require('./InvalidFieldType'),
+	Tabs = require('react-simpletabs');
 
 var EditForm = React.createClass({
 	
@@ -130,12 +131,14 @@ var EditForm = React.createClass({
 		
 	},
 	
-	renderFormElements: function() {
+	renderFormElements: function(src) {
 		
 		var elements = {},
 			headings = 0;
 		
-		_.each(this.props.list.uiElements, function(el) {
+		src = src || this.props.list.uiElements;
+		
+		_.each(src, function(el) {
 			
 			if (el.type === 'heading') {
 				
@@ -143,8 +146,19 @@ var EditForm = React.createClass({
 				el.options.values = this.state.values;
 				elements['h-' + headings] = React.createElement(FormHeading, el);
 				
-			} else if (el.type === 'field') {
+			} else if (el.type === 'tabs') {
+				var tabs = Object.keys(el.tabs).map(function(name) {
+					return (
+						<Tabs.Panel title={name}>
+							{this.renderFormElements(el.tabs[name])}
+						</Tabs.Panel>
+			        );
+				}.bind(this));
 				
+				elements.tabs = (
+					<Tabs>{tabs}</Tabs>
+				);
+			} else if (el.type === 'field') {
 				var field = this.props.list.fields[el.field];
 				
 				if ('function' !== typeof Fields[field.type]) {

--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -13,7 +13,8 @@ var EditForm = React.createClass({
 	
 	getInitialState: function() {
 		return {
-			values: _.clone(this.props.data.fields)
+			values: _.clone(this.props.data.fields),
+			tabs: {}
 		};
 	},
 	
@@ -138,7 +139,7 @@ var EditForm = React.createClass({
 		
 		src = src || this.props.list.uiElements;
 		
-		_.each(src, function(el) {
+		_.each(src, function(el, idx) {
 			
 			if (el.type === 'heading') {
 				
@@ -147,6 +148,8 @@ var EditForm = React.createClass({
 				elements['h-' + headings] = React.createElement(FormHeading, el);
 				
 			} else if (el.type === 'tabs') {
+				var key = 'tabs' + idx;
+
 				var tabs = Object.keys(el.tabs).map(function(name) {
 					return (
 						<Tabs.Panel title={name}>
@@ -154,9 +157,11 @@ var EditForm = React.createClass({
 						</Tabs.Panel>
 			        );
 				}.bind(this));
-				
+
 				elements.tabs = (
-					<Tabs>{tabs}</Tabs>
+					<Tabs tabActive={this.state.tabs[key] || 1} onBeforeChange={this.beforeTabChange.bind(this, key)}>
+					{tabs}
+					</Tabs>
 				);
 			} else if (el.type === 'field') {
 				var field = this.props.list.fields[el.field];
@@ -211,6 +216,10 @@ var EditForm = React.createClass({
 				{this.renderToolbar()}
 			</form>
 		);
+	},
+
+	beforeTabChange: function(key, index) {
+		this.state.tabs[key] = index;
 	}
 	
 });

--- a/admin/src/components/EditForm.js
+++ b/admin/src/components/EditForm.js
@@ -5,7 +5,8 @@ var _ = require('underscore'),
 	FormHeading = require('./FormHeading'),
 	Toolbar = require('./Toolbar'),
 	InvalidFieldType = require('./InvalidFieldType'),
-	Tabs = require('react-simpletabs');
+	Tabs = require("react-tab-view").Tabs,
+	Tab = require("react-tab-view").Tab;
 
 var EditForm = React.createClass({
 	
@@ -152,14 +153,14 @@ var EditForm = React.createClass({
 
 				var tabs = Object.keys(el.tabs).map(function(name) {
 					return (
-						<Tabs.Panel title={name} key={name}>
+						<Tab key={name}>
 							{this.renderFormElements(el.tabs[name])}
-						</Tabs.Panel>
+						</Tab>
 			        );
 				}.bind(this));
 
 				elements.tabs = (
-					<Tabs tabActive={this.state.tabs[key] || 1} onBeforeChange={this.beforeTabChange.bind(this, key)}>
+					<Tabs headers={Object.keys(el.tabs)}>
 					{tabs}
 					</Tabs>
 				);
@@ -218,7 +219,7 @@ var EditForm = React.createClass({
 		);
 	},
 
-	beforeTabChange: function(key, index) {
+	onTabChange: function(key, index) {
 		this.state.tabs[key] = index;
 	}
 	

--- a/lib/list.js
+++ b/lib/list.js
@@ -98,7 +98,7 @@ function List(key, options) {
 
 /**
  * Gets the options for the List, as used by the React components
- * 
+ *
  * @api public
  */
 
@@ -130,6 +130,7 @@ List.prototype.getOptions = function() {
 		uiElements: [],
 		initialFields: _.pluck(this.initialFields, 'path')
 	};
+
 	_.each(this.uiElements, function(el) {
 		switch (el.type) {
 			// TODO: handle indentation
@@ -156,6 +157,23 @@ List.prototype.getOptions = function() {
 					type: 'heading',
 					content: el.heading,
 					options: el.options
+				});
+			break;
+			case 'tabs':
+				ops.uiElements.push({
+					type: 'tabs',
+					tabs: _.mapObject(el.tabs, function(tab) {
+						return _.mapObject(tab, function(field) {
+							// add the field options by path
+							ops.fields[field.field.path] = field.field.getOptions();
+
+							// Transform to a simple field type
+							return {
+								type: 'field',
+								field: field.field.path
+							};
+						});
+					})
 				});
 			break;
 		}
@@ -260,50 +278,71 @@ List.prototype.automap = function(field) {
 
 List.prototype.add = function() {
 
-	var add = function(obj, prefix) {
+	var parse = function(obj, prefix) {
 
 		prefix = prefix || '';
 		var keys = Object.keys(obj);
+		var fields = [];
 
-		for (var i = 0; i < keys.length; ++i) {
-			var key = keys[i];
-
-			if (!obj[key]) {
-				throw new Error(
-					'Invalid value for schema path `'+ prefix + key +'` in `' + this.key + '`.\n' +
-					'Did you misspell the field type?\n'
-				);
+		_.each(obj, function(def, key) {
+			if (!def) {
+				throw new Error('Invalid value for schema path `'+ prefix + key +'` in `' + this.key + '`.\n' +
+					'Did you misspell the field type?\n');
 			}
 
-			if (utils.isObject(obj[key]) && (!obj[key].constructor || 'Object' === obj[key].constructor.name) && (!obj[key].type || obj[key].type.type)) {
-				if (Object.keys(obj[key]).length) {
+			if (utils.isObject(def) && (!def.constructor || 'Object' === def.constructor.name) && (!def.type || def.type.type)) {
+				if (Object.keys(def).length) {
 					// nested object, e.g. { last: { name: String }}
 					// matches logic in mongoose/Schema:add
 					this.schema.nested[this.path] = true;
-					add(obj[key], prefix + key + '.');
+					
+					fields = fields.concat(parse(def, prefix + key + '.'));
 				} else {
-					addField(prefix + key, obj[key]); // mixed type field
+					// mixed type field
+					fields.push({
+						path: prefix + key,
+						details: def
+					});
 				}
 			} else {
-				addField(prefix + key, obj[key]);
+				fields.push({
+					path: prefix + key,
+					options: def
+				});
 			}
-		}
+		}, this);
+
+		return fields;
 
 	}.bind(this);
 
-	var addField = function(path, options) {
-		if (this.isReserved(path)) {
-			throw new Error('Path ' + path + ' on list ' + this.key + ' is a reserved path');
-		}
+	var addFields = function(fields, config) {
+		config = config || false;
 
-		this.uiElements.push({
-			type: 'field',
-			field: this.field(path, options)
-		});
+		return _.map(fields, function(def) {
+			if (this.isReserved(def.path)) {
+				throw new Error("Path " + def.path + " on list " + this.key + " is a reserved path");
+			}
+			
+			var field = this.field(def.path, def.options);
+			
+			this.fields[def.path] = field;
+
+			var ui = {
+				type: 'field',
+				field: field
+			};
+			
+			if (config.ui) {
+				this.uiElements.push(ui);
+			}
+
+			return ui;
+		}, this);
+
 	}.bind(this);
 
 	_.each(arguments, function(def) {
-
 		if ('string' === typeof def) {
 			if (def === '>>>') {
 				this.uiElements.push({
@@ -327,8 +366,19 @@ List.prototype.add = function() {
 					heading: def.heading,
 					options: def
 				});
+			} else if (def.tabs && 'object' === typeof def.tabs) {
+				this.uiElements.push({
+					type: 'tabs',
+					tabs: _.mapObject(def.tabs, function(tab, name) {
+						var fields = parse(tab);
+
+						return addFields(fields);
+					}, this)
+				});
 			} else {
-				add(def);
+				var fields = parse(def);
+				
+				addFields(fields, { ui : true });
 			}
 		}
 
@@ -423,11 +473,7 @@ List.prototype.field = function(path, options) {
 		this.fieldTypes.wysiwyg = true;
 	}
 
-	var field = new options.type(this, path, options);
-
-	this.fields[path] = field;
-	return field;
-
+	return new options.type(this, path, options);
 };
 
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -370,7 +370,7 @@ List.prototype.add = function() {
 				this.uiElements.push({
 					type: 'tabs',
 					tabs: _.mapObject(def.tabs, function(tab, name) {
-						var fields = parse(tab);
+						var fields = parse(tab, name + '.');
 
 						return addFields(fields);
 					}, this)

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "range_check": "~0.0.5",
     "react": "~0.12.2",
     "react-select": "~0.3.5",
-    "react-simpletabs": "^0.5.3",
+    "react-tab-view": "0.0.2",
     "scmp": "~1.0.0",
     "semver": "~4.3.1",
     "serve-favicon": "~2.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "range_check": "~0.0.5",
     "react": "~0.12.2",
     "react-select": "~0.3.5",
+    "react-simpletabs": "^0.5.3",
     "scmp": "~1.0.0",
     "semver": "~4.3.1",
     "serve-favicon": "~2.2.0",

--- a/public/styles/keystone.less
+++ b/public/styles/keystone.less
@@ -87,6 +87,7 @@
 // COMPONENTS
 @import "keystone/wysiwyg.less";
 @import "keystone/select2.less";
+@import "keystone/tabs.less";
 
 // THEME SETUP
 @import "theme/variables.less";

--- a/public/styles/keystone/tabs.less
+++ b/public/styles/keystone/tabs.less
@@ -1,0 +1,41 @@
+.tabs-navigation {
+	padding: 0 50px;
+}
+
+.tabs-navigation {
+	padding: 0 20px;
+	max-height: 50px;
+	border-bottom: 1px solid #DDD;
+}
+
+.tabs-menu {
+	display: table;
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.tabs-menu-item {
+	float: left;
+}
+
+.tabs-menu-item a {
+	display: block;
+	padding: 0 40px;
+	height: 50px;
+	line-height: 50px;
+	border-bottom: 0;
+	color: #A9A9A9;
+}
+
+.tabs-menu-item:not(.is-active) a:hover {
+	color: #3498db;
+}
+
+.tabs-menu-item.is-active a {
+	background: #fff;
+	border: 1px solid #DDD;
+	border-top: 2px solid #3498db;
+	border-bottom: 0;
+	color: #333;
+}

--- a/public/styles/keystone/tabs.less
+++ b/public/styles/keystone/tabs.less
@@ -1,41 +1,40 @@
-.tabs-navigation {
-	padding: 0 50px;
-}
+.react-tabs {
+	& > .pure-menu {
+		padding: 0 20px;
+		max-height: 50px;
+		border-bottom: 1px solid #DDD;
+	}
 
-.tabs-navigation {
-	padding: 0 20px;
-	max-height: 50px;
-	border-bottom: 1px solid #DDD;
-}
+	.pure-menu > ul {
+		display: table;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
 
-.tabs-menu {
-	display: table;
-	list-style: none;
-	padding: 0;
-	margin: 0;
-}
+	.pure-menu .pure-menu,
+	.pure-menu .pure-menu-selected {
+		float: left;
+	}
 
-.tabs-menu-item {
-	float: left;
-}
+	.pure-menu a {
+		display: block;
+		padding: 0 40px;
+		height: 50px;
+		line-height: 50px;
+		border-bottom: 0;
+		color: #A9A9A9;
+	}
 
-.tabs-menu-item a {
-	display: block;
-	padding: 0 40px;
-	height: 50px;
-	line-height: 50px;
-	border-bottom: 0;
-	color: #A9A9A9;
-}
+	.pure-menu-selected a {
+		background: #fff;
+		border: 1px solid #DDD;
+		border-top: 2px solid #3498db;
+		border-bottom: 0;
+		color: #333;
+	}
 
-.tabs-menu-item:not(.is-active) a:hover {
-	color: #3498db;
-}
-
-.tabs-menu-item.is-active a {
-	background: #fff;
-	border: 1px solid #DDD;
-	border-top: 2px solid #3498db;
-	border-bottom: 0;
-	color: #333;
+	.pure-menu a:hover {
+		color: #3498db;
+	}
 }


### PR DESCRIPTION
Adds a concept of a `tabs` section, somewhat like a `heading`. Currently uses react-simpletabs for rendering but if someone else has a favorite I'm open to changes.

Example:

```js
Test.add({
    tabs : {
        "One" : {
            "text1" : {
                type : String
            },
            "box1" : {
                type : Boolean
            }
        },
        "two" : {
            "text2" : {
                type : String
            },
            "box2" : {
                type : Boolean
            }
        }
    }
});
```

I thought about doing some sort of array setup but decided that an object of objects was easier, as it provided an obvious place for tab names to live as top-level object keys.

Currently nested tabs ARE NOT supported, though they could be added with some further code restructuring.

Tests are passing (though I haven't added any new tests for this functionality yet). I will do that once the general direction/suitability of this feature is agreed upon.