### PR TITLE
Re-override shouldCollapse for Markdown fields

### DIFF
--- a/fields/types/markdown/MarkdownField.js
+++ b/fields/types/markdown/MarkdownField.js
@@ -98,6 +98,11 @@ var renderMarkdown = function(component) {
 module.exports = Field.create({
 	
 	displayName: 'MarkdownField',
+
+	// Override `shouldCollapse` to check the markdown field correctly
+	shouldCollapse : function() {
+		return this.props.collapse && !this.props.value.md;
+	},
 	
 	// only have access to `refs` once component is mounted
 	componentDidMount: function() {


### PR DESCRIPTION
This change was originally in #1144 (e8beaeb7ba63daa2faa66965c6b6c4987577e3ba) but got lost in the merges after it to fix #1145.

Probably my fault, I didn't want all my changes to depend on each other so I based them all off of master, which made the merge more complicated than it could've been. Sorry!