### PR TITLE
Added missing updateItem on S3FileType and CloudinaryImagesType type to allow DB updates

### DIFF
--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -238,7 +238,16 @@ cloudinaryimages.prototype.validateInput = function(data) {
  */
 
 cloudinaryimages.prototype.updateItem = function(item, data) {
-	// TODO - direct updating of data (not via upload)
+    if (! data[this.path] || (item.get(this.path) && _.isEqual(item.get(this.path), data[this.path]))) return;
+
+    var props = ['public_id', 'version', 'signature', 'format', 'resource_type', 'url', 'width', 'height', 'secure_url'];
+
+    var items = [];
+    data[this.path].forEach(function(image) {
+        items.push(_.pick(image, props));
+    });
+
+    item.set(this.path, items);
 };
 
 

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -211,7 +211,20 @@ s3file.prototype.validateInput = function(data) {
  */
 
 s3file.prototype.updateItem = function(item, data) {
-	// TODO - direct updating of data (not via upload)
+    var paths = this.paths;
+
+    var setValue = function(key) {
+        if (paths[key]) {
+            var index = paths[key].indexOf('.');
+			var field = paths[key].substr(0, index);
+
+            if (data[field] && data[field][key] && data[field][key] != item.get(paths[key])) {
+				item.set(paths[key], data[field][key] || null);
+			}
+        }
+    }
+
+    _.each(['filename', 'path', 'size', 'filetype', 'url'], setValue);
 };
 
 
@@ -243,7 +256,7 @@ var validateHeader = function(header, callback) {
 			return callback(new Error('Unsupported Header option: value for ' + key + ' header must be a String ' + header[key].toString()));
 		}
 	});
-	
+
 	return true;
 };
 
@@ -304,11 +317,11 @@ s3file.prototype.generateHeaders = function (item, file, callback){
 				var _header = {};
 				if (validateHeader(header, callback)){
 					_header[header.name] = header.value;
-					customHeaders = _.extend(customHeaders, _header); 
+					customHeaders = _.extend(customHeaders, _header);
 				}
 			});
 		} else if (_.isObject(defaultHeaders)){
-			customHeaders = _.extend(customHeaders, defaultHeaders);  
+			customHeaders = _.extend(customHeaders, defaultHeaders);
 		} else {
 			return callback(new Error('Unsupported Header option: defaults headers must be either an Object or Array ' + JSON.stringify(defaultHeaders)));
 		}
@@ -316,7 +329,7 @@ s3file.prototype.generateHeaders = function (item, file, callback){
 
 	if (field.options.headers){
 		headersOption = field.options.headers;
-		
+
 		if (_.isFunction(headersOption)){
 			computedHeaders = headersOption.call(field, item, file);
 
@@ -325,7 +338,7 @@ s3file.prototype.generateHeaders = function (item, file, callback){
 					var _header = {};
 					if (validateHeader(header, callback)){
 						_header[header.name] = header.value;
-						customHeaders = _.extend(customHeaders, _header); 
+						customHeaders = _.extend(customHeaders, _header);
 					}
 				});
 			} else if (_.isObject(computedHeaders)){
@@ -339,12 +352,12 @@ s3file.prototype.generateHeaders = function (item, file, callback){
 				var _header = {};
 				if (validateHeader(header, callback)){
 					_header[header.name] = header.value;
-					customHeaders = _.extend(customHeaders, _header); 
+					customHeaders = _.extend(customHeaders, _header);
 				}
 			});
 		} else if (_.isObject(headersOption)){
 			customHeaders = _.extend(customHeaders, headersOption);
-		} 
+		}
 	}
 
 	if (validateHeaders(customHeaders, callback)){
@@ -380,7 +393,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 	if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, filetype)) {
 		return callback(new Error('Unsupported File Type: ' + filetype));
 	}
-	
+
 	var doUpload = function() {
 
 		if ('function' === typeof field.options.filename) {

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -222,7 +222,7 @@ s3file.prototype.updateItem = function(item, data) {
 				item.set(paths[key], data[field][key] || null);
 			}
         }
-    }
+    };
 
     _.each(['filename', 'path', 'size', 'filetype', 'url'], setValue);
 };


### PR DESCRIPTION
Hi,

I've 'implemented' the missing updateItem method on the S3FileType and CloudinaryImagesType (plural).
In case of S3File that's mostly copy & paste of what's already in CloudinaryImage field type (all credits to @webteckie ), but with different properties.
The properties I've listed are the default ones that get populated for a simple S3 field.

For CloudinaryImagesType I check for deep equality and if it has changed or it was not present before, I update.
Comments/suggestions appreciated! 

Thanks.