### PR TITLE
Allows user to add mandrill template content

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -152,7 +152,8 @@ var Email = function(options) {
 	}
 
 	this.templateMandrillName = options.templateMandrillName;
-
+	this.templateMandrillContent = _.isArray(options.templateMandrillContent) ? options.templateMandrillContent : [];
+	
 	this.templateName = options.templateName || this.templateMandrillName;
 	this.templateExt = options.templateExt || Email.defaults.templateExt;
 	this.templateEngine = options.templateEngine || Email.defaults.templateEngine;
@@ -503,7 +504,10 @@ Email.prototype.buildOptions = function(err, options, callback) {
 
 	if (this.templateMandrillName) {
 		toSend.template_name = this.templateMandrillName;
-		toSend.template_content = [];
+		toSend.template_content = this.templateMandrillContent;
+		if (_.isArray(options.templateMandrillContent)) {
+			toSend.template_content = toSend.template_content.concat(options.templateMandrillContent);
+		}
 	}
 
 	callback(null, toSend);


### PR DESCRIPTION
Mandrill template content can be added when creating a new Email instance and during `Email.send(options)`

```javascript
/* set up Email */
			var Email = new keystone.Email({ 
				templateMandrillName: 'template-name',
				templateMandrillContent: [
					{
						"name": "header",
						"content": "<h2>" + keystone.get('name') + "</h2>"
					}
				]
			});
			
			Email.send({
				to: req.body.email,
				from: {
					name: 'from name',
					email: 'from@domain.tld'
				},
				subject: 'subject'
				templateMandrillContent: [
					{
						"name": "main",
						"content": "custom html for main block"
					}
				],
				mandrillOptions: {
					track_opens: false,
					track_clicks: false
				},
			}, 
			function(err, info) {
				//console.log(err, info);
			});
```