### PR TITLE
Make global "wysiwyg cloudinary images" key optional

### DIFF
--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -74,20 +74,12 @@ function routes(app) {
 		this.bindEmailTestRoutes(app, this.get('email tests'));
 	}
 	
-	// Cloudinary API for image uploading (only if Cloudinary is configured)
-	if (keystone.get('wysiwyg cloudinary images')) {
-		if (!keystone.get('cloudinary config')) {
-			throw new Error('KeystoneJS Initialisaton Error:\n\nTo use wysiwyg cloudinary images, the \'cloudinary config\' setting must be configured.\n\n');
-		}
-		debug('setting wysiwyg cloudinary images');
-		app.post('/keystone/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
-	}
-	
-	// Cloudinary API for selecting an existing image from the cloud
+	// Cloudinary API for selecting an existing image / upload a new image
 	if (keystone.get('cloudinary config')) {
 		debug('setting cloudinary api');
 		app.get('/keystone/api/cloudinary/get', require('../../routes/api/cloudinary').get);
 		app.get('/keystone/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
+		app.post('/keystone/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
 	}
 
 	// Generic Lists API


### PR DESCRIPTION
Now that per-field wysiwyg options are working, I don't see the point on forcing users to set that global setting (it adds the image button on every wysiwyg field).
However, without that option the upload does not work because the API route is set only if `wysiwyg cloudinary images` is `true`.

To fix it: change [lib/core/routes.js#L78-91](https://github.com/keystonejs/keystone/blob/master/lib/core/routes.js#L78-91) to:

```js
// Cloudinary API for selecting an existing image and uploading a new one
if (keystone.get('cloudinary config')) {
	debug('setting cloudinary api');
	app.get('/keystone/api/cloudinary/get', require('../../routes/api/cloudinary').get);
	app.get('/keystone/api/cloudinary/autocomplete', require('../../routes/api/cloudinary').autocomplete);
	app.post('/keystone/api/cloudinary/upload', require('../../routes/api/cloudinary').upload);
}
```

I can create a PR if you agree.