### PR TITLE
Allow boolean evaluation of dependsOn for fields and headings

### DIFF
--- a/admin/src/components/FormHeading.js
+++ b/admin/src/components/FormHeading.js
@@ -4,7 +4,11 @@ function evalDependsOn(dependsOn, values) {
 	if (!_.isObject(dependsOn)) return true;
 	var keys = _.keys(dependsOn);
 	return (keys.length) ? _.every(keys, function(key) {
-		var matches = _.isArray(dependsOn[key]) ? dependsOn[key] : [dependsOn[key]];
+		var dependsValue = dependsOn[key];
+		if(_.isBoolean(dependsValue)) {
+			return dependsValue !== _.isEmpty(values[key]);
+		}
+		var matches = _.isArray(dependsValue) ? dependsValue : [dependsValue];
 		return _.contains(matches, values[key]);
 	}, this) : true;
 }

--- a/fields/types/Field.js
+++ b/fields/types/Field.js
@@ -18,7 +18,11 @@ function evalDependsOn(dependsOn, values) {
 	if (!_.isObject(dependsOn)) return true;
 	var keys = _.keys(dependsOn);
 	return (keys.length) ? _.every(keys, function(key) {
-		var matches = _.isArray(dependsOn[key]) ? dependsOn[key] : [dependsOn[key]];
+		var dependsValue = dependsOn[key];
+		if(_.isBoolean(dependsValue)) {
+			return dependsValue !== _.isEmpty(values[key]);
+		}
+		var matches = _.isArray(dependsValue) ? dependsValue : [dependsValue];
 		return _.contains(matches, values[key]);
 	}, this) : true;
 }


### PR DESCRIPTION
Allow the `dependsOn` option to be `true` or `false`. If the field is populated then it will return true.
Fixes #1130