### PR TITLE
fixed an issue with schema inheritance and schemaPlugins

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -104,7 +104,23 @@ function List(key, options) {
 		return initialFields || (initialFields = _.filter(this.fields, function(i) { return i.initial; }));
 	}});
 
-	if (this.options.inherits) {
+	if (this.get('sortable')) {
+		schemaPlugins.sortable.apply(this);
+	}
+
+	if (this.get('autokey')) {
+		schemaPlugins.autokey.apply(this);
+	}
+
+	if (this.get('track')) {
+		schemaPlugins.track.apply(this);
+	}
+
+	if (this.get('history')) {
+		schemaPlugins.history.apply(this);
+	}
+
+	if (this.get('inherits')) {
 		var parentFields = this.get('inherits').schemaFields;
 		this.add.apply(this, parentFields);
 	}
@@ -113,7 +129,7 @@ function List(key, options) {
 
 /**
  * Gets the options for the List, as used by the React components
- * 
+ *
  * @api public
  */
 
@@ -713,21 +729,8 @@ List.prototype.register = function() {
 		return list;
 	});
 
-	if (this.get('sortable')) {
-		schemaPlugins.sortable.apply(this);
-	}
 
-	if (this.get('autokey')) {
-		schemaPlugins.autokey.apply(this);
-	}
 
-	if (this.get('track')) {
-		schemaPlugins.track.apply(this);
-	}
-
-	if (this.get('history')) {
-		schemaPlugins.history.apply(this);
-	}
 
 	if (!_.isEmpty(this.relationships)) {
 		this.schema.methods.getRelated = schemaPlugins.methods.getRelated;


### PR DESCRIPTION
This solves an issue brought on changes introduced by fixing #1301.

When using inheritance, if the parent list was using any of the schemaPlugins (i.e. had `track` set to `true`) then an exception would be thrown because of duplicate keys. These plugins should be added before any of the fields are inherited to prevent this.

Not sure if moving the plugin definition to the list initialization will have unintended side effects.