### PR TITLE
Implement text field max length w/ validation and counter

### DIFF
--- a/fields/types/Field.js
+++ b/fields/types/Field.js
@@ -53,7 +53,23 @@ var Base = module.exports.Base = {
 	},
 	
 	renderField: function() {
-		return <input type="text" ref="focusTarget" name={this.props.path} placeholder={this.props.placeholder} value={this.props.value} onChange={this.valueChanged} autoComplete="off" className="form-control" />;
+		var max = this.props.maxLen,
+				value = this.props.value || '',
+				counter;
+
+		if (max) {
+			var len = value.length
+					counterClassName = cx('field-max-counter', len > max.chars ? 'do-' + max.mode : '');
+			counter = (
+				<div className={counterClassName}>
+					{ max.mode == 'limit' ? max.chars - len : (len > max.chars ? len : '') }
+				</div>
+			);
+		}
+		return [
+			counter,
+			<input type="text" ref="focusTarget" name={this.props.path} placeholder={this.props.placeholder} value={value} onChange={this.valueChanged} autoComplete="off" className="form-control" />
+		];
 	},
 	
 	renderValue: function() {

--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -3,8 +3,9 @@
  */
 
 var util = require('util'),
-	utils = require('keystone-utils'),
-	super_ = require('../Type');
+  _ = require('underscore'),
+  utils = require('keystone-utils'),
+  super_ = require('../Type');
 
 /**
  * Text FieldType Constructor
@@ -13,9 +14,23 @@ var util = require('util'),
  */
 
 function text(list, path, options) {
-	this._nativeType = String;
-	this._underscoreMethods = ['crop'];
-	text.super_.call(this, list, path, options);
+  this._nativeType = String;
+  this._underscoreMethods = ['crop'];
+
+  this._properties = ['maxLen'];
+
+  // if max option, set maxLen
+  this.maxLen = null;
+  if (options.max) {
+    this.maxLen = { chars: 255, mode: 'limit' };
+    if (typeof options.max !== 'object') {
+      this.maxLen.chars = +options.max;
+    } else {
+      _.assign(this.maxLen, options.max);
+    }
+  }
+
+  text.super_.call(this, list, path, options);
 }
 
 /*!
@@ -26,13 +41,32 @@ util.inherits(text, super_);
 
 
 /**
+ * Validates that length is within the max range
+ *
+ * @api public
+ */
+
+text.prototype.validateInput = function(data, required, item) {
+  var validateMax = this.maxLen && this.maxLen.mode == 'limit';
+  if (!required && !validateMax) return true;
+  var value = this.getValueFromData(data);
+  if (value === undefined && item && item.get(this.path)) return true;
+  if(validateMax) {
+    return data[this.path].length <= this.maxLen.chars;
+  } else {
+    return (data[this.path].trim()) ? true : false;
+  }
+};
+
+
+/**
  * Crops the string to the specifed length.
  *
  * @api public
  */
 
 text.prototype.crop = function(item, length, append, preserveWords) {
-	return utils.cropString(item.get(this.path), length, append, preserveWords);
+  return utils.cropString(item.get(this.path), length, append, preserveWords);
 };
 
 

--- a/public/styles/keystone/forms.less
+++ b/public/styles/keystone/forms.less
@@ -115,6 +115,28 @@
 	}
 }
 
+// Field character count
+.field-max-counter {
+	position: absolute;
+	right: 10px + 15px;
+	bottom: 8px;
+	font-size: 0.8em;
+	color: @gray-light;
+
+	&.do-limit {
+		color: @brand-danger;
+	}
+
+	&.do-warn {
+		color: @brand-warning;
+	}
+
+	+ .form-control {
+		padding-right: 40px !important;
+	}
+}
+
+
 // Field value. Used for non-editable fields
 .field-value {
 	background-color: mix(white, @input-bg-disabled, 10%);

--- a/public/styles/theme/theme.less
+++ b/public/styles/theme/theme.less
@@ -518,6 +518,10 @@ h3.relationship-heading {
 	margin: 0;
 }
 
+.item-name-field .field-max-counter {
+	bottom: 14px;
+}
+
 // Boolean fields
 .type-boolean {
 	img {


### PR DESCRIPTION
As discussed on issue #126.
New option for field type Text:

``` js
max: 50 // limit the length to 50. Produces validation error if longer
max: { chars: 50, mode: 'limit' } // same as above
max: { chars: 50, mode: 'warn' } // shows a "warning" counter if longer
```
