### PR TITLE
Fixing case-insensitive user lookup in .session.signin()

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -44,7 +44,7 @@ function signinWithUser(user, req, res, onSuccess) {
 	if ('function' !== typeof onSuccess) {
 		throw new Error('keystone.sesson.signinWithUser requires onSuccess to be a function.');
 	}
-	
+
 	req.session.regenerate(function() {
 		req.user = user;
 		req.session.userId = user.id;
@@ -75,7 +75,7 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 	var User = keystone.list(keystone.get('user model'));
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
 		// match email address and password
-		User.model.findOne({ email: lookup.email }).exec(function(err, user) {
+		User.model.findOne({ email: new RegExp(lookup.email, 'i') }).exec(function(err, user) {
 			if (user) {
 				user._.password.compare(lookup.password, function(err, isMatch) {
 					if (!err && isMatch) {

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -53,7 +53,7 @@ describe('Keystone.session', function() {
 				sinon.assert.calledOnce(req.session.regenerate);
 
 				req.user.must.equal(user);
-				req.session.userId.must.equal(user.id);				
+				req.session.userId.must.equal(user.id);
 
 				sinon.assert.calledOnce(res.cookie);
 				sinon.assert.calledWith(res.cookie, 'keystone.uid');
@@ -73,7 +73,7 @@ describe('Keystone.session', function() {
 				sinon.assert.calledOnce(req.session.regenerate);
 
 				req.user.must.equal(user);
-				req.session.userId.must.equal(user.id);				
+				req.session.userId.must.equal(user.id);
 
 				sinon.assert.callCount(res.cookie, 0);
 
@@ -109,28 +109,28 @@ describe('Keystone.session', function() {
 			it('should error when user arg is not an object', function() {
 				function callWithInvalidUser() {
 					keystone.session.signinWithUser('user', req, res, onSuccess);
-				}				
+				}
 				callWithInvalidUser.must.throw('keystone.sesson.signinWithUser requires user to be an object.');
 			});
 
 			it('should error when req arg is not an object', function() {
 				function callWithInvalidReq() {
 					keystone.session.signinWithUser(user, 'req', res, onSuccess);
-				}				
+				}
 				callWithInvalidReq.must.throw('keystone.sesson.signinWithUser requires req to be an object.');
 			});
 
 			it('should error when res arg is not an object', function() {
 				function callWithInvalidRes() {
 					keystone.session.signinWithUser(user, req, 'res', onSuccess);
-				}				
+				}
 				callWithInvalidRes.must.throw('keystone.sesson.signinWithUser requires res to be an object.');
 			});
 
 			it('should error when onSuccess arg is not a function', function() {
 				function callWithInvalidCallback() {
 					keystone.session.signinWithUser(user, req, res, 'onSuccess');
-				}				
+				}
 				callWithInvalidCallback.must.throw('keystone.sesson.signinWithUser requires onSuccess to be a function.');
 			});
 
@@ -138,8 +138,135 @@ describe('Keystone.session', function() {
 
 	});
 
-	// TODO: test keystone.session.signin()
-	// describe('keystone.session.signin()');
+	// TODO: need more test for keystone.session.signin()
+	describe('keystone.session.signin()', function() {
+
+		describe('case-insensitive email lookup', function() {
+
+			before(function() {
+				var self = this;
+				this.onSuccess = sinon.stub();
+				this.onFailure = sinon.stub();
+
+				// simulate User model
+				this.User = {
+					model: {
+						findOne: sinon.spy(function(query) {
+							self.query = query;
+							return this;
+						}),
+						exec: sinon.spy(function(callback) {
+							var email = 'test@test.com';
+							self.query.match = self.query.email.test(email);
+							if (self.query.match) {
+								return callback(null, self.user);
+							}
+							callback(new Error('not found'))
+						})
+					}
+				};
+
+				// simulate user instance
+				this.user = {
+					_: {
+						password: {
+							compare: sinon.spy(function(password, callback) {
+								callback(null, true);
+							})
+						}
+					}
+				};
+
+				keystone.set('user model', 'User');
+				sinon.stub(keystone, 'list').withArgs('User').returns(this.User);
+				sinon.stub(keystone.session, 'signinWithUser').callsArg(3);
+			});
+
+			after(function() {
+				keystone.list.restore();
+				keystone.session.signinWithUser.restore();
+			});
+
+			afterEach(function() {
+				delete this.query;
+
+				this.User.model.findOne.reset();
+				this.User.model.exec.reset();
+				this.onSuccess.reset();
+				this.onFailure.reset();
+
+				keystone.list.reset();
+				keystone.session.signinWithUser.reset();
+			});
+
+			it('shoud match email with mixed case', function () {
+				var lookup = { email: 'Test@Test.Com', password: 'password'};
+
+				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+
+				// make sure .findOne() is called with a regular expression
+				sinon.assert.calledOnce(this.User.model.findOne);
+				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+				// make sure .exec() is called after
+				sinon.assert.calledOnce(this.User.model.exec);
+				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+				// make sure .signinWithUser() is called on successful match
+				sinon.assert.calledOnce(keystone.session.signinWithUser);
+				// make sure onSuccess callback is called on successful match
+				sinon.assert.calledOnce(this.onSuccess);
+			});
+
+			it('shoud match email with all uppercase', function () {
+				var lookup = { email: 'TEST@TEST.COM', password: 'password'};
+				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+
+				// make sure .findOne() is called with a regular expression
+				sinon.assert.calledOnce(this.User.model.findOne);
+				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+				// make sure .exec() is called after
+				sinon.assert.calledOnce(this.User.model.exec);
+				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+				// make sure .signinWithUser() is called on successful match
+				sinon.assert.calledOnce(keystone.session.signinWithUser);
+				// make sure onSuccess callback is called on successful match
+				sinon.assert.calledOnce(this.onSuccess);
+			});
+
+			it('shoud match email with all lowercase', function () {
+				var lookup = { email: 'test@test.com', password: 'password'};
+				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+
+				// make sure .findOne() is called with a regular expression
+				sinon.assert.calledOnce(this.User.model.findOne);
+				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+				// make sure .exec() is called after
+				sinon.assert.calledOnce(this.User.model.exec);
+				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+				// make sure .signinWithUser() is called on successful match
+				sinon.assert.calledOnce(keystone.session.signinWithUser);
+				// make sure onSuccess callback is called on successful match
+				sinon.assert.calledOnce(this.onSuccess);
+			});
+
+			it('shoud not match email when invalid', function () {
+				var lookup = { email: 'xxx', password: 'password'};
+				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+
+				// make sure .findOne() is called with a regular expression
+				sinon.assert.calledOnce(this.User.model.findOne);
+				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+				// make sure .exec() is called after
+				sinon.assert.calledOnce(this.User.model.exec);
+				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+				// make sure .signinWithUser() is NOT called on failed match
+				sinon.assert.notCalled(keystone.session.signinWithUser);
+				// make sure onFailure callback is called on failed match
+				sinon.assert.calledOnce(this.onFailure);
+			});
+
+		});
+
+	});
 
 	// TODO: test keystone.session.signout()
 	// describe('keystone.session.signout()');


### PR DESCRIPTION
Fix for #1323 

- used RegExp() to create a case-insensitive query (as suggested by @creynders)
- added unit tests to test this specific functionality
- removed some trailing whitespace I self on `test/lib/session-test.js` last time I edited it