### PR TITLE
Disabled drag and drop sorting in list view when xFilter is applied.

### DIFF
--- a/templates/mixins/rows.jade
+++ b/templates/mixins/rows.jade
@@ -6,7 +6,7 @@ mixin row(list, colums, item)
       td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
     else if !list.get('nodelete')
       td.control
-    if sortable
+    if sortable && !xFilters
       td.control: a(href=js).control-sort
     each col, i in columns
       td

--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -394,7 +394,7 @@ block content
 			if !list.get('nodelete')
 				- firstColspan++;
 				col(width=26)
-			if sortable
+			if sortable && !xFilters
 				- firstColspan++;
 				col(width=26)
 			each col in columns


### PR DESCRIPTION
This pull request addresses an issue where drag and drop sorting in the Admin UI can lead to items having non-unique sortOrder variables when filters are enabled. As a simple example, consider items with attributes category (consisting of cats and dogs) and unique names. If we use keystone to arrange them in the following order: 

Name | Category | sortOder
------------ | ------------- | -------------
russian blue  | cat | 0
golden retriever  | dog | 1
maltese  | dog | 2
himalayan  | cat | 3

Now if we apply a filter for cats we have: 

Name | Category | sortOder
------------ | ------------- | -------------
russian blue  | cat | 0
himalayan  | cat | 3

but this menu is still drag and drop sortable, so if we decide to switch the order in this view, we have:

Name | Category | sortOder
------------ | ------------- | -------------
himalayan  | cat | 0
russian blue  | cat | 1

and if we remove the category filter, we have 

Name | Category | sortOder
------------ | ------------- | -------------
himalayan  | cat | 0
russian blue  | cat | 1
golden retriever  | dog | 1
maltese  | dog | 2

This pull request disables the ability to sort when category filters are enabled to prevent sortOrder conflicts.