### PR TITLE
GeoPoint display fixes for Type.GeoPoint and Type.Location

### DIFF
--- a/fields/types/geopoint/GeoPointType.js
+++ b/fields/types/geopoint/GeoPointType.js
@@ -62,7 +62,10 @@ geopoint.prototype.getData = function(item) {
  */
 
 geopoint.prototype.format = function(item) {
-	return item.get(this.path).join(', ');
+	if (item.get(this.path)) {
+		return item.get(this.path).reverse().join(', ');	
+	}
+	return null;
 };
 
 

--- a/fields/types/location/LocationField.js
+++ b/fields/types/location/LocationField.js
@@ -136,14 +136,14 @@ module.exports = Field.create({
 		return (
 			<div className="row">
 				<div className="col-sm-2 location-field-label">
-					<label className="text-muted">Lng / Lat</label>
+					<label className="text-muted">Lat / Lng</label>
 				</div>
 				<div className="col-sm-10 col-md-7 col-lg-6 location-field-controls"><div className="form-row">
 					<div className="col-xs-6">
-						<input type="text" name={this.props.paths.geo} ref="geo0" value={this.props.value.geo ? this.props.value.geo[0] : ''} onChange={this.geoChanged.bind(this, 0)} placeholder="Longitude" className="form-control" />
+						<input type="text" name={this.props.paths.geo} ref="geo1" value={this.props.value.geo ? this.props.value.geo[1] : ''} onChange={this.geoChanged.bind(this, 1)} placeholder="Latitude" className="form-control" />
 					</div>
 					<div className="col-xs-6">
-						<input type="text" name={this.props.paths.geo} ref="geo1" value={this.props.value.geo ? this.props.value.geo[1] : ''} onChange={this.geoChanged.bind(this, 1)} placeholder="Latitude" className="form-control" />
+						<input type="text" name={this.props.paths.geo} ref="geo0" value={this.props.value.geo ? this.props.value.geo[0] : ''} onChange={this.geoChanged.bind(this, 0)} placeholder="Longitude" className="form-control" />
 					</div>
 				</div></div>
 			</div>


### PR DESCRIPTION
This fixes a crash when a GeoPoint is added as a column on the index page and there is no GeoPoint saved for the record. This also updates the location field to display the coordinates in Lat/Lng instead of Lng/Lat when editing the record.