### PR TITLE
Fix #1370 - inconsistencies between LocalFileType.js & LocalFilesType.js

### DIFF
--- a/fields/types/localfiles/LocalFilesField.js
+++ b/fields/types/localfiles/LocalFilesField.js
@@ -161,9 +161,9 @@ module.exports = Field.create({
 		var value = '';
 		var remove = [];
 		_.each(this.state.items, function (thumb) {
-			if (thumb && thumb.props.deleted) remove.push(thumb.props.public_id);
+			if (thumb && thumb.props.deleted) remove.push(thumb.props._id);
 		});
-		if (remove.length) value = 'remove:' + remove.join(',');
+		if (remove.length) value = 'delete:' + remove.join(',');
 
 		return <input ref="action" className="field-action" type="hidden" value={value} name={this.props.paths.action} />;
 	},

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -80,6 +80,7 @@ localfiles.prototype.addToSchema = function() {
 		// fields
 		filename:		this._path.append('.filename'),
 		path:			  this._path.append('.path'),
+		originalname:		this._path.append('.originalname'),
 		size:			  this._path.append('.size'),
 		filetype:		this._path.append('.filetype'),
 		// virtuals
@@ -91,6 +92,7 @@ localfiles.prototype.addToSchema = function() {
 
 	var schemaPaths = new mongoose.Schema({
 		filename:		String,
+		originalname:   String,
 		path:			String,
 		size:			Number,
 		filetype:		String
@@ -293,7 +295,7 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 		var doMove = function(doneMove) {
 			
 			if ('function' === typeof field.options.filename) {
-				filename = field.options.filename(item, filename);
+				filename = field.options.filename(item, file);
 			}
 			
 			fs.move(file.path, path.join(field.options.dest, filename), { clobber: field.options.overwrite }, function(err) {
@@ -301,6 +303,7 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 				
 				var fileData = {
 					filename: filename,
+					originalname: file.originalname,
 					path: field.options.dest,
 					size: file.size,
 					filetype: filetype


### PR DESCRIPTION
Hi!

This is just a quick normalization fix to #1370 - the [documented examples](http://keystonejs.com/docs/database/#fieldtypes-localfile) for the field type LocalFile can now be used with field type Localfiles.

 I added originalname to the schamaPath used in LocalFilesType, and also made sure that the entire file object is passed to field.options.filename.
