### PR TITLE
Extra hooks: `updates`, `signin` and `signout`

### DIFF
--- a/admin/routes/views/signin.js
+++ b/admin/routes/views/signin.js
@@ -38,8 +38,9 @@ exports = module.exports = function(req, res) {
 
 		};
 
-		var onFail = function () {
-			req.flash('error', 'Sorry, that email and password combo are not valid.');
+		var onFail = function (err) {
+			var message = (err && err.message) ? err.message : 'Sorry, that email and password combo are not valid.';
+			req.flash('error', message );
 			renderView();
 		};
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var moduleRoot = (function(_rootPath) {
  */
 var Keystone = function() {
 	grappling.mixin(this)
-		.allowHooks('pre:routes', 'pre:render');
+		.allowHooks('pre:routes', 'pre:render', 'updates');
 	this.lists = {};
 	this.paths = {};
 	this._options = {
@@ -205,7 +205,18 @@ Keystone.prototype.import = function(dirname) {
  */
 
 Keystone.prototype.applyUpdates = function(callback) {
-	require('./lib/updates').apply(callback);
+	var self = this;
+	self.callHook('pre:updates', function(err){
+		if(err){
+			callback(err);
+		}
+		require('./lib/updates').apply(function(err){
+			if(err){
+				callback(err);
+			}
+			self.callHook('post:updates', callback);
+		});
+	});
 };
 
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var moduleRoot = (function(_rootPath) {
  */
 var Keystone = function() {
 	grappling.mixin(this)
-		.allowHooks('pre:routes', 'pre:render', 'updates', 'signout');
+		.allowHooks('pre:routes', 'pre:render', 'updates', 'signout', 'signin');
 	this.lists = {};
 	this.paths = {};
 	this._options = {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var moduleRoot = (function(_rootPath) {
  */
 var Keystone = function() {
 	grappling.mixin(this)
-		.allowHooks('pre:routes', 'pre:render', 'updates');
+		.allowHooks('pre:routes', 'pre:render', 'updates', 'signout');
 	this.lists = {};
 	this.paths = {};
 	this._options = {

--- a/lib/session.js
+++ b/lib/session.js
@@ -55,9 +55,19 @@ function signinWithUser(user, req, res, onSuccess) {
 		}
 		onSuccess(user);
 	});
+
 }
 
 exports.signinWithUser = signinWithUser;
+
+var postHookedSigninWithUser = function(user, req, res, onSuccess, onFail) {
+	keystone.callHook(user, 'post:signin', function(err){
+		if(err){
+			return onFail(err);
+		}
+		exports.signinWithUser(user, req, res, onSuccess, onFail);
+	});
+};
 
 /**
  * Signs in a user user matching the lookup filters
@@ -69,7 +79,7 @@ exports.signinWithUser = signinWithUser;
  * @param {function()} onFail callback
  */
 
-exports.signin = function(lookup, req, res, onSuccess, onFail) {
+var doSignin = function(lookup, req, res, onSuccess, onFail) {
 	if (!lookup) {
 		return onFail(new Error('session.signin requires a User ID or Object as the first argument'));
 	}
@@ -80,9 +90,8 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			if (user) {
 				user._.password.compare(lookup.password, function(err, isMatch) {
 					if (!err && isMatch) {
-						exports.signinWithUser(user, req, res, onSuccess);
-					}
-					else {
+						postHookedSigninWithUser(user, req, res, onSuccess, onFail);
+					} else {
 						onFail(err);
 					}
 				});
@@ -97,12 +106,21 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 			passwordCheck = (lookup.indexOf(':') > 0) ? lookup.substr(lookup.indexOf(':') + 1) : false;
 		User.model.findById(userId).exec(function(err, user) {
 			if (user && (!passwordCheck || scmp(passwordCheck, hash(user.password)))) {
-				exports.signinWithUser(user, req, res, onSuccess);
+				postHookedSigninWithUser(user, req, res, onSuccess, onFail);
 			} else {
 				onFail(err);
 			}
 		});
 	}
+};
+
+exports.signin = function(lookup, req, res, onSuccess, onFail) {
+	keystone.callHook({}, 'pre:signin', function(err){
+		if(err){
+			return onFail(err);
+		}
+		doSignin(lookup, req, res, onSuccess, onFail);
+	});
 };
 
 /**
@@ -157,8 +175,11 @@ exports.persist = function(req, res, next) {
 	}
 
 	if (keystone.get('cookie signin') && !req.session.userId && req.signedCookies['keystone.uid'] && req.signedCookies['keystone.uid'].indexOf(':') > 0) {
-		var _next = function() { next(); }; // otherwise the matching user is passed to next() which messes with the middleware signature
-		exports.signin(req.signedCookies['keystone.uid'], req, res, _next, _next);
+		exports.signin(req.signedCookies['keystone.uid'], req, res, function() {
+			next();
+		}, function(err) {
+			next(err);
+		});
 
 	} else if (req.session.userId) {
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -115,10 +115,25 @@ exports.signin = function(lookup, req, res, onSuccess, onFail) {
 
 exports.signout = function(req, res, next) {
 
-	res.clearCookie('keystone.uid');
-	req.user = null;
+	keystone.callHook(req.user, 'pre:signout', function(err) {
+		if (err) {
+			console.log("An error occurred in signout 'pre' middleware", err);
+		}
+		res.clearCookie('keystone.uid');
+		req.user = null;
 
-	req.session.regenerate(next);
+		req.session.regenerate(function(err) {
+			if (err) {
+				return next(err);
+			}
+			keystone.callHook({}, 'post:signout', function(err) {
+				if (err) {
+					console.log("An error occurred in signout 'post' middleware", err);
+				}
+				next();
+			});
+		});
+	});
 
 };
 

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -199,69 +199,69 @@ describe('Keystone.session', function() {
 				keystone.session.signinWithUser.reset();
 			});
 
-			it('shoud match email with mixed case', function () {
+			it('shoud match email with mixed case', function (done) {
 				var lookup = { email: 'Test@Test.Com', password: 'password'};
 
-				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+				keystone.session.signin(lookup, null, null, function(){
+					// make sure .findOne() is called with a regular expression
+					sinon.assert.calledOnce(this.User.model.findOne);
+					this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+					// make sure .exec() is called after
+					sinon.assert.calledOnce(this.User.model.exec);
+					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					// make sure .signinWithUser() is called on successful match
+					sinon.assert.calledOnce(keystone.session.signinWithUser);
+					done();
+				}.bind(this), this.onFailure);
 
-				// make sure .findOne() is called with a regular expression
-				sinon.assert.calledOnce(this.User.model.findOne);
-				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
-				// make sure .exec() is called after
-				sinon.assert.calledOnce(this.User.model.exec);
-				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
-				// make sure .signinWithUser() is called on successful match
-				sinon.assert.calledOnce(keystone.session.signinWithUser);
-				// make sure onSuccess callback is called on successful match
-				sinon.assert.calledOnce(this.onSuccess);
 			});
 
-			it('shoud match email with all uppercase', function () {
+			it('shoud match email with all uppercase', function (done) {
 				var lookup = { email: 'TEST@TEST.COM', password: 'password'};
-				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+					keystone.session.signin(lookup, null, null, function(){
+					// make sure .findOne() is called with a regular expression
+					sinon.assert.calledOnce(this.User.model.findOne);
+					this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+					// make sure .exec() is called after
+					sinon.assert.calledOnce(this.User.model.exec);
+					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					// make sure .signinWithUser() is called on successful match
+					sinon.assert.calledOnce(keystone.session.signinWithUser);
+					done();
+				}.bind(this), this.onFailure);
 
-				// make sure .findOne() is called with a regular expression
-				sinon.assert.calledOnce(this.User.model.findOne);
-				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
-				// make sure .exec() is called after
-				sinon.assert.calledOnce(this.User.model.exec);
-				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
-				// make sure .signinWithUser() is called on successful match
-				sinon.assert.calledOnce(keystone.session.signinWithUser);
-				// make sure onSuccess callback is called on successful match
-				sinon.assert.calledOnce(this.onSuccess);
 			});
 
-			it('shoud match email with all lowercase', function () {
+			it('shoud match email with all lowercase', function (done) {
 				var lookup = { email: 'test@test.com', password: 'password'};
-				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+				keystone.session.signin(lookup, null, null, function(){
+					// make sure .findOne() is called with a regular expression
+					sinon.assert.calledOnce(this.User.model.findOne);
+					this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+					// make sure .exec() is called after
+					sinon.assert.calledOnce(this.User.model.exec);
+					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					// make sure .signinWithUser() is called on successful match
+					sinon.assert.calledOnce(keystone.session.signinWithUser);
+					done();
+				}.bind(this), this.onFailure);
 
-				// make sure .findOne() is called with a regular expression
-				sinon.assert.calledOnce(this.User.model.findOne);
-				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
-				// make sure .exec() is called after
-				sinon.assert.calledOnce(this.User.model.exec);
-				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
-				// make sure .signinWithUser() is called on successful match
-				sinon.assert.calledOnce(keystone.session.signinWithUser);
-				// make sure onSuccess callback is called on successful match
-				sinon.assert.calledOnce(this.onSuccess);
 			});
 
-			it('shoud not match email when invalid', function () {
+			it('shoud not match email when invalid', function (done) {
 				var lookup = { email: 'xxx', password: 'password'};
-				keystone.session.signin(lookup, null, null, this.onSuccess, this.onFailure);
+				keystone.session.signin(lookup, null, null, this.onSuccess, function(){
+					// make sure .findOne() is called with a regular expression
+					sinon.assert.calledOnce(this.User.model.findOne);
+					this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
+					// make sure .exec() is called after
+					sinon.assert.calledOnce(this.User.model.exec);
+					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					// make sure .signinWithUser() is NOT called on failed match
+					sinon.assert.notCalled(keystone.session.signinWithUser);
+					done();
+				}.bind(this));
 
-				// make sure .findOne() is called with a regular expression
-				sinon.assert.calledOnce(this.User.model.findOne);
-				this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
-				// make sure .exec() is called after
-				sinon.assert.calledOnce(this.User.model.exec);
-				this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
-				// make sure .signinWithUser() is NOT called on failed match
-				sinon.assert.notCalled(keystone.session.signinWithUser);
-				// make sure onFailure callback is called on failed match
-				sinon.assert.calledOnce(this.onFailure);
 			});
 
 		});


### PR DESCRIPTION
I added 3 new hooks:

* `updates`
* `signin` (see #1269)
* `signout`

Some things of note: (will update docs in a separate PR BTW)

* `signin` middleware is executed in the user object scope, i.e. `this` refers to the user object. It means the `pre:signin` middleware are executed _after_ pasword verification. TBH @ttsirkia it _is_ a bit weird though, if the user enters a wrong password the `signin` middleware isn't called, which is **really** odd IMO.
    @dcousens and @jedwatson what do you guys think?
* Had to modify `views/signin` too, since it always outputs "Sorry, that email and password combo are not valid." if an error occurs, which is no longer appropriate.
