### PR TITLE
support custom session store implementation

### DIFF
--- a/docs/content/en/pages/docs/configuration.jade
+++ b/docs/content/en/pages/docs/configuration.jade
@@ -290,7 +290,7 @@ block content
 						p The encryption key to use for your cookies. Passed to Express's cookie parser.
 						p It's a really good idea to set this to a long, random string.
 				tr
-					td <code>session store</code> <code class="data-type">String</code>
+					td <code>session store</code> <code class="data-type">String</code> or <code class="data-type">Function</code>
 					td
 						p Set this to <code class="default-value">mongo</code> to use your MongoDB database to persist session data.
 						p By default, Keystone will use the in-memory session store provided by Express, which should only be used in development because it does not scale past a single process, and leaks memory over time.
@@ -299,8 +299,26 @@ block content
 							li <code class="default-value">mongo</code> (or <code class="default-value">connect-mongo</code>)
 							li <code class="default-value">connect-mongostore</code> (supports replica sets, but requires explicit configuration - see below)
 							li <code class="default-value">connect-redis</code>
+							li <code class="default-value">function(expressSession){ ... }</code>.  You may specify a custom express-session store implementation by setting the <code>session store</code> property to a function that returns an express-session store implementation (see example below).
 						p.note Session store packages are not bundled with Keystone, so make sure you explicitly add the selected session store to your project's <code>package.json</code>.
 						p.note The session configuration passed to Express is available via <code class="language-javascript">keystone.get('express session')</code>
+
+						.code-header
+							h4 Example using custom express-session store
+						pre: code.language-javascript
+							| var keystone = require('keystone'),
+							|     ConnectMemcached = require('connect-memcached')
+							|
+							| keystone.init({
+							|   //...
+							|   'session store': function(session){
+							|     return new (ConnectMemcached(session))({
+							|       hosts: [
+							|         'localhost:11211'
+							|       ]
+							|     });
+							|   }
+							| });
 				tr
 					td <code>session store options</code> <code class="data-type">Object</code>
 					td

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -121,6 +121,8 @@ function mount(mountPath, parentApp, events) {
 	var sessionStorePromise;
 
 	if (sessionStore) {
+		sessionOptions.store = sessionStore(session);
+	} else if (sessionStore) {
 		
 		var sessionStoreOptions = this.get('session store options') || {};
 


### PR DESCRIPTION
This small change will allow keystone to support pluggable express session stores. I need to be able to use connect-memcached, and looked into adding it as one of the named/supported session store implementations, but as I went further down that rabbit hole, it occurred to me that maybe it was a bad idea to attempt to add support for every session store implementation into keystone.

This allows one to specify the 'session store' setting as a function which will be given keystone's internal express-session instance. It must return a working express session store. For example, configuring keystone to use connect-memcached is as straightforward as

```
var keystone = require('keystone'),
    ConnectMemcached = require('connect-memcached')

keystone.init({
  //...
  'session store': function(session){
    return new (ConnectMemcached(session))({
      hosts: [
        'localhost:11211'
      ]
    });
  }
});
```

This PR now includes documentation for this option.