### PR TITLE
Adding optional `logger options` feature

### DIFF
--- a/docs/content/en/pages/docs/configuration.jade
+++ b/docs/content/en/pages/docs/configuration.jade
@@ -177,6 +177,10 @@ block content
 				tr
 					td <code>logger</code> <code class="data-type">String</code>
 					td Set this to include the <code>morgan</code> middleware. The value will be passed to the middleware initialisation (<a href="https://github.com/expressjs/morgan" target="_blank">see docs here</a>). Set this to <code class="default-value">false</code> to disable logging altogether. Defaults to <code class="default-value">:method :url :status :response-time ms</code>.
+				tr
+					td <code>logger options</code> <code class="data-type">Object</code>
+					td
+						p Optional config options that will be passed to the <code>morgan</code> middleware; see <a href="https://github.com/expressjs/morgan" target="_blank">github.com/expressjs/morgan</a> for more information.
 
 				tr
 					td <code>trust proxy</code> <code class="data-type">Boolean</code>

--- a/docs/content/en/pages/docs/configuration.jade
+++ b/docs/content/en/pages/docs/configuration.jade
@@ -312,7 +312,7 @@ block content
 						pre: code.language-javascript
 							| var keystone = require('keystone'),
 							|     ConnectMemcached = require('connect-memcached')
-							|
+							| 
 							| keystone.init({
 							|   //...
 							|   'session store': function(session){

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -353,7 +353,7 @@ function mount(mountPath, parentApp, events) {
 	
 	if (this.get('logger')) {
 		debug('adding request logger');
-		app.use(morgan(this.get('logger')));
+		app.use(morgan(this.get('logger'), this.get('logger options')));
 	}
 	
 	if (this.get('file limit')) {


### PR DESCRIPTION
In this PR we address issue #1401
- Add `logger options` and pass as second argument to `morgan` middleware during `.mount()`
- Document `logger options`

And an unrelated issue found while documenting `logger options`
- Fixing `unexpected text |` error caused my missing trailing space (from 000b05455b37aef6ad0795d855d1518212288551)

I apologize for not including any unit tests. Given the current structure of the `.mount()` method, I found it difficult to create an isolated test for this functionality.