### PR TITLE
Slug for multilanguages

### DIFF
--- a/lib/schemaPlugins/autokey.js
+++ b/lib/schemaPlugins/autokey.js
@@ -94,7 +94,7 @@ module.exports = function autokey() {
 		if ((!modified || autokey.fixed) && this.get(autokey.path)) {
 			return next();
 		}
-		var newKey = utils.slug(values.join(' '), null, {locale: autokey.defaultLocale}) || this.id;
+		var newKey = utils.slug(values.join(' '), null, {locale: autokey.locale}) || this.id;
 		if (autokey.unique) {
 			return getUniqueKey(this, newKey, next);
 		} else {

--- a/lib/schemaPlugins/autokey.js
+++ b/lib/schemaPlugins/autokey.js
@@ -29,7 +29,7 @@ module.exports = function autokey() {
 		type: String,
 		index: true
 	};
-	
+
 	if (autokey.unique) {
 		def[autokey.path].index = { unique: true };
 	}
@@ -94,9 +94,7 @@ module.exports = function autokey() {
 		if ((!modified || autokey.fixed) && this.get(autokey.path)) {
 			return next();
 		}
-
-		var newKey = utils.slug(values.join(' ')) || this.id;
-
+		var newKey = utils.slug(values.join(' '), null, {locale: autokey.defaultLocale}) || this.id;
 		if (autokey.unique) {
 			return getUniqueKey(this, newKey, next);
 		} else {


### PR DESCRIPTION
Apply new keystone-utils slug method. 

The cld usually failed to find the locale, I allow ***autokey.defaultLocale*** to set up default locale.