### PR TITLE
Just proposal. Imposing new eslint rule "object-curly-spacing".

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
 		"no-trailing-spaces": 0,
 		"no-underscore-dangle": 0,
 		"no-use-before-define": 0,
+		"object-curly-spacing": [1, "always"],
 		"quotes": [2, "single", "avoid-escape"],
 		"react/jsx-boolean-value": 1,
 		"react/jsx-no-undef": 1,

--- a/admin/api/list.js
+++ b/admin/api/list.js
@@ -109,7 +109,7 @@ exports = module.exports = function(req, res) {
 
 			_.each(order, function(id, i) {
 				queue.push(function(done) {
-					req.list.model.update({ _id: id }, { $set: { sortOrder: i }}, done);
+					req.list.model.update({ _id: id }, { $set: { sortOrder: i } }, done);
 				});
 			});
 
@@ -238,7 +238,7 @@ exports = module.exports = function(req, res) {
 
 					locals = { list: req.list, columns: columns, item: items[0], csrf_query: req.query.csrf_query, _:_ };
 					row = jade.renderFile(__dirname + '/../../templates/partials/row.jade', locals);
-					pagination = jade.renderFile(__dirname + '/../../templates/partials/pagination.jade', {items: req.query.items, link_to: link_to });
+					pagination = jade.renderFile(__dirname + '/../../templates/partials/pagination.jade', { items: req.query.items, link_to: link_to });
 
 					return sendResponse({
 						item: items[0],

--- a/fields/types/azurefile/AzureFileType.js
+++ b/fields/types/azurefile/AzureFileType.js
@@ -70,7 +70,7 @@ util.inherits(azurefile, super_);
 
 Object.defineProperty(azurefile.prototype, 'azurefileconfig', { get: function() {
 	return this.options.azurefileconfig || keystone.get('azurefile config');
-}});
+} });
 
 
 /**
@@ -241,7 +241,7 @@ azurefile.prototype.uploadFile = function(item, file, update, callback) {
 		var blobService = azure.createBlobService();
 		var container = field.options.containerFormatter(item, file.name);
 
-		blobService.createContainerIfNotExists(container, {publicAccessLevel : 'blob'}, function(err) {
+		blobService.createContainerIfNotExists(container, { publicAccessLevel : 'blob' }, function(err) {
 			
 			if (err) return callback(err);
 

--- a/fields/types/boolean/BooleanField.js
+++ b/fields/types/boolean/BooleanField.js
@@ -34,7 +34,7 @@ module.exports = Field.create({
 			var imgSrc = '/keystone/images/icons/16/checkbox-' + state + '.png';
 			input = (
 				<div className={fieldClassName}>
-					<img src={imgSrc} width='16' height='16' className={state} style={{marginRight: 5}} />
+					<img src={imgSrc} width='16' height='16' className={state} style={{ marginRight: 5 }} />
 					<span>{this.props.label}</span>
 				</div>
 			);

--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -163,7 +163,7 @@ module.exports = Field.create({
 	},
 
 	renderImagePreviewThumbnail: function() {
-		return <img key={this.props.path + '_preview_thumbnail'} className='img-load' style={ { height: '90' } } src={this.getImageSource()} />;
+		return <img key={this.props.path + '_preview_thumbnail'} className='img-load' style={{ height: '90' }} src={this.getImageSource()} />;
 	},
 
 	/**

--- a/fields/types/cloudinaryimages/CloudinaryImagesField.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesField.js
@@ -39,7 +39,7 @@ var Thumbnail = React.createClass({
 			<div className='image-field image-sortable row col-sm-3 col-md-12' title={title}> 
 				<div className={previewClassName}> 
 					<a href={this.props.url} className='img-thumbnail'>
-						<img style={ { height: '90'} } className='img-load' src={this.props.url} />
+						<img style={{ height: '90' }} className='img-load' src={this.props.url} />
 						<span className={iconClassName} />
 					</a>
 				</div>

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -382,7 +382,7 @@ function doGoogleGeocodeRequest(address, region, callback) {
 					result = JSON.parse(dataBuff);
 				}
 				catch (exp) {
-					result = {'status_code': 500, 'status_text': 'JSON Parse Failed', 'status': 'UNKNOWN_ERROR'};
+					result = { 'status_code': 500, 'status_text': 'JSON Parse Failed', 'status': 'UNKNOWN_ERROR' };
 				}
 				callback(null, result);
 			});
@@ -417,7 +417,7 @@ location.prototype.googleLookup = function(item, region, update, callback) {
 		address = item.get(this.paths.serialised);
 
 	if (address.length === 0) {
-		return callback({'status_code': 500, 'status_text': 'No address to geocode', 'status': 'NO_ADDRESS'});
+		return callback({ 'status_code': 500, 'status_text': 'No address to geocode', 'status': 'NO_ADDRESS' });
 	}
 
 	doGoogleGeocodeRequest(address, region || keystone.get('default region'), function(err, geocode){

--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -67,7 +67,7 @@ module.exports = Field.create({
 					if (err) throw err;
 					
 					var value = res.body;
-					_.findWhere(expandedValues, {value: value.id}).label = value.name;
+					_.findWhere(expandedValues, { value: value.id }).label = value.name;
 
 					callbackCount++;
 					if (callbackCount === inputs.length) {

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -61,7 +61,7 @@ util.inherits(s3file, super_);
 
 Object.defineProperty(s3file.prototype, 's3config', { get: function() {
 	return this.options.s3config || keystone.get('s3 config');
-}});
+} });
 
 
 /**

--- a/lib/content/page.js
+++ b/lib/content/page.js
@@ -28,7 +28,7 @@ function Page(key, options) {
 
 Object.defineProperty(Page.prototype, 'name', { get: function() {
 	return this.get('name') || this.set('name', utils.keyToLabel(this.key));
-}});
+} });
 
 /**
  * Sets page options
@@ -200,8 +200,3 @@ Page.prototype.clean = function(data) {
  */
 
 exports = module.exports = Page;
-
-
-
-
-

--- a/lib/email.js
+++ b/lib/email.js
@@ -102,7 +102,7 @@ var objToMandrillVars = function (_var) {
 	if ('object' === typeof _var) {
 		var _flat = flattenObject(_var, '_');
 		_.each(_flat, function(value, key) {
-			_new.push({name: key, content: value });
+			_new.push({ name: key, content: value });
 		});
 		return _new;
 	}

--- a/lib/list.js
+++ b/lib/list.js
@@ -69,40 +69,40 @@ function List(key, options) {
 
 	Object.defineProperty(this, 'label', { get: function() {
 		return this.get('label') || this.set('label', utils.plural(utils.keyToLabel(key)));
-	}});
+	} });
 
 	Object.defineProperty(this, 'singular', { get: function() {
 		return this.get('singular') || this.set('singular', utils.singular(this.label));
-	}});
+	} });
 
 	Object.defineProperty(this, 'plural', { get: function() {
 		return this.get('plural') || this.set('plural', utils.plural(this.singular));
-	}});
+	} });
 
 	Object.defineProperty(this, 'namePath', { get: function() {
 		return this.mappings.name || '_id';
-	}});
+	} });
 
 	Object.defineProperty(this, 'nameField', { get: function() {
 		return this.fields[this.mappings.name];
-	}});
+	} });
 
 	Object.defineProperty(this, 'nameIsVirtual', { get: function() {
 		return this.model.schema.virtuals[this.mappings.name] ? true : false;
-	}});
+	} });
 
 	Object.defineProperty(this, 'nameIsEditable', { get: function() {
 		return (this.fields[this.mappings.name] && this.fields[this.mappings.name].type === 'text') ? !this.fields[this.mappings.name].noedit : false;
-	}});
+	} });
 
 	Object.defineProperty(this, 'nameIsInitial', { get: function() {
 		return (this.fields[this.mappings.name] && this.fields[this.mappings.name].options.initial === undefined);
-	}});
+	} });
 
 	var initialFields; // initialFields values are initialised once, on demand
 	Object.defineProperty(this, 'initialFields', { get: function() {
 		return initialFields || (initialFields = _.filter(this.fields, function(i) { return i.initial; }));
-	}});
+	} });
 
 	if (this.get('sortable')) {
 		schemaPlugins.sortable.apply(this);
@@ -957,10 +957,10 @@ List.prototype.getSearchFilters = function(search, add) {
 						value = utils.number(value);
 						if ( !isNaN(value) ) {
 							if (filter.operator === 'gt') {
-								filters[path] = { $gt: value};
+								filters[path] = { $gt: value };
 							}
 							else if (filter.operator === 'lt') {
-								filters[path] = { $lt: value};
+								filters[path] = { $lt: value };
 							}
 							else {
 								filters[path] = value;

--- a/lib/updates.js
+++ b/lib/updates.js
@@ -99,7 +99,7 @@ exports.apply = function(callback) {
 					update(function(err) {
 						if (!err) {
 							if (update.__commit__ !== false) {
-								new Update({key: file}).save();
+								new Update({ key: file }).save();
 							}
 						}
 					});
@@ -111,7 +111,7 @@ exports.apply = function(callback) {
 							if (update.__commit__ === false) {
 								done();
 							} else {
-								new Update({key: file}).save(done);
+								new Update({ key: file }).save(done);
 							}
 						}
 					});


### PR DESCRIPTION
Though I'm not sure about the space on the last line in such snippets:
```js
Object.defineProperty(azurefile.prototype, 'azurefileconfig', { get: function() {
  return this.options.azurefileconfig || keystone.get('azurefile config');
} });
```

Should I re-write them as ?:
```js
Object.defineProperty(azurefile.prototype, 'azurefileconfig', {
  get: function() {
    return this.options.azurefileconfig || keystone.get('azurefile config');
  }
});
```
