### PR TITLE
Timezone fix

### DIFF
--- a/fields/components/DateInput.js
+++ b/fields/components/DateInput.js
@@ -1,6 +1,6 @@
 var React = require('react'),
 	Pikaday = require('pikaday'),
-	moment = require('moment');
+	moment = require('moment-timezone');
 
 module.exports = React.createClass({
 	
@@ -14,6 +14,7 @@ module.exports = React.createClass({
 	},
 	
 	getInitialState: function() {
+		moment.tz.setDefault(this.props.timezone);
 		return {
 			value: this.props.value,
 			id: Math.round(Math.random() * 100000)
@@ -25,7 +26,7 @@ module.exports = React.createClass({
 		this.setState({
 			value: newProps.value
 		});
-		this.picker.setMoment(moment(newProps.value, this.props.format));
+		this.picker.setMoment(moment(newProps.value, this.props.format), true);
 	},
 
 	componentDidMount: function() {

--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -2,7 +2,7 @@ var React = require('react'),
 	Field = require('../Field'),
 	Note = require('../../components/Note'),
 	DateInput = require('../../components/DateInput'),
-	moment = require('moment');
+	moment = require('moment-timezone');
 
 module.exports = Field.create({
 	
@@ -14,7 +14,8 @@ module.exports = Field.create({
 	inputFormat: 'YYYY-MM-DD',
 
 	getInitialState: function() {
-		return { 
+		moment.tz.setDefault(this.props.timezone);
+		return {
 			value: this.props.value ? moment(this.props.value).format(this.inputFormat) : ''
 		};
 	},

--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -60,7 +60,7 @@ module.exports = Field.create({
 		if (this.shouldRenderField()) {
 			input = (
 				<div className={fieldClassName}>
-					<DateInput ref="dateInput" name={this.props.path} format={this.inputFormat} value={this.state.value} onChange={this.valueChanged} yearRange={this.props.yearRange} />
+					<DateInput ref="dateInput" name={this.props.path} format={this.inputFormat} value={this.state.value} onChange={this.valueChanged} yearRange={this.props.yearRange} timezone={this.props.timezone} />
 					<button type="button" className="btn btn-default btn-set-today" onClick={this.setToday}>Today</button>
 				</div>
 			);

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -91,7 +91,7 @@ date.prototype.validateInput = function(data, required, item) {
 
 	if (!(this.path in data) && item && item.get(this.path)) return true;
 
-	var newValue = moment(data[this.path], this.parseFormatString);
+	var newValue = moment.tz(data[this.path], this.parseFormatString, this.timezone);
 
 	if (required && (!newValue || !newValue.isValid())) {
 		return false;
@@ -116,7 +116,7 @@ date.prototype.updateItem = function(item, data) {
 		return;
 	}
 
-	var newValue = moment(data[this.path], this.parseFormatString);
+	var newValue = moment.tz(data[this.path], this.parseFormatString, this.timezone);
 
 	if (newValue && newValue.isValid()) {
 		if (!item.get(this.path) || !newValue.isSame(item.get(this.path))) {

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -3,7 +3,8 @@
  */
 
 var util = require('util'),
-	moment = require('moment'),
+	keystone = require('../../../'),
+	moment = require('moment-timezone'),
 	super_ = require('../Type');
 
 /**
@@ -17,11 +18,14 @@ function date(list, path, options) {
 	this._nativeType = Date;
 	this._underscoreMethods = ['format', 'moment', 'parse'];
 	this._fixedSize = 'large';
-	this._properties = ['formatString', 'yearRange'];
+	this._properties = ['formatString', 'yearRange', 'timezone'];
 	
 	this.parseFormatString = options.parseFormat || 'YYYY-MM-DD';
 	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY');
 	this.yearRange = options.yearRange;
+	
+	this.timezone = keystone.get('timezone') || 'UTC';
+	moment.tz.setDefault(this.timezone);
 	
 	if (this.formatString && 'string' !== typeof this.formatString) {
 		throw new Error('FieldType.Date: options.format must be a string.');

--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -2,7 +2,7 @@ var React = require('react'),
 	Field = require('../Field'),
 	Note = require('../../components/Note'),
 	DateInput = require('../../components/DateInput'),
-	moment = require('moment');
+	moment = require('moment-timezone');
 
 module.exports = Field.create({
 	
@@ -18,7 +18,8 @@ module.exports = Field.create({
 	parseFormats: ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m'],
 
 	getInitialState: function() {
-		return { 
+		moment.tz.setDefault(this.props.timezone);
+		return {
 			dateValue: this.props.value ? moment(this.props.value).format(this.dateInputFormat) : '',
 			timeValue: this.props.value ? moment(this.props.value).format(this.timeInputFormat) : ''
 		};

--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -81,7 +81,7 @@ module.exports = Field.create({
 		if (this.shouldRenderField()) {
 			input = (
 				<div className={fieldClassName}>
-					<DateInput ref="dateInput" name={this.props.paths.date} value={this.state.dateValue} format={this.dateInputFormat} onChange={this.dateChanged} />
+					<DateInput ref="dateInput" name={this.props.paths.date} value={this.state.dateValue} format={this.dateInputFormat} onChange={this.dateChanged} timezone={this.props.timezone} />
 					<input type="text" name={this.props.paths.time} value={this.state.timeValue} placeholder="HH:MM:SS am/pm" onChange={this.timeChanged} autoComplete="off" className="form-control time" />
 					<button type="button" className="btn btn-default btn-set-now" onClick={this.setNow}>Now</button>
 				</div>

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -3,7 +3,8 @@
  */
 
 var util = require('util'),
-	moment = require('moment'),
+	keystone = require('../../../'),
+	moment = require('moment-timezone'),
 	super_ = require('../Type');
 
 var parseFormats = ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m'];
@@ -19,7 +20,10 @@ function datetime(list, path, options) {
 	this._nativeType = Date;
 	this._underscoreMethods = ['format', 'moment', 'parse'];
 	this._fixedSize = 'large';
-	this._properties = ['formatString'];
+	this._properties = ['formatString', 'timezone'];
+	
+	this.timezone = keystone.get('timezone') || 'UTC';
+	moment.tz.setDefault(this.timezone);
 	
 	this.typeDescription = 'date and time';
 	this.parseFormatString = options.parseFormat || parseFormats;

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -114,7 +114,7 @@ datetime.prototype.validateInput = function(data, required, item) {
 
 	if (!(this.path in data && !(this.paths.date in data && this.paths.time in data)) && item && item.get(this.path)) return true;
 
-	var newValue = moment(this.getInputFromData(data), parseFormats);
+	var newValue = moment.tz(this.getInputFromData(data), parseFormats, this.timezone);
 
 	if (required && (!newValue || !newValue.isValid())) {
 		return false;
@@ -139,7 +139,7 @@ datetime.prototype.updateItem = function(item, data) {
 		return;
 	}
 
-	var newValue = moment(this.getInputFromData(data), parseFormats);
+	var newValue = moment.tz(this.getInputFromData(data), parseFormats, this.timezone);
 
 	if (newValue && newValue.isValid()) {
 		if (!item.get(this.path) || !newValue.isSame(item.get(this.path))) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "marked": "~0.3.3",
     "method-override": "~2.3.3",
     "moment": "~2.10.3",
+    "moment-timezone": "^0.3.1",
     "mongoose": "~3.8.29",
     "morgan": "~1.5.3",
     "mpromise": "~0.5.5",


### PR DESCRIPTION
This fixes #1345, and adds timezone support. Default timezone is set to UTC, and this adds a new keystone option, 'timezone'.

Additionally this fixes an edge case of #1038 that wasn't solved by e7a005866be458086a539d6855835a3523a68db9. If a content editors local machine was in a different timezone as the servers such that the dates don't line up, selecting "Today" would enter an infinite loop.
