### PR TITLE
Fix bug saving geo on Types.Location field

### DIFF
--- a/fields/types/location/LocationField.js
+++ b/fields/types/location/LocationField.js
@@ -140,10 +140,10 @@ module.exports = Field.create({
 				</div>
 				<div className="col-sm-10 col-md-7 col-lg-6 location-field-controls"><div className="form-row">
 					<div className="col-xs-6">
-						<input type="text" name={this.props.paths.geo} ref="geo1" value={this.props.value.geo ? this.props.value.geo[1] : ''} onChange={this.geoChanged.bind(this, 1)} placeholder="Latitude" className="form-control" />
+						<input type="text" name={this.props.paths.geo + '[1]'} ref="geo1" value={this.props.value.geo ? this.props.value.geo[1] : ''} onChange={this.geoChanged.bind(this, 1)} placeholder="Latitude" className="form-control" />
 					</div>
 					<div className="col-xs-6">
-						<input type="text" name={this.props.paths.geo} ref="geo0" value={this.props.value.geo ? this.props.value.geo[0] : ''} onChange={this.geoChanged.bind(this, 0)} placeholder="Longitude" className="form-control" />
+						<input type="text" name={this.props.paths.geo + '[0]'} ref="geo0" value={this.props.value.geo ? this.props.value.geo[0] : ''} onChange={this.geoChanged.bind(this, 0)} placeholder="Longitude" className="form-control" />
 					</div>
 				</div></div>
 			</div>

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -271,10 +271,6 @@ location.prototype.updateItem = function(item, data) {
 
 		if (!Array.isArray(newGeo) || newGeo.length !== 2) {
 			newGeo = [];
-		} else {
-			//reverse the array because value from UI will be in lat,lng format
-			//and db needs it in lng,lat for the GeoJSON type
-			newGeo.reverse();
 		}
 
 		if (newGeo[0] !== oldGeo[0] || newGeo[1] !== oldGeo[1]) {

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -271,6 +271,10 @@ location.prototype.updateItem = function(item, data) {
 
 		if (!Array.isArray(newGeo) || newGeo.length !== 2) {
 			newGeo = [];
+		} else {
+			//reverse the array because value from UI will be in lat,lng format
+			//and db needs it in lng,lat for the GeoJSON type
+			newGeo.reverse();
 		}
 
 		if (newGeo[0] !== oldGeo[0] || newGeo[1] !== oldGeo[1]) {


### PR DESCRIPTION
Now that the admin display is in Lat,Lng format (https://github.com/keystonejs/keystone/pull/1365) the newGeo variable needs to be reversed in the updateItem function to put it back into GeoJSON format when saving to the db.

