### PR TITLE
Add support for empty string in Money Fieldtype

### DIFF
--- a/fields/types/money/MoneyType.js
+++ b/fields/types/money/MoneyType.js
@@ -77,7 +77,7 @@ money.prototype.validateInput = function(data, required, item) {
 		return true;
 	}
 	
-	if (value !== undefined) {
+	if (value !== undefined && value !== '') {
 		var newValue = utils.number(value);
 		return (!isNaN(newValue));
 	} else {

--- a/fields/types/money/test/server.js
+++ b/fields/types/money/test/server.js
@@ -84,6 +84,8 @@ exports.testFieldType = function(List) {
 	it('should validate no input', function() {
 		demand(List.fields.money.validateInput({})).be(true);
 		demand(List.fields.money.validateInput({}, true)).be(false);
+		demand(List.fields.money.validateInput({money: ''})).be(true);
+		demand(List.fields.money.validateInput({money: ''}, true)).be(false);
 		testItem.money = 1;
 		demand(List.fields.money.validateInput({}, true, testItem)).be(true);
 		testItem.money = undefined;


### PR DESCRIPTION
* fixes https://github.com/keystonejs/keystone/issues/1457
* '' is a valid Money value
* if the field is `required` '' is not a valid Money value