### PR TITLE
Update required Elemental version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cookie-parser": "~1.3.4",
     "csv": "~0.3.7",
     "debug": "^2.2.0",
-    "elemental": "0.0.9",
+    "elemental": "~0.1.1",
     "embedly": "~1.0.4",
     "errorhandler": "^1.3.6",
     "express": "~4.12.3",


### PR DESCRIPTION
The 0.0.9 Elemental version doesn't causes Keystone to fail to compile the less files giving `Error: .u-text-truncate is undefined` on list.less:67.