### PR TITLE
Fix height property for TextArea not being used

### DIFF
--- a/fields/types/textarea/TextareaField.js
+++ b/fields/types/textarea/TextareaField.js
@@ -6,7 +6,10 @@ module.exports = Field.create({
 	displayName: 'TextareaField',
 	
 	renderField: function() {
-		return <textarea name={this.props.path} ref="focusTarget" value={this.props.value} onChange={this.valueChanged} autoComplete="off" className="form-control" />;
+		var styles = {
+			height: this.props.height
+		};
+		return <textarea name={this.props.path} styles={styles} ref="focusTarget" value={this.props.value} onChange={this.valueChanged} autoComplete="off" className="form-control" />;
 	}
 	
 });

--- a/fields/types/textarea/TextareaType.js
+++ b/fields/types/textarea/TextareaType.js
@@ -16,6 +16,9 @@ function textarea(list, path, options) {
 	this._nativeType = String;
 	this._underscoreMethods = ['format', 'crop'];
 	this.height = options.height || 90;
+
+	this._properties = ['height'];
+	
 	textarea.super_.call(this, list, path, options);
 }
 


### PR DESCRIPTION
[The docs](http://keystonejs.com/docs/database/#fieldtypes-textarea) mention that a `height` property can be passed to a textarea to set the height in pixels. However I found that this doesn't work and all textarea's are the same (default) height. This small pull request fixes that.

I followed the same standard used in the MarkdownType to implement this. 