### PR TITLE
Added support for importing an array of model directories

### DIFF
--- a/admin/public/styles/keystone/forms.less
+++ b/admin/public/styles/keystone/forms.less
@@ -299,6 +299,9 @@ label.checkbox {
 		background: transparent;
 		border-radius: @input-border-radius;
 	}
+	.CodeMirror-linenumber{
+		margin-left:-30px;
+	}
 }
 
 // Related Items

--- a/index.js
+++ b/index.js
@@ -154,29 +154,34 @@ keystone.security = {
 keystone.utils = utils;
 
 /**
- * returns all .js modules (recursively) in the path specified, relative
+ * returns all .js modules (recursively) in the path(s) specified.
+ *
+ * If the input dirname is a string then it will be assumed to be a relative path
  * to the module root (where the keystone project is being consumed from).
+ *
+ * If the input dirname is an array then it will be assumed that all paths in the
+ * array are fully qualified and will be imported as is.
  *
  * ####Example:
  *
- *     var models = keystone.import('models');
+ *     var models = keystone.import('relative-path-models-dir');
+ *     or
+ *     var models = keystone.import(['absolute-path-model-dir1', 'absolute-path-model-dir2',...]);
  *
- * @param {String} dirname
+ * @param {String | Array} dirname
  * @api public
  */
 
 Keystone.prototype.import = function(dirname) {
 
-	var initialPath = path.join(this.get('module root'), dirname);
+	var imported = {};
 
 	var doImport = function(fromPath) {
-
-		var imported = {};
 
 		fs.readdirSync(fromPath).forEach(function(name) {
 
 			var fsPath = path.join(fromPath, name),
-			info = fs.statSync(fsPath);
+				info = fs.statSync(fsPath);
 
 			// recur
 			if (info.isDirectory()) {
@@ -189,14 +194,28 @@ Keystone.prototype.import = function(dirname) {
 					imported[base] = require(fsPath);
 				}
 			}
-
 		});
-
-		return imported;
 	};
 
-	return doImport(initialPath);
+	if ('string' !== typeof dirname) {
+
+		if (Array.isArray(dirname)) {
+
+			_.each(dirname, function(dir) {
+				doImport(dir);
+			});
+
+		} else {
+			console.error("Invalid models path specified.");
+		}
+	} else {
+		var initialPath = path.join(this.get('module root'), dirname);
+		doImport(initialPath);
+	}
+
+	return imported;
 };
+
 
 
 /**

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ keystone.utils = utils;
  * to the module root (where the keystone project is being consumed from).
  *
  * If the input dirname is an array then it will be assumed that all paths in the
- * array are fully qualified and will be imported as is.
+ * array are absolute and will be imported as is.
  *
  * ####Example:
  *
@@ -183,7 +183,7 @@ Keystone.prototype.import = function(dirname) {
 			var fsPath = path.join(fromPath, name),
 				info = fs.statSync(fsPath);
 
-			// recur
+			// recurse
 			if (info.isDirectory()) {
 				imported[name] = doImport(fsPath);
 			} else {
@@ -206,7 +206,7 @@ Keystone.prototype.import = function(dirname) {
 			});
 
 		} else {
-			console.error("Invalid models path specified.");
+			console.error('Invalid models path specified');
 		}
 	} else {
 		var initialPath = path.join(this.get('module root'), dirname);

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -97,7 +97,7 @@ html
 		script(src="/keystone/js/lib/pikaday/pikaday.jquery-1.1.0.js")
 		script(src="/keystone/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
 		script(src="/keystone/js/lib/tinymce/tinymce.min.js")
-		script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
+		block js_codemirror
 
 		//- App
 		script.

--- a/templates/views/item.jade
+++ b/templates/views/item.jade
@@ -15,6 +15,10 @@ block js
 	script(src='/keystone/js/fields.js')
 	script(src='/keystone/js/item.js')
 		
+block js_codemirror
+	if list.fieldTypes.code
+		script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
+
 block content
 	// Attach point for new React View
 	div#item-view


### PR DESCRIPTION
When a model array is specified, each directory in the array is assumed to be an absolute path.  When the specified model directory is a string, the import will be behave as before and resolve its full path using the module root.

NOTE:  This may need documentation.