### PR TITLE
Fixes an error caused by the default value being an empty string

### DIFF
--- a/fields/types/name/NameType.js
+++ b/fields/types/name/NameType.js
@@ -18,6 +18,7 @@ function name(list, path, options) {
 	
 	// TODO: implement filtering, hard-coded as disabled for now
 	options.nofilter = true;
+	options.default = { first: '', last: '' };
 	name.super_.call(this, list, path, options);
 	
 }


### PR DESCRIPTION
The default value for an empty name field is '' and not { first: '', last: '' } which the field expects. Typing any character in the first/last name boxes creates a console warning saying "Uncaught TypeError: Cannot assign to read only property 'first'/'last' of ".