### PR TITLE
Fix for #1280 href working now on LocalFiles Type

### DIFF
--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -33,7 +33,7 @@ function localfiles(list, path, options) {
 		throw new Error('Invalid Configuration\n\n' +
 			'localfiles fields (' + list.key + '.' + path + ') do not currently support being used as initial fields.\n');
 	}
-	
+
 	if (options.overwrite !== false) {
 		options.overwrite = true;
 	}
@@ -54,7 +54,7 @@ function localfiles(list, path, options) {
 	if (options.post && options.post.move) {
 		this.post('move', options.post.move);
 	}
-	
+
 }
 
 /*!
@@ -79,9 +79,9 @@ localfiles.prototype.addToSchema = function() {
 	var paths = this.paths = {
 		// fields
 		filename:		this._path.append('.filename'),
-		path:			  this._path.append('.path'),
-		originalname:		this._path.append('.originalname'),
-		size:			  this._path.append('.size'),
+		path:			this._path.append('.path'),
+		originalname:	this._path.append('.originalname'),
+		size:			this._path.append('.size'),
 		filetype:		this._path.append('.filetype'),
 		// virtuals
 		exists:			this._path.append('.exists'),
@@ -92,7 +92,7 @@ localfiles.prototype.addToSchema = function() {
 
 	var schemaPaths = new mongoose.Schema({
 		filename:		String,
-		originalname:   String,
+		originalname:	String,
 		path:			String,
 		size:			Number,
 		filetype:		String
@@ -279,33 +279,33 @@ localfiles.prototype.updateItem = function(item, data) {//eslint-disable-line no
  */
 
 localfiles.prototype.uploadFiles = function(item, files, update, callback) {
-	
+
 	var field = this;
-	
+
 	if ('function' === typeof update) {
 		callback = update;
 		update = false;
 	}
-	
+
 	async.map(files, function(file, processedFile) {
-		
+
 		var prefix = field.options.datePrefix ? moment().format(field.options.datePrefix) + '-' : '',
 			filename = prefix + file.name,
 			filetype = file.mimetype || file.type;
-		
+
 		if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, filetype)) {
 			return processedFile(new Error('Unsupported File Type: ' + filetype));
 		}
-		
+
 		var doMove = function(doneMove) {
-			
+
 			if ('function' === typeof field.options.filename) {
 				filename = field.options.filename(item, file);
 			}
-			
+
 			fs.move(file.path, path.join(field.options.dest, filename), { clobber: field.options.overwrite }, function(err) {
 				if (err) return doneMove(err);
-				
+
 				var fileData = {
 					filename: filename,
 					originalname: file.originalname,
@@ -313,19 +313,19 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 					size: file.size,
 					filetype: filetype
 				};
-				
+
 				if (update) {
 					item.get(field.path).push(fileData);
 				}
-				
+
 				doneMove(null, fileData);
 			});
-			
+
 		};
-		
+
 		field.callHook('pre:move', [item, file], function(err) {
 			if (err) return processedFile(err);
-			
+
 			doMove(function(err, fileData) {
 				if (err) return processedFile(err);
 				field.callHook('post:move', [item, file, fileData], function(err) {
@@ -333,9 +333,9 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 				});
 			});
 		});
-		
+
 	}, callback);
-	
+
 };
 
 
@@ -396,7 +396,7 @@ localfiles.prototype.getRequestHandler = function(item, req, paths, callback) {
 
 		// Upload new files
 		if (req.files) {
-			
+
 			var upFiles = req.files[paths.upload];
 			if (upFiles) {
 				if (!Array.isArray(upFiles)) {
@@ -405,7 +405,7 @@ localfiles.prototype.getRequestHandler = function(item, req, paths, callback) {
 
 				if (upFiles.length > 0) {
 					upFiles = _.filter(upFiles, function(f) { return typeof f.name !== 'undefined' && f.name.length > 0; });
-					
+
 					if (upFiles.length > 0) {
 						console.log('uploading files:');
 						console.log(upFiles);

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -85,6 +85,7 @@ localfiles.prototype.addToSchema = function() {
 		filetype:		this._path.append('.filetype'),
 		// virtuals
 		exists:			this._path.append('.exists'),
+		href:			this._path.append('.href'),
 		upload:			this._path.append('_upload'),
 		action:			this._path.append('_action'),
 		order: 			this._path.append('_order')

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -85,7 +85,6 @@ localfiles.prototype.addToSchema = function() {
 		filetype:		this._path.append('.filetype'),
 		// virtuals
 		exists:			this._path.append('.exists'),
-		href:			this._path.append('.href'),
 		upload:			this._path.append('_upload'),
 		action:			this._path.append('_action'),
 		order: 			this._path.append('_order')
@@ -97,6 +96,11 @@ localfiles.prototype.addToSchema = function() {
 		path:			String,
 		size:			Number,
 		filetype:		String
+	});
+
+	// The .href virtual returns the public path of the file
+	schemaPaths.virtual('href').get(function() {
+		return field.href.call(field, this);
 	});
 
 	schema.add(this._path.addTo({}, [schemaPaths]));


### PR DESCRIPTION
Virtual `href` method was missing on nested schema. This fixes the initial issue of #1280. 

I left the rest of the methods how they were, while `exists` for example does not work. I was not clear to me how the expected behavior is.