### PR TITLE
Added check for duplicate _revisions models.

### DIFF
--- a/lib/schemaPlugins/history.js
+++ b/lib/schemaPlugins/history.js
@@ -1,8 +1,14 @@
 var keystone = require('../../');
 
+var historyModelSuffix = '_revisions'; 
+
+function getHistoryModelName (list) {
+	return list.options.schema.collection + historyModelSuffix;
+}
+
 function getHistoryModel(list, userModel) {
 	
-	var collection = list.options.schema.collection + '_revisions';
+	var collection = getHistoryModelName(list);
 	
 	var schema = new keystone.mongoose.Schema({
 		i: { type: keystone.mongoose.Schema.Types.ObjectId, ref: collection },
@@ -34,6 +40,16 @@ function getHistoryModel(list, userModel) {
 module.exports = function history() {
 
 	var list = this;
+	
+	//If model already exists for a '_revisions' in an inherited model, log a warning but skip creating the new model (inherited _revisions model will be used).
+	var collectionName = getHistoryModelName(list);
+	if (list.get('inherits') &&
+		collectionName.indexOf(historyModelSuffix, collectionName.length - historyModelSuffix.length) !== -1 &&
+		keystone.mongoose.models[collectionName]) {
+		console.log('List/model already exists for ' + collectionName + '.\nWon\'t re-create, keystone continuing.');
+		return;
+	}
+
 	var userModel = keystone.get('user model');
 	
 	var HistoryModel = list.HistoryModel = getHistoryModel(this, userModel);


### PR DESCRIPTION
This fixes Issue #1524.

To avoid collision of inherited models (which reuse the same _revisions historyModel as the model inherited from), check for existence of _revisions model for inherited models and skip attempt to create a new model. (Inherited _revisions model will be used.)

**NOTE**: I'm not at all suggesting this is the RightWay&trade; to solve this issue.
* It does "work on my machine" (ugg) and the related '_revisions' collection in Mongo seems to end up with the expected data.
* At my early understanding of the keystone codebase, it seems like a reasonable solution.



Final note: I couldn't get hub to work to convert Issue to PR, so I apologize if that is still the desired route (per PRO TIP in contributing.md).