### PR TITLE
Add Maps API key to request, Allow override per model, check for server instead of browser key

### DIFF
--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -24,7 +24,7 @@ function location(list, path, options) {
 	this._underscoreMethods = ['format', 'googleLookup', 'kmFrom', 'milesFrom'];
 	this._fixedSize = 'full';
 
-	this.enableMapsAPI = keystone.get('google api key') ? true : false;
+	this.enableMapsAPI = (options.geocodeGoogle===true || (options.geocodeGoogle !== false && keystone.get('google server api key'))) ? true : false;
 
 	this._properties = ['enableMapsAPI'];
 

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -368,6 +368,10 @@ function doGoogleGeocodeRequest(address, region, callback) {
 		options.region = region;
 	}
 
+	if (keystone.get('google server api key')){
+		options.key = keystone.get('google server api key');
+	}
+
 	var endpoint = 'https://maps.googleapis.com/maps/api/geocode/json?' + querystring.stringify(options);
 
 	https.get(endpoint, function(res) {


### PR DESCRIPTION
Regarding #1533 
- Added an option to Types.Location, which allows to explicitly enable/disable geocoding in the model, without breaking the current behaviour. 
- Added the Server API key - if available - to the request
- Check GOOGLE_SERVER_KEY instead of GOOGLE_BROWSER_KEY for availabilty of a server API key

