### PR TITLE
Escape special characters in email before creating a RegExp for case-…

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -1,6 +1,7 @@
 var crypto = require('crypto');
 var keystone = require('../');
 var scmp = require('scmp');
+var utils = require('keystone-utils');
 
 /**
  * Creates a hash of str with Keystone's cookie secret.
@@ -86,7 +87,7 @@ var doSignin = function(lookup, req, res, onSuccess, onFail) {
 	var User = keystone.list(keystone.get('user model'));
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
 		// create regex for email lookup with special characters escaped
-		var emailRegExp = new RegExp('^' + lookup.email.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&') + '$', 'i');
+		var emailRegExp = new RegExp('^' + utils.escapeRegExp(lookup.email) + '$', 'i');
 
 		// match email address and password
 		User.model.findOne({ email: emailRegExp }).exec(function(err, user) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -85,9 +85,8 @@ var doSignin = function(lookup, req, res, onSuccess, onFail) {
 	}
 	var User = keystone.list(keystone.get('user model'));
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
-
 		// create regex for email lookup with special characters escaped
-		var emailRegExp = new RegExp(lookup.email.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), 'i');
+		var emailRegExp = new RegExp('^' + lookup.email.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&') + '$', 'i');
 
 		// match email address and password
 		User.model.findOne({ email: emailRegExp }).exec(function(err, user) {

--- a/lib/session.js
+++ b/lib/session.js
@@ -85,8 +85,12 @@ var doSignin = function(lookup, req, res, onSuccess, onFail) {
 	}
 	var User = keystone.list(keystone.get('user model'));
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
+
+		// create regex for email lookup with special characters escaped
+		var emailRegExp = new RegExp(lookup.email.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'), 'i');
+
 		// match email address and password
-		User.model.findOne({ email: new RegExp(lookup.email, 'i') }).exec(function(err, user) {
+		User.model.findOne({ email: emailRegExp }).exec(function(err, user) {
 			if (user) {
 				user._.password.compare(lookup.password, function(err, isMatch) {
 					if (!err && isMatch) {


### PR DESCRIPTION
…insensitive lookup

Fixes a bug with emails addresses containing special characters introduced after the fix for #1323. These characters were not being escaped and were interpreted as part of the regular expression.