### PR TITLE
GeoLocation (for FieldType - Location) Fix: Validating new Geolocation correctly when updating field of type location

### DIFF
--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -267,7 +267,9 @@ location.prototype.updateItem = function(item, data) {
 	if (valuePaths.geo in values) {
 
 		var oldGeo = item.get(paths.geo) || [],
-			newGeo = values[valuePaths.geo];
+			newLat = utils.number(values[valuePaths.geo][0]),
+			newLng = utils.number(values[valuePaths.geo][1]),
+			newGeo = [newLng, newLat];
 
 		if (!Array.isArray(newGeo) || newGeo.length !== 2) {
 			newGeo = [];


### PR DESCRIPTION
https://github.com/keystonejs/keystone/issues/1493 should be fixed.