### PR TITLE
Load CodeMirror only in the item form

### DIFF
--- a/admin/public/styles/keystone/forms.less
+++ b/admin/public/styles/keystone/forms.less
@@ -299,6 +299,9 @@ label.checkbox {
 		background: transparent;
 		border-radius: @input-border-radius;
 	}
+	.CodeMirror-linenumber{
+		margin-left:-30px;
+	}
 }
 
 // Related Items

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -97,7 +97,7 @@ html
 		script(src="/keystone/js/lib/pikaday/pikaday.jquery-1.1.0.js")
 		script(src="/keystone/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
 		script(src="/keystone/js/lib/tinymce/tinymce.min.js")
-		script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
+		block js_codemirror
 
 		//- App
 		script.

--- a/templates/views/item.jade
+++ b/templates/views/item.jade
@@ -14,6 +14,10 @@ block js
 	script(src='/keystone/js/packages.js')
 	script(src='/keystone/js/fields.js')
 	script(src='/keystone/js/item.js')
+
+block js_codemirror
+	if list.fieldTypes.code
+		script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
 		
 block content
 	// Attach point for new React View


### PR DESCRIPTION
This change updates keystone's Admin UI to load CodeMirror only in the item form if and only if a code field is defined.  This should speed up loading of all other pages in the Admin UI as well as the item form if no code field is defined.