### PR TITLE
Fixed vertical alignment of Format menu icons.

### DIFF
--- a/admin/public/js/lib/tinymce/skins/keystone/less/Icons.less
+++ b/admin/public/js/lib/tinymce/skins/keystone/less/Icons.less
@@ -31,6 +31,9 @@
 	-webkit-font-smoothing: antialiased;
 }
 
+//icons in the TinyMCE Format dropdown
+.mce-floatpanel div.mce-stack-layout-item .mce-ico   { top: 1px; }
+
 // standard set
 .mce-i-bold                       { &:before { content: '\e838'; } }
 .mce-i-italic                     { &:before { content: '\e839'; } }


### PR DESCRIPTION
Tiny change to vertical spacing (leaves main button layout icons intact).
![Keystone-Format-Before-After](http://i.imgur.com/iATLvAL.png)