### PR TITLE
Add S3 support to wysiwyg editor

### DIFF
--- a/admin/api/s3.js
+++ b/admin/api/s3.js
@@ -15,11 +15,9 @@ exports = module.exports = {
 
 			var file = req.files.file,
 				path = s3Config.s3path ? s3Config.s3path + '/' : '';
-				originalname = file.originalname,
-				filetype = file.mimetype || file.type;
 
-			var headers = Types.S3File.prototype.generateHeaders.call({s3config: s3Config, options: {}}, null, file);
-			
+			var headers = Types.S3File.prototype.generateHeaders.call({ s3config: s3Config, options: {} }, null, file);
+
 			var s3Client = knox.createClient(s3Config);
 
 			s3Client.putFile(file.path, path + file.name, headers, function(err, s3Response) {
@@ -32,7 +30,7 @@ exports = module.exports = {
 						if (s3Response.statusCode !== 200) {
 							return res.send({ error: { message:'Amazon returned Http Code: ' + s3Response.statusCode } });
 						} else {
-							return res.send({ image: { url: "https://s3.amazonaws.com/" + s3Config.bucket + "/" + file.name } });
+							return res.send({ image: { url: 'https://s3.amazonaws.com/' + s3Config.bucket + '/' + file.name } });
 						}
 					}
 				};

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -10,9 +10,9 @@ function getId() {
 }
 
 module.exports = Field.create({
-	
+
 	displayName: 'HtmlField',
-	
+
 	getInitialState: function() {
 		return {
 			id: getId(),
@@ -41,7 +41,7 @@ module.exports = Field.create({
 		if (prevState.isCollapsed && !this.state.isCollapsed) {
 			this.initWysiwyg();
 		}
-		
+
 		if (_.isEqual(this.props.dependsOn, this.props.currentDependencies)
 			&& !_.isEqual(this.props.currentDependencies, prevProps.currentDependencies)) {
 			var instance = tinymce.get(prevState.id);
@@ -57,13 +57,13 @@ module.exports = Field.create({
 	componentDidMount: function() {
 		this.initWysiwyg();
 	},
-	
+
 	componentWillReceiveProps: function(nextProps) {
 		if (this.editor && this._currentValue !== nextProps.value) {
 			this.editor.setContent(nextProps.value);
 		}
 	},
-	
+
 	focusChanged: function(focused) {
 		this.setState({
 			isFocused: focused
@@ -102,7 +102,7 @@ module.exports = Field.create({
 			toolbar += ' | image';
 		}
 
-		if (options.enableCloudinaryUploads) {
+		if (options.enableCloudinaryUploads || options.enableS3Uploads) {
 			plugins.push('uploadimage');
 			toolbar += options.enableImages ? ' uploadimage' : ' | uploadimage';
 		}
@@ -126,10 +126,10 @@ module.exports = Field.create({
 				importcss_append: true,
 				importcss_merge_classes: true
 			};
-			
+
 			_.extend(options.additionalOptions, importcssOptions);
 		}
-		
+
 		if (!options.overrideToolbar) {
 			toolbar += ' | code';
 		}
@@ -143,7 +143,7 @@ module.exports = Field.create({
 		};
 
 		if (this.shouldRenderField()) {
-			opts.uploadimage_form_url = '/keystone/api/cloudinary/upload';
+			opts.uploadimage_form_url = options.enableS3Uploads ? '/keystone/api/s3/upload' : '/keystone/api/cloudinary/upload';
 		} else {
 			_.extend(opts, {
 				mode: 'textareas',
@@ -165,7 +165,7 @@ module.exports = Field.create({
 		var className = this.props.wysiwyg ? 'wysiwyg' : 'code';
 		return className;
 	},
-	
+
 	renderEditor: function(readOnly) {
 		var className = this.state.isFocused ? 'is-focused' : '';
 		var style = {
@@ -181,9 +181,9 @@ module.exports = Field.create({
 	renderField: function() {
 		return this.renderEditor();
 	},
-	
+
 	renderValue: function() {
 		return this.renderEditor(true);
 	}
-	
+
 });

--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -16,9 +16,9 @@ var utils = require('keystone-utils');
 var templateCache = {};
 
 function render(req, res, view, ext) {
-	
+
 	var keystone = this;
-		
+
 	var templatePath = __dirname + '/../../templates/views/' + view + '.jade';
 
 	debug('rendering ' + templatePath);
@@ -27,17 +27,17 @@ function render(req, res, view, ext) {
 		filename: templatePath,
 		pretty: keystone.get('env') !== 'production'
 	};
-	
+
 	// TODO: Allow custom basePath for extensions... like this or similar
 	// if (keystone.get('extensions')) {
 	// 	jadeOptions.basedir = keystone.getPath('extensions') + '/templates';
 	// }
-	
+
 	var compileTemplate = function() {
 		debug('compiling');
 		return jade.compile(fs.readFileSync(templatePath, 'utf8'), jadeOptions);
 	};
-	
+
 	var template = keystone.get('viewCache')
 		? templateCache[view] || (templateCache[view] = compileTemplate())
 		: compileTemplate();
@@ -53,7 +53,7 @@ function render(req, res, view, ext) {
 		error: res.req.flash('error'),
 		hilight: res.req.flash('hilight')
 	};
-	
+
 	var locals = {
 		_: _,
 		moment: moment,
@@ -83,6 +83,7 @@ function render(req, res, view, ext) {
 		wysiwygOptions: {
 			enableImages: keystone.get('wysiwyg images') ? true : false,
 			enableCloudinaryUploads: keystone.get('wysiwyg cloudinary images') ? true : false,
+			enableS3Uploads: keystone.get('wysiwyg s3 images') ? true : false,
 			additionalButtons: keystone.get('wysiwyg additional buttons') || '',
 			additionalPlugins: keystone.get('wysiwyg additional plugins') || '',
 			additionalOptions: keystone.get('wysiwyg additional options') || {},
@@ -92,10 +93,10 @@ function render(req, res, view, ext) {
 			importcss: keystone.get('wysiwyg importcss') || ''
 		}
 	};
-	
+
 	// optional extensions to the local scope
 	_.extend(locals, ext);
-	
+
 	// add cloudinary locals if configured
 	if (keystone.get('cloudinary config')) {
 		try {
@@ -120,12 +121,12 @@ function render(req, res, view, ext) {
 			}
 		}
 	}
-	
+
 	// fieldLocals defines locals that are provided to each field's `render` method
 	locals.fieldLocals = _.pick(locals, '_', 'moment', 'numeral', 'env', 'js', 'utils', 'user', 'cloudinary');
-	
+
 	var html = template(_.extend(locals, ext));
-	
+
 	debug('sending down html');
 	res.send(html);
 }

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -83,6 +83,12 @@ function routes(app) {
 		app.post('/keystone/api/cloudinary/upload', require('../../admin/api/cloudinary').upload);
 	}
 
+	// S3 API for uploading a new image
+	if (keystone.get('s3 config')) {
+		debug('setting S3 api');
+		app.post('/keystone/api/s3/upload', require('../../admin/api/s3').upload);
+	}
+
 	// Init API request helpers
 	app.use('/keystone/api', function(req, res, next) {
 		res.apiError = function(key, err) {

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -5,6 +5,7 @@ html
 	head
 		meta(charset="utf-8")
 		meta(name="viewport", content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width")
+		meta(name="csrf-token", content="#{csrf_token_value}")
 
 		title= title
 
@@ -63,7 +64,7 @@ html
 									- path = navList.path
 								else
 									- path = '/keystone/' + navList.path
-									
+
 								li(class=navList.key == list.key ? 'active' : null): a(href=path)= navList.label
 			#body: .container
 				block intro
@@ -71,10 +72,10 @@ html
 				block content
 
 		#footer: .container
-			p 	#{brand} #{appversion} 
+			p 	#{brand} #{appversion}
 				| Powered by <a href="http://keystonejs.com" target="_blank">KeystoneJS</a> version #{version}.
 				if User && user
-					|  Signed in as 
+					|  Signed in as
 					a(href='/keystone/' + User.path + '/' + user.id)= User.getDocumentName(user)
 					| .
 
@@ -128,7 +129,7 @@ html
 		script(src="/keystone/js/common/ui.js")
 		script(src="/keystone/js/common/ui-alt-text.js")
 		script(src="/keystone/js/common/ui-sortable.js")
-		
+
 		//- Page Scripts
 		block js
 


### PR DESCRIPTION
This resolves #1574 including the concern about CSRF. The image upload plugin for tinymce expects to find a meta tag with the CSRF value, so that needed to be added to the admin jade template. The rest is modeled on the existing Cloudinary API upload point and uses as much of the existing S3 file handling as seemed practical, mainly for header management.

Please let me know if you have any changes you'd like to see before this can be merged.