### PR TITLE
Fixed sortable so order is set correctly during initialization

### DIFF
--- a/lib/schemaPlugins/sortable.js
+++ b/lib/schemaPlugins/sortable.js
@@ -14,7 +14,7 @@ module.exports = function sortable() {
 
 		var item = this;
 		list.model.findOne().sort('-sortOrder').exec(function(err, max) {// eslint-disable-line no-unused-vars, handle-callback-err
-			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 0;
+			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
 			next();
 		});
 


### PR DESCRIPTION
The sortOrder field needs to start at 1 or the max check will always fail and the sortOrder field for models will be set to 0 when they are created, until the admin reorders the items.