### PR TITLE
Validation fix for GeoLocation (for FieldType - Location)

### DIFF
--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -266,8 +266,12 @@ location.prototype.updateItem = function(item, data) {
 
 	if (valuePaths.geo in values) {
 
-		var oldGeo = item.get(paths.geo) || [],
-			newGeo = values[valuePaths.geo];
+		var oldGeo = item.get(paths.geo) || [];
+		if (oldGeo.length > 1) {
+			oldGeo[0] = item.get(paths.geo)[1];
+			oldGeo[1] = item.get(paths.geo)[0];
+		}
+		var newGeo = values[valuePaths.geo];
 
 		if (!Array.isArray(newGeo) || newGeo.length !== 2) {
 			newGeo = [];


### PR DESCRIPTION
GeoLocation (for FieldType - Location) Fix: Validating new Geolocation correctly when updating field of type location