### PR TITLE
Update to grappling-hook v3.0.0

### DIFF
--- a/fields/types/azurefile/AzureFileType.js
+++ b/fields/types/azurefile/AzureFileType.js
@@ -270,7 +270,7 @@ azurefile.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	this.callHook('pre:upload', [item, file], function(err) {
+	this.callHook('pre:upload', item, file, function(err) {
 		if (err) return callback(err);
 		doUpload();
 	});

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -291,7 +291,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	field.callHook('pre:move', [item, file], function(err) {
+	field.callHook('pre:move', item, file, function(err) {
 		if (err) return callback(err);
 		doMove(function(err, fileData) {
 			if (err) return callback(err);

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -323,12 +323,12 @@ localfiles.prototype.uploadFiles = function(item, files, update, callback) {
 
 		};
 
-		field.callHook('pre:move', [item, file], function(err) {
+		field.callHook('pre:move', item, file, function(err) {
 			if (err) return processedFile(err);
 
 			doMove(function(err, fileData) {
 				if (err) return processedFile(err);
-				field.callHook('post:move', [item, file, fileData], function(err) {
+				field.callHook('post:move', item, file, fileData, function(err) {
 					return processedFile(err, fileData);
 				});
 			});

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -431,7 +431,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 		});
 	};
 
-	this.callHook('pre:upload', [item, file], function(err) {
+	this.callHook('pre:upload', item, file, function(err) {
 		if (err) return callback(err);
 		doUpload();
 	});

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -408,7 +408,7 @@ function mount(mountPath, parentApp, events) {
 	
 	app.use(function(req, res, next){
 		debug('adding pre-route middlewares');
-		keystone.callHook('pre:routes', [req, res], next);
+		keystone.callHook('pre:routes', req, res, next);
 	});
 	
 	// unless the headless option is set (which disables the Admin UI),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "express": "^4.13.3",
     "express-session": "^1.11.3",
     "fs-extra": "^0.23.1",
-    "grappling-hook": "^2.5.0",
+    "grappling-hook": "^3.0.0",
     "jade": "^1.11.0",
     "jquery": "^2.1.4",
     "keystone-utils": "^0.3.0",


### PR DESCRIPTION
Major reason for updating grappling-hook would be the addition of thenable middleware. 
However during development of v3.0.0 I realised I'd made a serious mistake when sketching out v2.x: all `callHook` parameters are flattened, i.e. this:

```js
this.callHook('pre:upload', [item, file], function(err) {
```

was translated automatically to 

```js
this.callHook('pre:upload', item, file, function(err) {
```

Which means that if you passed an array directly all of its elements were passed as separate parameters to the middleware functions. Ouch! :imp: 

Since I changed this in v3.0.0 all `callHook` calls in keystone that used an array to pass parameters needed updating, which is what this PR does.

Just to be clear: to the consumers of the middleware, i.e. keystone users, no backwards incompatible changes were introduced, i.e. they do NOT have to update anything, i.e. this is NOT a breaking change. 