### PR TITLE
Fix: Do not update null length strings

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -302,6 +302,12 @@ Field.prototype.updateItem = function(item, data) {
 	var value = this.getValueFromData(data);
 	// This is a deliberate type coercion so that numbers from forms play nice
 	if (value !== undefined && value != item.get(this.path)) { // eslint-disable-line eqeqeq
+
+		// Do not update empty strings
+		if ('string' === typeof value && !value.length) {
+			return;
+		}
+		
 		item.set(this.path, value);
 	}
 };


### PR DESCRIPTION
When updating records with empty fields they are saved as empty strings. When no value is present in a Types.Text field it should not be updated.