### PR TITLE
Fix datetime timezone bug

### DIFF
--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -20,7 +20,8 @@ module.exports = Field.create({
 	getInitialState: function() {
 		return {
 			dateValue: this.props.value ? this.moment(this.props.value).format(this.dateInputFormat) : '',
-			timeValue: this.props.value ? this.moment(this.props.value).format(this.timeInputFormat) : ''
+			timeValue: this.props.value ? this.moment(this.props.value).format(this.timeInputFormat) : '',
+			realValue: this.props.value ? this.moment(this.props.value).toISOString() : ''
 		};
 	},
 
@@ -50,6 +51,11 @@ module.exports = Field.create({
 	handleChange: function(dateValue, timeValue) {
 		var value = dateValue + ' ' + timeValue;
 		var datetimeFormat = this.dateInputFormat + ' ' + this.timeInputFormat;
+		this.setState({
+			dateValue: dateValue,
+			timeValue: timeValue,
+			realValue: moment(value, datetimeFormat).toISOString()
+		});
 		this.props.onChange({
 			path: this.props.path,
 			value: this.isValid(value) ? moment(value, datetimeFormat).toISOString() : null
@@ -57,12 +63,10 @@ module.exports = Field.create({
 	},
 
 	dateChanged: function(value) {
-		this.setState({ dateValue: value });
 		this.handleChange(value, this.state.timeValue);
 	},
 
 	timeChanged: function(event) {
-		this.setState({ timeValue: event.target.value });
 		this.handleChange(this.state.dateValue, event.target.value);
 	},
 
@@ -71,7 +75,8 @@ module.exports = Field.create({
 		var timeValue = moment().format(this.timeInputFormat);
 		this.setState({
 			dateValue: dateValue,
-			timeValue: timeValue
+			timeValue: timeValue,
+			realValue: moment().toISOString()
 		});
 		this.handleChange(dateValue, timeValue);
 	},
@@ -84,6 +89,7 @@ module.exports = Field.create({
 				<div className={fieldClassName}>
 					<DateInput ref="dateInput" name={this.props.paths.date} value={this.state.dateValue} format={this.dateInputFormat} onChange={this.dateChanged} />
 					<input type="text" name={this.props.paths.time} value={this.state.timeValue} placeholder="HH:MM:SS am/pm" onChange={this.timeChanged} autoComplete="off" className="form-control time" />
+					<input type="hidden" name={this.props.paths.real} value={this.state.realValue} />
 					<button type="button" className="btn btn-default btn-set-now" onClick={this.setNow}>Now</button>
 				</div>
 			);

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -25,7 +25,8 @@ function datetime(list, path, options) {
 	datetime.super_.call(this, list, path, options);
 	this.paths = {
 		date: this._path.append('_date'),
-		time: this._path.append('_time')
+		time: this._path.append('_time'),
+		real: this._path.append('_real')
 	};
 }
 util.inherits(datetime, FieldType);
@@ -40,6 +41,9 @@ datetime.prototype.parse = DateType.prototype.parse;
  * Get the value from a data object; may be simple or a pair of fields
  */
 datetime.prototype.getInputFromData = function(data) {
+	if(this.paths.real in data){
+		return data[this.paths.real];
+	}
 	if (this.paths.date in data && this.paths.time in data) {
 		return (data[this.paths.date] + ' ' + data[this.paths.time]).trim();
 	} else {
@@ -70,7 +74,7 @@ datetime.prototype.updateItem = function(item, data) {
 	if (!(this.path in data || (this.paths.date in data && this.paths.time in data))) {
 		return;
 	}
-	var m = this.isUTC ? moment.utc : moment;
+	var m = moment.utc;
 	var newValue = m(this.getInputFromData(data), parseFormats);
 	if (newValue.isValid()) {
 		if (!item.get(this.path) || !newValue.isSame(item.get(this.path))) {


### PR DESCRIPTION
backend:
    Add a new hidden input to hold the UTC ISOString.
    Save this real time to database.

frontend:
html:
convert utc to local time
span.timeZone #{blog.publishedDate.toISOString()}
script.
    $( document ).ready(function() {
        $('.timeZone').each(function(index,data){
            var time = $(data);
            time.text(moment.utc($(data).text()).local().format('LLL'));
            time.css('visibility', 'visible');
        })
    });

css:
prevent showing the utc time
.timeZone {
  visibility: hidden;
}
