### PR TITLE
Fixed bug in Number type column view displaying blank cell for value of 0

### DIFF
--- a/fields/types/number/NumberColumn.js
+++ b/fields/types/number/NumberColumn.js
@@ -5,7 +5,7 @@ var NumberColumn = React.createClass({
 		var value = this.props.data.fields[this.props.col.path];
 		return (
 			<td>
-				<div className="ItemList__col-value">{value ? value : null }</div>
+				<div className="ItemList__col-value">{ !isNaN(value) ? value : null }</div>
 			</td>
 		);
 	}


### PR DESCRIPTION
Number fields with value of 0 would be treated as falsy value, ignored and not displayed as valid value of 0 but rather as a blank