### PR TITLE
Fixed double-escaping of Amazon S3 File URLs

### DIFF
--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -411,7 +411,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 			}
 
 			var protocol = (field.s3config.protocol && field.s3config.protocol + ':') || '',
-				url = res.req.url.replace(/^https?:/i, protocol);
+				url = res.req.url.replace(/^https?:/i, protocol).replace(/%25/g, '%');
 
 			var fileData = {
 				filename: filename,


### PR DESCRIPTION
Added unescaping of percent symbol to avoid double-escaping from Amazon S3.

If you have special characters in the filename or path that you send to Amazon, when the url comes back it will have them double-escaped (escaping the character then escaping the percent). Not sure if this is Amazon or Knox who is the cause, but unescaping the '%' will fix the URLs.