### PR TITLE
Updated Email helper to better support custom template engines.

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -158,8 +158,8 @@ var Email = function(options) {
 	this.templateExt = options.templateExt || Email.defaults.templateExt;
 	this.templateEngine = options.templateEngine || Email.defaults.templateEngine;
 	this.templateBasePath = options.templateBasePath || Email.defaults.templateBasePath;
-	this.templateCompile = options.templateCompile;
-	this.templateRender = options.templateRender;
+	this.templateCompile = options.templateCompile || Email.defaults.templateCompile;
+	this.templateRender = options.templateRender || Email.defaults.templateRender;
 
 	if (!this.templateName) {
 		throw new ErrorNoEmailTemplateName();
@@ -222,6 +222,12 @@ Email.prototype.render = function(locals, callback) {
 			html = template(locals);
 		} else if (typeof template.render === 'function') {
 			html = template.render(locals);
+		} else {
+			return callback({
+				from: 'Email.compileTemplate',
+				key: 'invalid rendering function',
+				message: 'no template rendering function could be found.'
+			});
 		}
 
 		// ensure extended characters are replaced

--- a/lib/email.js
+++ b/lib/email.js
@@ -153,11 +153,13 @@ var Email = function(options) {
 
 	this.templateMandrillName = options.templateMandrillName;
 	this.templateMandrillContent = _.isArray(options.templateMandrillContent) ? options.templateMandrillContent : [];
-	
+
 	this.templateName = options.templateName || this.templateMandrillName;
 	this.templateExt = options.templateExt || Email.defaults.templateExt;
 	this.templateEngine = options.templateEngine || Email.defaults.templateEngine;
 	this.templateBasePath = options.templateBasePath || Email.defaults.templateBasePath;
+	this.templateCompile = options.templateCompile;
+	this.templateRender = options.templateRender;
 
 	if (!this.templateName) {
 		throw new ErrorNoEmailTemplateName();
@@ -212,7 +214,15 @@ Email.prototype.render = function(locals, callback) {
 			return callback(err);
 		}
 
-		var html = templateCache[this.templateName](locals);
+		var html = null;
+		var template = templateCache[this.templateName];
+		if (this.templateRender) {
+			html = this.templateRender(template, locals);
+		} else if (typeof template === 'function') {
+			html = template(locals);
+		} else if (typeof template.render === 'function') {
+			html = template.render(locals);
+		}
 
 		// ensure extended characters are replaced
 		html = html.replace(/[\u007f-\uffff]/g, function(c) {
@@ -310,7 +320,12 @@ Email.prototype.compileTemplate = function(callback) {
 
 		if (err) return callback(err);
 
-		var template = this.templateEngine.compile(contents.toString(), Email.defaults.compilerOptions || { filename: fs.realpathSync(filename), basedir: this.templateBasePath });
+		var template = null;
+		if (this.templateCompile) {
+			template = this.templateCompile(this.templateEngine, contents.toString(), Email.defaults.compilerOptions, fs.realpathSync(filename));
+		} else {
+			template = this.templateEngine.compile(contents.toString(), Email.defaults.compilerOptions || { filename: fs.realpathSync(filename), basedir: this.templateBasePath }, fs.realpathSync(filename));
+		}
 
 		templateCache[this.templateName] = template;
 
@@ -544,7 +559,7 @@ Email.prototype.buildOptions = function(err, options, callback) {
  * @param {Function} callback(err, info)
  *
  * @api private
- */ 
+ */
 
 Email.prototype.send = function(options, callback) {
 
@@ -557,7 +572,7 @@ Email.prototype.send = function(options, callback) {
 			prepareOptions.push(arguments[1]);
 		}
 		callback = arguments[2];
-		
+
 	} else if (arguments.length === 2 && !utils.isFunction(callback)) {
 		// no callback so we expect locals, options
 		if (_.isObject(arguments[1])) {
@@ -566,13 +581,13 @@ Email.prototype.send = function(options, callback) {
 		callback = function(err, info) {// eslint-disable-line no-unused-vars
 			if (err) console.log(err);
 		};
-		
+
 	} else if (arguments.length === 1) {
 		// we expect options here and it is pushed already
 		callback = function(err, info){// eslint-disable-line no-unused-vars
 			if (err) console.log(err);
 		};
-	}  
+	}
 
 	prepareOptions.push(function(err, toSend) {
 


### PR DESCRIPTION
Updated support for custom template engines in the Email helper. Specifically, by adding the capability to provide a custom compile and/or render call (via the new 'templateCompile' and 'templateRender' options). 

If either of these options (compile/render calls) are omitted, the Email helper will fallback to it's original methods (designed for Jade).

Reference Issue: [1663](https://github.com/keystonejs/keystone/issues/1663)