### PR TITLE
Fixing #1694

### DIFF
--- a/admin/app/static.js
+++ b/admin/app/static.js
@@ -47,6 +47,7 @@ var lessOptions = {
 /* Configure router */
 
 router.use('/styles', less(__dirname + '../../public/styles', lessOptions));
+router.use('/styles/fonts', express.static(__dirname + '../../public/js/lib/tinymce/skins/keystone/fonts'));
 router.use(express.static(__dirname + '../../public'));
 router.get('/js/fields.js', bundles.fields.serve);
 router.get('/js/signin.js', bundles.signin.serve);

--- a/admin/public/styles/react/react.less
+++ b/admin/public/styles/react/react.less
@@ -37,3 +37,4 @@
 @import "@{reactSelectPath}/less/select.less";
 
 @import "../../../../fields/types/markdown/less/bootstrap-markdown.less";
+@import "../../../public/js/lib/tinymce/skins/keystone/skin.less";


### PR DESCRIPTION
TinyMCE icons are not visible on Admin UI
Screenshot with the problem.
![bug-1694](https://cloud.githubusercontent.com/assets/517228/10102720/663401b2-6376-11e5-9d5c-36595a3f7374.png)
