### PR TITLE
Make the treatment of the View action and query queue consistent with that of init()

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -315,11 +315,9 @@ View.prototype.query = function(key, query, options) {
  * then executes the render function. If renderFn is a string, it is provided
  * to `res.render`.
  *
- * It is expected that *most* init stacks require processing in series,
- * but it is safe to execute actions in parallel.
- *
- * If there are several init methods that should be run in parallel, queue
- * them as an array, e.g. `view.on('init', [first, second])`.
+ * It is expected that *most* init and action stacks require processing in
+ * series.  If there are several init or action methods that should be run in
+ * parallel, queue them as an array, e.g. `view.on('init', [first, second])`.
  *
  * @api public
  */
@@ -343,8 +341,8 @@ View.prototype.render = function(renderFn, locals, callback) {
 	}
 
 	// Add actions, queries & renderQueue to the end of the initQueue
-	this.initQueue.push(this.actionQueue);
-	this.initQueue.push(this.queryQueue);
+	this.initQueue.push.apply(this.initQueue, this.actionQueue);
+	this.initQueue.push.apply(this.initQueue, this.queryQueue);
 
 	var preRenderQueue = [];
 


### PR DESCRIPTION
Currently, this:

    view.on('post', function a() { ... });
    view.on('post', function b() { ... });
    view.on('post', function c() { ... });

Would run a, b, and c in parallel, whereas this:

    view.on('init', function a() { ... });
    view.on('init', function b() { ... });
    view.on('init', function c() { ... });

Would run a, b, and c in series.  This PR makes the behavior of both to run in series.  init already allows you to specify an array of functions if you want to run them in parallel:

    view.on('init', [ function a() { ... },  function b() { ... }, function c() { ... } ])

Which is now also possible with post().  This PR will not affect compatibility because series still runs all of the callbacks as would be expected with parallel, but it will make it easier to queue up multiple post handlers without having to use async.js.


