### PR TITLE
Don't require CSRF tokens for signin

### DIFF
--- a/admin/api/session/signin.js
+++ b/admin/api/session/signin.js
@@ -3,9 +3,6 @@ var keystone = require('../../../');
 var session = require('../../../lib/session');
 
 function signin (req, res) {
-	if (!keystone.security.csrf.validate(req)) {
-		return res.status(403).json({ error: 'invalid csrf' });
-	}
 	if (!req.body.email || !req.body.password) {
 		return res.status(401).json({ error: 'email and password required' });
 	}

--- a/admin/src/views/signin.js
+++ b/admin/src/views/signin.js
@@ -118,7 +118,6 @@ var SigninView = React.createClass({
 		return (
 			<div className="auth-box__col">
 				<Form method="post" onSubmit={this.handleSubmit} noValidate>
-					<FormInput type="hidden" name={this.props.csrfTokenKey} value={this.props.csrfTokenValue} />
 					<FormField label="Email" htmlFor="email">
 						<FormInput type="email" name="email" onChange={this.handleInputChange} value={this.state.email} ref="email" />
 					</FormField>
@@ -157,8 +156,6 @@ var SigninView = React.createClass({
 
 ReactDOM.render(<SigninView
 		brand={Keystone.brand}
-		csrfTokenKey={Keystone.csrf_token_key}
-		csrfTokenValue={Keystone.csrf_token_value}
 		logo={Keystone.logo}
 		user={Keystone.user}
 		userCanAccessKeystone={Keystone.userCanAccessKeystone}

--- a/admin/templates/signin.jade
+++ b/admin/templates/signin.jade
@@ -11,9 +11,6 @@ html
 		script.
 			var Keystone = {
 				brand: !{JSON.stringify(brand || '')},
-				csrf_header_key: !{JSON.stringify(csrf_header_key || '')},
-				csrf_token_key: !{JSON.stringify(csrf_token_key || '')},
-				csrf_token_value: !{JSON.stringify(csrf_token_value || '')},
 				logo: !{JSON.stringify(logo || '')},
 				messages: !{JSON.stringify(messages || '')},
 				user: !{JSON.stringify(user || null)},


### PR DESCRIPTION
CSRF tokens are meant to prevent using an existing session, but for signin the current session is not used.

Therefore, CSRF tokens at login only serve to complicate matters.
