### PR TITLE
Fixed typo when creating auth url locals

### DIFF
--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -29,10 +29,10 @@ module.exports = function createDynamicRouter(keystone) {
 	if (keystone.get('auth') === true) {
 		// TODO: poor separation of concerns; settings should be defaulted elsewhere
 		if (!keystone.get('signout url')) {
-			keystone.set('signout url', '/signout');
+			keystone.set('signout url', '/keystone/signout');
 		}
 		if (!keystone.get('signin url')) {
-			keystone.set('signin url', '/signin');
+			keystone.set('signin url', '/keystone/signin');
 		}
 		if (!keystone.nativeApp || !keystone.get('session')) {
 			router.all('*', keystone.session.persist);


### PR DESCRIPTION
Couldn't log into admin when auth was true because signout url and signin url locals where missing '/keystone' in createDynamicRouter.js.