### PR TITLE
Remove redundant `Object.assign()` polyfill

### DIFF
--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -1,4 +1,3 @@
-var assign = require('object-assign');
 var utils = require('keystone-utils');
 
 function trim(i) { return i.trim(); }
@@ -51,7 +50,7 @@ function addSearchToQuery (searchString, query) {
 	if (searchFilters.length > 1) {
 		query.$or = searchFilters;
 	} else if (searchFilters.length) {
-		assign(query, searchFilters[0]);
+		Object.assign(query, searchFilters[0]);
 	}
 
 	return query;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "mpromise": "^0.5.5",
     "multer": "^0.1.8",
     "numeral": "^1.5.3",
-    "object-assign": "^4.0.1",
     "pikaday": "^1.3.3",
     "qs": "^5.2.0",
     "queryfilter": "^0.0.4",

--- a/server/initViewLocals.js
+++ b/server/initViewLocals.js
@@ -1,9 +1,7 @@
-var assign = require('object-assign');
-
 module.exports = function initTrustProxy (keystone, app) {
 	// Apply locals
 	if (typeof keystone.get('locals') === 'object') {
-		assign(app.locals, keystone.get('locals'));
+		Object.assign(app.locals, keystone.get('locals'));
 	}
 
 	// Default "pretty html" mode except in production


### PR DESCRIPTION
Since [`babel-plugin-object-assign`](https://www.npmjs.com/package/babel-plugin-object-assign) is already used in the codebase [this polyfill](https://www.npmjs.com/package/object-assign) is redundant.