### PR TITLE
Check if param value is defined in filtersFromUrlParams (#1723)

### DIFF
--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -162,7 +162,9 @@ var filtersFromUrlParams = function () {
 	if (qs) {
 		for (var field in qs) {
 			var value = qs[field];
-			CurrentListStore.setFilter(field, JSON.parse(decodeURIComponent(value)));
+			if (value) {
+				CurrentListStore.setFilter(field, JSON.parse(decodeURIComponent(value)));
+			}
 		}
 	}
 };


### PR DESCRIPTION
The '+' links in the Admin UI home page (#1723) weren't working because the ``filtersFromUrlParams`` function in CurrentListStore.js had an undefined value for the search param ``?create``