### PR TITLE
Remove unused code for search input visibility toggling

### DIFF
--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -10,19 +10,12 @@ var Header = React.createClass({
 
 	getInitialState () {
 		return {
-			searchIsFocused: false,
 			searchString: ''
 		};
 	},
 
 	toggleCreate (visible) {
 		this.props.toggleCreate(visible);
-	},
-
-	searchFocusChanged (focused) {
-		this.setState({
-			searchIsFocused: focused
-		});
 	},
 
 	searchStringChanged (event) {
@@ -99,8 +92,6 @@ var Header = React.createClass({
 						name="search"
 						value={this.state.searchString}
 						onChange={this.searchStringChanged}
-						onFocus={this.searchFocusChanged.bind(this, true)}
-						onBlur={this.searchFocusChanged.bind(this, false)}
 						placeholder="Search"
 						className="EditForm__header__search-input" />
 				</FormIconField>

--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -10,28 +10,13 @@ var Header = React.createClass({
 
 	getInitialState () {
 		return {
-			searchIsVisible: false,
 			searchIsFocused: false,
 			searchString: ''
 		};
 	},
 
-	componentDidUpdate (prevProps, prevState) {
-		if (this.state.searchIsVisible && !prevState.searchIsVisible) {
-			this.refs.searchField.getDOMNode().focus();
-		}
-	},
-
 	toggleCreate (visible) {
 		this.props.toggleCreate(visible);
-	},
-
-	toggleSearch (visible) {
-		this.setState({
-			searchIsVisible: visible,
-			searchIsFocused: visible,
-			searchString: ''
-		});
 	},
 
 	searchFocusChanged (focused) {
@@ -47,7 +32,6 @@ var Header = React.createClass({
 	},
 
 	renderDrilldown () {
-		if (this.state.searchIsVisible) return null;
 		/* eslint-disable no-script-url */
 		return (
 			<Toolbar.Section left>


### PR DESCRIPTION
Since the toggling of the visibility of the search input field is (very elegantly) handled by CSS this commit removes some no longer needed code.