### PR TITLE
Focus the focus target in the create form modal when opening the modal

### DIFF
--- a/admin/client/components/CreateForm.js
+++ b/admin/client/components/CreateForm.js
@@ -41,9 +41,9 @@ var CreateForm = React.createClass({
 	componentDidUpdate (prevProps, prevState) {
 		if (this.props.isOpen !== prevProps.isOpen) {
 			document.body.style.overflow = (this.props.isOpen) ? 'hidden' : '';
-			if (this.refs.focusTarget) {
-				this.refs.focusTarget.focus();
-			}
+
+			// focus the focusTarget after the "open modal" CSS animation has started
+			setTimeout(() => this.refs.focusTarget && this.refs.focusTarget.focus(), 0);
 		}
 	},
 


### PR DESCRIPTION
This PR fixes a bug that caused the focus target in the modal in `CreateForm` to not be focused when the modal was opened.

<img width="950" alt="screen shot 2015-11-10 at 10 16 17" src="https://cloud.githubusercontent.com/assets/76098/11065993/42215b3e-8794-11e5-8434-bb7c9d25c72b.png">

Another approach (probably better) would be to submit a PR to [Elemental UI](https://github.com/elementalui/elemental/blob/master/src/components/Modal.js) and refactor the `Modal` component there to use the low level API of `ReactTransitionGroup` instead of `ReactCSSTransitionGroup`, which has a lifecycle method `componentDidEnter` that could be used for the focusing. [More info on how this API could be used.](https://facebook.github.io/react/docs/animation.html)