### PR TITLE
Use autofocus prop in the `FormInput` component

### DIFF
--- a/admin/client/components/CreateForm.js
+++ b/admin/client/components/CreateForm.js
@@ -100,11 +100,14 @@ var CreateForm = React.createClass({
 		var list = this.props.list;
 		var formAction = `${Keystone.adminPath}/${list.path}`;
 		var nameField = this.props.list.nameField;
-		var focusRef;
+		var hasAutofocus = false;
 
 		if (list.nameIsInitial) {
 			var nameFieldProps = this.getFieldProps(nameField);
-			nameFieldProps.ref = focusRef = 'focusTarget';
+
+			nameFieldProps.inputProps = { autofocus: true };
+			hasAutofocus = true;
+
 			if (nameField.type === 'text') {
 				nameFieldProps.className = 'item-name-field';
 				nameFieldProps.placeholder = nameField.label;
@@ -120,8 +123,9 @@ var CreateForm = React.createClass({
 				return;
 			}
 			var fieldProps = this.getFieldProps(field);
-			if (!focusRef) {
-				fieldProps.ref = focusRef = 'focusTarget';
+			if (!hasAutofocus) {
+				fieldProps.inputProps = { autofocus: true };
+				hasAutofocus = true;
 			}
 			form.push(React.createElement(Fields[field.type], fieldProps));
 		});

--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -88,7 +88,7 @@ module.exports = Field.create({
 			input = (
 				<InputGroup>
 					<InputGroup.Section grow>
-						<DateInput ref="dateInput" name={this.props.paths.date} value={this.state.dateValue} format={this.dateInputFormat} onChange={this.dateChanged} />
+						<DateInput ref="dateInput" name={this.props.paths.date} value={this.state.dateValue} format={this.dateInputFormat} onChange={this.dateChanged} autofocus />
 					</InputGroup.Section>
 					<InputGroup.Section grow>
 						<FormInput name={this.props.paths.time} value={this.state.timeValue} placeholder="HH:MM:SS am/pm" onChange={this.timeChanged} autoComplete="off" />

--- a/fields/types/geopoint/GeoPointField.js
+++ b/fields/types/geopoint/GeoPointField.js
@@ -27,7 +27,7 @@ module.exports = Field.create({
 		return (
 			<FormRow>
 				<FormField width="one-half">
-					<FormInput name={this.props.path + '[1]'} placeholder="Latitude" ref="lat" value={this.props.value[1]} onChange={this.valueChanged.bind(this, 1)} autoComplete="off" />
+					<FormInput name={this.props.path + '[1]'} placeholder="Latitude" ref="lat" value={this.props.value[1]} onChange={this.valueChanged.bind(this, 1)} autoComplete="off" autofocus />
 				</FormField>
 				<FormField width="one-half">
 					<FormInput name={this.props.path + '[0]'} placeholder="Longitude" ref="lng" value={this.props.value[0]} onChange={this.valueChanged.bind(this, 0)} autoComplete="off" />

--- a/fields/types/name/NameField.js
+++ b/fields/types/name/NameField.js
@@ -33,7 +33,7 @@ module.exports = Field.create({
 		return (
 			<FormRow>
 				<FormField width="one-half">
-					<FormInput name={this.props.paths.first} placeholder="First name" ref="first" value={this.props.value.first} onChange={this.valueChanged.bind(this, 'first')} autoComplete="off" />
+					<FormInput name={this.props.paths.first} placeholder="First name" ref="first" value={this.props.value.first} onChange={this.valueChanged.bind(this, 'first')} autoComplete="off" autofocus />
 				</FormField>
 				<FormField width="one-half">
 					<FormInput name={this.props.paths.last} placeholder="Last name" ref="last" value={this.props.value.last} onChange={this.valueChanged.bind(this, 'last')} autoComplete="off" />


### PR DESCRIPTION
This PR uses the autofocus prop provided in [ElementalUI’s `FormInput` component](http://elemental-ui.com/forms) instead of doing an own implementation in the `CreateForm` component.

Based on @JedWatson's proposal in #1790 