### PR TITLE
ES2015 module import syntax for loading dependencies

### DIFF
--- a/admin/client/components/CreateForm.js
+++ b/admin/client/components/CreateForm.js
@@ -1,7 +1,7 @@
-var React = require('react');
-var Fields = require('../fields');
-var InvalidFieldType = require('./InvalidFieldType');
-var { Alert, Button, Form, Modal } = require('elemental');
+import React from 'react';
+import Fields from '../fields';
+import InvalidFieldType from './InvalidFieldType';
+import { Alert, Button, Form, Modal } from 'elemental';
 
 var CreateForm = React.createClass({
 

--- a/admin/client/components/EditForm.js
+++ b/admin/client/components/EditForm.js
@@ -1,12 +1,11 @@
-var moment = require('moment');
-var React = require('react');
-var Fields = require('../fields');
-var FormHeading = require('./FormHeading');
-var AltText = require('./AltText');
-var FooterBar = require('./FooterBar');
-var InvalidFieldType = require('./InvalidFieldType');
-
-var { Button, Col, Form, FormField, FormInput, ResponsiveText, Row } = require('elemental');
+import React from 'react';
+import moment from 'moment';
+import Fields from '../fields';
+import FormHeading from './FormHeading';
+import AltText from './AltText';
+import FooterBar from './FooterBar';
+import InvalidFieldType from './InvalidFieldType';
+import { Button, Col, Form, FormField, FormInput, ResponsiveText, Row } from 'elemental';
 
 var EditForm = React.createClass({
 	displayName: 'EditForm',

--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -1,7 +1,6 @@
-var React = require('react');
-var Toolbar = require('./Toolbar');
-
-var { Button, FormIconField, FormInput, ResponsiveText } = require('elemental');
+import React from 'react';
+import Toolbar from './Toolbar';
+import { Button, FormIconField, FormInput, ResponsiveText } from 'elemental';
 
 var Header = React.createClass({
 

--- a/admin/client/components/FlashMessages.js
+++ b/admin/client/components/FlashMessages.js
@@ -1,5 +1,5 @@
-const React = require('react');
-const { Alert } = require('elemental');
+import React from 'react';
+import { Alert } from 'elemental';
 
 var FlashMessage = React.createClass({
 	displayName: 'FlashMessage',

--- a/admin/client/components/FooterBar.js
+++ b/admin/client/components/FooterBar.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var blacklist = require('blacklist');
+import React from 'react';
+import blacklist from 'blacklist';
 
 var FooterBar = React.createClass({
 	getInitialState () {

--- a/admin/client/components/FormHeading.js
+++ b/admin/client/components/FormHeading.js
@@ -1,5 +1,5 @@
-var evalDependsOn = require('../../../fields/utils/evalDependsOn.js');
-var React = require('react');
+import React from 'react';
+import evalDependsOn from '../../../fields/utils/evalDependsOn';
 
 module.exports = React.createClass({
 

--- a/admin/client/components/InvalidFieldType.js
+++ b/admin/client/components/InvalidFieldType.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 

--- a/admin/client/components/ItemsTable.js
+++ b/admin/client/components/ItemsTable.js
@@ -1,7 +1,7 @@
-const Columns = require('../columns');
-const CurrentListStore = require('../stores/CurrentListStore');
-const ListControl = require('./ListControl');
-const React = require('react');
+import React from 'react';
+import Columns from '../columns';
+import CurrentListStore from '../stores/CurrentListStore';
+import ListControl from './ListControl';
 
 const CONTROL_COLUMN_WIDTH = 26;  // icon + padding
 

--- a/admin/client/components/ItemsTableValue.js
+++ b/admin/client/components/ItemsTableValue.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var ItemsTableValue = React.createClass({
 	displayName: 'ItemsTableValue',

--- a/admin/client/components/ListColumnsForm.js
+++ b/admin/client/components/ListColumnsForm.js
@@ -1,9 +1,8 @@
 import React from 'react';
-
-var CurrentListStore = require('../stores/CurrentListStore');
-var Popout = require('./Popout');
-var PopoutList = require('./PopoutList');
-var { Button, InputGroup } = require('elemental');
+import CurrentListStore from '../stores/CurrentListStore';
+import Popout from './Popout';
+import PopoutList from './PopoutList';
+import { Button, InputGroup } from 'elemental';
 
 var ListColumnsForm = React.createClass({
 	displayName: 'ListColumnsForm',

--- a/admin/client/components/ListControl.js
+++ b/admin/client/components/ListControl.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var classnames = require('classnames');
+import React from 'react';
+import classnames from 'classnames';
 
 var ListControl = React.createClass({
 

--- a/admin/client/components/ListDownloadForm.js
+++ b/admin/client/components/ListDownloadForm.js
@@ -1,10 +1,8 @@
 import React from 'react';
-
-var CurrentListStore = require('../stores/CurrentListStore');
-var Popout = require('./Popout');
-var PopoutList = require('./PopoutList');
-
-var { Button, Checkbox, Form, FormField, InputGroup, SegmentedControl } = require('elemental');
+import CurrentListStore from '../stores/CurrentListStore';
+import Popout from './Popout';
+import PopoutList from './PopoutList';
+import { Button, Checkbox, Form, FormField, InputGroup, SegmentedControl } from 'elemental';
 
 const FORMAT_OPTIONS = [
 	{ label: 'CSV', value: 'csv' },

--- a/admin/client/components/ListFilters.js
+++ b/admin/client/components/ListFilters.js
@@ -1,9 +1,8 @@
-const React = require('react');
-const filterComponents = require('../filters');
-const CurrentListStore = require('../stores/CurrentListStore');
-
-const Popout = require('./Popout');
-const { Pill } = require('elemental');
+import React from 'react';
+import filterComponents from '../filters';
+import CurrentListStore from '../stores/CurrentListStore';
+import Popout from './Popout';
+import { Pill } from 'elemental';
 
 const Filter = React.createClass({
 	propTypes: {

--- a/admin/client/components/ListFiltersAdd.js
+++ b/admin/client/components/ListFiltersAdd.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import Transition from 'react-addons-css-transition-group';
 import classnames from 'classnames';
-
-var CurrentListStore = require('../stores/CurrentListStore');
-var ListFiltersAddForm = require('./ListFiltersAddForm');
-var Popout = require('./Popout');
-var PopoutList = require('./PopoutList');
-var { Button, FormField, FormInput, InputGroup } = require('elemental');
+import CurrentListStore from '../stores/CurrentListStore';
+import ListFiltersAddForm from './ListFiltersAddForm';
+import Popout from './Popout';
+import PopoutList from './PopoutList';
+import { Button, FormField, FormInput, InputGroup } from 'elemental';
 
 function pluck(arr, key) {
 	return arr.map(obj => obj[key]);

--- a/admin/client/components/ListFiltersAddForm.js
+++ b/admin/client/components/ListFiltersAddForm.js
@@ -1,8 +1,7 @@
-var React = require('react');
-
-var CurrentListStore = require('../stores/CurrentListStore');
-var filters = require('../filters');
-var Popout = require('./Popout');
+import React from 'react';
+import CurrentListStore from '../stores/CurrentListStore';
+import filters from '../filters';
+import Popout from './Popout';
 
 var ListFiltersAddForm = React.createClass({
 

--- a/admin/client/components/ListSort.js
+++ b/admin/client/components/ListSort.js
@@ -3,7 +3,6 @@ import React from 'react';
 import Popout from './Popout';
 import PopoutList from './PopoutList';
 import vkey from 'vkey';
-
 import CurrentListStore from '../stores/CurrentListStore';
 
 var ListSort = React.createClass({

--- a/admin/client/components/PopoutBody.js
+++ b/admin/client/components/PopoutBody.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var PopoutBody = React.createClass({
 	displayName: 'PopoutBody',

--- a/admin/client/components/PopoutFooter.js
+++ b/admin/client/components/PopoutFooter.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 const buttonBaseClassname = 'Popout__footer__button Popout__footer__button--';
 

--- a/admin/client/components/PopoutList.js
+++ b/admin/client/components/PopoutList.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var PopoutList = React.createClass({
 	displayName: 'PopoutList',

--- a/admin/client/components/PopoutListHeading.js
+++ b/admin/client/components/PopoutListHeading.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var PopoutListHeading = React.createClass({
 	displayName: 'PopoutListHeading',

--- a/admin/client/components/PopoutListItem.js
+++ b/admin/client/components/PopoutListItem.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var PopoutListItem = React.createClass({
 	displayName: 'PopoutListItem',

--- a/admin/client/components/PopoutPane.js
+++ b/admin/client/components/PopoutPane.js
@@ -1,6 +1,6 @@
+import React from 'react';
 import blacklist from 'blacklist';
 import classnames from 'classnames';
-import React from 'react';
 
 var PopoutPane = React.createClass({
 	displayName: 'PopoutPane',

--- a/admin/client/components/Toolbar.js
+++ b/admin/client/components/Toolbar.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var { Container } = require('elemental');
+import React from 'react';
+import { Container } from 'elemental';
 
 module.exports = React.createClass({
 	displayName: 'Toolbar',

--- a/admin/client/components/ToolbarSection.js
+++ b/admin/client/components/ToolbarSection.js
@@ -1,6 +1,6 @@
-var React = require('react');
-var blacklist = require('blacklist');
-var classNames = require('classnames');
+import React from 'react';
+import blacklist from 'blacklist';
+import classNames from 'classnames';
 
 module.exports = React.createClass({
 	displayName: 'ToolbarSection',

--- a/admin/client/components/UpdateForm.js
+++ b/admin/client/components/UpdateForm.js
@@ -1,8 +1,8 @@
-const React = require('react');
-const Select = require ('react-select');
-const Fields = require('../fields');
-const { plural } = require('../utils');
-const { BlankState, Button, Form, Modal } = require('elemental');
+import React from 'react';
+import Select from 'react-select';
+import Fields from '../fields';
+import { plural } from '../utils';
+import { BlankState, Button, Form, Modal } from 'elemental';
 
 var UpdateForm = React.createClass({
 	displayName: 'UpdateForm',

--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Store = require('store-prototype');
-var List = require('../lib/List');
+import Store from 'store-prototype';
+import List from '../lib/List';
 
 var _list = new List(Keystone.list);
 var _ready = false;

--- a/admin/client/stores/Lists.js
+++ b/admin/client/stores/Lists.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const List = require('../lib/List');
+import List from '../lib/List';
 
 for (let key in Keystone.lists) {
 	exports[key] = new List(Keystone.lists[key]);

--- a/admin/client/stores/SessionStore.js
+++ b/admin/client/stores/SessionStore.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Store = require('store-prototype');
-const xhr = require('xhr');
+import Store from 'store-prototype';
+import xhr from 'xhr';
 
 const fn = function () {};
 

--- a/admin/client/views/home.js
+++ b/admin/client/views/home.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const { Container } = require('elemental');
-const xhr = require('xhr');
-const { plural } = require('../utils');
-const Footer = require('../components/Footer');
-const MobileNavigation = require('../components/MobileNavigation');
-const PrimaryNavigation = require('../components/PrimaryNavigation');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Container } from 'elemental';
+import xhr from 'xhr';
+import { plural } from '../utils';
+import Footer from '../components/Footer';
+import MobileNavigation from '../components/MobileNavigation';
+import PrimaryNavigation from '../components/PrimaryNavigation';
 
 var listsByKey = {};
 Keystone.lists.forEach((list) => {

--- a/admin/client/views/item.js
+++ b/admin/client/views/item.js
@@ -1,20 +1,17 @@
-const React = require('react');
-const ReactDOM = require('react-dom');
-const request = require('superagent');
-
-const Columns = require('../columns');
-const Lists = require('../stores/Lists');
-
-const CreateForm = require('../components/CreateForm');
-const EditForm = require('../components/EditForm');
-const EditFormHeader = require('../components/EditFormHeader');
-const FlashMessages = require('../components/FlashMessages');
-const Footer = require('../components/Footer');
-const MobileNavigation = require('../components/MobileNavigation');
-const PrimaryNavigation = require('../components/PrimaryNavigation');
-const SecondaryNavigation = require('../components/SecondaryNavigation');
-
-const { Container, Spinner } = require('elemental');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import request from 'superagent';
+import Columns from '../columns';
+import Lists from '../stores/Lists';
+import CreateForm from '../components/CreateForm';
+import EditForm from '../components/EditForm';
+import EditFormHeader from '../components/EditFormHeader';
+import FlashMessages from '../components/FlashMessages';
+import Footer from '../components/Footer';
+import MobileNavigation from '../components/MobileNavigation';
+import PrimaryNavigation from '../components/PrimaryNavigation';
+import SecondaryNavigation from '../components/SecondaryNavigation';
+import { Container, Spinner } from 'elemental';
 
 var RelatedItemsList = React.createClass({
 	propTypes: {

--- a/admin/client/views/list.js
+++ b/admin/client/views/list.js
@@ -1,30 +1,26 @@
 'use strict';
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const classnames = require('classnames');
-
-const Lists = require('../stores/Lists');
-const CurrentListStore = require('../stores/CurrentListStore');
-const Columns = require('../columns');
-
-const CreateForm = require('../components/CreateForm');
-const FlashMessages = require('../components/FlashMessages');
-const Footer = require('../components/Footer');
-const ListColumnsForm = require('../components/ListColumnsForm');
-const ListControl = require('../components/ListControl');
-const ListDownloadForm = require('../components/ListDownloadForm');
-const ListFilters = require('../components/ListFilters');
-const ListFiltersAdd = require('../components/ListFiltersAdd');
-const ListSort = require('../components/ListSort');
-const MobileNavigation = require('../components/MobileNavigation');
-const PrimaryNavigation = require('../components/PrimaryNavigation');
-const SecondaryNavigation = require('../components/SecondaryNavigation');
-const UpdateForm = require('../components/UpdateForm');
-
-const { Alert, BlankState, Button, Container, Dropdown, FormInput, InputGroup, Pagination, Spinner } = require('elemental');
-
-const { plural } = require('../utils');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import classnames from 'classnames';
+import Lists from '../stores/Lists';
+import CurrentListStore from '../stores/CurrentListStore';
+import Columns from '../columns';
+import CreateForm from '../components/CreateForm';
+import FlashMessages from '../components/FlashMessages';
+import Footer from '../components/Footer';
+import ListColumnsForm from '../components/ListColumnsForm';
+import ListControl from '../components/ListControl';
+import ListDownloadForm from '../components/ListDownloadForm';
+import ListFilters from '../components/ListFilters';
+import ListFiltersAdd from '../components/ListFiltersAdd';
+import ListSort from '../components/ListSort';
+import MobileNavigation from '../components/MobileNavigation';
+import PrimaryNavigation from '../components/PrimaryNavigation';
+import SecondaryNavigation from '../components/SecondaryNavigation';
+import UpdateForm from '../components/UpdateForm';
+import { Alert, BlankState, Button, Container, Dropdown, FormInput, InputGroup, Pagination, Spinner } from 'elemental';
+import { plural } from '../utils';
 
 const TABLE_CONTROL_COLUMN_WIDTH = 26;  // icon + padding
 


### PR DESCRIPTION
The way dependencies were loaded in the client side JS was a bit fragmented so to increase the consistency I've replaced the `require()` calls with the ES2015 `import` syntax.

I'm fine with either syntax but I think it should be consistent, and between the two I think the ES2015 syntax feels a bit more modern (and future proof). :)