### PR TITLE
Refactor `renderFormElements` in `EditForm`

### DIFF
--- a/admin/client/components/EditForm.js
+++ b/admin/client/components/EditForm.js
@@ -83,20 +83,21 @@ var EditForm = React.createClass({
 	},
 
 	renderFormElements () {
-		var elements = [];
 		var headings = 0;
-		this.props.list.uiElements.map((el) => {
+
+		return this.props.list.uiElements.map((el) => {
 			if (el.type === 'heading') {
 				headings++;
 				el.options.values = this.state.values;
 				el.key = 'h-' + headings;
-				elements.push(React.createElement(FormHeading, el));
-			} else if (el.type === 'field') {
+				return React.createElement(FormHeading, el);
+			}
+
+			if (el.type === 'field') {
 				var field = this.props.list.fields[el.field];
 				var props = this.getFieldProps(field);
 				if ('function' !== typeof Fields[field.type]) {
-					elements.push(React.createElement(InvalidFieldType, { type: field.type, path: field.path, key: field.path }));
-					return;
+					return React.createElement(InvalidFieldType, { type: field.type, path: field.path, key: field.path });
 				}
 				if (props.dependsOn) {
 					props.currentDependencies = {};
@@ -105,10 +106,9 @@ var EditForm = React.createClass({
 					}, this);
 				}
 				props.key = field.path;
-				elements.push(React.createElement(Fields[field.type], props));
+				return React.createElement(Fields[field.type], props);
 			}
 		}, this);
-		return elements;
 	},
 
 	renderFooterBar () {


### PR DESCRIPTION
Refactor of the `renderFormElements` method in `EditForm` to a more conventional use of `map` by returning the mapped array instead of mutating an array outside of it's closure.