### PR TITLE
Sign in is broken (v0.3.x)

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -84,6 +84,10 @@ var doSignin = function(lookup, req, res, onSuccess, onFail) {
 	}
 	var User = keystone.list(keystone.get('user model'));
 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
+		// ensure that it is an email, we don't want people being able to sign in by just using "\." and a haphazardly correct password.
+		if (!utils.isEmail(lookup.email)) {
+			return onFail(new Error('Incorrect email or password'));
+		}
 		// create regex for email lookup with special characters escaped
 		var emailRegExp = new RegExp('^' + utils.escapeRegExp(lookup.email) + '$', 'i');
 		// match email address and password

--- a/test/lib/session-test.js
+++ b/test/lib/session-test.js
@@ -246,20 +246,34 @@ describe('Keystone.session', function() {
 
 			});
 
-			it('shoud not match email when invalid', function (done) {
+			it('should not match email when invalid', function (done) {
 				var lookup = { email: 'xxx', password: 'password'};
-				keystone.session.signin(lookup, null, null, this.onSuccess, function(){
-					// make sure .findOne() is called with a regular expression
-					sinon.assert.calledOnce(this.User.model.findOne);
-					this.User.model.findOne.getCall(0).args[0].email.must.be.instanceof(RegExp);
-					// make sure .exec() is called after
-					sinon.assert.calledOnce(this.User.model.exec);
+				keystone.session.signin(lookup, null, null, this.onSuccess, function(err){
+					// make sure .findOne() was not called
+					sinon.assert.notCalled(this.User.model.findOne);
+					// make sure .exec() was not called
+					sinon.assert.notCalled(this.User.model.exec);
 					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					err.must.be.an.instanceof(Error)
 					// make sure .signinWithUser() is NOT called on failed match
 					sinon.assert.notCalled(keystone.session.signinWithUser);
-					done();
+					done()
 				}.bind(this));
+			});
 
+			it('should not match email when just a regex', function (done) {
+				var lookup = { email: '\.', password: 'password'};
+				keystone.session.signin(lookup, null, null, this.onSuccess, function(err){
+					// make sure .findOne() was not called
+					sinon.assert.notCalled(this.User.model.findOne);
+					// make sure .exec() was not called
+					sinon.assert.notCalled(this.User.model.exec);
+					this.User.model.exec.calledAfter(this.User.model.findOne).must.be.true;
+					err.must.be.an.instanceof(Error)
+					// make sure .signinWithUser() is NOT called on failed match
+					sinon.assert.notCalled(keystone.session.signinWithUser);
+					done()
+				}.bind(this));
 			});
 
 		});


### PR DESCRIPTION
If you try to sign in with just "\." it will work, given that you have the correct password. It shouldn't.

This fixes it.