### PR TITLE
drag drop across pages

### DIFF
--- a/admin/client/components/ItemsTable.js
+++ b/admin/client/components/ItemsTable.js
@@ -1,19 +1,20 @@
 import React from 'react';
+import classnames from 'classnames';
+
 import Columns from '../columns';
 import CurrentListStore from '../stores/CurrentListStore';
 import ListControl from './ListControl';
+import TableRow from './ItemsTableRow'
+import DrapDrop from './ItemsTableDragDrop'
 
 const CONTROL_COLUMN_WIDTH = 26;  // icon + padding
 
-var ItemsTable = React.createClass({
+
+const ItemsTable = React.createClass({
 	propTypes: {
 		columns: React.PropTypes.array,
-		items: React.PropTypes.array,
-		list: React.PropTypes.object,
-	},
-	deleteItem (item, e) {
-		if (!e.altKey && !confirm('Are you sure you want to delete ' + item.name + '?')) return;
-		CurrentListStore.deleteItem(item);
+		items: React.PropTypes.object,
+		list: React.PropTypes.object
 	},
 	renderCols () {
 		var cols = this.props.columns.map((col) => <col width={col.width} key={col.path} />);
@@ -25,7 +26,7 @@ var ItemsTable = React.createClass({
 		if (this.props.list.sortable) {
 			cols.unshift(<col width={CONTROL_COLUMN_WIDTH} key="sortable" />);
 		}
-		return <colgroup>{cols}</colgroup>;
+		return <colgroup width={CONTROL_COLUMN_WIDTH}>{cols}</colgroup>;
 	},
 	renderHeaders () {
 		var cells = this.props.columns.map((col, i) => {
@@ -39,36 +40,40 @@ var ItemsTable = React.createClass({
 		});
 		return <thead><tr>{cells}</tr></thead>;
 	},
-	renderRow (item) {
-		var cells = this.props.columns.map((col, i) => {
-			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
-			var linkTo = !i ? `/keystone/${this.props.list.path}/${item.id}` : undefined;
-			return <ColumnType key={col.path} list={this.props.list} col={col} data={item} linkTo={linkTo} />;
-		});
-		// add sortable icon when applicable
-		if (this.props.list.sortable) {
-			cells.unshift(<ListControl key="_sort" onClick={this.reorderItems} type="sortable" />);
-		}
-		// add delete icon when applicable
-		if (!this.props.list.nodelete) {
-			cells.unshift(<ListControl key="_delete" onClick={(e) => this.deleteItem(item, e)} type="delete" />);
-		}
-		return <tr key={'i' + item.id}>{cells}</tr>;
-	},
 	render () {
-		var sortable = this.props.list.sortable;
-		var tableClass = sortable ? 'sortable ' : '';
-		tableClass += 'Table ItemList';
-		return (
-			<table cellPadding="0" cellSpacing="0" className={tableClass}>
-				{this.renderCols()}
-				{this.renderHeaders()}
-				<tbody>
-					{this.props.items.map(this.renderRow)}
+		
+		if (!this.props.items.results.length) return null;
+		
+		let tableBody;
+		if (this.props.list.sortable) {
+			tableBody = <DrapDrop { ...this.props } />;
+		} else {
+			tableBody = (
+				<tbody >
+					{this.props.items.results.map((item, i) => { 
+						return (
+							<TableRow key={item.id}
+								index={i}
+								sortOrder={item.sortOrder || 0}
+								id={item.id}
+								item={item}
+								{ ...this.props }
+							/>
+						);
+					})}
 				</tbody>
-			</table>
+			);
+		}
+		return (
+			<div className="ItemList-wrapper">
+				<table cellPadding="0" cellSpacing="0" className="Table ItemList">
+					{this.renderCols()}
+					{this.renderHeaders()}
+					{tableBody}
+				</table>
+			</div>
 		);
 	}
 });
 
-module.exports = ItemsTable;
+module.exports = exports = ItemsTable;

--- a/admin/client/components/ItemsTable.js
+++ b/admin/client/components/ItemsTable.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
 import Columns from '../columns';
 import CurrentListStore from '../stores/CurrentListStore';
 import ListControl from './ListControl';
-import TableRow from './ItemsTableRow'
-import DrapDrop from './ItemsTableDragDrop'
+import TableRow from './ItemsTableRow';
+import DrapDrop from './ItemsTableDragDrop';
 
 const CONTROL_COLUMN_WIDTH = 26;  // icon + padding
 

--- a/admin/client/components/ItemsTableDragDrop.js
+++ b/admin/client/components/ItemsTableDragDrop.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { DragDropContext } from 'react-dnd';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { Sortable } from './ItemsTableRow'
+import DropZone from './ItemsTableDragDropZone'
+
+import CurrentListStore from '../stores/CurrentListStore';
+import classnames from 'classnames';
+
+var ItemsTableDragDrop = React.createClass({
+	displayName: 'ItemsTableDragDrop',
+	propTypes: {
+		columns: React.PropTypes.array,
+		items: React.PropTypes.object,
+		list: React.PropTypes.object,
+		index: React.PropTypes.number,
+		id: React.PropTypes.any
+	},
+	render () {
+		return (
+			<tbody >
+				{this.props.items.results.map((item, i) => { 
+					return (
+						<Sortable key={item.id}
+							index={i}
+							sortOrder={item.sortOrder || 0}
+							id={item.id}
+							item={item}
+							{ ...this.props }
+						/>
+					);
+				})}
+				<DropZone { ...this.props } />
+			</tbody>
+		);
+	}
+});
+
+module.exports = DragDropContext(HTML5Backend)(ItemsTableDragDrop);

--- a/admin/client/components/ItemsTableDragDrop.js
+++ b/admin/client/components/ItemsTableDragDrop.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { DragDropContext } from 'react-dnd';
 import HTML5Backend from 'react-dnd-html5-backend';
-import { Sortable } from './ItemsTableRow'
-import DropZone from './ItemsTableDragDropZone'
+import { Sortable } from './ItemsTableRow';
+import DropZone from './ItemsTableDragDropZone';
 
 import CurrentListStore from '../stores/CurrentListStore';
 import classnames from 'classnames';

--- a/admin/client/components/ItemsTableDragDropZone.js
+++ b/admin/client/components/ItemsTableDragDropZone.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import CurrentListStore from '../stores/CurrentListStore';
+import DropZoneTarget from './ItemsTableDragDropZoneTarget'
+import classnames from 'classnames';
+
+var ItemsTableDragDropZone = React.createClass({
+	displayName: 'ItemsTableDragDropZone',
+	propTypes: {
+		columns: React.PropTypes.array,
+		items: React.PropTypes.object,
+		list: React.PropTypes.object,
+		connectDropTarget: React.PropTypes.func,
+	},
+	renderPageDrops () {
+		let { items, list } = this.props;
+		let currentPage = CurrentListStore.getCurrentPage();
+		let pageSize = CurrentListStore.getPageSize();
+				
+		let totalPages = Math.ceil(items.count / pageSize);
+		
+		let pages = [];
+		for (let i = 0; i < totalPages; i++) {
+			let page = i + 1;
+			let pageItems = '' + (page * pageSize - (pageSize - 1)) + ' - ' + (page * pageSize);
+			let current = (page === currentPage);
+			let className = classnames('ItemList__dropzone--page', {
+				'is-active': current,
+			});
+			/* eslint-disable no-loop-func */
+			pages.push(<DropZoneTarget key={'page_' + page} page={page} className={className} pageItems={pageItems}  />);
+			/* eslint-enable */
+		}
+			
+		let cols = this.props.columns.length;
+		if (this.props.list.sortable) cols++;
+		if (!this.props.list.nodelete) cols++;
+		return (
+			<tr>
+				<td colSpan={cols}  >
+					<div className="ItemList__dropzone" >
+						{pages}
+						<div className="clearfix" />
+					</div>
+				</td>
+			</tr>
+		);
+	},
+	render () {
+		return this.renderPageDrops();
+	}
+});
+
+
+
+module.exports = ItemsTableDragDropZone;

--- a/admin/client/components/ItemsTableDragDropZone.js
+++ b/admin/client/components/ItemsTableDragDropZone.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import CurrentListStore from '../stores/CurrentListStore';
-import DropZoneTarget from './ItemsTableDragDropZoneTarget'
+import DropZoneTarget from './ItemsTableDragDropZoneTarget';
 import classnames from 'classnames';
 
 var ItemsTableDragDropZone = React.createClass({

--- a/admin/client/components/ItemsTableDragDropZoneTarget.js
+++ b/admin/client/components/ItemsTableDragDropZoneTarget.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { DropTarget } from 'react-dnd';
+import CurrentListStore from '../stores/CurrentListStore';
+
+let timeoutID = false;
+
+// drop target
+var ItemsTableDragDropZoneTarget = React.createClass({
+	displayName: 'ItemsTableDragDropZoneTarget',
+	propTypes: {
+		className: React.PropTypes.string,
+		pageItems: React.PropTypes.string,
+		connectDropTarget: React.PropTypes.func,
+		isOver: React.PropTypes.bool,
+	},
+	componentDidUpdate () {
+		if (timeoutID && !this.props.isOver) {
+			clearTimeout(timeoutID);
+			timeoutID = false;
+		}
+	},
+	render () {
+		let { className, pageItems, page, isOver } = this.props;
+		if (isOver) {
+			className += ( page === CurrentListStore.getCurrentPage() ) ? ' is-available ' : ' is-waiting ';
+		}
+		return this.props.connectDropTarget(<div className={className} onClick={(e) => { CurrentListStore.setCurrentPage(page); }} >{pageItems}</div>)
+	}
+});
+
+/**
+ * Implements drag target.
+ */
+const dropTarget = {
+	
+	drop (props, monitor, component) {
+		// we send manual data to endDrag to send this item to the correct page
+		const { page } = CurrentListStore.getDragBase();
+		const targetPage = props.page;
+		const pageSize = CurrentListStore.getPageSize();
+		
+		const item = monitor.getItem();
+		item.goToPage = props.page;
+		item.prevSortOrder = item.sortOrder;
+		// if the new page is greater, we will place the item at the beginning of the page
+		// if the new page is less, we will place the item at the end of the page
+		item.newSortOrder = (targetPage < page) ? (targetPage * pageSize) : (targetPage * pageSize - (pageSize - 1));
+		
+		return item;
+	},
+	hover (props, monitor, component) {
+		if (timeoutID) {
+			return;
+		}
+		let { page, getItem } = props;
+		const currentPage = CurrentListStore.getCurrentPage();
+		const original = CurrentListStore.getDragBase();
+		
+		// self
+		if (page === currentPage) {
+			return;
+		}
+		if(monitor.isOver()) {
+			timeoutID = setTimeout(() => { 
+				const newIndex = (original.page === page) ? original.index : (currentPage < page) ? 0 : CurrentListStore.getPageSize();
+				
+				CurrentListStore.dragDropChangePage(page);
+				monitor.getItem().index = newIndex;
+				
+				clearTimeout(timeoutID);
+				timeoutID = false;			
+			}, 750);
+		}
+		return;
+	},
+	canDrop (props, monitor) {
+		// if we drop on a page target, move the item to the correct first or last position in the new page
+		// if we want to stop this behaviour set return false
+		const original = CurrentListStore.getDragBase();
+		// self
+		if (original.page === props.page) {
+			return false;
+		}
+		return true;
+	}
+};
+/**
+ * Specifies the props to inject into your component.
+ */
+function dropProps (connect, monitor) {
+	 return {
+		 connectDropTarget: connect.dropTarget(),
+		 isOver: monitor.isOver(),
+	};
+};
+
+module.exports = DropTarget('item', dropTarget, dropProps)(ItemsTableDragDropZoneTarget);

--- a/admin/client/components/ItemsTableDragDropZoneTarget.js
+++ b/admin/client/components/ItemsTableDragDropZoneTarget.js
@@ -24,7 +24,7 @@ var ItemsTableDragDropZoneTarget = React.createClass({
 		if (isOver) {
 			className += ( page === CurrentListStore.getCurrentPage() ) ? ' is-available ' : ' is-waiting ';
 		}
-		return this.props.connectDropTarget(<div className={className} onClick={(e) => { CurrentListStore.setCurrentPage(page); }} >{pageItems}</div>)
+		return this.props.connectDropTarget(<div className={className} onClick={(e) => { CurrentListStore.setCurrentPage(page); }} >{pageItems}</div>);
 	}
 });
 

--- a/admin/client/components/ItemsTableRow.js
+++ b/admin/client/components/ItemsTableRow.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import Columns from '../columns';
+import CurrentListStore from '../stores/CurrentListStore';
+import ListControl from './ListControl';
+
+import { DropTarget, DragSource } from 'react-dnd';
+
+
+const ItemsRow = React.createClass({
+	propTypes: {
+		columns: React.PropTypes.array,
+		items: React.PropTypes.object,
+		list: React.PropTypes.object,
+		index: React.PropTypes.number,
+		id: React.PropTypes.any,
+		// Injected by React DnD:
+		isDragging: React.PropTypes.bool,
+		connectDragSource: React.PropTypes.func,
+		connectDropTarget: React.PropTypes.func,
+		connectDragPreview: React.PropTypes.func
+	},
+	deleteItem (item, e) {
+		if (!e.altKey && !confirm('Are you sure you want to delete ' + item.name + '?')) return;
+		CurrentListStore.deleteItem(item);
+	},
+	renderRow (item) {
+		let itemId = item.id;
+		let rowClassname = classnames({
+			'ItemList__row--dragging': this.props.isDragging,
+			'ItemList__row--selected': this.props.checkedItems[itemId],
+			'ItemList__row--manage': this.props.manageMode,
+			'ItemList__row--success': this.props.rowAlert.success === itemId,
+			'ItemList__row--failure': this.props.rowAlert.fail === itemId,
+		});
+		// item fields
+		var cells = this.props.columns.map((col, i) => {
+			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
+			var linkTo = !i ? `/keystone/${this.props.list.path}/${itemId}` : undefined;
+			return <ColumnType key={col.path} list={this.props.list} col={col} data={item} linkTo={linkTo} />;
+		});
+		
+		// add sortable icon when applicable
+		if (this.props.list.sortable) {
+			cells.unshift(<ListControl key="_sort" type="sortable" dragSource={this.props.connectDragSource} />);
+		}
+		
+		// add delete/check icon when applicable
+		if (!this.props.list.nodelete) {
+			cells.unshift(this.props.manageMode ? (
+				<ListControl key="_check" type="check" active={this.props.checkedItems[itemId]} />
+			) : (
+				<ListControl key="_delete" onClick={(e) => this.deleteItem(item, e)} type="delete" />
+			));
+		}
+		
+		var addRow = (<tr key={'i' + item.id} onClick={this.props.manageMode ? (e) => this.props.checkTableItem(item, e) : null} className={rowClassname}>{cells}</tr>);
+		
+		if(this.props.list.sortable) {	
+			return (
+				// we could add a preview container/image
+				// this.props.connectDragPreview(this.props.connectDropTarget(addRow))
+				this.props.connectDropTarget(addRow)
+			);
+		} else {
+			return (addRow);
+		}
+	},
+	render () {
+		return this.renderRow(this.props.item);
+	}
+});
+
+module.exports = exports = ItemsRow;
+
+// Expose Sortable
+
+/**
+ * Implements drag source.
+ */
+const dragItem = {
+	beginDrag (props) {
+		let send = { ...props }
+		CurrentListStore.setDragBase(props.item, props.index);
+		return { ...send };
+	},
+	endDrag (props, monitor, component) {
+		
+		if (!monitor.didDrop()) {
+			return CurrentListStore.resetItems(CurrentListStore.findClonedItemById(props.id).index);
+		}
+		
+		const droppedOn = monitor.getDropResult();
+		// some drops provide the data for us in newSortOrder and prevSortOrder
+		const prevSortOrder = droppedOn.prevSortOrder ? droppedOn.prevSortOrder : props.sortOrder;
+		// use a given newSortOrder prop or retrieve from the cloned items list
+		const newSortOrder = droppedOn.newSortOrder ? droppedOn.newSortOrder : CurrentListStore.findClonedItemByIndex(droppedOn.index).sortOrder;
+
+		// self
+		if (prevSortOrder === newSortOrder) {
+			return CurrentListStore.resetItems(CurrentListStore.findClonedItemById(props.id).index);
+		}
+		
+		// dropped on a target
+		// droppedOn.goToPage is a manual page override for dropping items on a new page target
+		CurrentListStore.reorderItems(props.item, prevSortOrder, newSortOrder, droppedOn.goToPage);
+	}
+};
+/**
+ * Implements drag target.
+ */
+const dropItem = {
+	
+	drop (props, monitor, component) {
+		return { ...props };
+	},
+	hover (props, monitor, component) {
+		
+		// reset row alerts
+		if(props.rowAlert.success || props.rowAlert.fail) {
+			CurrentListStore.rowAlert('reset');
+		}
+		
+		const dragged = monitor.getItem().index;
+		const over = props.index;
+
+		// self
+		if (dragged === over) {
+		  return;
+		}
+
+		CurrentListStore.moveItem(dragged, over, props);
+		monitor.getItem().index = over;
+	}
+};
+
+/**
+ * Specifies the props to inject into your component.
+ */
+function dragProps (connect, monitor) {
+  return {
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging(),
+    connectDragPreview: connect.dragPreview(),
+  };
+}
+
+function dropProps (connect) {
+	 return {
+		 connectDropTarget: connect.dropTarget()
+	};
+};
+
+exports.Sortable = DragSource('item', dragItem, dragProps)(DropTarget('item', dropItem, dropProps)(ItemsRow));
+

--- a/admin/client/components/ItemsTableRow.js
+++ b/admin/client/components/ItemsTableRow.js
@@ -81,7 +81,7 @@ module.exports = exports = ItemsRow;
  */
 const dragItem = {
 	beginDrag (props) {
-		let send = { ...props }
+		let send = { ...props };
 		CurrentListStore.setDragBase(props.item, props.index);
 		return { ...send };
 	},

--- a/admin/client/components/ListControl.js
+++ b/admin/client/components/ListControl.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 var ListControl = React.createClass({
 
 	propTypes: {
+		dragSource: React.PropTypes.func,
 		onClick: React.PropTypes.func,
 		type: React.PropTypes.oneOf(['check', 'delete', 'sortable'])
 	},
@@ -24,12 +25,17 @@ var ListControl = React.createClass({
 		if (this.props.type === 'sortable') {
 			icon += 'three-bars';
 		}
-
-		return (
+		
+		var renderButton = (
 			<button type="button" onClick={this.props.onClick} className={className} tabIndex={tabindex}>
 				<span className={icon} />
 			</button>
 		);
+		if(this.props.dragSource) {
+			return this.props.dragSource(renderButton);
+		} else {
+			return renderButton;
+		}
 	},
 
 	render () {

--- a/admin/client/lib/List.js
+++ b/admin/client/lib/List.js
@@ -96,7 +96,7 @@ List.prototype.expandSort = function (input) {
 			invert = true;
 			path = path.substr(1);
 		}
-		const field = this.fields[path];
+		let field = this.fields[path];
 		if (!field) {
 			// TODO: Support arbitary document paths
 			console.warn('Invalid Sort specified:', path);
@@ -177,6 +177,25 @@ List.prototype.deleteItems = function (itemIds, callback) {
 
 List.prototype.deleteItem = function (itemId, callback) {
 	return this.deleteItems([itemId], callback);
+};
+
+List.prototype.reorderItems = function (item, oldSortOrder, newSortOrder, pageOptions, callback) {
+	const url = '/keystone/api/' + this.path + '/' + item.id + '/sortOrder/' + oldSortOrder + '/' + newSortOrder + '/' + buildQueryString(pageOptions);
+	xhr({
+		url: url,
+		method: 'POST',
+		headers: Keystone.csrf.header
+	}, (err, resp, body) => {
+		if (err) return callback(err);
+		// TODO: check resp.statusCode
+		try {
+			body = JSON.parse(body);
+		} catch(e) {
+			console.log('Error parsing results json:', e, body);
+			return callback(e);
+		}
+		callback(null, body);
+	});
 };
 
 module.exports = List;

--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -24,7 +24,7 @@ function defaultDrag () {
 		item: false,
 		clonedItems: false,
 		index: false
-	}
+	};
 }
 
 var page = defaultPage();
@@ -56,7 +56,7 @@ var CurrentListStore = new Store({
 		drag.page = page.index;
 		drag.clonedItems = _itemsResultsClone.slice(0);
 		if(item) {
-			drag.item = item
+			drag.item = item;
 			if(index) {
 				drag.index = index;
 			}
@@ -224,7 +224,7 @@ var CurrentListStore = new Store({
 		page = {
 			size: page.size,
 			index: goToPage || page.index
-		}
+		};
 		// send the item, previous sortOrder and the new sortOrder
 		// we should get the proper list and new page results in return
 		_list.reorderItems(

--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -7,26 +7,61 @@ var _list = new List(Keystone.list);
 var _ready = false;
 var _loading = false;
 var _items = {};
+var _itemsResultsClone = [];
 
 var active = {
 	columns: _list.expandColumns(Keystone.list.defaultColumns),
 	filters: [],
 	search: '',
-	sort: _list.expandSort(Keystone.list.defaultSort)
+	sort: _list.expandSort(Keystone.list.defaultSort),
 };
+
+var drag = defaultDrag();
+
+function defaultDrag () {
+	return drag = {
+		page: 1,
+		item: false,
+		clonedItems: false,
+		index: false
+	}
+}
 
 var page = defaultPage();
 
 function defaultPage () {
 	return {
-		size: 100,
+		size: _list.perPage,
 		index: 1
+	};
+}
+
+var _rowAlert = defaultRowAlert();
+
+function defaultRowAlert () {
+	return _rowAlert = {
+		success: false,
+		fail: false
 	};
 }
 
 var CurrentListStore = new Store({
 	getList () {
 		return _list;
+	},
+	getDragBase () {
+		return drag;
+	},
+	setDragBase (item, index) {
+		drag.page = page.index;
+		drag.clonedItems = _itemsResultsClone.slice(0);
+		if(item) {
+			drag.item = item
+			if(index) {
+				drag.index = index;
+			}
+		}
+		return drag;
 	},
 	getAvailableColumns () {
 		return _list.columns;
@@ -104,8 +139,9 @@ var CurrentListStore = new Store({
 	isReady () {
 		return _ready;
 	},
-	loadItems () {
+	loadItems (options = {}) {
 		_loading = true;
+		defaultRowAlert();
 		_list.loadItems({
 			search: active.search,
 			filters: active.filters,
@@ -118,9 +154,29 @@ var CurrentListStore = new Store({
 			if (items) {
 				_ready = true;
 				_items = items;
+				if (page.index !== drag.page && drag.item) {
+					// add the dragging item
+					if (page.index > drag.page) {
+						_items.results.unshift(drag.item);
+					} else {
+						_items.results.push(drag.item);
+					}
+				}
+				_itemsResultsClone =  items.results.slice(0);
+				
+				if (options.success && options.id) {
+					// flashes a success background on the row
+					_rowAlert.success = options.id;
+				}
+				if (options.fail && options.id) {
+					// flashes a failure background on the row
+					_rowAlert.fail = options.id;
+				}
+				
 			}
 			this.notifyChange();
 		});
+		
 	},
 	getItems () {
 		return _items;
@@ -134,8 +190,103 @@ var CurrentListStore = new Store({
 	deleteItems (itemIds) {
 		_list.deleteItems(itemIds, (err, data) => {
 			// TODO: graceful error handling
+			if(err) {
+				return this.resetItems(this.findItemById[item.id]);
+			}
 			this.loadItems();
 		});
+	},
+	rowAlert (reset = false) {
+		//  reset the alerts or return the object
+		if(reset) {
+			defaultRowAlert();
+			return this.notifyChange();
+		}
+		return _rowAlert;
+	},
+	dragDropChangePage (page) {
+		this.setCurrentPage(page);
+	},
+	moveItem (prevIndex, newIndex, options) {
+		// moves an item up/down in the list
+		if (options.manageMode) {
+			// TODO: option to use manageMode for sortOrder
+			_items.results.splice(newIndex, 0, _items.results.splice(prevIndex, 1)[0]);
+		} else {
+			_items.results.splice(newIndex, 0, _items.results.splice(prevIndex, 1)[0]);
+		}
+		this.notifyChange();
+	},
+	reorderItems (item, prevSortOrder, newSortOrder, goToPage) {
+		// reset drag
+		defaultDrag();
+		// set the new page data
+		page = {
+			size: page.size,
+			index: goToPage || page.index
+		}
+		// send the item, previous sortOrder and the new sortOrder
+		// we should get the proper list and new page results in return
+		_list.reorderItems(
+			item,
+			prevSortOrder,
+			newSortOrder,
+			{
+				search: active.search,
+				filters: active.filters,
+				sort: active.sort,
+				columns: active.columns,
+				page
+			},
+			(err, items) => {
+				// if err flash the row alert
+				if(err) {
+					return this.resetItems(this.findItemById[item.id]);
+				}
+				if('object' === typeof items && items.results) {
+					_items = items;
+					_itemsResultsClone =  items.results.slice(0);
+					_rowAlert.success = item.id;
+				}	
+				return this.notifyChange();
+			}
+		);
+	},
+	findClonedItemById (id) {
+		// find an item in the clone by id
+		const item = _itemsResultsClone.filter(c => c.id === id)[0];
+		return {
+			item,
+			index: _itemsResultsClone.indexOf(item)
+		};
+	},
+	findClonedItemByIndex (index) {
+		// find an item in the clone by index
+		return _itemsResultsClone[index];
+	},
+	resetItems (itemIndex) {
+				
+		if (page.index !== drag.page) {
+			// we are not on the original page so we need to move back to it
+			page.index = drag.page;
+			this.loadItems({
+				fail: true,
+				id: this.findClonedItemByIndex(itemIndex).id
+			});
+			// reset drag
+			return defaultDrag();
+		}
+		
+		// reset the list if dragout or error
+		_rowAlert = {
+			success: false,
+			fail: this.findClonedItemByIndex(itemIndex).id
+		};
+		// we use the cached clone since this is the same page
+		// the clone contains the proper index numbers which get overwritten on drag
+		_items.results = drag.clonedItems;
+		defaultDrag();
+		this.notifyChange();
 	},
 	downloadItems (format, columns) {
 		var url = _list.getDownloadURL({

--- a/admin/client/views/list.js
+++ b/admin/client/views/list.js
@@ -14,11 +14,13 @@ import ListDownloadForm from '../components/ListDownloadForm';
 import ListFilters from '../components/ListFilters';
 import ListFiltersAdd from '../components/ListFiltersAdd';
 import ListSort from '../components/ListSort';
+import ItemsTable from '../components/ItemsTable';
 import MobileNavigation from '../components/MobileNavigation';
 import PrimaryNavigation from '../components/PrimaryNavigation';
 import SecondaryNavigation from '../components/SecondaryNavigation';
 import UpdateForm from '../components/UpdateForm';
 import { BlankState, Button, Container, FormInput, InputGroup, Pagination, Spinner } from 'elemental';
+
 import { plural } from '../utils';
 
 const TABLE_CONTROL_COLUMN_WIDTH = 26;  // icon + padding
@@ -61,7 +63,8 @@ const ListView = React.createClass({
 			loading: CurrentListStore.isLoading(),
 			pageSize: CurrentListStore.getPageSize(),
 			ready: CurrentListStore.isReady(),
-			search: CurrentListStore.getActiveSearch()
+			search: CurrentListStore.getActiveSearch(),
+			rowAlert: CurrentListStore.rowAlert()
 		};
 		state.showBlankState = (state.ready && !state.loading && !state.items.results.length && !state.search && !state.filters.length);
 		return state;
@@ -271,15 +274,15 @@ const ListView = React.createClass({
 				</Container>
 			</div>
 		);
-	},
-
+	},	
+	
 	// ==============================
 	// TABLE
 	// ==============================
-
+	
 	checkTableItem (item, e) {
 		e.preventDefault();
-		let newCheckedItems = this.state.checkedItems;
+		let newCheckedItems = { ...this.state.checkedItems };
 		let itemId = item.id;
 		if (this.state.checkedItems[itemId]) {
 			delete newCheckedItems[itemId];
@@ -308,81 +311,16 @@ const ListView = React.createClass({
 		if (!e.altKey && !confirm('Are you sure you want to delete ' + item.name + '?')) return;
 		CurrentListStore.deleteItem(item.id);
 	},
+	
+	// ==============================
+	// COMMON
+	// ==============================
+	
 	toggleTableWidth () {
 		this.setState({
 			constrainTableWidth: !this.state.constrainTableWidth
 		});
 	},
-	renderTableCols () {
-		var cols = this.state.columns.map((col) => <col width={col.width} key={col.path} />);
-		// add delete col when applicable
-		if (!this.state.list.nodelete) {
-			cols.unshift(<col width={TABLE_CONTROL_COLUMN_WIDTH} key="delete" />);
-		}
-		// add sort col when applicable
-		if (this.state.list.sortable) {
-			cols.unshift(<col width={TABLE_CONTROL_COLUMN_WIDTH} key="sortable" />);
-		}
-		return <colgroup>{cols}</colgroup>;
-	},
-	renderTableHeaders () {
-		var cells = this.state.columns.map((col, i) => {
-			// span first col for controls when present
-			var span = 1;
-			if (!i) {
-				if (this.state.list.sortable) span++;
-				if (!this.state.list.nodelete) span++;
-			}
-			return <th key={col.path} colSpan={span}>{col.label}</th>;
-		});
-		return <thead><tr>{cells}</tr></thead>;
-	},
-	renderTableRow (item) {
-		let itemId = item.id;
-		let rowClassname = classnames({
-			'ItemList__row--selected': this.state.checkedItems[itemId],
-			'ItemList__row--manage': this.state.manageMode,
-		});
-		var cells = this.state.columns.map((col, i) => {
-			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
-			var linkTo = !i ? `/keystone/${this.state.list.path}/${itemId}` : undefined;
-			return <ColumnType key={col.path} list={this.state.list} col={col} data={item} linkTo={linkTo} />;
-		});
-		// add sortable icon when applicable
-		if (this.state.list.sortable) {
-			cells.unshift(<ListControl key="_sort" onClick={this.reorderItems} type="sortable" />);
-		}
-		// add delete/check icon when applicable
-		if (!this.state.list.nodelete) {
-			cells.unshift(this.state.manageMode ? (
-				<ListControl key="_check" type="check" active={this.state.checkedItems[itemId]} />
-			) : (
-				<ListControl key="_delete" onClick={(e) => this.deleteTableItem(item, e)} type="delete" />
-			));
-		}
-		return <tr key={'i' + item.id} onClick={this.state.manageMode ? (e) => this.checkTableItem(item, e) : null} className={rowClassname}>{cells}</tr>;
-	},
-	renderTable () {
-		if (!this.state.items.results.length) return null;
-
-		return (
-			<div className="ItemList-wrapper">
-				<table cellPadding="0" cellSpacing="0" className="Table ItemList">
-					{this.renderTableCols()}
-					{this.renderTableHeaders()}
-					<tbody>
-						{this.state.items.results.map(this.renderTableRow)}
-					</tbody>
-				</table>
-			</div>
-		);
-	},
-
-
-	// ==============================
-	// COMMON
-	// ==============================
-
 	toggleCreateModal (visible) {
 		this.setState({
 			showCreateForm: visible
@@ -425,13 +363,20 @@ const ListView = React.createClass({
 			WebkitTransition: 'max-width 160ms ease-out',
 		};
 		if (!this.state.constrainTableWidth) containerStyle['maxWidth'] = '100%';
-
 		return (
 			<div>
 				{this.renderHeader()}
 				<Container style={containerStyle}>
 					<FlashMessages messages={this.props.messages} />
-					{this.renderTable()}
+					<ItemsTable
+						list={this.state.list} 
+						columns={this.state.columns} 
+						items={this.state.items}
+						manageMode={this.state.manageMode} 
+						checkedItems={this.state.checkedItems}
+						rowAlert={this.state.rowAlert}
+						checkTableItem={this.checkTableItem}
+					/>
 					{this.renderNoSearchResults()}
 				</Container>
 			</div>

--- a/admin/public/styles/keystone/list-controls.less
+++ b/admin/public/styles/keystone/list-controls.less
@@ -16,6 +16,7 @@ td.ItemList__col--control {
 
 
 
+
 // Buttons
 // ------------------------------
 
@@ -66,22 +67,22 @@ td.ItemList__col--control {
 
 
 // delete control
-
 .ItemList__control--delete {
 	&:hover,
 	&:focus {
 		color: @app-danger;
 	}
 }
+		
 
 
 // sortable control
-
 .ItemList__control--sortable {
 	cursor: hand;
 	cursor: -webkit-grab;
 	cursor: -moz-grab;
 
+	
 	&:hover {
 		color: @text-color;
 	}

--- a/admin/public/styles/keystone/list-dropzone.less
+++ b/admin/public/styles/keystone/list-dropzone.less
@@ -1,0 +1,49 @@
+//
+// Sortable List DropZone Controls
+// ==============================
+
+
+// Main
+// ------------------------------
+
+.ItemList__dropzone {
+	border: 0px dashed @gray-light;
+	color: @gray;
+	padding: 5px;
+	position: relative;
+
+	&:hover,
+	&:focus,
+	&:active {
+		outline: none;
+	}
+	.clearfix {
+		clear: both;
+	}
+}
+
+// page control
+.ItemList__dropzone--page {
+	text-align: center;
+	float:left;
+	width: 60px;
+	padding:10px;
+	margin: 5px;
+	border: 1px dashed @gray-light;
+	font-weight: normal;
+	font-size: 12px;
+	cursor: pointer;
+	&:hover {
+		background-color: white;
+	}
+	&.is-active {
+		background-color: @gray-lighter;
+	}
+	&.is-waiting {
+		background-color: @app-primary;
+		color: white;
+	}
+	&.is-available {
+		background-color: @app-success;
+	}
+}

--- a/admin/public/styles/keystone/list.less
+++ b/admin/public/styles/keystone/list.less
@@ -125,6 +125,39 @@
 }
 
 
+// Dropped States
+// ------------------------------
+.ItemList__row--dragging {
+	border-left: 2px solid #1385e5;
+	background-color: transparent;
+	cursor: move;
+	opacity: 1;
+}
+.ItemList__row--success {
+    -webkit-animation: fade-out-background-success 2s linear 1 normal;
+	-moz-animation: fade-out-background-success 2s linear  1 normal;
+	-ms-animation: fade-out-background-success 2s linear  1 normals;
+	-o-animation: fade-out-background-success 2s linear  1 normal;
+	animation: fade-out-background-success 2s linear 1 normal;
+}
+.ItemList__row--failure {
+	-webkit-animation: fade-out-background-fail 2s linear 1 normal;
+	-moz-animation: fade-out-background-fail 2s linear  1 normal;
+	-ms-animation: fade-out-background-fail 2s linear  1 normals;
+	-o-animation: fade-out-background-fail 2s linear  1 normal;
+	animation: fade-out-background-fail 2s linear 1 normal;
+}
+// Fade out row
+// ------------
+@-webkit-keyframes fade-out-background-success {
+	0% {background-color: lighten(@app-success, 40%);}
+	100% {background-color: initial;}
+}
+@-webkit-keyframes fade-out-background-fail {
+	0% { background-color: darken(#FDD4AE, 5%)}
+	100% {background-color: initial;}
+}
+
 
 
 // Links
@@ -237,10 +270,9 @@
 }
 
 
-
-
 // Complementary list files
 // ------------------------------
 
 @import "./list-controls";
 @import "./list-filters";
+@import "./list-dropzone";

--- a/admin/server/api/item/sortOrder.js
+++ b/admin/server/api/item/sortOrder.js
@@ -1,0 +1,13 @@
+var keystone = require('../../../../');
+var Get = require('../list/get');
+
+module.exports = function(req, res) {
+	if (!keystone.security.csrf.validate(req)) {
+		console.log('Refusing to reorder ' + req.list.key + ' ' + req.params.id + '; CSRF failure');
+		return res.apiError(403, 'invalid csrf');
+	}
+	req.list.model.reorderItems(req.params.id, req.params.sortOrder, req.params.newOrder, function (err, doc) {
+		if (err) return res.apiError('database error', err);
+		return Get(req, res);
+	});		
+};

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -66,15 +66,17 @@ module.exports = function createDynamicRouter(keystone) {
 
 	// Init req with list
 	var initList = require('../middleware/initList')(keystone);
-
+	// lists
 	router.all('/api/counts', require('../api/counts'));
 	router.get('/api/:list', initList(), require('../api/list/get'));
 	router.get('/api/:list/:format(export.csv|export.json)', initList(), require('../api/list/download'));
 	router.post('/api/:list/delete', initList(), require('../api/list/delete'));
+	// items
 	router.get('/api/:list/:id', initList(), require('../api/item/get'));
 	router.post('/api/:list/:id', initList(), require('../api/item/update'));
 	router.post('/api/:list/:id/delete', initList(), require('../api/list/delete'));
-
+	router.post('/api/:list/:id/sortOrder/:sortOrder/:newOrder', initList(), require('../api/item/sortOrder'));
+	
 	// #6: List Routes
 	router.all('/:list/:page([0-9]{1,5})?', initList(true), require('../routes/list'));
 	router.all('/:list/:item', initList(true), require('../routes/item'));

--- a/lib/list.js
+++ b/lib/list.js
@@ -25,6 +25,7 @@ function List(key, options) {
 		hidden: false,
 		track: false,
 		inherits: false,
+		perPage: 100,
 		searchFields: '__name__',
 		defaultSort: '__default__',
 		defaultColumns: '__name__'

--- a/lib/list/getData.js
+++ b/lib/list/getData.js
@@ -13,6 +13,9 @@ function getData (item, fields, expandRelationshipFields) {
 	if (this.autokey) {
 		data[this.autokey.path] = item.get(this.autokey.path);
 	}
+	if (this.options.sortable) {
+		data.sortOrder = item.sortOrder;
+	}
 	if (fields === undefined) {
 		fields = Object.keys(this.fields);
 	}

--- a/lib/list/getOptions.js
+++ b/lib/list/getOptions.js
@@ -24,6 +24,7 @@ function getOptions () {
 		noedit: this.options.noedit,
 		path: this.path,
 		plural: this.plural,
+		perPage: this.options.perPage,
 		searchFields: this.options.searchFields,
 		singular: this.singular,
 		sortable: this.options.sortable,

--- a/lib/schemaPlugins/sortable.js
+++ b/lib/schemaPlugins/sortable.js
@@ -37,7 +37,7 @@ module.exports = function sortable() {
 				if(err) {
 					console.log('err', err);
 				}
-				list.model.findOneAndUpdate({_id: id}, {sortOrder: newOrder}).exec(cb);
+				list.model.findOneAndUpdate({ _id: id }, { sortOrder: newOrder }).exec(cb);
 			});		
 	};
 };

--- a/lib/schemaPlugins/sortable.js
+++ b/lib/schemaPlugins/sortable.js
@@ -1,11 +1,11 @@
 module.exports = function sortable() {
 
 	var list = this;
-
-	this.schema.add({
-		sortOrder: { type: Number, index: true }
+	
+	this.add({
+		sortOrder: { type: Number, index: true, hidden: true }
 	});
-
+	
 	this.schema.pre('save', function(next) {
 
 		if (typeof this.sortOrder === 'number') {
@@ -19,5 +19,25 @@ module.exports = function sortable() {
 		});
 
 	});
-
+	
+	this.schema.statics.reorderItems = function reorderItems(id, prevOrder, newOrder, cb) {
+		
+		var newOrder = parseFloat(newOrder);
+		var prevOrder = parseFloat(prevOrder);
+		
+		var whichWay = (newOrder > prevOrder) ? -1 : 1;
+		var gte = (newOrder > prevOrder) ? prevOrder + 1 : newOrder;
+		var lte = (newOrder > prevOrder) ? newOrder : prevOrder - 1;
+		return list.model
+			.where('sortOrder')
+			.gte(gte)
+			.lte(lte)
+			.setOptions({ multi: true })
+			.update({ $inc: { 'sortOrder': whichWay } }, function(err) {
+				if(err) {
+					console.log('err', err);
+				}
+				list.model.findOneAndUpdate({_id: id}, {sortOrder: newOrder}).exec(cb);
+			});		
+	};
 };

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "react-alt-text": "^1.1.0",
     "react-color": "^1.2.1",
     "react-day-picker": "^1.0.10",
+    "react-dnd": "^2.0.2",
+    "react-dnd-html5-backend": "^2.0.0",
     "react-dom": "^0.14.1",
     "react-select": "^1.0.0-beta5",
     "scmp": "^1.0.0",


### PR DESCRIPTION
Can replace previous PR.  
Adds the ability to drag items across pages.
Adds `perPage` list configuration option.
#### Drag single page
![dnd1](https://cloud.githubusercontent.com/assets/6615106/11168789/9f33d5d6-8b6d-11e5-94f5-31059c762223.gif)
#### Drag across pages
![dnd3](https://cloud.githubusercontent.com/assets/6615106/11168794/bdc6041a-8b6d-11e5-96ab-a6b67226312b.gif)
#### Drop onto a page
![dnd2](https://cloud.githubusercontent.com/assets/6615106/11168790/a5ed2ec2-8b6d-11e5-8efc-ce3206cc4759.gif)