### PR TITLE
Support for using a custom admin path

### DIFF
--- a/admin/client/components/CreateForm.js
+++ b/admin/client/components/CreateForm.js
@@ -98,7 +98,7 @@ var CreateForm = React.createClass({
 		if (!this.props.isOpen) return;
 		var form = [];
 		var list = this.props.list;
-		var formAction = this.props.adminPath + '/' + list.path;
+		var formAction = `${this.props.adminPath}/${list.path}`;
 		var nameField = this.props.list.nameField;
 		var focusRef;
 

--- a/admin/client/components/CreateForm.js
+++ b/admin/client/components/CreateForm.js
@@ -98,7 +98,7 @@ var CreateForm = React.createClass({
 		if (!this.props.isOpen) return;
 		var form = [];
 		var list = this.props.list;
-		var formAction = '/keystone/' + list.path;
+		var formAction = this.props.adminPath + '/' + list.path;
 		var nameField = this.props.list.nameField;
 		var focusRef;
 

--- a/admin/client/components/EditForm.js
+++ b/admin/client/components/EditForm.js
@@ -75,7 +75,7 @@ var EditForm = React.createClass({
 				// TODO: slow a flash message on form
 				return;
 			}
-			top.location.href = '/keystone/' + list.path;
+			top.location.href = this.props.adminPath + '/' + list.path;
 		});
 	},
 
@@ -170,7 +170,7 @@ var EditForm = React.createClass({
 			<Button key="save" type="primary" submit>Save</Button>
 		];
 		buttons.push(
-			<Button key="reset" onClick={this.confirmReset} href={'/keystone/' + this.props.list.path + '/' + this.props.data.id} type="link-cancel">
+			<Button key="reset" onClick={this.confirmReset} type="link-cancel">
 				<ResponsiveText hiddenXS="reset changes" visibleXS="reset" />
 			</Button>
 		);

--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -73,7 +73,7 @@ var Header = React.createClass({
 
 		if (!els.length) {
 			return (
-				<Button type="link" href={this.props.adminPath + '/' + list.path}>
+				<Button type="link" href={`${this.props.adminPath}/${list.path}`}>
 					<span className="octicon octicon-chevron-left" />
 					{list.plural}
 				</Button>
@@ -82,7 +82,7 @@ var Header = React.createClass({
 			// add the current list
 			els.push(
 				<li key="back">
-					<a type="link" href={this.props.adminPath + '/' + list.path}>{list.plural}</a>
+					<a type="link" href={`${this.props.adminPath}/${list.path}`}>{list.plural}</a>
 				</li>
 			);
 			return <ul className="item-breadcrumbs" key="drilldown">{els}</ul>;
@@ -93,7 +93,7 @@ var Header = React.createClass({
 	renderSearch () {
 		var list = this.props.list;
 		return (
-			<form action={this.props.adminPath + '/' + list.path} className="EditForm__header__search">
+			<form action={`${this.props.adminPath}/${list.path}`} className="EditForm__header__search">
 				<FormIconField iconPosition="left" iconColor="primary" iconKey="search" className="EditForm__header__search-field">
 					<FormInput
 						ref="searchField"

--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -73,7 +73,7 @@ var Header = React.createClass({
 
 		if (!els.length) {
 			return (
-				<Button type="link" href={'/keystone/' + list.path}>
+				<Button type="link" href={this.props.adminPath + '/' + list.path}>
 					<span className="octicon octicon-chevron-left" />
 					{list.plural}
 				</Button>
@@ -82,7 +82,7 @@ var Header = React.createClass({
 			// add the current list
 			els.push(
 				<li key="back">
-					<a type="link" href={'/keystone/' + list.path}>{list.plural}</a>
+					<a type="link" href={this.props.adminPath + '/' + list.path}>{list.plural}</a>
 				</li>
 			);
 			return <ul className="item-breadcrumbs" key="drilldown">{els}</ul>;
@@ -93,7 +93,7 @@ var Header = React.createClass({
 	renderSearch () {
 		var list = this.props.list;
 		return (
-			<form action={'/keystone/' + list.path} className="EditForm__header__search">
+			<form action={this.props.adminPath + '/' + list.path} className="EditForm__header__search">
 				<FormIconField iconPosition="left" iconColor="primary" iconKey="search" className="EditForm__header__search-field">
 					<FormInput
 						ref="searchField"

--- a/admin/client/components/Footer.js
+++ b/admin/client/components/Footer.js
@@ -19,7 +19,7 @@ var Footer = React.createClass({
 		return (
 			<span>
 				<span>Signed in as </span>
-				<a href={this.props.adminPath + '/' + User.path + '/' + user.id} tabIndex="-1" className="keystone-footer__link">
+				<a href={`${this.props.adminPath}/${User.path}/${user.id}`} tabIndex="-1" className="keystone-footer__link">
 					{User.getDocumentName(user)}
 				</a>
 				<span>.</span>

--- a/admin/client/components/Footer.js
+++ b/admin/client/components/Footer.js
@@ -5,6 +5,7 @@ var Footer = React.createClass({
 	displayName: 'Footer',
 	propTypes: {
 		appversion: React.PropTypes.string,
+		adminPath: React.PropTypes.string,
 		backUrl: React.PropTypes.string,
 		brand: React.PropTypes.string,
 		User: React.PropTypes.object,
@@ -18,7 +19,7 @@ var Footer = React.createClass({
 		return (
 			<span>
 				<span>Signed in as </span>
-				<a href={'/keystone/' + User.path + '/' + user.id} tabIndex="-1" className="keystone-footer__link">
+				<a href={this.props.adminPath + '/' + User.path + '/' + user.id} tabIndex="-1" className="keystone-footer__link">
 					{User.getDocumentName(user)}
 				</a>
 				<span>.</span>

--- a/admin/client/components/ListFilters.js
+++ b/admin/client/components/ListFilters.js
@@ -6,6 +6,7 @@ import { Pill } from 'elemental';
 
 const Filter = React.createClass({
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		filter: React.PropTypes.object.isRequired
 	},
 	getInitialState () {
@@ -48,7 +49,7 @@ const Filter = React.createClass({
 					<form onSubmit={this.updateFilter}>
 						<Popout.Header title="Edit Filter" />
 						<Popout.Body>
-							<FilterComponent field={filter.field} filter={this.state.filterValue} onChange={this.updateValue} />
+							<FilterComponent field={filter.field} filter={this.state.filterValue} onChange={this.updateValue} adminPath={this.props.adminPath} />
 						</Popout.Body>
 						<Popout.Footer
 							ref="footer"
@@ -89,7 +90,7 @@ const ListFilters = React.createClass({
 
 		let currentFilters = this.state.filters.map((filter, i) => {
 			return (
-				<Filter key={'f' + i} filter={filter} />
+				<Filter key={'f' + i} filter={filter} adminPath={this.props.adminPath} />
 			);
 		});
 

--- a/admin/client/components/ListFiltersAddForm.js
+++ b/admin/client/components/ListFiltersAddForm.js
@@ -6,6 +6,7 @@ import Popout from './Popout';
 var ListFiltersAddForm = React.createClass({
 
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		field: React.PropTypes.object.isRequired,
 		maxHeight: React.PropTypes.number,
 		onApply: React.PropTypes.func,
@@ -62,7 +63,7 @@ var ListFiltersAddForm = React.createClass({
 		return (
 			<form onSubmit={this.handleFormSubmit}>
 				<Popout.Body ref="body" scrollable style={{ height: this.state.bodyHeight }}>
-					{FilterComponent ? <FilterComponent field={this.props.field} filter={this.state.filterValue} onChange={this.updateValue} onHeightChange={this.updateHeight} /> : this.renderInvalidFilter()}
+					{FilterComponent ? <FilterComponent field={this.props.field} filter={this.state.filterValue} onChange={this.updateValue} onHeightChange={this.updateHeight} adminPath={this.props.adminPath} /> : this.renderInvalidFilter()}
 				</Popout.Body>
 				<Popout.Footer
 					ref="footer"

--- a/admin/client/components/MobileNavigation.js
+++ b/admin/client/components/MobileNavigation.js
@@ -31,7 +31,7 @@ var MobileSectionItem = React.createClass({
 		if (!this.props.lists || this.props.lists.length <= 1) return null;
 
 		let navLists = this.props.lists.map((item) => {
-			let href = item.external ? item.path : (this.props.adminPath + '/' + item.path);
+			let href = item.external ? item.path : `${this.props.adminPath}/${item.path}`;
 			let className = (this.props.currentListKey && this.props.currentListKey === item.path) ? 'MobileNavigation__list-item is-active' : 'MobileNavigation__list-item';
 
 			return (
@@ -115,7 +115,7 @@ var MobileNavigation = React.createClass({
 		if (!this.props.sections || !this.props.sections.length) return null;
 
 		return this.props.sections.map((section) => {
-			let href = section.lists[0].external ? section.lists[0].path : (this.props.adminPath + '/' + section.lists[0].path);
+			let href = section.lists[0].external ? section.lists[0].path : `${this.props.adminPath}/${section.lists[0].path}`;
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'MobileNavigation__section is-active' : 'MobileNavigation__section';
 
 			return (

--- a/admin/client/components/MobileNavigation.js
+++ b/admin/client/components/MobileNavigation.js
@@ -4,6 +4,7 @@ import Transition from 'react-addons-css-transition-group';
 var MobileListItem = React.createClass({
 	displayName: 'MobileListItem',
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		children: React.PropTypes.node.isRequired,
 		className: React.PropTypes.string,
 		href: React.PropTypes.string.isRequired,
@@ -30,7 +31,7 @@ var MobileSectionItem = React.createClass({
 		if (!this.props.lists || this.props.lists.length <= 1) return null;
 
 		let navLists = this.props.lists.map((item) => {
-			let href = item.external ? item.path : ('/keystone/' + item.path);
+			let href = item.external ? item.path : (this.props.adminPath + '/' + item.path);
 			let className = (this.props.currentListKey && this.props.currentListKey === item.path) ? 'MobileNavigation__list-item is-active' : 'MobileNavigation__list-item';
 
 			return (
@@ -114,7 +115,7 @@ var MobileNavigation = React.createClass({
 		if (!this.props.sections || !this.props.sections.length) return null;
 
 		return this.props.sections.map((section) => {
-			let href = section.lists[0].external ? section.lists[0].path : ('/keystone/' + section.lists[0].path);
+			let href = section.lists[0].external ? section.lists[0].path : (this.props.adminPath + '/' + section.lists[0].path);
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'MobileNavigation__section is-active' : 'MobileNavigation__section';
 
 			return (

--- a/admin/client/components/PrimaryNavigation.js
+++ b/admin/client/components/PrimaryNavigation.js
@@ -75,7 +75,7 @@ var PrimaryNavigation = React.createClass({
 		if (!this.props.sections || !this.props.sections.length) return null;
 
 		return this.props.sections.map((section) => {
-			let href = section.lists[0].external ? section.lists[0].path : (this.props.adminPath + '/' + section.lists[0].path);
+			let href = section.lists[0].external ? section.lists[0].path : `${this.props.adminPath}/${section.lists[0].path}`;
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'active' : null;
 
 			return (

--- a/admin/client/components/PrimaryNavigation.js
+++ b/admin/client/components/PrimaryNavigation.js
@@ -4,6 +4,7 @@ import { Container } from 'elemental';
 var PrimaryNavItem = React.createClass({
 	displayName: 'PrimaryNavItem',
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		children: React.PropTypes.node.isRequired,
 		className: React.PropTypes.string,
 		href: React.PropTypes.string.isRequired,
@@ -65,7 +66,7 @@ var PrimaryNavigation = React.createClass({
 	renderBrand () {
 		// TODO: support navbarLogo from keystone config
 		return (
-			<PrimaryNavItem className={this.props.currentSectionKey === 'dashboard' ? 'active' : null} href="/keystone" title={'Dashboard - ' + this.props.brand}>
+			<PrimaryNavItem className={this.props.currentSectionKey === 'dashboard' ? 'active' : null} href={this.props.adminPath} title={'Dashboard - ' + this.props.brand}>
 				<span className="octicon octicon-home" />
 			</PrimaryNavItem>
 		);
@@ -74,7 +75,7 @@ var PrimaryNavigation = React.createClass({
 		if (!this.props.sections || !this.props.sections.length) return null;
 
 		return this.props.sections.map((section) => {
-			let href = section.lists[0].external ? section.lists[0].path : ('/keystone/' + section.lists[0].path);
+			let href = section.lists[0].external ? section.lists[0].path : (this.props.adminPath + '/' + section.lists[0].path);
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'active' : null;
 
 			return (

--- a/admin/client/components/RelatedItemsList.js
+++ b/admin/client/components/RelatedItemsList.js
@@ -4,6 +4,7 @@ import { Alert, Spinner } from 'elemental';
 
 const RelatedItemsList = React.createClass({
 	propTypes: {
+		adminPath: React.PropTypes.string.isRequired,
 		list: React.PropTypes.object.isRequired,
 		refList: React.PropTypes.object.isRequired,
 		relatedItemId: React.PropTypes.string.isRequired,
@@ -73,7 +74,7 @@ const RelatedItemsList = React.createClass({
 	renderTableRow (item) {
 		const cells = this.state.columns.map((col, i) => {
 			const ColumnType = Columns[col.type] || Columns.__unrecognised__;
-			const linkTo = !i ? `/keystone/${this.props.refList.path}/${item.id}` : undefined;
+			const linkTo = !i ? `${this.props.adminPath}/${this.props.refList.path}/${item.id}` : undefined;
 			return <ColumnType key={col.path} list={this.props.refList} col={col} data={item} linkTo={linkTo} />;
 		});
 		return <tr key={'i' + item.id}>{cells}</tr>;
@@ -82,7 +83,7 @@ const RelatedItemsList = React.createClass({
 		if (this.state.err) {
 			return <div className="Relationship">{this.state.err}</div>;
 		}
-		const listHref = '/keystone/' + this.props.refList.path;
+		const listHref = `${this.props.adminPath}/${this.props.refList.path}`;
 		return (
 			<div className="Relationship">
 				<h3><a href={listHref}>{this.props.refList.label}</a></h3>

--- a/admin/client/components/SecondaryNavigation.js
+++ b/admin/client/components/SecondaryNavigation.js
@@ -44,7 +44,7 @@ var SecondaryNavigation = React.createClass({
 	},
 	renderNavigation (lists) {
 		let navigation = lists.map((list) => {
-			let href = list.external ? list.path : (this.props.adminPath + '/' + list.path);
+			let href = list.external ? list.path : `${this.props.adminPath}/${list.path}`;
 			let className = (this.props.currentListKey && this.props.currentListKey === list.path) ? 'active' : null;
 
 			return (

--- a/admin/client/components/SecondaryNavigation.js
+++ b/admin/client/components/SecondaryNavigation.js
@@ -4,6 +4,7 @@ import { Container } from 'elemental';
 var SecondaryNavItem = React.createClass({
 	displayName: 'SecondaryNavItem',
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		children: React.PropTypes.node.isRequired,
 		className: React.PropTypes.string,
 		href: React.PropTypes.string.isRequired,
@@ -43,7 +44,7 @@ var SecondaryNavigation = React.createClass({
 	},
 	renderNavigation (lists) {
 		let navigation = lists.map((list) => {
-			let href = list.external ? list.path : ('/keystone/' + list.path);
+			let href = list.external ? list.path : (this.props.adminPath + '/' + list.path);
 			let className = (this.props.currentListKey && this.props.currentListKey === list.path) ? 'active' : null;
 
 			return (

--- a/admin/client/components/UpdateForm.js
+++ b/admin/client/components/UpdateForm.js
@@ -8,6 +8,7 @@ import { BlankState, Button, Form, Modal } from 'elemental';
 var UpdateForm = React.createClass({
 	displayName: 'UpdateForm',
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		isOpen: React.PropTypes.bool,
 		itemIds: React.PropTypes.array,
 		list: React.PropTypes.object,
@@ -99,7 +100,7 @@ var UpdateForm = React.createClass({
 	renderForm () {
 		let { itemIds, list } = this.props;
 		let itemCount = plural(itemIds, ('* ' + list.singular), ('* ' + list.plural));
-		let formAction = '/keystone/' + list.path;
+		let formAction = this.props.adminPath + '/' + list.path;
 
 		return (
 			<Form type="horizontal" encType="multipart/form-data" method="post" action={formAction}>

--- a/admin/client/components/UpdateForm.js
+++ b/admin/client/components/UpdateForm.js
@@ -100,7 +100,7 @@ var UpdateForm = React.createClass({
 	renderForm () {
 		let { itemIds, list } = this.props;
 		let itemCount = plural(itemIds, ('* ' + list.singular), ('* ' + list.plural));
-		let formAction = this.props.adminPath + '/' + list.path;
+		let formAction = `${this.props.adminPath}/${list.path}`;
 
 		return (
 			<Form type="horizontal" encType="multipart/form-data" method="post" action={formAction}>

--- a/admin/client/lib/List.js
+++ b/admin/client/lib/List.js
@@ -120,7 +120,7 @@ List.prototype.loadItem = function (itemId, options, callback) {
 		callback = options;
 		options = null;
 	}
-	let url = '/keystone/api/' + this.path + '/' + itemId;
+	let url = Keystone.adminPath + '/api/' + this.path + '/' + itemId;
 	let query = qs.stringify(options);
 	if (query.length) url += '?' + query;
 	xhr({
@@ -134,7 +134,7 @@ List.prototype.loadItem = function (itemId, options, callback) {
 };
 
 List.prototype.loadItems = function (options, callback) {
-	const url = '/keystone/api/' + this.path + buildQueryString(options);
+	const url = Keystone.adminPath + '/api/' + this.path + buildQueryString(options);
 	xhr({
 		url: url,
 		responseType: 'json',
@@ -145,7 +145,7 @@ List.prototype.loadItems = function (options, callback) {
 };
 
 List.prototype.getDownloadURL = function (options) {
-	const url = '/keystone/api/' + this.path;
+	const url = Keystone.adminPath + '/api/' + this.path;
 	const parts = [];
 	if (options.format !== 'json') {
 		options.format = 'csv';
@@ -163,7 +163,7 @@ List.prototype.deleteItem = function (itemId, callback) {
 };
 
 List.prototype.deleteItems = function (itemIds, callback) {
-	const url = '/keystone/api/' + this.path + '/' + itemIds.join() + '/delete';
+	const url = Keystone.adminPath + '/api/' + this.path + '/' + item.id + '/delete';
 	xhr({
 		url: url,
 		method: 'POST',

--- a/admin/client/stores/SessionStore.js
+++ b/admin/client/stores/SessionStore.js
@@ -7,6 +7,7 @@ var csrfHeaders = {};
 csrfHeaders[Keystone.csrf_header_key] = Keystone.csrf_token_value;
 
 var _user = Keystone.user;
+var _adminPath = Keystone.adminPath;
 
 function callbackResponse (callback) {
 	return function (err, resp, body) {
@@ -23,7 +24,7 @@ var SessionStore = new Store({
 	},
 	signin (options, callback) {
 		xhr({
-			url: '/keystone/api/session/signin',
+			url: _adminPath + '/api/session/signin',
 			method: 'post',
 			json: options,
 			headers: csrfHeaders
@@ -32,7 +33,7 @@ var SessionStore = new Store({
 	signout (callback) {
 		callback = callback || function () {};
 		xhr({
-			url: '/keystone/api/session/signout',
+			url: _adminPath + '/api/session/signout',
 			method: 'post',
 			json: {}
 		}, callbackResponse(callback));

--- a/admin/client/views/home.js
+++ b/admin/client/views/home.js
@@ -51,7 +51,7 @@ var HomeView = React.createClass({
 
 	loadCounts () {
 		xhr({
-			url: '/keystone/api/counts'
+			url: this.props.adminPath + '/api/counts'
 		}, (err, resp, body) => {
 			try {
 				body = JSON.parse(body);
@@ -97,7 +97,7 @@ var HomeView = React.createClass({
 
 	renderFlatNav () {
 		let lists = this.props.navLists.map((list) => {
-			var href = list.external ? list.path : '/keystone/' + list.path;
+			var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
 			return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 		});
 
@@ -116,7 +116,7 @@ var HomeView = React.createClass({
 							</div>
 							<div className="dashboard-group__lists">
 								{navSection.lists.map((list) => {
-									var href = list.external ? list.path : '/keystone/' + list.path;
+									var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
 									return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 								})}
 							</div>
@@ -138,7 +138,7 @@ var HomeView = React.createClass({
 				</div>
 				<div className="dashboard-group__lists">
 					{this.props.orphanedLists.map((list) => {
-						var href = list.external ? list.path : '/keystone/' + list.path;
+						var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
 						return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 					})}
 				</div>
@@ -151,12 +151,14 @@ var HomeView = React.createClass({
 			<div className="keystone-wrapper">
 				<header className="keystone-header">
 					<MobileNavigation
+						adminPath={this.props.adminPath}
 						brand={this.props.brand}
 						currentSectionKey="dashboard"
 						sections={this.props.nav.sections}
 						signoutUrl={this.props.signoutUrl}
 						/>
 					<PrimaryNavigation
+						adminPath={this.props.adminPath}
 						brand={this.props.brand}
 						currentSectionKey="dashboard"
 						sections={this.props.nav.sections}
@@ -175,6 +177,7 @@ var HomeView = React.createClass({
 				</div>
 				<Footer
 					appversion={this.props.appversion}
+					adminPath={this.props.adminPath}
 					backUrl={this.props.backUrl}
 					brand={this.props.brand}
 					User={this.props.User}
@@ -189,6 +192,7 @@ var HomeView = React.createClass({
 ReactDOM.render(
 	<HomeView
 		appversion={Keystone.appversion}
+		adminPath={Keystone.adminPath}
 		backUrl={Keystone.backUrl}
 		brand={Keystone.brand}
 		nav={Keystone.nav}

--- a/admin/client/views/home.js
+++ b/admin/client/views/home.js
@@ -51,7 +51,7 @@ var HomeView = React.createClass({
 
 	loadCounts () {
 		xhr({
-			url: this.props.adminPath + '/api/counts'
+			url: `${this.props.adminPath}/api/counts`
 		}, (err, resp, body) => {
 			try {
 				body = JSON.parse(body);
@@ -97,7 +97,7 @@ var HomeView = React.createClass({
 
 	renderFlatNav () {
 		let lists = this.props.navLists.map((list) => {
-			var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
+			var href = list.external ? list.path : `${this.props.adminPath}/${list.path}`;
 			return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 		});
 
@@ -116,7 +116,7 @@ var HomeView = React.createClass({
 							</div>
 							<div className="dashboard-group__lists">
 								{navSection.lists.map((list) => {
-									var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
+									var href = list.external ? list.path : `${this.props.adminPath}/${list.path}`;
 									return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 								})}
 							</div>
@@ -138,7 +138,7 @@ var HomeView = React.createClass({
 				</div>
 				<div className="dashboard-group__lists">
 					{this.props.orphanedLists.map((list) => {
-						var href = list.external ? list.path : this.props.adminPath + '/' + list.path;
+						var href = list.external ? list.path : `${this.props.adminPath}/${list.path}`;
 						return <ListTile key={list.path} label={list.label} href={href} count={plural(this.state.counts[list.key], '* Item', '* Items')} />;
 					})}
 				</div>

--- a/admin/client/views/item.js
+++ b/admin/client/views/item.js
@@ -56,7 +56,7 @@ var ItemView = React.createClass({
 				{keys.map(key => {
 					let relationship = relationships[key];
 					let refList = Lists[relationship.ref];
-					return <RelatedItemsList key={relationship.path} list={this.props.list} refList={refList} relatedItemId={this.props.itemId} relationship={relationship} />;
+					return <RelatedItemsList key={relationship.path} adminPath={this.props.adminPath} list={this.props.list} refList={refList} relatedItemId={this.props.itemId} relationship={relationship} />;
 				})}
 			</div>
 		);

--- a/admin/client/views/item.js
+++ b/admin/client/views/item.js
@@ -68,6 +68,7 @@ var ItemView = React.createClass({
 			<div className="keystone-wrapper">
 				<header className="keystone-header">
 					<MobileNavigation
+						adminPath={this.props.adminPath}
 						brand={this.props.brand}
 						currentListKey={this.props.list.path}
 						currentSectionKey={this.props.nav.currentSection.key}
@@ -75,28 +76,33 @@ var ItemView = React.createClass({
 						signoutUrl={this.props.signoutUrl}
 						/>
 					<PrimaryNavigation
+						adminPath={this.props.adminPath}
 						currentSectionKey={this.props.nav.currentSection.key}
 						brand={this.props.brand}
 						sections={this.props.nav.sections}
 						signoutUrl={this.props.signoutUrl} />
 					<SecondaryNavigation
+						adminPath={this.props.adminPath}
 						currentListKey={this.props.list.path}
 						lists={this.props.nav.currentSection.lists} />
 				</header>
 				<div className="keystone-body">
 					<EditFormHeader
+						adminPath={this.props.adminPath}
 						list={this.props.list}
 						data={this.state.itemData}
 						drilldown={this.state.itemDrilldown}
 						toggleCreate={this.toggleCreate} />
 					<Container>
 						<CreateForm
+							adminPath={this.props.adminPath}
 							list={this.props.list}
 							isOpen={this.state.createIsOpen}
 							onCancel={() => this.toggleCreate(false)} />
 						<FlashMessages
 							messages={this.props.messages} />
 						<EditForm
+							adminPath={this.props.adminPath}
 							list={this.props.list}
 							data={this.state.itemData} />
 						{this.renderRelationships()}
@@ -104,6 +110,7 @@ var ItemView = React.createClass({
 				</div>
 				<Footer
 					appversion={this.props.appversion}
+					adminPath={this.props.adminPath}
 					backUrl={this.props.backUrl}
 					brand={this.props.brand}
 					User={this.props.User}
@@ -118,6 +125,7 @@ var ItemView = React.createClass({
 ReactDOM.render(
 	<ItemView
 		appversion={Keystone.appversion}
+		adminPath={Keystone.adminPath}
 		backUrl={Keystone.backUrl}
 		brand={Keystone.brand}
 		itemId={Keystone.itemId}

--- a/admin/client/views/list.js
+++ b/admin/client/views/list.js
@@ -278,7 +278,7 @@ const ListView = React.createClass({
 						</InputGroup.Section>
 						{this.renderCreateButton()}
 					</InputGroup>
-					<ListFilters />
+					<ListFilters adminPath={this.props.adminPath} />
 					<div style={{ height: 34, marginBottom: '2em' }}>
 						{this.renderManagement()}
 						{this.renderPagination()}
@@ -382,7 +382,7 @@ const ListView = React.createClass({
 		});
 		var cells = this.state.columns.map((col, i) => {
 			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
-			var linkTo = !i ? `/keystone/${this.state.list.path}/${itemId}` : undefined;
+			var linkTo = !i ? `${this.props.adminPath}/${this.state.list.path}/${itemId}` : undefined;
 			return <ColumnType key={col.path} list={this.state.list} col={col} data={item} linkTo={linkTo} />;
 		});
 		// add sortable icon when applicable
@@ -495,6 +495,7 @@ const ListView = React.createClass({
 			<div className="keystone-wrapper">
 				<header className="keystone-header">
 					<MobileNavigation
+						adminPath={this.props.adminPath}
 						brand={this.props.brand}
 						currentListKey={this.state.list.path}
 						currentSectionKey={this.props.nav.currentSection.key}
@@ -502,11 +503,13 @@ const ListView = React.createClass({
 						signoutUrl={this.props.signoutUrl}
 						/>
 					<PrimaryNavigation
+						adminPath={this.props.adminPath}
 						brand={this.props.brand}
 						currentSectionKey={this.props.nav.currentSection.key}
 						sections={this.props.nav.sections}
 						signoutUrl={this.props.signoutUrl} />
 					<SecondaryNavigation
+						adminPath={this.props.adminPath}
 						currentListKey={this.state.list.path}
 						lists={this.props.nav.currentSection.lists} />
 				</header>
@@ -516,18 +519,21 @@ const ListView = React.createClass({
 				</div>
 				<Footer
 					appversion={this.props.appversion}
+					adminPath={this.props.adminPath}
 					backUrl={this.props.backUrl}
 					brand={this.props.brand}
 					User={this.props.User}
 					user={this.props.user}
 					version={this.props.version} />
 				<CreateForm
+					adminPath={this.props.adminPath}
 					err={this.props.createFormErrors}
 					isOpen={this.state.showCreateForm}
 					list={this.state.list}
 					onCancel={() => this.toggleCreateModal(false)}
 					values={this.props.createFormData} />
 				<UpdateForm
+					adminPath={this.props.adminPath}
 					isOpen={this.state.showUpdateForm}
 					itemIds={Object.keys(this.state.checkedItems)}
 					list={this.state.list}
@@ -542,6 +548,7 @@ const ListView = React.createClass({
 ReactDOM.render(
 	<ListView
 		appversion={Keystone.appversion}
+		adminPath={Keystone.adminPath}
 		backUrl={Keystone.backUrl}
 		brand={Keystone.brand}
 		createFormData={Keystone.createFormData}

--- a/admin/client/views/signin.js
+++ b/admin/client/views/signin.js
@@ -46,7 +46,7 @@ var SigninView = React.createClass({
 				this.displayError('The email and password you entered are not valid.');
 			} else {
 				// TODO: Handle custom signin redirections
-				top.location.href = '/keystone';
+				top.location.href = this.props.adminPath;
 			}
 		});
 	},
@@ -68,7 +68,7 @@ var SigninView = React.createClass({
 		});
 	},
 	renderBrand () {
-		let logo = { src: '/keystone/images/logo.png', width: 205, height: 68 };
+		let logo = { src: this.props.adminPath + '/images/logo.png', width: 205, height: 68 };
 		if (this.props.logo) {
 			logo = typeof this.props.logo === 'string' ? { src: this.props.logo } : this.props.logo;
 			// TODO: Deprecate this
@@ -88,13 +88,13 @@ var SigninView = React.createClass({
 	},
 	renderUserInfo () {
 		if (!this.props.user) return null;
-		let openKeystoneButton = this.props.userCanAccessKeystone ? <Button href="/keystone" type="primary">Open Keystone</Button> : null;
+		let openKeystoneButton = this.props.userCanAccessKeystone ? <Button href={this.props.adminPath} type="primary">Open Keystone</Button> : null;
 		return (
 			<div className="auth-box__col">
 				<p>Hi {this.props.user.name.first},</p>
 				<p>You're already signed in.</p>
 				{openKeystoneButton}
-				<Button href="/keystone/signout" type="link-cancel">Sign Out</Button>
+				<Button href={this.props.adminPath + '/signout'} type="link-cancel">Sign Out</Button>
 			</div>
 		);
 	},
@@ -153,6 +153,7 @@ var SigninView = React.createClass({
 });
 
 ReactDOM.render(<SigninView
+		adminPath={Keystone.adminPath}
 		brand={Keystone.brand}
 		logo={Keystone.logo}
 		user={Keystone.user}

--- a/admin/client/views/signin.js
+++ b/admin/client/views/signin.js
@@ -68,7 +68,7 @@ var SigninView = React.createClass({
 		});
 	},
 	renderBrand () {
-		let logo = { src: this.props.adminPath + '/images/logo.png', width: 205, height: 68 };
+		let logo = { src: `${this.props.adminPath}/images/logo.png`, width: 205, height: 68 };
 		if (this.props.logo) {
 			logo = typeof this.props.logo === 'string' ? { src: this.props.logo } : this.props.logo;
 			// TODO: Deprecate this
@@ -94,7 +94,7 @@ var SigninView = React.createClass({
 				<p>Hi {this.props.user.name.first},</p>
 				<p>You're already signed in.</p>
 				{openKeystoneButton}
-				<Button href={this.props.adminPath + '/signout'} type="link-cancel">Sign Out</Button>
+				<Button href={`${this.props.adminPath}/signout`} type="link-cancel">Sign Out</Button>
 			</div>
 		);
 	},

--- a/admin/public/js/content/editor.js
+++ b/admin/public/js/content/editor.js
@@ -35,7 +35,7 @@ jQuery(function($) {
 		switch (data.type) {
 			
 			case 'list':
-				var href = '/keystone/' + data.path,
+				var href = Keystone.adminPath + '/' + data.path,
 					label = 'Manage ' + data.plural;
 				
 				if (data.id) {

--- a/admin/public/styles/keystone/list.less
+++ b/admin/public/styles/keystone/list.less
@@ -15,24 +15,24 @@
 	display: inline-block;
 	vertical-align: middle;
 
-	&.fieldicon-text            { background-image: url( "/keystone/images/icons/16/field-text.png" ); }
-	&.fieldicon-textarea        { background-image: url( "/keystone/images/icons/16/field-textarea.png" ); }
-	&.fieldicon-name            { background-image: url( "/keystone/images/icons/16/field-name.png" ); }
-	&.fieldicon-html            { background-image: url( "/keystone/images/icons/16/field-html.png" ); }
-	&.fieldicon-url             { background-image: url( "/keystone/images/icons/16/field-url.png" ); }
-	&.fieldicon-key             { background-image: url( "/keystone/images/icons/16/field-key.png" ); }
-	&.fieldicon-email           { background-image: url( "/keystone/images/icons/16/field-email.png" ); }
-	&.fieldicon-select          { background-image: url( "/keystone/images/icons/16/field-select.png" ); }
-	&.fieldicon-location        { background-image: url( "/keystone/images/icons/16/field-location.png" ); }
-	&.fieldicon-boolean         { background-image: url( "/keystone/images/icons/16/field-boolean.png" ); }
-	&.fieldicon-cloudinaryimage { background-image: url( "/keystone/images/icons/16/field-image.png" ); }
-	&.fieldicon-s3file          { background-image: url( "/keystone/images/icons/16/field-file.png" ); }
-	&.fieldicon-relationship    { background-image: url( "/keystone/images/icons/16/field-numericSelect.png" ); }
-	&.fieldicon-date            { background-image: url( "/keystone/images/icons/16/field-date.png" ); }
-	&.fieldicon-datetime        { background-image: url( "/keystone/images/icons/16/field-dateTime.png" ); }
-	&.fieldicon-money           { background-image: url( "/keystone/images/icons/16/field-money.png" ); }
-	&.fieldicon-number          { background-image: url( "/keystone/images/icons/16/field-number.png" ); }
-	&.fieldicon-sort            { background-image: url( "/keystone/images/icons/16/field-sort.png" ); }
+	&.fieldicon-text            { background-image: url( "@{adminPath}/images/icons/16/field-text.png" ); }
+	&.fieldicon-textarea        { background-image: url( "@{adminPath}/images/icons/16/field-textarea.png" ); }
+	&.fieldicon-name            { background-image: url( "@{adminPath}/images/icons/16/field-name.png" ); }
+	&.fieldicon-html            { background-image: url( "@{adminPath}/images/icons/16/field-html.png" ); }
+	&.fieldicon-url             { background-image: url( "@{adminPath}/images/icons/16/field-url.png" ); }
+	&.fieldicon-key             { background-image: url( "@{adminPath}/images/icons/16/field-key.png" ); }
+	&.fieldicon-email           { background-image: url( "@{adminPath}/images/icons/16/field-email.png" ); }
+	&.fieldicon-select          { background-image: url( "@{adminPath}/images/icons/16/field-select.png" ); }
+	&.fieldicon-location        { background-image: url( "@{adminPath}/images/icons/16/field-location.png" ); }
+	&.fieldicon-boolean         { background-image: url( "@{adminPath}/images/icons/16/field-boolean.png" ); }
+	&.fieldicon-cloudinaryimage { background-image: url( "@{adminPath}/images/icons/16/field-image.png" ); }
+	&.fieldicon-s3file          { background-image: url( "@{adminPath}/images/icons/16/field-file.png" ); }
+	&.fieldicon-relationship    { background-image: url( "@{adminPath}/images/icons/16/field-numericSelect.png" ); }
+	&.fieldicon-date            { background-image: url( "@{adminPath}/images/icons/16/field-date.png" ); }
+	&.fieldicon-datetime        { background-image: url( "@{adminPath}/images/icons/16/field-dateTime.png" ); }
+	&.fieldicon-money           { background-image: url( "@{adminPath}/images/icons/16/field-money.png" ); }
+	&.fieldicon-number          { background-image: url( "@{adminPath}/images/icons/16/field-number.png" ); }
+	&.fieldicon-sort            { background-image: url( "@{adminPath}/images/icons/16/field-sort.png" ); }
 }
 .dropdown-menu .fieldicon {
 	margin-right: 10px;

--- a/admin/public/styles/keystone/wysiwyg.less
+++ b/admin/public/styles/keystone/wysiwyg.less
@@ -31,19 +31,19 @@
 	.wysihtml5-command-dialog-opened {
 		background-color: #eee;
 	}
-	
-	.icon-ok { background-image: url('/keystone/images/icons/16/tick-circle.png') }
-	.icon-remove { background-image: url('/keystone/images/icons/16/cross.png') }
-	.icon-edit-size { background-image: url('/keystone/images/icons/16/edit-size.png') }
-	.icon-edit-bold { background-image: url('/keystone/images/icons/16/edit-bold.png') }
-	.icon-edit-italic { background-image: url('/keystone/images/icons/16/edit-italic.png') }
-	.icon-edit-indent { background-image: url('/keystone/images/icons/16/edit-indent.png') }
-	.icon-edit-outdent { background-image: url('/keystone/images/icons/16/edit-outdent.png') }
-	.icon-edit-list { background-image: url('/keystone/images/icons/16/edit-list.png') }
-	.icon-edit-list-order { background-image: url('/keystone/images/icons/16/edit-list-order.png') }
-	.icon-edit-code { background-image: url('/keystone/images/icons/16/edit-code.png') }
-	.icon-edit-link { background-image: url('/keystone/images/icons/16/edit-link.png') }
-	.icon-edit-image { background-image: url('/keystone/images/icons/16/edit-image.png') }
+
+	.icon-ok { background-image: url('@{adminPath}/images/icons/16/tick-circle.png') }
+	.icon-remove { background-image: url('@{adminPath}/images/icons/16/cross.png') }
+	.icon-edit-size { background-image: url('@{adminPath}/images/icons/16/edit-size.png') }
+	.icon-edit-bold { background-image: url('@{adminPath}/images/icons/16/edit-bold.png') }
+	.icon-edit-italic { background-image: url('@{adminPath}/images/icons/16/edit-italic.png') }
+	.icon-edit-indent { background-image: url('@{adminPath}/images/icons/16/edit-indent.png') }
+	.icon-edit-outdent { background-image: url('@{adminPath}/images/icons/16/edit-outdent.png') }
+	.icon-edit-list { background-image: url('@{adminPath}/images/icons/16/edit-list.png') }
+	.icon-edit-list-order { background-image: url('@{adminPath}/images/icons/16/edit-list-order.png') }
+	.icon-edit-code { background-image: url('@{adminPath}/images/icons/16/edit-code.png') }
+	.icon-edit-link { background-image: url('@{adminPath}/images/icons/16/edit-link.png') }
+	.icon-edit-image { background-image: url('@{adminPath}/images/icons/16/edit-image.png') }
 }
 
 .ui-wysiwyg-hint {

--- a/admin/server/api/item/get.js
+++ b/admin/server/api/item/get.js
@@ -68,7 +68,7 @@ module.exports = function(req, res) {
 									items: _.map(results, function(i) {
 										return {
 											label: refList.getDocumentName(i),
-											href: '/keystone/' + refList.path + '/' + i.id
+											href: '/' + keystone.get('admin path') + '/' + refList.path + '/' + i.id
 										};
 									}),
 									more: (more) ? true : false
@@ -87,7 +87,7 @@ module.exports = function(req, res) {
 									list: refList.getOptions(),
 									items: [{
 										label: refList.getDocumentName(result),
-										href: '/keystone/' + refList.path + '/' + result.id
+										href: '/' + keystone.get('admin path') + '/' + refList.path + '/' + result.id
 									}]
 								});
 							}

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -29,10 +29,10 @@ module.exports = function createDynamicRouter(keystone) {
 	if (keystone.get('auth') === true) {
 		// TODO: poor separation of concerns; settings should be defaulted elsewhere
 		if (!keystone.get('signout url')) {
-			keystone.set('signout url', '/keystone/signout');
+			keystone.set('signout url', '/' + keystone.get('admin path') + '/signout');
 		}
 		if (!keystone.get('signin url')) {
-			keystone.set('signin url', '/keystone/signin');
+			keystone.set('signin url', '/' + keystone.get('admin path') + '/signin');
 		}
 		if (!keystone.nativeApp || !keystone.get('session')) {
 			router.all('*', keystone.session.persist);

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -41,7 +41,8 @@ module.exports = function createStaticRouter (keystone) {
 		render: {
 			modifyVars: {
 				elementalPath: JSON.stringify(elementalPath),
-				reactSelectPath: JSON.stringify(reactSelectPath)
+				reactSelectPath: JSON.stringify(reactSelectPath),
+				adminPath: JSON.stringify(keystone.get('admin path'))
 			}
 		}
 	};

--- a/admin/server/routes/item.js
+++ b/admin/server/routes/item.js
@@ -10,12 +10,12 @@ module.exports = function(req, res) {
 
 		if (err) {
 			req.flash('error', 'A database error occurred.');
-			return res.redirect('/keystone/' + req.list.path);
+			return res.redirect('/' + keystone.get('admin path') + '/' + req.list.path);
 		}
 
 		if (!item) {
 			req.flash('error', 'Item ' + req.params.item + ' could not be found.');
-			return res.redirect('/keystone/' + req.list.path);
+			return res.redirect('/' + keystone.get('admin path') + '/' + req.list.path);
 		}
 
 		var renderView = function() {
@@ -86,7 +86,7 @@ module.exports = function(req, res) {
 					return renderView();
 				}
 				req.flash('success', 'Your changes have been saved.');
-				return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+				return res.redirect('/' + keystone.get('admin path') + '/' + req.list.path + '/' + item.id);
 			});
 
 

--- a/admin/server/routes/list.js
+++ b/admin/server/routes/list.js
@@ -42,7 +42,7 @@ module.exports = function(req, res) {
 				renderView();
 			} else {
 				req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
-				return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+				return res.redirect('/' + keystone.get('admin path') + '/' + req.list.path + '/' + item.id);
 			}
 		});
 
@@ -72,7 +72,7 @@ module.exports = function(req, res) {
 				return renderView();
 			}
 			req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
-			return res.redirect('/keystone/' + req.list.path + '/' + item.id);
+			return res.redirect('/' + keystone.get('admin path') + '/' + req.list.path + '/' + item.id);
 		});
 
 	} else {

--- a/admin/server/routes/signout.js
+++ b/admin/server/routes/signout.js
@@ -8,7 +8,7 @@ module.exports = function(req, res) {
 		} else if ('function' === typeof keystone.get('signout redirect')) {
 			return keystone.get('signout redirect')(req, res);
 		} else {
-			return res.redirect('/keystone/signin?signedout');
+			return res.redirect('/' + keystone.get('admin path') + '/signin?signedout');
 		}
 	});
 };

--- a/admin/server/templates/home.jade
+++ b/admin/server/templates/home.jade
@@ -5,7 +5,7 @@ html
 		meta(name="viewport", content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width")
 		meta(name="csrf-token", content="#{csrf_token_value}")
 		title= title
-		link(rel="stylesheet", href="/keystone/styles/keystone.min.css")
+		link(rel="stylesheet", href="#{adminPath}/styles/keystone.min.css")
 		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
 
 	body
@@ -15,7 +15,7 @@ html
 		script.
 			Keystone.lists = !{JSON.stringify(_.map(lists, getListMeta))};
 			Keystone.orphanedLists = !{JSON.stringify(orphanedLists.map(getListMeta))};
-		script(src="/keystone/js/lib/underscore/underscore-1.5.1.min.js")
-		script(src='/keystone/js/packages.js')
-		script(src='/keystone/js/home.js')
+		script(src="#{adminPath}/js/lib/underscore/underscore-1.5.1.min.js")
+		script(src="#{adminPath}/js/packages.js")
+		script(src="#{adminPath}/js/home.js")
 		include includes/script/ga

--- a/admin/server/templates/includes/css/components.jade
+++ b/admin/server/templates/includes/css/components.jade
@@ -1,2 +1,2 @@
 if list.fieldTypes.code
-	link(rel='stylesheet', href='/keystone/js/lib/codemirror/codemirror.css')
+	link(rel="stylesheet", href="#{adminPath}/js/lib/codemirror/codemirror.css")

--- a/admin/server/templates/includes/script/cloudinary.jade
+++ b/admin/server/templates/includes/script/cloudinary.jade
@@ -1,7 +1,7 @@
-script(src='/keystone/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
-script(src='/keystone/js/lib/jqueryfileupload/jquery.iframe-transport.js')
-script(src='/keystone/js/lib/jqueryfileupload/jquery.fileupload.js')
-script(src='/keystone/js/lib/cloudinary/jquery.cloudinary.js')
+script(src='#{adminPath}/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
+script(src='#{adminPath}/js/lib/jqueryfileupload/jquery.iframe-transport.js')
+script(src='#{adminPath}/js/lib/jqueryfileupload/jquery.fileupload.js')
+script(src='#{adminPath}/js/lib/cloudinary/jquery.cloudinary.js')
 | !{cloudinary_js_config}
 script.
 	Keystone.cloudinary = {

--- a/admin/server/templates/includes/script/components.jade
+++ b/admin/server/templates/includes/script/components.jade
@@ -1,15 +1,15 @@
-script(src="/keystone/js/lib/moment/moment-1.7.2.min.js")
-script(src="/keystone/js/lib/move/move-0.1.1.min.js")
-script(src="/keystone/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
+script(src="#{adminPath}/js/lib/moment/moment-1.7.2.min.js")
+script(src="#{adminPath}/js/lib/move/move-0.1.1.min.js")
+script(src="#{adminPath}/js/lib/jquery-placeholder-shim/jquery-placeholder-shim.js")
 if list.fieldTypes.wysiwyg
-	script(src="/keystone/js/lib/tinymce/tinymce.min.js")
+	script(src="#{adminPath}/js/lib/tinymce/tinymce.min.js")
 if list.fieldTypes.code
-	script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
+	script(src="#{adminPath}/js/lib/codemirror/codemirror-compressed.js")
 if cloudinary
-	script(src='/keystone/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
-	script(src='/keystone/js/lib/jqueryfileupload/jquery.iframe-transport.js')
-	script(src='/keystone/js/lib/jqueryfileupload/jquery.fileupload.js')
-	script(src='/keystone/js/lib/cloudinary/jquery.cloudinary.js')
+	script(src='#{adminPath}/js/lib/jqueryfileupload/vendor/jquery.ui.widget.js')
+	script(src='#{adminPath}/js/lib/jqueryfileupload/jquery.iframe-transport.js')
+	script(src='#{adminPath}/js/lib/jqueryfileupload/jquery.fileupload.js')
+	script(src='#{adminPath}/js/lib/cloudinary/jquery.cloudinary.js')
 	| !{cloudinary_js_config}
 	script.
 		Keystone.cloudinary = {

--- a/admin/server/templates/includes/script/keystone.jade
+++ b/admin/server/templates/includes/script/keystone.jade
@@ -1,5 +1,6 @@
 script.
 	var Keystone = {};
+	Keystone.adminPath = !{JSON.stringify(adminPath)};
 	Keystone.backUrl = !{JSON.stringify(backUrl)};
 	Keystone.user = !{JSON.stringify(user)};
 	Keystone.version = !{JSON.stringify(version)};

--- a/admin/server/templates/item.jade
+++ b/admin/server/templates/item.jade
@@ -8,14 +8,14 @@ html
 		meta(name="csrf-token", content="#{csrf_token_value}")
 		title= title
 		include includes/css/components
-		link(rel="stylesheet", href="/keystone/styles/keystone.min.css")
+		link(rel="stylesheet", href="#{adminPath}/styles/keystone.min.css")
 		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
 
 	body
 		#item-view
 		//- Common
-		script(src="/keystone/js/lib/underscore/underscore-1.5.1.min.js")
-		script(src="/keystone/js/lib/jquery/jquery-1.10.2.min.js")
+		script(src="#{adminPath}/js/lib/underscore/underscore-1.5.1.min.js")
+		script(src="#{adminPath}/js/lib/jquery/jquery-1.10.2.min.js")
 
 		//- Components
 		include includes/script/keystone
@@ -25,9 +25,9 @@ html
 			Keystone.list = Keystone.lists[!{JSON.stringify(list.key)}];
 			Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
 			Keystone.itemId = '!{item.id}';
-		script(src='/keystone/js/packages.js')
-		script(src='/keystone/js/fields.js')
-		script(src='/keystone/js/item.js')
+		script(src='#{adminPath}/js/packages.js')
+		script(src='#{adminPath}/js/fields.js')
+		script(src='#{adminPath}/js/item.js')
 		include includes/script/ga
 
 // TODO: Rewrite relationships in React. Original source here for reference.
@@ -49,7 +49,7 @@ html
 //- 			else
 //- 				- var value = col.subField ? col.subField.format(refData) : refData[col.refPath]
 //- 				if col.refList && refData && refData.id
-//- 					+column_link(value, '/keystone/' + col.refList.path + '/' + refData.id)
+//- 					+column_link(value, '#{adminPath}/' + col.refList.path + '/' + refData.id)
 //- 				else
 //- 					+column_basic(value)
 //- 	else if col.type == 'markdown'
@@ -59,7 +59,7 @@ html
 //- 	else
 //- 		- var value = col.field ? col.field.format(item) : item.get(col.path)
 //- 		if col.isName
-//- 			+column_link(value || '(no name)', '/keystone/' + list.path + '/' + item.id)
+//- 			+column_link(value || '(no name)', '#{adminPath}/' + list.path + '/' + item.id)
 //- 		else if col.type == 'email'
 //- 			if value && col.field.options.displayGravatar
 //- 				+column_gravatar(col.field.gravatarUrl(item,35))
@@ -74,26 +74,26 @@ html
 //- 			+column_html(value)
 //- 		else
 //- 			+column_basic(value)
-//- 
+//-
 //- mixin column_link(value, href, newWindow)
 //- 	if value
 //- 		a(href=href, target=newWindow ? '_blank' : undefined)= value
-//- 
+//-
 //- mixin column_gravatar(src)
 //- 	img(src=src).img-thumbnail
-//- 
+//-
 //- mixin column_boolean(value)
 //- 	if (value)
-//- 		img(src='/keystone/images/icons/16/checkbox-checked.png', width=16, height=16)
+//- 		img(src='#{adminPath}/images/icons/16/checkbox-checked.png', width=16, height=16)
 //- 	else
-//- 		img(src='/keystone/images/icons/16/checkbox-unchecked.png', width=16, height=16)
-//- 
+//- 		img(src='#{adminPath}/images/icons/16/checkbox-unchecked.png', width=16, height=16)
+//-
 //- mixin column_html(value)
 //- 	div.ItemList__value!= value
-//- 
+//-
 //- mixin column_basic(value)
 //- 	div.ItemList__value= value
-//- 
+//-
 //- mixin column_color(value)
 //- 	div.ItemList__value
 //- 		if (value)
@@ -105,7 +105,7 @@ html
 //- 			each rel in relationships
 //- 				if rel.items.results.length
 //- 					h3.EditForm__relationships-subheading
-//- 						a(href='/keystone/' + rel.list.path)= (rel.label) ? rel.label : rel.list.label
+//- 						a(href='#{adminPath}/' + rel.list.path)= (rel.label) ? rel.label : rel.list.label
 //- 					if rel.note
 //- 						.field-note= rel.note
 //- 					- var firstColspan = 1

--- a/admin/server/templates/list.jade
+++ b/admin/server/templates/list.jade
@@ -8,14 +8,14 @@ html
 		meta(name="csrf-token", content="#{csrf_token_value}")
 		title= title
 		include includes/css/components
-		link(rel="stylesheet", href="/keystone/styles/keystone.min.css")
+		link(rel="stylesheet", href="#{adminPath}/styles/keystone.min.css")
 		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
 
 	body
 		#list-view
 		//- Common
-		script(src="/keystone/js/lib/underscore/underscore-1.5.1.min.js")
-		script(src="/keystone/js/lib/jquery/jquery-1.10.2.min.js")
+		script(src="#{adminPath}/js/lib/underscore/underscore-1.5.1.min.js")
+		script(src="#{adminPath}/js/lib/jquery/jquery-1.10.2.min.js")
 
 		//- Components
 		include includes/script/keystone
@@ -28,7 +28,7 @@ html
 			Keystone.showCreateForm = !{JSON.stringify(showCreateForm)};
 			Keystone.createFormData = !{JSON.stringify(submitted)};
 			Keystone.createFormErrors = !{JSON.stringify(createErrors || null)};
-		script(src='/keystone/js/packages.js')
-		script(src='/keystone/js/fields.js')
-		script(src='/keystone/js/list.js')
+		script(src='#{adminPath}/js/packages.js')
+		script(src='#{adminPath}/js/fields.js')
+		script(src='#{adminPath}/js/list.js')
 		include includes/script/ga

--- a/admin/server/templates/signin.jade
+++ b/admin/server/templates/signin.jade
@@ -4,20 +4,21 @@ html
 		meta(charset="utf-8")
 		meta(name="viewport", content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width")
 		title Sign in to #{brand ? brand : 'Keystone'}
-		link(rel="stylesheet", href="/keystone/styles/keystone.min.css")
+		link(rel="stylesheet", href="#{adminPath}/styles/keystone.min.css")
 		link(rel="shortcut icon", href="/favicon.ico", type="image/x-icon")
 	body
 		#signin-view
-		script(src='/keystone/js/packages.js')
+		script(src='#{adminPath}/js/packages.js')
 		script.
 			var Keystone = {
+				adminPath: !{JSON.stringify(adminPath)},
 				brand: !{JSON.stringify(brand || '')},
 				logo: !{JSON.stringify(logo || '')},
 				messages: !{JSON.stringify(messages || '')},
 				user: !{JSON.stringify(user || null)},
 				userCanAccessKeystone: !{user && user.canAccessKeystone ? 'true' : 'false'},
 			};
-		script(src='/keystone/js/signin.js')
+		script(src='#{adminPath}/js/signin.js')
 		//- Google Analytics
 		if env == 'production' && ga.property && ga.domain
 			script.

--- a/fields/components/columns/IdColumn.js
+++ b/fields/components/columns/IdColumn.js
@@ -14,7 +14,7 @@ var IdColumn = React.createClass({
 		if (!value) return null;
 
 		return (
-			<ItemsTableValue padded interior title={value} href={'/keystone/' + this.props.list.path + '/' + value} field={this.props.col.type}>
+			<ItemsTableValue padded interior title={value} href={Keystone.adminPath + '/' + this.props.list.path + '/' + value} field={this.props.col.type}>
 				{value}
 			</ItemsTableValue>
 		);

--- a/fields/types/Field.js
+++ b/fields/types/Field.js
@@ -26,6 +26,7 @@ var Base = module.exports.Base = {
 	},
 	getDefaultProps () {
 		return {
+			adminPath: Keystone.adminPath,
 			inputProps: {},
 			labelProps: {},
 			valueProps: {},

--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -322,7 +322,7 @@ module.exports = Field.create({
 	renderImageSelect () {
 		var selectPrefix = this.props.selectPrefix;
 		var getOptions = function(input, callback) {
-			$.get('/keystone/api/cloudinary/autocomplete', {
+			$.get(this.props.adminPath + '/api/cloudinary/autocomplete', {
 				dataType: 'json',
 				data: {
 					q: input

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -149,7 +149,9 @@ module.exports = Field.create({
 		};
 
 		if (this.shouldRenderField()) {
-			opts.uploadimage_form_url = options.enableS3Uploads ? '/keystone/api/s3/upload' : '/keystone/api/cloudinary/upload';
+			opts.uploadimage_form_url = options.enableS3Uploads ?
+				this.props.adminPath + '/api/s3/upload' :
+				this.props.adminPath + '/api/cloudinary/upload';
 		} else {
 			Object.assign(opts, {
 				mode: 'textareas',

--- a/fields/types/localfiles/LocalFilesField.js
+++ b/fields/types/localfiles/LocalFilesField.js
@@ -19,6 +19,7 @@ const ICON_EXTS = [
 
 var LocalFilesFieldItem = React.createClass({
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		deleted: React.PropTypes.bool,
 		filename: React.PropTypes.string,
 		isQueued: React.PropTypes.bool,
@@ -53,7 +54,7 @@ var LocalFilesFieldItem = React.createClass({
 
 		return (
 			<FormField>
-				<img key="file-type-icon" className="file-icon" src={'/keystone/images/icons/32/' + iconName + '.png'} />
+				<img key="file-type-icon" className="file-icon" src={this.props.adminPath + '/images/icons/32/' + iconName + '.png'} />
 				<FormInput key="file-name" noedit className="field-type-localfiles__filename">
 					{filename}
 					{this.props.size ? ' (' + bytes(this.props.size) + ')' : null}
@@ -97,6 +98,7 @@ module.exports = Field.create({
 		var i = thumbs.length;
 		args.toggleDelete = this.removeItem.bind(this, i);
 		args.shouldRenderActionButton = this.shouldRenderField();
+		args.adminPath = this.props.adminPath;
 		thumbs.push(<LocalFilesFieldItem key={i} {...args} />);
 	},
 

--- a/fields/types/relationship/RelationshipColumn.js
+++ b/fields/types/relationship/RelationshipColumn.js
@@ -12,6 +12,7 @@ const moreIndicatorStyle = {
 var RelationshipColumn = React.createClass({
 	displayName: 'RelationshipColumn',
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		col: React.PropTypes.object,
 		data: React.PropTypes.object,
 	},
@@ -25,7 +26,7 @@ var RelationshipColumn = React.createClass({
 				items.push(<span key={'comma' + i}>, </span>);
 			}
 			items.push(
-				<ItemsTableValue interior truncate={false} key={'anchor' + i} href={'/keystone/' + refList.path + '/' + value[i].id}>
+				<ItemsTableValue interior truncate={false} key={'anchor' + i} href={this.props.adminPath + '/' + refList.path + '/' + value[i].id}>
 					{value[i].name}
 				</ItemsTableValue>
 			);
@@ -43,7 +44,7 @@ var RelationshipColumn = React.createClass({
 		if (!value) return;
 		let refList = this.props.col.field.refList;
 		return (
-			<ItemsTableValue href={'/keystone/' + refList.path + '/' + value.id} padded interior field={this.props.col.type}>
+			<ItemsTableValue href={this.props.adminPath + '/' + refList.path + '/' + value.id} padded interior field={this.props.col.type}>
 				{value.name}
 			</ItemsTableValue>
 		);

--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -74,7 +74,7 @@ module.exports = Field.create({
 	},
 
 	cacheItem (item) {
-		item.href = '/keystone/' + this.props.refList.path + '/' + item.id;
+		item.href = this.props.adminPath + '/' + this.props.refList.path + '/' + item.id;
 		this._itemsCache[item.id] = item;
 	},
 
@@ -100,7 +100,7 @@ module.exports = Field.create({
 		});
 		async.map(values, (value, done) => {
 			xhr({
-				url: '/keystone/api/' + this.props.refList.path + '/' + value + '?basic',
+				url: this.props.adminPath + '/api/' + this.props.refList.path + '/' + value + '?basic',
 				responseType: 'json',
 			}, (err, resp, data) => {
 				if (err || !data) return done(err);
@@ -119,7 +119,7 @@ module.exports = Field.create({
 	loadOptions (input, callback) {
 		// TODO: Implement filters
 		xhr({
-			url: '/keystone/api/' + this.props.refList.path + '?basic&search=' + input,
+			url: this.props.adminPath + '/api/' + this.props.refList.path + '?basic&search=' + input,
 			responseType: 'json',
 		}, (err, resp, data) => {
 			if (err) {

--- a/fields/types/relationship/RelationshipFilter.js
+++ b/fields/types/relationship/RelationshipFilter.js
@@ -25,6 +25,7 @@ var RelationshipFilter = React.createClass({
 	},
 
 	propTypes: {
+		adminPath: React.PropTypes.string,
 		field: React.PropTypes.object,
 		filter: React.PropTypes.shape({
 			inverted: React.PropTypes.bool,
@@ -68,7 +69,7 @@ var RelationshipFilter = React.createClass({
 		async.map(value, (id, next) => {
 			if (this._itemsCache[id]) return next(null, this._itemsCache[id]);
 			xhr({
-				url: '/keystone/api/' + this.props.field.refList.path + '/' + id + '?basic',
+				url: this.props.adminPath + '/api/' + this.props.field.refList.path + '/' + id + '?basic',
 				responseType: 'json',
 			}, (err, resp, data) => {
 				if (err || !data) return done(err);
@@ -96,7 +97,7 @@ var RelationshipFilter = React.createClass({
 	loadSearchResults (thenPopulateValue) {
 		let searchString = this.state.searchString;
 		xhr({
-			url: '/keystone/api/' + this.props.field.refList.path + '?basic&search=' + searchString,
+			url: this.props.adminPath + '/api/' + this.props.field.refList.path + '?basic&search=' + searchString,
 			responseType: 'json',
 		}, (err, resp, data) => {
 			if (err) {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ var Keystone = function () {
 	this._options = {
 		'name': 'Keystone',
 		'brand': 'Keystone',
+		'admin path': 'keystone',
 		'compress': true,
 		'headless': false,
 		'logger': ':method :url :status :response-time ms',

--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -53,6 +53,7 @@ function render(req, res, view, ext) {
 		user: req.user,
 		title: 'Keystone',
 		signout: keystone.get('signout url'),
+		adminPath: '/' + keystone.get('admin path'),
 		backUrl: keystone.get('back url') || '/',
 		section: {},
 		version: keystone.version,

--- a/lib/core/wrapHTMLError.js
+++ b/lib/core/wrapHTMLError.js
@@ -6,7 +6,7 @@
 
 function wrapHTMLError(title, err) {
 	return '<html><head><meta charset=\'utf-8\'><title>Error</title>' +
-	'<link rel=\'stylesheet\' href=\'/keystone/styles/error.css\'>' +
+	'<link rel=\'stylesheet\' href=\'/' + this.get('admin path') + '/styles/error.css\'>' +
 	'</head><body><div class=\'error\'><h1 class=\'error-title\'>' + title + '</h1>' +
 	'<div class="error-message">' + (err || '') + '</div></div></body></html>';
 }

--- a/lib/list/getAdminURL.js
+++ b/lib/list/getAdminURL.js
@@ -1,3 +1,5 @@
+var keystone = require('../../');
+
 /**
  * Gets the Admin URL to view the list (or an item if provided)
  *
@@ -8,7 +10,7 @@
  * @param {Object} item
  */
 function getAdminURL(item) {
-	return '/keystone/' + this.path + (item ? '/' + item.id : '');
+	return '/' + keystone.get('admin path') + '/' + this.path + (item ? '/' + item.id : '');
 }
 
 module.exports = getAdminURL;

--- a/lib/session.js
+++ b/lib/session.js
@@ -214,7 +214,8 @@ exports.persist = function(req, res, next) {
 
 exports.keystoneAuth = function(req, res, next) {
 	if (!req.user || !req.user.canAccessKeystone) {
-		var from = new RegExp('^\/keystone\/?$', 'i').test(req.url) ? '' : '?from=' + req.url;
+		var regex = new RegExp('^\/' + keystone.get('admin path') + '\/?$', 'i');
+		var from = regex.test(req.url) ? '' : '?from=' + req.url;
 		return res.redirect(keystone.get('signin url') + from);
 	}
 	next();

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -44,7 +44,7 @@ module.exports = function createApp (keystone, express) {
 	// unless the headless option is set (which disables the Admin UI),
 	// bind the Admin UI's Static Router for public resources
 	if (!keystone.get('headless')) {
-		app.use('/keystone', require('../admin/server').createStaticRouter(keystone));
+		app.use('/' + keystone.get('admin path'), require('../admin/server').createStaticRouter(keystone));
 	}
 
 	require('./bindLessMiddleware')(keystone, app);
@@ -60,7 +60,7 @@ module.exports = function createApp (keystone, express) {
 	// unless the headless option is set (which disables the Admin UI),
 	// bind the Admin UI's Dynamic Router
 	if (!keystone.get('headless')) {
-		app.use('/keystone', require('../admin/server').createDynamicRouter(keystone));
+		app.use('/' + keystone.get('admin path'), require('../admin/server').createDynamicRouter(keystone));
 	}
 
 	// Pre bodyparser middleware


### PR DESCRIPTION
This PR adds support for using a custom path to the admin UI, as discussed in #627.

If I would want to to use e.g. `/foobar` instead of `/keystone` as the path to the admin UI I would need to add the `admin path` config parameter to the `keystone.init()` call, as such:

```
keystone.init({
	'admin path': 'foobar'
});
```

I think this PR needs to be thoroughly reviewed as there's alot of files involved, but it should be feature complete AFAICT.