### PR TITLE
correct popout body max-height

### DIFF
--- a/admin/public/styles/keystone/popout.less
+++ b/admin/public/styles/keystone/popout.less
@@ -5,6 +5,7 @@
 @popout-gutter:                     20px;
 @popout-arrow-size:                  8px;
 @popout-width:                     320px;
+@popout-body-height:               310px;
 
 @popout-pane-animation-duration:   360ms;
 @popout-pane-timing-function:      cubic-bezier(.36, .66, .04, 1);
@@ -104,6 +105,9 @@
 	overflow-x: hidden;
 	overflow-y: scroll;
 	-webkit-overflow-scrolling: touch;
+	&.Popout__body {
+		max-height: @popout-body-height;
+	}
 }
 
 


### PR DESCRIPTION
The popout body height of **360px** was pushing the footer into hidden overflow for `Types.Date`.  This sets correct max-height for the Type filter options page.

Current | Fixed
-----------|--------
![bad-filterheight](https://cloud.githubusercontent.com/assets/6615106/11173205/0cfaa25c-8be1-11e5-8c51-92825217864e.png) | ![fixed-filerterheight](https://cloud.githubusercontent.com/assets/6615106/11173206/1124a422-8be1-11e5-87ae-f741aecda37d.png)

