### PR TITLE
Remove redundant `module.exports`/`exports`

### DIFF
--- a/admin/server/api/cloudinary.js
+++ b/admin/server/api/cloudinary.js
@@ -1,7 +1,7 @@
 var cloudinary = require('cloudinary');
 var keystone = require('../../../');
 
-exports = module.exports = {
+module.exports = {
 
 	upload: function(req, res) {
 		if(req.files && req.files.file){

--- a/admin/server/api/download.js
+++ b/admin/server/api/download.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 
 var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 
 	var filters = req.list.processFilters(req.query.q);
 	var queryFilters = req.list.getSearchFilters(req.query.search, filters);

--- a/admin/server/api/list.js
+++ b/admin/server/api/list.js
@@ -2,7 +2,7 @@ var _ = require('underscore');
 var async = require('async');
 var keystone = require('../../../');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 
 	var sendResponse = function(status) {
 		res.json(status);

--- a/admin/server/api/s3.js
+++ b/admin/server/api/s3.js
@@ -2,7 +2,7 @@ var knox = require('knox');
 var keystone = require('../../../');
 var Types = keystone.Field.Types;
 
-exports = module.exports = {
+module.exports = {
 
 	upload: function(req, res) {
 		if (!keystone.security.csrf.validate(req, req.body.authenticity_token)) {

--- a/admin/server/routes/home.js
+++ b/admin/server/routes/home.js
@@ -1,6 +1,6 @@
 var keystone = require('../../../');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 
 	keystone.render(req, res, 'home', {
 		section: 'home',

--- a/admin/server/routes/item.js
+++ b/admin/server/routes/item.js
@@ -2,7 +2,7 @@ var keystone = require('../../../');
 var _ = require('underscore');
 var async = require('async');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 
 	var itemQuery = req.list.model.findById(req.params.item).select();
 

--- a/admin/server/routes/list.js
+++ b/admin/server/routes/list.js
@@ -2,7 +2,7 @@ var keystone = require('../../../');
 var _ = require('underscore');
 var querystring = require('querystring');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 
 	var viewLocals = {
 		validationErrors: {},

--- a/admin/server/routes/signin.js
+++ b/admin/server/routes/signin.js
@@ -1,6 +1,6 @@
 var keystone = require('../../../');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 	keystone.render(req, res, 'signin', {
 		submitted: req.body,
 		from: req.query.from,

--- a/admin/server/routes/signout.js
+++ b/admin/server/routes/signout.js
@@ -1,7 +1,7 @@
 var keystone = require('../../../');
 var session = require('../../../lib/session');
 
-exports = module.exports = function(req, res) {
+module.exports = function(req, res) {
 	session.signout(req, res, function() {
 		if ('string' === typeof keystone.get('signout redirect')) {
 			return res.redirect(keystone.get('signout redirect'));

--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -199,7 +199,7 @@ Field.prototype.getPreSaveWatcher = function() {
 	};
 
 };
-exports = module.exports = Field;
+module.exports = Field;
 
 /** Getter properties for the Field prototype */
 Object.defineProperty(Field.prototype, 'size', { get: function() { return this.getSize(); } });

--- a/fields/types/azurefile/AzureFileType.js
+++ b/fields/types/azurefile/AzureFileType.js
@@ -335,4 +335,4 @@ azurefile.prototype.handleRequest = function(item, req, paths, callback) {
  * Export class
  */
 
-exports = module.exports = azurefile;
+module.exports = azurefile;

--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -57,4 +57,4 @@ boolean.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = boolean;
+module.exports = boolean;

--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -440,4 +440,4 @@ cloudinaryimage.prototype.handleRequest = function(item, req, paths, callback) {
 /*!
  * Export class
  */
-exports = module.exports = cloudinaryimage;
+module.exports = cloudinaryimage;

--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -353,4 +353,4 @@ cloudinaryimages.prototype.handleRequest = function(item, req, paths, callback) 
 /*!
  * Export class
  */
-exports = module.exports = cloudinaryimages;
+module.exports = cloudinaryimages;

--- a/fields/types/code/CodeType.js
+++ b/fields/types/code/CodeType.js
@@ -24,4 +24,4 @@ util.inherits(code, FieldType);
 code.prototype.addFilterToQuery = TextType.prototype.addFilterToQuery;
 
 /* Export Field Type */
-exports = module.exports = code;
+module.exports = code;

--- a/fields/types/color/ColorType.js
+++ b/fields/types/color/ColorType.js
@@ -17,4 +17,4 @@ util.inherits(color, FieldType);
 color.prototype.addFilterToQuery = TextType.prototype.addFilterToQuery;
 
 /* Export Field Type */
-exports = module.exports = color;
+module.exports = color;

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -136,4 +136,4 @@ date.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = date;
+module.exports = date;

--- a/fields/types/datearray/DateArrayType.js
+++ b/fields/types/datearray/DateArrayType.js
@@ -137,4 +137,4 @@ datearray.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = datearray;
+module.exports = datearray;

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -82,4 +82,4 @@ datetime.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = datetime;
+module.exports = datetime;

--- a/fields/types/email/EmailType.js
+++ b/fields/types/email/EmailType.js
@@ -69,4 +69,4 @@ email.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = email;
+module.exports = email;

--- a/fields/types/embedly/EmbedlyType.js
+++ b/fields/types/embedly/EmbedlyType.js
@@ -279,4 +279,4 @@ embedly.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = embedly;
+module.exports = embedly;

--- a/fields/types/geopoint/GeoPointType.js
+++ b/fields/types/geopoint/GeoPointType.js
@@ -134,4 +134,4 @@ geopoint.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = geopoint;
+module.exports = geopoint;

--- a/fields/types/html/HtmlType.js
+++ b/fields/types/html/HtmlType.js
@@ -21,4 +21,4 @@ util.inherits(html, FieldType);
 html.prototype.addFilterToQuery = TextType.prototype.addFilterToQuery;
 
 /* Export Field Type */
-exports = module.exports = html;
+module.exports = html;

--- a/fields/types/key/KeyType.js
+++ b/fields/types/key/KeyType.js
@@ -53,4 +53,4 @@ key.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = key;
+module.exports = key;

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -363,4 +363,4 @@ localfile.prototype.handleRequest = function(item, req, paths, callback) {
  * Export class
  */
 
-exports = module.exports = localfile;
+module.exports = localfile;

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -436,4 +436,4 @@ localfiles.prototype.handleRequest = function(item, req, paths, callback) {
  * Export class
  */
 
-exports = module.exports = localfiles;
+module.exports = localfiles;

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -487,4 +487,4 @@ location.prototype.milesFrom = function(item, point) {
 /*!
  * Export class
  */
-exports = module.exports = location;
+module.exports = location;

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -142,4 +142,4 @@ markdown.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = markdown;
+module.exports = markdown;

--- a/fields/types/money/MoneyType.js
+++ b/fields/types/money/MoneyType.js
@@ -46,4 +46,4 @@ money.prototype.format = function(item, format) {
 };
 
 /* Export Field Type */
-exports = module.exports = money;
+module.exports = money;

--- a/fields/types/name/NameType.js
+++ b/fields/types/name/NameType.js
@@ -177,4 +177,4 @@ name.prototype.updateItem = function(item, data) {
 
 
 /* Export Field Type */
-exports = module.exports = name;
+module.exports = name;

--- a/fields/types/number/NumberType.js
+++ b/fields/types/number/NumberType.js
@@ -99,4 +99,4 @@ number.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = number;
+module.exports = number;

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -142,4 +142,4 @@ numberarray.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = numberarray;
+module.exports = numberarray;

--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -147,4 +147,4 @@ password.prototype.updateItem = function(item, data) {
 };
 
 /* Export Field Type */
-exports = module.exports = password;
+module.exports = password;

--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -226,4 +226,4 @@ relationship.prototype.addFilters = function(query, item) {
 };
 
 /* Export Field Type */
-exports = module.exports = relationship;
+module.exports = relationship;

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -498,4 +498,4 @@ s3file.prototype.handleRequest = function(item, req, paths, callback) {
  * Export class
  */
 
-exports = module.exports = s3file;
+module.exports = s3file;

--- a/fields/types/select/SelectType.js
+++ b/fields/types/select/SelectType.js
@@ -143,4 +143,4 @@ select.prototype.format = function(item) {
 };
 
 /* Export Field Type */
-exports = module.exports = select;
+module.exports = select;

--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -44,4 +44,4 @@ text.prototype.crop = function(item, length, append, preserveWords) {
 };
 
 /* Export Field Type */
-exports = module.exports = text;
+module.exports = text;

--- a/fields/types/textarea/TextareaType.js
+++ b/fields/types/textarea/TextareaType.js
@@ -30,4 +30,4 @@ textarea.prototype.format = function(item) {
 };
 
 /* Export Field Type */
-exports = module.exports = textarea;
+module.exports = textarea;

--- a/fields/types/textarray/TextArrayType.js
+++ b/fields/types/textarray/TextArrayType.js
@@ -75,4 +75,4 @@ textarray.prototype.updateItem = function(item, data) {
  * Export class
  */
 
-exports = module.exports = textarray;
+module.exports = textarray;

--- a/fields/types/url/UrlType.js
+++ b/fields/types/url/UrlType.js
@@ -37,4 +37,4 @@ function removeProtocolPrefix(url) {
 // TODO: Proper url validation
 
 /* Export Field Type */
-exports = module.exports = url;
+module.exports = url;

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ Keystone.prototype.wrapHTMLError = require('./lib/core/wrapHTMLError');
  *
  * @api public
  */
-var keystone = module.exports = exports = new Keystone();
+var keystone = module.exports = new Keystone();
 
 // Expose modules and Classes
 keystone.Admin = {

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -239,7 +239,7 @@ Content.prototype.editable = function(user, options) {
  * @api public
  */
 
-module.exports = exports = new Content();
+module.exports = new Content();
 
 // Expose Classes
 exports.Page = require('./page');

--- a/lib/content/page.js
+++ b/lib/content/page.js
@@ -201,4 +201,4 @@ Page.prototype.clean = function(data) {
  * Export class
  */
 
-exports = module.exports = Page;
+module.exports = Page;

--- a/lib/content/type.js
+++ b/lib/content/type.js
@@ -12,4 +12,4 @@ var Type = function(path, options) { //eslint-disable-line no-unused-vars
  * Export class
  */
 
-module.exports = exports = Type;
+module.exports = Type;

--- a/lib/content/types/html.js
+++ b/lib/content/types/html.js
@@ -26,4 +26,4 @@ util.inherits(html, super_);
  * Export class
  */
 
-module.exports = exports = html;
+module.exports = html;

--- a/lib/content/types/text.js
+++ b/lib/content/types/text.js
@@ -26,4 +26,4 @@ util.inherits(text, super_);
  * Export class
  */
 
-module.exports = exports = text;
+module.exports = text;

--- a/lib/email.js
+++ b/lib/email.js
@@ -693,4 +693,4 @@ Email.templateCache = templateCache;
 Email.templateCSSMethods = templateCSSMethods;
 Email.defaults = defaultConfig;
 
-exports = module.exports = Email;
+module.exports = Email;

--- a/lib/list.js
+++ b/lib/list.js
@@ -179,4 +179,4 @@ List.prototype.underscoreMethod = require('./list/underscoreMethod');
 /*!
  * Export class
  */
-exports = module.exports = List;
+module.exports = List;

--- a/lib/middleware/api.js
+++ b/lib/middleware/api.js
@@ -20,7 +20,7 @@
 // a reference to the keystone instance, so it can be
 // passed as middeware to the express app.
 
-exports = module.exports = function(keystone) {
+module.exports = function(keystone) {
 	return function initAPI(req, res, next) {
 		
 		res.apiResponse = function(data) {

--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -15,7 +15,7 @@
 // a reference to the keystone instance, so it can be
 // passed as middeware to the express app.
 
-exports = module.exports = function(keystone) {
+module.exports = function(keystone) {
 	return function cors(req, res, next) {
 		
 		var origin = keystone.get('cors allow origin');

--- a/lib/path.js
+++ b/lib/path.js
@@ -6,7 +6,7 @@ var utils = require('keystone-utils');
  * @api public
  */
 
-exports = module.exports = function Path(str) {
+module.exports = function Path(str) {
 
 	if (!(this instanceof Path)) {
 		return new Path(str);

--- a/lib/security/frameGuard.js
+++ b/lib/security/frameGuard.js
@@ -11,7 +11,7 @@
  * @api public
  */
 
-exports = module.exports = function(keystone) {
+module.exports = function(keystone) {
 	return function frameGuard(req, res, next) {
 		var options = keystone.get('frame guard');
 		if (options) {

--- a/lib/security/ipRangeRestrict.js
+++ b/lib/security/ipRangeRestrict.js
@@ -22,8 +22,8 @@ var util = require('util');
  * @param {string} ipRanges
  * @param {function} wrapHTMLError
  */
-exports = module.exports = function(ipRanges, wrapHTMLError) {
 	
+module.exports = function(ipRanges, wrapHTMLError) {
 	/**
 	 * Returns an Express middleware.
 	 *

--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -297,4 +297,4 @@ UpdateHandler.prototype.process = function(data, options, callback) {
  * Export class
  */
 
-exports = module.exports = UpdateHandler;
+module.exports = UpdateHandler;

--- a/lib/view.js
+++ b/lib/view.js
@@ -36,7 +36,7 @@ function View(req, res) {
 
 }
 
-module.exports = exports = View;
+module.exports = View;
 
 
 /**

--- a/test/helpers/getKeystoneApp.js
+++ b/test/helpers/getKeystoneApp.js
@@ -3,9 +3,6 @@ var request = require('supertest');
 var _ = require('underscore');
 var exec = require('child_process').exec;
 
-var exports = module.exports = {};
-
-
 function testApp(request, page , server, done) {
 	server = server || keystone.httpServer;
 	request
@@ -16,7 +13,7 @@ function testApp(request, page , server, done) {
 			server.close();
 			done();
 		});
-	
+
 }
 
 var routes = function(app){
@@ -46,7 +43,7 @@ exports.startHttp = function startHttp(cb) {
 			}
 		}
 	});
-	
+
 }
 
 exports.startHttps = function startHttps(cb) {
@@ -92,7 +89,7 @@ exports.startSocket = function startSocket(cb) {
 					return cb(false);
 				}
 				return cb(true);
-			});	
+			});
 		}
 	});
 }


### PR DESCRIPTION
This PR removes redundant `module.exports`/`exports` statements.

If these have any meaning that I'm not aware of please enlighten me. :)