### PR TITLE
v0.3.x Branch: Fixing a bug introduced in 9d28478 on CloudinaryImages

### DIFF
--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -337,8 +337,6 @@ cloudinaryimages.prototype.getRequestHandler = function(item, req, paths, callba
 
 				if (field.options.filenameAsPublicID) {
 					uploadOptions.public_id = file.originalname.substring(0, file.originalname.lastIndexOf('.'));
-				} else {
-					uploadOptions = undefined;
 				}
 
 				cloudinary.uploader.upload(file.path, function(result) {


### PR DESCRIPTION
[See commit (& discussion) here](https://github.com/keystonejs/keystone/commit/9d28478f208aa722470a99a863f5e642b029de0e).

Bugfix from 9d28478 (CloudinaryImagesType - filenameAsPublicID).

Same fix as PR #1843 but for the v0.3.x branch.