### PR TITLE
Markdown fields: added posibility of configure marked options, fixed #1798

### DIFF
--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -20,12 +20,13 @@ function markdown(list, path, options) {
 	options.nofilter = true;
 
 	this.toolbarOptions = options.toolbarOptions || {};
+	this.markedOptions = options.markedOptions || {};
 	this.height = options.height || 90;
 
 	// since wysiwyg option can be falsey this needs to use `in` instead of ||
 	this.wysiwyg = ('wysiwyg' in options) ? options.wysiwyg : true;
 
-	this._properties = ['wysiwyg', 'height', 'toolbarOptions'];
+	this._properties = ['wysiwyg', 'height', 'toolbarOptions', 'markedOptions'];
 
 	markdown.super_.call(this, list, path, options);
 
@@ -56,6 +57,8 @@ markdown.prototype.addToSchema = function() {
 		html: this._path.append('.html')
 	};
 
+	var markedOptions = this.markedOptions;
+
 	var setMarkdown = function(value) {
 
 		if (value === this.get(paths.md)) {
@@ -63,7 +66,7 @@ markdown.prototype.addToSchema = function() {
 		}
 
 		if (typeof value === 'string') {
-			this.set(paths.html, marked(value));
+			this.set(paths.html, marked(value, markedOptions));
 			return value;
 		} else {
 			this.set(paths.html, undefined);

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -26,7 +26,7 @@ function markdown(list, path, options) {
 	// since wysiwyg option can be falsey this needs to use `in` instead of ||
 	this.wysiwyg = ('wysiwyg' in options) ? options.wysiwyg : true;
 
-	this._properties = ['wysiwyg', 'height', 'toolbarOptions', 'markedOptions'];
+	this._properties = ['wysiwyg', 'height', 'toolbarOptions'];
 
 	markdown.super_.call(this, list, path, options);
 

--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -40,7 +40,7 @@ function render(req, res, view, ext) {
 	_.each(keystone.lists, function(list, key) {
 		lists[key] = list.getOptions();
 	});
-
+	
 	var locals = {
 		_: _,
 		env: keystone.get('env'),


### PR DESCRIPTION
This adds the feature of adding `markedOptions` to any markdown field.

Im my case, i needed it so i could do this:

````javascript
  content: {
    type: Types.Markdown,
    markedOptions: {
      gfm: true,
      highlight: function(code, lang) {
        var result = highlight.highlight(lang, code);
        return '<pre class="hljs"><code>' + result.value + '</code></pre>';
      }
    },
    height: 600
  },
````

I'm using https://github.com/isagalaev/highlight.js to format my custom languages

@creynders I've head you! Hope this gets merged soon. Cheers.