### PR TITLE
Clean up of the Page content type

### DIFF
--- a/lib/content/page.js
+++ b/lib/content/page.js
@@ -1,4 +1,5 @@
 var _ = require('underscore'),
+	assign = require('object-assign'),
 	keystone = require('../../'),
 	utils = keystone.utils,
 	Type = require('./type');
@@ -16,11 +17,8 @@ function Page(key, options) {
 	if (!(this instanceof Page)) {
 		return new Page(key, options);
 	}
-	
-	this.options = utils.options({
-		// ...
-	}, options);
-	
+
+	this.options = assign({}, options);
 	this.key = key;
 	this.fields = {};
 	
@@ -33,7 +31,7 @@ Object.defineProperty(Page.prototype, 'name', {
 });
 
 /**
- * Sets page options
+ * Sets page option
  *
  * ####Example:
  *
@@ -41,15 +39,17 @@ Object.defineProperty(Page.prototype, 'name', {
  *
  * @param {String} key
  * @param {String} value
+ * @return value
  * @api public
  */
 
 Page.prototype.set = function(key, value) {
-	
-	if (arguments.length === 1) {
-		return this.options[key];
+
+	if (!key) {
+		throw new Error('keystone.content.Page.set() Error: must be provided with a key to set a value.');
 	}
-	
+
+	value = value || null;
 	this.options[key] = value;
 	return value;
 	
@@ -57,18 +57,29 @@ Page.prototype.set = function(key, value) {
 
 
 /**
- * Gets page options
+ * Gets page option
  *
  * ####Example:
  *
- *     page.get('test') // returns the 'test' value
+ *     page.get('test') // returns the value of 'test' key
  *
  * @param {String} key
+ * @return any
  * @method get
  * @api public
  */
 
-Page.prototype.get = Page.prototype.set;
+Page.prototype.get = function(key) {
+	if (!key) {
+		throw new Error('keystone.content.Paget.get() Error: must be provided with a key to get a value.');
+	}
+
+	if (!this.options.hasOwnProperty(key)) {
+		return null;
+	}
+
+	return this.options[key];
+};
 
 /**
  * Adds one or more fields to the page
@@ -90,7 +101,7 @@ Page.prototype.add = function(fields) {
 		}
 		
 		if ('function' !== typeof options.type) {
-			throw new Error('Page fields must be specified with a type function');
+			throw new Error('keystone.content.page.add() Error: Page fields must be specified with a type function');
 		}
 		
 		if (options.type.prototype.__proto__ !== Type.prototype) {
@@ -110,7 +121,7 @@ Page.prototype.add = function(fields) {
 			// 	options.type = Field.Types.Datetime;
 			
 			else {
-				throw new Error('Unrecognised field constructor: ' + options.type);
+				throw new Error('keystone.content.page.add() Error: Unrecognised field constructor: ' + options.type);
 			}
 			
 		}
@@ -149,8 +160,8 @@ Page.prototype.register = function() {
  */
 
 Page.prototype.populate = function(data) {
-	
-	if (!utils.isObject(data)) {
+
+	if (typeof data !== 'object') {
 		data = {};
 	}
 	
@@ -167,8 +178,8 @@ Page.prototype.populate = function(data) {
  */
 
 Page.prototype.validate = function(data) {
-	
-	if (!_.isObject(data)) {
+
+	if (typeof data !== 'object') {
 		data = {};
 	}
 	
@@ -185,8 +196,8 @@ Page.prototype.validate = function(data) {
  */
 
 Page.prototype.clean = function(data) {
-	
-	if (!_.isObject(data)) {
+
+	if (typeof data !== 'object') {
 		data = {};
 	}
 	


### PR DESCRIPTION
#### Changes

- Page.set/Page.get should be pure and more strict.
- Removed `_.isObject` since the [implementation](https://github.com/jashkenas/underscore/blob/master/underscore.js#L1282) would pass the if-statement if a function is sent in instead.
- Removed `utils.options` since the [implementation](https://github.com/keystonejs/keystone-utils/blob/master/lib/index.js#L159) mutates the options passed in by the consumer of the API. Best practice is extend the default options of the class, which I presumed was the intent and the code should express that
- Updated the error messages to consistently begin with `keystone.content.Page`