### PR TITLE
Drop unused options.mandrillAPI

### DIFF
--- a/lib/core/options.js
+++ b/lib/core/options.js
@@ -57,12 +57,6 @@ module.exports = function options () {
 				}
 				value = cloudinary.config();
 			break;
-			case 'mandrill api key':
-				if (value) {
-					debug('found mandril key');
-					this.mandrillAPI = new mandrillapi.Mandrill(value);
-				}
-			break;
 			case 'auth':
 				if (value === true && !this.get('session')) {
 					debug('setting session for auth');


### PR DESCRIPTION
`option.mandrilAPI` is not used, i.e. it's an unused instance.
In https://github.com/keystonejs/keystone/blob/master/lib/email.js#L427 an option `mandrill` is set, not mandrillAPI.

TBH this is the reason why I think the `options` module should be replaced with a dedicated (3rd party) module, which allows strict getting and setting of options, it would be nice if an error was thrown or a warning issued whenever trying to retrieve/store an undeclared option.

Also, we _really_ have to move towards lazy instantiation, it will drastically reduce bootstrap times. I.e. I'll try to find some time to work on the DI lib :grin: 