### PR TITLE
Move the confirmation dialog from `EditForm` to own reusable component

### DIFF
--- a/admin/client/components/ConfirmationDialog.js
+++ b/admin/client/components/ConfirmationDialog.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Modal, ModalBody, ModalFooter, Button } from 'elemental';
+
+module.exports = React.createClass({
+	displayName: 'ConfirmationDialog',
+
+	propTypes: {
+		body: React.PropTypes.string.isRequired,
+		cancelLabel: React.PropTypes.string,
+		confirmationLabel: React.PropTypes.string,
+		onCancel: React.PropTypes.func.isRequired,
+		onConfirmation: React.PropTypes.func.isRequired,
+	},
+
+	getDefaultProps () {
+		return {
+			cancelLabel: 'Cancel',
+			confirmationLabel: 'Ok',
+		};
+	},
+
+	getBodyHtml () {
+		return {
+			__html: this.props.body
+		};
+	},
+
+	render () {
+		return (
+			<Modal onCancel={this.props.onCancel} width={400} isOpen backdropClosesModal>
+				<ModalBody>
+					<div dangerouslySetInnerHTML={this.getBodyHtml()} />
+				</ModalBody>
+				<ModalFooter>
+					<Button size="sm" type="danger" onClick={this.props.onConfirmation}>
+						{this.props.confirmationLabel}
+					</Button>
+					<Button size="sm" type="link-cancel" onClick={this.props.onCancel}>
+						{this.props.cancelLabel}
+					</Button>
+				</ModalFooter>
+			</Modal>
+		);
+	}
+});


### PR DESCRIPTION
I refactored the `EditForm` component a bit by moving out the confirmation dialog to an own component so we're able to reuse it in other places and have a better [SOC](https://en.wikipedia.org/wiki/Separation_of_concerns).