### PR TITLE
Removed redudant code

### DIFF
--- a/admin/client/lib/List.js
+++ b/admin/client/lib/List.js
@@ -181,8 +181,4 @@ List.prototype.deleteItems = function (itemIds, callback) {
 	});
 };
 
-List.prototype.deleteItem = function (itemId, callback) {
-	return this.deleteItems([itemId], callback);
-};
-
 module.exports = List;


### PR DESCRIPTION
```
List.prototype.deleteItem = function (itemId, callback) {
	this.deleteItems([itemId], callback);
};
```

is a redundant implementation, since this declaration already existed on [L161](https://github.com/keystonejs/keystone/blob/master/admin/client/lib/List.js#L161)