### PR TITLE
Show thumbnails when available in the admin UI instead of whole images

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -201,7 +201,16 @@ module.exports = Field.create({
 	},
 
 	renderImagePreviewThumbnail () {
-		return <img key={this.props.path + '_preview_thumbnail'} className="img-load" style={ { height: '90' } } src={this.getImageSource()} />;
+		var url = this.getImageURL();
+
+		if (url) {
+			// add cloudinary thumbnail parameters to the url
+			url = url.replace(/image\/upload/, 'image/upload/c_thumb,g_face,h_90,w_90');
+		} else {
+			url = this.getImageSource();
+		}
+
+		return <img key={this.props.path + '_preview_thumbnail'} className="img-load" style={ { height: '90' } } src={url} />;
 	},
 
 	/**


### PR DESCRIPTION
Currently whole source images is loaded in the admin UI even if they're only shown as 90*90 px thumbnails. In this commit the images are resized to thumbnail sizes with the Cloudinary service before they're sent to the user.

Before:
<img width="891" alt="" src="https://cloud.githubusercontent.com/assets/76098/11548766/c463a20a-992d-11e5-930c-ae26d29d104e.png">

After:
<img width="880" alt="" src="https://cloud.githubusercontent.com/assets/76098/11548769/c773ff9e-992d-11e5-9c0c-1ace36c4e922.png">
