### PR TITLE
add babelify to browserify source transforms, closes #1865

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   },
   "browserify": {
     "transform": [
+      "babelify",
       "browserify-shim"
     ]
   },


### PR DESCRIPTION
See https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed