### PR TITLE
Fix: Date fields default to Date.now()

### DIFF
--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -63,7 +63,7 @@ module.exports = Field.create({
 
 	renderField () {
 		let value = moment(this.props.value);
-		value = value.isValid() ? value.format(this.props.inputFormat) : this.props.value;
+		value = this.props.value && value.isValid() ? value.format(this.props.inputFormat) : this.props.value;
 		return (
 			<InputGroup>
 				<InputGroup.Section grow>

--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -19,8 +19,8 @@ module.exports = Field.create({
 
 	getInitialState () {
 		return {
-			dateValue: this.props.value ? this.moment(this.props.value).format(this.dateInputFormat) : this.moment(new Date()).format(this.dateInputFormat),
-			timeValue: this.props.value ? this.moment(this.props.value).format(this.timeInputFormat) : this.moment(new Date()).format(this.timeInputFormat)
+			dateValue: this.props.value && this.moment(this.props.value).format(this.dateInputFormat),
+			timeValue: this.props.value && this.moment(this.props.value).format(this.timeInputFormat)
 		};
 	},
 


### PR DESCRIPTION
Proposed fix for https://github.com/keystonejs/keystone/issues/1977 