### PR TITLE
Apply CodeField's height property to its CodeMirror instance

### DIFF
--- a/fields/types/code/CodeField.js
+++ b/fields/types/code/CodeField.js
@@ -35,6 +35,7 @@ module.exports = Field.create({
 		});
 
 		this.codeMirror = CodeMirror.fromTextArea(ReactDOM.findDOMNode(this.refs.codemirror), options);
+		this.codeMirror.setSize(undefined, this.props.height);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));


### PR DESCRIPTION
Fix for https://github.com/keystonejs/keystone/issues/2009. Apply the height property given to CodeField to the CodeMirror instance.