### PR TITLE
Change indicating width not to be changed when setting height of CodeMirror instance in CodeField to comply with its documentation

### DIFF
--- a/fields/types/code/CodeField.js
+++ b/fields/types/code/CodeField.js
@@ -35,7 +35,7 @@ module.exports = Field.create({
 		});
 
 		this.codeMirror = CodeMirror.fromTextArea(ReactDOM.findDOMNode(this.refs.codemirror), options);
-		this.codeMirror.setSize(undefined, this.props.height);
+		this.codeMirror.setSize(null, this.props.height);
 		this.codeMirror.on('change', this.codemirrorValueChanged);
 		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
 		this.codeMirror.on('blur', this.focusChanged.bind(this, false));


### PR DESCRIPTION
Change indicating width not to be changed when setting height of CodeMirror instance in CodeField to comply with its documentation. As suggested as an improvement on https://github.com/keystonejs/keystone/pull/2016 in order to fix https://github.com/keystonejs/keystone/issues/2009.