### PR TITLE
use displayName package to get full name

### DIFF
--- a/fields/types/name/NameColumn.js
+++ b/fields/types/name/NameColumn.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ItemsTableCell from '../../../admin/client/components/ItemsTableCell';
 import ItemsTableValue from '../../../admin/client/components/ItemsTableValue';
+import displayName from 'display-name';
 
 var NameColumn = React.createClass({
 	displayName: 'NameColumn',
@@ -12,7 +13,7 @@ var NameColumn = React.createClass({
 	renderValue () {
 		var value = this.props.data.fields[this.props.col.path];
 		if (!value || (!value.first && !value.last)) return '(no name)';
-		return [value.first, value.last].filter(i => i).join(' ');
+		return displayName(value.first, value.last);
 	},
 	render () {
 		return (

--- a/fields/types/name/NameType.js
+++ b/fields/types/name/NameType.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var FieldType = require('../Type');
 var util = require('util');
 var utils = require('keystone-utils');
+var displayName = require('display-name');
 
 /**
  * Name FieldType Constructor
@@ -41,7 +42,7 @@ name.prototype.addToSchema = function() {
 	}, this.path + '.');
 
 	schema.virtual(paths.full).get(function () {
-		return _.compact([this.get(paths.first), this.get(paths.last)]).join(' ');
+		return displayName(this.get(paths.first), this.get(paths.last));
 	});
 
 	schema.virtual(paths.full).set(function(value) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "connect-flash": "0.1.1",
     "cookie-parser": "1.4.0",
     "debug": "2.2.0",
+    "display-name": "0.1.0",
     "elemental": "0.5.11",
     "embedly": "1.0.4",
     "errorhandler": "1.4.2",


### PR DESCRIPTION
Use [this package](https://github.com/teaualune/displayName) for generating `full` property of field type `Name`.

The purpose of this PR is that the first/last name combination rule in Chinese and Japanese are different from English, and this package ensures the correct combination by detecting strings with regex. This feature would be great for Chinese users, thanks!