### PR TITLE
Express is a factory

### DIFF
--- a/server/createApp.js
+++ b/server/createApp.js
@@ -9,7 +9,7 @@ module.exports = function createApp (keystone, express) {
 		if (!express) {
 			express = require('express');
 		}
-		keystone.app = new express();
+		keystone.app = express();
 	}
 
 	var app = keystone.app;


### PR DESCRIPTION
Express is a factory. No need for `new` here.

See every express doc:

```js
var express = require('express');
var app = express();
```