### PR TITLE
Custom Logging Middleware for v0.3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var moduleRoot = (function(_rootPath) {
  * @api public
  */
 var Keystone = function() {
-	grappling.mixin(this).allowHooks('pre:static', 'pre:bodyparser', 'pre:session', 'pre:routes', 'pre:render', 'updates', 'signout', 'signin');
+	grappling.mixin(this).allowHooks('pre:static', 'pre:bodyparser', 'pre:session', 'pre:routes', 'pre:render', 'updates', 'signout', 'signin', 'logger');
 	this.lists = {};
 	this.paths = {};
 	this._options = {

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -358,6 +358,17 @@ function mount(mountPath, parentApp, events) {
 		app.use(morgan(this.get('logger'), this.get('logger options')));
 	}
 
+	// If the user wants to define their own middleware for logging,
+	// they should be able to
+	if (keystone.get('logging middleware')) {
+		app.use(keystone.get('logging middleware'));
+	}
+
+	// We should also allow custom logging middleware to exist in the normal middleware flow
+	app.use(function(req, res, next) {
+		keystone.callHook('logger', req, res, next);
+	});
+
 	// Pre bodyparser middleware
 	if ('function' === typeof this.get('pre:bodyparser')) {
 		debug('configuring pre:bodyparser middleware');


### PR DESCRIPTION
I would love to have the ability to define my own custom logging middleware. To be honest, I'd prefer to use Winston to Morgan, if I could.

This is a PR for v0.3.x that does just this.

I allow for two different manners of defining this.

* One is through an option on the keystone init.
* One is through the normal middleware hook, so that people will be able to use their normal middleware workflow rather than putting it in a weird place.