### PR TITLE
Drag drop styles

### DIFF
--- a/admin/client/components/ItemsTableDragDropZoneTarget.js
+++ b/admin/client/components/ItemsTableDragDropZoneTarget.js
@@ -76,6 +76,9 @@ const dropTarget = {
 	canDrop (props, monitor) {
 		// if we drop on a page target, move the item to the correct first or last position in the new page
 		// if we want to stop this behaviour set return false
+		
+		if (!Keystone.devMode) return;
+		
 		const original = CurrentListStore.getDragBase();
 		// self
 		if (original.page === props.page) {

--- a/admin/public/styles/keystone/list-dropzone.less
+++ b/admin/public/styles/keystone/list-dropzone.less
@@ -29,12 +29,13 @@
 	width: 75px;
 	padding:10px;
 	margin: 5px;
-	border: 1px dashed @gray-light;
+	
 	font-weight: normal;
 	font-size: 12px;
 	cursor: pointer;
 	&:hover {
 		background-color: white;
+		border: 1px solid @gray-lighter;
 	}
 	&.is-active {
 		background-color: @gray-lighter;


### PR DESCRIPTION
Mirrored pagination styling.

Placed drop on page target into dev mode.  Dropping on a page target requires a sane `sortOrder`, which requires additional methods when removing items and final order sanity checks.  