### PR TITLE
prevent admin js error for empty signout value

### DIFF
--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -52,7 +52,7 @@ function render(req, res, view, ext) {
 		userModel: keystone.get('user model'),
 		user: req.user,
 		title: 'Keystone',
-		signout: keystone.get('signout url'),
+		signout: keystone.get('signout url') || null,
 		adminPath: '/' + keystone.get('admin path'),
 		backUrl: keystone.get('back url') || '/',
 		section: {},


### PR DESCRIPTION
If `signout url` is not set, `keystone.jade` will render the following code:

```javascript
Keystone.signoutUrl = ;
```

which turns into a syntax error and blocks the following code execution in the browser.

Setting the empty `signout url` explicitly to `null` prevents this problem.