### PR TITLE
use serialize-javascript to render variables into jade

### DIFF
--- a/admin/server/templates/home.jade
+++ b/admin/server/templates/home.jade
@@ -13,8 +13,8 @@ html
 		include includes/script/keystone
 		- var getListMeta = function(list) { return _.pick(list, ['key', 'label', 'path']); }
 		script.
-			Keystone.lists = !{JSON.stringify(_.map(lists, getListMeta))};
-			Keystone.orphanedLists = !{JSON.stringify(orphanedLists.map(getListMeta))};
+			Keystone.lists = !{serializeJavaScript(_.map(lists, getListMeta))};
+			Keystone.orphanedLists = !{serializeJavaScript(orphanedLists.map(getListMeta))};
 		script(src="#{adminPath}/js/lib/underscore/underscore-1.5.1.min.js")
 		script(src="#{adminPath}/js/packages.js")
 		script(src="#{adminPath}/js/home.js")

--- a/admin/server/templates/includes/script/keystone.jade
+++ b/admin/server/templates/includes/script/keystone.jade
@@ -1,16 +1,16 @@
 script.
 	var Keystone = {};
-	Keystone.adminPath = !{JSON.stringify(adminPath)};
-	Keystone.backUrl = !{JSON.stringify(backUrl)};
-	Keystone.user = !{JSON.stringify(user)};
-	Keystone.version = !{JSON.stringify(version)};
+	Keystone.adminPath = !{serializeJavaScript(adminPath)};
+	Keystone.backUrl = !{serializeJavaScript(backUrl)};
+	Keystone.user = !{serializeJavaScript(user)};
+	Keystone.version = !{serializeJavaScript(version)};
 	Keystone.devMode = !{process.env.KEYSTONE_DEV ? 'true' : 'false'};
 	
-	Keystone.brand = !{JSON.stringify(brand)};
-	Keystone.nav = !{JSON.stringify(nav)};
-	Keystone.nav.currentSection = !{JSON.stringify(section)};
-	Keystone.messages = !{JSON.stringify(messages)};
-	Keystone.signoutUrl = !{JSON.stringify(signout)};
+	Keystone.brand = !{serializeJavaScript(brand)};
+	Keystone.nav = !{serializeJavaScript(nav)};
+	Keystone.nav.currentSection = !{serializeJavaScript(section)};
+	Keystone.messages = !{serializeJavaScript(messages)};
+	Keystone.signoutUrl = !{serializeJavaScript(signout)};
 	Keystone.csrf = function(obj) {
 		obj['#{csrf_token_key}'] = "#{csrf_token_value}";
 		return obj;

--- a/admin/server/templates/item.jade
+++ b/admin/server/templates/item.jade
@@ -21,9 +21,9 @@ html
 		include includes/script/keystone
 		include includes/script/components
 		script.
-			Keystone.lists = !{JSON.stringify(lists)};
-			Keystone.list = Keystone.lists[!{JSON.stringify(list.key)}];
-			Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
+			Keystone.lists = !{serializeJavaScript(lists)};
+			Keystone.list = Keystone.lists[!{serializeJavaScript(list.key)}];
+			Keystone.wysiwyg = { options: !{serializeJavaScript(wysiwygOptions)} };
 			Keystone.itemId = '!{item.id}';
 		script(src='#{adminPath}/js/packages.js')
 		script(src='#{adminPath}/js/fields.js')

--- a/admin/server/templates/list.jade
+++ b/admin/server/templates/list.jade
@@ -21,13 +21,13 @@ html
 		include includes/script/keystone
 		include includes/script/components
 		script.
-			Keystone.lists = !{JSON.stringify(lists)};
-			Keystone.list = Keystone.lists[!{JSON.stringify(list.key)}];
-			Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
+			Keystone.lists = !{serializeJavaScript(lists)};
+			Keystone.list = Keystone.lists[!{serializeJavaScript(list.key)}];
+			Keystone.wysiwyg = { options: !{serializeJavaScript(wysiwygOptions)} };
 			// Support for the POST-based create process
-			Keystone.showCreateForm = !{JSON.stringify(showCreateForm)};
-			Keystone.createFormData = !{JSON.stringify(submitted)};
-			Keystone.createFormErrors = !{JSON.stringify(createErrors || null)};
+			Keystone.showCreateForm = !{serializeJavaScript(showCreateForm)};
+			Keystone.createFormData = !{serializeJavaScript(submitted)};
+			Keystone.createFormErrors = !{serializeJavaScript(createErrors || null)};
 		script(src='#{adminPath}/js/packages.js')
 		script(src='#{adminPath}/js/fields.js')
 		script(src='#{adminPath}/js/list.js')

--- a/admin/server/templates/signin.jade
+++ b/admin/server/templates/signin.jade
@@ -11,11 +11,11 @@ html
 		script(src='#{adminPath}/js/packages.js')
 		script.
 			var Keystone = {
-				adminPath: !{JSON.stringify(adminPath)},
-				brand: !{JSON.stringify(brand || '')},
-				logo: !{JSON.stringify(logo || '')},
-				messages: !{JSON.stringify(messages || '')},
-				user: !{JSON.stringify(user || null)},
+				adminPath: !{serializeJavaScript(adminPath)},
+				brand: !{serializeJavaScript(brand || '')},
+				logo: !{serializeJavaScript(logo || '')},
+				messages: !{serializeJavaScript(messages || '')},
+				user: !{serializeJavaScript(user || null)},
 				userCanAccessKeystone: !{user && user.canAccessKeystone ? 'true' : 'false'},
 			};
 		script(src='#{adminPath}/js/signin.js')

--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var cloudinary = require('cloudinary');
 var fs = require('fs');
 var jade = require('jade');
+var serializeJavaScript = require('serialize-javascript');
 
 /**
  * Renders a Keystone View
@@ -43,6 +44,7 @@ function render(req, res, view, ext) {
 	
 	var locals = {
 		_: _,
+		serializeJavaScript: serializeJavaScript,
 		env: keystone.get('env'),
 		brand: keystone.get('brand'),
 		appversion : keystone.get('appversion'),

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-select": "1.0.0-beta8",
     "scmp": "1.0.0",
     "semver": "5.1.0",
+    "serialize-javascript": "1.1.2",
     "serve-favicon": "2.3.0",
     "store-prototype": "1.1.1",
     "superagent": "1.6.1",


### PR DESCRIPTION
Worth giving [serialize-javascript](https://github.com/yahoo/serialize-javascript) a try, since it is designed specifically to handle this use case, *e.g.* auto escaping `<script>` strings.