### PR TITLE
Add new sortable list items to the front of the list

### DIFF
--- a/admin/public/styles/keystone/list-dropzone.less
+++ b/admin/public/styles/keystone/list-dropzone.less
@@ -41,10 +41,9 @@
 		background-color: @gray-lighter;
 	}
 	&.is-waiting {
-		background-color: @app-primary;
-		color: white;
+		background-color: white;
 	}
 	&.is-available {
-		background-color: @app-success;
+		background-color: lighten(@app-success, 40%);
 	}
 }

--- a/lib/schemaPlugins/sortable.js
+++ b/lib/schemaPlugins/sortable.js
@@ -17,9 +17,9 @@ module.exports = function sortable() {
 		var addLast = function(done) {
 			list.model.findOne().sort('-sortOrder').exec(function(err, max) {// eslint-disable-line no-unused-vars, handle-callback-err
 				item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
-				next();
+				done();
 			});
-		}
+		};
 		
 		if(list.get('sortable') === 'unshift') {
 			list.model.where('sortOrder')
@@ -29,7 +29,7 @@ module.exports = function sortable() {
 					function (err) {
 						if(err) {
 							console.log('err', err);
-							return addLast();
+							return addLast( next );
 						}
 						item.sortOrder = 1;
 						next();
@@ -37,7 +37,7 @@ module.exports = function sortable() {
 				);		
 			
 		} else {
-			addLast();
+			addLast( next );
 			
 		}
 	});

--- a/lib/schemaPlugins/sortable.js
+++ b/lib/schemaPlugins/sortable.js
@@ -13,11 +13,33 @@ module.exports = function sortable() {
 		}
 
 		var item = this;
-		list.model.findOne().sort('-sortOrder').exec(function(err, max) {// eslint-disable-line no-unused-vars, handle-callback-err
-			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
-			next();
-		});
-
+		
+		var addLast = function(done) {
+			list.model.findOne().sort('-sortOrder').exec(function(err, max) {// eslint-disable-line no-unused-vars, handle-callback-err
+				item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
+				next();
+			});
+		}
+		
+		if(list.get('sortable') === 'unshift') {
+			list.model.where('sortOrder')
+				.setOptions({ multi: true })
+				.update(
+					{ $inc: { 'sortOrder': 1 } },
+					function (err) {
+						if(err) {
+							console.log('err', err);
+							return addLast();
+						}
+						item.sortOrder = 1;
+						next();
+					}
+				);		
+			
+		} else {
+			addLast();
+			
+		}
 	});
 	
 	this.schema.statics.reorderItems = function reorderItems(id, prevOrder, newOrder, cb) {


### PR DESCRIPTION
Allows `sortable` to be set to `unshift` which adds each item as number **1** and increments the current entries.