### PR TITLE
Refactor Pagination to allow optional expressions

### DIFF
--- a/lib/list/paginate.js
+++ b/lib/list/paginate.js
@@ -19,7 +19,8 @@ function paginate (options, callback) {
 
 	options = options || {};
 
-	var query = model.find(options.filters);
+	var query = model.find(options.filters, options.optionalExpression);
+	var countQuery = model.find(options.filters);
 
 	query._original_exec = query.exec;
 	query._original_sort = query.sort;
@@ -46,8 +47,8 @@ function paginate (options, callback) {
 	};
 
 	query.exec = function (callback) {
-		query.count(function (err, count) {
-			if (err) return callback(err);
+		countQuery.count(function(err, count) {
+			if (err) callback(err);
 
 			query.find().limit(resultsPerPage).skip(skip);
 


### PR DESCRIPTION
## Rationale
A user may want to paginate results that are from a full text search where an extra expression is used for sorting. Example:

    Product.paginate({
            page: req.query.page || 1,
            perPage: 1,
            filters: {
                $text: { $search: req.query.searchTerm || '' }
            },
            optionalExpression: {
                score: { $meta: 'textScore' }
            }
        })
        .sort({
            score: { $meta: 'textScore' }
        })
        .exec(function(error, results) {
            locals.results = results;
            next(error);
        });

## Problem
- The current implementation of [lib/list/paginate.js](https://github.com/keystonejs/keystone/blob/master/lib/list/paginate.js) does not allow for extra expressions to be passed to `model.find()`
- When extra metadata is added to the find statement, it interferes with the `query.count()` operation, causing it to fail with:
    
    ```Error: field selection and slice cannot be used with count```

## Solution
- Added `options.optionalExpression` value to `model.find()`. This allows an additional object to be passed to the find method. If `options.optionalExpression` is undefined, the `.find()` operation is unaffected.
- Added an additional query that does not include the `optionalExpression` object to perform the count of objects. This allows the count to be performed without additional parameters. See: https://github.com/aheckmann/mquery/issues/55 for more information.

## Testing / Linting
- All tests are passing via: `npm test`
- No jslint errors