### PR TITLE
feature(Roles & Permissions): initial support

### DIFF
--- a/admin/client/components/EditForm.js
+++ b/admin/client/components/EditForm.js
@@ -154,21 +154,35 @@ var EditForm = React.createClass({
 		}, this);
 	},
 	renderFooterBar () {
-		var buttons = [
-			<Button key="save" type="primary" submit>Save</Button>
-		];
-		buttons.push(
-			<Button key="reset" onClick={this.confirmReset} type="link-cancel">
-				<ResponsiveText hiddenXS="reset changes" visibleXS="reset" />
-			</Button>
-		);
-		if (!this.props.list.nodelete) {
+		if (this.props.list.noedit) return null;
+
+		let hasListUpdatePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.update.indexOf(n) != -1;
+			}).length > 0;
+
+		if (hasListUpdatePermissions) {
+			var buttons = [
+				<Button key="save" type="primary" submit>Save</Button>
+			];
+			buttons.push(
+				<Button key="reset" onClick={this.confirmReset} type="link-cancel">
+					<ResponsiveText hiddenXS="reset changes" visibleXS="reset"/>
+				</Button>
+			);
+		}
+
+		let hasListDeletePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.delete.indexOf(n) != -1;
+			}).length > 0;
+
+		if (hasListDeletePermissions) {
 			buttons.push(
 				<Button key="del" onClick={this.confirmDelete} type="link-delete" className="u-float-right">
 					<ResponsiveText hiddenXS={`delete ${this.props.list.singular.toLowerCase()}`} visibleXS="delete" />
 				</Button>
 			);
 		}
+
 		return (
 			<FooterBar className="EditForm__footer">
 				{buttons}

--- a/admin/client/components/EditFormHeader.js
+++ b/admin/client/components/EditFormHeader.js
@@ -108,6 +108,12 @@ var Header = React.createClass({
 	renderCreateButton () {
 		if (this.props.list.nocreate) return null;
 
+		let hasListCreatePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.create.indexOf(n) != -1;
+			}).length > 0;
+
+		if (!hasListCreatePermissions) return null;
+
 		var props = {};
 		if (this.props.list.autocreate) {
 			props.href = '?new' + Keystone.csrf.query;

--- a/admin/client/components/ItemsTable.js
+++ b/admin/client/components/ItemsTable.js
@@ -14,11 +14,18 @@ const ItemsTable = React.createClass({
 		columns: React.PropTypes.array,
 		items: React.PropTypes.object,
 		list: React.PropTypes.object,
+		user: React.PropTypes.object,
+		permissions: React.PropTypes.object,
 	},
 	renderCols () {
 		var cols = this.props.columns.map((col) => <col width={col.width} key={col.path} />);
+
+		let hasListDeletePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.delete.indexOf(n) != -1;
+			}).length > 0;
+
 		// add delete col when applicable
-		if (!this.props.list.nodelete) {
+		if (!this.props.list.nodelete && hasListDeletePermissions) {
 			cols.unshift(<col width={TABLE_CONTROL_COLUMN_WIDTH} key="delete" />);
 		}
 		// add sort col when applicable
@@ -28,12 +35,16 @@ const ItemsTable = React.createClass({
 		return <colgroup>{cols}</colgroup>;
 	},
 	renderHeaders () {
+		let hasListDeletePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.delete.indexOf(n) != -1;
+			}).length > 0;
+
 		var cells = this.props.columns.map((col, i) => {
 			// span first col for controls when present
 			var span = 1;
 			if (!i) {
 				if (this.props.list.sortable) span++;
-				if (!this.props.list.nodelete) span++;
+				if (!this.props.list.nodelete || hasListDeletePermissions) span++;
 			}
 			return <th key={col.path} colSpan={span}>{col.label}</th>;
 		});

--- a/admin/client/components/ItemsTableRow.js
+++ b/admin/client/components/ItemsTableRow.js
@@ -42,7 +42,11 @@ const ItemsRow = React.createClass({
 		}
 
 		// add delete/check icon when applicable
-		if (!this.props.list.nodelete) {
+		let hasListDeletePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.props.list.key].roles.delete.indexOf(n) != -1;
+			}).length > 0;
+
+		if (!this.props.list.nodelete && hasListDeletePermissions) {
 			cells.unshift(this.props.manageMode ? (
 				<ListControl key="_check" type="check" active={this.props.checkedItems[itemId]} />
 			) : (

--- a/admin/client/components/MobileNavigation.js
+++ b/admin/client/components/MobileNavigation.js
@@ -66,6 +66,8 @@ var MobileNavigation = React.createClass({
 		currentListKey: React.PropTypes.string,
 		sections: React.PropTypes.array.isRequired,
 		signoutUrl: React.PropTypes.string,
+		user: React.PropTypes.object.isRequired,
+		permissions: React.PropTypes.object.isRequired
 	},
 	getInitialState () {
 		return {
@@ -116,6 +118,16 @@ var MobileNavigation = React.createClass({
 		return this.props.sections.map((section) => {
 			let href = section.lists[0].external ? section.lists[0].path : `${Keystone.adminPath}/${section.lists[0].path}`;
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'MobileNavigation__section is-active' : 'MobileNavigation__section';
+			let hasPermissionsToReadSomeListsInSection = false;
+
+			section.lists.map((list) => {
+				if (hasPermissionsToReadSomeListsInSection) return;
+				hasPermissionsToReadSomeListsInSection = this.props.user.roles.filter((n) => {
+						return this.props.permissions[list.key].roles.read.indexOf(n) != -1;
+					}).length > 0;
+			});
+
+			if (!hasPermissionsToReadSomeListsInSection) return null;
 
 			return (
 				<MobileSectionItem key={section.key} className={className} href={href} lists={section.lists} currentListKey={this.props.currentListKey}>

--- a/admin/client/components/PrimaryNavigation.js
+++ b/admin/client/components/PrimaryNavigation.js
@@ -27,6 +27,8 @@ var PrimaryNavigation = React.createClass({
 		brand: React.PropTypes.string,
 		sections: React.PropTypes.array.isRequired,
 		signoutUrl: React.PropTypes.string,
+		user: React.PropTypes.object.isRequired,
+		permissions: React.PropTypes.object.isRequired
 	},
 	getInitialState() {
 		return {};
@@ -76,6 +78,16 @@ var PrimaryNavigation = React.createClass({
 		return this.props.sections.map((section) => {
 			let href = section.lists[0].external ? section.lists[0].path : `${Keystone.adminPath}/${section.lists[0].path}`;
 			let className = (this.props.currentSectionKey && this.props.currentSectionKey === section.key) ? 'active' : null;
+			let hasPermissionsToReadSomeListsInSection = false;
+
+			section.lists.map((list) => {
+				if (hasPermissionsToReadSomeListsInSection) return;
+				hasPermissionsToReadSomeListsInSection = this.props.user.roles.filter((n) => {
+					return this.props.permissions[list.key].roles.read.indexOf(n) != -1;
+				}).length > 0;
+			});
+
+			if (!hasPermissionsToReadSomeListsInSection) return null;
 
 			return (
 				<PrimaryNavItem key={section.key} className={className} href={href}>

--- a/admin/client/components/SecondaryNavigation.js
+++ b/admin/client/components/SecondaryNavigation.js
@@ -25,6 +25,8 @@ var SecondaryNavigation = React.createClass({
 	propTypes: {
 		currentListKey: React.PropTypes.string,
 		lists: React.PropTypes.array.isRequired,
+		user: React.PropTypes.object.isRequired,
+		permissions: React.PropTypes.object.isRequired
 	},
 	getInitialState() {
 		return {};
@@ -45,6 +47,12 @@ var SecondaryNavigation = React.createClass({
 		let navigation = lists.map((list) => {
 			let href = list.external ? list.path : `${Keystone.adminPath}/${list.path}`;
 			let className = (this.props.currentListKey && this.props.currentListKey === list.path) ? 'active' : null;
+
+			let hasListReadPermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[list.key].roles.read.indexOf(n) != -1;
+			}).length > 0;
+
+			if (!hasListReadPermissions) return null;
 
 			return (
 				<SecondaryNavItem key={list.path} className={className} href={href}>

--- a/admin/client/views/item.js
+++ b/admin/client/views/item.js
@@ -66,22 +66,33 @@ var ItemView = React.createClass({
 						currentSectionKey={this.props.nav.currentSection.key}
 						sections={this.props.nav.sections}
 						signoutUrl={this.props.signoutUrl}
+						user={this.props.user}
+						permissions={this.props.permissions}
 						/>
 					<PrimaryNavigation
 						currentSectionKey={this.props.nav.currentSection.key}
 						brand={this.props.brand}
 						sections={this.props.nav.sections}
-						signoutUrl={this.props.signoutUrl} />
+						signoutUrl={this.props.signoutUrl}
+						user={this.props.user}
+						permissions={this.props.permissions}
+						/>
 					<SecondaryNavigation
 						currentListKey={this.props.list.path}
-						lists={this.props.nav.currentSection.lists} />
+						lists={this.props.nav.currentSection.lists}
+						user={this.props.user}
+						permissions={this.props.permissions}
+						/>
 				</header>
 				<div className="keystone-body">
 					<EditFormHeader
 						list={this.props.list}
 						data={this.state.itemData}
 						drilldown={this.state.itemDrilldown}
-						toggleCreate={this.toggleCreate} />
+						toggleCreate={this.toggleCreate}
+						user={this.props.user}
+						permissions={this.props.permissions}
+						/>
 					<Container>
 						<CreateForm
 							list={this.props.list}
@@ -91,7 +102,10 @@ var ItemView = React.createClass({
 							messages={this.props.messages} />
 						<EditForm
 							list={this.props.list}
-							data={this.state.itemData} />
+							data={this.state.itemData}
+							user={this.props.user}
+							permissions={this.props.permissions}
+							/>
 						{this.renderRelationships()}
 					</Container>
 				</div>
@@ -119,6 +133,7 @@ ReactDOM.render(
 		signoutUrl={Keystone.signoutUrl}
 		User={Keystone.User}
 		user={Keystone.user}
+		permissions={Keystone.permissions}
 		version={Keystone.version}
 	/>,
 	document.getElementById('item-view')

--- a/admin/client/views/list.js
+++ b/admin/client/views/list.js
@@ -151,6 +151,13 @@ const ListView = React.createClass({
 	},
 	renderCreateButton () {
 		if (this.state.list.nocreate) return null;
+
+		let hasListCreatePermissions = this.props.user.roles.filter((n) => {
+			return this.props.permissions[this.state.list.key].roles.create.indexOf(n) != -1;
+		}).length > 0;
+
+		if (!hasListCreatePermissions) return null;
+
 		var props = { type: 'success' };
 		if (this.state.list.autocreate) {
 			props.href = '?new' + Keystone.csrf.query;
@@ -194,17 +201,27 @@ const ListView = React.createClass({
 		let checkedItemCount = Object.keys(checkedItems).length;
 		let buttonNoteStyles = { color: '#999', fontWeight: 'normal' };
 
+		let hasListUpdatePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.state.list.key].roles.update.indexOf(n) != -1;
+			}).length > 0;
+
 		// action buttons
-		let actionUpdateButton = !list.noedit ? (
+		let actionUpdateButton = (!list.noedit || hasListUpdatePermissions) ? (
 			<InputGroup.Section>
 				<Button onClick={this.toggleUpdateModal} disabled={!checkedItemCount}>Update</Button>
 			</InputGroup.Section>
 		) : null;
-		let actionDeleteButton = !list.nodelete ? (
+
+		let hasListDeletePermissions = this.props.user.roles.filter((n) => {
+				return this.props.permissions[this.state.list.key].roles.delete.indexOf(n) != -1;
+			}).length > 0;
+
+		let actionDeleteButton = (!list.nodelete || hasListDeletePermissions) ? (
 			<InputGroup.Section>
 				<Button onClick={this.massDelete} disabled={!checkedItemCount}>Delete</Button>
 			</InputGroup.Section>
 		) : null;
+
 		let actionButtons = manageMode ? (
 			<InputGroup.Section>
 				<InputGroup contiguous>
@@ -376,8 +393,15 @@ const ListView = React.createClass({
 		});
 	},
 	renderBlankStateCreateButton () {
-		var props = { type: 'success' };
 		if (this.state.list.nocreate) return null;
+
+		let hasListCreatePermissions = this.props.user.roles.filter((n) => {
+			return this.props.permissions[this.state.list.key].roles.create.indexOf(n) != -1;
+		}).length > 0;
+
+		if (!hasListCreatePermissions) return null;
+
+		let props = { type: 'success' };
 		if (this.state.list.autocreate) {
 			props.href = '?new' + this.props.csrfQuery;
 		} else {
@@ -427,6 +451,8 @@ const ListView = React.createClass({
 						checkedItems={this.state.checkedItems}
 						rowAlert={this.state.rowAlert}
 						checkTableItem={this.checkTableItem}
+						user={this.props.user}
+						permissions={this.props.permissions}
 					/>
 					{this.renderNoSearchResults()}
 				</Container>
@@ -459,15 +485,23 @@ const ListView = React.createClass({
 						currentSectionKey={this.props.nav.currentSection.key}
 						sections={this.props.nav.sections}
 						signoutUrl={this.props.signoutUrl}
+						user={this.props.user}
+						permissions={this.props.permissions}
 						/>
 					<PrimaryNavigation
 						brand={this.props.brand}
 						currentSectionKey={this.props.nav.currentSection.key}
 						sections={this.props.nav.sections}
-						signoutUrl={this.props.signoutUrl} />
+						signoutUrl={this.props.signoutUrl}
+						user={this.props.user}
+						permissions={this.props.permissions}
+						/>
 					<SecondaryNavigation
 						currentListKey={this.state.list.path}
-						lists={this.props.nav.currentSection.lists} />
+						lists={this.props.nav.currentSection.lists}
+						user={this.props.user}
+						permissions={this.props.permissions}
+						/>
 				</header>
 				<div className="keystone-body">
 					{this.renderBlankState()}
@@ -510,6 +544,7 @@ ReactDOM.render(
 		signoutUrl={Keystone.signoutUrl}
 		user={Keystone.user}
 		User={Keystone.User}
+		permissions={Keystone.permissions}
 		version={Keystone.version}
 	/>,
 	document.getElementById('list-view')

--- a/admin/server/routes/home.js
+++ b/admin/server/routes/home.js
@@ -7,7 +7,8 @@ module.exports = function(req, res) {
 		page: 'home',
 		title: keystone.get('name') || 'Keystone',
 		orphanedLists: keystone.getOrphanedLists(),
-		brand: keystone.get('name')
+		brand: keystone.get('name'),
+		permissions: keystone.permissions
 	});
 
 };

--- a/admin/server/routes/item.js
+++ b/admin/server/routes/item.js
@@ -66,9 +66,9 @@ module.exports = function(req, res) {
 					list: req.list,
 					item: item,
 					relationships: relationships,
-					showRelationships: showRelationships
+					showRelationships: showRelationships,
+					permissions: keystone.permissions
 				});
-
 			});
 
 		};

--- a/admin/server/routes/list.js
+++ b/admin/server/routes/list.js
@@ -15,7 +15,8 @@ module.exports = function(req, res) {
 			title: appName + ': ' + req.list.plural,
 			page: 'list',
 			list: req.list,
-			submitted: req.body || {}
+			submitted: req.body || {},
+			permissions: keystone.permissions
 		}));
 	};
 

--- a/admin/server/templates/home.jade
+++ b/admin/server/templates/home.jade
@@ -15,6 +15,7 @@ html
 		script.
 			Keystone.lists = !{JSON.stringify(_.map(lists, getListMeta))};
 			Keystone.orphanedLists = !{JSON.stringify(orphanedLists.map(getListMeta))};
+			Keystone.permissions = !{JSON.stringify(permissions)};
 		script(src="#{adminPath}/js/lib/underscore/underscore-1.5.1.min.js")
 		script(src="#{adminPath}/js/packages.js")
 		script(src="#{adminPath}/js/home.js")

--- a/admin/server/templates/item.jade
+++ b/admin/server/templates/item.jade
@@ -25,6 +25,7 @@ html
 			Keystone.list = Keystone.lists[!{JSON.stringify(list.key)}];
 			Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
 			Keystone.itemId = '!{item.id}';
+			Keystone.permissions = !{JSON.stringify(permissions)};
 		script(src='#{adminPath}/js/packages.js')
 		script(src='#{adminPath}/js/fields.js')
 		script(src='#{adminPath}/js/item.js')

--- a/admin/server/templates/list.jade
+++ b/admin/server/templates/list.jade
@@ -28,6 +28,7 @@ html
 			Keystone.showCreateForm = !{JSON.stringify(showCreateForm)};
 			Keystone.createFormData = !{JSON.stringify(submitted)};
 			Keystone.createFormErrors = !{JSON.stringify(createErrors || null)};
+			Keystone.permissions = !{JSON.stringify(permissions)};
 		script(src='#{adminPath}/js/packages.js')
 		script(src='#{adminPath}/js/fields.js')
 		script(src='#{adminPath}/js/list.js')

--- a/lib/acl.js
+++ b/lib/acl.js
@@ -1,0 +1,64 @@
+/**
+  The ACL API manages keystone roles, user roles, as well as list crud permission roles.
+*/
+'use strict';
+
+let keystone = require('../');
+let async = require('async');
+
+
+/**
+ getListPermissions( )
+ Return an object whose keys are the configured keystone lists with all permissions set.
+ @return {Promise} Promise resolved when finished
+ */
+function getListPermissions () {
+	let permissionModel = keystone.get('permission model');
+	let Permission = keystone.list(permissionModel);
+	let models = keystone.get('models');
+	let permissions = {};
+
+	return new Promise((resolve, reject) => {
+		async.each(Object.keys(models), function (list, done) {
+			permissions[list] = {
+				key: models[list].key,
+				path: models[list].path,
+				roles: {}
+			};
+
+			Permission.model.findOne( { listName: list } ).exec(function (err, permission) {
+				if (!err && permission) {
+					var aclo = permission.toObject();
+					permissions[list]['roles'] = {
+						create: aclo.create,
+						read: aclo.read,
+						update: aclo.update,
+						delete: aclo.delete
+					};
+				} else {
+					permissions[list]['roles'] = {
+						create: [],
+						read: [],
+						update: [],
+						delete: []
+					};
+				}
+				done(err);
+			});
+		}, function (err) {
+			if (!err) {
+				resolve(permissions);
+			} else {
+				console.error('getListPermissions failed: ' + err);
+				reject(err);
+			}
+		});
+	});
+}
+
+// Exports
+let Acl = {
+	getListPermissions: getListPermissions
+};
+
+module.exports = Acl;

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
   },
   "devDependencies": {
     "babel-eslint": "4.1.6",
+    "chai": "^3.4.1",
+    "chai-as-promised": "^5.2.0",
     "codeclimate-test-reporter": "0.2.0",
     "disc": "1.3.2",
     "eslint": "1.10.3",
@@ -101,6 +103,7 @@
     "istanbul": "0.4.2",
     "mocha": "2.3.4",
     "must": "0.13.1",
+    "proxyquire": "^1.7.3",
     "react-engine": "3.0.0",
     "rimraf": "2.5.0",
     "sinon": "1.17.2",

--- a/test/lib/acl_test.js
+++ b/test/lib/acl_test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+var proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+var chaiAsPromised = require("chai-as-promised");
+var chai = require("chai").use(chaiAsPromised).should();
+
+var acl = null;
+var permission = null;
+
+// Mocked Models
+var Permission = function Permission() {
+	this.name = '';
+	this.list = '';
+	this.model = {};
+};
+
+var models = {
+	List1: {
+		List: {
+			options: {
+				noedit: false,
+				nocreate: false,
+				nodelete: false,
+				autocreate: false
+			}
+		},
+		key: 'List1',
+		path: 'list1'
+	}
+};
+
+// Mocked Keystone
+var keystoneMock = {
+	get: function(what) {
+		switch(what){
+			case 'models':
+				return models;
+				break;
+			case 'permission model':
+				return 'Permission';
+				break;
+			default:
+				console.error('acl_test: invalid get value');
+		}
+	},
+	list: function(which) {
+		switch(which){
+			case 'Permission':
+				return permission;
+				break;
+			default:
+				console.error('acl_test: invalid list value');
+		}
+	}
+};
+
+describe("Acl", function() {
+	beforeEach(function () {
+		acl = proxyquire("../../lib/acl", {
+			'../': keystoneMock
+		});
+
+		permission = new Permission();
+	});
+
+	describe("getListPermissions", function() {
+		it("should return an object with list permissions", function(done) {
+
+			var createRoles = ['cr1'];
+			var readRoles = ['rr1'];
+			var updateRoles = ['ur1'];
+			var deleteRoles = ['dr1'];
+
+			permission.model.findOne = function(query) {
+				return {
+					exec: function (cb) {
+						var permissions = {
+							name: query.listName,
+							listName: query.listName,
+							create: createRoles,
+							read: readRoles,
+							update: updateRoles,
+							delete: deleteRoles,
+							toObject: function(){return this;}
+						};
+						cb(null, permissions);
+					}
+				}
+			};
+
+			var promise = acl.getListPermissions();
+			promise.should.be.fulfilled.then(function (permissions) {
+				permissions[models.List1.key].roles.create.must.equal(createRoles);
+				permissions[models.List1.key].roles.read.must.equal(readRoles);
+				permissions[models.List1.key].roles.update.must.equal(updateRoles);
+				permissions[models.List1.key].roles.delete.must.equal(deleteRoles);
+			}).should.notify(done);
+
+		})
+	});
+
+});


### PR DESCRIPTION
Initial support for roles and permissions in keystone (a possible approach for solving #803).  This PR mainly addresses defining a role and permissions model and based on this restricting Admin UI menus, list, and items per allow role/permissions.  Please see gist at https://gist.github.com/webteckie/139c0303eaac1179290d for instructions on including support for roles and permissions in your application.  This is definitely WIP and mainly putting out for review and comments and whether the approach makes sense.  The main thing left to do is to add support for restricting server side list operations based on the configured user roles/permissions.

For reference, here are some screen shots of how this would look in the admin ui:

Roles screen:
![image](https://cloud.githubusercontent.com/assets/5872515/15265721/68cbb998-195a-11e6-8786-3fffa132dc55.png)

Permissions Screen:
![image](https://cloud.githubusercontent.com/assets/5872515/15265716/50c50b7e-195a-11e6-85ef-1d35cb259656.png)
