### PR TITLE
New field type: JSON v0.3.x

### DIFF
--- a/admin/public/styles/keystone/forms.less
+++ b/admin/public/styles/keystone/forms.less
@@ -283,7 +283,7 @@ label.checkbox {
 
 
 // Code
-.field-type-code {
+.field-type-code, .field-type-json {
 	.CodeMirror-container {
 		.form-control;
 		height: auto;

--- a/admin/src/fields.js
+++ b/admin/src/fields.js
@@ -12,6 +12,7 @@ module.exports = {
 	embedly:          require('../../fields/types/embedly/EmbedlyField'),
 	geopoint:         require('../../fields/types/geopoint/GeoPointField'),
 	html:             require('../../fields/types/html/HtmlField'),
+	json:             require('../../fields/types/json/JsonField'),
 	key:              require('../../fields/types/key/KeyField'),
 	localfile:  	  require('../../fields/types/localfile/LocalFileField'),
 	localfiles:       require('../../fields/types/localfiles/LocalFilesField'),

--- a/fields/types/json/JsonField.js
+++ b/fields/types/json/JsonField.js
@@ -1,0 +1,96 @@
+var _ = require('underscore'),
+	React = require('react'),
+	Field = require('../Field'),
+	CodeMirror = require('codemirror');
+
+// See CodeMirror docs for API:
+// http://codemirror.net/doc/manual.html
+
+module.exports = Field.create({
+	
+	displayName: 'JsonField',
+	
+	getInitialState: function() {
+		return {
+			isFocused: false
+		};
+	},
+	
+	componentDidMount: function() {
+		if (!this.refs.codemirror) {
+			return;
+		}
+		
+		var options = _.defaults({}, this.props.editor, {
+			lineNumbers: true,
+			readOnly: this.shouldRenderField() ? false : true
+		});
+		
+		this.codeMirror = CodeMirror.fromTextArea(this.refs.codemirror.getDOMNode(), options);
+		this.codeMirror.on('change', this.codemirrorValueChanged);
+		this.codeMirror.on('focus', this.focusChanged.bind(this, true));
+		this.codeMirror.on('blur', this.focusChanged.bind(this, false));
+		this._currentCodemirrorValue = this.props.value;
+	},
+	
+	componentWillUnmount: function() {
+		// todo: is there a lighter-weight way to remove the cm instance?
+		if (this.codeMirror) {
+			this.codeMirror.toTextArea();
+		}
+	},
+	
+	componentWillReceiveProps: function(nextProps) {
+		if (this.codeMirror && this._currentCodemirrorValue !== nextProps.value) {
+			this.codeMirror.setValue(nextProps.value);
+		}
+	},
+	
+	focus: function() {
+		if (this.codeMirror) {
+			this.codeMirror.focus();
+		}
+	},
+	
+	focusChanged: function(focused) {
+		this.setState({
+			isFocused: focused
+		});
+	},
+	
+	codemirrorValueChanged: function(doc, change) {//eslint-disable-line no-unused-vars
+		var newValue = doc.getValue();
+		this._currentCodemirrorValue = newValue;
+		this.props.onChange({
+			path: this.props.path,
+			value: newValue
+		});
+	},
+	
+	renderCodemirror: function() {
+		var className = 'CodeMirror-container';
+		var propValue = this.props.value;
+		var jsonStringify = '';
+
+		if(propValue != null) {
+			jsonStringify = JSON.stringify(this.props.value, null, '\t');
+		}
+		if (this.state.isFocused && this.shouldRenderField()) {
+			className += ' is-focused';
+		}
+		return (
+			<div className={className}>
+				<textarea ref="codemirror" name={this.props.path} value={jsonStringify} onChange={this.valueChanged} autoComplete="off" className="form-control" />
+			</div>
+		);
+	},
+	
+	renderValue: function() {
+		return this.renderCodemirror();
+	},
+	
+	renderField: function() {
+		return this.renderCodemirror();
+	}
+	
+});

--- a/fields/types/json/JsonType.js
+++ b/fields/types/json/JsonType.js
@@ -1,0 +1,74 @@
+var _ = require('underscore');
+var FieldType = require('../Type');
+var TextType = require('../text/TextType');
+var util = require('util');
+var utils = require('keystone-utils');
+
+
+/**
+ * HTML FieldType Constructor
+ * @extends Field
+ * @api public
+ */
+function json(list, path, options) {
+	this._nativeType = Object;
+	this._defaultSize = 'full';
+	this.height = options.height || 180;
+	this._properties = ['editor', 'height'];
+	this.codemirror = options.codemirror || {};
+	this.editor = _.defaults(this.codemirror, { mode : json });
+	json.super_.call(this, list, path, options);
+}
+util.inherits(json, FieldType);
+
+/* Inherit from TextType prototype */
+json.prototype.addFilterToQuery = TextType.prototype.addFilterToQuery;
+
+
+json.prototype.getValueFromData = function(data, canThrow) {
+	var value = this.path in data ? data[this.path] : this._path.get(data);
+
+	if(typeof value == 'string') {
+		try {
+			value = JSON.parse(value);
+		} catch(ex) {
+			if(canThrow === true) {
+				throw ex;
+			} else {
+				value = null;
+			}
+		}
+	}
+
+	return value;
+};
+
+
+json.prototype.validateInput = function(data, required, item) {
+	var value = this.getValueFromData(data);
+
+	if (value === undefined && item && (item.get(this.path) || item.get(this.path) === 0)) {
+		return true;
+	}
+
+	if (value == null && required) {
+		return false;
+	} else if(value == null && !required) {
+		return true;
+	} else {
+		try {
+			value = this.getValueFromData(data, true);
+
+			if(typeof value != 'object') {
+				return false;
+			} else {
+				return true;
+			}
+		} catch(ex) {
+			return false;
+		}
+	}
+};
+
+/* Export Field Type */
+exports = module.exports = json;

--- a/fields/types/json/test/server.js
+++ b/fields/types/json/test/server.js
@@ -1,0 +1,83 @@
+var demand = require('must'),
+	CodeType = require('../CodeType');
+
+exports.initList = function(List) {
+	List.add({
+		code: { type: CodeType },
+		nested: {
+			code: { type: CodeType }
+		},
+		lang: {
+			type: CodeType,
+			lang: 'c'
+		},
+		language: {
+			type: CodeType,
+			lang: 'js'
+		},
+		codemirror: {
+			type: CodeType,
+			lang: 'html',
+			codemirror: {
+				value: 'fooga'
+			}
+		}
+	});
+};
+
+exports.createData = function(List) {//eslint-disable-line no-unused-vars
+
+};
+
+exports.testFilters = function(List) {//eslint-disable-line no-unused-vars
+
+};
+
+exports.testFieldType = function(List) {
+	var testItem = new List.model();
+
+	it('should update top level fields', function() {
+		List.fields.code.updateItem(testItem, {
+			code: 'foo(bar);'
+		});
+		demand(testItem.code).be('foo(bar);');
+		testItem.code = undefined;
+	});
+	
+	it('should update nested fields', function() {
+		List.fields['nested.code'].updateItem(testItem, {
+			nested: {
+				code: 'foo(bar);'
+			}
+		});
+		demand(testItem.nested.code).be('foo(bar);');
+		testItem.nested.code = undefined;
+	});
+	
+	it('should update nested fields with flat paths', function() {
+		List.fields['nested.code'].updateItem(testItem, {
+			'nested.code': 'foo(bar);'
+		});
+		demand(testItem.nested.code).be('foo(bar);');
+		testItem.nested.code = undefined;
+	});
+	
+	it('should handle a `lang` config property', function() {
+		demand(List.fields.lang.lang).be('c');
+	});
+	
+	it('should handle a `language` config property', function() {
+		demand(List.fields.language.lang).be('js');
+	});
+	
+	it('should support a `codemirror` config property', function() {
+		demand(List.fields.codemirror.codemirror).be.object();
+		demand(List.fields.codemirror.codemirror.value).be('fooga');
+	});
+	
+	it('should merge the `lang` and `codemirror` config properties', function() {
+		demand(List.fields.codemirror.editor).be.object();
+		demand(List.fields.codemirror.editor.mode).be('html');
+		demand(List.fields.codemirror.editor.value).be('fooga');
+	});
+};

--- a/lib/fieldTypes.js
+++ b/lib/fieldTypes.js
@@ -12,6 +12,7 @@ var fields = {
 	get Embedly () { return require('../fields/types/embedly/EmbedlyType'); },
 	get GeoPoint () { return require('../fields/types/geopoint/GeoPointType'); },
 	get Html () { return require('../fields/types/html/HtmlType'); },
+	get Json () { return require('../fields/types/json/JsonType'); },
 	get Key () { return require('../fields/types/key/KeyType'); },
 	get LocalFile () { return require('../fields/types/localfile/LocalFileType'); },
 	get LocalFiles () { return require('../fields/types/localfiles/LocalFilesType'); },

--- a/templates/views/item.jade
+++ b/templates/views/item.jade
@@ -3,7 +3,7 @@ extends ../layout/base
 include ../mixins/columns
 
 block css
-	if list.fieldTypes.code
+	if list.fieldTypes.code || list.fieldTypes.json
 		link(rel='stylesheet', href='/keystone/js/lib/codemirror/codemirror.css')
 
 block js
@@ -16,7 +16,7 @@ block js
 	script(src='/keystone/js/item.js')
 
 block js_codemirror
-	if list.fieldTypes.code
+	if list.fieldTypes.code || list.fieldTypes.json
 		script(src="/keystone/js/lib/codemirror/codemirror-compressed.js")
 		
 block content


### PR DESCRIPTION
New field type JSON based on Code field

Define in model like:

``` javascript
fieldname: { type: Types.Json }
```

Only accept valid JSON Object value. If try use a simple values like string, book, number keystone throws a error in this field.

Save the data in mongo in JSON format for make searchs.

Example of data:

``` json
{
    "prueba4": [
        1,
        2,
        3
    ],
    "prueba2": 1,
    "prueba": "valor",
    "prueba3": true
}
```

closes https://github.com/keystonejs/keystone/issues/190
