### PR TITLE
Add: ability to specify Date inputFormat

### DIFF
--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -12,9 +12,10 @@ function date(list, path, options) {
 	this._nativeType = Date;
 	this._underscoreMethods = ['format', 'moment', 'parse'];
 	this._fixedSize = 'medium';
-	this._properties = ['formatString', 'yearRange', 'isUTC'];
-	this.parseFormatString = options.parseFormat || 'YYYY-MM-DD';
+	this._properties = ['formatString', 'yearRange', 'isUTC', 'inputFormat'];
+	this.parseFormatString = options.inputFormat || 'YYYY-MM-DD';
 	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY');
+
 	this.yearRange = options.yearRange;
 	this.isUTC = options.utc || false;
 	if (this.formatString && 'string' !== typeof this.formatString) {


### PR DESCRIPTION
Allows the user to specify the format they use to input dates. YYYY-MM-DD isn't intuitive for US based users because the standard here is MM-DD-YYYY