### PR TITLE
Comment out S3FileType's updateItem method

### DIFF
--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -215,9 +215,10 @@ s3file.prototype.validateInput = function(data) {//eslint-disable-line no-unused
  * @api public
  */
 
-s3file.prototype.updateItem = function(item, data) {//eslint-disable-line no-unused-vars
+// s3file.prototype.updateItem = function(item, data) {//eslint-disable-line no-unused-vars
 	// TODO - direct updating of data (not via upload)
-};
+	// commented out for now so super's updateItem will be called and S3FileType can be seeded with an application update
+// };
 
 
 /**


### PR DESCRIPTION
In order to be able to seed data to a s3file field in an application update I would like to propose to comment out S3FileType's updateItem so Type's updateItem method will be used which is fine for just supplying an object strings (without actually uploading/replacing the uploaded image).