### PR TITLE
Fix tag to use the public id

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -181,7 +181,7 @@ cloudinaryimage.prototype.addToSchema = function() {
 			return src(this, options);
 		},
 		tag: function(options) {
-			return exists(this) ? cloudinary.image(this.get(field.path), options) : '';
+			return exists(this) ? cloudinary.image(this.get(field.path).public_id, options) : '';
 		},
 		scale: function(width, height, options) {
 			return src(this, addSize({ crop: 'scale' }, width, height, options));


### PR DESCRIPTION
This PR closes #2182 by passing only the public_id to the cloudinary.image function, and not an object (field.path)