### PR TITLE
Fix: Issue #2162

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -103,29 +103,29 @@ function createItems(data, ops, callback) {
 						refs[list.key][data.__ref] = doc;
 					}
 
-					_.each(list.fields, function(field) {
+					async.each(list.fields, function(field, callback) {
 						// skip relationship fields on the first pass.
 						if (field.type !== 'relationship') {
-							field.updateItem(doc, data);
+							// TODO: Validate items?
+							field.updateItem(doc, data, callback);
 						}
-					});
-
-					if (options.verbose) {
-						var documentName = list.getDocumentName(doc);
-						writeLog('Creating item [' + itemsProcessed + ' of ' + totalItems + '] - ' + documentName);
-					}
-
-					doc.save(function(err) {
-						if (err) {
-							err.model = key;
-							err.data = data;
-							debug('error saving ', key);
-						} else {
-							stats[list.key].created++;
+					}, function() {
+						if (options.verbose) {
+							var documentName = list.getDocumentName(doc);
+							writeLog('Creating item [' + itemsProcessed + ' of ' + totalItems + '] - ' + documentName);
 						}
-						doneItem(err);
-					});
 
+						doc.save(function(err) {
+							if (err) {
+								err.model = key;
+								err.data = data;
+								debug('error saving ', key);
+							} else {
+								stats[list.key].created++;
+							}
+							doneItem(err);
+						});
+					});
 				}, doneList);
 
 			}, next);


### PR DESCRIPTION
.updateItem wasn't updated to be async in keystone.createItems. This is
used by the shorthard update script syntax and therefore was only
throwing errors when applying updates with that syntax. See https://github.com/keystonejs/keystone/issues/2162