### PR TITLE
[0.3] move browserify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "blacklist": "^1.1.2",
     "bluebird": "^2.10.2",
     "body-parser": "^1.14.1",
+    "browserify": "^11.2.0",
     "browserify-shim": "^3.8.10",
     "bytes": "^2.1.0",
     "caller-id": "^0.1.0",
@@ -69,7 +70,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.3",
-    "browserify": "^11.2.0",
     "codeclimate-test-reporter": "0.1.1",
     "eslint": "^1.6.0",
     "eslint-plugin-react": "^3.5.1",


### PR DESCRIPTION
When running keystone v0.3.16 with `--production` it hangs on `Error: Cannot find module 'browserify'`, i.e. I think it should be moved to the `dependencies`