### PR TITLE
adding 'mongo options' option and deprecating 'mongo replica set' option

### DIFF
--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -9,11 +9,11 @@ module.exports = function openDatabaseConnection (callback) {
 	if (keystone.get('mongo replica set')) {
 
 		if (keystone.get('logger')) {
-			console.log('\nWarning: using the `mongo replica set` option has been deprecated and will be removed in' +
-				' a future version.\nInstead set the `mongo` connection string with your host details, e.g.' +
-				' mongodb://username:password@host:port,host:port,host:port/database and set any replica set options' +
-				' in `mongo options`.\n\nRefer to https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html' +
-				' for more details on the connection settings.');
+			console.log('\nWarning: using the `mongo replica set` option has been deprecated and will be removed in'
+				+ ' a future version.\nInstead set the `mongo` connection string with your host details, e.g.'
+				+ ' mongodb://username:password@host:port,host:port,host:port/database and set any replica set options'
+				+ ' in `mongo options`.\n\nRefer to https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html'
+				+ ' for more details on the connection settings.');
 		}
 
 		debug('setting up mongo replica set');

--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -7,6 +7,15 @@ module.exports = function openDatabaseConnection (callback) {
 
 	// support replica sets for mongoose
 	if (keystone.get('mongo replica set')) {
+
+		if (keystone.get('logger')) {
+			console.log('\nWarning: using the `mongo replica set` option has been deprecated and will be removed in' +
+				' a future version.\nInstead set the `mongo` connection string with your host details, e.g.' +
+				' mongodb://username:password@host:port,host:port,host:port/database and set any replica set options' +
+				' in `mongo options`.\n\nRefer to https://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html' +
+				' for more details on the connection settings.');
+		}
+
 		debug('setting up mongo replica set');
 		var replicaData = keystone.get('mongo replica set');
 		var replica = '';
@@ -30,7 +39,7 @@ module.exports = function openDatabaseConnection (callback) {
 
 	} else {
 		debug('connecting to mongo');
-		keystone.mongoose.connect(keystone.get('mongo'));
+		keystone.mongoose.connect(keystone.get('mongo'), keystone.get('mongo options'));
 	}
 
 	keystone.mongoose.connection.on('error', function (err) {


### PR DESCRIPTION
#2322 

- added depreciation warning when using `mongo replica set` 
- added `mongo options` option to replace this and provide access for passing options down to the native driver.