### PR TITLE
Admin can not save published posts

### DIFF
--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -63,7 +63,7 @@ module.exports = Field.create({
 
 	renderField () {
 		let value = this.moment(this.props.value);
-		value = this.props.value && value.isValid() ? value.format(this.props.formatString) : this.props.value;
+		value = this.props.value && value.isValid() ? value.format(this.props.inputFormat) : this.props.value;
 		return (
 			<InputGroup>
 				<InputGroup.Section grow>


### PR DESCRIPTION
Admin is unable to save posts that have been published, or publish new posts due to the publish date being set to a display format rather than edit format:

`DateField` was setting the input value using the `formatString` instead of the `inputFormat`. This causes all publish dates to be 'day month year' instead of 'year-month-day' on load or when clicking the today button. At that point the post can not be saved because the format violates the date validation requiring 'year-month-day'. The `DateTimeField` was already doing this correctly, so it should be safe to assume it was an oversight.

fixes #2273
