### PR TITLE
Fix admin UI static file mount path (v0.3.x only)

### DIFF
--- a/admin/app/static.js
+++ b/admin/app/static.js
@@ -42,8 +42,8 @@ var lessOptions = {
 
 /* Configure router */
 
-router.use('/styles', less(__dirname + '../../public/styles', lessOptions));
-router.use(express.static(__dirname + '../../public'));
+router.use('/styles', less(path.join(__dirname, '../public/styles'), lessOptions));
+router.use(express.static(path.join(__dirname, '../public')));
 router.get('/js/fields.js', bundles.fields.serve);
 router.get('/js/home.js', bundles.home.serve);
 router.get('/js/item.js', bundles.item.serve);


### PR DESCRIPTION
We deployed a KS app to heroku and noticed all our static assets in admin were coming back 404.

This seems to fix it.

I noticed this bug is already fixed in the v0.4.x branch.

Fixes #2377
