### PR TITLE
fixing removed function from lodash

### DIFF
--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -255,7 +255,7 @@ localfile.prototype.uploadFile = function (item, file, update, callback) {
 	var filename = prefix + file.name;
 	var filetype = file.mimetype || file.type;
 
-	if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, filetype)) {
+	if (field.options.allowedTypes && !_.includes(field.options.allowedTypes, filetype)) {
 		return callback(new Error('Unsupported File Type: ' + filetype));
 	}
 

--- a/fields/types/localfiles/LocalFilesType.js
+++ b/fields/types/localfiles/LocalFilesType.js
@@ -297,7 +297,7 @@ localfiles.prototype.uploadFiles = function (item, files, update, callback) {
 		var filename = prefix + file.name;
 		var filetype = file.mimetype || file.type;
 
-		if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, filetype)) {
+		if (field.options.allowedTypes && !_.includes(field.options.allowedTypes, filetype)) {
 			return processedFile(new Error('Unsupported File Type: ' + filetype));
 		}
 


### PR DESCRIPTION
_.contains has been removed in lodash v4 - using _.includes instead