### PR TITLE
Fix #2394 - tighten redirection destination sanitation

### DIFF
--- a/admin/routes/views/signin.js
+++ b/admin/routes/views/signin.js
@@ -1,5 +1,6 @@
 var keystone = require('../../../');
 var session = require('../../../lib/session');
+var url = require('url');
 
 exports = module.exports = function(req, res) {
 
@@ -27,7 +28,12 @@ exports = module.exports = function(req, res) {
 		var onSuccess = function (user) {
 
 			if (req.query.from && req.query.from.match(/^(?!http|\/\/|javascript).+/)) {
-				res.redirect(req.query.from);
+				var parsed = url.parse(req.query.from);
+				if(parsed.host || parsed.protocol || parsed.auth){
+					res.redirect('/keystone');
+				}else{
+					res.redirect(parsed.path);
+				}			
 			} else if ('string' === typeof keystone.get('signin redirect')) {
 				res.redirect(keystone.get('signin redirect'));
 			} else if ('function' === typeof keystone.get('signin redirect')) {


### PR DESCRIPTION
As discussed. It falls back to `/keystone` if the redirection destination contains a host, protocol or auth part and removes query strings.