### PR TITLE
 Fix for #2229: [0.4] Searching does not reset paging in list view

### DIFF
--- a/admin/client/lib/List.js
+++ b/admin/client/lib/List.js
@@ -35,7 +35,7 @@ function buildQueryString (options) {
 	if (options.filters.length) query.filters = JSON.stringify(getFilters(options.filters));
 	if (options.columns) query.select = options.columns.map(i => i.path).join(',');
 	if (options.page && options.page.size) query.limit = options.page.size;
-	if (options.page && options.page.index > 1) query.skip = (options.page.index - 1) * options.page.size;
+	if (!options.search && options.page && options.page.index > 1) query.skip = (options.page.index - 1) * options.page.size;
 	if (options.sort) query.sort = getSortString(options.sort);
 	query.expandRelationshipFields = true;
 	return '?' + qs.stringify(query);


### PR DESCRIPTION
**Problem** #2229 

On the client side, if the user is on the `page 3` within the pagination, and types a search string, the `List` currently pass `skip=300` as one of the parameter to the backend api.

- E.g., `http://localhost:3000/keystone/api/contacts?select=name%2Cemail%2CfavouriteFlavour%2Cbirthday%2Chomepage&limit=100&`***skip=300***`&sort=name&expandRelationshipFields=true`

And, on the server side, the query then skips `300` records from the search result. This is the root cause of the issue.

As a fix, the client side *List* is modified *to not send the `skip` parameter to the backend `api` call* if this is a  search operation. 

**Behaviour with this fix:**

![keystone-issue-2229-fix](https://cloud.githubusercontent.com/assets/5177920/13729860/6d0390e6-e915-11e5-8b0b-a10f286acc87.gif)

