### PR TITLE
Fix lib/list/field requires fields/types/Type ... 

### DIFF
--- a/lib/list/field.js
+++ b/lib/list/field.js
@@ -1,4 +1,4 @@
-var Field = require('../../fields/types/Type');
+var Field = require('../../').Field;
 
 /**
  * Creates a new field at the specified path, with the provided options.
@@ -20,7 +20,7 @@ function field (path, options) {
 	if (typeof options.type !== 'function') {
 		throw new Error('Fields must be specified with a type function');
 	}
-	if (options.type.prototype.__proto__ !== Field.prototype) { // eslint-disable-line no-proto
+	if (!(options.type.prototype instanceof Field)) {
 		// Convert native field types to their default Keystone counterpart
 		if (options.type === String) {
 			options.type = Field.Types.Text;


### PR DESCRIPTION
... but relies on behaviour in index and uses __proto__

Required index instead and replaced comparison of  __proto__ with instanceof operator, which also takes deep prototype chains into consideration. Gets rid of exception from eslint.