### PR TITLE
v0.3: RelationshipField: handle missing relations

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -64,10 +64,17 @@ module.exports = Field.create({
 				.get('/keystone/api/' + self.props.refList.path + '/' + input + '?simple')
 				.set('Accept', 'application/json')
 				.end(function (err, res) {
-					if (err) throw err;
-					
-					var value = res.body;
-					_.findWhere(expandedValues, { value: value.id }).label = value.name;
+					if (err) {
+						if (err.status === 404) {
+							_.findWhere(expandedValues, { value: input }).label = input;
+						} else {
+							throw err;
+						}
+					} else {
+						var value = res.body;
+						_.findWhere(expandedValues, { value: value.id }).label = value.name;
+					}
+
 
 					callbackCount++;
 					if (callbackCount === inputs.length) {


### PR DESCRIPTION
If someone deletes a related document, that killed the select field. Now it just shows the id, allowing you to delete it.