### PR TITLE
[v0.3] Change the color of the navbar in the admin

### DIFF
--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -91,7 +91,8 @@ function render(req, res, view, ext) {
 			skin: keystone.get('wysiwyg skin') || 'keystone',
 			menubar: keystone.get('wysiwyg menubar'),
 			importcss: keystone.get('wysiwyg importcss') || ''
-		}
+		},
+		admincolor: keystone.get('admin color')
 	};
 
 	// optional extensions to the local scope

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -21,7 +21,7 @@ html
 
 	body(id='page-' + page)
 		#wrap
-			nav(role='navigation')#header.navbar.navbar-default.navbar-static-top: .container
+			nav(role='navigation',style='background-color:#{admincolor}')#header.navbar.navbar-default.navbar-static-top: .container
 				a(href=backUrl).navbar-backtobrand-trigger.hidden-xs: span.ion-arrow-left-c
 				.navbar-backtobrand-message Back to the #{brand} website
 				.navbar-header


### PR DESCRIPTION
Very simple setting, but useful to know which env you are working on.

in keystone config

`keystone.init({'admin color': '#009933', ... `

related #1255