### PR TITLE
Add support for admin UI custom styling.

### DIFF
--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -221,5 +221,5 @@
 }
 
 // CUSTOM ADMIN APPLICATION STYLES
-@import (optional) "@{customStylesPath}/index.less";
+@import (optional) "@{customStylesPath}";
 

--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -219,3 +219,7 @@
 .DayPicker-Indicator__bg {
 	border-bottom-color: #fafafa;
 }
+
+// CUSTOM ADMIN APPLICATION STYLES
+@import (optional) "@{customStylesPath}/index.less";
+

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -36,8 +36,8 @@ module.exports = function createStaticRouter (keystone) {
 	/* Prepare LESS options */
 	var elementalPath = path.join(path.dirname(require.resolve('elemental')), '..');
 	var reactSelectPath = path.join(path.dirname(require.resolve('react-select')), '..');
-	var customStylesPath = keystone.getPath('adminui custom styles', 'customStyles');
-	
+	var customStylesPath = keystone.getPath('adminui custom styles', 'customStyles/index.less');
+
 	var lessOptions = {
 		render: {
 			modifyVars: {

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -36,12 +36,14 @@ module.exports = function createStaticRouter (keystone) {
 	/* Prepare LESS options */
 	var elementalPath = path.join(path.dirname(require.resolve('elemental')), '..');
 	var reactSelectPath = path.join(path.dirname(require.resolve('react-select')), '..');
-
+	var customStylesPath = keystone.getPath('adminui custom styles', 'customStyles');
+	
 	var lessOptions = {
 		render: {
 			modifyVars: {
 				elementalPath: JSON.stringify(elementalPath),
 				reactSelectPath: JSON.stringify(reactSelectPath),
+				customStylesPath: JSON.stringify(customStylesPath),
 				adminPath: JSON.stringify(keystone.get('admin path')),
 			},
 		},


### PR DESCRIPTION
Keystone apps can now custom style the admin UI.

**Usage**
At the application root directory, add a directory that will maintain the custom admin UI styles as well as a less file containing the desired custom styling.  Keystone defaults the directory and file to `customStyles/index.less`.  If you use a different directory or file name then you need to tell keystone about the path by configuring the it as follows:
```
keystone.init({
...
    'adminui custom styles': 'myOwnCustomStylesDir/myOwnCustomStylesFile'
...
})
```

The less file can contain any less processing you want applied to the admin UI.  For example,
`index.less:`
```
nav.primary-navbar {
  background-color: red;
}
```

Happy Styling :-)
