### PR TITLE
Fixed issue #2427 - wysiwyg cloudinary image upload https

### DIFF
--- a/admin/server/api/cloudinary.js
+++ b/admin/server/api/cloudinary.js
@@ -15,7 +15,7 @@ module.exports = {
 					if (result.error) {
 						res.send({ error: { message: result.error.message } });
 					} else {
-						res.send({ image: { url: result.url } });
+						res.send({ image: { url: (keystone.get('cloudinary secure') === true) ? result.secure_url : result.url } });
 					}
 				};
 


### PR DESCRIPTION
Fixed #2427. 

Issue: 
- Set the `keystone.set('cloudinary secure', true);` option and start the application.
- Upload an image to the cloudinary using the _wwysiwyg editor_.
- Click the `source code` button of the  _wwysiwyg editor_.
- The cloudinary image url used is `http` instead of `https`.

Solution: 

- The `cloudinary uploader` module does return both the `secure` and `non-secure` urls of the uploaded image. Modified the code to return `secure` url to the client if `cloudinary secure` option is set to `true`