### PR TITLE
Add pagination to bottom of lists

### DIFF
--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -72,6 +72,15 @@ function updateQueryParams (params, replace) {
 	history[replace ? 'replaceState' : 'pushState'](null, _location.pathname, newParams);
 }
 
+/**
+ * Smooth-scrolls to a position on the page
+ * @param {number} [x=0] The x-coordinate to scroll to
+ */
+function scrollTo (x) {
+	var xPos = x || 0;
+	document.documentElement.scrollTop = xPos;
+}
+
 const CurrentListStore = new Store({
 	getList () {
 		return _list;
@@ -163,6 +172,7 @@ const CurrentListStore = new Store({
 	setCurrentPage (index) {
 		if (index === 1) index = undefined;
 		updateQueryParams({ page: index });
+		scrollTo(0);
 	},
 	isLoading () {
 		return _loading;

--- a/admin/client/views/list.js
+++ b/admin/client/views/list.js
@@ -265,7 +265,7 @@ const ListView = React.createClass({
 				pageSize={pageSize}
 				plural={list.plural}
 				singular={list.singular}
-				style={{ marginBottom: 0 }}
+				style={{ marginBottom: '30px' }}
 				total={items.count}
 				limit={10}
 				/>
@@ -430,6 +430,7 @@ const ListView = React.createClass({
 						rowAlert={this.state.rowAlert}
 						checkTableItem={this.checkTableItem}
 					/>
+					{this.renderPagination()}
 					{this.renderNoSearchResults()}
 				</Container>
 			</div>

--- a/admin/public/styles/keystone/list.less
+++ b/admin/public/styles/keystone/list.less
@@ -56,7 +56,7 @@
 
 .ItemList {
 	line-height: 1;
-	margin-bottom: 60px;
+	margin-bottom: 30px;
 	table-layout: fixed;
 	width: 100%;
 }


### PR DESCRIPTION
This adds pagination to the bottom of lists in the admin interface. Before, when you reached the bottom of a list, you'd have to scroll all the way back up to go to the next page.

I've also added a function that scrolls the window to the top after the new page is open!