### PR TITLE
Display categories in filter list

### DIFF
--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -118,7 +118,7 @@ const CurrentListStore = new Store({
 		updateQueryParams({ sort });
 	},
 	getAvailableFilters () {
-		return _list.columns.filter(col => col.field && col.field.hasFilterMethod);
+		return _list.columns.filter(col => (col.field && col.field.hasFilterMethod) || col.type === 'heading');
 	},
 	getActiveFilters () {
 		return active.filters;


### PR DESCRIPTION
Previously in the admin interface, we'd show category headers in the "Columns" list but not in the "Filters" list. This PR fixes that:

<div  align="center">
<img src="https://cloud.githubusercontent.com/assets/7525670/14004220/870a1d4e-f1ac-11e5-8703-990e1651a636.png" alt="Filter list with category headers" width="200px" />
</div>
