### PR TITLE
Update to history v2

### DIFF
--- a/admin/client/stores/CurrentListStore.js
+++ b/admin/client/stores/CurrentListStore.js
@@ -1,7 +1,6 @@
 'use strict';
 
-import createHistory from 'history/lib/createBrowserHistory';
-import useQueries from 'history/lib/useQueries';
+import { createHistory, useQueries } from 'history';
 import Store from 'store-prototype';
 import List from '../lib/List';
 
@@ -69,7 +68,10 @@ function updateQueryParams (params, replace) {
 			delete newParams[i];
 		}
 	});
-	history[replace ? 'replaceState' : 'pushState'](null, _location.pathname, newParams);
+	history[replace ? 'replace' : 'push']({
+		pathname: _location.pathname,
+		query: newParams,
+	});
 }
 
 const CurrentListStore = new Store({

--- a/admin/client/views/signin.js
+++ b/admin/client/views/signin.js
@@ -21,8 +21,8 @@ var SigninView = React.createClass({
 		};
 	},
 	componentDidMount () {
-		if (this.state.signedOut && window.history.replaceState) {
-			history.replaceState({}, window.location.pathname);
+		if (this.state.signedOut && window.history.replace) {
+			history.replace({}, window.location.pathname);
 		}
 		if (this.refs.email) {
 			ReactDOM.findDOMNode(this.refs.email).select();


### PR DESCRIPTION
This was somewhat done, but history would throw an error in the console whenever we changed the query string:

![screen shot 2016-03-24 at 11 45 48](https://cloud.githubusercontent.com/assets/7525670/14005670/7efc4a52-f1b9-11e5-8c5e-2eeda4cdb729.png)

This finishes the update to history v2 and gets rid of the browser warnings.