### PR TITLE
Fix text filtering

### DIFF
--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -77,7 +77,7 @@ markdown.prototype.addFilterToQuery = function (filter, query) {
 		return query;
 	}
 	var value = utils.escapeRegExp(filter.value);
-	if (filter.mode === 'startsWith') {
+	if (filter.mode === 'beginsWith') {
 		value = '^' + value;
 	} else if (filter.mode === 'endsWith') {
 		value = value + '$';

--- a/fields/types/markdown/test/type.js
+++ b/fields/types/markdown/test/type.js
@@ -99,7 +99,7 @@ exports.testFieldType = function (List) {
 		it('should allow matching the start', function () {
 			var result = List.fields.markdown.addFilterToQuery({
 				value: 'abc',
-				mode: 'startsWith',
+				mode: 'beginsWith',
 			});
 			demand(result['markdown.md']).eql(/^abc/i);
 		});

--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -40,7 +40,7 @@ text.prototype.addFilterToQuery = function (filter, query) {
 		return query;
 	}
 	var value = utils.escapeRegExp(filter.value);
-	if (filter.mode === 'startsWith') {
+	if (filter.mode === 'beginsWith') {
 		value = '^' + value;
 	} else if (filter.mode === 'endsWith') {
 		value = value + '$';

--- a/fields/types/text/test/type.js
+++ b/fields/types/text/test/type.js
@@ -219,7 +219,7 @@ exports.testFieldType = function (List) {
 		it('should allow matching the start', function () {
 			var result = List.fields.text.addFilterToQuery({
 				value: 'abc',
-				mode: 'startsWith',
+				mode: 'beginsWith',
 			});
 			demand(result.text).eql(/^abc/i);
 		});


### PR DESCRIPTION
**Please functionally review.** I'm not 100% this isn't just my browser cache still having an old version but I think this fixes the "Begins with…" filter for the text and markdown fields.