### PR TITLE
Immutable filtering and searching methods

### DIFF
--- a/admin/server/api/list/download.js
+++ b/admin/server/api/list/download.js
@@ -1,6 +1,7 @@
 var baby = require('babyparse');
 var keystone = require('../../../../');
 var moment = require('moment');
+var assign = require('object-assign');
 
 module.exports = function (req, res) {
 	var format = req.params.format.split('.')[1]; // json or csv
@@ -11,10 +12,10 @@ module.exports = function (req, res) {
 		catch (e) { } // eslint-disable-line no-empty
 	}
 	if (typeof filters === 'object') {
-		req.list.addFiltersToQuery(filters, where);
+		where = assign({}, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
-		req.list.addSearchToQuery(req.query.search, where);
+		where = assign({}, req.list.addSearchToQuery(req.query.search));
 	}
 	var query = req.list.model.find(where);
 	if (req.query.populate) {

--- a/admin/server/api/list/download.js
+++ b/admin/server/api/list/download.js
@@ -12,10 +12,10 @@ module.exports = function (req, res) {
 		catch (e) { } // eslint-disable-line no-empty
 	}
 	if (typeof filters === 'object') {
-		where = assign({}, req.list.addFiltersToQuery(filters));
+		assign(where, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
-		where = assign({}, req.list.addSearchToQuery(req.query.search));
+		assign(where, req.list.addSearchToQuery(req.query.search));
 	}
 	var query = req.list.model.find(where);
 	if (req.query.populate) {

--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -9,10 +9,10 @@ module.exports = function (req, res) {
 		catch (e) { } // eslint-disable-line no-empty
 	}
 	if (typeof filters === 'object') {
-		where = assign({}, req.list.addFiltersToQuery(filters));
+		assign(where, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
-		where = assign({}, req.list.addSearchToQuery(req.query.search));
+		assign(where, req.list.addSearchToQuery(req.query.search));
 	}
 	var query = req.list.model.find(where);
 	if (req.query.populate) {

--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -1,4 +1,5 @@
 var async = require('async');
+var assign = require('object-assign');
 
 module.exports = function (req, res) {
 	var where = {};
@@ -8,10 +9,10 @@ module.exports = function (req, res) {
 		catch (e) { } // eslint-disable-line no-empty
 	}
 	if (typeof filters === 'object') {
-		req.list.addFiltersToQuery(filters, where);
+		where = assign({}, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
-		req.list.addSearchToQuery(req.query.search, where);
+		where = assign({}, req.list.addSearchToQuery(req.query.search));
 	}
 	var query = req.list.model.find(where);
 	if (req.query.populate) {

--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -38,8 +38,8 @@ boolean.prototype.validateRequiredInput = function (item, data, callback) {
 /**
  * Add filters to a query
  */
-boolean.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+boolean.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (!filter.value || filter.value === 'false') {
 		query[this.path] = { $ne: true };
 	} else {

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -32,8 +32,8 @@ date.prototype.validateRequiredInput = TextType.prototype.validateRequiredInput;
 /**
  * Add filters to a query
  */
-date.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+date.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'between') {
 		if (filter.after && filter.before) {
 			filter.after = moment(filter.after);

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -128,8 +128,8 @@ var FILTER_PATH_MAP = {
 	code: 'postcode',
 	country: 'country',
 };
-location.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+location.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	var field = this;
 	['street', 'city', 'state', 'code', 'country'].forEach(function (i) {
 		if (!filter[i]) return;

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -70,8 +70,8 @@ markdown.prototype.addToSchema = function () {
  * Add filters to a query (this is copy & pasted from the text field, with
  * the only difference being that the path isn't this.path but this.paths.md)
  */
-markdown.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+markdown.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'exactly' && !filter.value) {
 		query[this.paths.md] = filter.inverted ? { $nin: ['', null] } : { $in: ['', null] };
 		return query;

--- a/fields/types/name/NameType.js
+++ b/fields/types/name/NameType.js
@@ -73,8 +73,8 @@ name.prototype.getSortString = function (options) {
  * TODO: this filter will conflict with any other $or filter, including filters
  * on other "name" type fields; need to work out a better way to implement.
  */
-name.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+name.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'exactly' && !filter.value) {
 		query[this.paths.first] = query[this.paths.last] = filter.inverted ? { $nin: ['', null] } : { $in: ['', null] };
 		return;

--- a/fields/types/number/NumberType.js
+++ b/fields/types/number/NumberType.js
@@ -47,8 +47,8 @@ number.prototype.validateRequiredInput = function (item, data, callback) {
 /**
  * Add filters to a query
  */
-number.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+number.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'equals' && !filter.value) {
 		query[this.path] = filter.inverted ? { $nin: ['', 0, null] } : { $in: ['', 0, null] };
 		return query;

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -109,8 +109,8 @@ numberarray.prototype.validateRequiredInput = function (item, data, callback) {
 /**
  * Add filters to a query
  */
-numberarray.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+numberarray.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'equals' && !filter.value) {
 		query[this.path] = filter.inverted ? { $nin: ['', 0, null] } : { $in: ['', 0, null] };
 		return query;

--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -80,8 +80,8 @@ password.prototype.addToSchema = function () {
 /**
  * Add filters to a query
  */
-password.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+password.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	query[this.path] = (filter.exists) ? { $ne: null } : null;
 	return query;
 };

--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -101,8 +101,8 @@ relationship.prototype.addToSchema = function () {
 /**
  * Add filters to a query
  */
-relationship.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+relationship.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (!Array.isArray(filter.value)) {
 		if (typeof filter.value === 'string' && filter.value) {
 			filter.value = [filter.value];

--- a/fields/types/select/SelectType.js
+++ b/fields/types/select/SelectType.js
@@ -107,8 +107,8 @@ select.prototype.cloneMap = function () {
 /**
  * Add filters to a query
  */
-select.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+select.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (!Array.isArray(filter.value)) {
 		if (filter.value) {
 			filter.value = [filter.value];

--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -33,8 +33,8 @@ text.prototype.validateRequiredInput = function (item, data, callback) {
 /**
  * Add filters to a query
  */
-text.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+text.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	if (filter.mode === 'exactly' && !filter.value) {
 		query[this.path] = filter.inverted ? { $nin: ['', null] } : { $in: ['', null] };
 		return query;

--- a/fields/types/textarray/TextArrayType.js
+++ b/fields/types/textarray/TextArrayType.js
@@ -25,8 +25,8 @@ textarray.prototype.format = function (item, separator) {
 /**
  * Add filters to a query
  */
-textarray.prototype.addFilterToQuery = function (filter, query) {
-	query = query || {};
+textarray.prototype.addFilterToQuery = function (filter) {
+	var query = {};
 	// Filter empty/non-empty arrays
 	if (filter.mode === 'exactly' && !filter.value) {
 		query[this.path] = {

--- a/lib/list/addFiltersToQuery.js
+++ b/lib/list/addFiltersToQuery.js
@@ -1,10 +1,10 @@
-function addFiltersToQuery (filters, query) {
+function addFiltersToQuery (filters) {
 	var fields = Object.keys(this.fields);
-	query = query || {};
+	var query = {};
 	fields.forEach(function (path) {
 		var field = this.fields[path];
 		if (!field.addFilterToQuery || !filters[field.path]) return;
-		field.addFilterToQuery(filters[field.path], query);
+		query = field.addFilterToQuery(filters[field.path]);
 	}, this);
 	return query;
 }

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -22,9 +22,9 @@ function getStringFilter (path, searchRegExp) {
 	return filter;
 }
 
-function addSearchToQuery (searchString, query) {
+function addSearchToQuery (searchString) {
 	searchString = String(searchString || '').trim();
-	query = query || {};
+	var query = {};
 	if (!searchString) return query;
 
 	var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');


### PR DESCRIPTION
Refactored filtering and searching methods to make query immutable.

This is much cleaner than what we previously had, where `addFilterToQuery` and `addSearchToQuery` would mutate the query somewhere deep inside the fields.