### PR TITLE
Change config 'adminui custom styles' to 'adminui custom'

### DIFF
--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -17,6 +17,9 @@
 // KEYSTONE VARIABLES
 @import "variables.less";
 
+// CUSTOM ADMIN APPLICATION VARIABLES
+@import (optional) "@{customVariablesPath}";
+
 // KEYSTONE AUTH
 @import "auth.less";
 

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -36,13 +36,20 @@ module.exports = function createStaticRouter (keystone) {
 	/* Prepare LESS options */
 	var elementalPath = path.join(path.dirname(require.resolve('elemental')), '..');
 	var reactSelectPath = path.join(path.dirname(require.resolve('react-select')), '..');
-	var customStylesPath = keystone.getPath('adminui custom styles') || '';
+	var adminuiCustom = keystone.get('adminui custom');
+	var customVariablesPath = (adminuiCustom && adminuiCustom.variablesPath)
+															? keystone.expandPath(adminuiCustom.variablesPath)
+															: '';
+	var customStylesPath = (adminuiCustom && adminuiCustom.stylesPath)
+														? keystone.expandPath(adminuiCustom.stylesPath)
+														: '';
 
 	var lessOptions = {
 		render: {
 			modifyVars: {
 				elementalPath: JSON.stringify(elementalPath),
 				reactSelectPath: JSON.stringify(reactSelectPath),
+				customVariablesPath: JSON.stringify(customVariablesPath),
 				customStylesPath: JSON.stringify(customStylesPath),
 				adminPath: JSON.stringify(keystone.get('admin path')),
 			},


### PR DESCRIPTION
**PLEASE BE ADVISED THAT THERE ARE PLANS TO RESTRUCTURE THE ADMIN UI STYLING ARCHITECTURE WHICH MAY CAUSE ANY WORK DONE WITH THIS FEATURE TO POTENTIALLY BREAK...USE AT OWN RISK**

**Usage Example**

`app-root-dir`/adminuiCustom/variables.less:
```
@primary-navbar-bg:                   blue;
@primary-navbar-color:                yellow;
@primary-navbar-padding-vertical:     1em;
@primary-navbar-padding-horizontal:   2em;
@primary-navbar-active-bg:            darken(@primary-navbar-bg, 25%);
@primary-navbar-active-color:         white;
```
`app-root-dir`/adminuiCustom/styles.less:
```
nav.primary-navbar {
  background-color: green;
}
```
```
keystone init({
...,
    'adminui custom': {
        variablesPath: 'adminuiCustom/variables.less',
        stylesPath: 'adminuiCustom/styles.less'
    },
});
```
![image](https://cloud.githubusercontent.com/assets/5872515/14063524/d35eaaa4-f3a3-11e5-873d-020a20b6ee41.png)
