### PR TITLE
made localfiles previews properly show up in admin ui column

### DIFF
--- a/templates/mixins/columns.jade
+++ b/templates/mixins/columns.jade
@@ -22,6 +22,9 @@ mixin column(list, col, item)
 		+column_html(utils.textToHTML(utils.cropString(item.get(col.field.paths.md), 200, '...', true)))
 	else if col.type == 'html'
 		+column_html(utils.cropHTMLString(item.get(col.field.path), 200, '...', true))
+	else if col.type == 'localfiles'
+		- var value = item.get( col.path ).map(function(v, i){ return col.field.format(item, i) }).join("")
+		+column_html(value)
 	else
 		- var value = col.field ? col.field.format(item) : item.get(col.path)
 		if col.isName


### PR DESCRIPTION
I came across an issue when I wanted to have  preview images of uploaded localfiles in the admin ui column view. The localfiles format method was not properly called in templates/mixins/columns.jade, so the previews did not properly show up in the admin ui column. The format method expects an index of the file, which was never supplied to the method, so it always defaulted to returning just the number of files. This commit fixes the issue. possibly related to #916.