### PR TITLE
Array filtering update

### DIFF
--- a/fields/types/numberarray/NumberArrayFilter.js
+++ b/fields/types/numberarray/NumberArrayFilter.js
@@ -1,1 +1,139 @@
-module.exports = require('../number/NumberFilter');
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { FormField, FormInput, FormRow, FormSelect } from 'elemental';
+
+const CONTROL_OPTIONS = [
+	{ label: 'Exactly', value: 'equals' },
+	{ label: 'Greater Than', value: 'gt' },
+	{ label: 'Less Than', value: 'lt' },
+	{ label: 'Between', value: 'between' },
+];
+
+const SELECTION_OPTIONS = [
+	{ label: 'All elements', value: 'all' },
+	{ label: 'At least one element', value: 'moreThan' },
+	{ label: 'No element', value: 'none' },
+];
+
+var NumberArrayFilter = React.createClass({
+
+	getInitialState () {
+		return {
+			modeValue: CONTROL_OPTIONS[0].value, // 'matches'
+			modeLabel: CONTROL_OPTIONS[0].label, // 'Matches'
+			selectionValue: SELECTION_OPTIONS[0].value,
+			selectionLabel: SELECTION_OPTIONS[0].label,
+			value: '',
+			minValue: '',
+			maxValue: '',
+		};
+	},
+
+	componentDidMount () {
+		// focus the text input
+		ReactDOM.findDOMNode(this.refs.input).focus();
+	},
+
+	handleChangeBuilder (type) {
+		const self = this;
+		return function handleChange (e) {
+			const { value } = e.target;
+			const { modeValue } = self.state;
+			const { onChange } = self.props;
+			self.setState({
+				[type]: value,
+			});
+
+			switch (type) {
+				case 'minValue':
+					onChange({
+						mode: modeValue,
+						value: {
+							min: value,
+							max: self.state.maxValue,
+						},
+					});
+					break;
+				case 'maxValue':
+					onChange({
+						mode: modeValue,
+						value: {
+							max: value,
+							min: self.state.minValue,
+						},
+					});
+					break;
+				case 'value':
+					onChange({
+						mode: modeValue,
+						value,
+					});
+			}
+		};
+	},
+
+	toggleMode (mode) {
+		this.setState({
+			modeValue: mode,
+			modeLabel: CONTROL_OPTIONS.find(option => option.value === mode).label,
+		});
+
+		// focus the text input after a mode selection is made
+		ReactDOM.findDOMNode(this.refs.input).focus();
+	},
+
+	toggleSelection (selection) {
+		this.setState({
+			selectionValue: selection,
+			selectionLabel: SELECTION_OPTIONS.find(currSelection => currSelection.value === selection).label,
+		});
+
+		// focus the text input after a selection choice is made
+		ReactDOM.findDOMNode(this.refs.input).focus();
+	},
+
+	renderControls () {
+		let controls;
+		const { field } = this.props;
+		const { modeLabel, modeValue, selectionLabel, selectionValue } = this.state;
+		const beingVerb = selectionValue === 'all' ? ' are ' : ' is ';
+		const placeholder = selectionLabel + beingVerb + modeLabel.toLowerCase() + '...';
+
+		if (modeValue === 'between') {
+			controls = (
+				<FormRow>
+					<FormField width="one-half" style={{ marginBottom: 0 }}>
+						<FormInput type="number" ref="input" placeholder="Min." onChange={this.handleChangeBuilder('minValue')} />
+					</FormField>
+					<FormField width="one-half" style={{ marginBottom: 0 }}>
+						<FormInput type="number" placeholder="Max." onChange={this.handleChangeBuilder('maxValue')} />
+					</FormField>
+				</FormRow>
+			);
+		} else {
+			controls = (
+				<FormField>
+					<FormInput type="number" ref="input" placeholder={placeholder} onChange={this.handleChangeBuilder('value')} />
+				</FormField>
+			);
+		}
+
+		return controls;
+	},
+
+	render () {
+		const { modeValue, selectionValue } = this.state;
+
+		return (
+			<div>
+				<FormSelect options={CONTROL_OPTIONS} onChange={this.toggleMode} value={modeValue} />
+				<FormSelect options={SELECTION_OPTIONS} onChange={this.toggleSelection} value={selectionValue} />
+				{this.renderControls()}
+			</div>
+		);
+	},
+
+});
+
+module.exports = NumberArrayFilter;

--- a/fields/types/numberarray/NumberArrayFilter.js
+++ b/fields/types/numberarray/NumberArrayFilter.js
@@ -99,8 +99,7 @@ var NumberArrayFilter = React.createClass({
 		let controls;
 		const { field } = this.props;
 		const { modeLabel, modeValue, presenceLabel, presenceValue } = this.state;
-		const beingVerb = presenceValue === 'all' ? ' are ' : ' is ';
-		const placeholder = presenceLabel + beingVerb + modeLabel.toLowerCase() + '...';
+		const placeholder = presenceLabel + ' is ' + modeLabel.toLowerCase() + '...';
 
 		if (modeValue === 'between') {
 			controls = (

--- a/fields/types/numberarray/NumberArrayFilter.js
+++ b/fields/types/numberarray/NumberArrayFilter.js
@@ -10,9 +10,8 @@ const CONTROL_OPTIONS = [
 	{ label: 'Between', value: 'between' },
 ];
 
-const SELECTION_OPTIONS = [
-	{ label: 'All elements', value: 'all' },
-	{ label: 'At least one element', value: 'moreThan' },
+const PRESENCE_OPTIONS = [
+	{ label: 'At least one element', value: 'some' },
 	{ label: 'No element', value: 'none' },
 ];
 
@@ -20,10 +19,10 @@ var NumberArrayFilter = React.createClass({
 
 	getInitialState () {
 		return {
-			modeValue: CONTROL_OPTIONS[0].value, // 'matches'
-			modeLabel: CONTROL_OPTIONS[0].label, // 'Matches'
-			selectionValue: SELECTION_OPTIONS[0].value,
-			selectionLabel: SELECTION_OPTIONS[0].label,
+			modeValue: CONTROL_OPTIONS[0].value, // 'equals'
+			modeLabel: CONTROL_OPTIONS[0].label, // 'Exactly'
+			presenceValue: PRESENCE_OPTIONS[0].value,
+			presenceLabel: PRESENCE_OPTIONS[0].label,
 			value: '',
 			minValue: '',
 			maxValue: '',
@@ -39,7 +38,7 @@ var NumberArrayFilter = React.createClass({
 		const self = this;
 		return function handleChange (e) {
 			const { value } = e.target;
-			const { modeValue, selectionValue } = self.state;
+			const { modeValue, presenceValue } = self.state;
 			const { onChange } = self.props;
 			self.setState({
 				[type]: value,
@@ -49,7 +48,7 @@ var NumberArrayFilter = React.createClass({
 				case 'minValue':
 					onChange({
 						mode: modeValue,
-						selection: selectionValue,
+						presence: presenceValue,
 						value: {
 							min: value,
 							max: self.state.maxValue,
@@ -59,7 +58,7 @@ var NumberArrayFilter = React.createClass({
 				case 'maxValue':
 					onChange({
 						mode: modeValue,
-						selection: selectionValue,
+						presence: presenceValue,
 						value: {
 							max: value,
 							min: self.state.minValue,
@@ -69,7 +68,7 @@ var NumberArrayFilter = React.createClass({
 				case 'value':
 					onChange({
 						mode: modeValue,
-						selection: selectionValue,
+						presence: presenceValue,
 						value,
 					});
 			}
@@ -86,22 +85,22 @@ var NumberArrayFilter = React.createClass({
 		ReactDOM.findDOMNode(this.refs.input).focus();
 	},
 
-	toggleSelection (selection) {
+	togglePresence (presence) {
 		this.setState({
-			selectionValue: selection,
-			selectionLabel: SELECTION_OPTIONS.find(currSelection => currSelection.value === selection).label,
+			presenceValue: presence,
+			presenceLabel: PRESENCE_OPTIONS.find(currPresence => currPresence.value === presence).label,
 		});
 
-		// focus the text input after a selection choice is made
+		// focus the text input after a presence choice is made
 		ReactDOM.findDOMNode(this.refs.input).focus();
 	},
 
 	renderControls () {
 		let controls;
 		const { field } = this.props;
-		const { modeLabel, modeValue, selectionLabel, selectionValue } = this.state;
-		const beingVerb = selectionValue === 'all' ? ' are ' : ' is ';
-		const placeholder = selectionLabel + beingVerb + modeLabel.toLowerCase() + '...';
+		const { modeLabel, modeValue, presenceLabel, presenceValue } = this.state;
+		const beingVerb = presenceValue === 'all' ? ' are ' : ' is ';
+		const placeholder = presenceLabel + beingVerb + modeLabel.toLowerCase() + '...';
 
 		if (modeValue === 'between') {
 			controls = (
@@ -126,12 +125,12 @@ var NumberArrayFilter = React.createClass({
 	},
 
 	render () {
-		const { modeValue, selectionValue } = this.state;
+		const { modeValue, presenceValue } = this.state;
 
 		return (
 			<div>
+				<FormSelect options={PRESENCE_OPTIONS} 	onChange={this.togglePresence} value={presenceValue} />
 				<FormSelect options={CONTROL_OPTIONS} onChange={this.toggleMode} value={modeValue} />
-				<FormSelect options={SELECTION_OPTIONS} onChange={this.toggleSelection} value={selectionValue} />
 				{this.renderControls()}
 			</div>
 		);

--- a/fields/types/numberarray/NumberArrayFilter.js
+++ b/fields/types/numberarray/NumberArrayFilter.js
@@ -39,7 +39,7 @@ var NumberArrayFilter = React.createClass({
 		const self = this;
 		return function handleChange (e) {
 			const { value } = e.target;
-			const { modeValue } = self.state;
+			const { modeValue, selectionValue } = self.state;
 			const { onChange } = self.props;
 			self.setState({
 				[type]: value,
@@ -49,6 +49,7 @@ var NumberArrayFilter = React.createClass({
 				case 'minValue':
 					onChange({
 						mode: modeValue,
+						selection: selectionValue,
 						value: {
 							min: value,
 							max: self.state.maxValue,
@@ -58,6 +59,7 @@ var NumberArrayFilter = React.createClass({
 				case 'maxValue':
 					onChange({
 						mode: modeValue,
+						selection: selectionValue,
 						value: {
 							max: value,
 							min: self.state.minValue,
@@ -67,6 +69,7 @@ var NumberArrayFilter = React.createClass({
 				case 'value':
 					onChange({
 						mode: modeValue,
+						selection: selectionValue,
 						value,
 					});
 			}

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -123,6 +123,7 @@ numberarray.prototype.addFilterToQuery = function (filter) {
 	var presence = filter.presence || 'some';
 	// Filter empty/non-empty arrays
 	if (filter.mode === 'equals' && !filter.value) {
+		// TODO Fix this, filter.inverted doesn't exist
 		query[this.path] = filter.inverted ? { $nin: ['', 0, null] } : { $in: ['', 0, null] };
 		return query;
 	}

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -144,10 +144,7 @@ numberarray.prototype.addFilterToQuery = function (filter) {
 		var min = utils.number(filter.value.min);
 		var max = utils.number(filter.value.max);
 		if (!isNaN(min) && !isNaN(max)) {
-			query[this.path] = filter.inverted ? {
-				$gte: max,
-				$lte: min,
-			} : {
+			query[this.path] = {
 				$gte: min,
 				$lte: max,
 			};
@@ -159,16 +156,12 @@ numberarray.prototype.addFilterToQuery = function (filter) {
 	// Filter greater than, less than and equals
 	if (!isNaN(value)) {
 		if (filter.mode === 'gt') {
-			query[this.path] = filter.inverted ? {
-				$lt: value,
-			} : {
+			query[this.path] = {
 				$gt: value,
 			};
 		}
 		else if (filter.mode === 'lt') {
-			query[this.path] = filter.inverted ? {
-				$gt: value,
-			} : {
+			query[this.path] = {
 				$lt: value,
 			};
 		}

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -3,6 +3,7 @@ var numeral = require('numeral');
 var util = require('util');
 var utils = require('keystone-utils');
 var clone = require('lodash/clone');
+var addPresenceToQuery = require('../../utils/addPresenceToQuery');
 
 /**
  * Number FieldType Constructor
@@ -167,31 +168,6 @@ numberarray.prototype.addFilterToQuery = function (filter) {
 	}
 	return query;
 };
-
-/**
- * Accounts for the presence choice when filtering
- *
- * @param {Object} presence  		The current presence choice
- * @param {Object} currentPathQuery The current request query
- */
-function addPresenceToQuery (presence, currentPathQuery) {
-	var newQuery;
-	// Adds $elemMatch if the presence choice is 'all'
-	// ('all' is the default)
-	if (presence === 'some') {
-		newQuery = {
-			$elemMatch: currentPathQuery,
-		};
-	// Adds $not if the presence is 'none'
-	} else if (presence === 'none') {
-		newQuery = {
-			$not: currentPathQuery,
-		};
-	}
-	// Return the newQuery if the presence changed something
-	// otherwise return the original query
-	return newQuery || currentPathQuery;
-}
 
 /**
  * Checks that a valid array of number has been provided in a data object

--- a/fields/types/numberarray/NumberArrayType.js
+++ b/fields/types/numberarray/NumberArrayType.js
@@ -111,16 +111,16 @@ numberarray.prototype.validateRequiredInput = function (item, data, callback) {
 /**
  * Add filters to a query
  *
- * @param {Object} filter 			   The data from the frontend
- * @param {String} filter.mode  	   The filter mode, either one of "between",
- *                                     "gt" or "lt"
- * @param {String} filter.presence	   The presence mode, either on of
- *                                     "none" and "some"
- * @param {String|Object} filter.value The value that is filtered for
+ * @param {Object} filter 			   		The data from the frontend
+ * @param {String} filter.mode  	   		The filter mode, either one of
+ *                                     		"between", "gt" or "lt"
+ * @param {String} [filter.presence='some'] The presence mode, either on of
+ *                                          "none" and "some". Default: 'some'
+ * @param {String|Object} filter.value 		The value that is filtered for
  */
 numberarray.prototype.addFilterToQuery = function (filter) {
 	var query = {};
-	var presence = filter.presence || 'some'; // Default: 'some' mode
+	var presence = filter.presence || 'some';
 	// Filter empty/non-empty arrays
 	if (filter.mode === 'equals' && !filter.value) {
 		query[this.path] = filter.inverted ? { $nin: ['', 0, null] } : { $in: ['', 0, null] };

--- a/fields/types/numberarray/test/type.js
+++ b/fields/types/numberarray/test/type.js
@@ -411,34 +411,6 @@ exports.testFieldType = function (List) {
 				});
 			});
 
-			it('should support inverted less than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'some',
-					value: 10,
-					mode: 'lt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$gt: 10,
-					},
-				});
-			});
-
-			it('should support inverted greater than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'some',
-					value: 0,
-					mode: 'gt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$lt: 0,
-					},
-				});
-			});
-
 			it('should filter for existance', function () {
 				var result = List.fields.numarr.addFilterToQuery({
 					presence: 'some',
@@ -461,24 +433,6 @@ exports.testFieldType = function (List) {
 					$elemMatch: {
 						$gte: 0,
 						$lte: 10,
-					},
-				});
-			});
-
-			it('should filter exluding a range between two numbers', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'some',
-					mode: 'between',
-					value: {
-						min: 0,
-						max: 10,
-					},
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$gte: 10,
-						$lte: 0,
 					},
 				});
 			});
@@ -560,34 +514,6 @@ exports.testFieldType = function (List) {
 				});
 			});
 
-			it('should support inverted less than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'none',
-					value: 10,
-					mode: 'lt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$not: {
-						$gt: 10,
-					},
-				});
-			});
-
-			it('should support inverted greater than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'none',
-					value: 0,
-					mode: 'gt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$not: {
-						$lt: 0,
-					},
-				});
-			});
-
 			it('should filter for existance', function () {
 				var result = List.fields.numarr.addFilterToQuery({
 					presence: 'none',
@@ -612,24 +538,6 @@ exports.testFieldType = function (List) {
 					$not: {
 						$gte: 0,
 						$lte: 10,
-					},
-				});
-			});
-
-			it('should filter exluding a range between two numbers', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'none',
-					mode: 'between',
-					value: {
-						min: 0,
-						max: 10,
-					},
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$not: {
-						$gte: 10,
-						$lte: 0,
 					},
 				});
 			});
@@ -709,32 +617,6 @@ exports.testFieldType = function (List) {
 				});
 			});
 
-			it('should support inverted less than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					value: 10,
-					mode: 'lt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$gt: 10,
-					},
-				});
-			});
-
-			it('should support inverted greater than', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					value: 0,
-					mode: 'gt',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$lt: 0,
-					},
-				});
-			});
-
 			it('should filter for existance', function () {
 				var result = List.fields.numarr.addFilterToQuery({
 					mode: 'equals',
@@ -756,23 +638,6 @@ exports.testFieldType = function (List) {
 					$elemMatch: {
 						$gte: 0,
 						$lte: 10,
-					},
-				});
-			});
-
-			it('should filter exluding a range between two numbers', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					mode: 'between',
-					value: {
-						min: 0,
-						max: 10,
-					},
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$elemMatch: {
-						$gte: 10,
-						$lte: 0,
 					},
 				});
 			});

--- a/fields/types/numberarray/test/type.js
+++ b/fields/types/numberarray/test/type.js
@@ -372,151 +372,476 @@ exports.testFieldType = function (List) {
 	});
 
 	describe('addFilterToQuery', function () {
-		it('should filter for a specific number', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: 10,
+		describe('"some" present', function () {
+			it('should filter for a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: 10,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$eq: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$eq: 10,
-				},
+
+			it('should filter greater than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: 0,
+					mode: 'gt',
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gt: 0,
+					},
+				});
+			});
+
+			it('should filter less than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: 10,
+					mode: 'lt',
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$lt: 10,
+					},
+				});
+			});
+
+			it('should support inverted less than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: 10,
+					mode: 'lt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gt: 10,
+					},
+				});
+			});
+
+			it('should support inverted greater than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: 0,
+					mode: 'gt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$lt: 0,
+					},
+				});
+			});
+
+			it('should filter for existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'equals',
+				});
+				demand(result.numarr).eql({
+					$in: ['', 0, null],
+				});
+			});
+
+			it('should filter for non-existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'equals',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$nin: ['', 0, null],
+				});
+			});
+
+			it('should filter between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
+			});
+
+			it('should filter exluding a range between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 10,
+						$lte: 0,
+					},
+				});
+			});
+
+			it('should filter between two number strings', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'between',
+					value: {
+						min: '0',
+						max: '10',
+					},
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
+			});
+
+			it('should not filter if the value is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					value: NaN,
+				});
+				demand(result.numarr).be.undefined();
+			});
+
+			it('should not filter between two numbers if one is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'between',
+					value: {
+						min: NaN,
+						max: 10,
+					},
+				});
+				demand(result.numarr).be.undefined();
 			});
 		});
 
-		it('should filter greater than a specific number', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: 0,
-				mode: 'gt',
+		describe('"none" present', function () {
+			it('should filter for a non-existing specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: 10,
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$eq: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$gt: 0,
-				},
+
+			it('should filter greater than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: 0,
+					mode: 'gt',
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$gt: 0,
+					},
+				});
+			});
+
+			it('should filter less than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: 10,
+					mode: 'lt',
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$lt: 10,
+					},
+				});
+			});
+
+			it('should support inverted less than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: 10,
+					mode: 'lt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$gt: 10,
+					},
+				});
+			});
+
+			it('should support inverted greater than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: 0,
+					mode: 'gt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$lt: 0,
+					},
+				});
+			});
+
+			it('should filter for existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'equals',
+				});
+				demand(result.numarr).eql({
+					$in: ['', 0, null],
+				});
+			});
+
+			it('should filter for non-existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'equals',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$nin: ['', 0, null],
+				});
+			});
+
+			it('should filter between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
+			});
+
+			it('should filter exluding a range between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$gte: 10,
+						$lte: 0,
+					},
+				});
+			});
+
+			it('should filter between two number strings', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'between',
+					value: {
+						min: '0',
+						max: '10',
+					},
+				});
+				demand(result.numarr).eql({
+					$not: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
+			});
+
+			it('should not filter if the value is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					value: NaN,
+				});
+				demand(result.numarr).be.undefined();
+			});
+
+			it('should not filter between two numbers if one is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'between',
+					value: {
+						min: NaN,
+						max: 10,
+					},
+				});
+				demand(result.numarr).be.undefined();
 			});
 		});
 
-		it('should filter less than a specific number', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: 10,
-				mode: 'lt',
+		// Should default to the "some" behaviour
+		describe('no presence option specified', function () {
+			it('should filter for a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: 10,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$eq: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$lt: 10,
-				},
-			});
-		});
 
-		it('should support inverted less than', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: 10,
-				mode: 'lt',
-				inverted: true,
+			it('should filter greater than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: 0,
+					mode: 'gt',
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gt: 0,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$gt: 10,
-				},
-			});
-		});
 
-		it('should support inverted greater than', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: 0,
-				mode: 'gt',
-				inverted: true,
+			it('should filter less than a specific number', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: 10,
+					mode: 'lt',
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$lt: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$lt: 0,
-				},
-			});
-		});
 
-		it('should filter for existance', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'equals',
+			it('should support inverted less than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: 10,
+					mode: 'lt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gt: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$in: ['', 0, null],
-			});
-		});
 
-		it('should filter for non-existance', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'equals',
-				inverted: true,
+			it('should support inverted greater than', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: 0,
+					mode: 'gt',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$lt: 0,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$nin: ['', 0, null],
-			});
-		});
 
-		it('should filter between two numbers', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'between',
-				value: {
-					min: 0,
-					max: 10,
-				},
+			it('should filter for existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'equals',
+				});
+				demand(result.numarr).eql({
+					$in: ['', 0, null],
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$gte: 0,
-					$lte: 10,
-				},
-			});
-		});
 
-		it('should filter exluding a range between two numbers', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'between',
-				value: {
-					min: 0,
-					max: 10,
-				},
-				inverted: true,
+			it('should filter for non-existance', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'equals',
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$nin: ['', 0, null],
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$gte: 10,
-					$lte: 0,
-				},
-			});
-		});
 
-		it('should filter between two number strings', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'between',
-				value: {
-					min: '0',
-					max: '10',
-				},
+			it('should filter between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
 			});
-			demand(result.numarr).eql({
-				$elemMatch: {
-					$gte: 0,
-					$lte: 10,
-				},
-			});
-		});
 
-		it('should not filter if the value is NaN', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				value: NaN,
+			it('should filter exluding a range between two numbers', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'between',
+					value: {
+						min: 0,
+						max: 10,
+					},
+					inverted: true,
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 10,
+						$lte: 0,
+					},
+				});
 			});
-			demand(result.numarr).be.undefined();
-		});
 
-		it('should not filter between two numbers if one is NaN', function () {
-			var result = List.fields.numarr.addFilterToQuery({
-				mode: 'between',
-				value: {
-					min: NaN,
-					max: 10,
-				},
+			it('should filter between two number strings', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'between',
+					value: {
+						min: '0',
+						max: '10',
+					},
+				});
+				demand(result.numarr).eql({
+					$elemMatch: {
+						$gte: 0,
+						$lte: 10,
+					},
+				});
 			});
-			demand(result.numarr).be.undefined();
+
+			it('should not filter if the value is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					value: NaN,
+				});
+				demand(result.numarr).be.undefined();
+			});
+
+			it('should not filter between two numbers if one is NaN', function () {
+				var result = List.fields.numarr.addFilterToQuery({
+					mode: 'between',
+					value: {
+						min: NaN,
+						max: 10,
+					},
+				});
+				demand(result.numarr).be.undefined();
+			});
 		});
 	});
 

--- a/fields/types/numberarray/test/type.js
+++ b/fields/types/numberarray/test/type.js
@@ -442,21 +442,9 @@ exports.testFieldType = function (List) {
 			it('should filter for existance', function () {
 				var result = List.fields.numarr.addFilterToQuery({
 					presence: 'some',
-					mode: 'equals',
 				});
 				demand(result.numarr).eql({
-					$in: ['', 0, null],
-				});
-			});
-
-			it('should filter for non-existance', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'some',
-					mode: 'equals',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$nin: ['', 0, null],
+					$size: 0,
 				});
 			});
 
@@ -603,21 +591,11 @@ exports.testFieldType = function (List) {
 			it('should filter for existance', function () {
 				var result = List.fields.numarr.addFilterToQuery({
 					presence: 'none',
-					mode: 'equals',
 				});
 				demand(result.numarr).eql({
-					$in: ['', 0, null],
-				});
-			});
-
-			it('should filter for non-existance', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					presence: 'none',
-					mode: 'equals',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$nin: ['', 0, null],
+					$not: {
+						$size: 0,
+					},
 				});
 			});
 
@@ -762,17 +740,7 @@ exports.testFieldType = function (List) {
 					mode: 'equals',
 				});
 				demand(result.numarr).eql({
-					$in: ['', 0, null],
-				});
-			});
-
-			it('should filter for non-existance', function () {
-				var result = List.fields.numarr.addFilterToQuery({
-					mode: 'equals',
-					inverted: true,
-				});
-				demand(result.numarr).eql({
-					$nin: ['', 0, null],
+					$size: 0,
 				});
 			});
 

--- a/fields/types/textarray/TextArrayFilter.js
+++ b/fields/types/textarray/TextArrayFilter.js
@@ -1,1 +1,75 @@
-module.exports = require('../text/TextFilter');
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { FormField, FormInput, FormSelect, SegmentedControl } from 'elemental';
+
+const MODE_OPTIONS = [
+	{ label: 'Contains', value: 'contains' },
+	{ label: 'Exactly', value: 'exactly' },
+	{ label: 'Begins with', value: 'beginsWith' },
+	{ label: 'Ends with', value: 'endsWith' },
+];
+
+const PRESENCE_OPTIONS = [
+	{ label: 'At least one element', value: 'some' },
+	{ label: 'No element', value: 'none' },
+];
+
+function getDefaultValue () {
+	return {
+		mode: MODE_OPTIONS[0].value,
+		presence: PRESENCE_OPTIONS[0].value,
+		value: '',
+	};
+}
+
+var TextArrayFilter = React.createClass({
+	propTypes: {
+		filter: React.PropTypes.shape({
+			mode: React.PropTypes.oneOf(MODE_OPTIONS.map(i => i.value)),
+			presence: React.PropTypes.oneOf(PRESENCE_OPTIONS.map(i => i.value)),
+			value: React.PropTypes.string,
+		}),
+	},
+	statics: {
+		getDefaultValue: getDefaultValue,
+	},
+	getDefaultProps () {
+		return {
+			filter: getDefaultValue(),
+		};
+	},
+	updateFilter (value) {
+		this.props.onChange({ ...this.props.filter, ...value });
+	},
+	selectMode (mode) {
+		this.updateFilter({ mode });
+		ReactDOM.findDOMNode(this.refs.focusTarget).focus();
+	},
+	selectPresence (presence) {
+		this.updateFilter({ presence });
+		ReactDOM.findDOMNode(this.refs.focusTarget).focus();
+	},
+	updateValue (e) {
+		this.updateFilter({ value: e.target.value });
+	},
+	render () {
+		const { field, filter } = this.props;
+		const mode = MODE_OPTIONS.filter(i => i.value === filter.mode)[0];
+		const presence = PRESENCE_OPTIONS.filter(i => i.value === filter.presence)[0];
+		const beingVerb = mode.value === 'exactly' ? ' is ' : ' ';
+		const placeholder = presence.label + beingVerb + mode.label.toLowerCase() + '...';
+
+		return (
+			<div>
+				<FormSelect options={PRESENCE_OPTIONS} onChange={this.selectPresence} value={presence.value} />
+				<FormSelect options={MODE_OPTIONS} onChange={this.selectMode} value={mode.value} />
+				<FormField>
+					<FormInput autofocus ref="focusTarget" value={this.props.filter.value} onChange={this.updateValue} placeholder={placeholder} />
+				</FormField>
+			</div>
+		);
+	},
+});
+
+module.exports = TextArrayFilter;

--- a/fields/types/textarray/TextArrayType.js
+++ b/fields/types/textarray/TextArrayType.js
@@ -38,13 +38,17 @@ textarray.prototype.addFilterToQuery = function (filter) {
 	var query = {};
 	var presence = filter.presence || 'some';
 	// Filter empty/non-empty arrays
-	if (filter.mode === 'exactly' && !filter.value) {
-		// TODO Fix this, filter.inverted doesn't exist
-		query[this.path] = {
-			$elemMatch: filter.inverted ? {
-				$nin: ['', null],
-			} : {
-				$in: ['', null],
+	if (!filter.value) {
+		// "At least one element contains nothing"
+		// This isn't 100% accurate because this will only return arrays that
+		// don't have elements, not ones that have empty elements, but it works
+		// fine for 99% of the usecase
+		query[this.path] = presence === 'some' ? {
+			$size: 0,
+		// "No elements contain nothing"
+		} : {
+			$not: {
+				$size: 0,
 			},
 		};
 		return query;
@@ -65,7 +69,6 @@ textarray.prototype.addFilterToQuery = function (filter) {
 			$regex: value,
 		});
 	}
-	console.log(query);
 	return query;
 };
 

--- a/fields/types/textarray/test/type.js
+++ b/fields/types/textarray/test/type.js
@@ -302,95 +302,222 @@ exports.testFieldType = function (List) {
 	});
 
 	describe('addFilterToQuery', function () {
-		it('should return a regex with the "i" flag set', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
+		describe('"some" present', function () {
+			it('should return a regex with the "i" flag set', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					value: 'abc',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc/i,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$regex: /abc/i,
-				},
+
+			it('should allow case sensitive matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					value: 'abc',
+					caseSensitive: true,
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc/,
+					},
+				});
+			});
+
+			it('should allow exact matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					value: 'abc',
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /^abc$/i,
+					},
+				});
+			});
+
+			it('should allow matching the end', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					value: 'abc',
+					mode: 'endsWith',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc$/i,
+					},
+				});
+			});
+
+			it('should allow matching the start', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					value: 'abc',
+					mode: 'beginsWith',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /^abc/i,
+					},
+				});
+			});
+
+			it('should allow matching empty values in exact mode', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'some',
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$in: ['', null],
+					},
+				});
 			});
 		});
 
-		it('should allow case sensitive matching', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
-				caseSensitive: true,
+		describe('"none" present', function () {
+			it('should return a regex with the "i" flag set', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					value: 'abc',
+				});
+				demand(result.textarr).eql({
+					$not: /abc/i,
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$regex: /abc/,
-				},
+
+			it('should allow case sensitive matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					value: 'abc',
+					caseSensitive: true,
+				});
+				demand(result.textarr).eql({
+					$not: /abc/,
+				});
+			});
+
+			it('should allow exact matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					value: 'abc',
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$not: /^abc$/i,
+				});
+			});
+
+			it('should allow matching the end', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					value: 'abc',
+					mode: 'endsWith',
+				});
+				demand(result.textarr).eql({
+					$not: /abc$/i,
+				});
+			});
+
+			it('should allow matching the start', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					value: 'abc',
+					mode: 'beginsWith',
+				});
+				demand(result.textarr).eql({
+					$not: /^abc/i,
+				});
+			});
+
+			it('should allow matching empty values in exact mode', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					presence: 'none',
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$nin: ['', null],
+					},
+				});
 			});
 		});
 
-		it('should allow inverted matching', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
-				inverted: true,
+		// Presence undefined should behave exactly like presence === 'some'
+		describe('no presence option', function () {
+			it('should return a regex with the "i" flag set', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					value: 'abc',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc/i,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$not: /abc/i,
-			});
-		});
 
-		it('should allow exact matching', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
-				mode: 'exactly',
+			it('should allow case sensitive matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					value: 'abc',
+					caseSensitive: true,
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc/,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$regex: /^abc$/i,
-				},
-			});
-		});
 
-		it('should allow matching the end', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
-				mode: 'endsWith',
+			it('should allow exact matching', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					value: 'abc',
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /^abc$/i,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$regex: /abc$/i,
-				},
-			});
-		});
 
-		it('should allow matching the start', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				value: 'abc',
-				mode: 'beginsWith',
+			it('should allow matching the end', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					value: 'abc',
+					mode: 'endsWith',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /abc$/i,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$regex: /^abc/i,
-				},
-			});
-		});
 
-		it('should allow matching empty values in exact mode', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				mode: 'exactly',
+			it('should allow matching the start', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					value: 'abc',
+					mode: 'beginsWith',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$regex: /^abc/i,
+					},
+				});
 			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$in: ['', null],
-				},
-			});
-		});
 
-		it('should allow matching non-empty values in exact mode with the inverted option', function () {
-			var result = List.fields.textarr.addFilterToQuery({
-				mode: 'exactly',
-				inverted: true,
-			});
-			demand(result.textarr).eql({
-				$elemMatch: {
-					$nin: ['', null],
-				},
+			it('should allow matching empty values in exact mode', function () {
+				var result = List.fields.textarr.addFilterToQuery({
+					mode: 'exactly',
+				});
+				demand(result.textarr).eql({
+					$elemMatch: {
+						$in: ['', null],
+					},
+				});
 			});
 		});
 	});

--- a/fields/types/textarray/test/type.js
+++ b/fields/types/textarray/test/type.js
@@ -367,15 +367,12 @@ exports.testFieldType = function (List) {
 				});
 			});
 
-			it('should allow matching empty values in exact mode', function () {
+			it('should allow matching empty values', function () {
 				var result = List.fields.textarr.addFilterToQuery({
 					presence: 'some',
-					mode: 'exactly',
 				});
 				demand(result.textarr).eql({
-					$elemMatch: {
-						$in: ['', null],
-					},
+					$size: 0,
 				});
 			});
 		});
@@ -435,14 +432,13 @@ exports.testFieldType = function (List) {
 				});
 			});
 
-			it('should allow matching empty values in exact mode', function () {
+			it('should allow matching non-empty values', function () {
 				var result = List.fields.textarr.addFilterToQuery({
 					presence: 'none',
-					mode: 'exactly',
 				});
 				demand(result.textarr).eql({
-					$elemMatch: {
-						$nin: ['', null],
+					$not: {
+						$size: 0,
 					},
 				});
 			});
@@ -510,13 +506,9 @@ exports.testFieldType = function (List) {
 			});
 
 			it('should allow matching empty values in exact mode', function () {
-				var result = List.fields.textarr.addFilterToQuery({
-					mode: 'exactly',
-				});
+				var result = List.fields.textarr.addFilterToQuery({});
 				demand(result.textarr).eql({
-					$elemMatch: {
-						$in: ['', null],
-					},
+					$size: 0,
 				});
 			});
 		});

--- a/fields/utils/addPresenceToQuery.js
+++ b/fields/utils/addPresenceToQuery.js
@@ -1,0 +1,26 @@
+/**
+ * Accounts for the presence choice when filtering
+ *
+ * @param {Object} presence  		The current presence choice
+ * @param {Object} currentPathQuery The current request query
+ */
+function addPresenceToQuery (presence, currentPathQuery) {
+	var newQuery;
+	// Adds $elemMatch if the presence choice is 'all'
+	// ('all' is the default)
+	if (presence === 'some') {
+		newQuery = {
+			$elemMatch: currentPathQuery,
+		};
+	// Adds $not if the presence is 'none'
+	} else if (presence === 'none') {
+		newQuery = {
+			$not: currentPathQuery,
+		};
+	}
+	// Return the newQuery if the presence changed something
+	// otherwise return the original query
+	return newQuery || currentPathQuery;
+}
+
+module.exports = addPresenceToQuery;


### PR DESCRIPTION
~~WIP don't merge yet!~~

Add "presence" filter to array fields.

Basically, you should be able to select if "At least one of the elements" or "None of the elements" match the selected query. ("At least x of the elements" and "All elements" would make sense too, but those are impossible with MongoDB)

- [x] Number array
  - [x] Update filter component with new options
  - [x] Make old tests pass with new option when not set (or set to `some`, which is the default behaviour)
  - [x] Add support for `none`
  - [x] Tests
- [x] Text array
  - [x] Update filter component with new options
  - [x] Make old tests pass with new option when not set
  - [x] Add support for `none`
  - [x] Tests

![screen shot 2016-03-29 at 14 05 22](https://cloud.githubusercontent.com/assets/7525670/14096825/522a684a-f5b7-11e5-88b8-9e9655a4a5af.png)
