### PR TITLE
Make boolean field type render "for" attribute

### DIFF
--- a/fields/types/boolean/BooleanField.js
+++ b/fields/types/boolean/BooleanField.js
@@ -40,7 +40,7 @@ module.exports = Field.create({
 
 	renderUI () {
 		return (
-			<FormField offsetAbsentLabel={this.props.indent} className="field-type-boolean">
+			<FormField offsetAbsentLabel={this.props.indent} className="field-type-boolean" htmlFor={this.props.path}>
 				<label style={{ height: '2.3em' }}>
 					{this.renderFormInput()}
 					{this.renderCheckbox()}


### PR DESCRIPTION
This fixes #2551. I'm not sure if this is the best way to fix as I noticed that the Boolean field uses the base Field.js a little differently than other fields.