### PR TITLE
Fix #2469 : Unable to delete files for LocalFilesType.js 

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -29,6 +29,7 @@ var DEFAULT_OPTION_KEYS = [
 	'hidden',
 	'collapse',
 	'dependsOn',
+	'autoCleanup',
 ];
 
 /**

--- a/fields/types/localfile/LocalFileType.js
+++ b/fields/types/localfile/LocalFileType.js
@@ -17,6 +17,7 @@ function localfile (list, path, options) {
 		.allowHooks('move');
 	this._underscoreMethods = ['format', 'uploadFile'];
 	this._fixedSize = 'full';
+	this.autoCleanup = options.autoCleanup || false;
 
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;


### PR DESCRIPTION
**Fix #2469**


For the files to be deleted from the filesystem, the `autoCleanup`  property of the  `LocalFile` need to be set to `true`.

E.g.,
```
Docs.add({
	name: { type: String, required: true, index: true },
	myLocalFile: {
		type: Types.LocalFile,
		autoCleanup: true,
		dest: '/data/localfiles',
		prefix: '/files/',
		format: function (item, file) {
			return '<img src="/files/' + file.filename + '" style="max-width: 300px">'
		}
	},
```

However, there was still a bug in the code due to which `autoCleanup` property was not being passed to the react component. Modified the code to address this issue.