### PR TITLE
allow prefix + to specify ascending sorting of a column (fixes #2022)

### DIFF
--- a/admin/client/lib/List.js
+++ b/admin/client/lib/List.js
@@ -118,6 +118,9 @@ List.prototype.expandSort = function (input) {
 			invert = true;
 			path = path.substr(1);
 		}
+		if (path.charAt(0) === '+') {
+			path = path.substr(1);
+		}
 		const field = this.fields[path];
 		if (!field) {
 			// TODO: Support arbitary document paths


### PR DESCRIPTION
Conflicts with #2566 , but it's a pretty simple patch.