### PR TITLE
Post Signout Error Display Corrected

### DIFF
--- a/admin/server/api/session/signout.js
+++ b/admin/server/api/session/signout.js
@@ -9,7 +9,7 @@ function signout (req, res) {
 		req.session.regenerate(function (err) {
 			if (err) return res.json({ error: 'session error', detail: err });
 			keystone.callHook(user, 'post:signout', function (err) {
-				if (err) return res.json({ error: 'pre:signout error', detail: err });
+				if (err) return res.json({ error: 'post:signout error', detail: err });
 				res.json({ success: true });
 			});
 		});


### PR DESCRIPTION
It is a fix for https://github.com/keystonejs/keystone/blob/master/admin/server/api/session/signout.js where when post sign out error occurs the display is **error: 'pre:signout error'.**
Instead of this the display should be **error: 'post:signout error'**.