### PR TITLE
[e2e testing] Add ui and ux tests for text fields

### DIFF
--- a/test/e2e/adminUI/adminUI.js
+++ b/test/e2e/adminUI/adminUI.js
@@ -70,11 +70,6 @@ module.exports = {
 			labelForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-label',
 			plusIconLinkForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] a.dashboard-group__list-create.octicon.octicon-plus',
 			itemCountForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-count',
-			// Text List Tab
-			textsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"]',
-			labelForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] .dashboard-group__list-label',
-			plusIconLinkForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] a.dashboard-group__list-create.octicon.octicon-plus',
-			itemCountForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] .dashboard-group__list-count',
 
 			// Dashboard's Others Group
 			dashboardOthersSubheading: '.dashboard-group__heading[data-section-label="Other"]',
@@ -298,28 +293,6 @@ module.exports = {
 						},
 					},
 				},
-				text: {
-					user: {
-						text: {
-							label: '.EditForm-container .field-type-text[for="text"] .FormLabel',
-							value: '.EditForm-container .field-type-text[for="text"] input[name="text"]',
-						},
-					},
-					text: {
-						name: {
-							label: '.EditForm-container .field-type-text[for="name"] .FormLabel',
-							value: '.EditForm-container .field-type-text[for="name"] input[name="name"]',
-						},
-						fieldA: {
-							label: '.EditForm-container .field-type-text[for="fieldA"] .FormLabel',
-							value: '.EditForm-container .field-type-text[for="fieldA"] input[name="fieldA"]',
-						},
-						fieldB: {
-							label: '.EditForm-container .field-type-text[for="fieldB"] .FormLabel',
-							value: '.EditForm-container .field-type-text[for="fieldB"] input[name="fieldB"]',
-						},
-					},
-				},
 			},
 		},
 		initialModalView: {
@@ -443,24 +416,6 @@ module.exports = {
 							placeholder: '.Modal-dialog .field-type-name[for="fieldA"] .Select-placeholder',
 							dropdownArrow: '.Modal-dialog .field-type-name[for="fieldA"] .Select-arrow-zone',
 							optionOne: '.Modal-dialog .field-type-name[for="fieldA"] .Select-menu-outer option[value="One"]',
-						},
-					},
-				},
-				text: {
-					user: {
-						text: {
-							label: '.Modal-dialog .field-type-text[for="name"] .FormLabel',
-							value: '.Modal-dialog .field-type-text[for="text"] input[name="text"]',
-						},
-					},
-					text: {
-						name: {
-							label: '.Modal-dialog .field-type-text[for="name"] .FormLabel',
-							value: '.Modal-dialog .field-type-text[for="name"] input[name="name"]',
-						},
-						fieldA: {
-							label: '.Modal-dialog .field-type-text[for="fieldA"] .FormLabel',
-							value: '.Modal-dialog .field-type-text[for="fieldA"] input[name="fieldA"]',
 						},
 					},
 				},

--- a/test/e2e/adminUI/adminUI.js
+++ b/test/e2e/adminUI/adminUI.js
@@ -70,6 +70,11 @@ module.exports = {
 			labelForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-label',
 			plusIconLinkForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] a.dashboard-group__list-create.octicon.octicon-plus',
 			itemCountForSelectsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-count',
+			// Text List Tab
+			textsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"]',
+			labelForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] .dashboard-group__list-label',
+			plusIconLinkForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] a.dashboard-group__list-create.octicon.octicon-plus',
+			itemCountForTextsTabUnderDashboardFieldsSubheading: '.dashboard-group__list[data-list-path="texts"] .dashboard-group__list-count',
 
 			// Dashboard's Others Group
 			dashboardOthersSubheading: '.dashboard-group__heading[data-section-label="Other"]',
@@ -293,6 +298,28 @@ module.exports = {
 						},
 					},
 				},
+				text: {
+					user: {
+						text: {
+							label: '.EditForm-container .field-type-text[for="text"] .FormLabel',
+							value: '.EditForm-container .field-type-text[for="text"] input[name="text"]',
+						},
+					},
+					text: {
+						name: {
+							label: '.EditForm-container .field-type-text[for="name"] .FormLabel',
+							value: '.EditForm-container .field-type-text[for="name"] input[name="name"]',
+						},
+						fieldA: {
+							label: '.EditForm-container .field-type-text[for="fieldA"] .FormLabel',
+							value: '.EditForm-container .field-type-text[for="fieldA"] input[name="fieldA"]',
+						},
+						fieldB: {
+							label: '.EditForm-container .field-type-text[for="fieldB"] .FormLabel',
+							value: '.EditForm-container .field-type-text[for="fieldB"] input[name="fieldB"]',
+						},
+					},
+				},
 			},
 		},
 		initialModalView: {
@@ -416,6 +443,24 @@ module.exports = {
 							placeholder: '.Modal-dialog .field-type-name[for="fieldA"] .Select-placeholder',
 							dropdownArrow: '.Modal-dialog .field-type-name[for="fieldA"] .Select-arrow-zone',
 							optionOne: '.Modal-dialog .field-type-name[for="fieldA"] .Select-menu-outer option[value="One"]',
+						},
+					},
+				},
+				text: {
+					user: {
+						text: {
+							label: '.Modal-dialog .field-type-text[for="name"] .FormLabel',
+							value: '.Modal-dialog .field-type-text[for="text"] input[name="text"]',
+						},
+					},
+					text: {
+						name: {
+							label: '.Modal-dialog .field-type-text[for="name"] .FormLabel',
+							value: '.Modal-dialog .field-type-text[for="name"] input[name="name"]',
+						},
+						fieldA: {
+							label: '.Modal-dialog .field-type-text[for="fieldA"] .FormLabel',
+							value: '.Modal-dialog .field-type-text[for="fieldA"] input[name="fieldA"]',
 						},
 					},
 				},

--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -21,6 +21,7 @@ module.exports = {
 		emailsFieldsSubmenu: '.secondary-navbar [data-list-path="emails"]',
 		namesFieldsSubmenu: '.secondary-navbar [data-list-path="names"]',
 		selectsFieldsSubmenu: '.secondary-navbar [data-list-path="selects"]',
+		textsFieldsSubmenu: '.secondary-navbar [data-list-path="texts"]',
 		frontPageIcon: '.primary-navbar [data-section-label="octicon-globe"]',
 		frontPageIconLink: '.primary-navbar [data-section-label="octicon-globe"] a',
 		logoutIcon: '.primary-navbar [data-section-label="octicon-sign-out"]',

--- a/test/e2e/adminUI/pages/initialForm.js
+++ b/test/e2e/adminUI/pages/initialForm.js
@@ -1,4 +1,5 @@
 var NameList = require('./lists/name');
+var TextList = require('./lists/text');
 
 module.exports = {
 	sections: {
@@ -9,6 +10,7 @@ module.exports = {
 				// DEFINE ALL LISTS
 				//
 				nameList: new NameList(),
+				textList: new TextList(),
 			},
 			elements: {
 				//

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -1,4 +1,5 @@
 var NameList = require('./lists/name');
+var TextList = require('./lists/text');
 
 module.exports = {
 	sections: {
@@ -9,6 +10,7 @@ module.exports = {
 				// DEFINE ALL LISTS
 				//
 				nameList: new NameList(),
+				textList: new TextList(),
 			},
 			elements: {
 				//

--- a/test/e2e/adminUI/pages/lists/text.js
+++ b/test/e2e/adminUI/pages/lists/text.js
@@ -1,0 +1,16 @@
+var TextType = require('../fieldTypes/text');
+
+module.exports = function NameList(config) {
+	return {
+		selector: '.Form',
+		sections: {
+			name: new TextType({fieldName: 'name'}),
+			fieldA: new TextType({fieldName: 'fieldA'}),
+		},
+		commands: [{
+			//
+			// LIST LEVEL COMMANDS
+			//
+		}],
+	};
+};

--- a/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
@@ -1,0 +1,43 @@
+var adminUI = require('../../../adminUI');
+
+module.exports = {
+	before: function (browser) {
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.signinView.id)
+			.setValue(adminUI.cssSelector.signinView.emailInput, adminUI.login.email)
+			.setValue(adminUI.cssSelector.signinView.passwordInput, adminUI.login.password)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.signinView.submitButton)
+			.pause(browser.globals.defaultPauseTimeout)
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout);
+	},
+	after: function (browser) {
+		browser
+			.click(adminUI.cssSelector.allView.logoutIconLink)
+			.pause(browser.globals.defaultPauseTimeout)
+			.end();
+	},
+	'Text field should be visible in initial modal': function (browser) {
+		browser
+			.click(adminUI.cssSelector.homeView.plusIconLinkForTextsTabUnderDashboardFieldsSubheading)
+			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
+			.pause(browser.globals.defaultPauseTimeout);
+
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.label)
+			.to.be.visible;
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.label)
+			.text.to.equal('Name');
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.value)
+			.to.be.visible;
+
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.label)
+			.to.be.visible;
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.label)
+			.text.to.equal('Field A');
+		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.value)
+			.to.be.visible;
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
@@ -1,43 +1,46 @@
-var adminUI = require('../../../adminUI');
-
 module.exports = {
 	before: function (browser) {
 		browser
-			.url(adminUI.url)
-			.waitForElementVisible(adminUI.cssSelector.signinView.id)
-			.setValue(adminUI.cssSelector.signinView.emailInput, adminUI.login.email)
-			.setValue(adminUI.cssSelector.signinView.passwordInput, adminUI.login.password)
-			.pause(browser.globals.defaultPauseTimeout)
-			.click(adminUI.cssSelector.signinView.submitButton)
-			.pause(browser.globals.defaultPauseTimeout)
-			.url(adminUI.url)
-			.waitForElementVisible(adminUI.cssSelector.homeView.id)
-			.pause(browser.globals.defaultPauseTimeout);
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
 	},
 	after: function (browser) {
-		browser
-			.click(adminUI.cssSelector.allView.logoutIconLink)
-			.pause(browser.globals.defaultPauseTimeout)
-			.end();
+		browser.app.signout();
+		browser.end();
 	},
-	'Text field should be visible in initial modal': function (browser) {
-		browser
-			.click(adminUI.cssSelector.homeView.plusIconLinkForTextsTabUnderDashboardFieldsSubheading)
-			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
-			.pause(browser.globals.defaultPauseTimeout);
+	'Name field should be visible in initial modal': function (browser) {
+		browser.app
+			.click('@fieldsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@textsFieldsSubmenu')
+			.waitForElementVisible('@listScreen');
 
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.label)
-			.to.be.visible;
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.label)
-			.text.to.equal('Name');
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.name.value)
-			.to.be.visible;
+		browser.listPage
+			.click('@createFirstItemButton');
 
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.label)
-			.to.be.visible;
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.label)
-			.text.to.equal('Field A');
-		browser.expect.element(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.value)
-			.to.be.visible;
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.textList.section.name
+			.verifyUI();
+
+		browser.initialFormPage.section.form.section.textList.section.fieldA
+			.verifyUI();
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+		browser.initialFormPage.section.form
+			.click('@cancelButton');
+
+		browser.app
+			.waitForElementVisible('@listScreen');
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -1,63 +1,78 @@
-var adminUI = require('../../../adminUI');
-
 module.exports = {
 	before: function (browser) {
-		browser
-			.url(adminUI.url)
-			.waitForElementVisible(adminUI.cssSelector.signinView.id)
-			.setValue(adminUI.cssSelector.signinView.emailInput, adminUI.login.email)
-			.setValue(adminUI.cssSelector.signinView.passwordInput, adminUI.login.password)
-			.pause(browser.globals.defaultPauseTimeout)
-			.click(adminUI.cssSelector.signinView.submitButton)
-			.pause(browser.globals.defaultPauseTimeout)
-			.url(adminUI.url)
-			.waitForElementVisible(adminUI.cssSelector.homeView.id)
-			.pause(browser.globals.defaultPauseTimeout);
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
 	},
 	after: function (browser) {
+		browser.app
+			.signout();
 		browser
-			.click(adminUI.cssSelector.allView.logoutIconLink)
-			.pause(browser.globals.defaultPauseTimeout)
 			.end();
 	},
-	'Text field can be created via the initial modal': function (browser) {
-		browser
-			.click(adminUI.cssSelector.homeView.plusIconLinkForTextsTabUnderDashboardFieldsSubheading)
-			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
-			.pause(browser.globals.defaultPauseTimeout)
-			.setValue(adminUI.cssSelector.initialModalView.fieldType.text.text.name.value, 'Text Field Test')
-			.setValue(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.value, 'Test Text 1')
-			.pause(browser.globals.defaultPauseTimeout)
-			.click(adminUI.cssSelector.initialModalView.buttonCreate)
-			.waitForElementVisible(adminUI.cssSelector.itemView.id)
-			.pause(browser.globals.defaultPauseTimeout);
+	'Name field can be created via the initial modal': function (browser) {
+		browser.app
+			.click('@fieldsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@textsFieldsSubmenu')
+			.waitForElementVisible('@listScreen');
 
-		browser.expect.element(adminUI.cssSelector.itemView.flashMessage)
-			.text.to.equal('New Text Text Field Test created.');
+		browser.listPage
+			.click('@createFirstItemButton');
 
-		browser.getValue(adminUI.cssSelector.itemView.fieldType.text.text.name.value, function(result) {
-			this.assert.equal(result.value, 'Text Field Test');
-		});
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
 
-		browser.expect.element(adminUI.cssSelector.itemView.fieldType.text.text.fieldA.value)
-			.to.have.value.that.equals('Test Text 1');
+		browser.initialFormPage.section.form.section.textList.section.name
+			.fillInput({value: 'Text Field Test 1'});
+
+		browser.initialFormPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Text Field Test 1'});
+
+		browser.initialFormPage.section.form.section.textList.section.fieldA
+			.fillInput({value: 'Text Field Test Text 1'});
+
+		browser.initialFormPage.section.form
+			.click('@createButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('New Text Text Field Test 1 created.');
+
+		browser.itemPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Text Field Test 1'});
 	},
-	'Text field can be created via the edit form': function (browser) {
-		browser
-			.setValue(adminUI.cssSelector.itemView.fieldType.text.text.fieldB.value, 'Test Text 2')
-			.pause(browser.globals.defaultPauseTimeout)
-			.click(adminUI.cssSelector.itemView.itemSaveButton)
-			.waitForElementVisible(adminUI.cssSelector.itemView.id)
-			.pause(browser.globals.defaultPauseTimeout);
+	'Name field can be created via the edit form': function (browser) {
+		browser.itemPage.section.form.section.textList.section.name
+			.fillInput({value: 'Text Field Test 2'});
 
-		browser.expect.element(adminUI.cssSelector.itemView.flashMessage)
-			.text.to.equal('Your changes have been saved.');
+		browser.itemPage.section.form.section.textList.section.fieldA
+			.fillInput({value: 'Text Field Test Text 2'});
 
-		browser.getValue(adminUI.cssSelector.itemView.fieldType.text.text.name.value, function(result) {
-			this.assert.equal(result.value, 'Text Field Test');
-		});
+		browser.itemPage.section.form
+			.click('@saveButton');
 
-		browser.expect.element(adminUI.cssSelector.itemView.fieldType.text.text.fieldB.value)
-			.to.have.value.that.equals('Test Text 2');
+		browser.itemPage
+			.waitForElementVisible('@flashMessage');
+
+		browser.itemPage
+			.expect.element('@flashMessage').text.to.equal('Your changes have been saved.');
+
+		browser.itemPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Text Field Test 2'});
+
+		browser.itemPage.section.form.section.textList.section.fieldA
+			.verifyInput({value: 'Text Field Test Text 2'});
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -1,0 +1,63 @@
+var adminUI = require('../../../adminUI');
+
+module.exports = {
+	before: function (browser) {
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.signinView.id)
+			.setValue(adminUI.cssSelector.signinView.emailInput, adminUI.login.email)
+			.setValue(adminUI.cssSelector.signinView.passwordInput, adminUI.login.password)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.signinView.submitButton)
+			.pause(browser.globals.defaultPauseTimeout)
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout);
+	},
+	after: function (browser) {
+		browser
+			.click(adminUI.cssSelector.allView.logoutIconLink)
+			.pause(browser.globals.defaultPauseTimeout)
+			.end();
+	},
+	'Text field can be created via the initial modal': function (browser) {
+		browser
+			.click(adminUI.cssSelector.homeView.plusIconLinkForTextsTabUnderDashboardFieldsSubheading)
+			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.setValue(adminUI.cssSelector.initialModalView.fieldType.text.text.name.value, 'Text Field Test')
+			.setValue(adminUI.cssSelector.initialModalView.fieldType.text.text.fieldA.value, 'Test Text 1')
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.initialModalView.buttonCreate)
+			.waitForElementVisible(adminUI.cssSelector.itemView.id)
+			.pause(browser.globals.defaultPauseTimeout);
+
+		browser.expect.element(adminUI.cssSelector.itemView.flashMessage)
+			.text.to.equal('New Text Text Field Test created.');
+
+		browser.getValue(adminUI.cssSelector.itemView.fieldType.text.text.name.value, function(result) {
+			this.assert.equal(result.value, 'Text Field Test');
+		});
+
+		browser.expect.element(adminUI.cssSelector.itemView.fieldType.text.text.fieldA.value)
+			.to.have.value.that.equals('Test Text 1');
+	},
+	'Text field can be created via the edit form': function (browser) {
+		browser
+			.setValue(adminUI.cssSelector.itemView.fieldType.text.text.fieldB.value, 'Test Text 2')
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.itemView.itemSaveButton)
+			.waitForElementVisible(adminUI.cssSelector.itemView.id)
+			.pause(browser.globals.defaultPauseTimeout);
+
+		browser.expect.element(adminUI.cssSelector.itemView.flashMessage)
+			.text.to.equal('Your changes have been saved.');
+
+		browser.getValue(adminUI.cssSelector.itemView.fieldType.text.text.name.value, function(result) {
+			this.assert.equal(result.value, 'Text Field Test');
+		});
+
+		browser.expect.element(adminUI.cssSelector.itemView.fieldType.text.text.fieldB.value)
+			.to.have.value.that.equals('Test Text 2');
+	},
+};

--- a/test/e2e/models/fields/Text.js
+++ b/test/e2e/models/fields/Text.js
@@ -1,0 +1,32 @@
+var keystone = require('../../../../index.js');
+var Types = keystone.Field.Types;
+
+var Text = new keystone.List('Text', {
+	autokey: {
+		path: 'key',
+		from: 'name',
+		unique: true,
+	},
+	track: true,
+});
+
+Text.add({
+	name: {
+		type: String,
+		initial: true,
+		required: true,
+		index: true,
+	},
+	fieldA: {
+		type: Types.Text,
+		initial: true,
+	},
+	fieldB: {
+		type: Types.Text,
+	},
+});
+
+Text.defaultColumns = 'name, fieldA, fieldB';
+Text.register();
+
+module.exports = Text;

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -52,6 +52,7 @@ keystone.set('nav', {
 		'names',
 		'numbers',
 		'selects',
+		'texts'
 	],
 });
 


### PR DESCRIPTION
Add testing for text fields, as set out in #2291 

@webteckie - Was attracted by the 'easy for beginners' tag on the issue, so am new to all this. Thought it would be interesting to see how the testing worked. I think I've added the testing for the Text field successfully. Happy to try a few others if this is correct, however please check I haven't missed anything important! 

All e2e tests (including the new ones) pass locally. 