### PR TITLE
Update PasswordType.js to allow for inherited users

### DIFF
--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -60,20 +60,28 @@ password.prototype.addToSchema = function () {
 			return next();
 		}
 		var item = this;
-		bcrypt.genSalt(field.workFactor, function (err, salt) {
-			if (err) {
-				return next(err);
-			}
-			bcrypt.hash(item.get(field.path), salt, function () {}, function (err, hash) {
+
+		if(!item.isEncrypted) {
+			bcrypt.genSalt(field.workFactor, function (err, salt) {
 				if (err) {
 					return next(err);
 				}
-				// override the cleartext password with the hashed one
-				item.set(field.path, hash);
-				next();
+				bcrypt.hash(item.get(field.path), salt, function () {}, function (err, hash) {
+					if (err) {
+						return next(err);
+					}
+					// override the cleartext password with the hashed one
+					item.set(field.path, hash);
+					// inherited models save twice, this ensures the encrypted password hash won't be encrypted a second time
+					item.isEncrypted = true;
+					next();
+				});
 			});
-		});
+		} else {
+			return next();
+		}
 	});
+
 	this.bindUnderscoreMethods();
 };
 

--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -61,7 +61,7 @@ password.prototype.addToSchema = function () {
 		}
 		var item = this;
 
-		if(!item.isEncrypted) {
+		if (!item.isEncrypted) {
 			bcrypt.genSalt(field.workFactor, function (err, salt) {
 				if (err) {
 					return next(err);


### PR DESCRIPTION
Fix an issue where a user model that inherits from another model will have the bcrypt hash function run twice, causing an incorrect password hash to be saved.