### PR TITLE
Fixed rendering of DateArrayField

### DIFF
--- a/fields/types/datearray/DateArrayField.js
+++ b/fields/types/datearray/DateArrayField.js
@@ -31,7 +31,7 @@ module.exports = Field.create({
 	},
 
 	formatValue (value) {
-		return value ? this.moment(value).format(this.props.formatString) : '';
+		return value ? moment(value).format(this.props.formatString) : '';
 	},
 
 	getInputComponent () {


### PR DESCRIPTION
Lists with DateArrays were not rendering because of a simple error. I do not know how to provide the tests that would fail in order to conform with the contributing guidelines.

Since this is a very simple fix and it is clear that this.moment does not exist I hope that there's no need for the usual contribution bureaucracy.

If it is really needed I would appreciate some pointers on how to create such tests.