### PR TITLE
testing(e2e): Fix a typo in the code list

### DIFF
--- a/test/e2e/adminUI/pages/lists/code.js
+++ b/test/e2e/adminUI/pages/lists/code.js
@@ -7,7 +7,7 @@ module.exports = function NameList(config) {
 		sections: {
 			name: new TextType({fieldName: 'name'}),
 			fieldA: new CodeType({fieldName: 'fieldA'}),
-			fieldB: new CodeType({fieldName: 'fieldA'}),
+			fieldB: new CodeType({fieldName: 'fieldB'}),
 		},
 		commands: [{
 			//


### PR DESCRIPTION
Cc: @webteckie 
For work on #2291 

Spotted a typo in the code. It's not throwing errors anywhere as the testing currently does nothing with field 2, but thought it was worth fixing while I spotted it. 

Regarding work on #2291, I'm having a few problems adding the url tests. See my [current progress](https://github.com/jstockwin/keystone/commit/e057cbcf3e5cfc0c260403fd7bce92f59c36898b). I feel like it should work out of the box in this case, but for some reason I fail on the `browser.initialFormPage.section.form.section.textList.section.fieldA.verifyUI();` tests. I've had a look at the source code of the page it's testing, and can't see what the problem is. The label is there as expected. I feel like I maybe have something wrong in pages/fieldTypes/url.js, but can't see what's wrong. The `label: '.formLabel'` works for name, and I see no reason why it shouldn't work for fieldA. 

If you get a minute, would appreciate your input, but if not I'm sure I'll spot the problem eventually!