### PR TITLE
testing(e2e): Add testing for textarea

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -23,6 +23,7 @@ module.exports = {
 		namesFieldsSubmenu: '.secondary-navbar [data-list-path="names"]',
 		selectsFieldsSubmenu: '.secondary-navbar [data-list-path="selects"]',
 		textsFieldsSubmenu: '.secondary-navbar [data-list-path="texts"]',
+		textareasFieldsSubmenu: '.secondary-navbar [data-list-path="textareas"]',
 		frontPageIcon: '.primary-navbar [data-section-label="octicon-globe"]',
 		frontPageIconLink: '.primary-navbar [data-section-label="octicon-globe"] a',
 		logoutIcon: '.primary-navbar [data-section-label="octicon-sign-out"]',

--- a/test/e2e/adminUI/pages/fieldTypes/textarea.js
+++ b/test/e2e/adminUI/pages/fieldTypes/textarea.js
@@ -1,0 +1,39 @@
+var utils = require('../../../utils');
+
+module.exports = function TextareaType(config) {
+	var self = {
+		selector: '.field-type-textarea[for="' + config.fieldName + '"]',
+		elements: {
+			label: '.FormLabel',
+			value: 'textarea[name="' + config.fieldName + '"]',
+		},
+		commands: [{
+			verifyUI: function() {
+        this
+					.expect.element('@label').to.be.visible;
+				this
+					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
+				this
+					.expect.element('@value').to.be.visible;
+				return this;
+			},
+			fillInput: function(input) {
+        this
+					.clearValue('@value')
+					.setValue('@value', input.value);
+				return this;
+			},
+			verifyInput: function(input) {
+        this
+					.waitForElementVisible('@value');
+				this
+					.getValue('@value', function (result) {
+						this.api.assert.equal(result.state, "success");
+						this.api.assert.equal(result.value, input.value);
+					});
+			},
+		}],
+	};
+
+	return self;
+};

--- a/test/e2e/adminUI/pages/initialForm.js
+++ b/test/e2e/adminUI/pages/initialForm.js
@@ -2,6 +2,7 @@ var CodeList = require('./lists/code');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
+var TextareaList = require('./lists/textarea');
 
 module.exports = {
 	sections: {
@@ -15,6 +16,7 @@ module.exports = {
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),
+				textareaList: new TextareaList(),
 			},
 			elements: {
 				//

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -2,6 +2,7 @@ var CodeList = require('./lists/code');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
+var TextareaList = require('./lists/textarea');
 
 module.exports = {
 	sections: {
@@ -15,6 +16,7 @@ module.exports = {
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),
+				textareaList: new TextareaList(),
 			},
 			elements: {
 				//

--- a/test/e2e/adminUI/pages/lists/textarea.js
+++ b/test/e2e/adminUI/pages/lists/textarea.js
@@ -1,0 +1,18 @@
+var TextType = require('../fieldTypes/text');
+var TextareaType = require('../fieldTypes/textarea');
+
+module.exports = function TextareaList(config) {
+	return {
+		selector: '.Form',
+		sections: {
+			name: new TextType({fieldName: 'name'}),
+			fieldA: new TextareaType({fieldName: 'fieldA'}),
+			fieldB: new TextareaType({fieldName: 'fieldB'}),
+		},
+		commands: [{
+			//
+			// LIST LEVEL COMMANDS
+			//
+		}],
+	};
+};

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -18,7 +18,7 @@ module.exports = {
 		browser
 			.end();
 	},
-	'Name field can be created via the initial modal': function (browser) {
+	'Text field can be created via the initial modal': function (browser) {
 		browser.app
 			.click('@fieldsMenu')
 			.waitForElementVisible('@listScreen')
@@ -53,7 +53,7 @@ module.exports = {
 		browser.itemPage.section.form.section.textList.section.name
 			.verifyInput({value: 'Text Field Test 1'});
 	},
-	'Name field can be created via the edit form': function (browser) {
+	'Text field can be created via the edit form': function (browser) {
 		browser.itemPage.section.form.section.textList.section.name
 			.fillInput({value: 'Text Field Test 2'});
 

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -18,7 +18,7 @@ module.exports = {
 		browser
 			.end();
 	},
-	'Text field can be created via the initial modal': function (browser) {
+	'Text field can be filled via the initial modal': function (browser) {
 		browser.app
 			.click('@fieldsMenu')
 			.waitForElementVisible('@listScreen')
@@ -53,7 +53,7 @@ module.exports = {
 		browser.itemPage.section.form.section.textList.section.name
 			.verifyInput({value: 'Text Field Test 1'});
 	},
-	'Text field can be created via the edit form': function (browser) {
+	'Text field can be filled via the edit form': function (browser) {
 		browser.itemPage.section.form.section.textList.section.name
 			.fillInput({value: 'Text Field Test 2'});
 

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
@@ -29,7 +29,7 @@ module.exports = {
 		browser.app
 			.waitForElementVisible('@initialFormScreen');
 
-		browser.initialFormPage.section.form.section.textList.section.name
+		browser.initialFormPage.section.form.section.textareaList.section.name
 			.verifyUI();
 
 		browser.initialFormPage.section.form.section.textareaList.section.fieldA

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
@@ -16,11 +16,11 @@ module.exports = {
 		browser.app.signout();
 		browser.end();
 	},
-	'Text field should be visible in initial modal': function (browser) {
+	'Textarea field should show correctly in the initial modal': function (browser) {
 		browser.app
 			.click('@fieldsMenu')
 			.waitForElementVisible('@listScreen')
-			.click('@textsFieldsSubmenu')
+			.click('@textareasFieldsSubmenu')
 			.waitForElementVisible('@listScreen');
 
 		browser.listPage
@@ -32,7 +32,7 @@ module.exports = {
 		browser.initialFormPage.section.form.section.textList.section.name
 			.verifyUI();
 
-		browser.initialFormPage.section.form.section.textList.section.fieldA
+		browser.initialFormPage.section.form.section.textareaList.section.fieldA
 			.verifyUI();
 	},
 	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -1,0 +1,83 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Textarea field can be filled via the initial modal': function (browser) {
+		browser.app
+			.click('@fieldsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@textareasFieldsSubmenu')
+			.waitForElementVisible('@listScreen');
+
+		browser.listPage
+			.click('@createFirstItemButton');
+
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.textList.section.name
+			.fillInput({value: 'Name Field Test 1'});
+
+		browser.initialFormPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.initialFormPage.section.form.section.textareaList.section.fieldA
+			.fillInput({value: 'Textarea Field Test 1'});
+
+		browser.initialFormPage.section.form.section.textareaList.section.fieldA
+			.verifyInput({value: 'Textarea Field Test 1'});
+
+		browser.initialFormPage.section.form
+			.click('@createButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('New Textarea Name Field Test 1 created.');
+
+		browser.itemPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.itemPage.section.form.section.textareaList.section.fieldA
+			.verifyInput({value: 'Textarea Field Test 1'});
+	},
+	'Textarea field can be filled via the edit form': function (browser) {
+		browser.itemPage.section.form.section.textareaList.section.fieldB
+			.fillInput({value: 'Textarea Field Test 2'});
+
+		browser.itemPage.section.form
+			.click('@saveButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('Your changes have been saved.');
+
+		browser.itemPage.section.form.section.textList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.itemPage.section.form.section.textareaList.section.fieldB
+			.verifyInput({value: 'Textarea Field Test 2'});
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -29,10 +29,10 @@ module.exports = {
 		browser.app
 			.waitForElementVisible('@initialFormScreen');
 
-		browser.initialFormPage.section.form.section.textList.section.name
+		browser.initialFormPage.section.form.section.textareaList.section.name
 			.fillInput({value: 'Name Field Test 1'});
 
-		browser.initialFormPage.section.form.section.textList.section.name
+		browser.initialFormPage.section.form.section.textareaList.section.name
 			.verifyInput({value: 'Name Field Test 1'});
 
 		browser.initialFormPage.section.form.section.textareaList.section.fieldA
@@ -51,7 +51,7 @@ module.exports = {
 			.expect.element('@flashMessage')
 			.text.to.equal('New Textarea Name Field Test 1 created.');
 
-		browser.itemPage.section.form.section.textList.section.name
+		browser.itemPage.section.form.section.textareaList.section.name
 			.verifyInput({value: 'Name Field Test 1'});
 
 		browser.itemPage.section.form.section.textareaList.section.fieldA
@@ -71,7 +71,7 @@ module.exports = {
 			.expect.element('@flashMessage')
 			.text.to.equal('Your changes have been saved.');
 
-		browser.itemPage.section.form.section.textList.section.name
+		browser.itemPage.section.form.section.textareaList.section.name
 			.verifyInput({value: 'Name Field Test 1'});
 
 		browser.itemPage.section.form.section.textareaList.section.fieldB

--- a/test/e2e/models/fields/Textarea.js
+++ b/test/e2e/models/fields/Textarea.js
@@ -1,0 +1,32 @@
+var keystone = require('../../../../index.js');
+var Types = keystone.Field.Types;
+
+var Textarea = new keystone.List('Textarea', {
+	autokey: {
+		path: 'key',
+		from: 'name',
+		unique: true,
+	},
+	track: true,
+});
+
+Textarea.add({
+	name: {
+		type: String,
+		initial: true,
+		required: true,
+		index: true,
+	},
+	fieldA: {
+		type: Types.Textarea,
+		initial: true,
+	},
+	fieldB: {
+		type: Types.Textarea,
+	},
+});
+
+Textarea.defaultColumns = 'name, fieldA, fieldB';
+Textarea.register();
+
+module.exports = Textarea;

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -52,7 +52,8 @@ keystone.set('nav', {
 		'names',
 		'numbers',
 		'selects',
-		'texts'
+		'texts',
+		'textareas',
 	],
 });
 


### PR DESCRIPTION
In line with testing for #2291 

@webteckie I'd like to point out a slight deviation from what seems to be the norm before this one gets merged please.

We have these `verifyUI()` functions, which do different things depending on the type of field we are looking at. However, all the name fields for each type are text fields, rather than e.g. select fields. However, [here](https://github.com/keystonejs/keystone/blob/master/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js#L32) for example, as far as I can tell, we still call the `verifyUI` function for select fields, even though the name is a text field? 

As such, (e.g. [here](https://github.com/keystonejs/keystone/compare/master...jstockwin:e2e-testing-textarea?expand=1#diff-b8f3aa8477d58e3d69c68ac5a8dfc3edR32)) instead of
`browser.initialFormPage.section.form.section.textareaList.section.name.verifyUI();`
I have used
`browser.initialFormPage.section.form.section.textList.section.name.verifyUI();`

Obviously for `.fieldA.verifyUI()` I have still used `section.textareaList`, since field A is a textarea. 


I hope this makes sense. If I am right (which I'm probably not) this is an issue for all the current tests. For textarea at least, it seems to pass the tests either way (which seems strange...). 

Anyway, I obviously am not an expert, so am happy to bow to your wisdom and push a commit to go back to using `textareaList.section.name.verifyUI();` if that's the right thing to do. 