### PR TITLE
test(e2e): Add testing for color field

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -19,6 +19,7 @@ module.exports = {
 		fieldsMenu: '.primary-navbar [data-section-label="Fields"]',
 		booleansFieldsSubmenu: '.secondary-navbar [data-list-path="booleans"]',
 		codesFieldsSubmenu: '.secondary-navbar [data-list-path="codes"]',
+		colorsFieldsSubmenu: '.secondary-navbar [data-list-path="colors"]',
 		emailsFieldsSubmenu: '.secondary-navbar [data-list-path="emails"]',
 		namesFieldsSubmenu: '.secondary-navbar [data-list-path="names"]',
 		selectsFieldsSubmenu: '.secondary-navbar [data-list-path="selects"]',

--- a/test/e2e/adminUI/pages/fieldTypes/color.js
+++ b/test/e2e/adminUI/pages/fieldTypes/color.js
@@ -1,0 +1,46 @@
+var utils = require('../../../utils');
+
+module.exports = function ColorType(config) {
+	var self = {
+		selector: '.field-type-color[for="' + config.fieldName + '"]',
+		elements: {
+			label: '.FormLabel',
+			value: 'input[name="' + config.fieldName + '"]',
+      button: '.field-type-color__button',
+      swatch: '.field-type-color__swatch',
+      picker: '.field-type-color__picker',
+		},
+		commands: [{
+			verifyUI: function() {
+				this
+					.expect.element('@label').to.be.visible;
+				this
+					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
+				this
+					.expect.element('@value').to.be.visible;
+				this
+					.expect.element('@button').to.be.visible;
+				this
+					.expect.element('@picker').to.be.visible;
+				return this;
+			},
+			fillInput: function(input) {
+				this
+					.clearValue('@value')
+					.setValue('@value', input.value);
+				return this;
+			},
+			verifyInput: function(input) {
+				this
+					.waitForElementVisible('@value');
+				this
+					.getValue('@value', function (result) {
+						this.api.assert.equal(result.state, "success");
+						this.api.assert.equal(result.value, input.value);
+					});
+			},
+		}],
+	};
+
+	return self;
+};

--- a/test/e2e/adminUI/pages/initialForm.js
+++ b/test/e2e/adminUI/pages/initialForm.js
@@ -1,4 +1,5 @@
 var CodeList = require('./lists/code');
+var ColorList = require('./lists/color');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
@@ -13,6 +14,7 @@ module.exports = {
 				// DEFINE ALL LISTS
 				//
 				codeList: new CodeList(),
+				colorList: new ColorList(),
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -1,4 +1,5 @@
 var CodeList = require('./lists/code');
+var ColorList = require('./lists/color');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
@@ -13,6 +14,7 @@ module.exports = {
 				// DEFINE ALL LISTS
 				//
 				codeList: new CodeList(),
+				colorList: new ColorList(),
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),

--- a/test/e2e/adminUI/pages/lists/color.js
+++ b/test/e2e/adminUI/pages/lists/color.js
@@ -1,0 +1,18 @@
+var TextType = require('../fieldTypes/text');
+var ColorType = require('../fieldTypes/color');
+
+module.exports = function ColorList(config) {
+	return {
+		selector: '.Form',
+		sections: {
+			name: new TextType({fieldName: 'name'}),
+			fieldA: new ColorType({fieldName: 'fieldA'}),
+			fieldB: new ColorType({fieldName: 'fieldB'}),
+		},
+		commands: [{
+			//
+			// LIST LEVEL COMMANDS
+			//
+		}],
+	};
+};

--- a/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
@@ -1,0 +1,46 @@
+module.exports = {
+	before: function (browser) {
+		browser
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Color field should show correctly in the initial modal': function (browser) {
+		browser.app
+			.click('@fieldsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@colorsFieldsSubmenu')
+			.waitForElementVisible('@listScreen');
+
+		browser.listPage
+			.click('@createFirstItemButton');
+
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.colorList.section.name
+			.verifyUI();
+
+		browser.initialFormPage.section.form.section.colorList.section.fieldA
+			.verifyUI();
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+		browser.initialFormPage.section.form
+			.click('@cancelButton');
+
+		browser.app
+			.waitForElementVisible('@listScreen');
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -1,0 +1,83 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Color field can be filled via the initial modal': function (browser) {
+		browser.app
+			.click('@fieldsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@colorsFieldsSubmenu')
+			.waitForElementVisible('@listScreen');
+
+		browser.listPage
+			.click('@createFirstItemButton');
+
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.colorList.section.name
+			.fillInput({value: 'Name Field Test 1'});
+
+		browser.initialFormPage.section.form.section.colorList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.initialFormPage.section.form.section.colorList.section.fieldA
+			.fillInput({value: '#002147'});
+
+		browser.initialFormPage.section.form.section.colorList.section.fieldA
+			.verifyInput({value: '#002147'});
+
+		browser.initialFormPage.section.form
+			.click('@createButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('New Color Name Field Test 1 created.');
+
+		browser.itemPage.section.form.section.colorList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.itemPage.section.form.section.colorList.section.fieldA
+			.verifyInput({value: '#002147'});
+	},
+	'Color field can be filled via the edit form': function (browser) {
+		browser.itemPage.section.form.section.colorList.section.fieldB
+			.fillInput({value: '#f8e71c'});
+
+		browser.itemPage.section.form
+			.click('@saveButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('Your changes have been saved.');
+
+		browser.itemPage.section.form.section.colorList.section.name
+			.verifyInput({value: 'Name Field Test 1'});
+
+		browser.itemPage.section.form.section.colorList.section.fieldB
+			.verifyInput({value: '#f8e71c'});
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+	},
+};

--- a/test/e2e/models/fields/Color.js
+++ b/test/e2e/models/fields/Color.js
@@ -1,0 +1,32 @@
+var keystone = require('../../../../index.js');
+var Types = keystone.Field.Types;
+
+var Color = new keystone.List('Color', {
+	autokey: {
+		path: 'key',
+		from: 'name',
+		unique: true,
+	},
+	track: true,
+});
+
+Color.add({
+	name: {
+		type: String,
+		initial: true,
+		required: true,
+		index: true,
+	},
+	fieldA: {
+		type: Types.Color,
+		initial: true,
+	},
+	fieldB: {
+		type: Types.Color,
+	},
+});
+
+Color.defaultColumns = 'name, fieldA, fieldB';
+Color.register();
+
+module.exports = Color;

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -48,6 +48,7 @@ keystone.set('nav', {
 	'fields': [
 		'booleans',
 		'codes',
+		'colors',
 		'emails',
 		'names',
 		'numbers',


### PR DESCRIPTION
cc @webteckie 
For #2291 

I couldn't find any identifying marks on the swatch that would allow me to actually click on a color properly. They don't have a class name or id or anything, and just have their styles set. I could potentially select them based on their style, but that seemed a bit silly, especially given how long the style string actually is. 

I check the color picker etc is visible, but when it comes to actually testing the fields, hex codes are just added into the input as normal. Completely understand if this is not sufficient, but may need some pointers if not...

All tests pass locally.