### PR TITLE
Add missing return statements

### DIFF
--- a/test/e2e/adminUI/pages/fieldTypes/color.js
+++ b/test/e2e/adminUI/pages/fieldTypes/color.js
@@ -38,6 +38,7 @@ module.exports = function ColorType(config) {
 						this.api.assert.equal(result.state, "success");
 						this.api.assert.equal(result.value, input.value);
 					});
+				return this;
 			},
 		}],
 	};

--- a/test/e2e/adminUI/pages/fieldTypes/date.js
+++ b/test/e2e/adminUI/pages/fieldTypes/date.js
@@ -34,6 +34,7 @@ module.exports = function DateType(config) {
 						this.api.assert.equal(result.state, "success");
 						this.api.assert.equal(result.value, input.value);
 					});
+				return this;
 			},
 		}],
 	};

--- a/test/e2e/adminUI/pages/fieldTypes/textarea.js
+++ b/test/e2e/adminUI/pages/fieldTypes/textarea.js
@@ -31,6 +31,7 @@ module.exports = function TextareaType(config) {
 						this.api.assert.equal(result.state, "success");
 						this.api.assert.equal(result.value, input.value);
 					});
+				return this;
 			},
 		}],
 	};

--- a/test/e2e/adminUI/pages/fieldTypes/url.js
+++ b/test/e2e/adminUI/pages/fieldTypes/url.js
@@ -31,6 +31,7 @@ module.exports = function UrlType(config) {
 						this.api.assert.equal(result.state, "success");
 						this.api.assert.equal(result.value, input.value);
 					});
+				return this;
 			},
 		}],
 	};


### PR DESCRIPTION
cc @webteckie 

Following my comment [here](https://github.com/keystonejs/keystone/pull/2714#discussion-diff-61636227R50), this makes the code more consistent, and correct. 

I'm surprised this wasn't throwing errors. I must have lost this in one of my first ones, and then have been copying and pasting every since....