### PR TITLE
modified relationship-type's update-item method behavior

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -213,11 +213,9 @@ relationship.prototype.inputIsValid = function (data, required, item) {
  * Updates the value for this field in the item from a data object.
  * Only updates the value if it has changed.
  * Treats an empty string as a null value.
+ * If data object does not contain the path field, then delete the field. 
  */
 relationship.prototype.updateItem = function (item, data, callback) {
-	if (!(this.path in data)) {
-		return process.nextTick(callback);
-	}
 	if (item.populated(this.path)) {
 		throw new Error('fieldTypes.relationship.updateItem() Error - You cannot update populated relationships.');
 	}

--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -213,7 +213,7 @@ relationship.prototype.inputIsValid = function (data, required, item) {
  * Updates the value for this field in the item from a data object.
  * Only updates the value if it has changed.
  * Treats an empty string as a null value.
- * If data object does not contain the path field, then delete the field. 
+ * If data object does not contain the path field, then delete the field.
  */
 relationship.prototype.updateItem = function (item, data, callback) {
 	if (item.populated(this.path)) {

--- a/fields/types/relationship/test/type.js
+++ b/fields/types/relationship/test/type.js
@@ -179,6 +179,22 @@ exports.testFieldType = function (List) {
 				});
 			});
 		});
+
+		it('should clear the current value when data object does not contain the field', function (done) {
+			var testItem = new List.model({
+				single: relatedItem.id,
+			});
+			testItem.save(function (err) {
+				List.fields.single.updateItem(testItem, {}, function () {
+					testItem.save(function (err, updatedItem) {
+						List.model.findById(updatedItem.id, function (err, persistedData) {
+							demand(persistedData.single).be.null();
+							done();
+						});
+					});
+				});
+			});
+		});
 	});
 
 	describe('many', function () {
@@ -214,6 +230,38 @@ exports.testFieldType = function (List) {
 			List.fields.many.validateInput({}, function (result) {
 				demand(result).be.true();
 				done();
+			});
+		});
+
+		it('should clear the current values when data object does not contain the field', function (done) {
+			var testItem = new List.model({
+				many: [relatedItem.id, relatedItem.id],
+			});
+			testItem.save(function (err) {
+				List.fields.many.updateItem(testItem, {}, function () {
+					testItem.save(function (err, updatedItem) {
+						List.model.findById(updatedItem.id, function (err, persistedData) {
+							demand(persistedData.many).to.eql([]);
+							done();
+						});
+					});
+				});
+			});
+		});
+
+		it('should update the current values with the new values from the data object', function (done) {
+			var testItem = new List.model({
+				many: [relatedItem.id, relatedItem.id, relatedItem.id],
+			});
+			testItem.save(function (err) {
+				List.fields.many.updateItem(testItem, { many: [relatedItem.id, relatedItem.id] }, function () {
+					testItem.save(function (err, updatedItem) {
+						List.model.findById(updatedItem.id, function (err, persistedData) {
+							demand(String(persistedData.many)).to.eql(String([relatedItem.id, relatedItem.id]));
+							done();
+						});
+					});
+				});
 			});
 		});
 	});

--- a/test/unit/track.js
+++ b/test/unit/track.js
@@ -233,7 +233,7 @@ describe('List "track" option', function () {
 				setTimeout(function () {
 					request(app)
 						.post('/using-update-handler/' + post.get('id'))
-						.send({ name: 'test2' })
+						.send({ name: 'test2', 'updatedBy': dummyUser2.get('id'), 'createdBy': dummyUser1.get('id') })
 						.expect('GOOD')
 						.end(function (err, res) {
 							if (err) {


### PR DESCRIPTION
#2664 

1.  `updateItem()` method will now `delete` the `field` if the `path` not present in `data` object. This should fix the issue where -  the last item cannot be removed - because the `data` object will not contain the `empty` item.

2.  Fixed the breaking unit test.

**Note: please review this carefully before merging.**