### PR TITLE
testing(e2e): Add (partial) testing for datetime

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -30,6 +30,7 @@ module.exports = {
 		codeListSubmenu: '.secondary-navbar [data-list-path="codes"]',
 		colorListSubmenu: '.secondary-navbar [data-list-path="colors"]',
 		dateListSubmenu: '.secondary-navbar [data-list-path="dates"]',
+		datetimeListSubmenu: '.secondary-navbar [data-list-path="datetimes"]',
 		emailListSubmenu: '.secondary-navbar [data-list-path="emails"]',
 		nameListSubmenu: '.secondary-navbar [data-list-path="names"]',
 		selectListSubmenu: '.secondary-navbar [data-list-path="selects"]',

--- a/test/e2e/adminUI/pages/fieldTypes/datetime.js
+++ b/test/e2e/adminUI/pages/fieldTypes/datetime.js
@@ -1,0 +1,59 @@
+var utils = require('../../../utils');
+
+module.exports = function DatetimeType(config) {
+	var self = {
+		// TODO
+		// Pending a fix for issue #2715 the selector line should read the following
+		// selector: '.field-type-datetime[for="' + config.fieldName + '"]',
+		selector: '.field-type-datetime',
+		elements: {
+			label: '.FormLabel',
+			nowButton: '.Button--default',
+			date: 'input[name="' + config.fieldName + '_date"]',
+			datePlaceholder: 'input[placeholder="YYYY-MM-DD"]',
+			time: 'input[name="' + config.fieldName + '_time"]',
+			timePlaceholder: 'input[placeholder="HH:MM:SS am/pm"]',
+		},
+		commands: [{
+			verifyUI: function() {
+				this
+					.expect.element('@label').to.be.visible;
+				this
+					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
+				this
+					.expect.element('@nowButton').to.be.visible;
+				this
+					.expect.element('@date').to.be.visible;
+				this
+					.expect.element('@datePlaceholder').to.be.visible;
+				this
+					.expect.element('@time').to.be.visible;
+				this
+					.expect.element('@timePlaceholder').to.be.visible;
+				return this;
+			},
+			fillInput: function(input) {
+				this
+					.clearValue('@date')
+					.setValue('@date', input.date)
+					.clearValue('@time')
+					.setValue('@time', input.time)
+
+				return this;
+			},
+			verifyInput: function(input) {
+				this
+					.getValue('@date', function(result) {
+						this.api.assert.equal(result.value, input.date);
+					});
+				this
+					.getValue('@time', function(result) {
+						this.api.assert.equal(result.value, input.time);
+					});
+				return this;
+			},
+		}],
+	};
+
+	return self;
+};

--- a/test/e2e/adminUI/pages/initialForm.js
+++ b/test/e2e/adminUI/pages/initialForm.js
@@ -1,6 +1,7 @@
 var CodeList = require('./lists/code');
 var ColorList = require('./lists/color');
 var DateList = require('./lists/date');
+var DatetimeList = require('./lists/datetime');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
@@ -18,6 +19,7 @@ module.exports = {
 				codeList: new CodeList(),
 				colorList: new ColorList(),
 				dateList: new DateList(),
+				datetimeList: new DatetimeList(),
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -1,6 +1,7 @@
 var CodeList = require('./lists/code');
 var ColorList = require('./lists/color');
 var DateList = require('./lists/date');
+var DatetimeList = require('./lists/datetime');
 var NameList = require('./lists/name');
 var SelectList = require('./lists/select');
 var TextList = require('./lists/text');
@@ -18,6 +19,7 @@ module.exports = {
 				codeList: new CodeList(),
 				colorList: new ColorList(),
 				dateList: new DateList(),
+				datetimeList: new DatetimeList(),
 				nameList: new NameList(),
 				selectList: new SelectList(),
 				textList: new TextList(),

--- a/test/e2e/adminUI/pages/lists/datetime.js
+++ b/test/e2e/adminUI/pages/lists/datetime.js
@@ -1,0 +1,18 @@
+var TextType = require('../fieldTypes/text');
+var DatetimeType = require('../fieldTypes/datetime');
+
+module.exports = function DatetimeList(config) {
+	return {
+		selector: '.Form',
+		sections: {
+			name: new TextType({fieldName: 'name'}),
+			fieldA: new DatetimeType({fieldName: 'fieldA'}),
+			fieldB: new DatetimeType({fieldName: 'fieldB'}),
+		},
+		commands: [{
+			//
+			// LIST LEVEL COMMANDS
+			//
+		}],
+	};
+};

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
@@ -1,0 +1,46 @@
+module.exports = {
+	before: function (browser) {
+		browser
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Datetime field should show correctly in the initial modal': function (browser) {
+		browser.app
+			.click('@fieldListsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@datetimeListSubmenu')
+			.waitForElementVisible('@listScreen');
+
+		browser.listPage
+			.click('@createFirstItemButton');
+
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.datetimeList.section.name
+			.verifyUI();
+
+		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
+			.verifyUI();
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+		browser.initialFormPage.section.form
+			.click('@cancelButton');
+
+		browser.app
+			.waitForElementVisible('@listScreen');
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -1,0 +1,86 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Datetime field can be filled via the initial modal': function (browser) {
+		browser.app
+			.click('@fieldListsMenu')
+			.waitForElementVisible('@listScreen')
+			.click('@datetimeListSubmenu')
+			.waitForElementVisible('@listScreen');
+
+		browser.listPage
+			.click('@createFirstItemButton');
+
+		browser.app
+			.waitForElementVisible('@initialFormScreen');
+
+		browser.initialFormPage.section.form.section.datetimeList.section.name
+			.fillInput({value: 'Datetime Field Test 1'});
+
+		browser.initialFormPage.section.form.section.datetimeList.section.name
+			.verifyInput({value: 'Datetime Field Test 1'});
+
+		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
+			.fillInput({date: '2016-01-01', time: '12:00:00 am'});
+
+		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
+			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
+
+		browser.initialFormPage.section.form
+			.click('@createButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('New Datetime Datetime Field Test 1 created.');
+
+		browser.itemPage.section.form.section.datetimeList.section.name
+			.verifyInput({value: 'Datetime Field Test 1'});
+
+		browser.itemPage.section.form.section.datetimeList.section.fieldA
+			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
+	},
+	'Datetime field can be filled via the edit form': function (browser) {
+		// Commented out pending a fix for issue #2715
+		// browser.itemPage.section.form.section.datetimeList.section.fieldB
+		// 	.fillInput({date: '2016-01-02', time: '12:00:00 am'});
+
+
+		browser.itemPage.section.form
+			.click('@saveButton');
+
+		browser.app
+			.waitForElementVisible('@itemScreen');
+
+		browser.itemPage
+			.expect.element('@flashMessage')
+			.text.to.equal('Your changes have been saved.');
+
+		browser.itemPage.section.form.section.datetimeList.section.name
+			.verifyInput({value: 'Datetime Field Test 1'});
+
+		// Commented out pending a fix for issue #2715
+		// browser.itemPage.section.form.section.datetimeList.section.fieldB
+		//	.verifyInput({date: '2016-01-02', time: '12:00:00 am'});
+	},
+	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
+	'restoring test state': function (browser) {
+	},
+};

--- a/test/e2e/models/fields/Datetime.js
+++ b/test/e2e/models/fields/Datetime.js
@@ -1,0 +1,32 @@
+var keystone = require('../../../../index.js');
+var Types = keystone.Field.Types;
+
+var Datetime = new keystone.List('Datetime', {
+	autokey: {
+		path: 'key',
+		from: 'name',
+		unique: true,
+	},
+	track: true,
+});
+
+Datetime.add({
+	name: {
+		type: String,
+		initial: true,
+		required: true,
+		index: true,
+	},
+	fieldA: {
+		type: Types.Datetime,
+		initial: true,
+	},
+	fieldB: {
+		type: Types.Datetime,
+	},
+});
+
+Datetime.defaultColumns = 'name, fieldA, fieldB';
+Datetime.register();
+
+module.exports = Datetime;

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -50,6 +50,7 @@ keystone.set('nav', {
 		'codes',
 		'colors',
 		'dates',
+		'datetimes',
 		'emails',
 		'names',
 		'numbers',


### PR DESCRIPTION
cc @webteckie @mxstbr 
For work on #2291 

This is adds partial testing for datetime. Full testing was attempted in #2714, which is currently blocked by #2715. 

There are TODO comments in the code which will need updating once #2715 is resolved. It'll be easier to update these than it will to resolve merge conflicts in #2714, so happy for #2714 to be closed if needbe, as long as issue #2715 remains on the radar. 