### PR TITLE
modified the text-array-type's update-item method to allow delete one or all items in a single update

### DIFF
--- a/fields/types/textarray/TextArrayType.js
+++ b/fields/types/textarray/TextArrayType.js
@@ -156,27 +156,26 @@ textarray.prototype.inputIsValid = function (data, required, item) {
 };
 
 /**
- * Updates the value for this field in the item from a data object
+ * Updates the value for this field in the item from a data object.
+ * If the data object does not contain the value, then the value is set to empty array.
  */
 textarray.prototype.updateItem = function (item, data, callback) {
 	var value = this.getValueFromData(data);
-	if (typeof value !== 'undefined') {
-		if (value === null || value === '') {
-			value = [];
-		}
-		if (!Array.isArray(value)) {
-			value = [value];
-		}
-		value = value.map(function (str) {
-			if (str && str.toString) {
-				str = str.toString();
-			}
-			return str;
-		}).filter(function (str) {
-			return (typeof str === 'string' && str);
-		});
-		item.set(this.path, value);
+	if (value === undefined || value === null || value === '') {
+		value = [];
 	}
+	if (!Array.isArray(value)) {
+		value = [value];
+	}
+	value = value.map(function (str) {
+		if (str && str.toString) {
+			str = str.toString();
+		}
+		return str;
+	}).filter(function (str) {
+		return (typeof str === 'string' && str);
+	});
+	item.set(this.path, value);
 	process.nextTick(callback);
 };
 

--- a/fields/types/textarray/test/type.js
+++ b/fields/types/textarray/test/type.js
@@ -259,6 +259,30 @@ exports.testFieldType = function (List) {
 			});
 		});
 
+		it('should update nested fields non-empty arrays to empty arrays when the data is empty', function (done) {
+			var testItem = new List.model();
+			List.fields['nested.textarr'].updateItem(testItem, {
+				'nested.textarr': ['a', 'b'],
+			}, function () {
+				List.fields['nested.textarr'].updateItem(testItem, {}, function () {
+					demand(testItem.nested.textarr).eql([]);
+					done();
+				});
+			});
+		});
+
+		it('should update non-empty arrays to empty arrays when the data is empty', function (done) {
+			var testItem = new List.model();
+			List.fields.textarr.updateItem(testItem, {
+				textarr: ['a', 'b'],
+			}, function () {
+				List.fields.textarr.updateItem(testItem, {}, function () {
+					demand(testItem.textarr).eql([]);
+					done();
+				});
+			});
+		});
+
 		it('should update empty arrays', function (done) {
 			var testItem = new List.model();
 			List.fields.textarr.updateItem(testItem, {


### PR DESCRIPTION
should fix #1655

1.  modified the text-array-type's update-item method to delete the values if the data object does not contain any value.

2.  added unit tests to verify the new behavior.