### PR TITLE
test(e2e): Enforce consistent naming of test fields

### DIFF
--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.codeList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Code Field Test 1'});
 
 		browser.initialFormPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Code Field Test 1'});
 
 		browser.initialFormPage.section.form.section.codeList.section.fieldA
 			.fillInput({value: 'Some Test Code for Field A'});
@@ -46,10 +46,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Code Name Field Test 1 created.');
+			.text.to.equal('New Code Code Field Test 1 created.');
 
 		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Code Field Test 1'});
 
 		browser.itemPage.section.form.section.codeList.section.fieldA
 			.verifyInput({value: 'Some Test Code for Field A'});
@@ -69,7 +69,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Code Field Test 1'});
 
 		browser.itemPage.section.form.section.codeList.section.fieldB
 			.verifyInput({value: 'Some Test Code for Field B'});

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.colorList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Color Field Test 1'});
 
 		browser.initialFormPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Color Field Test 1'});
 
 		browser.initialFormPage.section.form.section.colorList.section.fieldA
 			.fillInput({value: '#002147'});
@@ -49,10 +49,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Color Name Field Test 1 created.');
+			.text.to.equal('New Color Color Field Test 1 created.');
 
 		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Color Field Test 1'});
 
 		browser.itemPage.section.form.section.colorList.section.fieldA
 			.verifyInput({value: '#002147'});
@@ -72,7 +72,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Color Field Test 1'});
 
 		browser.itemPage.section.form.section.colorList.section.fieldB
 			.verifyInput({value: '#f8e71c'});

--- a/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.dateList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Date Field Test 1'});
 
 		browser.initialFormPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Date Field Test 1'});
 
 		browser.initialFormPage.section.form.section.dateList.section.fieldA
 			.fillInput({value: '2016-01-01'});
@@ -49,10 +49,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Date Name Field Test 1 created.');
+			.text.to.equal('New Date Date Field Test 1 created.');
 
 		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Date Field Test 1'});
 
 		browser.itemPage.section.form.section.dateList.section.fieldA
 			.verifyInput({value: '2016-01-01'});
@@ -72,7 +72,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Date Field Test 1'});
 
 		browser.itemPage.section.form.section.dateList.section.fieldB
 			.verifyInput({value: '2016-01-02'});

--- a/test/e2e/adminUI/tests/group005Fields/number/uxTestNumberField.js
+++ b/test/e2e/adminUI/tests/group005Fields/number/uxTestNumberField.js
@@ -38,7 +38,7 @@ module.exports = {
 		browser.expect.element(adminUI.cssSelector.itemView.fieldType.number.number.fieldA.value)
 			.to.have.value.that.equals('10');
 	},
-	'Name field can be filled via the edit form': function (browser) {
+	'Number field can be filled via the edit form': function (browser) {
 		browser
 			.setValue(adminUI.cssSelector.itemView.fieldType.number.number.fieldB.value, '20')
 			.pause(browser.globals.defaultPauseTimeout)

--- a/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.selectList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Select Field Test 1'});
 
 		browser.initialFormPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Select Field Test 1'});
 
 		browser.initialFormPage.section.form.section.selectList.section.fieldA
 			.fillInput({value: ''});
@@ -49,10 +49,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Select Name Field Test 1 created.');
+			.text.to.equal('New Select Select Field Test 1 created.');
 
 		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Select Field Test 1'});
 
 		browser.itemPage.section.form.section.selectList.section.fieldA
 			.verifyInput({value: 'One'});
@@ -72,7 +72,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Select Field Test 1'});
 
 		browser.itemPage.section.form.section.selectList.section.fieldB
 			.verifyInput({value: 'Two'});

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.textareaList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Textarea Field Test 1'});
 
 		browser.initialFormPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Textarea Field Test 1'});
 
 		browser.initialFormPage.section.form.section.textareaList.section.fieldA
 			.fillInput({value: 'Textarea Field Test 1'});
@@ -49,10 +49,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Textarea Name Field Test 1 created.');
+			.text.to.equal('New Textarea Textarea Field Test 1 created.');
 
 		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Textarea Field Test 1'});
 
 		browser.itemPage.section.form.section.textareaList.section.fieldA
 			.verifyInput({value: 'Textarea Field Test 1'});
@@ -72,7 +72,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Textarea Field Test 1'});
 
 		browser.itemPage.section.form.section.textareaList.section.fieldB
 			.verifyInput({value: 'Textarea Field Test 2'});

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -30,10 +30,10 @@ module.exports = {
 			.waitForElementVisible('@initialFormScreen');
 
 		browser.initialFormPage.section.form.section.urlList.section.name
-			.fillInput({value: 'Name Field Test 1'});
+			.fillInput({value: 'Url Field Test 1'});
 
 		browser.initialFormPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Url Field Test 1'});
 
 		browser.initialFormPage.section.form.section.urlList.section.fieldA
 			.fillInput({value: 'www.example1.com'});
@@ -49,10 +49,10 @@ module.exports = {
 
 		browser.itemPage
 			.expect.element('@flashMessage')
-			.text.to.equal('New Url Name Field Test 1 created.');
+			.text.to.equal('New Url Url Field Test 1 created.');
 
 		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Url Field Test 1'});
 
 		browser.itemPage.section.form.section.urlList.section.fieldA
 			.verifyInput({value: 'www.example1.com'});
@@ -72,7 +72,7 @@ module.exports = {
 			.text.to.equal('Your changes have been saved.');
 
 		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
+			.verifyInput({value: 'Url Field Test 1'});
 
 		browser.itemPage.section.form.section.urlList.section.fieldB
 			.verifyInput({value: 'www.example2.com'});


### PR DESCRIPTION
cc: @webteckie #2291 

Following your comment [here](https://github.com/keystonejs/keystone/pull/2706#discussion-diff-61503351R33) this should enforce consistency across all tests. 

I have replaced instances "Name Field Test" with e.g. "Color Field Test". I can see why it used to say "Name", as this is the text placed into the Name field, but agree it makes more sense this way. 

All tests pass locally