### PR TITLE
test(e2e): Refactor field tests to use common functions

### DIFF
--- a/test/e2e/adminUI/nightwatch.json
+++ b/test/e2e/adminUI/nightwatch.json
@@ -33,7 +33,8 @@
         "browserName": "firefox",
         "javascriptEnabled": true,
         "acceptSslCerts": true
-      }
+      },
+			"exclude": "test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js"
     },
     "saucelabs-travis": {
       "selenium_host": "ondemand.saucelabs.com",

--- a/test/e2e/adminUI/pages/lists/name.js
+++ b/test/e2e/adminUI/pages/lists/name.js
@@ -7,6 +7,7 @@ module.exports = function NameList(config) {
 		sections: {
 			name: new TextType({fieldName: 'name'}),
 			fieldA: new NameType({fieldName: 'fieldA'}),
+			fieldB: new NameType({fieldName: 'fieldB'}),
 		},
 		commands: [{
 			//

--- a/test/e2e/adminUI/pages/lists/text.js
+++ b/test/e2e/adminUI/pages/lists/text.js
@@ -6,6 +6,7 @@ module.exports = function NameList(config) {
 		sections: {
 			name: new TextType({fieldName: 'name'}),
 			fieldA: new TextType({fieldName: 'fieldA'}),
+			fieldB: new TextType({fieldName: 'fieldB'}),
 		},
 		commands: [{
 			//

--- a/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Code field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@codeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.codeList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Code field should be visible in initial modal': fieldTests.assertInitialFormUI('Code'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -1,80 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Code field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@codeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.fillInput({value: 'Code Field Test 1'});
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.initialFormPage.section.form.section.codeList.section.fieldA
-			.fillInput({value: 'Some Test Code for Field A'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Code Code Field Test 1 created.');
-
-		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.itemPage.section.form.section.codeList.section.fieldA
-			.verifyInput({value: 'Some Test Code for Field A'});
-	},
-	'Code field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.codeList.section.fieldB
-			.fillInput({value: 'Some Test Code for Field B'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.itemPage.section.form.section.codeList.section.fieldB
-			.verifyInput({value: 'Some Test Code for Field B'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Code field can be filled via the initial modal': fieldTests.assertInitialFormUX('Code', {value: 'Some test code for field A'}),
+	'Code field can be filled via the edit form': fieldTests.assertEditFormUX('Code', {value: 'Some test code for field B'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Color field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@colorListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Color field should be visible in initial modal': fieldTests.assertInitialFormUI('Color'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Color field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@colorListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.fillInput({value: 'Color Field Test 1'});
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.fillInput({value: '#002147'});
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.verifyInput({value: '#002147'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Color Color Field Test 1 created.');
-
-		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.itemPage.section.form.section.colorList.section.fieldA
-			.verifyInput({value: '#002147'});
-	},
-	'Color field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.colorList.section.fieldB
-			.fillInput({value: '#f8e71c'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.itemPage.section.form.section.colorList.section.fieldB
-			.verifyInput({value: '#f8e71c'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Color field can be filled via the initial modal': fieldTests.assertInitialFormUX('Color', {value: '#002147'}),
+	'Color field can be filled via the edit form': fieldTests.assertEditFormUX('Color', {value: '#f8e71c'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -1,0 +1,128 @@
+module.exports = {
+	beforeUI: function (browser) {
+		browser
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	beforeUX: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	assertInitialFormUI: function (name) {
+		var nameLowercase = name.toLowerCase();
+		return function (browser) {
+			browser.app
+				.click('@fieldListsMenu')
+				.waitForElementVisible('@listScreen')
+				.click('@' + nameLowercase + 'ListSubmenu')
+				.waitForElementVisible('@listScreen');
+
+			browser.listPage
+				.click('@createFirstItemButton');
+
+			browser.app
+				.waitForElementVisible('@initialFormScreen');
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.name
+				.verifyUI();
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.fieldA
+				.verifyUI();
+		}
+	},
+	assertInitialFormUX: function(name, testInputArray){
+		var nameLowercase = name.toLowerCase();
+		return function (browser) {
+			browser.app
+				.click('@fieldListsMenu')
+				.waitForElementVisible('@listScreen')
+				.click('@' + nameLowercase + 'ListSubmenu')
+				.waitForElementVisible('@listScreen');
+
+			browser.listPage
+				.click('@createFirstItemButton');
+
+			browser.app
+				.waitForElementVisible('@initialFormScreen');
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.name
+				.fillInput({value: name + ' Field Test 1'});
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.name
+				.verifyInput({value: name + ' Field Test 1'});
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.fieldA
+				.fillInput(testInputArray);
+
+			browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section.fieldA
+				.verifyInput(testInputArray);
+
+			browser.initialFormPage.section.form
+				.click('@createButton');
+
+			browser.app
+				.waitForElementVisible('@itemScreen');
+
+			browser.itemPage
+				.expect.element('@flashMessage')
+				.text.to.equal('New ' + name + ' ' + name + ' Field Test 1 created.');
+
+			browser.itemPage.section.form.section[ nameLowercase + 'List' ].section.name
+				.verifyInput({value: name + ' Field Test 1'});
+
+			browser.itemPage.section.form.section[ nameLowercase + 'List' ].section.fieldA
+				.verifyInput(testInputArray);
+		}
+	},
+	assertEditFormUX: function(name, testInputArray) {
+		var nameLowercase = name.toLowerCase();
+		return function (browser) {
+			browser.itemPage.section.form.section[ nameLowercase + 'List' ].section.fieldB
+				.fillInput(testInputArray);
+
+			browser.itemPage.section.form
+				.click('@saveButton');
+
+			browser.app
+				.waitForElementVisible('@itemScreen');
+
+			browser.itemPage
+				.expect.element('@flashMessage')
+				.text.to.equal('Your changes have been saved.');
+
+			browser.itemPage.section.form.section[ nameLowercase + 'List' ].section.name
+				.verifyInput({value: name + ' Field Test 1'});
+
+			browser.itemPage.section.form.section[ nameLowercase + 'List' ].section.fieldB
+				.verifyInput(testInputArray);
+		}
+	},
+	restore: function (browser) {
+		browser.initialFormPage.section.form
+			.click('@cancelButton');
+
+		browser.app
+			.waitForElementVisible('@listScreen');
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Date field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@dateListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Date field should be visible in initial modal': fieldTests.assertInitialFormUI('Date'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Date field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@dateListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.fillInput({value: 'Date Field Test 1'});
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.fillInput({value: '2016-01-01'});
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.verifyInput({value: '2016-01-01'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Date Date Field Test 1 created.');
-
-		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.itemPage.section.form.section.dateList.section.fieldA
-			.verifyInput({value: '2016-01-01'});
-	},
-	'Date field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.dateList.section.fieldB
-			.fillInput({value: '2016-01-02'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.itemPage.section.form.section.dateList.section.fieldB
-			.verifyInput({value: '2016-01-02'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Date field can be filled via the initial modal': fieldTests.assertInitialFormUX('Date', {value: '2016-01-01'}),
+	'Date field can be filled via the edit form': fieldTests.assertEditFormUX('Date', {value: '2016-01-02'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Datetime field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@datetimeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Datetime field should be visible in initial modal': fieldTests.assertInitialFormUI('Datetime'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -1,86 +1,9 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Datetime field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@datetimeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.fillInput({value: 'Datetime Field Test 1'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.fillInput({date: '2016-01-01', time: '12:00:00 am'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Datetime Datetime Field Test 1 created.');
-
-		browser.itemPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		browser.itemPage.section.form.section.datetimeList.section.fieldA
-			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
-	},
-	'Datetime field can be filled via the edit form': function (browser) {
-		// Commented out pending a fix for issue #2715
-		// browser.itemPage.section.form.section.datetimeList.section.fieldB
-		// 	.fillInput({date: '2016-01-02', time: '12:00:00 am'});
-
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		// Commented out pending a fix for issue #2715
-		// browser.itemPage.section.form.section.datetimeList.section.fieldB
-		//	.verifyInput({date: '2016-01-02', time: '12:00:00 am'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Datetime field can be filled via the initial modal': fieldTests.assertInitialFormUX('Datetime', {date: '2016-01-01', time: '12:00:00 am'}),
+	// Pending fix for #2715
+	//'Datetime field can be filled via the edit form': fieldTests.assertEditFormUX('Datetime', {date: '2016-01-02', time: '12:00:00 am'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Html field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@htmlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Html field should be visible in initial modal': fieldTests.assertInitialFormUI('Html'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Html field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@htmlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.fillInput({value: 'Html Field Test 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.fillInput({value: 'Test html code 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.verifyInput({value: 'Test html code 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Html Html Field Test 1 created.');
-
-		browser.itemPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.itemPage.section.form.section.htmlList.section.fieldA
-			.verifyInput({value: 'Test html code 1'});
-	},
-	'Html field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.htmlList.section.fieldB
-			.fillInput({value: 'Test html code 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.itemPage.section.form.section.htmlList.section.fieldB
-			.verifyInput({value: 'Test html code 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Html field can be filled via the initial modal': fieldTests.assertInitialFormUX('Html', {value: 'Test html code 1'}),
+	'Html field can be filled via the edit form': fieldTests.assertEditFormUX('Html', {value: 'Test html code 2'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Name field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@nameListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Name field should be visible in initial modal': fieldTests.assertInitialFormUI('Name'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
@@ -1,82 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Name field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@nameListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.fillInput({value: 'Name Field Test 1'});
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
-
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
-			.fillInput({firstName: 'First 1', lastName: 'Last 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Name Name Field Test 1 created.');
-
-		browser.itemPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.verifyInput({firstName: 'First 1', lastName: 'Last 1'});
-	},
-	'Name field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.nameList.section.name
-			.fillInput({value: 'Name Field Test 2'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.fillInput({firstName: 'First 2', lastName: 'Last 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.itemPage
-			.waitForElementVisible('@flashMessage');
-
-		browser.itemPage
-			.expect.element('@flashMessage').text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 2'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.verifyInput({firstName: 'First 2', lastName: 'Last 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Name field can be filled via the initial modal': fieldTests.assertInitialFormUX('Name', {firstName: 'First 1', lastName: 'Last 1'}),
+	'Name field can be filled via the edit form': fieldTests.assertEditFormUX('Name', {firstName: 'First 2', lastName: 'Last 2'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Select field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@selectListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Select field should be visible in initial modal': fieldTests.assertInitialFormUI('Select'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Select field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@selectListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.fillInput({value: 'Select Field Test 1'});
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.fillInput({value: ''});
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.verifyInput({value: 'One'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Select Select Field Test 1 created.');
-
-		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.itemPage.section.form.section.selectList.section.fieldA
-			.verifyInput({value: 'One'});
-	},
-	'Select field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.selectList.section.fieldB
-			.fillInput({value: 'Two'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.itemPage.section.form.section.selectList.section.fieldB
-			.verifyInput({value: 'Two'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Select field can be filled via the initial modal': fieldTests.assertInitialFormUX('Select', {value: 'One'}),
+	'Select field can be filled via the edit form': fieldTests.assertEditFormUX('Select', {value: 'Two'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Text field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.textList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Text field should be visible in initial modal': fieldTests.assertInitialFormUI('Text'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -1,78 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app
-			.signout();
-		browser
-			.end();
-	},
-	'Text field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.fillInput({value: 'Text Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textList.section.fieldA
-			.fillInput({value: 'Text Field Test Text 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Text Text Field Test 1 created.');
-
-		browser.itemPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 1'});
-	},
-	'Text field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.textList.section.name
-			.fillInput({value: 'Text Field Test 2'});
-
-		browser.itemPage.section.form.section.textList.section.fieldA
-			.fillInput({value: 'Text Field Test Text 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.itemPage
-			.waitForElementVisible('@flashMessage');
-
-		browser.itemPage
-			.expect.element('@flashMessage').text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 2'});
-
-		browser.itemPage.section.form.section.textList.section.fieldA
-			.verifyInput({value: 'Text Field Test Text 2'});
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Text field can be filled via the initial modal': fieldTests.assertInitialFormUX('Text', {value: 'Text Field Test Text 1'}),
+	'Text field can be filled via the edit form': fieldTests.assertEditFormUX('Text', {value: 'Text Field Test Text 1'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Textarea field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textareaListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Textarea field should be visible in initial modal': fieldTests.assertInitialFormUI('Textarea'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Textarea field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textareaListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.fillInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.fillInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Textarea Textarea Field Test 1 created.');
-
-		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.itemPage.section.form.section.textareaList.section.fieldA
-			.verifyInput({value: 'Textarea Field Test 1'});
-	},
-	'Textarea field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.textareaList.section.fieldB
-			.fillInput({value: 'Textarea Field Test 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.itemPage.section.form.section.textareaList.section.fieldB
-			.verifyInput({value: 'Textarea Field Test 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Textarea field can be filled via the initial modal': fieldTests.assertInitialFormUX('Textarea', {value: 'Textarea Field Test 1'}),
+	'Textarea field can be filled via the edit form': fieldTests.assertEditFormUX('Textarea', {value: 'Textarea Field Test 2'}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Url field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@urlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.beforeUI,
+	after: fieldTests.after,
+	'Url field should be visible in initial modal': fieldTests.assertInitialFormUI('Url'),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -1,83 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Url field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@urlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.fillInput({value: 'Url Field Test 1'});
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.fillInput({value: 'www.example1.com'});
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.verifyInput({value: 'www.example1.com'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Url Url Field Test 1 created.');
-
-		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.itemPage.section.form.section.urlList.section.fieldA
-			.verifyInput({value: 'www.example1.com'});
-	},
-	'Url field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.urlList.section.fieldB
-			.fillInput({value: 'www.example2.com'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.itemPage.section.form.section.urlList.section.fieldB
-			.verifyInput({value: 'www.example2.com'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.beforeUX,
+	after: fieldTests.after,
+	'Url field can be filled via the initial modal': fieldTests.assertInitialFormUX('Url', {value: 'www.example1.com'}),
+	'Url field can be filled via the edit form': fieldTests.assertEditFormUX('Url', {value: 'www.example2.com'}),
 };


### PR DESCRIPTION
cc @webteckie @joerter 

Following our discussions on slack, and for work on #2291. See what you think. 

The functions that are run by every test are now in a common file, `commonFieldTestUtils`, and all the `uiTest....Field` and `uxTest...Field` stuff imports these functions. Saves on repeated code (hence the 1,245 deletions compared to 253 additions). 