### PR TITLE
test(e2e): Use common functions for field tests

### DIFF
--- a/test/e2e/adminUI/nightwatch.json
+++ b/test/e2e/adminUI/nightwatch.json
@@ -33,7 +33,8 @@
         "browserName": "firefox",
         "javascriptEnabled": true,
         "acceptSslCerts": true
-      }
+      },
+			"exclude": "test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js"
     },
     "saucelabs-travis": {
       "selenium_host": "ondemand.saucelabs.com",

--- a/test/e2e/adminUI/pages/home.js
+++ b/test/e2e/adminUI/pages/home.js
@@ -1,38 +1,95 @@
-var dashboardGroup = require('./dashboardGroup');
-
-var accessdashboardGroup = dashboardGroup({
-	groupName: 'Access',
-	tabs: [
-		{name: 'users', items: '1 Item'},
-	],
-});
-
-var fieldsdashboardGroup = dashboardGroup({
-	groupName: 'Fields',
-	tabs: [
-		{name: 'booleans', items: '0 Items'},
-		{name: 'codes', items: '0 Items'},
-		{name: 'emails', items: '0 Items'},
-		{name: 'names', items: '0 Items'},
-		{name: 'numbers', items: '0 Items'},
-		{name: 'selects', items: '0 Items'},
-	],
-});
-
-var otherdashboardGroup = dashboardGroup({
-	groupName: 'Other',
-	tabs: [
-		{name: 'other-lists', items: '0 Items'},
-	],
-});
-
 module.exports = {
 	elements: {
-		dashboardHeader: '.dashboard-heading',
+		dashboardHeader: '.dashboard-heading'
 	},
 	sections: {
-		accessGroup: accessdashboardGroup,
-		fieldsGroup: fieldsdashboardGroup,
-		otherGroup: otherdashboardGroup,
+		accessGroup: {
+			selector: '.dashboard-group[data-section-label="Access"]',
+			elements: {
+				subheading: '.dashboard-group__heading',
+			},
+			sections: {
+				usersTab: {
+					selector: '.dashboard-group__list[data-list-path="users"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="users"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="users"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="users"] .dashboard-group__list-count',
+					},
+				},
+			},
+		},
+		fieldsGroup: {
+			selector: '.dashboard-group[data-section-label="Fields"]',
+			elements: {
+				subheading: '.dashboard-group__heading',
+			},
+			sections: {
+				booleansTab: {
+					selector: '.dashboard-group__list[data-list-path="booleans"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="booleans"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="booleans"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="booleans"] .dashboard-group__list-count',
+					},
+				},
+				codesTab: {
+					selector: '.dashboard-group__list[data-list-path="codes"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="codes"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="codes"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="codes"] .dashboard-group__list-count',
+					},
+				},
+				emailsTab: {
+					selector: '.dashboard-group__list[data-list-path="emails"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="emails"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="emails"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="emails"] .dashboard-group__list-count',
+					},
+				},
+				namesTab: {
+					selector: '.dashboard-group__list[data-list-path="names"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="names"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="names"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="names"] .dashboard-group__list-count',
+					},
+				},
+				numbersTab: {
+					selector: '.dashboard-group__list[data-list-path="numbers"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="numbers"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="numbers"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="numbers"] .dashboard-group__list-count',
+					},
+				},
+				selectsTab: {
+					selector: '.dashboard-group__list[data-list-path="selects"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="selects"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="selects"] .dashboard-group__list-count',
+					},
+				},
+			},
+		},
+		otherGroup: {
+			selector: '.dashboard-group[data-section-label="Other"]',
+			elements: {
+				subheading: '.dashboard-group__heading',
+			},
+			sections: {
+				otherListsTab: {
+					selector: '.dashboard-group__list[data-list-path="other-lists"]',
+					elements: {
+						label: '.dashboard-group__list[data-list-path="other-lists"] .dashboard-group__list-label',
+						plusIconLink: '.dashboard-group__list[data-list-path="other-lists"] a.dashboard-group__list-create.octicon.octicon-plus',
+						itemCount: '.dashboard-group__list[data-list-path="other-lists"] .dashboard-group__list-count',
+					},
+				},
+			},
+		},
 	},
 }

--- a/test/e2e/adminUI/pages/lists/name.js
+++ b/test/e2e/adminUI/pages/lists/name.js
@@ -7,6 +7,7 @@ module.exports = function NameList(config) {
 		sections: {
 			name: new TextType({fieldName: 'name'}),
 			fieldA: new NameType({fieldName: 'fieldA'}),
+			fieldB: new NameType({fieldName: 'fieldB'}),
 		},
 		commands: [{
 			//

--- a/test/e2e/adminUI/pages/lists/text.js
+++ b/test/e2e/adminUI/pages/lists/text.js
@@ -6,6 +6,7 @@ module.exports = function NameList(config) {
 		sections: {
 			name: new TextType({fieldName: 'name'}),
 			fieldA: new TextType({fieldName: 'fieldA'}),
+			fieldB: new TextType({fieldName: 'fieldB'}),
 		},
 		commands: [{
 			//

--- a/test/e2e/adminUI/tests/group002Home/uiTestBooleansTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestBooleansTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.booleansTab = browser.page.home().section.fieldsGroup.section.booleansTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Booleans tab under the Fields dashboard sub-heading': function (browser) {
+		browser.booleansTab.expect.element('@label')
+			.text.to.equal('Booleans');
+	},
+	'Home view should have a + link for the Booleans tab under the Fields dashboard sub-heading': function (browser) {
+		browser.booleansTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Booleans tab under the Fields dashboard sub-heading': function (browser) {
+		browser.booleansTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Booleans tab under the Fields dashboard sub-heading': function (browser) {
+		browser.booleansTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestCodeTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestCodeTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.codesTab = browser.page.home().section.fieldsGroup.section.codesTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Codes tab under the Fields dashboard sub-heading': function (browser) {
+		browser.codesTab.expect.element('@label')
+			.text.to.equal('Codes');
+	},
+	'Home view should have a + link for the Codes tab under the Fields dashboard sub-heading': function (browser) {
+		browser.codesTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Codes tab under the Fields dashboard sub-heading': function (browser) {
+		browser.codesTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Codes tab under the Fields dashboard sub-heading': function (browser) {
+		browser.codesTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestEmailsTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestEmailsTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.emailsTab = browser.page.home().section.fieldsGroup.section.emailsTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Emails tab under the Fields dashboard sub-heading': function (browser) {
+		browser.emailsTab.expect.element('@label')
+			.text.to.equal('Emails');
+	},
+	'Home view should have a + link for the Emails tab under the Fields dashboard sub-heading': function (browser) {
+		browser.emailsTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Emails tab under the Fields dashboard sub-heading': function (browser) {
+		browser.emailsTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Emails tab under the Fields dashboard sub-heading': function (browser) {
+		browser.emailsTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
@@ -66,13 +66,4 @@ module.exports = {
 		browser.homeScreen.section.otherGroup.expect.element('@subheading')
 			.text.to.equal('Other');
 	},
-	'Home view should have tabs under Access dashboard group': function (browser) {
-		browser.homeScreen.section.accessGroup.verifyUI();
-	},
-	'Home view should have tabs under Fields dashboard group': function (browser) {
-		browser.homeScreen.section.fieldsGroup.verifyUI();
-	},
-	'Home view should have tabs under Other dashboard group': function (browser) {
-		browser.homeScreen.section.otherGroup.verifyUI();
-	},
 };

--- a/test/e2e/adminUI/tests/group002Home/uiTestNamesTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestNamesTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.namesTab = browser.page.home().section.fieldsGroup.section.namesTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Names tab under the Fields dashboard sub-heading': function (browser) {
+		browser.namesTab.expect.element('@label')
+			.text.to.equal('Names');
+	},
+	'Home view should have a + link for the Names tab under the Fields dashboard sub-heading': function (browser) {
+		browser.namesTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Names tab under the Fields dashboard sub-heading': function (browser) {
+		browser.namesTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Names tab under the Fields dashboard sub-heading': function (browser) {
+		browser.namesTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestNumbersTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestNumbersTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.numbersTab = browser.page.home().section.fieldsGroup.section.numbersTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Numbers tab under the Fields dashboard sub-heading': function (browser) {
+		browser.numbersTab.expect.element('@label')
+			.text.to.equal('Numbers');
+	},
+	'Home view should have a + link for the Numbers tab under the Fields dashboard sub-heading': function (browser) {
+		browser.numbersTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Numbers tab under the Fields dashboard sub-heading': function (browser) {
+		browser.numbersTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Numbers tab under the Fields dashboard sub-heading': function (browser) {
+		browser.numbersTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestOtherListsTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestOtherListsTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.otherListsTab = browser.page.home().section.otherGroup.section.otherListsTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Other Lists tab under the Other dashboard sub-heading': function (browser) {
+		browser.otherListsTab.expect.element('@label')
+			.text.to.equal('Other Lists');
+	},
+	'Home view should have a + link for the Other Lists tab under the Other dashboard sub-heading': function (browser) {
+		browser.otherListsTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Other Lists tab under the Other dashboard sub-heading': function (browser) {
+		browser.otherListsTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Other Lists tab under the Other dashboard sub-heading': function (browser) {
+		browser.otherListsTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestSelectsTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestSelectsTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.selectsTab = browser.page.home().section.fieldsGroup.section.selectsTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Selects tab under the Fields dashboard sub-heading': function (browser) {
+		browser.selectsTab.expect.element('@label')
+			.text.to.equal('Selects');
+	},
+	'Home view should have a + link for the Selects tab under the Fields dashboard sub-heading': function (browser) {
+		browser.selectsTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Selects tab under the Fields dashboard sub-heading': function (browser) {
+		browser.selectsTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 0 Items for the Selects tab under the Fields dashboard sub-heading': function (browser) {
+		browser.selectsTab.expect.element('@itemCount')
+			.text.to.equal('0 Items');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uiTestUsersTab.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestUsersTab.js
@@ -1,0 +1,33 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinScreen = browser.page.signin();
+		browser.usersTab = browser.page.home().section.accessGroup.section.usersTab;
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinScreen.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	'Home view should have a Users tab under the Access dashboard sub-heading': function (browser) {
+		browser.usersTab.expect.element('@label')
+			.text.to.equal('Users');
+	},
+	'Home view should have a + link for the Users tab under the Access dashboard sub-heading': function (browser) {
+		browser.usersTab.expect.element('@plusIconLink')
+			.to.be.visible;
+	},
+	'Home view should have a + icon for the Users tab under the Access dashboard sub-heading ': function (browser) {
+		browser.usersTab.expect.element('@plusIconLink')
+			.to.have.attribute('class').which.contains('dashboard-group__list-create octicon octicon-plus');
+	},
+	'Home view should show 1 Item for the Users tab under the Access dashboard sub-heading': function (browser) {
+		browser.usersTab.expect.element('@itemCount')
+			.text.to.equal('1 Item');
+	},
+};

--- a/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
@@ -2,121 +2,107 @@ var adminUI = require('../../adminUI');
 
 module.exports = {
 	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinScreen = browser.page.signin();
-		browser.homeScreen = browser.page.home();
-		browser.initialForm = browser.page.initialForm();
-		browser.listScreen = browser.page.list();
-		browser.deleteConfirmation = browser.page.deleteConfirmation();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinScreen.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.signinView.id)
+			.setValue(adminUI.cssSelector.signinView.emailInput, adminUI.login.email)
+			.setValue(adminUI.cssSelector.signinView.passwordInput, adminUI.login.password)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.signinView.submitButton)
+			.pause(browser.globals.defaultPauseTimeout);
 	},
 	after: function (browser) {
-		browser.app.signout();
-		browser.end();
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.allView.logoutIconLink)
+			.pause(browser.globals.defaultPauseTimeout)
+			.end();
 	},
-	'Home view should allow clicking a nav menu item such as Access and Fields to show the list of items': function (browser) {
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen')
-			.click('@accessMenu')
-			.waitForElementVisible('@listScreen')
-			.navigate()
-			.waitForElementVisible('@homeScreen')
-			.click('@fieldsMenu')
-			.waitForElementVisible('@listScreen');
+	'Home view should allow clicking a nav menu item such as Access to show the list of items': function (browser) {
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.allView.accessMenu)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.allView.fieldListsMenu)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.pause(browser.globals.defaultPauseTimeout);
 	},
 	'Home view should allow clicking a card list item such as Users to should show the list of those items': function (browser) {
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
-
-		browser.homeScreen.section.accessGroup.section.users
-			.click('@label');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.homeView.usersTabUnderDashboardAccessSubheading)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.pause(browser.globals.defaultPauseTimeout);
 	},
 	'Home view should allow an admin to create a new list item such as a user': function (browser) {
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
-
-		browser.homeScreen.section.accessGroup.section.users
-			.click('@plusIconLink');
-
-		browser.initialForm.section.form
-			.waitForElementVisible('@createButton');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.homeView.plusIconLinkForUsersTabUnderDashboardAccessSubheading)
+			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
+			.pause(browser.globals.defaultPauseTimeout);
 	},
 	'Home view should allow an admin to create a new list item and increment the item count': function (browser) {
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout);
 
-		browser.homeScreen.section.fieldsGroup.section.names
-			.expect.element('@itemCount').text.to.equal('0 Items');
-		browser.homeScreen.section.fieldsGroup.section.names
-			.click('@plusIconLink');
+		browser.expect.element(adminUI.cssSelector.homeView.itemCountForNamesTabUnderDashboardFieldsSubheading)
+			.text.to.equal('0 Items');
 
-		browser.initialForm.section.form
-			.waitForElementVisible('@createButton');
+		browser
+			.click(adminUI.cssSelector.homeView.plusIconLinkForNamesTabUnderDashboardFieldsSubheading)
+			.waitForElementVisible(adminUI.cssSelector.initialModalView.id)
+			.setValue(adminUI.cssSelector.initialModalView.fieldType.name.name.name.value, 'Name Field Test')
+			.setValue(adminUI.cssSelector.initialModalView.fieldType.name.name.fieldA.first, 'First')
+			.setValue(adminUI.cssSelector.initialModalView.fieldType.name.name.fieldA.last, 'Last')
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.initialModalView.buttonCreate)
+			.waitForElementVisible(adminUI.cssSelector.itemView.id)
+			.url(adminUI.url);
 
-		browser.initialForm.section.form.section.nameList.section.name
-			.fillInput({value: 'Name Field Test'});
-		browser.initialForm.section.form.section.nameList.section.fieldA
-			.fillInput({firstName: 'First', lastName: 'Last'});
-
-		browser.initialForm.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen')
-			.navigate()
-			.waitForElementVisible('@homeScreen');
-
-		browser.homeScreen.section.fieldsGroup.section.names
-			.expect.element('@itemCount').text.to.equal('1 Item');
+		browser.expect.element(adminUI.cssSelector.homeView.itemCountForNamesTabUnderDashboardFieldsSubheading)
+			.text.to.equal('1 Item');
 	},
 	'Home view should be accessible from any other non-modal view by clicking the Home link': function (browser) {
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
-
-		browser.homeScreen.section.accessGroup.section.users
-			.click('@label');
-		browser.app
-			.waitForElementVisible('@listScreen');
-
-		browser.app
-			.click('@homeIconLink')
-			.waitForElementVisible('@homeScreen');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.homeView.usersTabUnderDashboardAccessSubheading)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.allView.homeIconLink)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout);
 	},
+
 	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
 	'Home view ... undoing any state changes': function (browser) {
 		// Delete the Name Field added
-		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
-
-		browser.app
-			.click('@fieldsMenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.app
-			.click('@namesFieldsSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listScreen
-			.click('@singleItemDeleteIcon');
-
-		browser.deleteConfirmation
-			.waitForElementVisible('@deleteButton');
-
-		browser.deleteConfirmation
-			.click('@deleteButton');
+		browser
+			.url(adminUI.url)
+			.waitForElementVisible(adminUI.cssSelector.homeView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.allView.fieldListsMenu)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.click(adminUI.cssSelector.allView.nameListSubmenu)
+			.waitForElementVisible(adminUI.cssSelector.listView.id)
+			.pause(browser.globals.defaultPauseTimeout)
+			.click(adminUI.cssSelector.listView.singleItemDeleteIcon)
+			.waitForElementVisible(adminUI.cssSelector.deleteConfirmationModalView.id)
+			.click(adminUI.cssSelector.deleteConfirmationModalView.buttonDelete);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Code field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Code', fields: ['name', 'fieldA']}),
+	'Code field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Code',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uiTestCodeField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Code field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@codeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.codeList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Code field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Code', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -3,17 +3,52 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Code field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Code field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Code',
+	}),
+	'Code field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Code',
 		inputs: {
-			'name': {value: 'Url Field Test 1'},
+			'name': {value: 'Code Field Test 1'},
 			'fieldA': {value: 'Some test code for field A'},
 		}
 	}),
-	'Code field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Code field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Code',
 		inputs: {
-			'fieldB': {value: 'Some test code for field B'},
+			'name': {value: 'Code Field Test 1'},
+			'fieldA': {value: 'Some test code for field A'},
 		}
 	}),
+	'Code field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Code field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Code Code Field Test 1 created.'
+	}),
+	'Code field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Code',
+		inputs: {
+			'name': {value: 'Code Field Test 1'},
+			'fieldA': {value: 'Some test code for field A'}
+		}
+	}),
+	/* TODO Removed pending code's fillInput function filling the correct field.
+	'Code field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Code',
+		inputs: {
+			'fieldB': {value: 'Some test code for field B'}
+		}
+	}),
+	'Code field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Code field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Code field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Code',
+		inputs: {
+			'name': {value: 'Code Field Test 1'},
+			'fieldA': {value: 'Some test code for field A'},
+			'fieldB': {value: 'Some test code for field B'}
+		}
+	})
+	*/
 };

--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Code field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Code',
+		listName: 'Code',
 		inputs: {
 			'name': {value: 'Url Field Test 1'},
 			'fieldA': {value: 'Some test code for field A'},
 		}
 	}),
 	'Code field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Code',
+		listName: 'Code',
 		inputs: {
 			'fieldB': {value: 'Some test code for field B'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -1,80 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Code field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@codeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.fillInput({value: 'Code Field Test 1'});
-
-		browser.initialFormPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.initialFormPage.section.form.section.codeList.section.fieldA
-			.fillInput({value: 'Some Test Code for Field A'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Code Code Field Test 1 created.');
-
-		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.itemPage.section.form.section.codeList.section.fieldA
-			.verifyInput({value: 'Some Test Code for Field A'});
-	},
-	'Code field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.codeList.section.fieldB
-			.fillInput({value: 'Some Test Code for Field B'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.codeList.section.name
-			.verifyInput({value: 'Code Field Test 1'});
-
-		browser.itemPage.section.form.section.codeList.section.fieldB
-			.verifyInput({value: 'Some Test Code for Field B'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Code field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Code',
+		inputs: {
+			'name': {value: 'Url Field Test 1'},
+			'fieldA': {value: 'Some test code for field A'},
+		}
+	}),
+	'Code field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Code',
+		inputs: {
+			'fieldB': {value: 'Some test code for field B'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Color field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Color', fields: ['name', 'fieldA']}),
+	'Color field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Color',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uiTestColorField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Color field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@colorListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Color field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Color', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Color field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Color',
+		listName: 'Color',
 		inputs: {
 			'name': {value: 'Color Field Test 1'},
 			'fieldA': {value: '#002147'},
 		}
 	}),
 	'Color field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Color',
+		listName: 'Color',
 		inputs: {
 			'fieldB': {value: '#f8e71c'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Color field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@colorListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.fillInput({value: 'Color Field Test 1'});
-
-		browser.initialFormPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.fillInput({value: '#002147'});
-
-		browser.initialFormPage.section.form.section.colorList.section.fieldA
-			.verifyInput({value: '#002147'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Color Color Field Test 1 created.');
-
-		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.itemPage.section.form.section.colorList.section.fieldA
-			.verifyInput({value: '#002147'});
-	},
-	'Color field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.colorList.section.fieldB
-			.fillInput({value: '#f8e71c'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.colorList.section.name
-			.verifyInput({value: 'Color Field Test 1'});
-
-		browser.itemPage.section.form.section.colorList.section.fieldB
-			.verifyInput({value: '#f8e71c'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Color field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Color',
+		inputs: {
+			'name': {value: 'Color Field Test 1'},
+			'fieldA': {value: '#002147'},
+		}
+	}),
+	'Color field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Color',
+		inputs: {
+			'fieldB': {value: '#f8e71c'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/color/uxTestColorField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Color field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Color field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Color',
+	}),
+	'Color field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Color',
 		inputs: {
 			'name': {value: 'Color Field Test 1'},
 			'fieldA': {value: '#002147'},
 		}
 	}),
-	'Color field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Color field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Color',
 		inputs: {
-			'fieldB': {value: '#f8e71c'},
+			'name': {value: 'Color Field Test 1'},
+			'fieldA': {value: '#002147'},
 		}
 	}),
+	'Color field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Color field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Color Color Field Test 1 created.'
+	}),
+	'Color field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Color',
+		inputs: {
+			'name': {value: 'Color Field Test 1'},
+			'fieldA': {value: '#002147'}
+		}
+	}),
+	'Color field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Color',
+		inputs: {
+			'fieldB': {value: '#f8e71c'}
+		}
+	}),
+	'Color field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Color field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Color field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Color',
+		inputs: {
+			'name': {value: 'Color Field Test 1'},
+			'fieldA': {value: '#002147'},
+			'fieldB': {value: '#f8e71c'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -38,10 +38,10 @@ module.exports = {
 			});
 		}
 	},
-	assertInitialFormUX: function(config){
+	openInitialFormUX: function(config) {
 		var list = config.listName.toLowerCase() + 'List';
 		var listSubmenu = '@' + list + 'Submenu';
-		return function (browser) {
+		return function (browser){
 			browser.app
 				.click('@fieldListsMenu')
 				.waitForElementVisible('@listScreen')
@@ -53,30 +53,51 @@ module.exports = {
 
 			browser.app
 				.waitForElementVisible('@initialFormScreen');
-
+		}
+	},
+	fillInitialFormUX: function(config) {
+		var list = config.listName.toLowerCase() + 'List';
+		return function (browser) {
 			fields = Object.keys(config.inputs);
 			fields.forEach(function(field) {
 				browser.initialFormPage.section.form.section[list].section[field]
 					.fillInput(config.inputs[field]);
-
+			});
+		}
+	},
+	assertInitialFormUX: function(config) {
+		var list = config.listName.toLowerCase() + 'List';
+		return function (browser) {
+			fields = Object.keys(config.inputs);
+			fields.forEach(function(field) {
 				browser.initialFormPage.section.form.section[list].section[field]
 					.verifyInput(config.inputs[field]);
 			});
-
+		}
+	},
+	saveInitialFormUX: function() {
+		return function(browser) {
 			browser.initialFormPage.section.form
 				.click('@createButton');
+		}
+	},
+	fillEditFormUX: function(config) {
+		var list = config.listName.toLowerCase() + 'List';
+		var listSubmenu = '@' + list + 'Submenu';
+		return function (browser) {
 
-			browser.app
-				.waitForElementVisible('@itemScreen');
-
-			browser.itemPage
-				.expect.element('@flashMessage')
-				.text.to.equal('New ' + config.listName + ' ' + config.inputs.name.value + ' created.');
+			fields = Object.keys(config.inputs);
 
 			fields.forEach(function(field) {
 				browser.itemPage.section.form.section[list].section[field]
-					.verifyInput(config.inputs[field]);
+					.fillInput(config.inputs[field]);
 			});
+		}
+	},
+	saveEditFormUX: function(config) {
+		return function(browser) {
+		browser.itemPage.section.form
+			.click('@saveButton');
 		}
 	},
 	assertEditFormUX: function(config) {
@@ -88,23 +109,19 @@ module.exports = {
 
 			fields.forEach(function(field) {
 				browser.itemPage.section.form.section[list].section[field]
-					.fillInput(config.inputs[field]);
+					.verifyInput(config.inputs[field]);
 			});
-
-			browser.itemPage.section.form
-				.click('@saveButton');
-
+		}
+	},
+	assertFlashMessage: function(config) {
+		var message = config.message;
+		return function(browser) {
 			browser.app
 				.waitForElementVisible('@itemScreen');
 
 			browser.itemPage
 				.expect.element('@flashMessage')
-				.text.to.equal('Your changes have been saved.');
-
-			fields.forEach(function(field) {
-				browser.itemPage.section.form.section[list].section[field]
-					.verifyInput(config.inputs[field]);
-			});
+				.text.to.equal(message);
 		}
 	},
 	restore: function (browser) {

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -17,12 +17,13 @@ module.exports = {
 		browser.end();
 	},
 	assertInitialFormUI: function (config) {
-		var nameLowercase = config.fieldName.toLowerCase();
+		var list = config.listName.toLowerCase() + 'List';
+		var listSubmenu = '@' + list + 'Submenu';
 		return function (browser) {
 			browser.app
 				.click('@fieldListsMenu')
 				.waitForElementVisible('@listScreen')
-				.click('@' + nameLowercase + 'ListSubmenu')
+				.click(listSubmenu)
 				.waitForElementVisible('@listScreen');
 
 			browser.listPage
@@ -32,18 +33,19 @@ module.exports = {
 				.waitForElementVisible('@initialFormScreen');
 
 			config.fields.forEach(function(field) {
-				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.initialFormPage.section.form.section[list].section[field]
 					.verifyUI();
 			});
 		}
 	},
 	assertInitialFormUX: function(config){
-		var nameLowercase = config.fieldName.toLowerCase();
+		var list = config.listName.toLowerCase() + 'List';
+		var listSubmenu = '@' + list + 'Submenu';
 		return function (browser) {
 			browser.app
 				.click('@fieldListsMenu')
 				.waitForElementVisible('@listScreen')
-				.click('@' + nameLowercase + 'ListSubmenu')
+				.click(listSubmenu)
 				.waitForElementVisible('@listScreen');
 
 			browser.listPage
@@ -54,10 +56,10 @@ module.exports = {
 
 			fields = Object.keys(config.inputs);
 			fields.forEach(function(field) {
-				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.initialFormPage.section.form.section[list].section[field]
 					.fillInput(config.inputs[field]);
 
-				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.initialFormPage.section.form.section[list].section[field]
 					.verifyInput(config.inputs[field]);
 			});
 
@@ -69,22 +71,23 @@ module.exports = {
 
 			browser.itemPage
 				.expect.element('@flashMessage')
-				.text.to.equal('New ' + config.fieldName + ' ' + config.inputs.name.value + ' created.');
+				.text.to.equal('New ' + config.listName + ' ' + config.inputs.name.value + ' created.');
 
 			fields.forEach(function(field) {
-				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.itemPage.section.form.section[list].section[field]
 					.verifyInput(config.inputs[field]);
 			});
 		}
 	},
 	assertEditFormUX: function(config) {
-		var nameLowercase = config.fieldName.toLowerCase();
+		var list = config.listName.toLowerCase() + 'List';
+		var listSubmenu = '@' + list + 'Submenu';
 		return function (browser) {
 
 			fields = Object.keys(config.inputs);
 
 			fields.forEach(function(field) {
-				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.itemPage.section.form.section[list].section[field]
 					.fillInput(config.inputs[field]);
 			});
 
@@ -99,7 +102,7 @@ module.exports = {
 				.text.to.equal('Your changes have been saved.');
 
 			fields.forEach(function(field) {
-				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+				browser.itemPage.section.form.section[list].section[field]
 					.verifyInput(config.inputs[field]);
 			});
 		}

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -1,0 +1,114 @@
+module.exports = {
+	before: function (browser) {
+		browser.app = browser.page.app();
+		browser.signinPage = browser.page.signin();
+		browser.listPage = browser.page.list();
+		browser.itemPage = browser.page.item();
+		browser.initialFormPage = browser.page.initialForm();
+
+		browser.app.navigate();
+		browser.app.waitForElementVisible('@signinScreen');
+
+		browser.signinPage.signin();
+		browser.app.waitForElementVisible('@homeScreen');
+	},
+	after: function (browser) {
+		browser.app.signout();
+		browser.end();
+	},
+	assertInitialFormUI: function (config) {
+		var nameLowercase = config.fieldName.toLowerCase();
+		return function (browser) {
+			browser.app
+				.click('@fieldListsMenu')
+				.waitForElementVisible('@listScreen')
+				.click('@' + nameLowercase + 'ListSubmenu')
+				.waitForElementVisible('@listScreen');
+
+			browser.listPage
+				.click('@createFirstItemButton');
+
+			browser.app
+				.waitForElementVisible('@initialFormScreen');
+
+			config.fields.forEach(function(field) {
+				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.verifyUI();
+			});
+		}
+	},
+	assertInitialFormUX: function(config){
+		var nameLowercase = config.fieldName.toLowerCase();
+		return function (browser) {
+			browser.app
+				.click('@fieldListsMenu')
+				.waitForElementVisible('@listScreen')
+				.click('@' + nameLowercase + 'ListSubmenu')
+				.waitForElementVisible('@listScreen');
+
+			browser.listPage
+				.click('@createFirstItemButton');
+
+			browser.app
+				.waitForElementVisible('@initialFormScreen');
+
+			fields = Object.keys(config.inputs);
+			fields.forEach(function(field) {
+				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.fillInput(config.inputs[field]);
+
+				browser.initialFormPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.verifyInput(config.inputs[field]);
+			});
+
+			browser.initialFormPage.section.form
+				.click('@createButton');
+
+			browser.app
+				.waitForElementVisible('@itemScreen');
+
+			browser.itemPage
+				.expect.element('@flashMessage')
+				.text.to.equal('New ' + config.fieldName + ' ' + config.inputs.name.value + ' created.');
+
+			fields.forEach(function(field) {
+				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.verifyInput(config.inputs[field]);
+			});
+		}
+	},
+	assertEditFormUX: function(config) {
+		var nameLowercase = config.fieldName.toLowerCase();
+		return function (browser) {
+
+			fields = Object.keys(config.inputs);
+
+			fields.forEach(function(field) {
+				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.fillInput(config.inputs[field]);
+			});
+
+			browser.itemPage.section.form
+				.click('@saveButton');
+
+			browser.app
+				.waitForElementVisible('@itemScreen');
+
+			browser.itemPage
+				.expect.element('@flashMessage')
+				.text.to.equal('Your changes have been saved.');
+
+			fields.forEach(function(field) {
+				browser.itemPage.section.form.section[ nameLowercase + 'List' ].section[field]
+					.verifyInput(config.inputs[field]);
+			});
+		}
+	},
+	restore: function (browser) {
+		browser.initialFormPage.section.form
+			.click('@cancelButton');
+
+		browser.app
+			.waitForElementVisible('@listScreen');
+	},
+};

--- a/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Date field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@dateListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Date field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Date', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uiTestDateField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Date field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Date', fields: ['name', 'fieldA']}),
+	'Date field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Date',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Date field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Date field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Date',
+	}),
+	'Date field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Date',
 		inputs: {
 			'name': {value: 'Date Field Test 1'},
 			'fieldA': {value: '2016-01-01'},
 		}
 	}),
-	'Date field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Date field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Date',
 		inputs: {
-			'fieldB': {value: '2016-01-02'},
+			'name': {value: 'Date Field Test 1'},
+			'fieldA': {value: '2016-01-01'},
 		}
 	}),
+	'Date field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Date field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Date Date Field Test 1 created.'
+	}),
+	'Date field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Date',
+		inputs: {
+			'name': {value: 'Date Field Test 1'},
+			'fieldA': {value: '2016-01-01'}
+		}
+	}),
+	'Date field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Date',
+		inputs: {
+			'fieldB': {value: '2016-01-02'}
+		}
+	}),
+	'Date field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Date field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Date field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Date',
+		inputs: {
+			'name': {value: 'Date Field Test 1'},
+			'fieldA': {value: '2016-01-01'},
+			'fieldB': {value: '2016-01-02'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Date field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@dateListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.fillInput({value: 'Date Field Test 1'});
-
-		browser.initialFormPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.fillInput({value: '2016-01-01'});
-
-		browser.initialFormPage.section.form.section.dateList.section.fieldA
-			.verifyInput({value: '2016-01-01'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Date Date Field Test 1 created.');
-
-		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.itemPage.section.form.section.dateList.section.fieldA
-			.verifyInput({value: '2016-01-01'});
-	},
-	'Date field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.dateList.section.fieldB
-			.fillInput({value: '2016-01-02'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.dateList.section.name
-			.verifyInput({value: 'Date Field Test 1'});
-
-		browser.itemPage.section.form.section.dateList.section.fieldB
-			.verifyInput({value: '2016-01-02'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Date field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Date',
+		inputs: {
+			'name': {value: 'Date Field Test 1'},
+			'fieldA': {value: '2016-01-01'},
+		}
+	}),
+	'Date field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Date',
+		inputs: {
+			'fieldB': {value: '2016-01-02'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/date/uxTestDateField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Date field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Date',
+		listName: 'Date',
 		inputs: {
 			'name': {value: 'Date Field Test 1'},
 			'fieldA': {value: '2016-01-01'},
 		}
 	}),
 	'Date field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Date',
+		listName: 'Date',
 		inputs: {
 			'fieldB': {value: '2016-01-02'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Datetime field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Datetime', fields: ['name', 'fieldA']}),
+	'Datetime field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Datetime',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uiTestDatetimeField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Datetime field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@datetimeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Datetime field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Datetime', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -4,7 +4,7 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Datetime field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Datetime',
+		listName: 'Datetime',
 		inputs: {
 			'name': {value: 'Datetime Field Test 1'},
 			'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
@@ -12,7 +12,7 @@ module.exports = {
 	}),
 	// Pending fix for #2715
 	//'Datetime field can be filled via the edit form': fieldTests.assertEditFormUX('Datetime', {
-	//	fieldName: 'Datetime',
+	//	listName: 'Datetime',
 	//	inputs: {
 	//		'fieldB': {date: '2016-01-02', time: '12:00:00 am'},
 	//	}

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -1,86 +1,20 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Datetime field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@datetimeListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.fillInput({value: 'Datetime Field Test 1'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.fillInput({date: '2016-01-01', time: '12:00:00 am'});
-
-		browser.initialFormPage.section.form.section.datetimeList.section.fieldA
-			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Datetime Datetime Field Test 1 created.');
-
-		browser.itemPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		browser.itemPage.section.form.section.datetimeList.section.fieldA
-			.verifyInput({date: '2016-01-01', time: '12:00:00 am'});
-	},
-	'Datetime field can be filled via the edit form': function (browser) {
-		// Commented out pending a fix for issue #2715
-		// browser.itemPage.section.form.section.datetimeList.section.fieldB
-		// 	.fillInput({date: '2016-01-02', time: '12:00:00 am'});
-
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.datetimeList.section.name
-			.verifyInput({value: 'Datetime Field Test 1'});
-
-		// Commented out pending a fix for issue #2715
-		// browser.itemPage.section.form.section.datetimeList.section.fieldB
-		//	.verifyInput({date: '2016-01-02', time: '12:00:00 am'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Datetime field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Datetime',
+		inputs: {
+			'name': {value: 'Datetime Field Test 1'},
+			'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
+		}
+	}),
+	// Pending fix for #2715
+	//'Datetime field can be filled via the edit form': fieldTests.assertEditFormUX('Datetime', {
+	//	fieldName: 'Datetime',
+	//	inputs: {
+	//		'fieldB': {date: '2016-01-02', time: '12:00:00 am'},
+	//	}
+	//}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -3,18 +3,52 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Datetime field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Datetime field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Datetime',
+	}),
+	'Datetime field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Datetime',
 		inputs: {
 			'name': {value: 'Datetime Field Test 1'},
 			'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
 		}
 	}),
-	// Pending fix for #2715
-	//'Datetime field can be filled via the edit form': fieldTests.assertEditFormUX('Datetime', {
-	//	listName: 'Datetime',
-	//	inputs: {
-	//		'fieldB': {date: '2016-01-02', time: '12:00:00 am'},
-	//	}
-	//}),
+	'Datetime field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
+		listName: 'Datetime',
+		inputs: {
+			'name': {value: 'Datetime Field Test 1'},
+			'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
+		}
+	}),
+	'Datetime field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Datetime field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Datetime Datetime Field Test 1 created.'
+	}),
+	'Datetime field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Datetime',
+		inputs: {
+			'name': {value: 'Datetime Field Test 1'},
+			'fieldA': {date: '2016-01-01', time: '12:00:00 am'}
+		}
+	}),
+	/* TODO pending a fix for issue #2715
+	'Datetime field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Datetime',
+		inputs: {
+			'fieldB': {date: '2016-01-02', time: '12:00:00 am'}
+		}
+	}),
+	'Datetime field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Datetime field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Datetime field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Datetime',
+		inputs: {
+			'name': {value: 'Datetime Field Test 1'},
+			'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
+			'fieldB': {date: '2016-01-02', time: '12:00:00 am'}
+		}
+	})
+	*/
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Html field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@htmlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Html field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Html', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uiTestHtmlField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Html field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Html', fields: ['name', 'fieldA']}),
+	'Html field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Html',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Html field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Html field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Html',
+	}),
+	'Html field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Html',
 		inputs: {
 			'name': {value: 'Html Field Test 1'},
 			'fieldA': {value: 'Some html code for field A'},
 		}
 	}),
-	'Html field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Html field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Html',
 		inputs: {
-			'fieldB': {value: 'Some html code for field B'},
+			'name': {value: 'Html Field Test 1'},
+			'fieldA': {value: 'Some html code for field A'},
 		}
 	}),
+	'Html field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Html field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Html Html Field Test 1 created.'
+	}),
+	'Html field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Html',
+		inputs: {
+			'name': {value: 'Html Field Test 1'},
+			'fieldA': {value: 'Some html code for field A'}
+		}
+	}),
+	'Html field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Html',
+		inputs: {
+			'fieldB': {value: 'Some html code for field B'}
+		}
+	}),
+	'Html field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Html field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Html field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Html',
+		inputs: {
+			'name': {value: 'Html Field Test 1'},
+			'fieldA': {value: 'Some html code for field A'},
+			'fieldB': {value: 'Some html code for field B'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Html field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Html',
+		listName: 'Html',
 		inputs: {
 			'name': {value: 'Html Field Test 1'},
 			'fieldA': {value: 'Some html code for field A'},
 		}
 	}),
 	'Html field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Html',
+		listName: 'Html',
 		inputs: {
 			'fieldB': {value: 'Some html code for field B'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/html/uxTestHtmlField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Html field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@htmlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.fillInput({value: 'Html Field Test 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.fillInput({value: 'Test html code 1'});
-
-		browser.initialFormPage.section.form.section.htmlList.section.fieldA
-			.verifyInput({value: 'Test html code 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Html Html Field Test 1 created.');
-
-		browser.itemPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.itemPage.section.form.section.htmlList.section.fieldA
-			.verifyInput({value: 'Test html code 1'});
-	},
-	'Html field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.htmlList.section.fieldB
-			.fillInput({value: 'Test html code 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.htmlList.section.name
-			.verifyInput({value: 'Html Field Test 1'});
-
-		browser.itemPage.section.form.section.htmlList.section.fieldB
-			.verifyInput({value: 'Test html code 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Html field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Html',
+		inputs: {
+			'name': {value: 'Html Field Test 1'},
+			'fieldA': {value: 'Some html code for field A'},
+		}
+	}),
+	'Html field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Html',
+		inputs: {
+			'fieldB': {value: 'Some html code for field B'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Name field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Name', fields: ['name', 'fieldA']}),
+	'Name field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Name',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uiTestNameField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Name field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@nameListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Name field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Name', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Name field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Name',
+		listName: 'Name',
 		inputs: {
 			'name': {value: 'Name Field Test 1'},
 			'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
 		}
 	}),
 	'Name field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Name',
+		listName: 'Name',
 		inputs: {
 			'fieldB': {firstName: 'First 2', lastName: 'Last 2'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
@@ -1,82 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Name field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@nameListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.fillInput({value: 'Name Field Test 1'});
-
-		browser.initialFormPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
-
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
-			.fillInput({firstName: 'First 1', lastName: 'Last 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Name Name Field Test 1 created.');
-
-		browser.itemPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 1'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.verifyInput({firstName: 'First 1', lastName: 'Last 1'});
-	},
-	'Name field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.nameList.section.name
-			.fillInput({value: 'Name Field Test 2'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.fillInput({firstName: 'First 2', lastName: 'Last 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.itemPage
-			.waitForElementVisible('@flashMessage');
-
-		browser.itemPage
-			.expect.element('@flashMessage').text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.nameList.section.name
-			.verifyInput({value: 'Name Field Test 2'});
-
-		browser.itemPage.section.form.section.nameList.section.fieldA
-			.verifyInput({firstName: 'First 2', lastName: 'Last 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Name field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Name',
+		inputs: {
+			'name': {value: 'Name Field Test 1'},
+			'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
+		}
+	}),
+	'Name field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Name',
+		inputs: {
+			'fieldB': {firstName: 'First 2', lastName: 'Last 2'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/name/uxTestNameField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Name field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Name field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Name',
+	}),
+	'Name field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Name',
 		inputs: {
 			'name': {value: 'Name Field Test 1'},
 			'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
 		}
 	}),
-	'Name field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Name field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Name',
 		inputs: {
-			'fieldB': {firstName: 'First 2', lastName: 'Last 2'},
+			'name': {value: 'Name Field Test 1'},
+			'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
 		}
 	}),
+	'Name field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Name field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Name Name Field Test 1 created.'
+	}),
+	'Name field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Name',
+		inputs: {
+			'name': {value: 'Name Field Test 1'},
+			'fieldA': {firstName: 'First 1', lastName: 'Last 1'}
+		}
+	}),
+	'Name field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Name',
+		inputs: {
+			'fieldB': {firstName: 'First 2', lastName: 'Last 2'}
+		}
+	}),
+	'Name field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Name field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Name field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Name',
+		inputs: {
+			'name': {value: 'Name Field Test 1'},
+			'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
+			'fieldB': {firstName: 'First 2', lastName: 'Last 2'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Select field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@selectListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Select field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Select', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uiTestSelectField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Select field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Select', fields: ['name', 'fieldA']}),
+	'Select field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Select',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Select field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@selectListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.fillInput({value: 'Select Field Test 1'});
-
-		browser.initialFormPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.fillInput({value: ''});
-
-		browser.initialFormPage.section.form.section.selectList.section.fieldA
-			.verifyInput({value: 'One'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Select Select Field Test 1 created.');
-
-		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.itemPage.section.form.section.selectList.section.fieldA
-			.verifyInput({value: 'One'});
-	},
-	'Select field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.selectList.section.fieldB
-			.fillInput({value: 'Two'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.selectList.section.name
-			.verifyInput({value: 'Select Field Test 1'});
-
-		browser.itemPage.section.form.section.selectList.section.fieldB
-			.verifyInput({value: 'Two'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Select field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Select',
+		inputs: {
+			'name': {value: 'Select Field Test 1'},
+			'fieldA': {value: 'One'},
+		}
+	}),
+	'Select field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Select',
+		inputs: {
+			'fieldB': {value: 'Two'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
@@ -3,17 +3,52 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Select field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Select field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Select',
+	}),
+	'Select field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Select',
 		inputs: {
 			'name': {value: 'Select Field Test 1'},
 			'fieldA': {value: 'One'},
 		}
 	}),
-	'Select field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Select field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Select',
 		inputs: {
-			'fieldB': {value: 'Two'},
+			'name': {value: 'Select Field Test 1'},
+			'fieldA': {value: 'One'},
 		}
 	}),
+	'Select field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Select field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Select Select Field Test 1 created.'
+	}),
+	'Select field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Select',
+		inputs: {
+			'name': {value: 'Select Field Test 1'},
+			'fieldA': {value: 'One'}
+		}
+	}),
+	/* TODO pending select's fillInput function actually filling the correct field
+	'Select field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Select',
+		inputs: {
+			'fieldB': {value: 'Two'}
+		}
+	}),
+	'Select field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Select field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Select field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Select',
+		inputs: {
+			'name': {value: 'Select Field Test 1'},
+			'fieldA': {value: 'One'},
+			'fieldB': {value: 'Two'}
+		}
+	})
+	*/
 };

--- a/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/select/uxTestSelectField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Select field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Select',
+		listName: 'Select',
 		inputs: {
 			'name': {value: 'Select Field Test 1'},
 			'fieldA': {value: 'One'},
 		}
 	}),
 	'Select field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Select',
+		listName: 'Select',
 		inputs: {
 			'fieldB': {value: 'Two'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Text field should be visible in initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.textList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Text field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Text', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uiTestTextField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Text field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Text', fields: ['name', 'fieldA']}),
+	'Text field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Text',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Text field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Text field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Text',
+	}),
+	'Text field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Text',
 		inputs: {
 			'name': {value: 'Text Field Test 1'},
-			'fieldA': {value: 'Some text for field A'},
+			'fieldA': {value: 'Some test text for field A'},
 		}
 	}),
-	'Text field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Text field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Text',
 		inputs: {
-			'fieldB': {value: 'Some text for field B'},
+			'name': {value: 'Text Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'},
 		}
 	}),
+	'Text field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Text field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Text Text Field Test 1 created.'
+	}),
+	'Text field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Text',
+		inputs: {
+			'name': {value: 'Text Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'}
+		}
+	}),
+	'Text field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Text',
+		inputs: {
+			'fieldB': {value: 'Some test text for field B'}
+		}
+	}),
+	'Text field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Text field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Text field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Text',
+		inputs: {
+			'name': {value: 'Text Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'},
+			'fieldB': {value: 'Some test text for field B'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -1,78 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app
-			.signout();
-		browser
-			.end();
-	},
-	'Text field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.fillInput({value: 'Text Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textList.section.fieldA
-			.fillInput({value: 'Text Field Test Text 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Text Text Field Test 1 created.');
-
-		browser.itemPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 1'});
-	},
-	'Text field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.textList.section.name
-			.fillInput({value: 'Text Field Test 2'});
-
-		browser.itemPage.section.form.section.textList.section.fieldA
-			.fillInput({value: 'Text Field Test Text 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.itemPage
-			.waitForElementVisible('@flashMessage');
-
-		browser.itemPage
-			.expect.element('@flashMessage').text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.textList.section.name
-			.verifyInput({value: 'Text Field Test 2'});
-
-		browser.itemPage.section.form.section.textList.section.fieldA
-			.verifyInput({value: 'Text Field Test Text 2'});
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Text field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Text',
+		inputs: {
+			'name': {value: 'Text Field Test 1'},
+			'fieldA': {value: 'Some text for field A'},
+		}
+	}),
+	'Text field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Text',
+		inputs: {
+			'fieldB': {value: 'Some text for field B'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/text/uxTestTextField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Text field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Text',
+		listName: 'Text',
 		inputs: {
 			'name': {value: 'Text Field Test 1'},
 			'fieldA': {value: 'Some text for field A'},
 		}
 	}),
 	'Text field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Text',
+		listName: 'Text',
 		inputs: {
 			'fieldB': {value: 'Some text for field B'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Textarea field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textareaListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Textarea field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Textarea', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uiTestTextareaField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Textarea field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Textarea', fields: ['name', 'fieldA']}),
+	'Textarea field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Textarea',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Textarea field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Textarea',
+		listName: 'Textarea',
 		inputs: {
 			'name': {value: 'Textarea Field Test 1'},
 			'fieldA': {value: 'Some text for field A'},
 		}
 	}),
 	'Textarea field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Textarea',
+		listName: 'Textarea',
 		inputs: {
 			'fieldB': {value: 'Some text for field B'},
 		}

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Textarea field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Textarea field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Textarea',
+	}),
+	'Textarea field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Textarea',
 		inputs: {
 			'name': {value: 'Textarea Field Test 1'},
-			'fieldA': {value: 'Some text for field A'},
+			'fieldA': {value: 'Some test text for field A'},
 		}
 	}),
-	'Textarea field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Textarea field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
 		listName: 'Textarea',
 		inputs: {
-			'fieldB': {value: 'Some text for field B'},
+			'name': {value: 'Textarea Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'},
 		}
 	}),
+	'Textarea field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Textarea field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Textarea Textarea Field Test 1 created.'
+	}),
+	'Textarea field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Textarea',
+		inputs: {
+			'name': {value: 'Textarea Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'}
+		}
+	}),
+	'Textarea field can be filled via the edit form': fieldTests.fillEditFormUX({
+		listName: 'Textarea',
+		inputs: {
+			'fieldB': {value: 'Some test text for field B'}
+		}
+	}),
+	'Textarea field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Textarea field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Textarea field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Textarea',
+		inputs: {
+			'name': {value: 'Textarea Field Test 1'},
+			'fieldA': {value: 'Some test text for field A'},
+			'fieldB': {value: 'Some test text for field B'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/textarea/uxTestTextareaField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Textarea field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@textareaListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.fillInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.fillInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form.section.textareaList.section.fieldA
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Textarea Textarea Field Test 1 created.');
-
-		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.itemPage.section.form.section.textareaList.section.fieldA
-			.verifyInput({value: 'Textarea Field Test 1'});
-	},
-	'Textarea field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.textareaList.section.fieldB
-			.fillInput({value: 'Textarea Field Test 2'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.textareaList.section.name
-			.verifyInput({value: 'Textarea Field Test 1'});
-
-		browser.itemPage.section.form.section.textareaList.section.fieldB
-			.verifyInput({value: 'Textarea Field Test 2'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Textarea field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Textarea',
+		inputs: {
+			'name': {value: 'Textarea Field Test 1'},
+			'fieldA': {value: 'Some text for field A'},
+		}
+	}),
+	'Textarea field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Textarea',
+		inputs: {
+			'fieldB': {value: 'Some text for field B'},
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
@@ -3,6 +3,9 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Url field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Url', fields: ['name', 'fieldA']}),
+	'Url field should be visible in initial modal': fieldTests.assertInitialFormUI({
+		listName: 'Url',
+		fields: ['name', 'fieldA']
+	}),
 	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uiTestUrlField.js
@@ -1,46 +1,8 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Url field should show correctly in the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@urlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.verifyUI();
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.verifyUI();
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-		browser.initialFormPage.section.form
-			.click('@cancelButton');
-
-		browser.app
-			.waitForElementVisible('@listScreen');
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Url field should be visible in initial modal': fieldTests.assertInitialFormUI({fieldName: 'Url', fields: ['name', 'fieldA']}),
+	'restoring test state': fieldTests.restore,
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -1,83 +1,19 @@
+var fieldTests = require('../commonFieldTestUtils.js');
+
 module.exports = {
-	before: function (browser) {
-		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
-
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
-	},
-	after: function (browser) {
-		browser.app.signout();
-		browser.end();
-	},
-	'Url field can be filled via the initial modal': function (browser) {
-		browser.app
-			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen')
-			.click('@urlListSubmenu')
-			.waitForElementVisible('@listScreen');
-
-		browser.listPage
-			.click('@createFirstItemButton');
-
-		browser.app
-			.waitForElementVisible('@initialFormScreen');
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.fillInput({value: 'Url Field Test 1'});
-
-		browser.initialFormPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.fillInput({value: 'www.example1.com'});
-
-		browser.initialFormPage.section.form.section.urlList.section.fieldA
-			.verifyInput({value: 'www.example1.com'});
-
-		browser.initialFormPage.section.form
-			.click('@createButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('New Url Url Field Test 1 created.');
-
-		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.itemPage.section.form.section.urlList.section.fieldA
-			.verifyInput({value: 'www.example1.com'});
-	},
-	'Url field can be filled via the edit form': function (browser) {
-		browser.itemPage.section.form.section.urlList.section.fieldB
-			.fillInput({value: 'www.example2.com'});
-
-		browser.itemPage.section.form
-			.click('@saveButton');
-
-		browser.app
-			.waitForElementVisible('@itemScreen');
-
-		browser.itemPage
-			.expect.element('@flashMessage')
-			.text.to.equal('Your changes have been saved.');
-
-		browser.itemPage.section.form.section.urlList.section.name
-			.verifyInput({value: 'Url Field Test 1'});
-
-		browser.itemPage.section.form.section.urlList.section.fieldB
-			.verifyInput({value: 'www.example2.com'});
-	},
-	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
-	'restoring test state': function (browser) {
-	},
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'Url field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+		fieldName: 'Url',
+		inputs: {
+			'name': {value: 'Url Field Test 1'},
+			'fieldA': {value: 'www.example1.com'},
+		}
+	}),
+	'Url field can be filled via the edit form': fieldTests.assertEditFormUX({
+		fieldName: 'Url',
+		inputs: {
+			'fieldB': {value: 'www.example2.com'}
+		}
+	}),
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -3,17 +3,50 @@ var fieldTests = require('../commonFieldTestUtils.js');
 module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
-	'Url field can be filled via the initial modal': fieldTests.assertInitialFormUX({
+	'Url field initial modal can be opened': fieldTests.openInitialFormUX({
+		listName: 'Url',
+	}),
+	'Url field can be filled via the initial modal': fieldTests.fillInitialFormUX({
 		listName: 'Url',
 		inputs: {
 			'name': {value: 'Url Field Test 1'},
 			'fieldA': {value: 'www.example1.com'},
 		}
 	}),
-	'Url field can be filled via the edit form': fieldTests.assertEditFormUX({
+	'Url field filled correctly via the initial modal': fieldTests.assertInitialFormUX({
+		listName: 'Url',
+		inputs: {
+			'name': {value: 'Url Field Test 1'},
+			'fieldA': {value: 'www.example1.com'},
+		}
+	}),
+	'Url field can be created via the initial modal': fieldTests.saveInitialFormUX(),
+	'New Url field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'New Url Url Field Test 1 created.'
+	}),
+	'Url field has been created correctly': fieldTests.assertEditFormUX({
+		listName: 'Url',
+		inputs: {
+			'name': {value: 'Url Field Test 1'},
+			'fieldA': {value: 'www.example1.com'}
+		}
+	}),
+	'Url field can be filled via the edit form': fieldTests.fillEditFormUX({
 		listName: 'Url',
 		inputs: {
 			'fieldB': {value: 'www.example2.com'}
 		}
 	}),
+	'Url field changes can be saved via the edit form': fieldTests.saveEditFormUX(),
+	'Updated Url field flash message is visible': fieldTests.assertFlashMessage({
+		message: 'Your changes have been saved.'
+	}),
+	'Url field has been filled correctly': fieldTests.assertEditFormUX({
+		listName: 'Url',
+		inputs: {
+			'name': {value: 'Url Field Test 1'},
+			'fieldA': {value: 'www.example1.com'},
+			'fieldB': {value: 'www.example2.com'}
+		}
+	})
 };

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -4,14 +4,14 @@ module.exports = {
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Url field can be filled via the initial modal': fieldTests.assertInitialFormUX({
-		fieldName: 'Url',
+		listName: 'Url',
 		inputs: {
 			'name': {value: 'Url Field Test 1'},
 			'fieldA': {value: 'www.example1.com'},
 		}
 	}),
 	'Url field can be filled via the edit form': fieldTests.assertEditFormUX({
-		fieldName: 'Url',
+		listName: 'Url',
 		inputs: {
 			'fieldB': {value: 'www.example2.com'}
 		}


### PR DESCRIPTION
cc @webteckie 
#2291 

Replaces #2735

I've made the changes you suggested here, and am also allowing different fields to be in each test. Say `url` was the only type to also have a `fieldC`, perhaps because we want to check it accepts both `www.example.com` and `example.com` type addresses. Then the function call in `uxTestUrlField` would change to include a `fieldC` input, and provided the `urlList` has this field, everything will just work.  

Let me know if you have any questions. A possible future improvement would be to split `assertEditFormUX` into `fillEditFormUX` and `assertEditFormUX`. This would allow us to `assertInitialFormUX(... name: ... , fieldA: ... )`, then `fillEditFormUX(.... fieldB: ...)`, but then `assertEditFormUX(... name: ..., fieldA: ..., fieldB: ...)` which has the advantage of checking the data inputted in the initial form are not lost when entering additional info into the edit form.