### PR TITLE
test(e2e): Fix code field's assertInput command

### DIFF
--- a/test/e2e/adminUI/pages/fieldTypes/code.js
+++ b/test/e2e/adminUI/pages/fieldTypes/code.js
@@ -28,7 +28,7 @@ module.exports = function CodeType(config) {
 						var x = document.querySelector(selector);
 						var y = x.getElementsByClassName('CodeMirror')[0];
 						y.CodeMirror.setValue(input.value);
-					}, [self.elements.codeMirror, input]);
+					}, [self.selector, input]);
 				return this;
 			},
 			assertInput: function(input) {
@@ -37,7 +37,7 @@ module.exports = function CodeType(config) {
 						 var x = document.querySelector(selector);
 						 var y = x.getElementsByClassName('CodeMirror')[0];
 						 return y.CodeMirror.getValue();
-					}, [self.elements.codeMirror], function (result) {
+					}, [self.selector], function (result) {
 						this.assert.equal(result.value, input.value);
 					});
 				return this;

--- a/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/code/uxTestCodeField.js
@@ -32,7 +32,6 @@ module.exports = {
 			}
 		})
 	},
-	/* TODO Pending Code's assertInput checking the given field
 	'Code field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Code',
@@ -51,5 +50,4 @@ module.exports = {
 			}
 		})
 	},
-	*/
 };


### PR DESCRIPTION
cc @webteckie 
#2291 

Using the selector as an input for querySelector fixes the issue, because the selector depends on the field whereas the codeMirror does not. 