### PR TITLE
test(e2e): Fixed url and password field ux tests

### DIFF
--- a/test/e2e/adminUI/tests/group005Fields/password/uxTestPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/password/uxTestPasswordField.js
@@ -48,7 +48,6 @@ module.exports = {
 		});
 		browser.itemPage.save();
 		browser.itemPage.assertFlashError('Error');
-		browser.itemPage.section.form.section.passwordList.section.fieldB.clickSetPassword();
 		browser.itemPage.fillInputs({
 			listName: 'Password',
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/url/uxTestUrlField.js
@@ -11,24 +11,24 @@ module.exports = {
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'www.example1.com'},
+				'fieldA': {value: 'http://www.example1.com'},
 			}
 		});
 		browser.initialFormPage.assertInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'www.example1.com'},
+				'fieldA': {value: 'http://www.example1.com'},
 			}
 		});
 		browser.initialFormPage.save();
 		browser.app.waitForItemScreen();
-		
+
 		browser.itemPage.assertInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'www.example1.com'},
+				'fieldA': {value: 'http://www.example1.com'},
 			}
 		})
 	},
@@ -36,7 +36,7 @@ module.exports = {
 		browser.itemPage.fillInputs({
 			listName: 'Url',
 			fields: {
-				'fieldB': {value: 'www.example2.com'}
+				'fieldB': {value: 'http://www.example2.com'}
 			}
 		});
 		browser.itemPage.save();
@@ -45,8 +45,8 @@ module.exports = {
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'www.example1.com'},
-				'fieldB': {value: 'www.example2.com'}
+				'fieldA': {value: 'http://www.example1.com'},
+				'fieldB': {value: 'http://www.example2.com'}
 			}
 		})
 	},


### PR DESCRIPTION
@webteckie @mxstbr 

Fixes url and password tests failing. 

The url field now seems to actually check the input, and http is required for it to accept it. 

The password behaviour has changed slightly. It used to be that on the edit screen if you clicked save with non-matching passwords it would error and you'd have to click the "Set Password" button again. Now, it errors without removing the input fields (which is better), so the button click is not required. 