### PR TITLE
hex encode token so that it does not contain special characters

### DIFF
--- a/lib/security/csrf.js
+++ b/lib/security/csrf.js
@@ -18,7 +18,7 @@ exports.XSRF_HEADER_KEY = 'x-xsrf-token';
 exports.XSRF_COOKIE_KEY = 'XSRF-TOKEN';
 
 function tokenize (salt, secret) {
-	return salt + crypto.createHash('sha1').update(salt + secret).digest('base64');
+	return salt + crypto.createHash('sha1').update(salt + secret).digest('hex');
 }
 
 exports.createSecret = function () {

--- a/test/unit/lib/security.js
+++ b/test/unit/lib/security.js
@@ -48,7 +48,7 @@ describe('CSRF', function () {
 	describe('createToken(req)', function () {
 		it('must create a new token', function () {
 			memory.token = csrf.createToken(memory.req);
-			memory.token.substr(memory.token.length - 1, 1).must.equal('=');
+			memory.token.length.must.be.above(38);
 		});
 	});
 	describe('getToken(req, res)', function () {
@@ -93,7 +93,7 @@ describe('CSRF', function () {
 			var req = REQ(), res = RES();
 			csrf.middleware.init(req, res, function (err) {
 				var token = res.locals[csrf.LOCAL_VALUE];
-				token.substr(token.length - 1, 1).must.equal('=');
+				token.length.must.above(38);
 				next();
 			});
 		});


### PR DESCRIPTION
should fix #2734 

I locally ran few stats on the token generation that we have inside [csrf.js](https://github.com/keystonejs/keystone/blob/master/lib/security/csrf.js#L21)

For a sample 10,000 consecutive token generations:

- Around 33% of the tokens generated contained url un-safe characters. As a fix:
   - we can either `encodeURIComponent()` the generated token.
   - or specify the `crypto digest` to be `hex` encoded from the `tokenize()`. 

The difference between these two approaches is the length (in chars) of the resulting token, and the performance.

Presently a token is 38 characters. 
 - If we use `encodeURIComponent()` the length varies between 40 chars to 48 chars (in rare cases this can be even more).
 - If we use the `hex` encoding approach, then the token will be always 50 chars, however, the performance is 40% faster (sample of 10,000 token generation) compared to `encodeURIComponent()`.

The latter approach has been used in this PR.
