### PR TITLE
2804: upgrade react-color for latest react support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react": "15.0.2",
     "react-addons-css-transition-group": "15.0.2",
     "react-alt-text": "2.0.0",
-    "@jedwatson/react-color": "1.3.8",
+    "react-color": "2.1.0",
     "react-day-picker": "1.3.2",
     "react-dnd": "2.1.4",
     "react-dnd-html5-backend": "2.1.2",


### PR DESCRIPTION
Finally we forced @casesandberg to upgrade the react library and solved react-color peer dependency error. :-D 

https://github.com/keystonejs/keystone/issues/2601
https://github.com/keystonejs/keystone/issues/2804