### PR TITLE
Add datetime for field

### DIFF
--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -101,7 +101,7 @@ module.exports = Field.create({
 			input = <FormInput noedit>{this.format(this.props.value, this.props.formatString)}</FormInput>;
 		}
 		return (
-			<FormField label={this.props.label} className="field-type-datetime">
+			<FormField label={this.props.label} className="field-type-datetime" htmlFor={this.props.path}>
 				{input}
 				{this.renderNote()}
 			</FormField>

--- a/test/e2e/adminUI/pages/fieldTypes/datetime.js
+++ b/test/e2e/adminUI/pages/fieldTypes/datetime.js
@@ -2,10 +2,7 @@ var utils = require('../../../utils');
 
 module.exports = function DatetimeType(config) {
 	var self = {
-		// TODO
-		// Pending a fix for issue #2715 the selector line should read the following
-		// selector: '.field-type-datetime[for="' + config.fieldName + '"]',
-		selector: '.field-type-datetime',
+		selector: '.field-type-datetime[for="' + config.fieldName + '"]',
 		elements: {
 			label: '.FormLabel',
 			nowButton: '.Button--default',

--- a/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/datetime/uxTestDatetimeField.js
@@ -23,7 +23,7 @@ module.exports = {
 		});
 		browser.initialFormPage.save();
 		browser.app.waitForItemScreen();
-		
+
 		browser.itemPage.assertInputs({
 			listName: 'Datetime',
 			fields: {
@@ -32,7 +32,6 @@ module.exports = {
 			}
 		})
 	},
-	/* TODO Pending a fix for issue #2715
 	'Datetime field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Datetime',
@@ -51,5 +50,4 @@ module.exports = {
 			}
 		})
 	},
-	*/
 };


### PR DESCRIPTION
@mxstbr 

Fixes #2715, which was on hold due to #2566 being a WIP, which has now been merged. 

This therefore unblocks #2714, and also implements those changes to add the e2e tests for datetime properly in line with #2291 - @webteckie 