### PR TITLE
Adds the utility keystone.listFor(item)

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ Keystone.prototype.initExpressApp = require('./lib/core/initExpressApp');
 Keystone.prototype.initExpressSession = require('./lib/core/initExpressSession');
 Keystone.prototype.initNav = require('./lib/core/initNav');
 Keystone.prototype.list = require('./lib/core/list');
+Keystone.prototype.listFor = require('./lib/core/listFor');
 Keystone.prototype.openDatabaseConnection = require('./lib/core/openDatabaseConnection');
 Keystone.prototype.populateRelated = require('./lib/core/populateRelated');
 Keystone.prototype.redirect = require('./lib/core/redirect');

--- a/lib/core/listFor.js
+++ b/lib/core/listFor.js
@@ -1,0 +1,14 @@
+/**
+ * Retrieves the list for a given item
+ */
+
+module.exports = function listFor (item) {
+  if (!item.schema) throw new ReferenceError('Given item has no schema');
+  var keys = Object.keys(this.lists);
+  var found = keys.find((key) => {
+    return this.lists[key].schema.options.collection == item.schema.options.collection;
+  });
+  if (found) {
+    return this.lists[found];
+  }
+};

--- a/test/unit/lib/list/listFor.js
+++ b/test/unit/lib/list/listFor.js
@@ -1,0 +1,21 @@
+var keystone = require('../../../../index.js');
+var assert = require('core-assert');
+
+keystone.mongoose = require('../../../helpers/getMongooseConnection.js');
+
+keystone.import('../models');
+
+var Post = keystone.list('Post');
+
+describe('Test list utilities', function () {
+
+  it('listFor will return Post list definition when passing a model instance', function () {
+      var newPost = new Post.model({
+        title: 'new post',
+        state: 'draft'
+      });
+
+      var list = keystone.listFor(newPost);
+      assert.equal(list, Post);
+  });
+});


### PR DESCRIPTION
For a given model instance get back the ketystone List instance

Works by comparing the collection name on the schema for the item, and the available lists on `keystone.lists`