### PR TITLE
Fixed #2584: initExpressApp can receive the express app

### DIFF
--- a/lib/core/initExpressApp.js
+++ b/lib/core/initExpressApp.js
@@ -1,7 +1,12 @@
-module.exports = function initExpressApp () {
+module.exports = function initExpressApp (customApp) {
 	if (this.app) return this;
 	this.initDatabase();
 	this.initExpressSession();
-	this.app = require('../../server/createApp')(this);
+	if (customApp) {
+		this.app = customApp;
+		require('../../server/createApp')(this);
+	} else {
+		this.app = require('../../server/createApp')(this);
+	}
 	return this;
 };


### PR DESCRIPTION
This enabled instancing the express app, and then pass it to keystone for mounting etc.