### PR TITLE
test(e2e): add ui tests for edit form

### DIFF
--- a/test/e2e/adminUI/pages/fieldTypes/password.js
+++ b/test/e2e/adminUI/pages/fieldTypes/password.js
@@ -16,13 +16,20 @@ module.exports = function PasswordType(config) {
 					.waitForElementVisible('@value');
 				return this;
 			},
-			verifyUI: function() {
+			verifyUI: function(args) {
 				this
 					.expect.element('@label').to.be.visible;
 				this
 					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
-				this
-					.expect.element('@value').to.be.visible;
+				if (args.editForm){
+					// In the edit form, a "Set Password" button is shown.
+					this
+						.expect.element('@setPasswordButton').to.be.visible;
+				} else {
+					// In the initial form, the input field is shown immediately.
+					this
+						.expect.element('@value').to.be.visible;
+				}
 				return this;
 			},
 			fillInput: function(input) {

--- a/test/e2e/adminUI/pages/fieldTypes/select.js
+++ b/test/e2e/adminUI/pages/fieldTypes/select.js
@@ -12,15 +12,18 @@ module.exports = function SelectType(config) {
 			optionOne: '.Select-menu-outer option[value="One"]',
 		},
 		commands: [{
-			verifyUI: function() {
+			verifyUI: function(args) {
 				this
 					.expect.element('@label').to.be.visible;
 				this
 					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
 				this
 					.expect.element('@selectField').to.be.visible;
-				this
-					.expect.element('@placeholder').to.be.visible;
+				if(!args.editForm) {
+					// Placeholder won't be there in the edit form as the select will be filled.
+					this
+						.expect.element('@placeholder').to.be.visible;
+				}
 				this
 					.expect.element('@dropdownArrow').to.be.visible;
 				return this;

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -103,6 +103,17 @@ module.exports = {
 		//
 		// PAGE LEVEL COMMANDS
 		//
+		assertUI: function (config) {
+			var list = config.listName.toLowerCase() + 'List';
+			var tasks = [];
+			var form = this.section.form;
+			config.fields.forEach( function(field) {
+				var task = form.section[list].section[field]
+					.verifyUI(config.args);
+				tasks.push(task);
+			});
+			return tasks;
+		},
 		new: function() {
 			return this
 				.click('@newItemButton');

--- a/test/e2e/adminUI/tests/group005Fields/testCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCodeField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Code field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Code',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Code field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Code',

--- a/test/e2e/adminUI/tests/group005Fields/testColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testColorField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Color field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Color',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Color field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Color',

--- a/test/e2e/adminUI/tests/group005Fields/testDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateField.js
@@ -49,6 +49,12 @@ module.exports = {
 		})
 		*/
 	},
+	'Date field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Date',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Date field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Date',

--- a/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
@@ -49,6 +49,12 @@ module.exports = {
 		})
 		*/
 	},
+	'Datetime field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Datetime',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Datetime field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Datetime',

--- a/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Html field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Html',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Html field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Html',

--- a/test/e2e/adminUI/tests/group005Fields/testKeyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testKeyField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Key field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Key',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Key field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Key',

--- a/test/e2e/adminUI/tests/group005Fields/testLocationField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testLocationField.js
@@ -89,8 +89,25 @@ module.exports = {
 			}
 		})
 	},
-	'Location field can be filled via the edit form': function(browser) {
+	'Location field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Location',
+			fields: ['fieldA'],
+			args: { 'showMore': true },
+		});
+		browser.itemPage.assertUI({
+			listName: 'Location',
+			fields: ['fieldB'],
+			args: { 'showMore': false },
+		});
 		browser.itemPage.section.form.section.locationList.section.fieldB.showMore();
+		browser.itemPage.assertUI({
+			listName: 'Location',
+			fields: ['fieldB'],
+			args: { 'showMore': true },
+		});
+	},
+	'Location field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Location',
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
@@ -54,6 +54,12 @@ module.exports = {
 			}
 		})
 	},
+	'Markdown field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Markdown',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Markdown field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Markdown',

--- a/test/e2e/adminUI/tests/group005Fields/testNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNameField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Name field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Name',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Name field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Name',

--- a/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
@@ -10,7 +10,8 @@ module.exports = {
 
 		browser.initialFormPage.assertUI({
 			listName: 'Password',
-			fields: ['name', 'fieldA']
+			fields: ['name', 'fieldA'],
+			args: {'editForm': false}, // To check for @value instead of @button
 		});
 	},
 	'restoring test state': function(browser) {
@@ -51,6 +52,13 @@ module.exports = {
 				'name': {value: 'Password Field Test 1'},
 			}
 		})
+	},
+	'Password field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Password',
+			fields: ['fieldA', 'fieldB'],
+			args: {'editForm': true}, // To check for @button instead of @value
+		});
 	},
 	'Password field can be filled via the edit form': function(browser) {
 		browser.itemPage.section.form.section.passwordList.section.fieldB.clickSetPassword();

--- a/test/e2e/adminUI/tests/group005Fields/testSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testSelectField.js
@@ -10,7 +10,8 @@ module.exports = {
 
 		browser.initialFormPage.assertUI({
 			listName: 'Select',
-			fields: ['name', 'fieldA']
+			fields: ['name', 'fieldA'],
+			args: {'editForm': false}, // To check for @value instead of @button
 		});
 	},
 	'restoring test state': function(browser) {
@@ -45,6 +46,13 @@ module.exports = {
 				'fieldA': {value: 'One'},
 			}
 		})
+	},
+	'Select field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Select',
+			fields: ['fieldA', 'fieldB'],
+			args: {'editForm': true},
+		});
 	},
 	'Select field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({

--- a/test/e2e/adminUI/tests/group005Fields/testTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Text field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Text',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Text field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Text',

--- a/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Textarea field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Textarea',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Textarea field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Textarea',

--- a/test/e2e/adminUI/tests/group005Fields/testUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testUrlField.js
@@ -46,6 +46,12 @@ module.exports = {
 			}
 		})
 	},
+	'Url field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'Url',
+			fields: ['fieldA', 'fieldB']
+		});
+	},
 	'Url field can be filled via the edit form': function(browser) {
 		browser.itemPage.fillInputs({
 			listName: 'Url',


### PR DESCRIPTION
cc @webteckie 

Password and Select were a little different, as they look different on the initial form compared with the edit form in this case. (Passwords display as a "Set Password" button in the edit form, but as input fields in the initial form, Select's placeholder is not there in the edit form, since we have already selected the value before save). I've therefore added an `args` parameter to their verifyUI commands, and pass in whether I'm calling it from the editForm or not. If you think there's a better way of doing this then let me know. 

Similarly, notice we don't pass the "name" field into the edit form's verifyUI. This is because in the edit form there is no label next to the name's test field, which causes the tests to fail. My fix for this was similar to the above, but that made the code messy in every test file, which I decided it was best not to do, so we just skip checking the name field. I figured we're running these tests for FieldA and fieldB really, the name field is just there because it has to be. 