### PR TITLE
test(e2e): Added date array e2e tests

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -32,6 +32,7 @@ module.exports = {
 		codeListSubmenu: '.secondary-navbar [data-list-path="codes"]',
 		colorListSubmenu: '.secondary-navbar [data-list-path="colors"]',
 		dateListSubmenu: '.secondary-navbar [data-list-path="dates"]',
+		datearrayListSubmenu: '.secondary-navbar [data-list-path="date-arrays"]',
 		datetimeListSubmenu: '.secondary-navbar [data-list-path="datetimes"]',
 		emailListSubmenu: '.secondary-navbar [data-list-path="emails"]',
 		htmlListSubmenu: '.secondary-navbar [data-list-path="htmls"]',

--- a/test/e2e/adminUI/pages/fieldTypes/dateArray.js
+++ b/test/e2e/adminUI/pages/fieldTypes/dateArray.js
@@ -1,0 +1,67 @@
+var utils = require('../../../utils');
+
+module.exports = function DateArrayType(config) {
+	var self = {
+		selector: '.field-type-datearray[for="' + config.fieldName + '"]',
+		elements: {
+			label: '.FormLabel',
+			addButton: '.Button--default',
+			date1: '#_DateInput_1',
+			date2: '#_DateInput_2',
+			date3: '#_DateInput_3',
+			date4: '#_DateInput_4',
+			date5: '#_DateInput_5',
+			date6: '#_DateInput_6',
+			date7: '#_DateInput_7',
+			date8: '#_DateInput_8',
+			date9: '#_DateInput_9',
+			date10: '#_DateInput_10',
+		},
+		commands: [{
+			verifyUI: function(args) {
+				this
+					.expect.element('@label').to.be.visible;
+				this
+					.expect.element('@label').text.to.equal(utils.titlecase(config.fieldName));
+				this
+					.expect.element('@addButton').to.be.visible;
+				if (args !== undefined && args.dateInputs !== undefined) {
+					var self = this;
+					args.dateInputs.forEach(function(dateInput) {
+						self
+							.expect.element('@' + dateInput).to.be.visible;
+					});
+				}
+				return this;
+			},
+			fillInput: function(input) {
+				dateInputs = Object.keys(input);
+				var self = this;
+				dateInputs.forEach(function(dateInput) {
+					self
+						.clearValue('@' + dateInput)
+						.setValue('@' + dateInput, input[dateInput]);
+				});
+				return this;
+			},
+			assertInput: function(input) {
+				dateInputs = Object.keys(input);
+				var self = this;
+				dateInputs.forEach(function(dateInput) {
+					self
+						.getValue('@' + dateInput, function (result) {
+							self.api.assert.equal(result.state, "success");
+							self.api.assert.equal(result.value, input[dateInput]);
+					});
+				});
+				return this;
+			},
+			addDate: function() {
+				this.click('@addButton');
+				return this;
+			}
+		}],
+	};
+
+	return self;
+};

--- a/test/e2e/adminUI/pages/initialForm.js
+++ b/test/e2e/adminUI/pages/initialForm.js
@@ -1,13 +1,14 @@
-var CloudinaryImageList = require('./lists/cloudinaryImage.js');
-var CloudinaryImagexList = require('./lists/cloudinaryImagex.js');
+var CloudinaryImageList = require('./lists/cloudinaryImage');
+var CloudinaryImagexList = require('./lists/cloudinaryImagex');
 var CodeList = require('./lists/code');
 var ColorList = require('./lists/color');
 var DateList = require('./lists/date');
+var DateArrayList = require('./lists/dateArray');
 var DatetimeList = require('./lists/datetime');
 var HtmlList = require('./lists/html');
 var KeyList = require('./lists/key');
-var LocalFileList = require('./lists/localFile.js');
-var LocalFilexList = require('./lists/localFilex.js');
+var LocalFileList = require('./lists/localFile');
+var LocalFilexList = require('./lists/localFilex');
 var LocationList = require('./lists/location');
 var MarkdownList = require('./lists/markdown');
 var NameList = require('./lists/name');
@@ -31,6 +32,7 @@ module.exports = {
 				codeList: new CodeList(),
 				colorList: new ColorList(),
 				dateList: new DateList(),
+				datearrayList: new DateArrayList(),
 				datetimeList: new DatetimeList(),
 				htmlList: new HtmlList(),
 				keyList: new KeyList(),

--- a/test/e2e/adminUI/pages/item.js
+++ b/test/e2e/adminUI/pages/item.js
@@ -3,11 +3,12 @@ var CloudinaryImagexList = require('./lists/cloudinaryImagex.js');
 var CodeList = require('./lists/code');
 var ColorList = require('./lists/color');
 var DateList = require('./lists/date');
+var DateArrayList = require('./lists/dateArray');
 var DatetimeList = require('./lists/datetime');
 var HtmlList = require('./lists/html');
 var KeyList = require('./lists/key');
-var LocalFileList = require('./lists/localFile.js');
-var LocalFilexList = require('./lists/localFilex.js');
+var LocalFileList = require('./lists/localFile');
+var LocalFilexList = require('./lists/localFilex');
 var LocationList = require('./lists/location');
 var MarkdownList = require('./lists/markdown');
 var NameList = require('./lists/name');
@@ -31,6 +32,7 @@ module.exports = {
 				codeList: new CodeList(),
 				colorList: new ColorList(),
 				dateList: new DateList(),
+				datearrayList: new DateArrayList(),
 				datetimeList: new DatetimeList(),
 				htmlList: new HtmlList(),
 				keyList: new KeyList(),

--- a/test/e2e/adminUI/pages/lists/dateArray.js
+++ b/test/e2e/adminUI/pages/lists/dateArray.js
@@ -1,0 +1,18 @@
+var TextType = require('../fieldTypes/text');
+var DateArrayType = require('../fieldTypes/dateArray');
+
+module.exports = function DateArrayList(config) {
+	return {
+		selector: '.Form',
+		sections: {
+			name: new TextType({fieldName: 'name'}),
+			fieldA: new DateArrayType({fieldName: 'fieldA'}),
+			fieldB: new DateArrayType({fieldName: 'fieldB'}),
+		},
+		commands: [{
+			//
+			// LIST LEVEL COMMANDS
+			//
+		}],
+	};
+};

--- a/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
@@ -1,0 +1,101 @@
+var fieldTests = require('./commonFieldTestUtils.js');
+
+module.exports = {
+	before: fieldTests.before,
+	after: fieldTests.after,
+	'DateArray field should show correctly in the initial modal': function (browser) {
+		browser.app.openFieldList('DateArray');
+		browser.listPage.createFirstItem();
+		browser.app.waitForInitialFormScreen();
+
+		browser.initialFormPage.assertUI({
+			listName: 'DateArray',
+			fields: ['name']
+		});
+	},
+	'restoring test state': function(browser) {
+		browser.initialFormPage.cancel();
+		browser.app.waitForListScreen();
+	},
+	'DateArray field can be filled via the initial modal': function(browser) {
+		browser.app.openFieldList('DateArray');
+		browser.listPage.createFirstItem();
+		browser.app.waitForInitialFormScreen();
+		browser.initialFormPage.fillInputs({
+			listName: 'DateArray',
+			fields: {
+				'name': {value: 'DateArray Field Test 1'},
+			}
+		});
+		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
+		browser.initialFormPage.assertInputs({
+			listName: 'DateArray',
+			fields: {
+				'name': {value: 'DateArray Field Test 1'},
+			}
+		});
+		*/
+		browser.initialFormPage.save();
+		browser.app.waitForItemScreen();
+		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
+		browser.itemPage.assertInputs({
+			listName: 'DateArray',
+			fields: {
+				'name': {value: 'DateArray Field Test 1'},
+			}
+		})
+		*/
+	},
+	'DateArray field should show correctly in the edit form': function(browser) {
+		browser.itemPage.assertUI({
+			listName: 'DateArray',
+			fields: ['fieldA', 'fieldB']
+		});
+		browser.itemPage.section.form.section.datearrayList.section.fieldA.addDate();
+		browser.itemPage.assertUI({
+			listName: 'DateArray',
+			fields: ['fieldA'],
+			args: {'dateInputs': ['date1']}
+		});
+		browser.itemPage.section.form.section.datearrayList.section.fieldA.addDate();
+		browser.itemPage.assertUI({
+			listName: 'DateArray',
+			fields: ['fieldA'],
+			args: {'dateInputs': ['date3']}
+		});
+		browser.itemPage.section.form.section.datearrayList.section.fieldB.addDate();
+		browser.itemPage.section.form.section.datearrayList.section.fieldB.addDate();
+		browser.itemPage.assertUI({
+			listName: 'DateArray',
+			fields: ['fieldB'],
+			args: {'dateInputs': ['date5', 'date6']}
+		});
+	},
+	'DateArray field can be filled via the edit form': function(browser) {
+		browser.itemPage.fillInputs({
+			listName: 'DateArray',
+			fields: {
+				'fieldA': {date2: '2016-01-01', date3: '2016-01-02'}
+			}
+		});
+		browser.itemPage.fillInputs({
+			listName: 'DateArray',
+			fields: {
+				'fieldB': {date5: '2016-01-03', date6: '2016-01-04'}
+			}
+		});
+		browser.itemPage.save();
+		browser.app.waitForItemScreen();
+		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
+		browser.itemPage.assertInputs({
+			listName: 'DateArray',
+			fields: {
+				'name': {value: 'DateArray Field Test 1'},
+				'fieldA': {date7: '2016-01-01', date8: '2016-01-02'},
+				'fieldB': {date9: '2016-01-03', date10: '2016-01-04'},
+			}
+		})
+		*/
+	},
+};

--- a/test/e2e/models/fields/DateArray.js
+++ b/test/e2e/models/fields/DateArray.js
@@ -1,0 +1,31 @@
+var keystone = require('../../../../index.js');
+var Types = keystone.Field.Types;
+
+var DateArray = new keystone.List('DateArray', {
+	autokey: {
+		path: 'key',
+		from: 'name',
+		unique: true,
+	},
+	track: true,
+});
+
+DateArray.add({
+	name: {
+		type: String,
+		initial: true,
+		required: true,
+		index: true,
+	},
+	fieldA: {
+		type: Types.DateArray,
+	},
+	fieldB: {
+		type: Types.DateArray,
+	},
+});
+
+DateArray.defaultColumns = 'name, fieldA, fieldB';
+DateArray.register();
+
+module.exports = DateArray;

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -52,6 +52,7 @@ keystone.set('nav', {
 		'codes',
 		'colors',
 		'dates',
+		'date-arrays',
 		'datetimes',
 		'emails',
 		'htmls',


### PR DESCRIPTION
cc @webteckie #2291 

The commented out code works locally, but would probably cause travis to fail due to the timezone issue. Will leave it like this for now.

I have to pass an additional argument to the date array functions, as they need to know the id of the date that they should be looking for. This ID increments slightly strangely, which is why we have to go all the way up to `date10`, which is `#_DateInput_10`, even though we only add a total of 4 fields. (e.g. when you click save, it re-draws with higher ID numbers). 