### PR TITLE
test(e2e): Add workaround for selenium failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "test-all": "npm test && npm run test-e2e",
     "test-unit": "node test/pretest.js && mocha",
     "test-e2e": "node test/e2e/server.js --env default --config ./test/e2e/adminUI/nightwatch.json",
+    "test-e2e-bg": "node test/e2e/server.js --env default --selenium-in-background --config ./test/e2e/adminUI/nightwatch-no-process.json",
     "test-e2e-saucelabs": "if [ -n \"$SAUCE_ACCESS_KEY\" ]; then node test/e2e/server.js --env saucelabs-travis --config ./test/e2e/adminUI/nightwatch.json; fi",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",

--- a/test/e2e/adminUI/nightwatch-no-process.json
+++ b/test/e2e/adminUI/nightwatch-no-process.json
@@ -1,0 +1,90 @@
+{
+  "src_folders": [
+    "test/e2e/adminUI/tests"
+  ],
+  "output_folder": "reports",
+  "custom_commands_path": "",
+  "custom_assertions_path": "",
+  "page_objects_path": "test/e2e/adminUI/pages",
+  "globals_path": "test/e2e/globals.js",
+  "selenium": {
+    "start_process": false,
+    "server_path": "test/e2e/bin/selenium-server-standalone-2.53.0.jar",
+    "log_path": "",
+    "host": "127.0.0.1",
+    "port": 4444,
+    "cli_args": {
+      "webdriver.chrome.driver": "",
+      "webdriver.ie.driver": ""
+    }
+  },
+  "test_settings": {
+    "default": {
+      "launch_url": "http://localhost",
+      "selenium_host": "127.0.0.1",
+      "selenium_port": 4444,
+      "silent": true,
+      "disable_colors": false,
+      "screenshots": {
+        "enabled": false,
+        "path": ""
+      },
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      },
+			"exclude": "test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js"
+    },
+    "saucelabs-travis": {
+      "selenium_host": "ondemand.saucelabs.com",
+      "selenium_port": 80,
+      "username": "${SAUCE_USERNAME}",
+      "access_key": "${SAUCE_ACCESS_KEY}",
+      "use_ssl": false,
+      "silent": true,
+      "output": true,
+      "screenshots": {
+        "enabled": false,
+        "on_failure": true,
+        "path": ""
+      },
+      "desiredCapabilities": {
+        "name": "test-firefox",
+        "browserName": "firefox",
+        "tunnel-identifier": "${TRAVIS_JOB_NUMBER}"
+      },
+      "selenium": {
+        "start_process": false
+      }
+    },
+    "saucelabs-local": {
+      "selenium_host": "ondemand.saucelabs.com",
+      "selenium_port": 80,
+      "username": "${SAUCE_USERNAME}",
+      "access_key": "${SAUCE_ACCESS_KEY}",
+      "use_ssl": false,
+      "silent": true,
+      "output": true,
+      "screenshots": {
+        "enabled": false,
+        "on_failure": true,
+        "path": ""
+      },
+      "desiredCapabilities": {
+        "name": "test-firefox",
+        "browserName": "firefox"
+      },
+      "selenium": {
+        "start_process": false
+      }
+    },
+    "chrome": {
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is for people who see selenium failing with a "Bad request" when running e2e tests.

* adds alternative command 'npm run test-e2e-bg'
* workaround https://github.com/nightwatchjs/nightwatch/issues/470