### PR TITLE
Remove tinyMCE in HtmlField when dependsOn is disabled

### DIFF
--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -15,6 +15,15 @@ function getId () {
 	return 'keystone-html-' + lastId++;
 }
 
+// Workaround for #2834 found here https://github.com/tinymce/tinymce/issues/794#issuecomment-203701329
+function removeTinyMCEInstance (editor) {
+	var oldLength = tinymce.editors.length;
+	tinymce.remove(editor);
+	if (oldLength == tinymce.editors.length) {
+		tinymce.editors.remove(editor);
+	}
+}
+
 module.exports = Field.create({
 
 	displayName: 'HtmlField',
@@ -52,10 +61,15 @@ module.exports = Field.create({
 			&& !_.isEqual(this.props.currentDependencies, prevProps.currentDependencies)) {
 			var instance = tinymce.get(prevState.id);
 			if (instance) {
-				tinymce.EditorManager.execCommand('mceRemoveEditor', true, prevState.id);
 				this.initWysiwyg();
 			} else {
 				this.initWysiwyg();
+			}
+		}
+		else if (_.isEqual(prevProps.dependsOn, prevProps.currentDependencies)) {
+			var instance = tinymce.get(prevState.id);
+			if (instance) {
+				removeTinyMCEInstance(instance);
 			}
 		}
 	},

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -19,7 +19,7 @@ function getId () {
 function removeTinyMCEInstance (editor) {
 	var oldLength = tinymce.editors.length;
 	tinymce.remove(editor);
-	if (oldLength == tinymce.editors.length) {
+	if (oldLength === tinymce.editors.length) {
 		tinymce.editors.remove(editor);
 	}
 }
@@ -57,19 +57,16 @@ module.exports = Field.create({
 			this.initWysiwyg();
 		}
 
-		if (_.isEqual(this.props.dependsOn, this.props.currentDependencies)
-			&& !_.isEqual(this.props.currentDependencies, prevProps.currentDependencies)) {
-			var instance = tinymce.get(prevState.id);
-			if (instance) {
-				this.initWysiwyg();
-			} else {
-				this.initWysiwyg();
+		if (!_.isEqual(this.props.currentDependencies, prevProps.currentDependencies)) {
+			if (_.isEqual(prevProps.dependsOn, prevProps.currentDependencies)) {
+				var instance = tinymce.get(prevState.id);
+				if (instance) {
+					removeTinyMCEInstance(instance);
+				}
 			}
-		}
-		else if (_.isEqual(prevProps.dependsOn, prevProps.currentDependencies)) {
-			var instance = tinymce.get(prevState.id);
-			if (instance) {
-				removeTinyMCEInstance(instance);
+
+			if (_.isEqual(this.props.dependsOn, this.props.currentDependencies)) {
+				this.initWysiwyg();
 			}
 		}
 	},


### PR DESCRIPTION
* also remove instance from tinymce.editors, as suggested in https://github.com/tinymce/tinymce/issues/794#issuecomment-203701329
* fixes #2834

Note: this does not get rid of the exception NS_ERROR_UNEXPECTED thrown by Firefox. However it does re-create the tinyMCE editor when needed.