### PR TITLE
Modify s3 URL to use bucket subdomain in order that it will work for multiple AWS regions

### DIFF
--- a/admin/server/api/s3.js
+++ b/admin/server/api/s3.js
@@ -31,7 +31,7 @@ module.exports = {
 						if (s3Response.statusCode !== 200) {
 							return res.send({ error: { message: 'Amazon returned Http Code: ' + s3Response.statusCode } });
 						} else {
-							return res.send({ image: { url: 'https://s3.amazonaws.com/' + s3Config.bucket + '/' + file.name } });
+							return res.send({ image: { url: 'https://' + s3Config.bucket + '.s3.amazonaws.com/' + file.name } });
 						}
 					}
 				};


### PR DESCRIPTION
The current hard coded format for S3 location:
`https://s3.amazonaws.com/[BUCKET]/[FILENAME]`
Doesn't work when the s3 bucket is located in a different AWS region.
Instead this format works with all regions:
`https://[BUCKET].s3.amazonaws.com/[FILENAME]`

see here for more info: http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
