### PR TITLE
Add Region to S3 Image URL

### DIFF
--- a/admin/server/api/s3.js
+++ b/admin/server/api/s3.js
@@ -31,7 +31,11 @@ module.exports = {
 						if (s3Response.statusCode !== 200) {
 							return res.send({ error: { message: 'Amazon returned Http Code: ' + s3Response.statusCode } });
 						} else {
-							return res.send({ image: { url: 'https://s3.amazonaws.com/' + s3Config.bucket + '/' + file.name } });
+							var region = 's3';
+							if (s3Config.region && s3Config.region !== 'us-east-1') {
+								region = 's3-' + s3Config.region;
+							}
+							return res.send({ image: { url: 'https://' + region + '.amazonaws.com/' + s3Config.bucket + '/' + file.name } });
 						}
 					}
 				};


### PR DESCRIPTION
The current hard coded format for S3 location:
`https://s3.amazonaws.com/[BUCKET]/[FILENAME]`
Doesn't work when the s3 bucket is located in a different AWS region.
Instead the subdomain s3 needs to be replaced by the region specific subdomain:
`https://[S3_REGION].amazonaws.com/[BUCKET]/[FILENAME]`
See here for list of s3 subdomains for different regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region