### PR TITLE
Fix text array behaviour

### DIFF
--- a/fields/mixins/ArrayField.js
+++ b/fields/mixins/ArrayField.js
@@ -72,12 +72,21 @@ module.exports = {
 	},
 
 	renderField: function () {
-		return (
-			<div>
-				{this.state.values.map(this.renderItem)}
-				<Button ref="button" onClick={this.addItem}>Add item</Button>
-			</div>
-		);
+		if (this.state.values !== undefined && this.state.values.map !== undefined) {
+			return (
+				<div>
+					{this.state.values.map(this.renderItem)}
+					<Button ref="button" onClick={this.addItem}>Add item</Button>
+				</div>
+			);
+		} else {
+			return (
+				<div>
+					{this.renderItem}
+					<Button ref="button" onClick={this.addItem}>Add item</Button>
+				</div>
+			);
+		}
 	},
 
 	renderItem: function (item, index) {


### PR DESCRIPTION
Potential fix for #2865 

It certainly resolves the issue, but I'm perhaps not addressing the underlying problem? 
Sometimes, `renderUI` is called when `this.state.values.map` is not a function, however `this.renderItem` is. 

Always using `this.renderItem` doesn't work all the time either, specifically it breaks the buttons to add new fields. 

Happy to be pointed in the right direction of a better fix if this is not it. 