### PR TITLE
Fix timezone handling for Datetime field

### DIFF
--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -22,7 +22,7 @@ module.exports = Field.create({
 		return {
 			dateValue: this.props.value && this.moment(this.props.value).format(this.dateInputFormat),
 			timeValue: this.props.value && this.moment(this.props.value).format(this.timeInputFormat),
-			tzOffsetValue: this.props.value ? this.moment(this.props.value).format(this.tzOffsetInputFormat) : moment().format(this.tzOffsetInputFormat),
+			tzOffsetValue: this.props.value ? this.moment(this.props.value).format(this.tzOffsetInputFormat) : this.moment().format(this.tzOffsetInputFormat),
 		};
 	},
 
@@ -32,15 +32,14 @@ module.exports = Field.create({
 		};
 	},
 
-	moment (value) {
-		var m = moment(value);
-		if (this.props.isUTC) m.utc();
-		return m;
+	moment () {
+		if (this.props.isUTC) return moment.utc.apply(moment, arguments);
+		else return moment.apply(undefined, arguments);
 	},
 
 	// TODO: Move isValid() so we can share with server-side code
 	isValid (value) {
-		return moment(value, this.parseFormats).isValid();
+		return this.moment(value, this.parseFormats).isValid();
 	},
 
 	// TODO: Move format() so we can share with server-side code
@@ -60,12 +59,12 @@ module.exports = Field.create({
 		}
 		// if not, calculate the timezone offset based on the date (respect different DST values)
 		else {
-			this.setState({ tzOffsetValue: moment(value, datetimeFormat).format(this.tzOffsetInputFormat) });
+			this.setState({ tzOffsetValue: this.moment(value, datetimeFormat).format(this.tzOffsetInputFormat) });
 		}
 
 		this.props.onChange({
 			path: this.props.path,
-			value: this.isValid(value) ? moment(value, datetimeFormat).toISOString() : null,
+			value: this.isValid(value) ? this.moment(value, datetimeFormat).toISOString() : null,
 		});
 	},
 
@@ -80,9 +79,9 @@ module.exports = Field.create({
 	},
 
 	setNow () {
-		var dateValue = moment().format(this.dateInputFormat);
-		var timeValue = moment().format(this.timeInputFormat);
-		var tzOffsetValue = moment().format(this.tzOffsetInputFormat);
+		var dateValue = this.moment().format(this.dateInputFormat);
+		var timeValue = this.moment().format(this.timeInputFormat);
+		var tzOffsetValue = this.moment().format(this.tzOffsetInputFormat);
 		this.setState({
 			dateValue: dateValue,
 			timeValue: timeValue,

--- a/fields/types/datetime/DatetimeField.js
+++ b/fields/types/datetime/DatetimeField.js
@@ -13,6 +13,7 @@ module.exports = Field.create({
 	// default input formats
 	dateInputFormat: 'YYYY-MM-DD',
 	timeInputFormat: 'h:mm:ss a',
+	tzOffsetInputFormat: 'Z',
 
 	// parse formats (duplicated from lib/fieldTypes/datetime.js)
 	parseFormats: ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m'],
@@ -21,6 +22,7 @@ module.exports = Field.create({
 		return {
 			dateValue: this.props.value && this.moment(this.props.value).format(this.dateInputFormat),
 			timeValue: this.props.value && this.moment(this.props.value).format(this.timeInputFormat),
+			tzOffsetValue: this.props.value ? this.moment(this.props.value).format(this.tzOffsetInputFormat) : moment().format(this.tzOffsetInputFormat),
 		};
 	},
 
@@ -47,9 +49,20 @@ module.exports = Field.create({
 		return value ? this.moment(value).format(format) : '';
 	},
 
-	handleChange () {
-		var value = this.state.dateValue + ' ' + this.state.timeValue;
+	handleChange (dateValue, timeValue, tzOffsetValue) {
+		var value = dateValue + ' ' + timeValue;
 		var datetimeFormat = this.dateInputFormat + ' ' + this.timeInputFormat;
+
+		// if the change included a timezone offset, include that in the calculation (so NOW works correctly during DST changes)
+		if (typeof tzOffsetValue !== 'undefined') {
+			value += ' ' + tzOffsetValue;
+			datetimeFormat += ' ' + this.tzOffsetInputFormat;
+		}
+		// if not, calculate the timezone offset based on the date (respect different DST values)
+		else {
+			this.setState({ tzOffsetValue: moment(value, datetimeFormat).format(this.tzOffsetInputFormat) });
+		}
+
 		this.props.onChange({
 			path: this.props.path,
 			value: this.isValid(value) ? moment(value, datetimeFormat).toISOString() : null,
@@ -58,22 +71,24 @@ module.exports = Field.create({
 
 	dateChanged ({ value }) {
 		this.setState({ dateValue: value });
-		this.handleChange();
+		this.handleChange(value, this.state.timeValue);
 	},
 
 	timeChanged (evt) {
 		this.setState({ timeValue: evt.target.value });
-		this.handleChange();
+		this.handleChange(this.state.dateValue, evt.target.value);
 	},
 
 	setNow () {
 		var dateValue = moment().format(this.dateInputFormat);
 		var timeValue = moment().format(this.timeInputFormat);
+		var tzOffsetValue = moment().format(this.tzOffsetInputFormat);
 		this.setState({
 			dateValue: dateValue,
 			timeValue: timeValue,
+			tzOffsetValue: tzOffsetValue,
 		});
-		this.handleChange(dateValue, timeValue);
+		this.handleChange(dateValue, timeValue, tzOffsetValue);
 	},
 
 	renderNote () {
@@ -95,6 +110,7 @@ module.exports = Field.create({
 					<InputGroup.Section>
 						<Button onClick={this.setNow}>Now</Button>
 					</InputGroup.Section>
+					<input type="hidden" name={this.props.paths.tzOffset} value={this.state.tzOffsetValue} />
 				</InputGroup>
 			);
 		} else {

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -6,7 +6,7 @@ var utils = require('keystone-utils');
 var TextType = require('../text/TextType');
 
 // ISO_8601 is needed for the automatically created createdAt and updatedAt fields
-var parseFormats = ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m', moment.ISO_8601];
+var parseFormats = ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m', 'YYYY-MM-DD h:mm:s a Z', moment.ISO_8601];
 /**
  * DateTime FieldType Constructor
  * @extends Field
@@ -28,6 +28,7 @@ function datetime (list, path, options) {
 	this.paths = {
 		date: this._path.append('_date'),
 		time: this._path.append('_time'),
+		tzOffset: this._path.append('_tzOffset'),
 	};
 }
 util.inherits(datetime, FieldType);
@@ -46,9 +47,15 @@ datetime.prototype.validateRequiredInput = TextType.prototype.validateRequiredIn
 datetime.prototype.getInputFromData = function (data) {
 	var dateValue = this.getValueFromData(data, '_date');
 	var timeValue = this.getValueFromData(data, '_time');
+	var tzOffsetValue = this.getValueFromData(data, '_tzOffset');
 	if (dateValue && timeValue) {
-		return dateValue + ' ' + timeValue;
+		var ret = dateValue + ' ' + timeValue;
+		if (typeof tzOffsetValue !== 'undefined') {
+			ret += ' ' + tzOffsetValue;
+		}
+		return ret;
 	}
+
 	return this.getValueFromData(data);
 };
 


### PR DESCRIPTION
## Description of changes

Changed behaviour of Datetime field type:
* UTC date is always stored in database and used on the server
* Client sends timezone offset of currently set date & time to the API when saving
* If field option `utc: true` is set, UTC is used on the client, local time otherwise

## Related issues (if any)

Fixes #1345 for v0.4 (not v0.3!)

## Testing

Passed `npm run test`, going check e2e tests later. Feel free to leave pull request open until then.
