### PR TITLE
test(e2e): Slightly refactor group001 e2e tests

### DIFF
--- a/test/e2e/adminUI/pages/signin.js
+++ b/test/e2e/adminUI/pages/signin.js
@@ -17,5 +17,14 @@ module.exports = {
 				.setValue('@passwordInput', 'test')
 				.click('@submitButton');
 		},
+		assertUI: function () {
+			this
+				.expect.element('@emailInput').to.be.visible;
+			this
+				.expect.element('@emailInput').to.be.visible;
+			this
+				.expect.element('@emailInput').to.be.visible;
+			return this;
+		}
 	}],
 };

--- a/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
@@ -13,16 +13,7 @@ module.exports = {
 		browser.app
 			.expect.element('@signinScreen').to.be.visible;
 	},
-	'Signin page should have an email field': function (browser) {
-		browser.signinPage
-			.expect.element('@emailInput').to.be.visible;
-	},
-	'Signin page should have an password field': function (browser) {
-		browser.signinPage
-			.expect.element('@passwordInput').to.be.visible;
-	},
-	'Signin page should have a submit button': function (browser) {
-		browser.signinPage
-			.expect.element('@submitButton').to.be.visible;
+	'Signin page should show correctly': function (browser) {
+		browser.signinPage.assertUI();
 	},
 };

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
@@ -4,19 +4,16 @@ module.exports = {
 		browser.signinPage = browser.page.signin();
 
 		browser.url(browser.app.url + 'users');
-		browser.app
-			.waitForElementVisible('@signinScreen')
-			.assert.urlEquals(browser.app.url + 'signin?from=/keystone/users');
+		browser.app.waitForSigninScreen();
+		browser.assert.urlEquals(browser.app.url + 'signin?from=/keystone/users');
 	},
 	after: function (browser) {
 		browser.
 			end();
 	},
 	'AdminUI should allow users to login and redirect to custom url': function (browser) {
-		browser.signinPage
-			.signin();
-		browser.app
-			.waitForElementVisible('@listScreen')
-			.assert.urlEquals(browser.app.url + 'users');
+		browser.signinPage.signin();
+		browser.app.waitForListScreen();
+		browser.assert.urlEquals(browser.app.url + 'users');
 	},
 };

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
@@ -4,19 +4,16 @@ module.exports = {
 		browser.signinPage = browser.page.signin();
 
 		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.waitForSigninScreen();
 	},
 	after: function (browser) {
 		browser.end();
 	},
 	'Signin page should allow users to login': function (browser) {
-		browser.signinPage
-			.signin();
-		browser.app
-			.waitForElementVisible('@homeScreen');
+		browser.signinPage.signin();
+		browser.app.waitForHomeScreen();
 	},
 	'Signin page should be presented upon signout': function (browser) {
-		browser.app
-			.signout();
+		browser.app.signout();
 	},
 };


### PR DESCRIPTION
Please make sure the following is filled in before submitting your Pull Request - thanks!

## Description of changes
cc: @webteckie 
Refactored the ux tests in group001 to use the (already in place) app page object commands. 

## Related issues (if any)


## Testing

- [X] Please confirm that you have successfully ran `npm run test-all`.

Notes:
- If you are developing in Windows you may run into linebreak linting issues. One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.


