### PR TITLE
Fix dependson initial

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -141,7 +141,7 @@ Field.prototype.getSize = function () {
  * Gets default value for the field, based on the option or default for the type
  */
 Field.prototype.getDefaultValue = function () {
-	return this.options.default || '';
+	return typeof this.options.default !== 'undefined' ? this.options.default : '';
 };
 
 /**

--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -16,6 +16,10 @@ function boolean (list, path, options) {
 }
 util.inherits(boolean, FieldType);
 
+boolean.prototype.defaults = {
+	default: false,
+};
+
 boolean.prototype.validateInput = function (data, callback) {
 	var value = this.getValueFromData(data);
 	var result = true;


### PR DESCRIPTION
## Description of changes
Check for typeof instead of doing || in Type.prototype.getDefaultValue, so an empty string is really only returned if no default value is set. (compared to when `default: false` is set). Also ensure that a boolean is always the default for a boolean fields.
There should maybe also other default default values be defined for other field types apart from boolean, but it's the most common use case and I can't think of  sensible defaults for most other field types. Feel free to discuss here.
## Related issues (if any)

#2929 

## Testing

- [x] Please confirm that you have successfully ran `npm run test`. e2e tests take too long and make me unproductive by popping up browser windows in random intervals.