### PR TITLE
Check blacklisted lists when deleting resources

### DIFF
--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -1,6 +1,9 @@
 var async = require('async');
 var keystone = require('../../../../');
 
+// lists which user.id will be validated through collection ids to avoid self-delete
+var LISTS_TO_CHECK_USER_PERMISSIONS = ['user']
+
 module.exports = function (req, res) {
 	if (!keystone.security.csrf.validate(req)) {
 		console.log('Refusing to delete ' + req.list.key + ' items; CSRF failure');
@@ -17,13 +20,16 @@ module.exports = function (req, res) {
 	if (!Array.isArray(ids)) {
 		ids = [ids];
 	}
+
 	if (req.user) {
+		var checkResourceId = (LISTS_TO_CHECK_USER_PERMISSIONS.indexOf(req.list.key.toLowerCase()) >= 0)
 		var userId = String(req.user.id);
-		if (ids.some(function (id) {
+		// check if user can delete this resources based on resources ids and userId
+		if (checkResourceId && ids.some(function (id) {
 			return id === userId;
 		})) {
-			console.log('Refusing to delete ' + req.list.key + ' items; ids contains current User');
-			return res.apiError(403, 'not allowed', 'You can not delete yourself');
+			console.log('Refusing to delete ' + req.list.key + ' items; resources ids contains current User id');
+			return res.apiError(403, 'not allowed', "You can not delete this resource");
 		}
 	}
 	var deletedCount = 0;

--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -2,7 +2,7 @@ var async = require('async');
 var keystone = require('../../../../');
 
 // lists which user.id will be validated through collection ids to avoid self-delete
-var LISTS_TO_CHECK_USER_PERMISSIONS = ['user']
+var LISTS_TO_CHECK_USER_PERMISSIONS = ['user'];
 
 module.exports = function (req, res) {
 	if (!keystone.security.csrf.validate(req)) {
@@ -22,14 +22,14 @@ module.exports = function (req, res) {
 	}
 
 	if (req.user) {
-		var checkResourceId = (LISTS_TO_CHECK_USER_PERMISSIONS.indexOf(req.list.key.toLowerCase()) >= 0)
+		var checkResourceId = (LISTS_TO_CHECK_USER_PERMISSIONS.indexOf(req.list.key.toLowerCase()) >= 0);
 		var userId = String(req.user.id);
 		// check if user can delete this resources based on resources ids and userId
 		if (checkResourceId && ids.some(function (id) {
 			return id === userId;
 		})) {
 			console.log('Refusing to delete ' + req.list.key + ' items; resources ids contains current User id');
-			return res.apiError(403, 'not allowed', "You can not delete this resource");
+			return res.apiError(403, 'not allowed', 'You can not delete this resource');
 		}
 	}
 	var deletedCount = 0;

--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -1,9 +1,6 @@
 var async = require('async');
 var keystone = require('../../../../');
 
-// lists which user.id will be validated through collection ids to avoid self-delete
-var LISTS_TO_CHECK_USER_PERMISSIONS = ['user'];
-
 module.exports = function (req, res) {
 	if (!keystone.security.csrf.validate(req)) {
 		console.log('Refusing to delete ' + req.list.key + ' items; CSRF failure');
@@ -22,7 +19,8 @@ module.exports = function (req, res) {
 	}
 
 	if (req.user) {
-		var checkResourceId = (LISTS_TO_CHECK_USER_PERMISSIONS.indexOf(req.list.key.toLowerCase()) >= 0);
+		var checkResourceId = (keystone.get('user model') === req.list.key);
+
 		var userId = String(req.user.id);
 		// check if user can delete this resources based on resources ids and userId
 		if (checkResourceId && ids.some(function (id) {

--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -26,8 +26,8 @@ module.exports = function (req, res) {
 		if (checkResourceId && ids.some(function (id) {
 			return id === userId;
 		})) {
-			console.log('Refusing to delete ' + req.list.key + ' items; resources ids contains current User id');
-			return res.apiError(403, 'not allowed', 'You can not delete this resource');
+			console.log('Refusing to delete ' + req.list.key + ' items; ids contains current User id');
+			return res.apiError(403, 'not allowed', 'You can not delete yourself');
 		}
 	}
 	var deletedCount = 0;


### PR DESCRIPTION
## Description of changes

I'm know that Keystone uses mongoDB as default(at least only for now) database driver, and for this reason primary key `_id` is a `ObjectId` value(which is generated using  timestamp, machine ID, process ID, and a process-local incremental counter), and this make almost impossible to two collection share the **same id**, butttttt MongoDB also supports [`Auto Increment Field`](https://docs.mongodb.com/manual/tutorial/create-an-auto-incrementing-field/) as primary key, so in this scenario is possible to share **multiples EQUALS ids** through the whole database. 
(eg: user.id = 10, post.id = 10, notification.id = 10)

So, this change **only** make sure to validate if user is really trying to delete **YOURSELF**, and not simply check if `userId`(logged user id) is the same that one of the resources which will be deleted.

In the current scenario, suppose your user is the `id = 10`, and you try to deleted a post with `id = 10`, this will not be possible...
## Testing

- [x] Please confirm `npm run test-all` ran successfully.