### PR TITLE
Fix typo in RelationshipField (fixes #2855)

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -1,6 +1,6 @@
 import async from 'async';
 import Field from '../Field';
-import listsByKey from '../../../admin/client/utils/lists';
+import { listsByKey } from '../../../admin/client/utils/lists';
 import React from 'react';
 import Select from 'react-select';
 import xhr from 'xhr';

--- a/test/e2e/adminUI/tests/group007Misc/testInlineRelationshipCreate.js
+++ b/test/e2e/adminUI/tests/group007Misc/testInlineRelationshipCreate.js
@@ -16,21 +16,20 @@ module.exports = {
 		browser.app.signout();
 		browser.end();
 	},
-	'Demonstrate issue 2855': function(browser) {
+	'Should be able to create an inline relationship': function(browser) {
 		// Create items
 		browser.app.openMiscList('InlineRelationship');
 		browser.listPage.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 		browser.initialFormPage.save();
 
-		// Issue demonstration: The item screen never loads.
 		browser.app.waitForItemScreen();
 		browser.itemPage.assertUI({
 			listName: 'Relationship',
 			fields: ['fieldA']
 		});
 
-
+		// TODO: test button and create form
 
 	}
 };


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

This fixes a small typo that imported the wrong object from the list store in RelationshipField

## Related issues (if any)

#2855 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

@jstockwin I moved the test to misc and renamed it to 'Should be able to create an inline relationship'. Maybe you can extend it to test the + button and the create form. Either you merge it and fix it in master or I will try to give you commit rights to this branch of mine.
<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->