### PR TITLE
Fix checkKeystoneReady() when using KEYSTONEJS_PORT env variable por …

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -2,8 +2,10 @@
 	This page object describes global admin UI configuration and commands that are or should be
 	most likely available in all pages.
  */
+var keystone = require('../../../..');
+
 module.exports = {
-	url: 'http://localhost:3000/keystone/',
+	url: 'http://' + keystone.get('host') + ':' + keystone.get('port') + '/keystone/',
 	pause: 1000,
 	elements: {
 		// ADMIN UI APP SCREENS

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -105,7 +105,7 @@ function dropTestDatabase(done) {
 function checkKeystoneReady (done, results) {
 	console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: checking if KeystoneJS ready for request');
 	request
-		.get('http://localhost:3000/keystone')
+		.get('http://' + keystone.get('host') + ':' + keystone.get('port') + '/keystone')
 		.end(done);
 }
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Uses `keystone.get` to know the correct uri on testing e2e

## Related issues (if any)


## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->