### PR TITLE
Fixes #1895: User session does not survive browser close

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -51,7 +51,7 @@ function signinWithUser (user, req, res, onSuccess) {
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true });
+			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true, maxAge: keystone.get('cookie signin expire') || 900000 });
 		}
 		onSuccess(user);
 	});


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Add a `cookie signin expire` option for making signin cookies to survive across browser sessions.

For example, my current setup uses this like:

````
  'cookie signin': true,
  'cookie signin expire': 172800000, // 2 days
````

## Related issues (if any)


## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


