### PR TITLE
Cookie signin persistent across subdomains

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -55,7 +55,7 @@ function signinWithUser (user, req, res, onSuccess) {
 			var cookieOpts = _.defaults({
 				signed: true,
 				httpOnly: true,
-				maxAge:  10 * 24 * 60 * 60
+				maxAge: 10 * 24 * 60 * 60,
 			}, keystone.get('cookie signin options'));
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
@@ -150,7 +150,7 @@ exports.signout = function (req, res, next) {
 		var cookieOpts = _.defaults({
 			signed: true,
 			httpOnly: true,
-			maxAge:  10 * 24 * 60 * 60
+			maxAge: 10 * 24 * 60 * 60,
 		}, keystone.get('cookie signin options'));
 		res.clearCookie('keystone.uid', cookieOpts);
 		req.user = null;
@@ -192,7 +192,7 @@ exports.persist = function (req, res, next) {
 			var cookieOpts = _.defaults({
 				signed: true,
 				httpOnly: true,
-				maxAge:  10 * 24 * 60 * 60
+				maxAge: 10 * 24 * 60 * 60,
 			}, keystone.get('cookie signin options'));
 			res.clearCookie('keystone.uid', cookieOpts);
 			req.user = null;

--- a/lib/session.js
+++ b/lib/session.js
@@ -51,7 +51,7 @@ function signinWithUser (user, req, res, onSuccess) {
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true });
+			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true, maxAge: keystone.get('cookie signin expire') || 900000 });
 		}
 		onSuccess(user);
 	});

--- a/lib/session.js
+++ b/lib/session.js
@@ -2,6 +2,7 @@ var crypto = require('crypto');
 var keystone = require('../');
 var scmp = require('scmp');
 var utils = require('keystone-utils');
+var _ = require('lodash');
 
 /**
  * Creates a hash of str with Keystone's cookie secret.
@@ -51,10 +52,11 @@ function signinWithUser (user, req, res, onSuccess) {
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			var cookieOpts = { signed: true, httpOnly: true, maxAge: keystone.get('cookie signin expire') || 900000 };
-			if (keystone.get('cookie signin domain')) {
-				cookieOpts.domain = keystone.get('cookie signin domain');
-			}
+			var cookieOpts = _.defaults({
+				signed: true,
+				httpOnly: true,
+				maxAge:  10 * 24 * 60 * 60
+			}, keystone.get('cookie signin options'));
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);
@@ -145,7 +147,12 @@ exports.signout = function (req, res, next) {
 		if (err) {
 			console.log("An error occurred in signout 'pre' middleware", err);
 		}
-		res.clearCookie('keystone.uid');
+		var cookieOpts = _.defaults({
+			signed: true,
+			httpOnly: true,
+			maxAge:  10 * 24 * 60 * 60
+		}, keystone.get('cookie signin options'));
+		res.clearCookie('keystone.uid', cookieOpts);
 		req.user = null;
 		req.session.regenerate(function (err) {
 			if (err) {
@@ -182,7 +189,12 @@ exports.persist = function (req, res, next) {
 		exports.signin(req.signedCookies['keystone.uid'], req, res, function () {
 			next();
 		}, function (err) {
-			res.clearCookie('keystone.uid');
+			var cookieOpts = _.defaults({
+				signed: true,
+				httpOnly: true,
+				maxAge:  10 * 24 * 60 * 60
+			}, keystone.get('cookie signin options'));
+			res.clearCookie('keystone.uid', cookieOpts);
 			req.user = null;
 			next();
 		});

--- a/lib/session.js
+++ b/lib/session.js
@@ -52,11 +52,11 @@ function signinWithUser (user, req, res, onSuccess) {
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			var cookieOpts = _.defaults({
+			var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
 				signed: true,
 				httpOnly: true,
 				maxAge: 10 * 24 * 60 * 60,
-			}, keystone.get('cookie signin options'));
+			});
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);
@@ -147,11 +147,12 @@ exports.signout = function (req, res, next) {
 		if (err) {
 			console.log("An error occurred in signout 'pre' middleware", err);
 		}
-		var cookieOpts = _.defaults({
+		var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
 			signed: true,
 			httpOnly: true,
-			maxAge: 10 * 24 * 60 * 60,
-		}, keystone.get('cookie signin options'));
+		});
+		// Force the cookie to expire!
+		cookieOpts.maxAge = 0;
 		res.clearCookie('keystone.uid', cookieOpts);
 		req.user = null;
 		req.session.regenerate(function (err) {
@@ -189,11 +190,12 @@ exports.persist = function (req, res, next) {
 		exports.signin(req.signedCookies['keystone.uid'], req, res, function () {
 			next();
 		}, function (err) {
-			var cookieOpts = _.defaults({
+			var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
 				signed: true,
 				httpOnly: true,
-				maxAge: 10 * 24 * 60 * 60,
-			}, keystone.get('cookie signin options'));
+			});
+			// Force the cookie to expire!
+			cookieOpts.maxAge = 0;
 			res.clearCookie('keystone.uid', cookieOpts);
 			req.user = null;
 			next();

--- a/lib/session.js
+++ b/lib/session.js
@@ -51,7 +51,11 @@ function signinWithUser (user, req, res, onSuccess) {
 		// if the user has a password set, store a persistence cookie to resume sessions
 		if (keystone.get('cookie signin') && user.password) {
 			var userToken = user.id + ':' + hash(user.password);
-			res.cookie('keystone.uid', userToken, { signed: true, httpOnly: true, maxAge: keystone.get('cookie signin expire') || 900000 });
+			var cookieOpts = { signed: true, httpOnly: true, maxAge: keystone.get('cookie signin expire') || 900000 };
+			if (keystone.get('cookie signin domain')) {
+				cookieOpts.domain = keystone.get('cookie signin domain');
+			}
+			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);
 	});


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Adds the `cookie signin domain` keystone option, which allows to have the same keystone instance running across subdomains and every instance remembers the logged in user.

For example: user 'sam' logs in to http://www.example.com/keystone, and later when accesing http://support.example.com he is already logged in!

## Related issues (if any)

#1895 

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

