### PR TITLE
Fix no default columns

### DIFF
--- a/admin/client/App/screens/List/index.js
+++ b/admin/client/App/screens/List/index.js
@@ -59,16 +59,20 @@ const ListView = React.createClass({
 		// possibly specified query parameters
 		this.initializeList(this.props.params.listId);
 		this.parseQueryParams();
+		this.loadItems();
 	},
 	componentWillReceiveProps (nextProps) {
 		// We've opened a new list from the client side routing, so initialize
 		// again with the new list id
 		if (nextProps.params.listId !== this.props.params.listId) {
 			this.initializeList(nextProps.params.listId);
+			this.loadItems();
 		}
 	},
 	initializeList (listId) {
 		this.props.dispatch(selectList(listId));
+	},
+	loadItems () {
 		this.props.dispatch(loadItems());
 	},
 	/**

--- a/admin/client/utils/List.js
+++ b/admin/client/utils/List.js
@@ -144,14 +144,14 @@ List.prototype.expandColumns = function (input) {
 		if (path === '__name__') {
 			path = this.namePath;
 		}
-		if (path === this.namePath) {
-			nameIncluded = true;
-		}
 		const field = this.fields[path];
 		if (!field) {
 			// TODO: Support arbitary document paths
 			console.warn('Invalid Column specified:', i);
 			return;
+		}
+		if (path === this.namePath) {
+			nameIncluded = true;
 		}
 		return {
 			field: field,

--- a/test/e2e/adminUI/tests/group003List/uiNoDefaultColumn.js
+++ b/test/e2e/adminUI/tests/group003List/uiNoDefaultColumn.js
@@ -16,7 +16,7 @@ module.exports = {
 		browser.app.signout();
 		browser.end();
 	},
-	'Demonstrate issue 2945': function(browser) {
+	'List screen must show ID column if it has neither default nor name columns': function(browser) {
 		// Create items
 		browser.app.openMiscList('NoDefaultColumn');
 		browser.listPage.createFirstItem();
@@ -30,11 +30,12 @@ module.exports = {
 		browser.initialFormPage.save();
 		browser.app.waitForItemScreen();
 
-		// Issue demonstration #1. If no default is set, the ID should be used.
+		// If no default is set, the ID should be used.
 		browser.app.navigate('http://localhost:3000/keystone/no-default-columns');
 		browser.listPage.expect.element('@firstColumnHeader').text.to.equal('ID');
-
-		// Issue demonstration #2. If specific columns have been requested, they should be shown.
+	},
+	'List screen must show requested columns': function(browser) {
+		// If specific columns have been requested, they should be shown.
 		browser.app.navigate('http://localhost:3000/keystone/no-default-columns?columns=id%2CfieldA');
 		browser.listPage.expect.element('@firstColumnHeader').text.to.equal('ID');
 		browser.listPage.expect.element('@secondColumnHeader').text.to.equal('Field A');

--- a/test/e2e/models/misc/NoDefaultColumn.js
+++ b/test/e2e/models/misc/NoDefaultColumn.js
@@ -1,14 +1,7 @@
 var keystone = require('../../../../index.js');
 var Types = keystone.Field.Types;
 
-// Model to demonstrate issue #2945
-
 var NoDefaultColumn = new keystone.List('NoDefaultColumn', {
-	autokey: {
-		path: 'key',
-		from: 'name',
-		unique: true,
-	},
 	track: true,
 });
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Move around order of operations in admin/client/App/screens/List/index.js and admin/client/utils/List.js to fix display of lists without default or name column.

## Related issues (if any)

#2945 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

