### PR TITLE
Replace options() from keystone-utils with _.defaults

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -48,7 +48,7 @@ function Field (list, path, options) {
 	this.path = path;
 
 	this.type = this.constructor.name;
-	this.options = utils.options(this.defaults, options);
+	this.options = _.defaults({}, options, this.defaults);
 	this.label = options.label || utils.keyToLabel(this.path);
 	this.typeDescription = options.typeDescription || this.typeDescription || this.type;
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Handling of the defaults property on field types was IMO broken by the fact that options() from keystone-utils actually modifies the defaults object. This went unnoticed until I added a defaults property on the prototype of the Boolean field type. Replaced usage of options() by defaults() from lodash.

## Related issues (if any)

#2931 

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


…nt modification of Field.prototype.defaults