### PR TITLE
Replace double slashes with single ones when `mount`ing keystone on existing express app

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -225,7 +225,7 @@ function mount(mountPath, parentApp, events) {
 	if (mountPath) {
 		//fix root-relative keystone urls for assets (gets around having to re-write all the keystone templates)
 		parentApp.all(/^\/keystone($|\/.*)/, function(req, res, next) {
-			req.url = mountPath + req.url;
+			req.url = (mountPath + req.url).replace(new RegExp(/\/\//, 'g'), '/');
 			next();
 		});
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

When using the `mount` function as described [in the wiki](https://github.com/keystonejs/keystone/wiki/Keystone-API#mountmountpath-parentapp-events), one runs into issues when mounting on root path '/' and trying to open keystone-related URLs as e.g. the admin area. Express doesn't correctly redirect, leading to 404 errors.  
This PR fixes this issue by replacing double slashes with single slashes after the current url concatenation via `mountPath + req.url`.

## Related issues (if any)


## Testing

- [x] Please confirm `npm run test` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->