### PR TITLE
#2561 | Inherited Users can't log in

### DIFF
--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -59,25 +59,23 @@ password.prototype.addToSchema = function() {
 			return next();
 		}
 		var item = this;
-		if(!item.isEncrypted) {
-            bcrypt.genSalt(field.workFactor, function(err, salt) {
+        bcrypt.genSalt(field.workFactor, function(err, salt) {
+            if (err) {
+                return next(err);
+            }
+            bcrypt.hash(item.get(field.path), salt, function () {}, function(err, hash) {
                 if (err) {
                     return next(err);
                 }
-                bcrypt.hash(item.get(field.path), salt, function () {}, function(err, hash) {
-                    if (err) {
-                        return next(err);
-                    }
-                    // override the cleartext password with the hashed one
-                    item.set(field.path, hash);
-                    // inherited models save twice, this ensures the encrypted password hash won't be encrypted a second time
-                    item.isEncrypted = true;
-                    next();
-                });
+                // override the cleartext password with the hashed one
+                item.set(field.path, hash);
+                // reset the [needs_hashing] flag so that new values can't be hashed more than once
+				// (inherited models double up on pre save handlers for password fields)
+				item[needs_hashing] = false;
+
+                next();
             });
-        } else {
-            return next();
-        }
+        });
 	});
 	this.bindUnderscoreMethods();
 };

--- a/fields/types/password/PasswordType.js
+++ b/fields/types/password/PasswordType.js
@@ -59,19 +59,25 @@ password.prototype.addToSchema = function() {
 			return next();
 		}
 		var item = this;
-		bcrypt.genSalt(field.workFactor, function(err, salt) {
-			if (err) {
-				return next(err);
-			}
-			bcrypt.hash(item.get(field.path), salt, function () {}, function(err, hash) {
-				if (err) {
-					return next(err);
-				}
-				// override the cleartext password with the hashed one
-				item.set(field.path, hash);
-				next();
-			});
-		});
+		if(!item.isEncrypted) {
+            bcrypt.genSalt(field.workFactor, function(err, salt) {
+                if (err) {
+                    return next(err);
+                }
+                bcrypt.hash(item.get(field.path), salt, function () {}, function(err, hash) {
+                    if (err) {
+                        return next(err);
+                    }
+                    // override the cleartext password with the hashed one
+                    item.set(field.path, hash);
+                    // inherited models save twice, this ensures the encrypted password hash won't be encrypted a second time
+                    item.isEncrypted = true;
+                    next();
+                });
+            });
+        } else {
+            return next();
+        }
 	});
 	this.bindUnderscoreMethods();
 };


### PR DESCRIPTION
## Description of changes

fix an issue where a model inheriting from the model allowed to sign in to the admin UI wasn't able to log in.  This was caused by inherited models being saved twice (Mongoose functionality I believe) which caused the password hash to be re-encrypted and made unusable.

## Related issues (if any)

#2561 - Inherited users can't log in

## Testing

No unit tests were written as the change is on the v0.3.x branch.