### PR TITLE
Add 'list' to the list of reserved words

### DIFF
--- a/lib/list/isReserved.js
+++ b/lib/list/isReserved.js
@@ -4,20 +4,21 @@
  */
 
 var reservedPaths = [
-	'id',
-	'_id',
 	'_',
-	'prototype',
-	'__proto__',
-	'hasOwnProperty',
-	'toString',
 	'__defineGetter__',
 	'__defineSetter__',
 	'__lookupGetter__',
 	'__lookupSetter__',
+	'__proto__',
+	'_id',
+	'hasOwnProperty',
+	'id',
 	'isPrototypeOf',
+	'list',
 	'propertyIsEnumerable',
+	'prototype',
 	'toLocaleString',
+	'toString',
 	'valueOf',
 ];
 

--- a/test/e2e/models/misc/ReservedListKeyword.js
+++ b/test/e2e/models/misc/ReservedListKeyword.js
@@ -1,0 +1,30 @@
+// THIS MODEL IS USED TO QUICKLY DETECT RESERVED WORDS IN KEYSTONE LISTS
+var keystone = require('../../../../index');
+
+var ReservedListKeyword = new keystone.List('ReservedListKeyword', {
+	hidden: true,
+});
+
+// THE LIST BELOW CORRESPONDS TO THE LIST IN lib/list/isReserved.js
+ReservedListKeyword.add({
+	//_: { type: String },
+	//__defineGetter__: { type: String },
+	//__defineSetter__: { type: String },
+	//__lookupGetter__: { type: String },
+	//__lookupSetter__: { type: String },
+	//__proto__: { type: String },
+	//_id: { type: String },
+	//hasOwnProperty: { type: String },
+	//id: { type: String },
+	//isPrototypeOf: { type: String },
+	//list: { type: String },
+	//propertyIsEnumerable: { type: String },
+	//prototype: { type: String },
+	//toLocaleString: { type: String },
+	//toString: { type: String },
+	//valueOf: { type: String },
+});
+
+ReservedListKeyword.register();
+
+module.exports = ReservedListKeyword;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Add 'list' to the list of reserved words that cannot be used in list models.

## Related issues (if any)

#2871

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->
