### PR TITLE
Log a more useful message if an invalid list default column is specified

### DIFF
--- a/admin/client/utils/List.js
+++ b/admin/client/utils/List.js
@@ -147,7 +147,13 @@ List.prototype.expandColumns = function (input) {
 		const field = this.fields[path];
 		if (!field) {
 			// TODO: Support arbitary document paths
-			console.warn('Invalid Column specified:', i);
+			if (!this.hidden) {
+				if (path === this.namePath) {
+					console.warn(`List ${this.key} did not specify any default columns or a name field`);
+				} else {
+					console.warn(`List ${this.key} specified an invalid default column: ${path}`);
+				}
+			}
 			return;
 		}
 		if (path === this.namePath) {

--- a/test/e2e/models/misc/InvalidDefaultColumn.js
+++ b/test/e2e/models/misc/InvalidDefaultColumn.js
@@ -1,0 +1,15 @@
+// THIS MODEL IS USED TO MAKE SURE INVALID DEFAULT COLUMNS ARE PROPERLY WARNED ABOUT
+var keystone = require('../../../../index');
+
+var InvalidDefaultColumn = new keystone.List('InvalidDefaultColumn');
+
+// THIS SHOULD CAUSE THE FOLLOWING WARNING TO BE GENERATED IN THE ADMIN UI CONSOLE:
+// 'List InvalidDefaultColumn specified an invalid default column: bar'
+InvalidDefaultColumn.add({
+	foo: {type: String}
+});
+
+InvalidDefaultColumn.defaultColumns = 'bar';
+InvalidDefaultColumn.register();
+
+module.exports = InvalidDefaultColumn;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Log a more useful message in the admin ui console when there is an invalid default column configuration.

## Related issues (if any)

N/A

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


