### PR TITLE
Set next list upon transitioning to another item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
   - "5"
   - "6"
 
+env:
+- KEYSTONE_PREBUILD_ADMIN=true
+
 before_script:
   - npm run lint
   - sleep 15

--- a/admin/client/App/screens/Item/index.js
+++ b/admin/client/App/screens/Item/index.js
@@ -45,6 +45,7 @@ var ItemView = React.createClass({
 		// We've opened a new item from the client side routing, so initialize
 		// again with the new item id
 		if (nextProps.params.itemId !== this.props.params.itemId) {
+			this.props.dispatch(selectList(nextProps.params.listId));
 			this.initializeItem(nextProps.params.itemId);
 		}
 	},

--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -6,8 +6,8 @@ module.exports = function (req, res) {
 	var codemirrorPath = keystone.get('codemirror url path')
 												? path.join('/', keystone.get('codemirror url path'))
 												: path.join('/', keystone.get('admin path'), '/js/lib/codemirror');
-	codemirrorPath = codemirrorPath.replace(/\\/g,'/');	// ensure for windows :-)											
-													
+	// ensure for windows :-)
+	codemirrorPath = codemirrorPath.replace(/\\/g, '/');
 	keystone.render(req, res, 'index', {
 		// section: keystone.nav.by.list[req.list.key] || {},
 		title: appName,

--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -6,7 +6,8 @@ module.exports = function (req, res) {
 	var codemirrorPath = keystone.get('codemirror url path')
 												? path.join('/', keystone.get('codemirror url path'))
 												: path.join('/', keystone.get('admin path'), '/js/lib/codemirror');
-
+	codemirrorPath = codemirrorPath.replace(/\\/g,'/');	// ensure for windows :-)											
+													
 	keystone.render(req, res, 'index', {
 		// section: keystone.nav.by.list[req.list.key] || {},
 		title: appName,

--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -112,7 +112,7 @@ module.exports = {
 		},
 		waitForListScreen: function() {
 			return this
-				.waitForElementVisible('@listScreen', 20000);
+				.waitForElementVisible('@listScreen');
 		},
 		waitForItemScreen: function() {
 			return this

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -38,6 +38,8 @@ keystone.init({
 	'adminui custom styles': 'adminuiCustom/styles.less',
 
 	'cloudinary config': 'cloudinary://api_key:api_secret@cloud_name',
+	
+	'codemirror url path': '/keystone/js/lib/codemirror'
 });
 
 keystone.import('models');


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Sets the next list upon a list item transition happening within an item as when there are relationship links.  This ensures that the correct item will be loaded.

## Related issues (if any)

#2940

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->
