### PR TITLE
Fix bug while checking for allowed S3 filetypes

### DIFF
--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -338,7 +338,7 @@ s3file.prototype.uploadFile = function (item, file, update, callback) {
 		update = false;
 	}
 
-	if (field.options.allowedTypes && !_.contains(field.options.allowedTypes, filetype)) {
+	if (field.options.allowedTypes && field.options.allowedTypes.indexOf(filetype) === -1) {
 		return callback(new Error('Unsupported File Type: ' + filetype));
 	}
 


### PR DESCRIPTION
lodash doesn't offer a `contains` function (underscore.js does, maybe that's why it was mistakenly used). I've changed the code to make the check without the use of a library.

* Fixes #2966