### PR TITLE
Fix issue #3001 - Markdown not showing up in downloads

### DIFF
--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -93,6 +93,10 @@ markdown.prototype.addFilterToQuery = function (filter) {
  * Formats the field value
  */
 markdown.prototype.format = function (item) {
+	return item.get(this.paths.html);
+};
+
+markdown.prototype.getMarkdown = function (item) {
 	return item.get(this.paths.md);
 };
 

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -93,7 +93,7 @@ markdown.prototype.addFilterToQuery = function (filter) {
  * Formats the field value
  */
 markdown.prototype.format = function (item) {
-	return item.get(this.paths.html);
+	return item.get(this.paths.md);
 };
 
 /**

--- a/lib/list/getCSV.js
+++ b/lib/list/getCSV.js
@@ -26,6 +26,8 @@ function getData (item, fields, expandRelationshipFields) {
 			if (field) {
 				if (field.type === 'relationship' && expandRelationshipFields) {
 					data[path] = field.getExpandedData(item);
+				} else if (field.type === 'markdown') {
+					data[path] = field.getMarkdown(item);
 				} else {
 					data[path] = field.format(item);
 				}


### PR DESCRIPTION
## Description of changes
See https://github.com/keystonejs/keystone/issues/3001 for context. Small change to MarkdownType.js.


## Related issues (if any)


## Testing

- [X] Please confirm `npm run test-all` ran successfully.
