### PR TITLE
Fix bug in fullscreen TinyMCE

### DIFF
--- a/admin/public/styles/keystone/item.less
+++ b/admin/public/styles/keystone/item.less
@@ -196,7 +196,7 @@
 	box-shadow: 0 -2px 0 rgba(0, 0, 0, 0.1);
 	// margin-top: 3em;
 	padding: @grid-gutter-width 0;
-	z-index: 100;
+	z-index: 99;
 }
 
 


### PR DESCRIPTION
The footer in the edit page remains above TinyMCE's fullscreen editor because they both have a z-index of 100. By lowering by 1, the footer remains above everything except the editor when it's fullscreen.

## Description of changes

* Lower `.EditForm__footer`'s `z-index` by 1 (to 99) so it's below fullscreen editor