### PR TITLE
Fixes problem with cloudinary.url formats

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -159,7 +159,9 @@ cloudinaryimage.prototype.addToSchema = function () {
 
 		options.version = item.get(paths.version);
 
-		return cloudinary.url(item.get(paths.public_id) + '.' + item.get(paths.format), options);
+		options.format = options.format || item.get(paths.format);
+
+		return cloudinary.url(item.get(paths.public_id), options);
 
 	};
 

--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -142,7 +142,8 @@ cloudinaryimages.prototype.addToSchema = function () {
 			options = options || {};
 			options.secure = true;
 		}
-		return img.public_id ? cloudinary.url(img.public_id + '.' + img.format, options) : '';
+		options.format = options.format || img.format;
+		return img.public_id ? cloudinary.url(img.public_id, options) : '';
 	};
 
 	var addSize = function (options, width, height, other) {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Moves Cloudinary url format to ONLY be set in the options object. This solves a problem where the return of `cloudinary.url()` will append the `options.format` to the default extension instead of replacing it. I think this is a problem with cloudinary itself, but this should fix for the time being and should be future proof even if they fix the problem. See https://github.com/cloudinary/cloudinary_npm/issues/103

## Related issues (if any)

https://github.com/cloudinary/cloudinary_npm/issues/103

## Testing

- [?] Please confirm `npm run test-all` ran successfully.

Tests fail: `Uncaught Error: connect ECONNREFUSED 127.0.0.1:27017`
But I don't think it's related to this simple change.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


