### PR TITLE
Misc fixes to CloudinaryImagesType.js

### DIFF
--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -3,7 +3,6 @@ var assign = require('object-assign');
 var async = require('async');
 var FieldType = require('../Type');
 var keystone = require('../../../');
-var super_ = require('../Type');
 var util = require('util');
 var utils = require('keystone-utils');
 
@@ -45,7 +44,7 @@ function cloudinaryimages (list, path, options) {
 			+ 'See http://keystonejs.com/docs/configuration/#services-cloudinary for more information.\n');
 	}
 }
-cloudinaryimages.properName = 'CloudinaryImage';
+cloudinaryimages.properName = 'CloudinaryImages';
 util.inherits(cloudinaryimages, FieldType);
 
 /**


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Fixes lint error and 
```
08:53:21:042 e2e: KeystoneJS Started Successfully
08:53:21:042 e2e: checking if KeystoneJS ready for request
GET /keystone/ 302 4.091 ms
GET /keystone/signin 200 99.043 ms
08:53:21:455 e2e: KeystoneJS Ready!
2016-06-11 08:06:45 error building FieldTypes:
Cannot find module '../../fields/types/cloudinaryimages/CloudinaryImageColumn' from 'd:\Documents\Development\GitHub\keystone\admin\client'
2016-06-11 08:06:45 error building FieldTypes:
Cannot find module '../../fields/types/cloudinaryimages/CloudinaryImageField' from 'd:\Documents\Development\GitHub\keystone\admin\client'
2016-06-11 08:06:46 error building FieldTypes:
Cannot find module '../../fields/types/cloudinaryimages/CloudinaryImageFilter' from 'd:\Documents\Development\GitHub\keystone\admin\client'
```

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


