### PR TITLE
Fix date and datearray e2e tests

### DIFF
--- a/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
@@ -84,6 +84,11 @@ module.exports = {
 				'fieldB': {date1: '2016-01-03', date2: '2016-01-04'}
 			}
 		});
+		// Drop focus on the date field so the popup disappears. 
+		browser.execute(function() {
+			document.activeElement.blur();
+		});
+
 		browser.itemPage.save();
 		browser.app.waitForItemScreen();
 		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');

--- a/test/e2e/adminUI/tests/group005Fields/testDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateField.js
@@ -62,6 +62,10 @@ module.exports = {
 				'fieldB': {value: '2016-01-02'}
 			}
 		});
+		// Drop focus on the date field so the popup disappears.
+		browser.execute(function() {
+			document.activeElement.blur();
+		});
 		browser.itemPage.save();
 		browser.app.waitForItemScreen();
 		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

cc: @webteckie. This is a solution to our problems about making the datearray popup go away so we can click save. It's not exactly a neat solution, but it works. Let me know what you think. 

## Related issues (if any)

Should fix travis.

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


