### PR TITLE
Supports showing pdf thumbnails in the AdminUI

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -180,6 +180,24 @@ module.exports = Field.create({
 	},
 
 	/**
+	 * Apply Cloudinary transforms to url
+	 */
+	applyTranforms (url) {
+		var format = this.props.value.format;
+
+		if (format === 'pdf') {
+			// support cloudinary pdf previews in jpg format
+			url = url.substr(0, url.lastIndexOf('.')) + '.jpg';
+			url = url.replace(/image\/upload/, 'image/upload/c_thumb,h_90,w_90');
+		} else {
+			// add cloudinary thumbnail parameters to the url
+			url = url.replace(/image\/upload/, 'image/upload/c_thumb,g_face,h_90,w_90');
+		}
+
+		return url;
+	},
+
+	/**
 	 * Render an image preview
 	 */
 	renderImagePreview () {
@@ -198,8 +216,11 @@ module.exports = Field.create({
 		if (iconClassName) body.push(<div key={this.props.path + '_preview_icon'} className={iconClassName} />);
 
 		var url = this.getImageURL();
+		var format = this.props.value.format;
 
-		if (url) {
+		if (format === 'pdf') {
+			body = <a className="img-thumbnail" href={this.getImageURL()} target="__blank">{body}</a>;
+		} else if (url) {
 			body = <a className="img-thumbnail" href={this.getImageURL()} onClick={this.openLightbox.bind(this, 0)} target="__blank">{body}</a>;
 		} else {
 			body = <div className="img-thumbnail">{body}</div>;
@@ -212,8 +233,7 @@ module.exports = Field.create({
 		var url = this.getImageURL();
 
 		if (url) {
-			// add cloudinary thumbnail parameters to the url
-			url = url.replace(/image\/upload/, 'image/upload/c_thumb,g_face,h_90,w_90');
+			url = this.applyTranforms(url);
 		} else {
 			url = this.getImageSource();
 		}

--- a/fields/types/cloudinaryimages/CloudinaryImagesField.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesField.js
@@ -34,6 +34,21 @@ var Thumbnail = React.createClass({
 		width: React.PropTypes.number,
 	},
 
+	applyTranforms (url) {
+		var format = this.props.format;
+
+		if (format === 'pdf') {
+			// support cloudinary pdf previews in jpg format
+			url = url.substr(0, url.lastIndexOf('.')) + '.jpg';
+			url = url.replace(/image\/upload/, 'image/upload/c_thumb,h_90,w_90');
+		} else {
+			// add cloudinary thumbnail parameters to the url
+			url = url.replace(/image\/upload/, 'image/upload/c_thumb,g_face,h_90,w_90');
+		}
+
+		return url;
+	},
+
 	renderActionButton () {
 		if (!this.props.shouldRenderActionButton || this.props.isQueued) return null;
 		return <Button type={this.props.deleted ? 'link-text' : 'link-cancel'} block onClick={this.props.toggleDelete}>{this.props.deleted ? 'Undo' : 'Remove'}</Button>;
@@ -41,7 +56,7 @@ var Thumbnail = React.createClass({
 
 	render () {
 		let iconClassName;
-		const { deleted, height, isQueued, url, width, openLightbox } = this.props;
+		const { deleted, height, isQueued, url, width, openLightbox, format } = this.props;
 		const previewClassName = classnames('image-preview', {
 			action: (deleted || isQueued),
 		});
@@ -53,11 +68,15 @@ var Thumbnail = React.createClass({
 			iconClassName = classnames(iconClassQueued);
 		}
 
+		let shouldOpenLightbox = true;
+		let thumbUrl = this.applyTranforms(url);
+		if (format === 'pdf') shouldOpenLightbox = false;
+
 		return (
 			<div className="image-field image-sortable" title={title}>
 				<div className={previewClassName}>
-					<a href={url} onClick={openLightbox} className="img-thumbnail">
-						<img style={{ height: '90' }} className="img-load" src={url} />
+					<a href={url} onClick={shouldOpenLightbox ? openLightbox : null} className="img-thumbnail" target="_blank">
+						<img style={{ height: '90' }} className="img-load" src={thumbUrl} />
 						<span className={iconClassName} />
 					</a>
 				</div>


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

This adds a condition when generating the CloudinaryImage previews to check for pdfs (since they are a supported upload) and generate an appropriate thumbnail. Previously it would show a broken image. Clicking the image now opens the PDF in a new tab.

Note: I broke the `applyTranforms` function out to possibly support other formats later as well.

## Related issues (if any)

![cursor_and_hydrochem](https://cloud.githubusercontent.com/assets/1088089/16026254/20f9e0fa-319b-11e6-98c4-949d666f3d2a.png)

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

