### PR TITLE
Api search

### DIFF
--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -24,9 +24,7 @@ function getStringFilter (path, searchRegExp) {
 
 function getRelationshipFilter (path, id) {
 	var filter = {};
-	if (utils.isValidObjectId(id)) {
-		filter[path] = id;
-	}
+	filter[path] = id;
 	return filter;
 }
 
@@ -49,15 +47,20 @@ function addSearchToQuery (searchString) {
 	} else {
 		var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
 		searchFilters = this.searchFields.map(function (i) {
-
 			if (i.field && i.field.type === 'name') {
 				return getNameFilter(i.field, searchString);
 			} else if (i.field && i.field.type === 'relationship') {
-				return getRelationshipFilter(i.path, searchString);
+				if (utils.isValidObjectId(searchString)) {
+					return getRelationshipFilter(i.path, searchString);
+				}
 			} else {
 				return getStringFilter(i.path, searchRegExp);
 			}
-		}, this);
+		}, this).filter(function (item) {
+			if (item !== undefined) {
+				return true;
+			} else return false;
+		});
 	}
 
 	if (this.autokey) {

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -22,19 +22,43 @@ function getStringFilter (path, searchRegExp) {
 	return filter;
 }
 
+function getRelationshipFilter (path, id) {
+	var filter = {};
+	if (utils.isValidObjectId(id)) {
+		filter[path] = id;
+	}
+	return filter;
+}
+
 function addSearchToQuery (searchString) {
+
 	searchString = String(searchString || '').trim();
 	var query = {};
 	if (!searchString) return query;
 
-	var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
-	var searchFilters = this.searchFields.map(function (i) {
-		if (i.field && i.field.type === 'name') {
-			return getNameFilter(i.field, searchString);
-		} else {
-			return getStringFilter(i.path, searchRegExp);
-		}
-	}, this);
+	var parsed;
+	try {
+		parsed = JSON.parse(searchString);
+	} catch (ex) {
+		// we don't care. We'll handle non-objects below
+	}
+
+	if (typeof parsed === 'object') {
+		var searchFilters = [];
+		searchFilters.push(parsed);
+	} else {
+		var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
+		searchFilters = this.searchFields.map(function (i) {
+
+			if (i.field && i.field.type === 'name') {
+				return getNameFilter(i.field, searchString);
+			} else if (i.field && i.field.type === 'relationship') {
+				return getRelationshipFilter(i.path, searchString);
+			} else {
+				return getStringFilter(i.path, searchRegExp);
+			}
+		}, this);
+	}
 
 	if (this.autokey) {
 		var autokeyFilter = {};


### PR DESCRIPTION
## Description of changes

Adding two API search improvements: 
1. Previously if a search field was a relationship, it failed to parse the object id
2. Can now pass a valid JSON object to search a specific field
## Testing
- [X] Please confirm `npm run test-all` ran successfully.
