### PR TITLE
Implement item not found error handling

### DIFF
--- a/admin/client/App/screens/Item/actions.js
+++ b/admin/client/App/screens/Item/actions.js
@@ -5,7 +5,6 @@ import {
 	DATA_LOADING_ERROR,
 	DELETE_ITEM,
 } from './constants';
-import { NETWORK_ERROR_RETRY_DELAY } from '../../../constants';
 
 /**
  * Select an item
@@ -59,15 +58,12 @@ export function dataLoaded (data) {
  *
  * @param  {Object} error The error
  */
-export function dataLoadingError () {
+export function dataLoadingError (err) {
 	return (dispatch) => {
 		dispatch({
 			type: DATA_LOADING_ERROR,
-			error: 'Loading error',
+			error: err,
 		});
-		setTimeout(() => {
-			dispatch(loadItemData());
-		}, NETWORK_ERROR_RETRY_DELAY);
 	};
 }
 

--- a/admin/client/App/screens/Item/index.js
+++ b/admin/client/App/screens/Item/index.js
@@ -8,13 +8,14 @@
 import React from 'react';
 import { Container, Spinner } from 'elemental';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 
 import { listsByKey } from '../../../utils/lists';
 import CreateForm from '../../shared/CreateForm';
 import EditForm from './components/EditForm';
 import EditFormHeader from './components/EditFormHeader';
 import RelatedItemsList from './components/RelatedItemsList';
-import FlashMessages from '../../shared/FlashMessages';
+// import FlashMessages from '../../shared/FlashMessages';
 
 import {
 	selectItem,
@@ -96,6 +97,25 @@ var ItemView = React.createClass({
 			</div>
 		);
 	},
+	// Handle errors
+	handleError (error) {
+		const detail = error.detail;
+		if (detail) {
+			// Item not found
+			if (detail.name === 'CastError'
+				&& detail.path === '_id') {
+				return (
+					<Container>
+						<p>Item not found!</p>
+						<Link to={`${Keystone.adminPath}/${this.props.routeParams.listId}`}>
+							Go to list
+						</Link>
+					</Container>
+				);
+			}
+		}
+		return error;
+	},
 	render () {
 		// If we don't have any data yet, show the loading indicator
 		if (!this.props.ready) {
@@ -105,18 +125,11 @@ var ItemView = React.createClass({
 				</div>
 			);
 		}
+
 		// When we have the data, render the item view with it
 		return (
 			<div data-screen-id="item">
-				{(this.props.error) ? (
-					<FlashMessages
-						messages={{
-							error: [{
-								title: "There's a problem with the network, we're trying to reconnect...",
-							}],
-						}}
-					/>
-				) : (
+				{(this.props.error) ? this.handleError(this.props.error) : (
 					<div>
 						<Container>
 							<EditFormHeader

--- a/admin/client/App/screens/Item/index.js
+++ b/admin/client/App/screens/Item/index.js
@@ -114,7 +114,17 @@ var ItemView = React.createClass({
 				);
 			}
 		}
-		return error;
+		if (error.message) {
+			// Server down + possibly other errors
+			if (error.message === 'Internal XMLHttpRequest Error') {
+				return (
+					<Container>
+						<p>We encountered some network problems, please try refreshing!</p>
+					</Container>
+				);
+			}
+		}
+		return (<p>Error!</p>);
 	},
 	render () {
 		// If we don't have any data yet, show the loading indicator


### PR DESCRIPTION
**Description of changes**

Shows an error when users go to the URL of an item that doesn't exist.

Probably needs more styling, @jossmac could you look into this? We should probably have a general error display that works for all sorts of messages.

**Related issues:** #3041

**Testing**

- [ ] Please confirm `npm run test-all` ran successfully.

Getting `Error retrieving a new session from the selenium server` when running `npm run test-all`, that's probably environment related though. (Updated to the macOS Sierra beta, now my laptop barely works)