### PR TITLE
Repeated subexpressions in DomParser.js

### DIFF
--- a/admin/public/js/lib/tinymce/classes/html/DomParser.js
+++ b/admin/public/js/lib/tinymce/classes/html/DomParser.js
@@ -132,13 +132,13 @@ define("tinymce/html/DomParser", [
 					// If it's an LI try to find a UL/OL for it or wrap it
 					if (node.name === 'li') {
 						sibling = node.prev;
-						if (sibling && (sibling.name === 'ul' || sibling.name === 'ul')) {
+						if (sibling && (sibling.name === 'ul' || sibling.name === 'ol')) {
 							sibling.append(node);
 							continue;
 						}
 
 						sibling = node.next;
-						if (sibling && (sibling.name === 'ul' || sibling.name === 'ul')) {
+						if (sibling && (sibling.name === 'ul' || sibling.name === 'ol')) {
 							sibling.insert(node, sibling.firstChild, true);
 							continue;
 						}


### PR DESCRIPTION
## Description of changes

`sibling.name === 'ul'` is repeated. Based on the comment on line 132, looks like this should be `ol`?

## Related issues (if any)

-

## Testing

Tested against travis
