### PR TITLE
#3011 | Fix Date format option bug

### DIFF
--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -13,7 +13,7 @@ function date(list, path, options) {
 	this._underscoreMethods = ['format', 'moment', 'parse'];
 	this._fixedSize = 'large';
 	this._properties = ['dateFormat', 'datePlaceholder', 'yearRange', 'isUTC'];
-	this.parseDateFormat = options.parseFormat || 'YYYY-MM-DD';
+	this.parseDateFormat = options.format || 'YYYY-MM-DD';
 	this.dateFormat = (options.format === false) ? false : (options.format || 'YYYY-MM-DD');
 	this.datePlaceholder = this.dateFormat ? 'e.g. ' + moment().format(this.parseDateFormat) : '';
 	this.yearRange = options.yearRange;


### PR DESCRIPTION
## Description of changes

- Update parseFormat in DateType.js to reference the correct format field.

## Related issues (if any)

#3011 

## Testing

`npm run test-all` does not exist in the 0.3.x branch, and `npm run test` doesn't appear to run.


