### PR TITLE
Fine-tune uglify settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "url": "https://github.com/keystonejs/keystone/issues"
   },
   "scripts": {
-    "build": "NODE_ENV=production node build.js | uglifyjs -mc warnings=false > ./admin/public/js/packages.js",
+    "build": "NODE_ENV=production node build.js | uglifyjs -mc warnings=false,screw_ie8=true -b beautify=false,semicolons=false > ./admin/public/js/packages.js",
     "build-dev": "node build.js > ./admin/public/js/packages.js",
     "pretest": "npm run lint && node test/pretest.js",
     "test": "mocha",


### PR DESCRIPTION
## Description of changes

Nicer minified packages build for debugging

When an error occurs in KS, it is hard to debug.
With the semicolons turned off, the minified build at least has short lines so the browser debugger works faster with it.

Furthermore, IE8 is not supported so that allows further optimization.