### PR TITLE
Changing case sensitivity of "exact" filters to fix performance issues on large lists

### DIFF
--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -210,8 +210,9 @@ function getSearchFilters (search, add) {
 				case 'key':
 					if (filter.exact) {
 						if (value) {
-							cond = new RegExp('^' + utils.escapeRegExp(value) + '$', 'i');
-							filters[path] = filter.inverse ? { $not: cond } : cond;
+							// Don't use regex when searching for an exact match on a string value
+							// Regex makes the search case-insensitive but prevents indexes from being used
+							filters[path] = filter.inverse ? { $not: value } : value;
 						} else {
 							if (filter.inverse) {
 								filters[path] = { $nin: ['', null] };


### PR DESCRIPTION
This fixes a (fairly serious) issue we're seeing in systems with large collections/lists. The current Keystone admin ui search/filtering code uses regex matching for.. basically everything. Presumably this is to allow case insensitive matching but it has the serious side effect of preventing any indexes on the field from being used (!).

This update causes "exact" filters to be supplied directly to mongoose, without being converted to a regex, allowing users to work around the issue. The downside is that all "exact" filters given string fields will now be applied in a case-sensitive manner.