### PR TITLE
Fields explorer

### DIFF
--- a/fields/explorer/index.html
+++ b/fields/explorer/index.html
@@ -11,9 +11,6 @@
 			body {
 				padding: 20px;
 			}
-      .ExplorerField {
-        width: 300px;
-      }
 		</style>
   </head>
   <body>

--- a/fields/explorer/index.html
+++ b/fields/explorer/index.html
@@ -7,6 +7,14 @@
     <title>Keystone Fields Explorer</title>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link href="/styles/keystone.css" rel="stylesheet">
+		<style type="text/css">
+			body {
+				padding: 20px;
+			}
+      .ExplorerField {
+        width: 300px;
+      }
+		</style>
   </head>
   <body>
     <div id="explorer"></div>

--- a/fields/explorer/index.html
+++ b/fields/explorer/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Language" content="en">
+    <title>Keystone Fields Explorer</title>
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link href="/styles/keystone.css" rel="stylesheet">
+  </head>
+  <body>
+    <div id="explorer"></div>
+    <script src="/js/packages.js"></script>
+    <script src="/js/explorer.js"></script>
+  </body>
+</html>

--- a/fields/explorer/index.html
+++ b/fields/explorer/index.html
@@ -10,6 +10,7 @@
   </head>
   <body>
     <div id="explorer"></div>
+    <script>var Keystone = {};</script>
     <script src="/js/packages.js"></script>
     <script src="/js/explorer.js"></script>
   </body>

--- a/fields/explorer/index.html
+++ b/fields/explorer/index.html
@@ -1,22 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Language" content="en">
-    <title>Keystone Fields Explorer</title>
-    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-    <link href="/styles/keystone.css" rel="stylesheet">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="Content-Language" content="en">
+		<title>Keystone Fields Explorer</title>
+		<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+		<link href="/styles/keystone.css" rel="stylesheet">
 		<style type="text/css">
 			body {
 				padding: 20px;
 			}
+			h2 {
+				background: white;
+				border-bottom: 1px solid #ddd;
+				border-top: 1px solid #ddd;
+				font-size: 1em;
+				font-weight: bold;
+				margin: 15px -20px;
+				padding: 10px 20px;
+				text-transform: uppercase;
+			}
+			h3 {
+				border-top: 1px solid #ddd;
+				color: #666;
+				font-size: 1em;
+				margin-top: 10px;
+				padding-top: 15px;
+				text-transform: uppercase;
+			}
+			.ExplorerField {
+				margin-bottom: 20px;
+			}
+			.Domify {
+				font-family: Monaco, Menlo, Consolas, "Courier New", monospace;
+				font-size: 0.9em;
+			}
 		</style>
-  </head>
-  <body>
-    <div id="explorer"></div>
-    <script>var Keystone = {};</script>
-    <script src="/js/packages.js"></script>
-    <script src="/js/explorer.js"></script>
-  </body>
+	</head>
+	<body>
+		<div id="explorer"></div>
+		<script>var Keystone = {};</script>
+		<script src="/js/packages.js"></script>
+		<script src="/js/explorer.js"></script>
+	</body>
 </html>

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -9,10 +9,29 @@ const Types = {
 			label: 'Text Field',
 			path: 'textField',
 		},
+		value: '',
 	},
 };
 
-const Field = React.createClass({
+const FieldType = React.createClass({
+	getInitialState () {
+		return {
+			fieldValue: Types[this.props.type].value,
+			filterValue: {},
+		};
+	},
+	onFieldChange (e) {
+		console.log(`${this.props.type} field value changed:`, e.value);
+		this.setState({
+			value: e.value,
+		});
+	},
+	onFilterChange (value) {
+		console.log(`${this.props.type} filter value changed:`, value);
+		this.setState({
+			filter: value,
+		});
+	},
 	render () {
 		const FieldComponent = Types[this.props.type].Field;
 		const FilterComponent = Types[this.props.type].Filter;
@@ -21,9 +40,9 @@ const Field = React.createClass({
 			<div className="ExplorerField">
 				<h2>{this.props.type}</h2>
 				<h3>Field</h3>
-				<FieldComponent path={spec.path} onChange={(e) => console.log(e)} />
+				<FieldComponent path={spec.path} onChange={this.onFieldChange} value={this.state.value} />
 				<h3>Filter</h3>
-				<FilterComponent field={spec} onChange={(e) => console.log(e)} />
+				<FilterComponent field={spec} onChange={this.onFilterChange} filter={this.state.filter} />
 			</div>
 		);
 	},
@@ -32,7 +51,7 @@ const Field = React.createClass({
 ReactDOM.render(
 	<div>
 		<h1>Fields Explorer</h1>
-		<Field type="Text" />
+		<FieldType type="Text" />
 	</div>,
 	document.getElementById('explorer')
 );

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -6,7 +6,17 @@ import { Col, Row } from 'elemental';
 
 const Types = {
 	Boolean: require('../types/boolean/test/explorer'),
+	Color: require('../types/color/test/explorer'),
+	Date: require('../types/date/test/explorer'),
+	Datetime: require('../types/datetime/test/explorer'),
+	Email: require('../types/email/test/explorer'),
+	Key: require('../types/key/test/explorer'),
+	Name: require('../types/name/test/explorer'),
+	Password: require('../types/password/test/explorer'),
 	Text: require('../types/text/test/explorer'),
+	Textarea: require('../types/textarea/test/explorer'),
+	Textarray: require('../types/textarray/test/explorer'),
+	Url: require('../types/url/test/explorer'),
 };
 const TypeKeys = Object.keys(Types);
 

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -5,8 +5,10 @@ import ReactDOM from 'react-dom';
 import { Col, Row } from 'elemental';
 
 const Types = {
+	Boolean: require('../types/boolean/test/explorer'),
 	Text: require('../types/text/test/explorer'),
 };
+const TypeKeys = Object.keys(Types);
 
 const FieldType = React.createClass({
 	getInitialState () {
@@ -62,7 +64,7 @@ const FieldType = React.createClass({
 ReactDOM.render(
 	<div>
 		<h1>Fields Explorer</h1>
-		<FieldType type="Text" />
+		{TypeKeys.map(type => <FieldType key={type} type={type} />)}
 	</div>,
 	document.getElementById('explorer')
 );

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -5,15 +5,7 @@ import ReactDOM from 'react-dom';
 import { Col, Row } from 'elemental';
 
 const Types = {
-	Text: {
-		Field: require('../types/text/TextField'),
-		Filter: require('../types/text/TextFilter'),
-		spec: {
-			label: 'Text Field',
-			path: 'textField',
-		},
-		value: '',
-	},
+	Text: require('../types/text/test/explorer'),
 };
 
 const FieldType = React.createClass({

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -1,3 +1,4 @@
+import Domify from 'react-domify';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -24,7 +25,8 @@ const FieldType = React.createClass({
 		};
 	},
 	onFieldChange (e) {
-		console.log(`${this.props.type} field value changed:`, e.value);
+		var logValue = typeof e.value === 'string' ? `"${e.value}"` : e.value;
+		console.log(`${this.props.type} field value changed:`, logValue);
 		this.setState({
 			value: e.value,
 		});
@@ -42,24 +44,22 @@ const FieldType = React.createClass({
 		return (
 			<div className="ExplorerField">
 				<h2>{this.props.type}</h2>
+				<h3>Field</h3>
 				<Row>
 					<Col sm="1/3">
-						<h3>Field</h3>
-						<FieldComponent path={spec.path} onChange={this.onFieldChange} value={this.state.value} />
+						<FieldComponent {...spec} onChange={this.onFieldChange} value={this.state.value} />
 					</Col>
 					<Col sm="2/3">
-						<h4>Value</h4>
-						{JSON.stringify(this.state.value)}
+						<Domify value={{ value: this.state.value }} />
 					</Col>
 				</Row>
+				<h3>Filter</h3>
 				<Row>
 					<Col sm="1/3">
-						<h3>Filter</h3>
 						<FilterComponent field={spec} onChange={this.onFilterChange} filter={this.state.filter} />
 					</Col>
 					<Col sm="2/3">
-						<h4>Value</h4>
-						{JSON.stringify(this.state.filter)}
+						<Domify value={this.state.filter} />
 					</Col>
 				</Row>
 			</div>

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -1,7 +1,38 @@
 const React = require('react');
 const ReactDOM = require('react-dom');
 
+const Types = {
+	Text: {
+		Field: require('../types/text/TextField'),
+		Filter: require('../types/text/TextFilter'),
+		spec: {
+			label: 'Text Field',
+			path: 'textField',
+		},
+	},
+};
+
+const Field = React.createClass({
+	render () {
+		const FieldComponent = Types[this.props.type].Field;
+		const FilterComponent = Types[this.props.type].Filter;
+		const spec = Types[this.props.type].spec;
+		return (
+			<div>
+				<h2>{this.props.type}</h2>
+				<h3>Field</h3>
+				<FieldComponent path={spec.path} onChange={(e) => console.log(e)} />
+				<h3>Filter</h3>
+				<FilterComponent field={spec} onChange={(e) => console.log(e)} />
+			</div>
+		);
+	},
+});
+
 ReactDOM.render(
-	<div>Fields Explorer</div>,
+	<div>
+		<h1>Fields Explorer</h1>
+		<Field type="Text" />
+	</div>,
 	document.getElementById('explorer')
 );

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -38,13 +38,12 @@ const FieldType = React.createClass({
 		return (
 			<div className="ExplorerField">
 				<h2>{this.props.type}</h2>
-				<h3>Field</h3>
 				<Row>
 					<Col sm="1/3">
 						<FieldComponent {...spec} onChange={this.onFieldChange} value={this.state.value} />
 					</Col>
-					<Col sm="2/3">
-						<Domify value={{ value: this.state.value }} />
+					<Col sm="2/3" style={{ paddingLeft: 50 }}>
+						<Domify className="Domify" value={{ value: this.state.value }} />
 					</Col>
 				</Row>
 				<h3>Filter</h3>
@@ -52,8 +51,8 @@ const FieldType = React.createClass({
 					<Col sm="1/3">
 						<FilterComponent field={spec} onChange={this.onFilterChange} filter={this.state.filter} />
 					</Col>
-					<Col sm="2/3">
-						<Domify value={this.state.filter} />
+					<Col sm="2/3" style={{ paddingLeft: 50 }}>
+						<Domify className="Domify" value={this.state.filter} />
 					</Col>
 				</Row>
 			</div>

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -1,5 +1,7 @@
-const React = require('react');
-const ReactDOM = require('react-dom');
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { Col, Row } from 'elemental';
 
 const Types = {
 	Text: {
@@ -15,9 +17,10 @@ const Types = {
 
 const FieldType = React.createClass({
 	getInitialState () {
+		const FilterComponent = Types[this.props.type].Filter;
 		return {
-			fieldValue: Types[this.props.type].value,
-			filterValue: {},
+			value: Types[this.props.type].value,
+			filter: FilterComponent.getDefaultValue(),
 		};
 	},
 	onFieldChange (e) {
@@ -39,10 +42,26 @@ const FieldType = React.createClass({
 		return (
 			<div className="ExplorerField">
 				<h2>{this.props.type}</h2>
-				<h3>Field</h3>
-				<FieldComponent path={spec.path} onChange={this.onFieldChange} value={this.state.value} />
-				<h3>Filter</h3>
-				<FilterComponent field={spec} onChange={this.onFilterChange} filter={this.state.filter} />
+				<Row>
+					<Col sm="1/3">
+						<h3>Field</h3>
+						<FieldComponent path={spec.path} onChange={this.onFieldChange} value={this.state.value} />
+					</Col>
+					<Col sm="2/3">
+						<h4>Value</h4>
+						{JSON.stringify(this.state.value)}
+					</Col>
+				</Row>
+				<Row>
+					<Col sm="1/3">
+						<h3>Filter</h3>
+						<FilterComponent field={spec} onChange={this.onFilterChange} filter={this.state.filter} />
+					</Col>
+					<Col sm="2/3">
+						<h4>Value</h4>
+						{JSON.stringify(this.state.filter)}
+					</Col>
+				</Row>
 			</div>
 		);
 	},

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -1,0 +1,7 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+
+ReactDOM.render(
+	<div>Fields Explorer</div>,
+	document.getElementById('explorer')
+);

--- a/fields/explorer/index.js
+++ b/fields/explorer/index.js
@@ -18,7 +18,7 @@ const Field = React.createClass({
 		const FilterComponent = Types[this.props.type].Filter;
 		const spec = Types[this.props.type].spec;
 		return (
-			<div>
+			<div className="ExplorerField">
 				<h2>{this.props.type}</h2>
 				<h3>Field</h3>
 				<FieldComponent path={spec.path} onChange={(e) => console.log(e)} />

--- a/fields/explorer/server.js
+++ b/fields/explorer/server.js
@@ -9,7 +9,7 @@ const packages = require('../../admin/client/packages');
 const app = new express();
 
 // Serve script bundles
-app.use('/js/explorer.js', browserify('./index.js', {
+app.use('/js/explorer.js', browserify('./fields/explorer/index.js', {
 	external: packages,
 	transform: [babelify.configure({
 		plugins: [require('babel-plugin-transform-object-rest-spread'), require('babel-plugin-transform-object-assign')],
@@ -31,13 +31,13 @@ const lessOptions = {
 		},
 	},
 };
-app.use('/styles', less(path.resolve('../../admin/public/styles'), lessOptions));
-app.use('/styles/fonts', express.static(path.resolve('../../admin/public/js/lib/tinymce/skins/keystone/fonts')));
-app.use(express.static('../../admin/public'));
+app.use('/styles', less(path.resolve('./admin/public/styles'), lessOptions));
+app.use('/styles/fonts', express.static(path.resolve('./admin/public/js/lib/tinymce/skins/keystone/fonts')));
+app.use(express.static('./admin/public'));
 
 // Serve the index template
-app.use('/', (req, res) => res.sendFile(path.resolve('./index.html')));
+app.use('/', (req, res) => res.sendFile(path.resolve('./fields/explorer/index.html')));
 
 app.listen(8000, function () {
-	console.log('Field Types Explorer listening on http://localhost:8000');
+	console.log('Field Types Explorer ready on http://localhost:8000');
 });

--- a/fields/explorer/server.js
+++ b/fields/explorer/server.js
@@ -1,0 +1,43 @@
+const babelify = require('babelify');
+const browserify = require('browserify-middleware');
+const express = require('express');
+const less = require('less-middleware');
+const path = require('path');
+
+const packages = require('../../admin/client/packages');
+
+const app = new express();
+
+// Serve script bundles
+app.use('/js/explorer.js', browserify('./index.js', {
+	external: packages,
+	transform: [babelify.configure({
+		plugins: [require('babel-plugin-transform-object-rest-spread'), require('babel-plugin-transform-object-assign')],
+		presets: [require('babel-preset-es2015'), require('babel-preset-react')],
+	})],
+}));
+
+
+// Serve stylesheet and static assets
+const elementalPath = path.join(path.dirname(require.resolve('elemental')), '..');
+const reactSelectPath = path.join(path.dirname(require.resolve('react-select')), '..');
+const lessOptions = {
+	render: {
+		modifyVars: {
+			adminPath: JSON.stringify('/'),
+			customStylesPath: '',
+			elementalPath: JSON.stringify(elementalPath),
+			reactSelectPath: JSON.stringify(reactSelectPath),
+		},
+	},
+};
+app.use('/styles', less(path.resolve('../../admin/public/styles'), lessOptions));
+app.use('/styles/fonts', express.static(path.resolve('../../admin/public/js/lib/tinymce/skins/keystone/fonts')));
+app.use(express.static('../../admin/public'));
+
+// Serve the index template
+app.use('/', (req, res) => res.sendFile(path.resolve('./index.html')));
+
+app.listen(8000, function () {
+	console.log('Field Types Explorer listening on http://localhost:8000');
+});

--- a/fields/types/boolean/test/explorer.js
+++ b/fields/types/boolean/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../BooleanField'),
+	Filter: require('../BooleanFilter'),
+	spec: {
+		label: 'Boolean Field',
+		path: 'boolean',
+	},
+	value: false,
+};

--- a/fields/types/color/test/explorer.js
+++ b/fields/types/color/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../ColorField'),
+	Filter: require('../ColorFilter'),
+	spec: {
+		label: 'Color Field',
+		path: 'color',
+	},
+	value: 'white',
+};

--- a/fields/types/date/test/explorer.js
+++ b/fields/types/date/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../DateField'),
+	Filter: require('../DateFilter'),
+	spec: {
+		label: 'Date Field',
+		path: 'date',
+	},
+	value: '2016-07-11',
+};

--- a/fields/types/datetime/test/explorer.js
+++ b/fields/types/datetime/test/explorer.js
@@ -1,0 +1,13 @@
+module.exports = {
+	Field: require('../DatetimeField'),
+	Filter: require('../DatetimeFilter'),
+	spec: {
+		label: 'Datetime Field',
+		path: 'datetime',
+		paths: {
+			date: 'datetime.date',
+			time: 'datetime.time',
+		},
+	},
+	value: new Date(),
+};

--- a/fields/types/email/test/explorer.js
+++ b/fields/types/email/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../EmailField'),
+	Filter: require('../EmailFilter'),
+	spec: {
+		label: 'Email Field',
+		path: 'email',
+	},
+	value: 'user@keystonejs.com',
+};

--- a/fields/types/key/test/explorer.js
+++ b/fields/types/key/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../KeyField'),
+	Filter: require('../KeyFilter'),
+	spec: {
+		label: 'Key Field',
+		path: 'key',
+	},
+	value: 'keystone',
+};

--- a/fields/types/name/test/explorer.js
+++ b/fields/types/name/test/explorer.js
@@ -1,0 +1,16 @@
+module.exports = {
+	Field: require('../NameField'),
+	Filter: require('../NameFilter'),
+	spec: {
+		label: 'Name Field',
+		path: 'name',
+		paths: {
+			first: 'name.first',
+			last: 'name.last',
+		},
+	},
+	value: {
+		first: 'Jed',
+		last: 'Watson',
+	},
+};

--- a/fields/types/password/test/explorer.js
+++ b/fields/types/password/test/explorer.js
@@ -1,0 +1,12 @@
+module.exports = {
+	Field: require('../PasswordField'),
+	Filter: require('../PasswordFilter'),
+	spec: {
+		label: 'Password Field',
+		path: 'password',
+		paths: {
+			confirm: 'password_confirm',
+		},
+	},
+	value: undefined,
+};

--- a/fields/types/text/test/explorer.js
+++ b/fields/types/text/test/explorer.js
@@ -5,5 +5,5 @@ module.exports = {
 		label: 'Text Field',
 		path: 'text',
 	},
-	value: '',
+	value: 'Hello World',
 };

--- a/fields/types/text/test/explorer.js
+++ b/fields/types/text/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../TextField'),
+	Filter: require('../TextFilter'),
+	spec: {
+		label: 'Text Field',
+		path: 'textField',
+	},
+	value: '',
+};

--- a/fields/types/text/test/explorer.js
+++ b/fields/types/text/test/explorer.js
@@ -3,7 +3,7 @@ module.exports = {
 	Filter: require('../TextFilter'),
 	spec: {
 		label: 'Text Field',
-		path: 'textField',
+		path: 'text',
 	},
 	value: '',
 };

--- a/fields/types/textarea/test/explorer.js
+++ b/fields/types/textarea/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../TextareaField'),
+	Filter: require('../TextareaFilter'),
+	spec: {
+		label: 'Textarea Field',
+		path: 'textarea',
+	},
+	value: 'Hello World',
+};

--- a/fields/types/textarray/test/explorer.js
+++ b/fields/types/textarray/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../TextarrayField'),
+	Filter: require('../TextarrayFilter'),
+	spec: {
+		label: 'Textarray Field',
+		path: 'textarray',
+	},
+	value: ['Hello', 'World'],
+};

--- a/fields/types/url/test/explorer.js
+++ b/fields/types/url/test/explorer.js
@@ -1,0 +1,9 @@
+module.exports = {
+	Field: require('../UrlField'),
+	Filter: require('../UrlFilter'),
+	spec: {
+		label: 'Url Field',
+		path: 'textarea',
+	},
+	value: 'http://keystonejs.com',
+};

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-dnd": "2.1.4",
     "react-dnd-html5-backend": "2.1.2",
     "react-dom": "15.2.0",
+    "react-domify": "^0.2.6",
     "react-redux": "4.4.5",
     "react-router": "2.5.2",
     "react-router-redux": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "url": "https://github.com/keystonejs/keystone.git"
   },
   "dependencies": {
-    "react-color": "2.2.0",
     "async": "1.5.2",
     "asyncdi": "1.1.0",
     "azure": "0.10.6",
@@ -23,6 +22,7 @@
     "blacklist": "1.1.2",
     "body-parser": "1.15.2",
     "browserify": "13.0.1",
+    "browserify-middleware": "^7.0.0",
     "browserify-shim": "3.8.12",
     "bytes": "2.4.0",
     "caller-id": "0.1.0",
@@ -71,6 +71,7 @@
     "react": "15.2.0",
     "react-addons-css-transition-group": "15.2.0",
     "react-alt-text": "2.0.0",
+    "react-color": "2.2.0",
     "react-day-picker": "2.3.3",
     "react-dnd": "2.1.4",
     "react-dnd-html5-backend": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "current": "updtr",
     "test-cov": "istanbul cover ./node_modules/mocha/bin/_mocha",
     "posttest-cov": "if [ -n \"$CODECLIMATE_REPO_TOKEN\" ]; then codeclimate-test-reporter < coverage/lcov.info; fi",
-    "clean": "rimraf ./coverage"
+    "clean": "rimraf ./coverage",
+    "fields-explorer": "node ./fields/explorer/server.js"
   },
   "engines": {
     "node": ">= 0.12.0",


### PR DESCRIPTION
As part of the effort to get all our field types reviewed, tested and up to spec I’ve created a UI explorer for the Field and Filter components.

It’s a bit of a hack, but hopefully an effective way to review the state of all the field components and work through whatever’s left to do on each of them in isolation.

To use it, run `npm run fields-explorer` and point your browser at http://localhost:8000/

Not all field types have explorer integrations yet because I’m still working through them, and some field types are more complex or are hitting errors.

To add a field type explorer, you add a `fields/types/{type}/test/explorer.js` file with the components and spec, then add it to the list in the `fields/explorer/index.js` file.

We need to make sure all the components are working as expected (i.e. are controlled inputs, respect previous values, update state with new input, etc) and should also review the quality of each field’s UI.

Explorers should be added for all field types; they should all be straight-forward except for the Relationship field which will need some custom stub endpoints added to the `server.js` file.