### PR TITLE
Max characters validation added

### DIFF
--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -8,6 +8,7 @@ var utils = require('keystone-utils');
  * @api public
  */
 function text (list, path, options) {
+	this.options = options;
 	this._nativeType = String;
 	this._properties = ['monospace'];
 	this._underscoreMethods = ['crop'];
@@ -17,8 +18,12 @@ text.properName = 'Text';
 util.inherits(text, FieldType);
 
 text.prototype.validateInput = function (data, callback) {
+	var max = this.options.max;
 	var value = this.getValueFromData(data);
 	var result = value === undefined || value === null || typeof value === 'string';
+	if (max && typeof value === 'string') {
+		result = value.length < max;
+	}
 	utils.defer(callback, result);
 };
 

--- a/fields/types/text/test/type.js
+++ b/fields/types/text/test/type.js
@@ -6,6 +6,10 @@ exports.initList = function (List) {
 		nested: {
 			text: String,
 		},
+		maxChar: {
+			type: String,
+			max: 55,
+		},
 	});
 };
 
@@ -128,6 +132,14 @@ exports.testFieldType = function (List) {
 				done();
 			});
 		});
+
+		it('should invalidate string over max characters', function (done) {
+			List.fields.maxChar.validateInput({ maxChar: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit' }, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
 	});
 
 	describe('validateRequiredInput', function () {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

We added max character validation to validateInput method and 'should invalidate string over max characters' test case

## Related issues (if any)
#126 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


