### PR TITLE
🔒 Add automated Let's Encrypt support 🎉

### DIFF
--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -56,11 +56,21 @@ function start (events) {
 		var ssl = keystone.get('ssl');
 		var unixSocket = keystone.get('unix socket');
 		var startupMessages = ['KeystoneJS Started:'];
+		var letsencrypt = keystone.get('letsencrypt');
 
 		async.parallel([
+			// Let's Encrypt
+			function (done) {
+				if (!letsencrypt || unixSocket) return done();
+				require('../../server/startLetsEncrypt')(keystone, app, function (err, msg) {
+					fireEvent('onHttpServerCreated');
+					startupMessages.push(msg);
+					done(err);
+				});
+			},
 			// HTTP Server
 			function (done) {
-				if (ssl === 'only' || unixSocket) return done();
+				if (ssl === 'only' || letsencrypt || unixSocket) return done();
 				require('../../server/startHTTPServer')(keystone, app, function (err, msg) {
 					fireEvent('onHttpServerCreated');
 					startupMessages.push(msg);
@@ -69,7 +79,7 @@ function start (events) {
 			},
 			// HTTPS Server
 			function (done) {
-				if (!ssl || unixSocket) return done();
+				if (!ssl || letsencrypt || unixSocket) return done();
 				require('../../server/startSecureServer')(keystone, app, function () {
 					fireEvent('onHttpsServerCreated');
 				}, function (err, msg) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "keystone-utils": "0.4.0",
     "knox": "0.9.2",
     "less-middleware": "2.2.0",
+    "letsencrypt-express": "^1.1.5",
     "list-to-array": "1.1.0",
     "lodash": "4.13.1",
     "mailgun-js": "^0.7.11",

--- a/server/startLetsEncrypt.js
+++ b/server/startLetsEncrypt.js
@@ -1,0 +1,100 @@
+/**
+ * Configures and starts express server via Let's Encrypt.
+ *
+ * Events are fired during initialisation to allow customisation, including:
+ *   - onHttpServerCreated
+ *
+ * consumed by lib/core/start.js
+ *
+ * @api private
+ */
+
+var async = require('async');
+var http = require('http');
+var https;
+try {
+	// Use spdy if available
+	https = require('spdy');
+} catch (e) {
+	https = require('https');
+}
+var path = require('path');
+var letsencrypt = require('letsencrypt-express');
+var letsencryptDir = path.join(require('os').homedir(), 'letsencrypt', 'etc');
+
+function sslRedirect (req, res) {
+	res.setHeader('Location', 'https://' + req.headers.host + req.url);
+	res.statusCode = 302;
+	res.end();
+}
+
+function autoRegister (domains, email) {
+	if (!Array.isArray(domains)) {
+		domains = [domains];
+	}
+	return function (hostname, approve) {
+		if (domains.indexOf(hostname) !== -1) {
+			console.warn("Keystone Let's Encrypt: Approving registration for " + hostname);
+			approve(null, {
+				domains: domains,
+				email: email,
+				agreeTos: true,
+			});
+		} else {
+			console.log("Keystone Let's Encrypt: Denying registration for " + hostname);
+			approve('Nope.');
+		}
+	};
+}
+module.exports = function (keystone, app, callback) {
+
+	var name = keystone.get('name');
+	var host = keystone.get('host') || '0.0.0.0';
+	var port = keystone.get('port') || 3000;
+	var forceSsl = (keystone.get('ssl') === 'force');
+	var sslHost = keystone.get('ssl host') || host;
+	var sslPort = keystone.get('ssl port') || port + 1;
+
+	var options = keystone.get('letsencrypt ');
+	var email = options.email;
+	var domains = options.domains;
+	var approveRegistration;
+	if (options.register) {
+		if (options.tos && email && domains) {
+			approveRegistration = autoRegister(domains, email);
+		} else {
+			callback("For auto registation with Let's Encrypt you should agree to the TOS, provide domains and a domain owner email");
+			return;
+		}
+	}
+	var instance = letsencrypt.create({
+		configDir: options.configDir || letsencryptDir,
+		onRequest: app,
+		approveRegistration: approveRegistration,
+		// TODO handleRenewFailure
+	});
+
+	async.parallel([
+		function (done) {
+			var serve = (forceSsl) ? sslRedirect : app;
+			keystone.httpServer = http.createServer(
+				letsencrypt.createAcmeResponder(instance, serve)
+			).listen(port, host, done);
+		},
+		function (done) {
+			keystone.httpsServer = https.createServer(
+				instance.httpsOptions,
+				letsencrypt.createAcmeResponder(instance, app)
+			).listen(sslPort, sslHost, done);
+		},
+	], 	function ready (err) {
+		if (err) { return callback(err); }
+
+		var message = name + ' is ready on '
+		+ 'http://' + host + ':' + port
+		+ (forceSsl ? ' (SSL redirect)' : '')
+		+ ' and ' + 'https://' + sslHost + ':' + sslPort;
+		callback(null, message);
+	});
+
+};


### PR DESCRIPTION
## Description of changes

Adds support for https://letsencrypt.org. All you need to do is enable it, set your domain name, and you will have https support!

Example configuration lines:
```
                'letsencrypt': (process.env.NODE_ENV === 'production'),
                'letsencrypt email': 'yours@foo.com',
                'letsencrypt domains': ['www.bar.com', 'bar.com'],
                'letsencrypt register': true,
                'letsencrypt agree TOS': true,
                'letsencrypt production': true,
```

## Testing

I didn't implement any tests for this. I suppose there could be a unit test that verifies it fails to accept registration without email and domain.


