### PR TITLE
Implement admin interface analytics

### DIFF
--- a/admin/client/Signin/Signin.js
+++ b/admin/client/Signin/Signin.js
@@ -13,6 +13,8 @@ import Brand from './components/Brand';
 import UserInfo from './components/UserInfo';
 import LoginForm from './components/LoginForm';
 
+import Analytics from '../utils/Analytics';
+
 var SigninView = React.createClass({
 	getInitialState () {
 		return {
@@ -25,6 +27,8 @@ var SigninView = React.createClass({
 		};
 	},
 	componentDidMount () {
+		Analytics.init();
+		Analytics.sendEvent('Page', 'render', 'Signin');
 		// Focus the email field when we're mounted
 		if (this.refs.email) {
 			ReactDOM.findDOMNode(this.refs.email).select();

--- a/admin/client/utils/Analytics.js
+++ b/admin/client/utils/Analytics.js
@@ -1,0 +1,40 @@
+/**
+ * Analytics
+ *
+ * Utility class to handle admin interface analytics. Exports Analytics.init, Analytics.sendEvent,
+ * Analytics.sendPageview and Analytics.send
+ */
+
+// Constants
+const TRACKER_NAME = 'adminui';
+const UA_STRING = 'UA-49258834-9';
+
+class Analytics {
+	// Initialize admin interface Google Analytics tracker
+	static init () {
+		this.ga('create', UA_STRING, 'auto', TRACKER_NAME);
+		this.sendPageview();
+	}
+
+	// Send an event
+	static sendEvent () {
+		this.send('event', ...arguments);
+	}
+
+	// Send a pageview
+	static sendPageview () {
+		this.send('pageview');
+	}
+
+	// Send something with our tracker name
+	static send () {
+		this.ga(`${TRACKER_NAME}.send`, ...arguments);
+	}
+
+	static ga () {
+		// TODO Gate here against option to disable
+		window.ga && window.ga(...arguments);
+	}
+}
+
+export default Analytics;

--- a/admin/server/templates/index.jade
+++ b/admin/server/templates/index.jade
@@ -70,13 +70,17 @@ html
 		script(src="#{adminPath}/js/packages.js")
 		script(src='#{adminPath}/js/fields.js')
 		script(src="#{adminPath}/js/admin.js")
-
-		//- Analytics (project-sepecific)
-		if env == 'production' && ga.property && ga.domain
-			script.
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-				ga('create', '#{ga.property}', '#{ga.domain}');
-				ga('send', 'pageview');
+				
+		// Google Analytics
+		script
+			| window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+			if env == 'production' && ga.domain && ga.property
+				// User analytics
+				| 
+				| ga('create', '#{ga.property}', '#{ga.domain}');
+				| ga('send', 'pageview');
+			// Admin interface analytics
+			| 
+			| ga('create', 'UA-49258834-9', 'auto', 'adminui');
+			| ga('adminui.send', 'pageview');
+		script(async='', src='https://www.google-analytics.com/analytics.js')

--- a/admin/server/templates/index.jade
+++ b/admin/server/templates/index.jade
@@ -65,13 +65,8 @@ html
 		if wysiwygOptions
 			script.
 				Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
-
-		//- Bundles
-		script(src="#{adminPath}/js/packages.js")
-		script(src='#{adminPath}/js/fields.js')
-		script(src="#{adminPath}/js/admin.js")
 				
-		// Google Analytics
+		// Initialize Google Analytics
 		script
 			| window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 			if env == 'production' && ga.domain && ga.property
@@ -79,8 +74,11 @@ html
 				| 
 				| ga('create', '#{ga.property}', '#{ga.domain}');
 				| ga('send', 'pageview');
-			// Admin interface analytics
-			| 
-			| ga('create', 'UA-49258834-9', 'auto', 'adminui');
-			| ga('adminui.send', 'pageview');
+		
+		//- Bundles
+		script(src="#{adminPath}/js/packages.js")
+		script(src='#{adminPath}/js/fields.js')
+		script(src="#{adminPath}/js/admin.js")
+		
+		// Google Analytics Script
 		script(async='', src='https://www.google-analytics.com/analytics.js')

--- a/admin/server/templates/signin.jade
+++ b/admin/server/templates/signin.jade
@@ -20,13 +20,17 @@ html
 				user: !{JSON.stringify(user || null)},
 				userCanAccessKeystone: !{user && user.canAccessKeystone ? 'true' : 'false'},
 			};
+			
+		// Initialize Google Analytics
+		script
+			| window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+			if env == 'production' && ga.domain && ga.property
+				// User analytics
+				| 
+				| ga('create', '#{ga.property}', '#{ga.domain}');
+				| ga('send', 'pageview');
+
 		script(src='#{adminPath}/js/signin.js')
-		//- Google Analytics
-		if env == 'production' && ga.property && ga.domain
-			script.
-				(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-				})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-				ga('create', '#{ga.property}', '#{ga.domain}');
-				ga('send', 'pageview');
+
+		// Google Analytics Script
+		script(async='', src='https://www.google-analytics.com/analytics.js')


### PR DESCRIPTION
This is a first pass at implementing admin interface analytics. By abstracting Google Analytics behind a common `Analytics` class we only need a single gate to disable it with an option. (not yet implemented)

This is a very rough early prototype to test the waters if anybody can think of a better approach. @keystonejs/core-devs

Ref: #3075 

**DO NOT MERGE, PROTOTYPE**
