### PR TITLE
Added minimum character validation

### DIFF
--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -19,10 +19,14 @@ util.inherits(text, FieldType);
 
 text.prototype.validateInput = function (data, callback) {
 	var max = this.options.max;
+	var min = this.options.min;
 	var value = this.getValueFromData(data);
 	var result = value === undefined || value === null || typeof value === 'string';
 	if (max && typeof value === 'string') {
 		result = value.length < max;
+	}
+	if (min && typeof value === 'string') {
+		result = value.length > min;
 	}
 	utils.defer(callback, result);
 };

--- a/fields/types/text/test/type.js
+++ b/fields/types/text/test/type.js
@@ -12,7 +12,7 @@ exports.initList = function (List) {
 		},
 		minChar: {
 			type: String,
-			min: 5,
+			min: 10,
 		},
 	});
 };

--- a/fields/types/text/test/type.js
+++ b/fields/types/text/test/type.js
@@ -10,6 +10,10 @@ exports.initList = function (List) {
 			type: String,
 			max: 55,
 		},
+		minChar: {
+			type: String,
+			min: 5,
+		},
 	});
 };
 
@@ -135,6 +139,13 @@ exports.testFieldType = function (List) {
 
 		it('should invalidate string over max characters', function (done) {
 			List.fields.maxChar.validateInput({ maxChar: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit' }, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
+		it('should invalidate string shorter than min characters', function (done) {
+			List.fields.minChar.validateInput({ minChar: 'Short' }, function (result) {
 				demand(result).be.false();
 				done();
 			});


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Minimum character validation added to `validateInput` method.
Test case added - `should invalidate string shorter than min characters`.

## Related issues (if any)
 
#126 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


