### PR TITLE
connect-mongo: Reuse the mongoose connection

### DIFF
--- a/lib/core/initExpressApp.js
+++ b/lib/core/initExpressApp.js
@@ -1,7 +1,7 @@
 module.exports = function initExpressApp (customApp) {
 	if (this.app) return this;
 	this.initDatabase();
-	this.initExpressSession();
+	this.initExpressSession(this.mongoose);
 	if (customApp) {
 		this.app = customApp;
 		require('../../server/createApp')(this);

--- a/lib/core/initExpressSession.js
+++ b/lib/core/initExpressSession.js
@@ -4,7 +4,7 @@ var cookieParser = require('cookie-parser');
 var debug = require('debug')('keystone:core:initExpressSession');
 var Promise = require('es6-promise').Promise;
 
-module.exports = function initExpressSession () {
+module.exports = function initExpressSession (mongoose) {
 
 	if (this.expressSession) return this;
 
@@ -68,7 +68,7 @@ module.exports = function initExpressSession () {
 				}
 				_.defaults(sessionStoreOptions, {
 					collection: 'app_sessions',
-					url: this.get('mongo'),
+					mongooseConnection: mongoose.connection,
 				});
 				break;
 

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -17,7 +17,7 @@ module.exports = function createApp (keystone, express) {
 	var app = keystone.app;
 
 	keystone.initDatabase();
-	keystone.initExpressSession();
+	keystone.initExpressSession(keystone.mongoose);
 
 	require('./initTrustProxy')(keystone, app);
 	require('./initViewEngine')(keystone, app);

--- a/server/startLetsEncrypt.js
+++ b/server/startLetsEncrypt.js
@@ -25,7 +25,7 @@ var letsencryptDir = path.join(require('os').homedir(), 'letsencrypt', 'etc');
 function makeSslRedirect (app) {
 	return function sslRedirect (req, res) {
 		// This runs outside Express, so use pure NodeJS only
-		const s = req.socket
+		const s = req.socket;
 		if (s && s.remoteAddress === '127.0.0.1' && s.localAddress === '127.0.0.1' && !req.headers['x-forwarded-for']) {
 			return app(req, res);
 		} else {
@@ -33,7 +33,7 @@ function makeSslRedirect (app) {
 			res.statusCode = 302;
 			res.end();
 		}
-	}
+	};
 }
 
 function autoRegister (domains, email) {


### PR DESCRIPTION
## Description of changes

I had trouble using sessions with a MongoDB Replicaset. It would work initially, but then suddenly stop working, hanging at session retrieval.

Since we are using Mongoose anyway, I figured we can give its connection to connect-mongo, which is more efficient, and that seems to have cleared up the issue (so far).

I believe this to be a safe change, because before, the code was force-setting `url`, which overrode other connection mechanisms.

## Related issues (if any)

https://github.com/kcbanner/connect-mongo/issues/227

