### PR TITLE
Auto-build mongo text indexes for searchable fields

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -26,8 +26,9 @@ function List(key, options) {
 		track: false,
 		inherits: false,
 		searchFields: '__name__',
+		searchUsesTextIndex: false,
 		defaultSort: '__default__',
-		defaultColumns: '__name__'
+		defaultColumns: '__name__',
 	};
 
 	// initialFields values are initialised on demand by the getter
@@ -172,6 +173,8 @@ List.prototype.updateAll = require('./list/updateAll');
 List.prototype.getUniqueValue = require('./list/getUniqueValue');
 List.prototype.getPages = require('./list/getPages');
 List.prototype.paginate = require('./list/paginate');
+List.prototype.buildSearchTextIndex = require('./list/buildSearchTextIndex');
+List.prototype.declaresTextIndex = require('./list/declaresTextIndex');
 
 /*!
  * Export class

--- a/lib/list/addFiltersToQuery.js
+++ b/lib/list/addFiltersToQuery.js
@@ -1,11 +1,16 @@
+var debug = require('debug')('keystone:core:list:addFiltersToQuery');
+
 function addFiltersToQuery (filters, query) {
 	var fields = Object.keys(this.fields);
+	
 	query = query || {};
 	fields.forEach(function (path) {
 		var field = this.fields[path];
 		if (!field.addFilterToQuery || !filters[field.path]) return;
 		field.addFilterToQuery(filters[field.path], query);
 	}, this);
+	
+	debug('Adding filters to query for list \'' + list.key + '\', returned:', query);
 	return query;
 }
 

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -1,5 +1,6 @@
 var assign = require('object-assign');
 var utils = require('keystone-utils');
+var debug = require('debug')('keystone:core:list:addSearchToQuery');
 
 function trim(i) { return i.trim(); }
 function truthy(i) { return i; }
@@ -54,6 +55,7 @@ function addSearchToQuery (searchString, query) {
 		assign(query, searchFilters[0]);
 	}
 
+	debug('Adding search to query for list \'' + list.key + '\', returned:', query);
 	return query;
 }
 

--- a/lib/list/buildSearchTextIndex.js
+++ b/lib/list/buildSearchTextIndex.js
@@ -1,0 +1,33 @@
+
+/**
+ * Returns either false if the list has no search fields defined or a structure 
+ * describing the text index that should exist.
+ */
+function buildSearchTextIndex () {
+	var list = this;
+	var idxDef = {};
+	
+	for (var i = 0; i < list.searchFields.length; i ++) {
+		var sf = list.searchFields[i];
+		if (!sf.path || !sf.field) continue;
+		// Also maybe skip the field if it: a) isn't type === 'name' and b) doesn't have typeof _nativeType === 'string'
+		
+		// Does the field have a single path or does it use nested values (like 'name')
+		if (sf.field.paths) {
+			var nFields = sf.field.paths;
+			var nKeys = Object.keys(nFields);
+			for (var n = 0; n < nKeys.length; n ++) {
+				idxDef[nFields[nKeys[n]]] = 'text';
+			}
+		}
+		else if (sf.field.path) {
+			idxDef[sf.field.path] = 'text';
+		}
+	}
+	
+	// debug('text index for \'' + list.key + '\':', idxDef);
+	return Object.keys(idxDef).length > 0 ? idxDef : false;
+}
+
+
+module.exports = buildSearchTextIndex;

--- a/lib/list/declaresTextIndex.js
+++ b/lib/list/declaresTextIndex.js
@@ -1,0 +1,23 @@
+
+/**
+ * Look for a text index defined in the current list schema; returns boolean
+ * Note this doesn't check for text indexes that exist in the DB
+ */
+function declaresTextIndex (list) {
+	var list = this;
+	var indexes = list.schema.indexes();
+	
+	for (var i = 0; i < indexes.length; i ++) {
+		var fields = indexes[i][0];
+		var fieldNames = Object.keys(fields);
+					
+		for (var h = 0; h < fieldNames.length; h ++) {
+			var val = fields[fieldNames[h]];
+			if (typeof val == 'string' && val.toLowerCase() === 'text') return true;
+		}
+	}
+	return false;
+}
+
+
+module.exports = declaresTextIndex;

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -2,6 +2,8 @@ var _ = require('underscore');
 var moment = require('moment');
 var utils = require('keystone-utils');
 
+var debug = require('debug')('keystone:core:list:getSearchFilters');
+
 /**
  * Gets filters for a Mongoose query that will search for the provided string,
  * based on the searchFields List option.
@@ -237,6 +239,7 @@ function getSearchFilters (search, add) {
 		});
 	}
 	
+	debug('Applying filters to list \'' + list.key + '\':', filters);
 	return filters;
 }
 

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -21,66 +21,73 @@ var utils = require('keystone-utils');
 function getSearchFilters (search, add) {
 	var filters = {};
 	var list = this;
-
+	
 	search = String(search || '').trim();
-
+		
 	if (search.length) {
-		var searchFilter;
-		var searchParts = search.split(' ');
-		var searchRx = new RegExp(utils.escapeRegExp(search), 'i');
-		var splitSearchRx = new RegExp((searchParts.length > 1) ? _.map(searchParts, utils.escapeRegExp).join('|') : search, 'i');
-		var searchFields = this.get('searchFields');
-		var searchFilters = [];
-		var searchIdField = utils.isValidObjectId(search);
-
-		if ('string' === typeof searchFields) {
-			searchFields = searchFields.split(',');
+		// Use the text index if both a) it's enabled by the list and b) we have one
+		// If searchUsesTextIndex is true AND the list defines it's own custom text index this might not behave as expected.
+		// In this scenario you'll also get an error when the list is register()'ed though so hopefully someone will have noticed that..
+		if (this.options.searchUsesTextIndex && this.declaresTextIndex()) {
+			filters.$text = { $search: search };
 		}
+		else {
+			var searchFilter;
+			var searchParts = search.split(' ');
+			var searchRx = new RegExp(utils.escapeRegExp(search), 'i');
+			var splitSearchRx = new RegExp((searchParts.length > 1) ? _.map(searchParts, utils.escapeRegExp).join('|') : search, 'i');
+			var searchFields = this.get('searchFields');
+			var searchFilters = [];
+			var searchIdField = utils.isValidObjectId(search);
 
-		searchFields.forEach(function (path) {
-			path = path.trim();
-
-			if (path === '__name__') {
-				path = list.mappings.name;
+			if ('string' === typeof searchFields) {
+				searchFields = searchFields.split(',');
 			}
 
-			var field = list.fields[path];
+			searchFields.forEach(function (path) {
+				path = path.trim();
 
-			if (field && field.type === 'name') {
-				var first = {};
-				first[field.paths.first] = splitSearchRx;
-				var last = {};
-				last[field.paths.last] = splitSearchRx;
+				if (path === '__name__') {
+					path = list.mappings.name;
+				}
+
+				var field = list.fields[path];
+
+				if (field && field.type === 'name') {
+					var first = {};
+					first[field.paths.first] = splitSearchRx;
+					var last = {};
+					last[field.paths.last] = splitSearchRx;
+					searchFilter = {};
+					searchFilter.$or = [first, last];
+					searchFilters.push(searchFilter);
+				} else {
+					searchFilter = {};
+					searchFilter[path] = searchRx;
+					searchFilters.push(searchFilter);
+				}
+			});
+
+			if (list.autokey) {
 				searchFilter = {};
-				searchFilter.$or = [first, last];
-				searchFilters.push(searchFilter);
-			} else {
-				searchFilter = {};
-				searchFilter[path] = searchRx;
+				searchFilter[list.autokey.path] = searchRx;
 				searchFilters.push(searchFilter);
 			}
-		});
 
-		if (list.autokey) {
-			searchFilter = {};
-			searchFilter[list.autokey.path] = searchRx;
-			searchFilters.push(searchFilter);
+			if (searchIdField) {
+				searchFilter = {};
+				searchFilter._id = search;
+				searchFilters.push(searchFilter);
+			}
+
+			if (searchFilters.length > 1) {
+				filters.$or = searchFilters;
+			} else if (searchFilters.length) {
+				filters = searchFilters[0];
+			}
 		}
-
-		if (searchIdField) {
-			searchFilter = {};
-			searchFilter._id = search;
-			searchFilters.push(searchFilter);
-		}
-
-		if (searchFilters.length > 1) {
-			filters.$or = searchFilters;
-		} else if (searchFilters.length) {
-			filters = searchFilters[0];
-		}
-
 	}
-
+	
 	if (add) {
 		_.each(add, function(filter) {
 			var cond;
@@ -229,6 +236,7 @@ function getSearchFilters (search, add) {
 			}
 		});
 	}
+	
 	return filters;
 }
 

--- a/lib/list/register.js
+++ b/lib/list/register.js
@@ -2,6 +2,8 @@ var keystone = require('../../');
 var schemaPlugins = require('../schemaPlugins');
 var UpdateHandler = require('../updateHandler');
 var utils = require('keystone-utils');
+var debug = require('debug')('keystone:core:list:register');
+
 
 /**
  * Registers the Schema with Mongoose, and the List with Keystone
@@ -28,11 +30,43 @@ function register() {
 	this.schema.method('getUpdateHandler', function(req, res, ops) {
 		return new UpdateHandler(list, this, req, res, ops);
 	});
+	
+	// If the list is configured to use a text index for search..
+	if (this.options.searchUsesTextIndex) {
+		var textIndex = this.buildSearchTextIndex();
+		
+		// .. and there are valid fields to search and there isn't already a text index manually defined for the list..
+		// .. then add one to the list now
+		if (textIndex && !this.declaresTextIndex()) {
+			debug('Ensuring text index for list \'' + list.key + '\':', textIndex);
+			// Always set a name; if there are too many fields included the default name will be too long
+			this.schema.index(textIndex, { name: 'searchFields_text_index' });
+		}
+	}
+	
 	if (this.get('inherits')) {
 		this.model = this.get('inherits').model.discriminator(this.key, this.schema);
 	} else {
 		this.model = keystone.mongoose.model(this.key, this.schema);
 	}
+	
+	// Add a listener for model events; some of this stuff is important
+	// http://mongoosejs.com/docs/api.html#model_Model
+	this.model.on('index', function (err) {
+		if (err) console.error('Mongoose model \'index\' event fired on \'' + list.key + '\' with error:\n', err.message, err.stack);
+	});
+	this.model.on('index-single-start', function (index) {
+		debug('Mongoose model \'index-single-start\' event fired on \'' + list.key + '\' for index:\n', index);
+	});
+	this.model.on('index-single-done', function (err, index) {
+		if (err) console.error('Mongoose model \'index-single-done\' event fired on \'' + list.key + '\' for index:\n', index, '\nWith error:\n', err.message, err.stack);
+		else debug('Mongoose model \'index-single-done\' event fired on \'' + list.key + '\' for index:\n', index);
+	});
+	this.model.on('error', function (err) {
+		if (err) console.error('Mongoose model \'error\' event fired on \'' + list.key + '\' with error:\n', err.message, err.stack);
+	});
+	
+	
 	keystone.list(this);
 	return this;
 }


### PR DESCRIPTION
Introduces a `searchUsesTextIndex` flag for lists that causes Keystone to create text indexes for the specified `searchFields` while being registered (defaults to false). Listeners have been added so that, if mongo returns an error during index creation, it will bubble out to stderr. If a text index has already been specified *in the Keystone list definition* no new text index will be added (only one text index can exist on a collection).

The `searchUsesTextIndex` flag is also used to enable the filtering logic that utilises these indexes for searches initiated from the admin UI. 

I've also added some debug calls (using the npm `debug` module) to some of the functions that deal with query/filter generation.

The main effect of the above changes is to dramatically reduce response time when searching large lists using the Keystone admin UI. However search behaviour differs slightly compared to the default regex based search. In both cases all `searchFields` are searched for all terms and the search remains case insensitive but, when using text indexes the search behaviour, *only whole words are matched*.

Eg. given a value like `address: {street: '191 Clarence St', suburb: 'Sydney', state: 'NSW'}` in which all fields are indexed, a search for 'clarence Sydney' will return the document with either the text index or regex based approaches but, when searching for just 'clarence syd', the text index search will not return the document since 'syd' doesn't match any complete words.