### PR TITLE
ItemsTableRow to handles 'id' columns

### DIFF
--- a/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
+++ b/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
@@ -38,6 +38,10 @@ const ItemsRow = React.createClass({
 		});
 		// item fields
 		var cells = this.props.columns.map((col, i) => {
+			if (col.type === 'id') {
+				col.field = {};
+				col.type = 'text';
+			}
 			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
 			var linkTo = !i ? `${Keystone.adminPath}/${this.props.list.path}/${itemId}` : undefined;
 			return <ColumnType key={col.path} list={this.props.list} col={col} data={item} linkTo={linkTo} />;

--- a/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
+++ b/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
@@ -38,10 +38,6 @@ const ItemsRow = React.createClass({
 		});
 		// item fields
 		var cells = this.props.columns.map((col, i) => {
-			if (col.type === 'id') {
-				col.field = {};
-				col.type = 'text';
-			}
 			var ColumnType = Columns[col.type] || Columns.__unrecognised__;
 			var linkTo = !i ? `${Keystone.adminPath}/${this.props.list.path}/${itemId}` : undefined;
 			return <ColumnType key={col.path} list={this.props.list} col={col} data={item} linkTo={linkTo} />;

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -21,6 +21,12 @@ function buildFieldTypesStream (fieldTypes) {
 			if (typeof fieldTypes[type] !== 'string') return;
 			src += type + ': require("../../fields/types/' + type + '/' + fieldTypes[type] + i + '"),\n';
 		});
+		// Append ID and Unrecognised column types
+		if (i === 'Column') {
+			src += 'id: require("../../fields/components/columns/IdColumn"),\n';
+			src += '__unrecognised__: require("../../fields/components/columns/InvalidColumn"),\n';
+		}
+
 		src += '};\n';
 	});
 	return str(src);


### PR DESCRIPTION
With `Columns.__unrecognised__` currently not existing, and 'id' columns have a set of values not stored in keystone.

This solution allows ID columns to render but leaves two underlying problems:

There should be handling for 'id' fields, or id columns should have the type text intrinsically.

When passing props, the id column object in `itemsTable` has an empty field object, but this does not seem to be passed down.

This addresses issues #3130 and the most common case of #3157.