### PR TITLE
Removing hardcoded keystone references in the API

### DIFF
--- a/admin/api/cloudinary.js
+++ b/admin/api/cloudinary.js
@@ -1,9 +1,10 @@
 var cloudinary = require('cloudinary');
-var keystone = require('../../');
 
 exports = module.exports = {
 
 	upload: function(req, res) {
+		var keystone = req.keystone;
+		
 		if(req.files && req.files.file){
 			var options = {};
 

--- a/admin/api/download.js
+++ b/admin/api/download.js
@@ -1,12 +1,13 @@
 var _ = require('underscore');
 var async = require('async');
 var baby = require('babyparse');
-var keystone = require('../../');
 var moment = require('moment');
 
 var FN_ARGS = /^function\s*[^\(]*\(\s*([^\)]*)\)/m;
 
 exports = module.exports = function(req, res) {
+
+	var keystone = req.keystone;
 
 	var filters = req.list.processFilters(req.query.q);
 	var queryFilters = req.list.getSearchFilters(req.query.search, filters);

--- a/admin/api/item/delete.js
+++ b/admin/api/item/delete.js
@@ -1,6 +1,6 @@
-var keystone = require('../../../');
-
 module.exports = function(req, res) {
+	var keystone = req.keystone;
+	
 	if (!keystone.security.csrf.validate(req)) {
 		return res.apiError('invalid csrf');
 	}

--- a/admin/api/item/get.js
+++ b/admin/api/item/get.js
@@ -1,8 +1,9 @@
 var _ = require('underscore');
 var async = require('async');
-var keystone = require('../../../');
 
 module.exports = function(req, res) {
+
+	var keystone = req.keystone;
 
 	var query = req.list.model.findById(req.params.id);
 

--- a/admin/api/list.js
+++ b/admin/api/list.js
@@ -1,10 +1,11 @@
 var _ = require('underscore');
 var async = require('async');
-var keystone = require('../../');
 var jade = require('jade');
 
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	var sendResponse = function(status) {
 		res.json(status);
 	};

--- a/admin/api/list/delete.js
+++ b/admin/api/list/delete.js
@@ -1,7 +1,8 @@
 var async = require('async');
-var keystone = require('../../../');
 
 module.exports = function(req, res) {
+	var keystone = req.keystone;
+
 	if (!keystone.security.csrf.validate(req)) {
 		return res.apiError('invalid csrf');
 	}

--- a/admin/api/session/signin.js
+++ b/admin/api/session/signin.js
@@ -1,8 +1,8 @@
 var utils = require('keystone-utils');
-var keystone = require('../../../');
 var session = require('../../../lib/session');
 
 function signin (req, res) {
+	var keystone = req.keystone;
 	if (!keystone.security.csrf.validate(req)) {
 		return res.status(403).json({ error: 'invalid csrf' });
 	}

--- a/admin/api/session/signout.js
+++ b/admin/api/session/signout.js
@@ -1,6 +1,5 @@
-var keystone = require('../../../');
-
 function signout (req, res) {
+	var keystone = req.keystone;
 	var user = req.user;
 	keystone.callHook(user, 'pre:signout', function(err) {
 		if (err) return res.json({ error: 'pre:signout error', detail: err });

--- a/admin/routes/views/home.js
+++ b/admin/routes/views/home.js
@@ -1,7 +1,7 @@
-var keystone = require('../../../');
-
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	keystone.render(req, res, 'home', {
 		section: 'home',
 		page: 'home',

--- a/admin/routes/views/item.js
+++ b/admin/routes/views/item.js
@@ -1,9 +1,10 @@
-var keystone = require('../../../');
 var _ = require('underscore');
 var async = require('async');
 
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	var itemQuery = req.list.model.findById(req.params.item).select();
 
 	itemQuery.exec(function(err, item) {

--- a/admin/routes/views/list.js
+++ b/admin/routes/views/list.js
@@ -1,9 +1,10 @@
-var keystone = require('../../../');
 var _ = require('underscore');
 var querystring = require('querystring');
 
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	var viewLocals = {
 		validationErrors: {},
 		showCreateForm: _.has(req.query, 'new')

--- a/admin/routes/views/signin.js
+++ b/admin/routes/views/signin.js
@@ -1,9 +1,10 @@
-var keystone = require('../../../');
 var session = require('../../../lib/session');
 var url = require('url');
 
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	function renderView() {
 		keystone.render(req, res, 'signin', {
 			submitted: req.body,

--- a/admin/routes/views/signout.js
+++ b/admin/routes/views/signout.js
@@ -1,8 +1,9 @@
-var keystone = require('../../../');
 var session = require('../../../lib/session');
 
 exports = module.exports = function(req, res) {
 
+	var keystone = req.keystone;
+	
 	session.signout(req, res, function() {
 
 		if ('string' === typeof keystone.get('signout redirect')) {

--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -395,6 +395,12 @@ function mount(mountPath, parentApp, events) {
 	app.use(methodOverride());
 	app.use(sessionOptions.cookieParser);
 
+	// Bind the request to the keystone instance
+	app.use(function(req, res, next) {
+		req.keystone = keystone;
+		next();
+	});
+
 	// Pre session config
 	if ('function' === typeof this.get('pre:session')) {
 		debug('configuring pre:session middleware');

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,5 +1,4 @@
 var _ = require('underscore');
-var keystone = require('../');
 var schemaPlugins = require('./schemaPlugins');
 var utils = require('keystone-utils');
 
@@ -10,8 +9,13 @@ var utils = require('keystone-utils');
  * @param {Object} options
  */
 
-function List(key, options) {
-	if (!(this instanceof List)) return new List(key, options);
+function List(key, options, keystone) {
+	if (!(this instanceof List)) return new List(key, options, keystone);
+
+	if (!keystone)
+		keystone = require('../');
+
+	this.keystone = keystone;
 
 	var defaultOptions = {
 		schema: {

--- a/lib/list/register.js
+++ b/lib/list/register.js
@@ -1,4 +1,3 @@
-var keystone = require('../../');
 var schemaPlugins = require('../schemaPlugins');
 var UpdateHandler = require('../updateHandler');
 var utils = require('keystone-utils');
@@ -10,6 +9,7 @@ var utils = require('keystone-utils');
  */
 function register() {
 	var list = this;
+	var keystone = this.keystone;
 	this.schema.virtual('list').get(function () {
 		return list;
 	});

--- a/lib/list/relationship.js
+++ b/lib/list/relationship.js
@@ -1,10 +1,10 @@
-var keystone = require('../../');
 var utils = require('keystone-utils');
 
 /**
  * Registers relationships to this list defined on others
  */
 function relationship (def) {
+	var keystone = this.keystone;
 	if (arguments.length > 1) {
 		for (var i = 0; i < arguments.length; i++) {
 			this.relationship(arguments[i]);


### PR DESCRIPTION
This PR is analogous for your recent commit for v0.4  (10897d1d73778dcbf8688d49d794336ec8b988a8), adopted for v0.3.
Note: I haven't looked at the `content/` stuff yet.