### PR TITLE
Fixed issue with RelationshipField auto complete feature

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -117,7 +117,7 @@ module.exports = Field.create({
 	},
 
 	buildOptionQuery: function (input) {
-		var value = input && input[0] && input[0].value || '';
+		var value = (input && input[0] && input[0].value) || input || '';
 		var filters = this.buildFilters();
 		return 'context=relationship&q=' + value +
 				'&list=' + Keystone.list.path +


### PR DESCRIPTION
## Description of changes

Fixed issue with RelationshipField auto complete feature
## Related issues (if any)

Auto complete was not forwarding the `q` params to the API
## Testing
- [ ] Please confirm `npm run test-all` ran successfully.
