### PR TITLE
implement fix to determine whether input param is string or object an…

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -117,7 +117,12 @@ module.exports = Field.create({
 	},
 
 	buildOptionQuery: function (input) {
-		var value = input && input[0] && input[0].value || '';
+		var value = '';
+		if(typeof input === 'string' && input.length) {
+			value = input;
+		}else if(typeof input === 'object' && input[0] && input[0].value) {
+			value = input[0].value;
+		}
 		var filters = this.buildFilters();
 		return 'context=relationship&q=' + value +
 				'&list=' + Keystone.list.path +


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
modified the `getOptions` function in `RelationshipField` to discern between `input` type. if the input type is a string the ternary breaks and returns '' as `q=`.  Added logic to check `typeof` an act accordingly.


## Related issues (if any)
https://github.com/keystonejs/keystone/pull/3043
There could be others. I am not sure there are a bunch of issues regarding autocomplete/relationships

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

`npm run test-all` doesn't exist in this branch
`npm run test` passes
`npm run build` technically works. just not on windows because of npm, but the gulp command works.

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


…d act accordingly to set q  value