### PR TITLE
Bugfix-3112 Admin path added to editable options

### DIFF
--- a/admin/public/js/content/editor.js
+++ b/admin/public/js/content/editor.js
@@ -35,7 +35,7 @@ jQuery(function ($) {
 		switch (data.type) {
 
 			case 'list':
-				var href = data.adminPath + '/' + data.path;
+				var href = data.path;
 				var label = 'Manage ' + data.plural;
 
 				if (data.id) {

--- a/admin/public/js/content/editor.js
+++ b/admin/public/js/content/editor.js
@@ -1,6 +1,5 @@
 jQuery(function ($) {
 
-	var adminPath = (typeof Keystone !== 'undefined' && Keystone.adminPath) ? Keystone.adminPath : '/keystone';
 	var refs = $('[data-ks-editable]');
 
 	function addButton ($editable, href, label) {
@@ -36,7 +35,7 @@ jQuery(function ($) {
 		switch (data.type) {
 
 			case 'list':
-				var href = adminPath + '/' + data.path;
+				var href = data.adminPath + '/' + data.path;
 				var label = 'Manage ' + data.plural;
 
 				if (data.id) {

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -220,6 +220,7 @@ Content.prototype.editable = function (user, options) {
 			path: list.path,
 			singular: list.singular,
 			plural: list.plural,
+      adminPath: keystone.get('admin path'),
 		};
 
 		if (options.id) {

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -217,10 +217,9 @@ Content.prototype.editable = function (user, options) {
 
 		var data = {
 			type: 'list',
-			path: list.path,
+			path: keystone.get('admin path') + '/' + list.path,
 			singular: list.singular,
 			plural: list.plural,
-      adminPath: keystone.get('admin path'),
 		};
 
 		if (options.id) {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Admin path added to editable options


## Related issues (if any)
#3112 

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


