### PR TITLE
Add lodash import to RelationshipField, resolve #3241

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -5,6 +5,7 @@ import React from 'react';
 import Select from 'react-select';
 import xhr from 'xhr';
 import { Button, InputGroup } from 'elemental';
+import _ from 'lodash';
 
 function compareValues (current, next) {
 	const currentLength = current ? current.length : 0;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Have added lodash as a dependency to RelationshipField as it appears to have been removed and the component breaks when updating filters. 

You can replicate this with a default 0.4.0 set up and check the Author relationship on Post model in the Admin UI.


## Related issues (if any)

Resolves https://github.com/keystonejs/keystone/issues/3241

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

Unit tests are running successfully, but I am having issues running selenium on my machine. It just opens up an empty firefox browser. I will try and sort this.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


