### PR TITLE
Fixes #2941 duplicate UI fields with inheritance

### DIFF
--- a/admin/client/App/shared/CreateForm.js
+++ b/admin/client/App/shared/CreateForm.js
@@ -134,8 +134,12 @@ const CreateForm = React.createClass({
 		}
 
 		// Render inputs for all initial fields
-		Object.keys(list.initialFields).forEach(key => {
-			var field = list.fields[list.initialFields[key]];
+		for (var initialField of list.initialFields) {
+			let field = list.fields[initialField];
+			// don't output hidden fields
+			if (field.hidden) {
+				continue;
+			}
 			// If there's something weird passed in as field type, render the
 			// invalid field type component
 			if (typeof Fields[field.type] !== 'function') {
@@ -143,7 +147,7 @@ const CreateForm = React.createClass({
 				return;
 			}
 			// Get the props for the input field
-			var fieldProps = this.getFieldProps(field);
+			let fieldProps = this.getFieldProps(field);
 			// If there was no focusRef set previously, set the current field to
 			// be the one to be focussed. Generally the first input field, if
 			// there's an initial name field that takes precedence.
@@ -151,7 +155,7 @@ const CreateForm = React.createClass({
 				fieldProps.ref = focusRef = 'focusTarget';
 			}
 			form.push(React.createElement(Fields[field.type], fieldProps));
-		});
+		}
 
 		return (
 			<Form

--- a/lib/list.js
+++ b/lib/list.js
@@ -91,7 +91,7 @@ module.exports = function (keystone) {
 			return (this.fields[this.mappings.name] && this.fields[this.mappings.name].options.initial === undefined);
 		} });
 		Object.defineProperty(this, 'initialFields', { get: function () {
-			return initialFields || (initialFields = _.filter(this.fields, function (i) { return i.initial; }));
+			return initialFields || (initialFields = _.filter(this.fields, i => i.initial));
 		} });
 		if (this.get('sortable')) {
 			schemaPlugins.sortable.apply(this);

--- a/lib/list/add.js
+++ b/lib/list/add.js
@@ -6,18 +6,19 @@ var utils = require('keystone-utils');
  * Based on Mongoose's Schema.add
  */
 function add () {
-	var add = function (obj, prefix) {
+	var add = (obj, prefix) => {
 		prefix = prefix || '';
-		var keys = Object.keys(obj);
-		for (var i = 0; i < keys.length; ++i) {
-			var key = keys[i];
+		for (var key in obj) {
 			if (!obj[key]) {
 				throw new Error(
 					'Invalid value for schema path `' + prefix + key + '` in `' + this.key + '`.\n'
 					+ 'Did you misspell the field type?\n'
 				);
 			}
-			if (utils.isObject(obj[key]) && (!obj[key].constructor || obj[key].constructor.name === 'Object') && (!obj[key].type || obj[key].type.type)) {
+			if (utils.isObject(obj[key])
+				&& (!obj[key].constructor || obj[key].constructor.name === 'Object')
+				&& (!obj[key].type || obj[key].type.type)
+			) {
 				if (Object.keys(obj[key]).length) {
 					// nested object, e.g. { last: { name: String }}
 					// matches logic in mongoose/Schema:add
@@ -30,34 +31,34 @@ function add () {
 				addField(prefix + key, obj[key]);
 			}
 		}
-	}.bind(this);
+	};
 
-	var addField = function (path, options) {
+	var addField = (path, options) => {
+		var idx;
 		if (this.isReserved(path)) {
-			throw new Error('Path ' + path + ' on list ' + this.key + ' is a reserved path');
+			throw new Error(`Path ${path} on list ${this.key} is a reserved path`);
 		}
-		this.uiElements.push({
+		idx = _.findIndex(this.uiElements, ['field.path', path]);
+		idx = idx !== -1 ? idx : this.uiElements.length;
+		this.uiElements[idx] = {
 			type: 'field',
 			field: this.field(path, options),
-		});
-	}.bind(this);
+		};
+	};
 
-	var args = Array.prototype.slice.call(arguments);
-	var self = this;
-
-	_.forEach(args, function (def) {
-		self.schemaFields.push(def);
+	_.forEach([...arguments], (def) => {
+		this.schemaFields.push(def);
 		if (typeof def === 'string') {
 			if (def === '>>>') {
-				self.uiElements.push({
+				this.uiElements.push({
 					type: 'indent',
 				});
 			} else if (def === '<<<') {
-				self.uiElements.push({
+				this.uiElements.push({
 					type: 'outdent',
 				});
 			} else {
-				self.uiElements.push({
+				this.uiElements.push({
 					type: 'heading',
 					heading: def,
 					options: {},
@@ -65,7 +66,7 @@ function add () {
 			}
 		} else {
 			if (def.heading && typeof def.heading === 'string') {
-				self.uiElements.push({
+				this.uiElements.push({
 					type: 'heading',
 					heading: def.heading,
 					options: def,

--- a/test/e2e/adminUI/tests/group999FixMe/2941.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2941.js
@@ -23,10 +23,10 @@ module.exports = {
 		browser.app.waitForInitialFormScreen();
 
 
-		// Issue demonstration - the field should not be visible, but it is.
+		// Issue demonstration - the field should not be present, but it is.
 
 		browser.initialFormPage.section.form.section.hiddenrelationshipList.section.fieldA
-			.expect.element('@label').to.not.be.visible;
+			.expect.element('@label').to.not.be.present;
 
 		browser.initialFormPage.cancel();
 


### PR DESCRIPTION
## Description of changes
`list.uiElements` were not populated properly: all fields from the both `Base` and `Child` collections were added to this array, causing duplicate fields in UI vs `list.fields` object that has the only one instance of each field.

## Testing
- [ ] Please confirm `node test/e2e/server.js --env chrome --config ./test/e2e/adminUI/nightwatch.json --test test/e2e/adminUI/tests/group999FixMe/2941.js` ran successfully.