### PR TITLE
add window.open for click handler of relationship field

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -184,6 +184,13 @@ module.exports = Field.create({
 		}
 	},
 
+	handleOptionLabelClick: function(value, event) {
+		var refPath = this.props.refList.path;
+		if(value && value.value && refPath) {
+			window.open('/keystone/'+refPath+'/'+value.value);
+		}
+	},
+
 	renderField: function() {
 		if (!this.state.ready) {
 			return this.renderLoadingUI();
@@ -198,7 +205,7 @@ module.exports = Field.create({
 			);
 		}
 
-		body.push(<Select multi={this.props.many} onChange={this.updateValue} name={this.props.path} asyncOptions={this.getOptions} value={this.state.expandedValues} />);
+		body.push(<Select multi={this.props.many} onChange={this.updateValue} name={this.props.path} asyncOptions={this.getOptions} value={this.state.expandedValues} onOptionLabelClick={this.handleOptionLabelClick} />);
 
 		return body;
 	}


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
WARNING: OPINIONATED
We were having a lot of issues going into our related fields from page to page. I modified the relationship field class to add the onOptionLabelClick handler to the Select (react-select) field. It works. 

IMO, its better than nothing.


## Related issues (if any)


## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


