### PR TITLE
Relationship Field: Fix inline create popup close

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -181,7 +181,7 @@ module.exports = Field.create({
 			complete: true,
 			options: Object.keys(this._itemsCache).map((k) => this._itemsCache[k]),
 		});
-		this.toggleCreate(false);
+		this.closeCreate();
 	},
 
 	renderSelect (noedit) {


### PR DESCRIPTION
Without this change, the create popup stays put and the console gets an error about toggleCreate missing.