### PR TITLE
disable "back url" icon in main navigation via config

### DIFF
--- a/admin/client/App/components/Navigation/Primary/index.js
+++ b/admin/client/App/components/Navigation/Primary/index.js
@@ -45,20 +45,20 @@ var PrimaryNavigation = React.createClass({
 			</PrimaryNavItem>
 		);
 	},
-  // Render the back button
-  renderBackButton () {
-    if (!Keystone.backUrl) return null;
+	// Render the back button
+	renderBackButton () {
+		if (!Keystone.backUrl) return null;
 
-    return (
-      <PrimaryNavItem
-          label="octicon-globe"
-          href={Keystone.backUrl}
-          title={'Front page - ' + this.props.brand}
-        >
-          <span className="octicon octicon-globe" />
-        </PrimaryNavItem>
-    );
-  },
+		return (
+			<PrimaryNavItem
+				label="octicon-globe"
+				href={Keystone.backUrl}
+				title={'Front page - ' + this.props.brand}
+			>
+				<span className="octicon octicon-globe" />
+			</PrimaryNavItem>
+		);
+	},
 	// Render the link to the webpage
 	renderFrontLink () {
 		return (

--- a/admin/client/App/components/Navigation/Primary/index.js
+++ b/admin/client/App/components/Navigation/Primary/index.js
@@ -45,17 +45,25 @@ var PrimaryNavigation = React.createClass({
 			</PrimaryNavItem>
 		);
 	},
+  // Render the back button
+  renderBackButton () {
+    if (!Keystone.backUrl) return null;
+
+    return (
+      <PrimaryNavItem
+          label="octicon-globe"
+          href={Keystone.backUrl}
+          title={'Front page - ' + this.props.brand}
+        >
+          <span className="octicon octicon-globe" />
+        </PrimaryNavItem>
+    );
+  },
 	// Render the link to the webpage
 	renderFrontLink () {
 		return (
 			<ul className="app-nav app-nav--primary app-nav--right">
-				<PrimaryNavItem
-					label="octicon-globe"
-					href={Keystone.backUrl}
-					title={'Front page - ' + this.props.brand}
-				>
-					<span className="octicon octicon-globe" />
-				</PrimaryNavItem>
+				{this.renderBackButton()}
 				{this.renderSignout()}
 			</ul>
 		);

--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -17,10 +17,12 @@ module.exports = function IndexRoute (req, res) {
 		return _.pick(list, ['key', 'label', 'path']);
 	});
 
+	var backUrl = keystone.get('back url') || keystone.get('back url') === undefined ? keystone.get('back url') : '/';
+
 	var keystoneData = {
 		adminPath: '/' + keystone.get('admin path'),
 		appversion: keystone.get('appversion'),
-		backUrl: (_.isString(keystone.get('back url')) || _.isUndefined(keystone.get('back url'))) ? keystone.get('back url') : '/',
+		backUrl: backUrl,
 		brand: keystone.get('brand'),
 		csrf: { header: {} },
 		devMode: !!process.env.KEYSTONE_DEV,

--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -20,7 +20,7 @@ module.exports = function IndexRoute (req, res) {
 	var keystoneData = {
 		adminPath: '/' + keystone.get('admin path'),
 		appversion: keystone.get('appversion'),
-		backUrl: keystone.get('back url') || '/',
+		backUrl: (_.isString(keystone.get('back url')) || _.isUndefined(keystone.get('back url'))) ? keystone.get('back url') : '/',
 		brand: keystone.get('brand'),
 		csrf: { header: {} },
 		devMode: !!process.env.KEYSTONE_DEV,


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
* allow option 'back url' to be undefined (as the only falsy value), otherwise still overwrite with `/`
* create separate method to render back button in React component `PrimaryNavigation`
    * check for `Keystone.backUrl` to be truthy
    * skip rendering the back button if falsy


## Related issues (if any)


## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

