### PR TITLE
Removed most of azure from dependancies

### DIFF
--- a/fields/types/azurefile/AzureFileType.js
+++ b/fields/types/azurefile/AzureFileType.js
@@ -82,7 +82,7 @@ Object.defineProperty(azurefile.prototype, 'azurefileconfig', {
  */
 azurefile.prototype.addToSchema = function (schema) {
 
-	var azure = require('azure');
+	var azure = require('azure-storage');
 
 	var field = this;
 
@@ -209,7 +209,7 @@ azurefile.prototype.updateItem = function (item, data, callback) {
  */
 azurefile.prototype.uploadFile = function (item, file, update, callback) {
 
-	var azure = require('azure');
+	var azure = require('azure-storage');
 
 	var field = this;
 	var filetype = file.mimetype || file.type;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aphrodite": "^0.5.0",
     "async": "2.0.1",
     "asyncdi": "1.1.0",
-    "azure": "0.10.6",
+    "azure-storage": "^1.2.0",
     "babel-core": "6.10.4",
     "babel-plugin-transform-object-assign": "6.8.0",
     "babel-preset-es2015": "6.9.0",


### PR DESCRIPTION
## Description of changes

This PR removes most of azure, replacing the umbrella dependancy `azure` with the much more specific `azure-storage`. The azure library is literally `azure-storage` with some extra stuff we don't use.

We're going to remove this storage adapter anyway, but this is such a cheap win.

Pre:

```
$ du -hs node_modules
244M	node_modules
```

Post:

```
$ du -hs node_modules
199M	node_modules
```


## Related issues (if any)

None

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

This code is impossible to test properly because the azure storage engine doesn't have unit tests.