### PR TITLE
Correctly show new filename when upload has finished

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -36,6 +36,14 @@ module.exports = Field.create({
 	shouldCollapse () {
 		return this.props.collapse && !this.hasExisting();
 	},
+	componentWillUpdate (nextProps) {
+		// Show the new filename when it's finished uploading
+		if (this.props.value.filename !== nextProps.value.filename) {
+			this.setState({
+				userSelectedFile: null,
+			});
+		}
+	},
 
 	// ==============================
 	// HELPERS


### PR DESCRIPTION
Closes #3268

Verified by creating a new File item and then changing the file multiple times afterwards. This works on both new uploads and removes.