### PR TITLE
Allow select type to link to item in column

### DIFF
--- a/fields/components/columns/IdColumn.js
+++ b/fields/components/columns/IdColumn.js
@@ -14,7 +14,7 @@ var IdColumn = React.createClass({
 		if (!value) return null;
 
 		return (
-			<ItemsTableValue padded interior title={value} href={Keystone.adminPath + '/' + this.props.list.path + '/' + value} field={this.props.col.type}>
+			<ItemsTableValue padded interior title={value} to={Keystone.adminPath + '/' + this.props.list.path + '/' + value} field={this.props.col.type}>
 				{value}
 			</ItemsTableValue>
 		);

--- a/fields/components/test/ItemTableValue.test.js
+++ b/fields/components/test/ItemTableValue.test.js
@@ -31,7 +31,7 @@ describe('<ItemsTableValue/> tests', () => {
 
 	it('should render <Link> with default properties and css class', () => {
 		const actualUrl = 'http://hello.world';
-		const tableValue = shallow(<ItemsTableValue href={actualUrl} />);
+		const tableValue = shallow(<ItemsTableValue to={actualUrl} />);
 
 		demand(tableValue.name()).eql('Link');
 		demand(tableValue.prop('href')).eql(actualUrl);

--- a/fields/types/email/EmailColumn.js
+++ b/fields/types/email/EmailColumn.js
@@ -13,7 +13,7 @@ var EmailColumn = React.createClass({
 		if (!value) return;
 
 		return (
-			<ItemsTableValue href={'mailto:' + value} padded exterior field={this.props.col.type}>
+			<ItemsTableValue to={'mailto:' + value} padded exterior field={this.props.col.type}>
 				{value}
 			</ItemsTableValue>
 		);

--- a/fields/types/name/NameColumn.js
+++ b/fields/types/name/NameColumn.js
@@ -18,7 +18,7 @@ var NameColumn = React.createClass({
 	render () {
 		return (
 			<ItemsTableCell>
-				<ItemsTableValue href={this.props.linkTo} padded interior field={this.props.col.type}>
+				<ItemsTableValue to={this.props.linkTo} padded interior field={this.props.col.type}>
 					{this.renderValue()}
 				</ItemsTableValue>
 			</ItemsTableCell>

--- a/fields/types/relationship/RelationshipColumn.js
+++ b/fields/types/relationship/RelationshipColumn.js
@@ -25,7 +25,7 @@ var RelationshipColumn = React.createClass({
 				items.push(<span key={'comma' + i}>, </span>);
 			}
 			items.push(
-				<ItemsTableValue interior truncate={false} key={'anchor' + i} href={Keystone.adminPath + '/' + refList.path + '/' + value[i].id}>
+				<ItemsTableValue interior truncate={false} key={'anchor' + i} to={Keystone.adminPath + '/' + refList.path + '/' + value[i].id}>
 					{value[i].name}
 				</ItemsTableValue>
 			);
@@ -43,7 +43,7 @@ var RelationshipColumn = React.createClass({
 		if (!value) return;
 		const refList = this.props.col.field.refList;
 		return (
-			<ItemsTableValue href={Keystone.adminPath + '/' + refList.path + '/' + value.id} padded interior field={this.props.col.type}>
+			<ItemsTableValue to={Keystone.adminPath + '/' + refList.path + '/' + value.id} padded interior field={this.props.col.type}>
 				{value.name}
 			</ItemsTableValue>
 		);

--- a/fields/types/select/SelectColumn.js
+++ b/fields/types/select/SelectColumn.js
@@ -7,18 +7,21 @@ var SelectColumn = React.createClass({
 	propTypes: {
 		col: React.PropTypes.object,
 		data: React.PropTypes.object,
+		linkTo: React.PropTypes.string,
 	},
-	renderValue () {
+	getValue () {
 		const value = this.props.data.fields[this.props.col.path];
 		const option = this.props.col.field.ops.filter(i => i.value === value)[0];
 
 		return option ? option.label : null;
 	},
 	render () {
+		const value = this.getValue();
+		const empty = !value && this.props.linkTo ? true : false;
 		return (
 			<ItemsTableCell>
-				<ItemsTableValue field={this.props.col.type}>
-					{this.renderValue()}
+				<ItemsTableValue field={this.props.col.type} to={this.props.linkTo} empty={empty}>
+					{value}
 				</ItemsTableValue>
 			</ItemsTableCell>
 		);

--- a/fields/types/text/TextColumn.js
+++ b/fields/types/text/TextColumn.js
@@ -20,7 +20,7 @@ var TextColumn = React.createClass({
 		const className = this.props.col.field.monospace ? 'ItemList__value--monospace' : undefined;
 		return (
 			<ItemsTableCell>
-				<ItemsTableValue className={className} href={this.props.linkTo} empty={empty} padded interior field={this.props.col.type}>
+				<ItemsTableValue className={className} to={this.props.linkTo} empty={empty} padded interior field={this.props.col.type}>
 					{value}
 				</ItemsTableValue>
 			</ItemsTableCell>

--- a/fields/types/url/UrlColumn.js
+++ b/fields/types/url/UrlColumn.js
@@ -22,7 +22,7 @@ var UrlColumn = React.createClass({
 		var label = value.replace(/^https?\:\/\//i, '');
 
 		return (
-			<ItemsTableValue href={href} padded exterior field={this.props.col.type}>
+			<ItemsTableValue to={href} padded exterior field={this.props.col.type}>
 				{label}
 			</ItemsTableValue>
 		);


### PR DESCRIPTION
## Description of changes

When using a select field as the name field, it breaks linking in the item view. This PR fixes it using code similar to the TextColumn.
