### PR TITLE
Adding support for binding express.Router with keystone.set('routes')

### DIFF
--- a/server/createApp.js
+++ b/server/createApp.js
@@ -118,8 +118,22 @@ module.exports = function createApp (keystone, express) {
 	});
 
 	// Configure application routes
-	if (typeof keystone.get('routes') === 'function') {
-		keystone.get('routes')(app);
+	var appRouter = keystone.get('routes');
+	if (typeof appRouter === 'function') {
+		if (appRouter.length === 3) {
+			// new:
+			//    var myRouter = new express.Router();
+			//    myRouter.get('/', (req, res) => res.send('hello world'));
+			//    keystone.set('routes', myRouter);
+			app.use(appRouter);
+		} else {
+			// old:
+			//    var initRoutes = function (app) {
+			//      app.get('/', (req, res) => res.send('hello world'));
+			//    }
+			//    keystone.set('routes', initRoutes);
+			appRouter(app);
+		}
 	}
 
 


### PR DESCRIPTION
This adds support for using express router instances instead of binding routes on the root express app. It is backwards compatible with the old method of binding routes.

Previously application routes needed to be set on the express app that Keystone initialises, like this:

```js
var initRoutes = function (app) {
  app.get('/', (req, res) => res.send('hello world'));
}
keystone.set('routes', initRoutes);
```

Now, you can provide an `express.Router` instance, which will be used by keystone’s app instance:

```js
var myRouter = new express.Router();
myRouter.get('/', (req, res) => res.send('hello world'));
keystone.set('routes', myRouter);
```