### PR TITLE
feat (admin ui custom field): extend keystone field with application custom field

### DIFF
--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -11,12 +11,12 @@ var express = require('express');
 var less = require('less-middleware');
 var path = require('path');
 var str = require('string-to-stream');
-var compose = require('../../../fields/utils/compose').default;
+var compose = require('../../../fields/utils/compose');
 
 function buildFieldTypesStream (next) {
 	return (fieldTypes) => {
 		var types = Object.keys(fieldTypes);
-		let sections = { Columns: {}, Fields: {}, Filters: {} };
+		var sections = { Columns: {}, Fields: {}, Filters: {} };
 		['Column', 'Field', 'Filter'].forEach(i => {
 			types.forEach(type => {
 				sections[i + 's'][type] = '../../fields/types/' + type + '/' + fieldTypes[type] + i;
@@ -30,8 +30,9 @@ function buildFieldTypesStream (next) {
 	};
 }
 
-function finalFieldsSrcStream (sections = { Columns: {}, Fields: {}, Filters: {} }) {
-	let src = '';
+function finalFieldsSrcStream (sections) {
+	sections = sections || { Columns: {}, Fields: {}, Filters: {} };
+	var src = '';
 	Object.keys(sections).forEach(section => {
 		src += 'module.exports.' + section + ' = {\n';
 		Object.keys(sections[section]).forEach(type => {

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -11,22 +11,33 @@ var express = require('express');
 var less = require('less-middleware');
 var path = require('path');
 var str = require('string-to-stream');
+var compose = require('../../../fields/utils/compose').default;
 
-function buildFieldTypesStream (fieldTypes) {
-	var src = '';
-	var types = Object.keys(fieldTypes);
-	['Column', 'Field', 'Filter'].forEach(function (i) {
-		src += 'exports.' + i + 's = {\n';
-		types.forEach(function (type) {
-			if (typeof fieldTypes[type] !== 'string') return;
-			src += type + ': require("../../fields/types/' + type + '/' + fieldTypes[type] + i + '"),\n';
+function buildFieldTypesStream (next) {
+	return (fieldTypes) => {
+		var types = Object.keys(fieldTypes);
+		let sections = { Columns: {}, Fields: {}, Filters: {} };
+		['Column', 'Field', 'Filter'].forEach(i => {
+			types.forEach(type => {
+				sections[i + 's'][type] = '../../fields/types/' + type + '/' + fieldTypes[type] + i;
+			});
+			if (i === 'Column') {
+				sections[i + 's'].id = '../../fields/components/columns/IdColumn';
+				sections[i + 's'].__unrecognised__ = '../../fields/components/columns/InvalidColumn';
+			}
 		});
-		// Append ID and Unrecognised column types
-		if (i === 'Column') {
-			src += 'id: require("../../fields/components/columns/IdColumn"),\n';
-			src += '__unrecognised__: require("../../fields/components/columns/InvalidColumn"),\n';
-		}
+		return next(sections);
+	};
+}
 
+function finalFieldsSrcStream (sections = { Columns: {}, Fields: {}, Filters: {} }) {
+	let src = '';
+	Object.keys(sections).forEach(section => {
+		src += 'module.exports.' + section + ' = {\n';
+		Object.keys(sections[section]).forEach(type => {
+			const path = sections[section][type];
+			src += type + ': require("' + path + '"), \n';
+		});
 		src += '};\n';
 	});
 	return str(src);
@@ -34,10 +45,15 @@ function buildFieldTypesStream (fieldTypes) {
 
 module.exports = function createStaticRouter (keystone) {
 	var router = express.Router();
+	if (typeof keystone.middlewareFieldTypes !== 'function') {
+		keystone.middlewareFieldTypes = next => sections => next(sections);
+	}
+
+	const makeFieldTypeSrcStream = compose(buildFieldTypesStream, keystone.middlewareFieldTypes)(finalFieldsSrcStream);
 
 	/* Prepare browserify bundles */
 	var bundles = {
-		fields: browserify(buildFieldTypesStream(keystone.fieldTypes), 'FieldTypes'),
+		fields: browserify(makeFieldTypeSrcStream(keystone.fieldTypes), 'FieldTypes', keystone.fieldsLookupPaths || []),
 		signin: browserify('./Signin/index.js'),
 		admin: browserify('./App/index.js'),
 	};

--- a/admin/server/app/test/createStaticRouter.test.js
+++ b/admin/server/app/test/createStaticRouter.test.js
@@ -4,7 +4,7 @@ import request from 'supertest';
 import path from 'path';
 import demand from 'must';
 
-describe.only('createStaticRouter', () => {
+describe('createStaticRouter', () => {
 	let keystone = {
 		get (confKey) {
 			switch (confKey) {
@@ -18,7 +18,7 @@ describe.only('createStaticRouter', () => {
 		fieldTypes: { boolean: 'Boolean' },
 	};
 
-	it.skip('given no config, it should serve `FieldTypes` bundle normally', done => {
+	it('given no config, it should serve `FieldTypes` bundle normally', done => {
 		const router = createStaticRouter(keystone);
 		const app = express();
 		app.use(router);

--- a/admin/server/app/test/createStaticRouter.test.js
+++ b/admin/server/app/test/createStaticRouter.test.js
@@ -1,0 +1,72 @@
+import createStaticRouter from '../createStaticRouter';
+import express from 'express';
+import request from 'supertest';
+import path from 'path';
+import demand from 'must';
+
+describe.only('createStaticRouter', () => {
+	let keystone = {
+		get (confKey) {
+			switch (confKey) {
+				case 'admin path':
+					return 'keystone';
+			}
+		},
+		getPath () {
+			return '';
+		},
+		fieldTypes: { boolean: 'Boolean' },
+	};
+
+	it.skip('given no config, it should serve `FieldTypes` bundle normally', done => {
+		const router = createStaticRouter(keystone);
+		const app = express();
+		app.use(router);
+		request(app)
+			.get('/js/fields.js')
+			.expect('Content-Type', 'application/javascript')
+			.end((err, res) => {
+				demand(err).be.null();
+				done();
+			});
+	});
+
+	it('given correct field middleware config, it should serve `FieldTypes` bundle normally', done => {
+		const custoKeystone = Object.assign({}, keystone, {
+			middlewareFieldTypes: next => sections => {
+				sections.Fields.custofield = path.join(__dirname, './custofield/custofieldField.js');
+				return next(sections);
+			},
+		});
+		const router = createStaticRouter(custoKeystone);
+		const app = express();
+		app.use(router);
+		request(app)
+			.get('/js/fields.js')
+			.expect('Content-Type', 'application/javascript')
+			.end((err, res) => {
+				demand(err).be.null();
+				done();
+			});
+	});
+
+	it('given middleware config, given custom field lookup path, it should serve `FieldTypes` bundle normally', done => {
+		const custoKeystone = Object.assign({}, keystone, {
+			middlewareFieldTypes: next => sections => {
+				sections.Fields.custofield = 'custofield/custofieldField.js';
+				return next(sections);
+			},
+			fieldsLookupPaths: [__dirname],
+		});
+		const router = createStaticRouter(custoKeystone);
+		const app = express();
+		app.use(router);
+		request(app)
+			.get('/js/fields.js')
+			.expect('Content-Type', 'application/javascript')
+			.end((err, res) => {
+				demand(err).be.null();
+				done();
+			});
+	});
+});

--- a/admin/server/app/test/custofield/custofieldField.js
+++ b/admin/server/app/test/custofield/custofieldField.js
@@ -1,0 +1,1 @@
+// test field type admin

--- a/admin/server/middleware/browserify.js
+++ b/admin/server/middleware/browserify.js
@@ -26,7 +26,7 @@ function logError (file, err) {
 	console.log(ts() + chalk.red('error building ' + chalk.underline(file) + ':') + '\n' + err.message);
 }
 
-module.exports = function (file, name) {
+module.exports = function (file, name, lookupPaths) {
 	var b;
 	var building = false;
 	var queue = [];
@@ -34,6 +34,8 @@ module.exports = function (file, name) {
 	var src;
 	var logName = typeof file === 'string' ? file.replace(/^\.\//, '') : name;
 	var fileName = logName;
+	var moreLookupPaths = lookupPaths || [];
+
 	if (fileName.substr(-3) !== '.js') fileName += '.js';
 	function writeBundle (buff) {
 		if (devWriteBundles) {
@@ -57,7 +59,8 @@ module.exports = function (file, name) {
 		var babelify = require('babelify');
 		var browserify = require('browserify');
 		var watchify = require('watchify');
-		var opts = { basedir: basedir };
+		var opts = { basedir: basedir, paths: moreLookupPaths };
+		console.log(opts);
 		if (devMode) {
 			logInit(logName);
 			opts.debug = true;

--- a/fields/utils/compose.js
+++ b/fields/utils/compose.js
@@ -1,0 +1,24 @@
+/**
+ * Composes single-argument functions from right to left. The rightmost
+ * function can take multiple arguments as it provides the signature for
+ * the resulting composite function.
+ *
+ * @param {...Function} funcs The functions to compose.
+ * @returns {Function} A function obtained by composing the argument functions
+ * from right to left. For example, compose(f, g, h) is identical to doing
+ * (...args) => f(g(h(...args))).
+ */
+
+export default function compose (...funcs) {
+	if (funcs.length === 0) {
+		return arg => arg;
+	}
+
+	if (funcs.length === 1) {
+		return funcs[0];
+	}
+
+	const last = funcs[funcs.length - 1];
+	const rest = funcs.slice(0, -1);
+	return (...args) => rest.reduceRight((composed, f) => f(composed), last(...args));
+}

--- a/fields/utils/compose.js
+++ b/fields/utils/compose.js
@@ -9,9 +9,10 @@
  * (...args) => f(g(h(...args))).
  */
 
-export default function compose (...funcs) {
+module.exports = function compose () {
+	var funcs = Array.prototype.slice.call(arguments);
 	if (funcs.length === 0) {
-		return arg => arg;
+		return function (arg) { return arg; };
 	}
 
 	if (funcs.length === 1) {
@@ -20,5 +21,10 @@ export default function compose (...funcs) {
 
 	const last = funcs[funcs.length - 1];
 	const rest = funcs.slice(0, -1);
-	return (...args) => rest.reduceRight((composed, f) => f(composed), last(...args));
-}
+	return function () {
+		var args = Array.prototype.slice.call(arguments);
+		return rest.reduceRight(function (composed, f) {
+			return f(composed);
+		}, last.apply(null, args));
+	};
+};

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "rimraf": "2.5.4",
     "sinon": "1.17.5",
     "superagent": "1.8.3",
-    "supertest": "1.2.0",
+    "supertest": "^1.2.0",
     "uglify-js": "2.7.0",
     "updtr": "0.2.1",
     "watch": "0.19.1"


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Extend keystone admin UI field with custom field defined by application.

## Related issues (if any)


## Testing
- [x] Add Unit test for `createStaticRouter`
- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->
