### PR TITLE
Fixed path to templates

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -53,7 +53,7 @@ function Field(list, path, options) {
 	}
 
 	// Set up templates
-	this.templateDir = fspath.normalize(options.templateDir || (__dirname + '../../templates/fields/' + this.type));
+	this.templateDir = fspath.normalize(options.templateDir || fspath.join(__dirname, '../templates/fields/', this.type));
 
 	var defaultTemplates = {
 		form: this.templateDir + '/' + 'form.jade',
@@ -254,19 +254,19 @@ Field.prototype.validateInput = function(data, required, item) {
  */
 
 Field.prototype.updateItem = function(item, data) {
-	
+
 	var value = this.getValueFromData(data);
-	
+
 	// This is a deliberate type coercion so that numbers from forms play nice
 	if (value !== undefined && value != item.get(this.path)) { // jshint ignore:line
 		item.set(this.path, value);
 	}
-	
+
 };
 
 /**
  * Retrieves the value from an object, whether the path is nested or flattened
- * 
+ *
  * @api public
  */
 


### PR DESCRIPTION
## Description of changes

Fixes path to field templates
## Related issues (if any)

When trying to run my keystone app, I was getting this error:

```
ENOENT: no such file or directory, open '.../node_modules/keystone/lib/templates/fields/date/form.jade'
  at Error (native)
  at Object.fs.openSync (fs.js:634:18)
  at Object.fs.readFileSync (fs.js:502:33)
  at date.Field.render (.../node_modules/keystone/lib/field.js:321:17)
  at eval (<anonymous>:1815:42)
```
## Testing
- [x] Please confirm `npm run test-all` ran successfully.
