### PR TITLE
Full text search

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -10,7 +10,7 @@ module.exports = function (keystone) {
 
 		var defaultOptions = {
 			schema: {
-				collection: keystone.prefixModel(key)
+				collection: keystone.prefixModel(key),
 			},
 			noedit: false,
 			nocreate: false,

--- a/lib/list.js
+++ b/lib/list.js
@@ -177,6 +177,7 @@ module.exports = function (keystone) {
 	List.prototype.validateInput = require('./list/validateInput');
 	List.prototype.buildSearchTextIndex = require('./list/buildSearchTextIndex');
 	List.prototype.declaresTextIndex = require('./list/declaresTextIndex');
+	List.prototype.actuallyEnsureTextIndex = require('./list/actuallyEnsureTextIndex');
 
 	return List;
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -6,12 +6,11 @@ module.exports = function (keystone) {
 
 	function List (key, options) {
 		if (!(this instanceof List)) return new List(key, options);
-
 		this.keystone = keystone;
 
 		var defaultOptions = {
 			schema: {
-				collection: keystone.prefixModel(key),
+				collection: keystone.prefixModel(key)
 			},
 			noedit: false,
 			nocreate: false,
@@ -21,8 +20,8 @@ module.exports = function (keystone) {
 			hidden: false,
 			track: false,
 			inherits: false,
-			perPage: 100,
 			searchFields: '__name__',
+			searchUsesTextIndex: false,
 			defaultSort: '__default__',
 			defaultColumns: '__name__',
 		};
@@ -176,6 +175,8 @@ module.exports = function (keystone) {
 	List.prototype.updateItem = require('./list/updateItem');
 	List.prototype.underscoreMethod = require('./list/underscoreMethod');
 	List.prototype.validateInput = require('./list/validateInput');
+	List.prototype.buildSearchTextIndex = require('./list/buildSearchTextIndex');
+	List.prototype.declaresTextIndex = require('./list/declaresTextIndex');
 
 	return List;
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -110,6 +110,9 @@ module.exports = function (keystone) {
 		}
 	}
 
+	// TODO: Protect dynamic properties from being accessed until the List
+	// has been registered (otherwise, incomplete schema could be cached)
+
 	// Search Fields
 	Object.defineProperty(List.prototype, 'searchFields', {
 		get: function () {

--- a/lib/list/actuallyEnsureTextIndex.js
+++ b/lib/list/actuallyEnsureTextIndex.js
@@ -1,0 +1,96 @@
+var debug = require('debug')('keystone:core:list:actuallyEnsureTextIndex');
+
+
+// A basic string hashing function
+function hashString (string) {
+    var hash = 0;
+    if (string.length == 0) return hash;
+    for (i = 0; i < string.length; i++) {
+        char = string.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32bit integer
+    }
+    return hash;
+}
+
+
+/**
+ * Does what it can to ensure the collection has an appropriate text index.
+ * 
+ * Works around unreliable behaviour with the Mongo drivers ensureIndex()
+ * Specifically, when the following are true..
+ * 		* Relying on collection.ensureIndexes() to create text indexes
+ * 		* A text index already exists on the collection
+ * 		* The existing index has a different definition but the same name
+ * The index is not created/updated and no error is returned, either by the 
+ * ensureIndexes() call or the connection error listener.
+ * Or at least that's what was happening for me (mongoose v3.8.40, mongodb v1.4.38)..
+ */
+function actuallyEnsureTextIndex (callback) {
+	var list = this;
+	var collection = list.model.collection;
+	
+	var textIndex = list.buildSearchTextIndex();
+	var fieldsHash = Math.abs(hashString(Object.keys(textIndex).sort().join(';')));
+	var indexNamePrefix = 'keystone_searchFields_textIndex_';
+	var newIndexName = indexNamePrefix + fieldsHash;
+	
+	// We use this later to create a new index if needed
+	var createNewIndex = function () {
+		collection.createIndex(textIndex, { name: newIndexName }, function (result) {
+		 	debug('collection.createIndex() result for \'' + list.key + '\:', result);
+		 	return callback();
+		});
+	};
+	
+	collection.getIndexes(function (err, indexes) {
+		if (err) throw err;  // Not sure what else to do here..
+		var indexNames = Object.keys(indexes);
+		// debug('indexes', indexes);
+		// debug('indexNames', indexNames);
+		
+		// Search though the 
+		for (var i = 0; i < indexNames.length; i++) {
+			var existingIndexName = indexNames[i];
+			var isText = false;
+			
+			// Check we're dealing with a text index
+			for (var h = 0; h < indexes[existingIndexName].length; h ++) {
+				var column = indexes[existingIndexName][h];
+				if (column[1] === 'text') isText = isText || true;
+			}
+			
+			// Skip non-text indexes
+			if (!isText) continue;
+			
+			// Already exists with correct def
+			if (existingIndexName === newIndexName) {
+				debug('Existing text index \'' + existingIndexName + '\' already matches the searchFields for \'' + list.key + '\'');
+				return;
+			}
+			
+			// Exists but hash (def) doesn't match
+			// Check for 'searchFields_text_index' for backwards compatibility
+			if (existingIndexName.slice(0, indexNamePrefix.length) === indexNamePrefix || existingIndexName === 'searchFields_text_index') {
+				debug('Existing text index \'' + existingIndexName + '\' doesn\'t match the searchFields for \'' + list.key + '\' and will be recreated as \'' + newIndexName + '\'');
+				
+				collection.dropIndex(existingIndexName, function (result) {
+					debug('collection.dropIndex() result for \'' + list.key + '\:', result);
+					createNewIndex();
+				});
+				return;
+			}
+
+			// It's a text index but not one of ours; nothing we can do
+			debug('Existing text index \'' + existingIndexName + '\' in \'' + list.key + '\' not recognised; no action taken');
+			return;
+		}
+		
+		// No text indexes found at all; create ours now
+		debug('No existing text index found in \'' + list.key + '\'; Creating ours now');
+		createNewIndex();
+	});
+}
+
+
+module.exports = actuallyEnsureTextIndex;

--- a/lib/list/actuallyEnsureTextIndex.js
+++ b/lib/list/actuallyEnsureTextIndex.js
@@ -18,9 +18,9 @@ function hashString (string) {
  *
  * Works around unreliable behaviour with the Mongo drivers ensureIndex()
  * Specifically, when the following are true..
- *     * Relying on collection.ensureIndexes() to create text indexes
- *     * A text index already exists on the collection
- *     * The existing index has a different definition but the same name
+ *   - Relying on collection.ensureIndexes() to create text indexes
+ *   - A text index already exists on the collection
+ *   - The existing index has a different definition but the same name
  * The index is not created/updated and no error is returned, either by the
  * ensureIndexes() call or the connection error listener.
  * Or at least that's what was happening for me (mongoose v3.8.40, mongodb v1.4.38)..

--- a/lib/list/actuallyEnsureTextIndex.js
+++ b/lib/list/actuallyEnsureTextIndex.js
@@ -1,79 +1,78 @@
 var debug = require('debug')('keystone:core:list:actuallyEnsureTextIndex');
 
-
 // A basic string hashing function
 function hashString (string) {
-    var hash = 0;
-    if (string.length == 0) return hash;
-    for (i = 0; i < string.length; i++) {
-        char = string.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash; // Convert to 32bit integer
-    }
-    return hash;
+	var char;
+	var hash = 0;
+	if (string.length === 0) return hash;
+	for (var i = 0; i < string.length; i++) {
+		char = string.charCodeAt(i);
+		hash = ((hash << 5) - hash) + char;
+		hash = hash & hash; // Convert to 32bit integer
+	}
+	return hash;
 }
-
 
 /**
  * Does what it can to ensure the collection has an appropriate text index.
- * 
+ *
  * Works around unreliable behaviour with the Mongo drivers ensureIndex()
  * Specifically, when the following are true..
- * 		* Relying on collection.ensureIndexes() to create text indexes
- * 		* A text index already exists on the collection
- * 		* The existing index has a different definition but the same name
- * The index is not created/updated and no error is returned, either by the 
+ *     * Relying on collection.ensureIndexes() to create text indexes
+ *     * A text index already exists on the collection
+ *     * The existing index has a different definition but the same name
+ * The index is not created/updated and no error is returned, either by the
  * ensureIndexes() call or the connection error listener.
  * Or at least that's what was happening for me (mongoose v3.8.40, mongodb v1.4.38)..
  */
 function actuallyEnsureTextIndex (callback) {
 	var list = this;
 	var collection = list.model.collection;
-	
+
 	var textIndex = list.buildSearchTextIndex();
 	var fieldsHash = Math.abs(hashString(Object.keys(textIndex).sort().join(';')));
 	var indexNamePrefix = 'keystone_searchFields_textIndex_';
 	var newIndexName = indexNamePrefix + fieldsHash;
-	
+
 	// We use this later to create a new index if needed
 	var createNewIndex = function () {
 		collection.createIndex(textIndex, { name: newIndexName }, function (result) {
-		 	debug('collection.createIndex() result for \'' + list.key + '\:', result);
-		 	return callback();
+			debug('collection.createIndex() result for \'' + list.key + '\:', result);
+			return callback();
 		});
 	};
-	
+
 	collection.getIndexes(function (err, indexes) {
 		if (err) throw err;  // Not sure what else to do here..
 		var indexNames = Object.keys(indexes);
 		// debug('indexes', indexes);
 		// debug('indexNames', indexNames);
-		
-		// Search though the 
+
+		// Search though the
 		for (var i = 0; i < indexNames.length; i++) {
 			var existingIndexName = indexNames[i];
 			var isText = false;
-			
+
 			// Check we're dealing with a text index
-			for (var h = 0; h < indexes[existingIndexName].length; h ++) {
+			for (var h = 0; h < indexes[existingIndexName].length; h++) {
 				var column = indexes[existingIndexName][h];
 				if (column[1] === 'text') isText = isText || true;
 			}
-			
+
 			// Skip non-text indexes
 			if (!isText) continue;
-			
+
 			// Already exists with correct def
 			if (existingIndexName === newIndexName) {
 				debug('Existing text index \'' + existingIndexName + '\' already matches the searchFields for \'' + list.key + '\'');
 				return;
 			}
-			
+
 			// Exists but hash (def) doesn't match
 			// Check for 'searchFields_text_index' for backwards compatibility
 			if (existingIndexName.slice(0, indexNamePrefix.length) === indexNamePrefix || existingIndexName === 'searchFields_text_index') {
 				debug('Existing text index \'' + existingIndexName + '\' doesn\'t match the searchFields for \'' + list.key + '\' and will be recreated as \'' + newIndexName + '\'');
-				
+
 				collection.dropIndex(existingIndexName, function (result) {
 					debug('collection.dropIndex() result for \'' + list.key + '\:', result);
 					createNewIndex();
@@ -85,12 +84,11 @@ function actuallyEnsureTextIndex (callback) {
 			debug('Existing text index \'' + existingIndexName + '\' in \'' + list.key + '\' not recognised; no action taken');
 			return;
 		}
-		
+
 		// No text indexes found at all; create ours now
 		debug('No existing text index found in \'' + list.key + '\'; Creating ours now');
 		createNewIndex();
 	});
 }
-
 
 module.exports = actuallyEnsureTextIndex;

--- a/lib/list/addFiltersToQuery.js
+++ b/lib/list/addFiltersToQuery.js
@@ -1,4 +1,5 @@
 var assign = require('object-assign');
+var debug = require('debug')('keystone:core:list:addFiltersToQuery');
 
 function combineQueries (a, b) {
 	if (a.$or && b.$or) {
@@ -21,6 +22,8 @@ function addFiltersToQuery (filters) {
 		if (!field.addFilterToQuery || !filters[field.path]) return;
 		combineQueries(query, field.addFilterToQuery(filters[field.path]));
 	}, this);
+
+	debug('Adding filters to query, returned:', query);
 	return query;
 }
 

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -28,25 +28,41 @@ function addSearchToQuery (searchString) {
 	var query = {};
 	if (!searchString) return query;
 
-	var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
-	var searchFilters = this.searchFields.map(function (i) {
-		if (i.field && i.field.type === 'name') {
-			return getNameFilter(i.field, searchString);
-		} else {
-			return getStringFilter(i.path, searchRegExp);
-		}
-	}, this);
+	var useTextIndex = this.options.searchUsesTextIndex && this.declaresTextIndex();
+	if (useTextIndex) {
+		searchFilters.push({
+			$text: {
+				$search: searchString,
+			},
+		});
 
-	if (this.autokey) {
-		var autokeyFilter = {};
-		autokeyFilter[this.autokey.path] = searchRegExp;
-		searchFilters.push(autokeyFilter);
+		if (this.autokey) {
+			var strictAutokeyFilter = {};
+			var autokeyRegExp = new RegExp('^' + utils.escapeRegExp(searchString));
+			strictAutokeyFilter[this.autokey.path] = autokeyRegExp;
+			searchFilters.push(strictAutokeyFilter);
+		}
+	} else {
+		var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
+		var searchFilters = this.searchFields.map(function (i) {
+			if (i.field && i.field.type === 'name') {
+				return getNameFilter(i.field, searchString);
+			} else {
+				return getStringFilter(i.path, searchRegExp);
+			}
+		}, this);
+
+		if (this.autokey) {
+			var autokeyFilter = {};
+			autokeyFilter[this.autokey.path] = searchRegExp;
+			searchFilters.push(autokeyFilter);
+		}
 	}
 
 	if (utils.isValidObjectId(searchString)) {
-		var idFilter = {};
-		idFilter._id = searchString;
-		searchFilters.push(idFilter);
+		searchFilters.push({
+			_id: searchString,
+		});
 	}
 
 	if (searchFilters.length > 1) {

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -1,5 +1,6 @@
 var assign = require('object-assign');
 var utils = require('keystone-utils');
+var debug = require('debug')('keystone:core:list:addSearchToQuery');
 
 function trim (i) { return i.trim(); }
 function truthy (i) { return i; }
@@ -54,6 +55,7 @@ function addSearchToQuery (searchString) {
 		assign(query, searchFilters[0]);
 	}
 
+	debug('Adding search to query for list \'' + list.key + '\', returned:', query);
 	return query;
 }
 

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -26,10 +26,11 @@ function getStringFilter (path, searchRegExp) {
 function addSearchToQuery (searchString) {
 	searchString = String(searchString || '').trim();
 	var query = {};
+	var searchFilters = [];
 	if (!searchString) return query;
 
-	var useTextIndex = this.options.searchUsesTextIndex && this.declaresTextIndex();
-	if (useTextIndex) {
+	if (this.options.searchUsesTextIndex) {
+		debug('Using text search index for value: "' + searchString + '"');
 		searchFilters.push({
 			$text: {
 				$search: searchString,
@@ -43,8 +44,9 @@ function addSearchToQuery (searchString) {
 			searchFilters.push(strictAutokeyFilter);
 		}
 	} else {
+		debug('Using regular expression search for value: "' + searchString + '"');
 		var searchRegExp = new RegExp(utils.escapeRegExp(searchString), 'i');
-		var searchFilters = this.searchFields.map(function (i) {
+		searchFilters = this.searchFields.map(function (i) {
 			if (i.field && i.field.type === 'name') {
 				return getNameFilter(i.field, searchString);
 			} else {
@@ -71,7 +73,7 @@ function addSearchToQuery (searchString) {
 		assign(query, searchFilters[0]);
 	}
 
-	debug('Adding search to query, returned:', query);
+	debug('Built search query for value: "' + searchString + '"', query);
 	return query;
 }
 

--- a/lib/list/addSearchToQuery.js
+++ b/lib/list/addSearchToQuery.js
@@ -55,7 +55,7 @@ function addSearchToQuery (searchString) {
 		assign(query, searchFilters[0]);
 	}
 
-	debug('Adding search to query for list \'' + list.key + '\', returned:', query);
+	debug('Adding search to query, returned:', query);
 	return query;
 }
 

--- a/lib/list/buildSearchTextIndex.js
+++ b/lib/list/buildSearchTextIndex.js
@@ -1,0 +1,33 @@
+
+/**
+ * Returns either false if the list has no search fields defined or a structure 
+ * describing the text index that should exist.
+ */
+function buildSearchTextIndex () {
+	var list = this;
+	var idxDef = {};
+	
+	for (var i = 0; i < list.searchFields.length; i ++) {
+		var sf = list.searchFields[i];
+		if (!sf.path || !sf.field) continue;
+		// Also maybe skip the field if it: a) isn't type === 'name' and b) doesn't have typeof _nativeType === 'string'
+		
+		// Does the field have a single path or does it use nested values (like 'name')
+		if (sf.field.paths) {
+			var nFields = sf.field.paths;
+			var nKeys = Object.keys(nFields);
+			for (var n = 0; n < nKeys.length; n ++) {
+				idxDef[nFields[nKeys[n]]] = 'text';
+			}
+		}
+		else if (sf.field.path) {
+			idxDef[sf.field.path] = 'text';
+		}
+	}
+	
+	// debug('text index for \'' + list.key + '\':', idxDef);
+	return Object.keys(idxDef).length > 0 ? idxDef : false;
+}
+
+
+module.exports = buildSearchTextIndex;

--- a/lib/list/buildSearchTextIndex.js
+++ b/lib/list/buildSearchTextIndex.js
@@ -8,8 +8,12 @@ function buildSearchTextIndex () {
 	for (var i = 0; i < this.searchFields.length; i++) {
 		var sf = this.searchFields[i];
 		if (!sf.path || !sf.field) continue;
-		// Also maybe skip the field if it: a) isn't type === 'name'
-		// and b) doesn't have typeof _nativeType === 'string'
+
+		// TODO: Allow fields to define their own `getTextIndex` method, so that
+		// each type can define the right options for their schema. This is unlikely
+		// to behave as expected for fields that aren't simple strings or names
+		// until that has been done. Should error if the field type doesn't support
+		// text indexing, as the list has been misconfigured.
 
 		// Does the field have a single path or does it use nested values (like 'name')
 		if (sf.field.paths) {

--- a/lib/list/buildSearchTextIndex.js
+++ b/lib/list/buildSearchTextIndex.js
@@ -1,22 +1,21 @@
-
 /**
- * Returns either false if the list has no search fields defined or a structure 
+ * Returns either false if the list has no search fields defined or a structure
  * describing the text index that should exist.
  */
 function buildSearchTextIndex () {
 	var list = this;
 	var idxDef = {};
-	
-	for (var i = 0; i < list.searchFields.length; i ++) {
+
+	for (var i = 0; i < list.searchFields.length; i++) {
 		var sf = list.searchFields[i];
 		if (!sf.path || !sf.field) continue;
 		// Also maybe skip the field if it: a) isn't type === 'name' and b) doesn't have typeof _nativeType === 'string'
-		
+
 		// Does the field have a single path or does it use nested values (like 'name')
 		if (sf.field.paths) {
 			var nFields = sf.field.paths;
 			var nKeys = Object.keys(nFields);
-			for (var n = 0; n < nKeys.length; n ++) {
+			for (var n = 0; n < nKeys.length; n++) {
 				idxDef[nFields[nKeys[n]]] = 'text';
 			}
 		}
@@ -24,10 +23,9 @@ function buildSearchTextIndex () {
 			idxDef[sf.field.path] = 'text';
 		}
 	}
-	
+
 	// debug('text index for \'' + list.key + '\':', idxDef);
 	return Object.keys(idxDef).length > 0 ? idxDef : false;
 }
-
 
 module.exports = buildSearchTextIndex;

--- a/lib/list/buildSearchTextIndex.js
+++ b/lib/list/buildSearchTextIndex.js
@@ -3,13 +3,13 @@
  * describing the text index that should exist.
  */
 function buildSearchTextIndex () {
-	var list = this;
 	var idxDef = {};
 
-	for (var i = 0; i < list.searchFields.length; i++) {
-		var sf = list.searchFields[i];
+	for (var i = 0; i < this.searchFields.length; i++) {
+		var sf = this.searchFields[i];
 		if (!sf.path || !sf.field) continue;
-		// Also maybe skip the field if it: a) isn't type === 'name' and b) doesn't have typeof _nativeType === 'string'
+		// Also maybe skip the field if it: a) isn't type === 'name'
+		// and b) doesn't have typeof _nativeType === 'string'
 
 		// Does the field have a single path or does it use nested values (like 'name')
 		if (sf.field.paths) {
@@ -24,7 +24,7 @@ function buildSearchTextIndex () {
 		}
 	}
 
-	// debug('text index for \'' + list.key + '\':', idxDef);
+	// debug('text index for \'' + this.key + '\':', idxDef);
 	return Object.keys(idxDef).length > 0 ? idxDef : false;
 }
 

--- a/lib/list/declaresTextIndex.js
+++ b/lib/list/declaresTextIndex.js
@@ -1,0 +1,23 @@
+
+/**
+ * Look for a text index defined in the current list schema; returns boolean
+ * Note this doesn't check for text indexes that exist in the DB
+ */
+function declaresTextIndex (list) {
+	var list = this;
+	var indexes = list.schema.indexes();
+	
+	for (var i = 0; i < indexes.length; i ++) {
+		var fields = indexes[i][0];
+		var fieldNames = Object.keys(fields);
+					
+		for (var h = 0; h < fieldNames.length; h ++) {
+			var val = fields[fieldNames[h]];
+			if (typeof val == 'string' && val.toLowerCase() === 'text') return true;
+		}
+	}
+	return false;
+}
+
+
+module.exports = declaresTextIndex;

--- a/lib/list/declaresTextIndex.js
+++ b/lib/list/declaresTextIndex.js
@@ -1,23 +1,21 @@
-
 /**
  * Look for a text index defined in the current list schema; returns boolean
  * Note this doesn't check for text indexes that exist in the DB
  */
-function declaresTextIndex (list) {
+function declaresTextIndex () {
 	var list = this;
 	var indexes = list.schema.indexes();
-	
-	for (var i = 0; i < indexes.length; i ++) {
+
+	for (var i = 0; i < indexes.length; i++) {
 		var fields = indexes[i][0];
 		var fieldNames = Object.keys(fields);
-					
-		for (var h = 0; h < fieldNames.length; h ++) {
+
+		for (var h = 0; h < fieldNames.length; h++) {
 			var val = fields[fieldNames[h]];
-			if (typeof val == 'string' && val.toLowerCase() === 'text') return true;
+			if (typeof val === 'string' && val.toLowerCase() === 'text') return true;
 		}
 	}
 	return false;
 }
-
 
 module.exports = declaresTextIndex;

--- a/lib/list/declaresTextIndex.js
+++ b/lib/list/declaresTextIndex.js
@@ -2,6 +2,7 @@
  * Look for a text index defined in the current list schema; returns boolean
  * Note this doesn't check for text indexes that exist in the DB
  */
+
 function declaresTextIndex () {
 	var indexes = this.schema.indexes();
 

--- a/lib/list/declaresTextIndex.js
+++ b/lib/list/declaresTextIndex.js
@@ -3,8 +3,7 @@
  * Note this doesn't check for text indexes that exist in the DB
  */
 function declaresTextIndex () {
-	var list = this;
-	var indexes = list.schema.indexes();
+	var indexes = this.schema.indexes();
 
 	for (var i = 0; i < indexes.length; i++) {
 		var fields = indexes[i][0];

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -25,60 +25,67 @@ function getSearchFilters (search, add) {
 	search = String(search || '').trim();
 
 	if (search.length) {
-		var searchFilter;
-		var searchParts = search.split(' ');
-		var searchRx = new RegExp(utils.escapeRegExp(search), 'i');
-		var splitSearchRx = new RegExp((searchParts.length > 1) ? _.map(searchParts, utils.escapeRegExp).join('|') : search, 'i');
-		var searchFields = this.get('searchFields');
-		var searchFilters = [];
-		var searchIdField = utils.isValidObjectId(search);
-
-		if (typeof searchFields === 'string') {
-			searchFields = searchFields.split(',');
+		// Use the text index if both a) it's enabled by the list and b) we have one
+		// If searchUsesTextIndex is true AND the list defines it's own custom text index this might not behave as expected.
+		// In this scenario you'll also get an error when the list is register()'ed though so it's not to bad
+		if (this.options.searchUsesTextIndex && this.declaresTextIndex()) {
+			filters.$text = { $search: search };
 		}
+		else {
+			var searchFilter;
+			var searchParts = search.split(' ');
+			var searchRx = new RegExp(utils.escapeRegExp(search), 'i');
+			var splitSearchRx = new RegExp((searchParts.length > 1) ? _.map(searchParts, utils.escapeRegExp).join('|') : search, 'i');
+			var searchFields = this.get('searchFields');
+			var searchFilters = [];
+			var searchIdField = utils.isValidObjectId(search);
 
-		searchFields.forEach(function (path) {
-			path = path.trim();
-
-			if (path === '__name__') {
-				path = list.mappings.name;
+			if ('string' === typeof searchFields) {
+				searchFields = searchFields.split(',');
 			}
 
-			var field = list.fields[path];
+			searchFields.forEach(function (path) {
+				path = path.trim();
 
-			if (field && field.type === 'name') {
-				var first = {};
-				first[field.paths.first] = splitSearchRx;
-				var last = {};
-				last[field.paths.last] = splitSearchRx;
+				if (path === '__name__') {
+					path = list.mappings.name;
+				}
+
+				var field = list.fields[path];
+
+				if (field && field.type === 'name') {
+					var first = {};
+					first[field.paths.first] = splitSearchRx;
+					var last = {};
+					last[field.paths.last] = splitSearchRx;
+					searchFilter = {};
+					searchFilter.$or = [first, last];
+					searchFilters.push(searchFilter);
+				} else {
+					searchFilter = {};
+					searchFilter[path] = searchRx;
+					searchFilters.push(searchFilter);
+				}
+			});
+
+			if (list.autokey) {
 				searchFilter = {};
-				searchFilter.$or = [first, last];
-				searchFilters.push(searchFilter);
-			} else {
-				searchFilter = {};
-				searchFilter[path] = searchRx;
+				searchFilter[list.autokey.path] = searchRx;
 				searchFilters.push(searchFilter);
 			}
-		});
 
-		if (list.autokey) {
-			searchFilter = {};
-			searchFilter[list.autokey.path] = searchRx;
-			searchFilters.push(searchFilter);
+			if (searchIdField) {
+				searchFilter = {};
+				searchFilter._id = search;
+				searchFilters.push(searchFilter);
+			}
+
+			if (searchFilters.length > 1) {
+				filters.$or = searchFilters;
+			} else if (searchFilters.length) {
+				filters = searchFilters[0];
+			}
 		}
-
-		if (searchIdField) {
-			searchFilter = {};
-			searchFilter._id = search;
-			searchFilters.push(searchFilter);
-		}
-
-		if (searchFilters.length > 1) {
-			filters.$or = searchFilters;
-		} else if (searchFilters.length) {
-			filters = searchFilters[0];
-		}
-
 	}
 
 	if (add) {
@@ -228,6 +235,9 @@ function getSearchFilters (search, add) {
 			}
 		});
 	}
+
+	console.log('final filters', filters);
+
 	return filters;
 }
 

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -27,7 +27,7 @@ function getSearchFilters (search, add) {
 	if (search.length) {
 		// Use the text index if both a) it's enabled by the list and b) we have one
 		// If searchUsesTextIndex is true AND the list defines it's own custom text index this might not behave as expected.
-		// In this scenario you'll also get an error when the list is register()'ed though so it's not to bad
+		// In this scenario you'll also get an error when the list is register()'ed though so hopefully someone will have noticed that..
 		if (this.options.searchUsesTextIndex && this.declaresTextIndex()) {
 			filters.$text = { $search: search };
 		}
@@ -235,8 +235,6 @@ function getSearchFilters (search, add) {
 			}
 		});
 	}
-
-	console.log('final filters', filters);
 
 	return filters;
 }

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 var moment = require('moment');
 var utils = require('keystone-utils');
 
+var debug = require('debug')('keystone:core:list:getSearchFilters');
+
 /**
  * Gets filters for a Mongoose query that will search for the provided string,
  * based on the searchFields List option.
@@ -235,7 +237,8 @@ function getSearchFilters (search, add) {
 			}
 		});
 	}
-
+	
+	debug('Applying filters to list \'' + list.key + '\':', filters);
 	return filters;
 }
 

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -42,7 +42,7 @@ function getSearchFilters (search, add) {
 			var searchFilters = [];
 			var searchIdField = utils.isValidObjectId(search);
 
-			if ('string' === typeof searchFields) {
+			if (typeof searchFields === 'string') {
 				searchFields = searchFields.split(',');
 			}
 
@@ -237,7 +237,7 @@ function getSearchFilters (search, add) {
 			}
 		});
 	}
-	
+
 	debug('Applying filters to list \'' + list.key + '\':', filters);
 	return filters;
 }

--- a/lib/list/register.js
+++ b/lib/list/register.js
@@ -32,11 +32,16 @@ function register () {
 		return new UpdateHandler(list, this, req, res, ops);
 	});
 
-	// If we need a text index but haven't manually defined one for the list, add one to the list now
+	// If the list is configured to use a text index for search..
 	if (this.options.searchUsesTextIndex) {
 		var textIndex = this.buildSearchTextIndex();
+
+		// .. and there are valid fields to search and there isn't already a text index manually defined for the list..
+		// .. then add one to the list now
 		if (textIndex && !this.declaresTextIndex()) {
-			this.schema.index(textIndex);
+			debug('Ensuring text index for list \'' + list.key + '\':', textIndex);
+			// Always set a name; if there are too many fields included the default name will be too long
+			this.schema.index(textIndex, { name: 'searchFields_text_index' });
 		}
 	}
 

--- a/lib/list/register.js
+++ b/lib/list/register.js
@@ -2,6 +2,8 @@ var assign = require('object-assign');
 var schemaPlugins = require('../schemaPlugins');
 var UpdateHandler = require('../updateHandler');
 var utils = require('keystone-utils');
+var debug = require('debug')('keystone:core:list:register');
+
 
 /**
  * Registers the Schema with Mongoose, and the List with Keystone
@@ -29,6 +31,15 @@ function register () {
 	this.schema.method('getUpdateHandler', function (req, res, ops) {
 		return new UpdateHandler(list, this, req, res, ops);
 	});
+
+	// If we need a text index but haven't manually defined one for the list, add one to the list now
+	if (this.options.searchUsesTextIndex) {
+		var textIndex = this.buildSearchTextIndex();
+		if (textIndex && !this.declaresTextIndex()) {
+			this.schema.index(textIndex);
+		}
+	}
+
 	if (this.get('inherits')) {
 		this.model = this.get('inherits').model.discriminator(this.key, this.schema);
 	} else {
@@ -38,6 +49,22 @@ function register () {
 	keystone.lists[this.key] = this;
 	keystone.paths[this.path] = this.key;
 	assign(keystone.fieldTypes, this.fieldTypes);
+
+	// Add a listener for model events; some of this stuff is important
+	// http://mongoosejs.com/docs/api.html#model_Model
+	this.model.on('index', function (err) {
+		if (err) console.error('Mongoose model \'index\' event fired on \'' + list.key + '\' with error:\n', err.message, err.stack);
+	});
+	this.model.on('index-single-start', function (index) {
+		debug('Mongoose model \'index-single-start\' event fired on \'' + list.key + '\' for index:\n', index);
+	});
+	this.model.on('index-single-done', function (err, index) {
+		if (err) console.error('Mongoose model \'index-single-done\' event fired on \'' + list.key + '\' for index:\n', index, '\nWith error:\n', err.message, err.stack);
+		else debug('Mongoose model \'index-single-done\' event fired on \'' + list.key + '\' for index:\n', index);
+	});
+	this.model.on('error', function (err) {
+		if (err) console.error('Mongoose model \'error\' event fired on \'' + list.key + '\' with error:\n', err.message, err.stack);
+	});
 	return this;
 }
 

--- a/lib/list/register.js
+++ b/lib/list/register.js
@@ -32,19 +32,6 @@ function register () {
 		return new UpdateHandler(list, this, req, res, ops);
 	});
 
-	// If the list is configured to use a text index for search..
-	if (this.options.searchUsesTextIndex) {
-		var textIndex = this.buildSearchTextIndex();
-
-		// .. and there are valid fields to search and there isn't already a text index manually defined for the list..
-		// .. then add one to the list now
-		if (textIndex && !this.declaresTextIndex()) {
-			debug('Ensuring text index for list \'' + list.key + '\':', textIndex);
-			// Always set a name; if there are too many fields included the default name will be too long
-			this.schema.index(textIndex, { name: 'searchFields_text_index' });
-		}
-	}
-
 	if (this.get('inherits')) {
 		this.model = this.get('inherits').model.discriminator(this.key, this.schema);
 	} else {
@@ -54,6 +41,15 @@ function register () {
 	keystone.lists[this.key] = this;
 	keystone.paths[this.path] = this.key;
 	assign(keystone.fieldTypes, this.fieldTypes);
+	// If the list is configured to use a text index for search and the list doesn't explicitly define one, create (or update) one of our own
+	if (this.options.searchUsesTextIndex && !this.declaresTextIndex()) {
+		this.actuallyEnsureTextIndex(function () {
+			debug('this.actuallyEnsureTextIndex() done for \'' + list.key + '\'');
+		});
+	}
+	else {
+		debug('No text index need for \'' + list.key + '\' or the list defines one explicitly');
+	}
 
 	// Add a listener for model events; some of this stuff is important
 	// http://mongoosejs.com/docs/api.html#model_Model


### PR DESCRIPTION
This change was ported forward from some changes @molomby did in his `v0.3.x` version for a client.

@JedWatson **this does not currently work** (it builds the indexes, but the searching doesn't actually use them) I'm missing waaaay to much context of the changes in this area of the codebase between 0.3.x and `master`, could you please take a look at this and implement whatever fixes are needed?

> Note: To test this, you have to add `searchUsesTextIndex: true,` to your list.