### PR TITLE
test(e2e):  refactor

### DIFF
--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -7,6 +7,7 @@ var keystone = require('../../../..');
 module.exports = {
 	url: 'http://' + keystone.get('host') + ':' + keystone.get('port') + '/keystone/',
 	pause: 1000,
+	defaultWaitForTimeout: 60000,
 	elements: {
 		// ADMIN UI APP SCREENS
 		signinScreen: '#signin-view',
@@ -94,33 +95,33 @@ module.exports = {
 				.click('@logoutIconLink')
 				.waitForSigninScreen();
 		},
-		waitForSigninScreen: function() {
+		waitForSigninScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@signinScreen', 60000);
+				.waitForElementVisible('@signinScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForHomeScreen: function() {
+		waitForHomeScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@homeScreen', 60000);
+				.waitForElementVisible('@homeScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForInitialFormScreen: function() {
+		waitForInitialFormScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@initialFormScreen');
+				.waitForElementVisible('@initialFormScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForDeleteConfirmationScreen: function() {
+		waitForDeleteConfirmationScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@deleteConfirmationScreen');
+				.waitForElementVisible('@deleteConfirmationScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForResetConfirmationScreen: function() {
+		waitForResetConfirmationScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@resetConfirmationScreen');
+				.waitForElementVisible('@resetConfirmationScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForListScreen: function() {
+		waitForListScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@listScreen', 60000);
+				.waitForElementVisible('@listScreen', timeout || this.defaultWaitForTimeout);
 		},
-		waitForItemScreen: function() {
+		waitForItemScreen: function(timeout) {
 			return this
-				.waitForElementVisible('@itemScreen', 60000);
+				.waitForElementVisible('@itemScreen', timeout || this.defaultWaitForTimeout);
 		},
 	}],
 };

--- a/test/e2e/adminUI/pages/app.js
+++ b/test/e2e/adminUI/pages/app.js
@@ -67,36 +67,40 @@ module.exports = {
 		targetrelationshipListSubmenu: '.secondary-navbar [data-list-path="target-relationships"]',
 	},
 	commands: [{
+		gotoHomeScreen: function() {
+			return this
+				.navigate();		// navigate to the configure Url
+		},
 		openMiscList: function(list) {
 			var list = list.toLowerCase() + 'List';
 			var listSubmenu = '@' + list + 'Submenu';
 			return this.click('@miscListsMenu')
-				.waitForElementVisible('@listScreen')
+				.waitForListScreen()
 				.click(listSubmenu)
-				.waitForElementVisible('@listScreen');
+				.waitForListScreen();
 		},
 		openFieldList: function(field) {
 				var list = field.toLowerCase() + 'List';
 				var listSubmenu = '@' + list + 'Submenu';
 				return this.click('@fieldListsMenu')
-					.waitForElementVisible('@listScreen')
+					.waitForListScreen()
 					.click(listSubmenu)
-					.waitForElementVisible('@listScreen');
+					.waitForListScreen();
 		},
 		signout: function() {
 			this.api.pause(500);
 			return this
 				.waitForElementVisible('@logoutIcon')
 				.click('@logoutIconLink')
-				.waitForElementVisible('@signinScreen');
+				.waitForSigninScreen();
 		},
 		waitForSigninScreen: function() {
 			return this
-				.waitForElementVisible('@signinScreen', 20000);
+				.waitForElementVisible('@signinScreen', 60000);
 		},
 		waitForHomeScreen: function() {
 			return this
-				.waitForElementVisible('@homeScreen', 20000);
+				.waitForElementVisible('@homeScreen', 60000);
 		},
 		waitForInitialFormScreen: function() {
 			return this
@@ -112,11 +116,11 @@ module.exports = {
 		},
 		waitForListScreen: function() {
 			return this
-				.waitForElementVisible('@listScreen');
+				.waitForElementVisible('@listScreen', 60000);
 		},
 		waitForItemScreen: function() {
 			return this
-				.waitForElementVisible('@itemScreen');
+				.waitForElementVisible('@itemScreen', 60000);
 		},
 	}],
 };

--- a/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
@@ -1,19 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
+		browser.signinScreen = browser.page.signin();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 	},
 	after: function (browser) {
 		browser.end();
 	},
-	'AdminUI should have a signin page': function (browser) {
-		browser.app
-			.expect.element('@signinScreen').to.be.visible;
-	},
 	'Signin page should show correctly': function (browser) {
-		browser.signinPage.assertUI();
+		browser.signinScreen.assertUI();
 	},
 };

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
+		browser.signinScreen = browser.page.signin();
 
 		browser.url(browser.app.url + 'users');
 		browser.app.waitForSigninScreen();
@@ -12,7 +12,7 @@ module.exports = {
 			end();
 	},
 	'AdminUI should allow users to login and redirect to custom url': function (browser) {
-		browser.signinPage.signin();
+		browser.signinScreen.signin();
 		browser.app.waitForListScreen();
 		browser.assert.urlEquals(browser.app.url + 'users');
 	},

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
@@ -1,19 +1,22 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
+		browser.signinScreen = browser.page.signin();
 
-		browser.app.navigate();
-		browser.app.waitForSigninScreen();
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 	},
 	after: function (browser) {
 		browser.end();
 	},
 	'Signin page should allow users to login': function (browser) {
-		browser.signinPage.signin();
+		browser.signinScreen.signin();
 		browser.app.waitForHomeScreen();
 	},
 	'Signin page should be presented upon signout': function (browser) {
-		browser.app.signout();
+		browser.app
+			.signout()
+			.waitForSigninScreen();
 	},
 };

--- a/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
@@ -4,11 +4,13 @@ module.exports = {
 		browser.signinScreen = browser.page.signin();
 		browser.homeScreen = browser.page.home();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
 		browser.signinScreen.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();

--- a/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
@@ -3,15 +3,17 @@ module.exports = {
 		browser.app = browser.page.app();
 		browser.signinScreen = browser.page.signin();
 		browser.homeScreen = browser.page.home();
-		browser.initialForm = browser.page.initialForm();
+		browser.initialFormScreen = browser.page.initialForm();
 		browser.listScreen = browser.page.list();
-		browser.deleteConfirmation = browser.page.deleteConfirmation();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
 		browser.signinScreen.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,102 +21,102 @@ module.exports = {
 	},
 	'Home view should allow clicking a nav menu item such as Access and Fields to show the list of items': function (browser) {
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen')
+			.gotoHomeScreen()
+			.waitForHomeScreen()
 			.click('@accessMenu')
-			.waitForElementVisible('@listScreen')
-			.navigate()
-			.waitForElementVisible('@homeScreen')
+			.waitForListScreen()
+			.gotoHomeScreen()
+			.waitForHomeScreen()
 			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 	},
 	'Home view should allow clicking a card list item such as Users to should show the list of those items': function (browser) {
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.homeScreen.section.accessGroup.section.users
 			.click('@label');
 
 		browser.app
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 	},
 	'Home view should allow an admin to create a new list item such as a user': function (browser) {
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.homeScreen.section.accessGroup.section.users
 			.click('@plusIconLink');
 
-		browser.initialForm.section.form
+		browser.initialFormScreen.section.form
 			.waitForElementVisible('@createButton');
 	},
 	'Home view should allow an admin to create a new list item and increment the item count': function (browser) {
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.homeScreen.section.fieldsGroup.section.names
 			.expect.element('@itemCount').text.to.equal('0 Items');
 		browser.homeScreen.section.fieldsGroup.section.names
 			.click('@plusIconLink');
 
-		browser.initialForm.section.form
+		browser.initialFormScreen.section.form
 			.waitForElementVisible('@createButton');
 
-		browser.initialForm.section.form.section.nameList.section.name
+		browser.initialFormScreen.section.form.section.nameList.section.name
 			.fillInput({value: 'Name Field Test'});
-		browser.initialForm.section.form.section.nameList.section.fieldA
+		browser.initialFormScreen.section.form.section.nameList.section.fieldA
 			.fillInput({firstName: 'First', lastName: 'Last'});
 
-		browser.initialForm.section.form
+		browser.initialFormScreen.section.form
 			.click('@createButton');
 
 		browser.app
-			.waitForElementVisible('@itemScreen')
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.waitForItemScreen()
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.homeScreen.section.fieldsGroup.section.names
 			.expect.element('@itemCount').text.to.equal('1 Item');
 	},
 	'Home view should be accessible from any other non-modal view by clicking the Home link': function (browser) {
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.homeScreen.section.accessGroup.section.users
 			.click('@label');
 		browser.app
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 
 		browser.app
 			.click('@homeIconLink')
-			.waitForElementVisible('@homeScreen');
+			.waitForHomeScreen();
 	},
 	// UNDO ANY STATE CHANGES -- THIS TEST SHOULD RUN LAST
 	'Home view ... undoing any state changes': function (browser) {
 		// Delete the Name Field added
 		browser.app
-			.navigate()
-			.waitForElementVisible('@homeScreen');
+			.gotoHomeScreen()
+			.waitForHomeScreen();
 
 		browser.app
 			.click('@fieldListsMenu')
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 
 		browser.app
 			.click('@nameListSubmenu')
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 
 		browser.listScreen
 			.click('@singleItemDeleteIcon');
 
-		browser.deleteConfirmation
+		browser.deleteConfirmationScreen
 			.waitForElementVisible('@deleteButton');
 
-		browser.deleteConfirmation
+		browser.deleteConfirmationScreen
 			.click('@deleteButton');
 
 		browser.app.waitForListScreen();

--- a/test/e2e/adminUI/tests/group003List/uiTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uiTestListView.js
@@ -1,17 +1,19 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmationPage = browser.page.deleteConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -20,21 +22,21 @@ module.exports = {
 	'List screen must have a search bar': function (browser) {
 		browser.app
 			.click('@accessMenu')
-			.waitForElementVisible('@listScreen');
+			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@searchInputField').to.be.visible;
 	},
 	'List screen must have a filter input': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@filterDropdown').to.be.visible;
 	},
 	'List screen must have a column input': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@columnDropdown').to.be.visible;
 	},
 	'List screen must have a download input': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@downloadDropdown').to.be.visible;
 	},
 	// TODO:  For some reason the expand table width input control does not show in saucelabs' Firefox 44...why?
@@ -44,85 +46,85 @@ module.exports = {
 	//			      .to.be.visible;
 	//},
 	'List screen must have a create list item button': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@createMoreItemsButton').to.be.visible;
 	},
 	'List screen must have a pagination count': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').to.be.visible;
 	},
 	'List screen must have a name column header': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstColumnHeader').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstColumnHeader').text.to.equal('Name');
 	},
 	'List screen must have an email column header': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondColumnHeader').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondColumnHeader').text.to.equal('Email');
 	},
 	'List screen must have an Is Admin column header': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@thirdColumnHeader').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@thirdColumnHeader').text.to.equal('Is Admin');
 	},
 	'List screen items must a delete icon': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemDeleteIcon').to.be.visible;
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemDeleteIcon').to.be.visible;
 	},
 	'List screen user item must have a name value': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemFirstColumnValue').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemFirstColumnValue').text.to.equal('e2e member');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemFirstColumnValue').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemFirstColumnValue').text.to.equal('e2e user');
 	},
 	'List screen user item must have a value in the email column': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemSecondColumnValue').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemSecondColumnValue').text.to.equal('member@test.e2e');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemSecondColumnValue').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemSecondColumnValue').text.to.equal('user@test.e2e');
 	},
 	'List screen user item must have a value in the Is Admin column': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemThirdColumnValue').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemThirdColumnValue').to.be.visible;
 	},
 	'List screen user item must be an Admin and not a Member': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondUserItemIsAdmin').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondUserItemIsNotMember').to.be.visible;
 	},
 	'List screen member item must be a Member and not an Admin': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstUserItemIsMember').to.be.visible;
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstUserItemIsNotAdmin').to.be.visible;
 	},
 };

--- a/test/e2e/adminUI/tests/group003List/uxTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uxTestListView.js
@@ -1,17 +1,19 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmationPage = browser.page.deleteConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -24,22 +26,22 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.click('@createFirstItemButton');
 
 		browser.app
-			.waitForElementVisible('@initialFormScreen');
+			.waitForInitialFormScreen();
 
-		browser.initialFormPage.section.form.section.nameList.section.name
+		browser.initialFormScreen.section.form.section.nameList.section.name
 			.fillInput({value: 'Name Field Test 1'});
 
-		browser.initialFormPage.section.form.section.nameList.section.name
+		browser.initialFormScreen.section.form.section.nameList.section.name
 			.assertInput({value: 'Name Field Test 1'});
 
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
+		browser.initialFormScreen.section.form.section.nameList.section.fieldA
 			.fillInput({firstName: 'First 1', lastName: 'Last 1'});
 
-		browser.initialFormPage.section.form
+		browser.initialFormScreen.section.form
 			.click('@createButton');
 
 		browser.app
@@ -51,10 +53,10 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').text.to.equal('Showing 1 Name');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemNameValue').text.to.equal('Name Field Test 1');
 	},
 	'List view should allow users to create more new list items': function (browser) {
@@ -64,22 +66,22 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.click('@createMoreItemsButton');
 
 		browser.app
-			.waitForElementVisible('@initialFormScreen');
+			.waitForInitialFormScreen();
 
-		browser.initialFormPage.section.form.section.nameList.section.name
+		browser.initialFormScreen.section.form.section.nameList.section.name
 			.fillInput({value: 'Name Field Test 2'});
 
-		browser.initialFormPage.section.form.section.nameList.section.name
+		browser.initialFormScreen.section.form.section.nameList.section.name
 			.assertInput({value: 'Name Field Test 2'});
 
-		browser.initialFormPage.section.form.section.nameList.section.fieldA
+		browser.initialFormScreen.section.form.section.nameList.section.fieldA
 			.fillInput({firstName: 'First 2', lastName: 'Last 2'});
 
-		browser.initialFormPage.section.form
+		browser.initialFormScreen.section.form
 			.click('@createButton');
 
 		browser.app
@@ -91,13 +93,13 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').text.to.equal('Showing 2 Names');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemNameValue').text.to.equal('Name Field Test 1');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemNameValue').text.to.equal('Name Field Test 2');
 	},
 	'List view should allow users to browse an item by clicking the item name': function (browser) {
@@ -107,7 +109,7 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.click('@firstItemNameValue');
 
 		browser.app
@@ -120,13 +122,13 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.click('@firstItemNameValue');
 
 		browser.app
 			.waitForItemScreen();
 
-		browser.itemPage
+		browser.itemScreen
 			.click('@listBreadcrumb');
 
 		browser.app
@@ -139,51 +141,51 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.setValue('@searchInputField', 'Name Field Test 2');
 
 		browser.app
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').text.to.equal('Showing 1 Name');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemNameValue').text.to.equal('Name Field Test 2');
 	},
 	'List view should allow users to clear search filter': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.click('@searchInputFieldClearIcon');
 
 		browser.app
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').text.to.equal('Showing 2 Names');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemNameValue').text.to.equal('Name Field Test 1');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@secondItemNameValue').text.to.equal('Name Field Test 2');
 	},
 	'List view should allow users to delete items': function (browser) {
-		browser.listPage
+		browser.listScreen
 			.click('@firstItemDeleteIcon');
 
 		browser.app
-			.waitForElementVisible('@deleteConfirmationScreen');
+			.waitForDeleteConfirmationScreen();
 
-		browser.deleteConfirmationPage
+		browser.deleteConfirmationScreen
 			.click('@deleteButton');
 
 		browser.app
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@paginationCount').text.to.equal('Showing 1 Name');
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@firstItemNameValue').text.to.equal('Name Field Test 2');
 	},
 	'List view should allow users to delete last item': function (browser) {
@@ -193,19 +195,19 @@ module.exports = {
 			.click('@nameListSubmenu')
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.click('@firstItemDeleteIcon');
 
 		browser.app
-			.waitForElementVisible('@deleteConfirmationScreen');
+			.waitForDeleteConfirmationScreen();
 
-		browser.deleteConfirmationPage
+		browser.deleteConfirmationScreen
 			.click('@deleteButton');
 
 		browser.app
 			.waitForListScreen();
 
-		browser.listPage
+		browser.listScreen
 			.expect.element('@noItemsFoundNoText').text.to.equal('No names found…');
 	},
 

--- a/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
@@ -1,23 +1,24 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmationPage = browser.page.deleteConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
-		browser.app.waitForSigninScreen();
+		browser.signinScreen.signin();
 
-		browser.signinPage.signin();
+		browser.app
+			.waitForHomeScreen()
+			.click('@accessMenu')
+			.waitForListScreen();
 
-		browser.app.waitForHomeScreen();
-
-		browser.app.click('@accessMenu').waitForListScreen();
-
-		browser.listPage.click('@secondItemLink');
+		browser.listScreen.click('@secondItemLink');
 
 		browser.app.waitForItemScreen();
 	},
@@ -26,57 +27,57 @@ module.exports = {
 		browser.end();
 	},
 	'Item screen should show a search input icon to search for list items': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@searchInputIcon')
 			.to.be.visible;
 	},
 	'Item screen should show breadcrumb links to go back to the origin list': function (browser) {
-		browser.itemPage.expect.element('@listBreadcrumb')
+		browser.itemScreen.expect.element('@listBreadcrumb')
 			.to.be.visible;
 
-		browser.itemPage.expect.element('@listBreadcrumb')
+		browser.itemScreen.expect.element('@listBreadcrumb')
 			.text.to.equal('Users');
 	},
 	'Item screen should show a + New <item> button to create new items': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@newItemButton')
 			.to.be.visible;
 	},
 	'Item screen should show an item name header': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@readOnlyNameHeader')
 			.to.be.visible;
 
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@readOnlyNameHeader')
 			.text.to.equal('e2e user');
 	},
 	'Item screen should show an item id label': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@idLabel')
 			.to.be.visible;
 	},
 	'Item screen should show an item id value': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@idValue')
 			.to.be.visible;
 	},
 	'Item screen should show an item Meta header': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@metaHeader')
 			.to.be.visible;
 
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@metaHeader')
 			.text.to.equal('Meta');
 	},
 	'Item screen should show an item meta Created On label': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@metaCreatedOnLabel')
 			.to.be.visible;
 	},
 	'Item screen should show an item meta Created On value': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@metaCreatedOnValue')
 			.to.be.visible;
 	},
@@ -84,49 +85,49 @@ module.exports = {
 	//		  Currently the admin User is not created via a user session.
 	//		  These assertions should be done by the fields!
 	// 'Item screen should show an item meta Created By label': function (browser) {
-	// 	browser.itemPage
+	// 	browser.itemScreen
 	// 		.expect.element('@metaCreatedByLabel')
 	// 		.to.be.visible;
 	// },
 	// 'Item screen should show an item meta Created By value': function (browser) {
-	// 	browser.itemPage
+	// 	browser.itemScreen
 	// 		.expect.element('@metaCreatedByValue')
 	// 		.to.be.visible;
 	// },
 	// 'Item screen should show an item meta Updated By label': function (browser) {
-	// 	browser.itemPage
+	// 	browser.itemScreen
 	// 		.expect.element('@metaUpdatedByLabel')
 	// 		.to.be.visible;
 	// },
 	// 'Item screen should show an item meta Updated By value': function (browser) {
-	// 	browser.itemPage
+	// 	browser.itemScreen
 	// 		.expect.element('@metaUpdatedByValue')
 	// 		.to.be.visible;
 	// },
 	'Item screen should show an item save button': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@saveButton')
 			.to.be.visible;
 
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@saveButton')
 			.text.to.equal('Save');
 	},
 	'Item screen should show an item reset button': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@resetButton')
 			.to.be.visible;
 
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@resetButtonText')
 			.text.to.equal('reset changes');
 	},
 	'Item screen should show an item delete button': function (browser) {
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@deleteButton')
 			.to.be.visible;
 
-		browser.itemPage
+		browser.itemScreen
 			.expect.element('@deleteButtonText')
 			.text.to.equal('delete user');
 	},

--- a/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
@@ -4,24 +4,25 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmationPage = browser.page.deleteConfirmation();
-		browser.resetConfirmationPage = browser.page.resetConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
+		browser.resetConfirmationScreen = browser.page.resetConfirmation();
 
-		browser.app.navigate();
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
-		browser.app.waitForSigninScreen();
+		browser.signinScreen.signin();
 
-		browser.signinPage.signin();
+		browser.app
+			.waitForHomeScreen()
+			.click('@accessMenu')
+			.waitForListScreen();
 
-		browser.app.waitForHomeScreen();
-
-		browser.app.click('@accessMenu').waitForListScreen();
-
-		browser.listPage.click('@secondItemLink');
+		browser.listScreen.click('@secondItemLink');
 
 		browser.app.waitForItemScreen();
 	},
@@ -30,68 +31,68 @@ module.exports = {
 		browser.end();
 	},
 	'Item screen should allow creating an item of the same type': function (browser) {
-		browser.itemPage.new();
+		browser.itemScreen.new();
 
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 1', lastName: 'Last 1'},
 			},
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 1', lastName: 'Last 1'},
 			},
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
 	},
 	'Item screen should allow saving an item without changes': function (browser) {
-		browser.itemPage.save();
+		browser.itemScreen.save();
 
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 	},
 	'Item screen should allow saving an item with changes': function (browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 2', lastName: 'Last 2'},
 			},
 		});
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 2', lastName: 'Last 2'},
 			},
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 	},
 	'Item screen should allow resetting an item with changes': function (browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 3', lastName: 'Last 3'},
 			},
 		});
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 3', lastName: 'Last 3'},
 			},
 		});
 
-		browser.itemPage.reset();
+		browser.itemScreen.reset();
 		browser.app.waitForResetConfirmationScreen();
-		browser.resetConfirmationPage.reset();
+		browser.resetConfirmationScreen.reset();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'User',
 			fields: {
 				'name': {firstName: 'First 2', lastName: 'Last 2'},
@@ -99,9 +100,9 @@ module.exports = {
 		});
 	},
 	'Item screen should allow deleting an item': function (browser) {
-		browser.itemPage.delete();
+		browser.itemScreen.delete();
 		browser.app.waitForDeleteConfirmationScreen();
-		browser.deleteConfirmationPage.delete();
+		browser.deleteConfirmationScreen.delete();
 		browser.app.waitForListScreen();
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -1,15 +1,17 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForSigninScreen();
+		browser.app
+			.gotoHomeScreen()
+			.waitForSigninScreen();
 
-		browser.signinPage.signin();
+		browser.signinScreen.signin();
+
 		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
@@ -5,23 +5,23 @@ module.exports = {
 	after: fieldTests.after,
 	'Boolean field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Boolean');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'Boolean',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Boolean field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Boolean');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Boolean',
 			fields: {
 				'name': {value: 'Boolean Field Test 1'},
@@ -29,17 +29,17 @@ module.exports = {
 				'fieldD': {value: 'Test'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Boolean',
 			fields: {
 				'name': {value: 'Boolean Field Test 1'},
 				'fieldA': {value: 'true'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Boolean',
 			fields: {
 				'name': {value: 'Boolean Field Test 1'},
@@ -48,7 +48,7 @@ module.exports = {
 		})
 	},
 	'Boolean field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'Boolean',
 			fields: ['fieldA', 'fieldB']
 		});
@@ -56,22 +56,22 @@ module.exports = {
 	'Boolean field should have its default value if hidden': function(browser) {
 		// The hidden boolean field fieldC should have its default value true, meaning that fieldD should be visible.
 		// This used not to be correct as per issue https://github.com/keystonejs/keystone/issues/3029
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'Boolean',
 			fields: ['fieldD'],
 		});
 	},
 	'Boolean field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Boolean',
 			fields: {
 				'fieldB': {value: 'false'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Boolean',
 			fields: {
 				'name': {value: 'Boolean Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
@@ -5,38 +5,38 @@ module.exports = {
 	after: fieldTests.after,
 	'CloudinaryImage field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('CloudinaryImage');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'CloudinaryImage',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'CloudinaryImage field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('CloudinaryImage');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'CloudinaryImage',
 			fields: {
 				'name': {value: 'CloudinaryImage Field Test 1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'CloudinaryImage',
 			fields: {
 				'name': {value: 'CloudinaryImage Field Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'CloudinaryImage',
 			fields: {
 				'name': {value: 'CloudinaryImage Field Test 1'},
@@ -44,7 +44,7 @@ module.exports = {
 		})
 	},
 	'CloudinaryImage field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'CloudinaryImage',
 			fields: ['fieldA', 'fieldB']
 		});

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
@@ -5,38 +5,38 @@ module.exports = {
 	after: fieldTests.after,
 	'CloudinaryImageMultiple field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('CloudinaryImageMultiple');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'CloudinaryImageMultiple',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'CloudinaryImageMultiple field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('CloudinaryImageMultiple');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'CloudinaryImageMultiple',
 			fields: {
 				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'CloudinaryImageMultiple',
 			fields: {
 				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'CloudinaryImageMultiple',
 			fields: {
 				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
@@ -44,7 +44,7 @@ module.exports = {
 		})
 	},
 	'CloudinaryImageMultiple field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'CloudinaryImageMultiple',
 			fields: ['fieldA', 'fieldB']
 		});

--- a/test/e2e/adminUI/tests/group005Fields/testCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCodeField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Code field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Code');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Code',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Code field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Code');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Code',
 			fields: {
 				'name': {value: 'Code Field Test 1'},
 				'fieldA': {value: 'Some test code for field A'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Code',
 			fields: {
 				'name': {value: 'Code Field Test 1'},
 				'fieldA': {value: 'Some test code for field A'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Code',
 			fields: {
 				'name': {value: 'Code Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Code field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Code',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Code field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Code',
 			fields: {
 				'fieldB': {value: 'Some test code for field B'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Code',
 			fields: {
 				'name': {value: 'Code Field Test 1'},
@@ -72,7 +72,7 @@ module.exports = {
 		})
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testColorField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Color field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Color');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Color',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Color field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Color');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Color',
 			fields: {
 				'name': {value: 'Color Field Test 1'},
 				'fieldA': {value: '#002147'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Color',
 			fields: {
 				'name': {value: 'Color Field Test 1'},
 				'fieldA': {value: '#002147'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Color',
 			fields: {
 				'name': {value: 'Color Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Color field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Color',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Color field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Color',
 			fields: {
 				'fieldB': {value: '#f8e71c'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Color',
 			fields: {
 				'name': {value: 'Color Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'DateArray field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('DateArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'DateArray',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'DateArray field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('DateArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'DateArray',
 			fields: {
 				'name': {value: 'DateArray Field Test 1'},
 			}
 		});
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'DateArray',
 			fields: {
 				'name': {value: 'DateArray Field Test 1'},
 			}
 		});
 		*/
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'DateArray',
 			fields: {
 				'name': {value: 'DateArray Field Test 1'},
@@ -47,38 +47,38 @@ module.exports = {
 		*/
 	},
 	'DateArray field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'DateArray',
 			fields: ['fieldA', 'fieldB']
 		});
-		browser.itemPage.section.form.section.datearrayList.section.fieldA.addDate();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.datearrayList.section.fieldA.addDate();
+		browser.itemScreen.assertUI({
 			listName: 'DateArray',
 			fields: ['fieldA'],
 			args: {'dateInputs': ['date1']}
 		});
-		browser.itemPage.section.form.section.datearrayList.section.fieldA.addDate();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.datearrayList.section.fieldA.addDate();
+		browser.itemScreen.assertUI({
 			listName: 'DateArray',
 			fields: ['fieldA'],
 			args: {'dateInputs': ['date1', 'date2']}
 		});
-		browser.itemPage.section.form.section.datearrayList.section.fieldB.addDate();
-		browser.itemPage.section.form.section.datearrayList.section.fieldB.addDate();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.datearrayList.section.fieldB.addDate();
+		browser.itemScreen.section.form.section.datearrayList.section.fieldB.addDate();
+		browser.itemScreen.assertUI({
 			listName: 'DateArray',
 			fields: ['fieldB'],
 			args: {'dateInputs': ['date1', 'date2']}
 		});
 	},
 	'DateArray field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'DateArray',
 			fields: {
 				'fieldA': {date1: '2016-01-01', date2: '2016-01-02'}
 			}
 		});
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'DateArray',
 			fields: {
 				'fieldB': {date1: '2016-01-03', date2: '2016-01-04'}
@@ -89,11 +89,11 @@ module.exports = {
 			document.activeElement.blur();
 		});
 
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'DateArray',
 			fields: {
 				'name': {value: 'DateArray Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateField.js
@@ -5,23 +5,23 @@ module.exports = {
 	after: fieldTests.after,
 	'Date field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Date');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Date',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Date field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Date');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Date',
 			fields: {
 				'name': {value: 'Date Field Test 1'},
@@ -29,7 +29,7 @@ module.exports = {
 			}
 		});
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Date',
 			fields: {
 				'name': {value: 'Date Field Test 1'},
@@ -37,10 +37,10 @@ module.exports = {
 			}
 		});
 		*/
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Date',
 			fields: {
 				'name': {value: 'Date Field Test 1'},
@@ -50,13 +50,13 @@ module.exports = {
 		*/
 	},
 	'Date field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Date',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Date field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Date',
 			fields: {
 				'fieldB': {value: '2016-01-02'}
@@ -66,11 +66,11 @@ module.exports = {
 		browser.execute(function() {
 			document.activeElement.blur();
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Date',
 			fields: {
 				'name': {value: 'Date Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
@@ -6,23 +6,23 @@ module.exports = {
 	after: fieldTests.after,
 	'Datetime field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Datetime');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Datetime',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Datetime field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Datetime');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'Datetime Field Test 1'},
@@ -30,7 +30,7 @@ module.exports = {
 			}
 		});
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'Datetime Field Test 1'},
@@ -38,10 +38,10 @@ module.exports = {
 			}
 		});
 		*/
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'Datetime Field Test 1'},
@@ -51,23 +51,23 @@ module.exports = {
 		*/
 	},
 	'Datetime field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Datetime',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Datetime field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Datetime',
 			fields: {
 				'fieldB': {date: '2016-01-02', time: '12:00:00 am'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'Datetime Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testEmailField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testEmailField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Email field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Email');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Email',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Email field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Email');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Email',
 			fields: {
 				'name': {value: 'Email Field Test 1'},
 				'fieldA': {value: 'user@example1.com'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Email',
 			fields: {
 				'name': {value: 'Email Field Test 1'},
 				'fieldA': {value: 'user@example1.com'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Email',
 			fields: {
 				'name': {value: 'Email Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Email field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Email',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Email field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Email',
 			fields: {
 				'fieldB': {value: 'user@example2.com'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Email',
 			fields: {
 				'name': {value: 'Email Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testFileField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testFileField.js
@@ -5,38 +5,38 @@ module.exports = {
 	after: fieldTests.after,
 	'File field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('File');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'File',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'File field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('File');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'File',
 			fields: {
 				'name': {value: 'File Field Test 1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'File',
 			fields: {
 				'name': {value: 'File Field Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'File',
 			fields: {
 				'name': {value: 'File Field Test 1'},
@@ -44,7 +44,7 @@ module.exports = {
 		})
 	},
 	'File field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'File',
 			fields: ['fieldA', 'fieldB']
 		});

--- a/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'GeoPoint field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('GeoPoint');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'GeoPoint',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'GeoPoint field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('GeoPoint');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'GeoPoint',
 			fields: {
 				'name': {value: 'GeoPoint Field Test 1'},
 				'fieldA': {lat: '123', lng: '456'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'GeoPoint',
 			fields: {
 				'name': {value: 'GeoPoint Field Test 1'},
 				'fieldA': {lat: '123', lng: '456'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'GeoPoint',
 			fields: {
 				'name': {value: 'GeoPoint Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'GeoPoint field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'GeoPoint',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'GeoPoint field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'GeoPoint',
 			fields: {
 				'fieldB': {lat: '789', lng: '246'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'GeoPoint',
 			fields: {
 				'name': {value: 'GeoPoint Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Html field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Html');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Html',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Html field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Html');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Html',
 			fields: {
 				'name': {value: 'Html Field Test 1'},
 				'fieldA': {value: 'Some test html code for field A'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Html',
 			fields: {
 				'name': {value: 'Html Field Test 1'},
 				'fieldA': {value: 'Some test html code for field A'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Html',
 			fields: {
 				'name': {value: 'Html Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Html field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Html',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Html field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Html',
 			fields: {
 				'fieldB': {value: 'Some test html code for field B'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Html',
 			fields: {
 				'name': {value: 'Html Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testKeyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testKeyField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Key field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Key');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Key',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Key field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Key');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Key',
 			fields: {
 				'name': {value: 'Key Field Test 1'},
 				'fieldA': {value: 'A test key for field A'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Key',
 			fields: {
 				'name': {value: 'Key Field Test 1'},
 				'fieldA': {value: 'A test key for field A'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Key',
 			fields: {
 				'name': {value: 'Key Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Key field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Key',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Key field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Key',
 			fields: {
 				'fieldB': {value: 'A test key for field B'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Key',
 			fields: {
 				'name': {value: 'Key Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testLocationField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testLocationField.js
@@ -5,39 +5,39 @@ module.exports = {
 	after: fieldTests.after,
 	'Location field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Location');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'Location',
 			fields: ['name', 'fieldA'],
 			args: { 'showMore': false },
 		});
 
-		browser.initialFormPage.showMoreFields({
+		browser.initialFormScreen.showMoreFields({
 			listName: 'Location',
 			fields: ['fieldA'],
 		});
 
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'Location',
 			fields: ['name', 'fieldA'],
 			args: { 'showMore': true },
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Location field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Location');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.showMoreFields({
+		browser.initialFormScreen.showMoreFields({
 			listName: 'Location',
 			fields: ['fieldA'],
 		});
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Location',
 			fields: {
 				'name': {value: 'Location Field Test 1'},
@@ -55,7 +55,7 @@ module.exports = {
 				},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Location',
 			fields: {
 				'name': {value: 'Location Field Test 1'},
@@ -73,10 +73,10 @@ module.exports = {
 				},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Location',
 			fields: {
 				'name': {value: 'Location Field Test 1'},
@@ -96,28 +96,28 @@ module.exports = {
 		})
 	},
 	'Location field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'Location',
 			fields: ['fieldA'],
 			args: { 'showMore': true },
 		});
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'Location',
 			fields: ['fieldB'],
 			args: { 'showMore': false },
 		});
-		browser.itemPage.showMoreFields({
+		browser.itemScreen.showMoreFields({
 			listName: 'Location',
 			fields: ['fieldB'],
 		});
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'Location',
 			fields: ['fieldB'],
 			args: { 'showMore': true },
 		});
 	},
 	'Location field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Location',
 			fields: {
 				'fieldB': {
@@ -134,10 +134,10 @@ module.exports = {
 				},
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Location',
 			fields: {
 				'name': {value: 'Location Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
@@ -5,48 +5,48 @@ module.exports = {
 	after: fieldTests.after,
 	'Markdown field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Markdown');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Markdown',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Markdown field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Markdown');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},
 				'fieldA': {md: 'Some __test__ markdown for **field A**'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},
 				'fieldA': {md: 'Some __test__ markdown for **field A**'},
 			}
 		});
-		browser.initialFormPage.section.form.section.markdownList.section.fieldA.togglePreview();
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.section.form.section.markdownList.section.fieldA.togglePreview();
+		browser.initialFormScreen.assertInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},
 				'fieldA': {html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},
@@ -55,22 +55,22 @@ module.exports = {
 		})
 	},
 	'Markdown field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Markdown',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Markdown field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Markdown',
 			fields: {
 				'fieldB': {md: 'Some __test__ markdown for **field B**'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},
@@ -80,9 +80,9 @@ module.exports = {
 		});
 		/* TODO Work out why this was breaking travis, and re-implement
 		See https://travis-ci.org/keystonejs/keystone/builds/130040822#L2215
-		browser.itemPage.section.form.section.markdownList.section.fieldA.togglePreview();
-		browser.itemPage.section.form.section.markdownList.section.fieldB.togglePreview();
-		browser.itemPage.assertInputs({
+		browser.itemScreen.section.form.section.markdownList.section.fieldA.togglePreview();
+		browser.itemScreen.section.form.section.markdownList.section.fieldB.togglePreview();
+		browser.itemScreen.assertInputs({
 			listName: 'Markdown',
 			fields: {
 				'name': {value: 'Markdown Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Money field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Money');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Money',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Money field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Money');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Money',
 			fields: {
 				'name': {value: 'Money Field Test 1'},
 				'fieldA': {value: '1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Money',
 			fields: {
 				'name': {value: 'Money Field Test 1'},
 				'fieldA': {value: '1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Money',
 			fields: {
 				'name': {value: 'Money Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Money field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Money',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Money field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Money',
 			fields: {
 				'fieldB': {value: '2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Money',
 			fields: {
 				'name': {value: 'Money Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNameField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Name field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Name');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Name',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Name field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Name');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Name',
 			fields: {
 				'name': {value: 'Name Field Test 1'},
 				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Name',
 			fields: {
 				'name': {value: 'Name Field Test 1'},
 				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Name',
 			fields: {
 				'name': {value: 'Name Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Name field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Name',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Name field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Name',
 			fields: {
 				'fieldB': {firstName: 'First 2', lastName: 'Last 2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Name',
 			fields: {
 				'name': {value: 'Name Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
@@ -5,37 +5,37 @@ module.exports = {
 	after: fieldTests.after,
 	'NumberArray field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('NumberArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'NumberArray',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'NumberArray field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('NumberArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'NumberArray',
 			fields: {
 				'name': {value: 'NumberArray Field Test 1'},
 			}
 		});
-		 browser.initialFormPage.assertInputs({
+		 browser.initialFormScreen.assertInputs({
 			 listName: 'NumberArray',
 			 fields: {
 			 	'name': {value: 'NumberArray Field Test 1'},
 			 }
 		 });
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
-		 browser.itemPage.assertInputs({
+		 browser.itemScreen.assertInputs({
 			 listName: 'NumberArray',
 			 fields: {
 			 	'name': {value: 'NumberArray Field Test 1'},
@@ -43,47 +43,47 @@ module.exports = {
 		 })
 	},
 	'NumberArray field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'NumberArray',
 			fields: ['fieldA', 'fieldB']
 		});
-		browser.itemPage.section.form.section.numberarrayList.section.fieldA.addNumber();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.numberarrayList.section.fieldA.addNumber();
+		browser.itemScreen.assertUI({
 			listName: 'NumberArray',
 			fields: ['fieldA'],
 			args: {'numberInputs': ['number1']}
 		});
-		browser.itemPage.section.form.section.numberarrayList.section.fieldA.addNumber();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.numberarrayList.section.fieldA.addNumber();
+		browser.itemScreen.assertUI({
 			listName: 'NumberArray',
 			fields: ['fieldA'],
 			args: {'numberInputs': ['number1', 'number2']}
 		});
-		browser.itemPage.section.form.section.numberarrayList.section.fieldB.addNumber();
-		browser.itemPage.section.form.section.numberarrayList.section.fieldB.addNumber();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.numberarrayList.section.fieldB.addNumber();
+		browser.itemScreen.section.form.section.numberarrayList.section.fieldB.addNumber();
+		browser.itemScreen.assertUI({
 			listName: 'NumberArray',
 			fields: ['fieldB'],
 			args: {'numberInputs': ['number1', 'number2']}
 		});
 	},
 	'NumberArray field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'NumberArray',
 			fields: {
 				'fieldA': {number1: '1', number2: '2'}
 			}
 		});
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'NumberArray',
 			fields: {
 				'fieldB': {number1: '3', number2: '4'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'NumberArray',
 		 	fields: {
 		 		'name': {value: 'NumberArray Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testNumberField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Number field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Number');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Number',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Number field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Number');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Number',
 			fields: {
 				'name': {value: 'Number Field Test 1'},
 				'fieldA': {value: '1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Number',
 			fields: {
 				'name': {value: 'Number Field Test 1'},
 				'fieldA': {value: '1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Number',
 			fields: {
 				'name': {value: 'Number Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Number field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Number',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Number field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Number',
 			fields: {
 				'fieldB': {value: '2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Number',
 			fields: {
 				'name': {value: 'Number Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
@@ -5,48 +5,48 @@ module.exports = {
 	after: fieldTests.after,
 	'Password field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Password');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Password',
 			fields: ['name', 'fieldA'],
 			args: {'editForm': false}, // To check for @value instead of @button
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Password field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Password');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Password',
 			fields: {
 				'name': {value: 'Password Field Test 1'},
 				'fieldA': {value: 'password1', confirm: 'wrongPassword1'},
 			}
 		});
-		browser.initialFormPage.save();
-		browser.initialFormPage.assertFlashError("Passwords must match");
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.save();
+		browser.initialFormScreen.assertFlashError("Passwords must match");
+		browser.initialFormScreen.fillInputs({
 			listName: 'Password',
 			fields: {
 				'fieldA': {value: 'password1', confirm: 'password1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Password',
 			fields: {
 				'name': {value: 'Password Field Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Password',
 			fields: {
 				'name': {value: 'Password Field Test 1'},
@@ -54,33 +54,33 @@ module.exports = {
 		})
 	},
 	'Password field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Password',
 			fields: ['fieldA', 'fieldB'],
 			args: {'editForm': true}, // To check for @button instead of @value
 		});
 	},
 	'Password field can be filled via the edit form': function(browser) {
-		browser.itemPage.section.form.section.passwordList.section.fieldB.clickSetPassword();
-		browser.itemPage.fillInputs({
+		browser.itemScreen.section.form.section.passwordList.section.fieldB.clickSetPassword();
+		browser.itemScreen.fillInputs({
 			listName: 'Password',
 			fields: {
 				'fieldB': {value: 'password2', confirm: 'wrongPassword2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashError('Passwords must match');
-		browser.itemPage.fillInputs({
+		browser.itemScreen.assertFlashError('Passwords must match');
+		browser.itemScreen.fillInputs({
 			listName: 'Password',
 			fields: {
 				'fieldB': {value: 'password2', confirm: 'password2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Password',
 			fields: {
 				'name': {value: 'Password Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
@@ -5,39 +5,39 @@ module.exports = {
 	after: fieldTests.after,
 	'Relationship field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Relationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Relationship',
 			fields: ['name', 'fieldA']
 		});
 
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Relationship field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Relationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Relationship',
 			fields: {
 				'name': {value: 'Relationship Field Test 1'},
 				'fieldA': {option: 'option1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Relationship',
 			fields: {
 				'name': {value: 'Relationship Field Test 1'},
 				'fieldA': {value: 'e2e member'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Relationship',
 			fields: {
 				'name': {value: 'Relationship Field Test 1'},
@@ -46,22 +46,22 @@ module.exports = {
 		})
 	},
 	'Relationship field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Relationship',
 			fields: ['fieldB']
 		});
 	},
 	'Relationship field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Relationship',
 			fields: {
 				'fieldB': {option: 'option2'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Relationship',
 			fields: {
 				'name': {value: 'Relationship Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testSelectField.js
@@ -5,41 +5,41 @@ module.exports = {
 	after: fieldTests.after,
 	'Select field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Select');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Select',
 			fields: ['name', 'fieldA'],
 			args: {'editForm': false}, // To check for @value instead of @button
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Select field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Select');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Select',
 			fields: {
 				'name': {value: 'Select Field Test 1'},
 				'fieldA': {value: 'One'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Select',
 			fields: {
 				'name': {value: 'Select Field Test 1'},
 				'fieldA': {value: 'One'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Select',
 			fields: {
 				'name': {value: 'Select Field Test 1'},
@@ -48,23 +48,23 @@ module.exports = {
 		})
 	},
 	'Select field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Select',
 			fields: ['fieldA', 'fieldB'],
 			args: {'editForm': true},
 		});
 	},
 	'Select field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Select',
 			fields: {
 				'fieldB': {value: 'Two'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Select',
 			fields: {
 				'name': {value: 'Select Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
@@ -5,37 +5,37 @@ module.exports = {
 	after: fieldTests.after,
 	'TextArray field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('TextArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'TextArray',
 			fields: ['name']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'TextArray field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('TextArray');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'TextArray',
 			fields: {
 				'name': {value: 'TextArray Field Test 1'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'TextArray',
 			fields: {
 				'name': {value: 'TextArray Field Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'TextArray',
 			fields: {
 				'name': {value: 'TextArray Field Test 1'},
@@ -43,47 +43,47 @@ module.exports = {
 		})
 	},
 	'TextArray field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'TextArray',
 			fields: ['fieldA', 'fieldB']
 		});
-		browser.itemPage.section.form.section.textarrayList.section.fieldA.addText();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.textarrayList.section.fieldA.addText();
+		browser.itemScreen.assertUI({
 			listName: 'TextArray',
 			fields: ['fieldA'],
 			args: {'textInputs': ['text1']}
 		});
-		browser.itemPage.section.form.section.textarrayList.section.fieldA.addText();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.textarrayList.section.fieldA.addText();
+		browser.itemScreen.assertUI({
 			listName: 'TextArray',
 			fields: ['fieldA'],
 			args: {'textInputs': ['text1', 'text2']}
 		});
-		browser.itemPage.section.form.section.textarrayList.section.fieldB.addText();
-		browser.itemPage.section.form.section.textarrayList.section.fieldB.addText();
-		browser.itemPage.assertUI({
+		browser.itemScreen.section.form.section.textarrayList.section.fieldB.addText();
+		browser.itemScreen.section.form.section.textarrayList.section.fieldB.addText();
+		browser.itemScreen.assertUI({
 			listName: 'TextArray',
 			fields: ['fieldB'],
 			args: {'textInputs': ['text1', 'text2']}
 		});
 	},
 	'TextArray field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'TextArray',
 			fields: {
 				'fieldA': {text1: 'Test text 1', text2: 'Test text 2'}
 			}
 		});
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'TextArray',
 			fields: {
 				'fieldB': {text1: 'Test text 3', text2: 'Test text 4'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'TextArray',
 			fields: {
 				'name': {value: 'TextArray Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Text field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Text');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Text',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Text field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Text');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Text',
 			fields: {
 				'name': {value: 'Text Field Test 1'},
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Text',
 			fields: {
 				'name': {value: 'Text Field Test 1'},
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Text',
 			fields: {
 				'name': {value: 'Text Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Text field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Text',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Text field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Text',
 			fields: {
 				'fieldB': {value: 'Some test text for field B'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Text',
 			fields: {
 				'name': {value: 'Text Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Textarea field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Textarea');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Textarea',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Textarea field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Textarea');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Textarea',
 			fields: {
 				'name': {value: 'Textarea Field Test 1'},
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Textarea',
 			fields: {
 				'name': {value: 'Textarea Field Test 1'},
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Textarea',
 			fields: {
 				'name': {value: 'Textarea Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Textarea field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Textarea',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Textarea field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Textarea',
 			fields: {
 				'fieldB': {value: 'Some test text for field B'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Textarea',
 			fields: {
 				'name': {value: 'Textarea Field Test 1'},

--- a/test/e2e/adminUI/tests/group005Fields/testUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testUrlField.js
@@ -5,40 +5,40 @@ module.exports = {
 	after: fieldTests.after,
 	'Url field should show correctly in the initial modal': function (browser) {
 		browser.app.openFieldList('Url');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'Url',
 			fields: ['name', 'fieldA']
 		});
 	},
 	'restoring test state': function(browser) {
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 		browser.app.waitForListScreen();
 	},
 	'Url field can be filled via the initial modal': function(browser) {
 		browser.app.openFieldList('Url');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
 				'fieldA': {value: 'http://www.example1.com'},
 			}
 		});
-		browser.initialFormPage.assertInputs({
+		browser.initialFormScreen.assertInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
 				'fieldA': {value: 'http://www.example1.com'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},
@@ -47,22 +47,22 @@ module.exports = {
 		})
 	},
 	'Url field should show correctly in the edit form': function(browser) {
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Url',
 			fields: ['fieldA', 'fieldB']
 		});
 	},
 	'Url field can be filled via the edit form': function(browser) {
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'Url',
 			fields: {
 				'fieldB': {value: 'http://www.example2.com'}
 			}
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertInputs({
 			listName: 'Url',
 			fields: {
 				'name': {value: 'Url Field Test 1'},

--- a/test/e2e/adminUI/tests/group999FixMe/2382.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2382.js
@@ -1,17 +1,17 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmation = browser.page.deleteConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
+		browser.app.gotoHomeScreen();
 		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -22,16 +22,16 @@ module.exports = {
 		// Add new text item
 
 		browser.app.openFieldList('Text');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Text',
 			fields: {
 				'name': {value: 'Test 1'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
 		browser.app.click('@homeIconLink');
@@ -40,17 +40,17 @@ module.exports = {
 		// Add new relationship with the above text item
 
 		browser.app.openMiscList('ManyRelationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'ManyRelationship',
 			fields: {
 				'name': {value: 'Test 1'},
 				'fieldA': {value: 'Test 1'}
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
 		browser.app.click('@homeIconLink');
@@ -62,21 +62,21 @@ module.exports = {
 		browser.app.waitForListScreen();
 
 
-		browser.listPage.navigateToFirstItem();
+		browser.listScreen.navigateToFirstItem();
 		browser.app.waitForItemScreen();
-		browser.itemPage.delete();
+		browser.itemScreen.delete();
 
-		browser.deleteConfirmation
+		browser.deleteConfirmationScreen
 			.waitForElementVisible('@deleteButton');
 
-		browser.deleteConfirmation
+		browser.deleteConfirmationScreen
 			.click('@deleteButton');
 
 		browser.app.click('@homeIconLink');
 		browser.app.waitForHomeScreen();
 
 		browser.app.openMiscList('ManyRelationship');
-		browser.listPage.navigateToFirstItem();
+		browser.listScreen.navigateToFirstItem();
 
 		// TODO since we've not established the intended behaviour yet, just pause.
 		// Currently, a blank box appears.

--- a/test/e2e/adminUI/tests/group999FixMe/2898.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2898.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.gotoHomeScreen();
+		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,10 +19,10 @@ module.exports = {
 	'Demonstrate issue 2898': function(browser) {
 		// Create items
 		browser.app.openFieldList('Datetime');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'testing'},
@@ -30,10 +30,10 @@ module.exports = {
 			}
 		});
 
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 
 		// The following assertion passes where it should fail.
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'Datetime',
 			fields: {
 				'name': {value: 'testing'},
@@ -42,9 +42,9 @@ module.exports = {
 		});
 
 		// The following assertion fails where is should pass.
-		browser.initialFormPage.assertFlashError("Please enter a valid date and time in the Field A field");
+		browser.initialFormScreen.assertFlashError("Please enter a valid date and time in the Field A field");
 
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 
 	}
 };

--- a/test/e2e/adminUI/tests/group999FixMe/2940.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2940.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
+		browser.app.gotoHomeScreen();
 		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -18,69 +18,69 @@ module.exports = {
 	},
 	'List items with relationships to them should allow navigating to the source relationships': function(browser) {
 		browser.app.openMiscList('TargetRelationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'TargetRelationship',
 			fields: ['name'],
 		});
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'TargetRelationship',
 			fields: {
 				'name': {value: 'Test Target 1'},
 			},
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
 		browser.app.openMiscList('SourceRelationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.assertUI({
+		browser.initialFormScreen.assertUI({
 			listName: 'SourceRelationship',
 			fields: ['name'],
 		});
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'SourceRelationship',
 			fields: {
 				'name': {value: 'Test Source 1'},
 			},
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'SourceRelationship',
 			fields: {
 				'fieldA': {value: 'Test Target 1'},
 				//'fieldA': {option: 'option1'},
 			},
 		});
-		browser.itemPage.save();
+		browser.itemScreen.save();
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertFlashMessage('Your changes have been saved successfully');
+		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.app.openMiscList('TargetRelationship');
-		browser.listPage.navigateToFirstItem();
+		browser.listScreen.navigateToFirstItem();
 
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'TargetRelationship',
 			fields: {
 				'name': {value: 'Test Target 1'},
 			},
 		});
 
-		browser.itemPage.navitageToFirstRelationship();
+		browser.itemScreen.navitageToFirstRelationship();
 
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.assertInputs({
+		browser.itemScreen.assertInputs({
 			listName: 'SourceRelationship',
 			fields: {
 				'name': {value: 'Select Field Test 1'},

--- a/test/e2e/adminUI/tests/group999FixMe/2941.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2941.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.gotoHomeScreen();
+		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,16 +19,16 @@ module.exports = {
 	'Demonstrate issue 2941': function(browser) {
 		// Create items
 		browser.app.openMiscList('HiddenRelationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
 
 		// Issue demonstration - the field should not be visible, but it is.
 
-		browser.initialFormPage.section.form.section.hiddenrelationshipList.section.fieldA
+		browser.initialFormScreen.section.form.section.hiddenrelationshipList.section.fieldA
 			.expect.element('@label').to.not.be.visible;
 
-		browser.initialFormPage.cancel();
+		browser.initialFormScreen.cancel();
 
 	}
 };

--- a/test/e2e/adminUI/tests/group999FixMe/2945.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2945.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.gotoHomeScreen();
+		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,26 +19,26 @@ module.exports = {
 	'List screen must show ID column if it has neither default nor name columns': function(browser) {
 		// Create items
 		browser.app.openMiscList('NoDefaultColumn');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'NoDefaultColumn',
 			fields: {
 				'fieldA': {value: 'testing'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
 		// If no default is set, the ID should be used.
 		browser.app.navigate('http://localhost:3000/keystone/no-default-columns');
-		browser.listPage.expect.element('@firstColumnHeader').text.to.equal('ID');
+		browser.listScreen.expect.element('@firstColumnHeader').text.to.equal('ID');
 	},
 	'List screen must show requested columns': function(browser) {
 		// If specific columns have been requested, they should be shown.
 		browser.app.navigate('http://localhost:3000/keystone/no-default-columns?columns=id%2CfieldA');
-		browser.listPage.expect.element('@firstColumnHeader').text.to.equal('ID');
-		browser.listPage.expect.element('@secondColumnHeader').text.to.equal('Field A');
+		browser.listScreen.expect.element('@firstColumnHeader').text.to.equal('ID');
+		browser.listScreen.expect.element('@secondColumnHeader').text.to.equal('Field A');
 
 	}
 };

--- a/test/e2e/adminUI/tests/group999FixMe/3028.js
+++ b/test/e2e/adminUI/tests/group999FixMe/3028.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.gotoHomeScreen();
+		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,12 +19,12 @@ module.exports = {
 	'Should be able to create an inline relationship': function(browser) {
 		// Create items
 		browser.app.openMiscList('InlineRelationship');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 
 		browser.app.waitForItemScreen();
-		browser.itemPage.assertUI({
+		browser.itemScreen.assertUI({
 			listName: 'Relationship',
 			fields: ['fieldA']
 		});

--- a/test/e2e/adminUI/tests/group999FixMe/3126.js
+++ b/test/e2e/adminUI/tests/group999FixMe/3126.js
@@ -1,17 +1,17 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
-		browser.deleteConfirmation = browser.page.deleteConfirmation();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
+		browser.deleteConfirmationScreen = browser.page.deleteConfirmation();
 
-		browser.app.navigate();
+		browser.app.gotoHomeScreen();
 		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -22,24 +22,24 @@ module.exports = {
 		// Add new text item
 
 		browser.app.openMiscList('DateFieldMap');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'DateFieldMap',
 			fields: {
 				'datefield': {value: '2016-01-01'},
 			}
 		});
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 		browser.app.waitForItemScreen();
 
-		browser.itemPage.back();
+		browser.itemScreen.back();
 
 
 		// The following command fails, because there is no link to follow. This is a bug. 
 		// If you remove the map from test/e2e/models/misc/DateFieldMap.js then the command works.
-		browser.listPage.navigateToFirstItem();
+		browser.listScreen.navigateToFirstItem();
 
 	}
 };

--- a/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
+++ b/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
@@ -1,16 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.app = browser.page.app();
-		browser.signinPage = browser.page.signin();
-		browser.listPage = browser.page.list();
-		browser.itemPage = browser.page.item();
-		browser.initialFormPage = browser.page.initialForm();
+		browser.signinScreen = browser.page.signin();
+		browser.listScreen = browser.page.list();
+		browser.itemScreen = browser.page.item();
+		browser.initialFormScreen = browser.page.initialForm();
 
-		browser.app.navigate();
-		browser.app.waitForElementVisible('@signinScreen');
+		browser.app.gotoHomeScreen();
+		browser.app.waitForSigninScreen();
 
-		browser.signinPage.signin();
-		browser.app.waitForElementVisible('@homeScreen');
+		browser.signinScreen.signin();
+		browser.app.waitForHomeScreen();
 	},
 	after: function (browser) {
 		browser.app.signout();
@@ -19,12 +19,12 @@ module.exports = {
 	'Depends On field should work in initial form': function(browser) {
 		// Create items
 		browser.app.openMiscList('DependsOn');
-		browser.listPage.createFirstItem();
+		browser.listScreen.createFirstItem();
 		browser.app.waitForInitialFormScreen();
 
 
 		// The dependency condition is met by default, so the dependent field should show.
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'DependsOn',
 			fields: ['dependency', 'dependent'],
 			args: {
@@ -32,14 +32,14 @@ module.exports = {
 			}
 		});
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'DependsOn',
 			fields: {
 				'dependency': true
 			}
 		});
 
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'DependsOn',
 			fields: ['dependency'],
 			args: {
@@ -47,7 +47,7 @@ module.exports = {
 			}
 		});
 
-		browser.initialFormPage.assertUINotPresent({
+		browser.initialFormScreen.assertUINotPresent({
 			listName: 'DependsOn',
 			fields: ['dependent'],
 			args: {
@@ -55,14 +55,14 @@ module.exports = {
 			}
 		});
 
-		browser.initialFormPage.fillInputs({
+		browser.initialFormScreen.fillInputs({
 			listName: 'DependsOn',
 			fields: {
 				'dependency': false
 			}
 		});
 
-		browser.initialFormPage.assertUIVisible({
+		browser.initialFormScreen.assertUIVisible({
 			listName: 'DependsOn',
 			fields: ['dependency', 'dependent'],
 			args: {
@@ -70,19 +70,19 @@ module.exports = {
 			}
 		});
 
-		browser.initialFormPage.save();
+		browser.initialFormScreen.save();
 	},
 
 	'Depends On field should work in the edit form': function(browser) {
 
 		// The dependency condition is met, so the dependent field should show.
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'DependsOn',
 			fields: ['dependency', 'dependent'],
 			args: {'editForm': false}
 		});
 
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'DependsOn',
 			fields: {
 				'dependency': true
@@ -90,7 +90,7 @@ module.exports = {
 		});
 
 		// The dependency condition is no longer met, field should not be visible.
-		browser.itemPage.assertUINotPresent({
+		browser.itemScreen.assertUINotPresent({
 			listName: 'DependsOn',
 			fields: ['dependent'],
 			args: {
@@ -98,14 +98,14 @@ module.exports = {
 			}
 		});
 
-		browser.itemPage.fillInputs({
+		browser.itemScreen.fillInputs({
 			listName: 'DependsOn',
 			fields: {
 				'dependency': false
 			}
 		});
 
-		browser.itemPage.assertUIVisible({
+		browser.itemScreen.assertUIVisible({
 			listName: 'DependsOn',
 			fields: ['dependency', 'dependent'],
 			args: {
@@ -113,6 +113,6 @@ module.exports = {
 			}
 		});
 
-		browser.itemPage.save();
+		browser.itemScreen.save();
 	}
 };


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

This is the first of a series of e2e refactoring.  In this change set the following was done:

- use the app PO `waitFor*Screen()` to wait for screens to show up during tests
- change the variable that reflect the screen to actually be called `*Screen` to be more consistent with their names in the admin UI code
- remove latency as a factor where obvious (e.g., waiting for screens).  Latency should not be a function testable by e2e since different users have different test environments.
- some other misc changes

## Related issues (if any)

N/A

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


