### PR TITLE
Fix pre:validate errors not displaying

### DIFF
--- a/admin/server/api/item/update.js
+++ b/admin/server/api/item/update.js
@@ -9,7 +9,7 @@ module.exports = function (req, res) {
 		req.list.validateInput(item, req.body, function (err) {
 			if (err) return res.status(400).json(err);
 			req.list.updateItem(item, req.body, { files: req.files }, function (err) {
-				if (err) return res.status(500).json(err);
+				if (err) return res.apiError(500, err.detail);
 				res.json(req.list.getData(item));
 			});
 		});


### PR DESCRIPTION
@josephg and @jossmac alerted (hah get it, alerted) me of this problem.
When passing on an error from the `pre:validate` hook it would display in the admin interface as `"Database error"` instead of showing the error messages because Error objects cannot be stringified.

Something like this would show up as "Database error":

```
Model.schema.pre('validate', function (next) {
  if (this.something === false) {
    next(new Error('My error message'));
  }
});
```

This is now fixed, but I'm not sure if there isn't a better way of going about passing that error down to the frontend. @JedWatson @creynders