### PR TITLE
Better keyboard handling

### DIFF
--- a/admin/client/App/screens/Item/index.js
+++ b/admin/client/App/screens/Item/index.js
@@ -26,8 +26,6 @@ import {
 	selectList,
 } from '../List/actions';
 
-const ESC_KEY_CODE = 27;
-
 var ItemView = React.createClass({
 	displayName: 'ItemView',
 	contextTypes: {
@@ -67,19 +65,9 @@ var ItemView = React.createClass({
 	},
 	// Open and close the create new item modal
 	toggleCreateModal (visible) {
-		if (visible) {
-			document.body.addEventListener('keyup', this.handleKeyPress, false);
-		} else {
-			document.body.removeEventListener('keyup', this.handleKeyPress, false);
-		}
 		this.setState({
 			createIsOpen: visible,
 		});
-	},
-	handleKeyPress (evt) {
-		if (evt.which === ESC_KEY_CODE) {
-			this.toggleCreateModal(false);
-		}
 	},
 	// Render this items relationships
 	renderRelationships () {

--- a/admin/client/App/screens/List/index.js
+++ b/admin/client/App/screens/List/index.js
@@ -52,9 +52,6 @@ const ListView = React.createClass({
 	},
 	getInitialState () {
 		const showCreateForm = this.props.location.search === '?create' || Keystone.createFormErrors;
-		if (showCreateForm) {
-			document.body.addEventListener('keyup', this.handleKeyPress, false);
-		}
 		return {
 			confirmationDialog: {
 				isOpen: false,
@@ -369,22 +366,12 @@ const ListView = React.createClass({
 		this.props.dispatch(setActiveSort(path));
 	},
 	toggleCreateModal (visible) {
-		if (visible) {
-			document.body.addEventListener('keyup', this.handleKeyPress, false);
-		} else {
-			document.body.removeEventListener('keyup', this.handleKeyPress, false);
-		}
 		this.setState({
 			showCreateForm: visible,
 		});
 	},
 	openCreateModal () {
 		this.toggleCreateModal(true);
-	},
-	handleKeyPress (evt) {
-		if (evt.which === ESC_KEY_CODE) {
-			this.toggleCreateModal(false);
-		}
 	},
 	closeCreateModal () {
 		this.toggleCreateModal(false);

--- a/admin/client/App/shared/ConfirmationDialog.js
+++ b/admin/client/App/shared/ConfirmationDialog.js
@@ -3,9 +3,29 @@
  */
 
 import React, { Component, PropTypes } from 'react';
+import vkey from 'vkey';
 import { Modal, ModalBody, ModalFooter, Button } from 'elemental';
 
 class ConfirmationDialog extends Component {
+	constructor () {
+		super();
+		this.handleKeyPress = this.handleKeyPress.bind(this);
+	}
+
+	componentDidMount () {
+		document.body.addEventListener('keyup', this.props.onCancel, false);
+	}
+
+	componentWillUnmount () {
+		document.body.removeEventListener('keyup', this.props.onCancel, false);
+	}
+
+	handleKeyPress (evt) {
+		if (vkey[evt.keyCode] === '<escape>') {
+			this.props.onCancel();
+		}
+	}
+
 	render () {
 		const {
 			cancelLabel,

--- a/admin/client/App/shared/CreateForm.js
+++ b/admin/client/App/shared/CreateForm.js
@@ -5,6 +5,7 @@
 
 import React from 'react';
 import assign from 'object-assign';
+import vkey from 'vkey';
 import AlertMessages from './AlertMessages';
 import { Fields } from 'FieldTypes';
 import InvalidFieldType from './InvalidFieldType';
@@ -39,6 +40,17 @@ const CreateForm = React.createClass({
 			values: values,
 			alerts: {},
 		};
+	},
+	componentDidMount () {
+		document.body.addEventListener('keyup', this.handleKeyPress, false);
+	},
+	componentWillUnmount () {
+		document.body.removeEventListener('keyup', this.handleKeyPress, false);
+	},
+	handleKeyPress (evt) {
+		if (vkey[evt.keyCode] === '<escape>') {
+			this.props.onCancel();
+		}
 	},
 	// Handle input change events
 	handleChange (event) {


### PR DESCRIPTION
Moves the keyboard handling to the actual components that need to close,
i.e. ConfirmationDialog and CreateForm. This way we avoid duplicating
the logic in all screens that need to close those two on ESC keypress.

Also adds support for closing the ConfirmationDialogs across the app
with ESC.

Fixes #3375

Note: Possibly conflicts with #3371, merge that first and I'll fix this
one!