### PR TITLE
Display error when going to invalid list path

### DIFF
--- a/admin/client/App/App.js
+++ b/admin/client/App/App.js
@@ -4,6 +4,8 @@
  */
 
 import React from 'react';
+import { Container } from 'elemental';
+import { Link } from 'react-router';
 
 import MobileNavigation from './components/Navigation/Mobile';
 import PrimaryNavigation from './components/Navigation/Primary';
@@ -12,12 +14,26 @@ import Footer from './components/Footer';
 
 const App = (props) => {
 	const listsByPath = require('../utils/lists').listsByPath;
+	let children = props.children;
 	// If we're on either a list or an item view
 	let currentList, currentSection;
 	if (props.params.listId) {
 		currentList = listsByPath[props.params.listId];
-		// Get the current section we're in for the navigation
-		currentSection = Keystone.nav.by.list[currentList.key];
+		// If we're on a list path that doesn't exist (e.g. /keystone/gibberishasfw34afsd) this will
+		// be undefined
+		if (!currentList) {
+			children = (
+				<Container>
+					<p>List not found!</p>
+					<Link to={`${Keystone.adminPath}`}>
+						Go back home
+					</Link>
+				</Container>
+			);
+		} else {
+			// Get the current section we're in for the navigation
+			currentSection = Keystone.nav.by.list[currentList.key];
+		}
 	}
 	// Default current section key to dashboard
 	const currentSectionKey = (currentSection && currentSection.key) || 'dashboard';
@@ -47,7 +63,7 @@ const App = (props) => {
 				) : null}
 			</header>
 			<div className="keystone-body">
-				{props.children}
+				{children}
 			</div>
 			<Footer
 				appversion={Keystone.appversion}


### PR DESCRIPTION
Previously going to `/keystone/gibberishnonexistantlist24qfvxz` would
throw an error in the console and show a blank page. (!) Really bad
behaviour, now properly shows "List not found" and links back to the
home page.

This is currently almost unstyled, just like the item not found page. We
need to sit down after the beta release (cc @jossmac) and put something
nice there, maybe some sort of illustration?