### PR TITLE
Fix deleting multiple items at once

### DIFF
--- a/admin/client/App/screens/List/actions/items.js
+++ b/admin/client/App/screens/List/actions/items.js
@@ -4,9 +4,6 @@ import {
 	ITEM_LOADING_ERROR,
 } from '../constants';
 
-import {
-	deleteItem,
-} from '../../Item/actions';
 import { NETWORK_ERROR_RETRY_DELAY } from '../../../../constants';
 
 export function loadItems (options = {}) {
@@ -113,8 +110,10 @@ export function itemLoadingError () {
 
 export function deleteItems (ids) {
 	return (dispatch, getState) => {
-		for (var i = 0; i < ids.length; i++) {
-			dispatch(deleteItem(ids[i]));
-		}
+		const list = getState().lists.currentList;
+		list.deleteItems(ids, (err, data) => {
+			// TODO ERROR HANDLING
+			dispatch(loadItems());
+		});
 	};
 }

--- a/admin/client/utils/List.js
+++ b/admin/client/utils/List.js
@@ -305,19 +305,16 @@ List.prototype.deleteItem = function (itemId, callback) {
  * @param  {Function} callback
  */
 List.prototype.deleteItems = function (itemIds, callback) {
-	const url = Keystone.adminPath + '/api/' + this.path + '/' + itemIds.join(',') + '/delete';
+	const url = Keystone.adminPath + '/api/' + this.path + '/delete';
 	xhr({
 		url: url,
 		method: 'POST',
 		headers: Keystone.csrf.header,
+		json: {
+			ids: itemIds,
+		},
 	}, (err, resp, body) => {
 		if (err) return callback(err);
-		try {
-			body = JSON.parse(body);
-		} catch (e) {
-			console.log('Error parsing results json:', e, body);
-			return callback(e);
-		}
 		// Pass the body as result or error, depending on the statusCode
 		if (resp.statusCode === 200) {
 			callback(null, body);


### PR DESCRIPTION
- Only dispatch one request for deleting multiple items using the existing endpoint for this
- Load items after deleting them so if users delete an entire page the UX doesn't suffer