### PR TITLE
Fix filter popout closing when any button is pressed

### DIFF
--- a/admin/client/App/screens/List/components/Filtering/ListFiltersAdd.js
+++ b/admin/client/App/screens/List/components/Filtering/ListFiltersAdd.js
@@ -29,9 +29,6 @@ var ListFiltersAdd = React.createClass({
 			selectedField: false,
 		};
 	},
-	componentWillReceiveProps (nextProps) {
-		this.setState({ isOpen: nextProps.isOpen });
-	},
 	updateSearch (e) {
 		this.setState({ searchString: e.target.value });
 	},


### PR DESCRIPTION
I have no idea why this code was there. The filter popout was closing
because `this.props.isOpen` was _always_ undefined – we simply did't
pass anything in from `ListHeaderToolbar`! (and never have)

I also have no idea what this code is doing there and why this only
showed up now (probably due to some bug fix in the past few days), but
as far as a I can tell from digging through the code this is good to
remove.

Closes #404