### PR TITLE
Fix hook errors (again)

### DIFF
--- a/admin/server/api/item/update.js
+++ b/admin/server/api/item/update.js
@@ -9,7 +9,8 @@ module.exports = function (req, res) {
 		req.list.updateItem(item, req.body, { files: req.files }, function (err) {
 			if (err) {
 				var status = err.error === 'validation errors' ? 400 : 500;
-				return res.apiError(status, err);
+				var error = err.error === 'database error' ? err.detail : err;
+				return res.apiError(status, error);
 			}
 			res.json(req.list.getData(item));
 		});


### PR DESCRIPTION
The changes in #3322 broke the hook error fixes introduced in #3343

These changes fix it again, but we need to look into a better way to
discern custom errors from general database errors for the full release.

cc @JedWatson