### PR TITLE
Add markdown and embedly field default value

### DIFF
--- a/fields/types/embedly/EmbedlyField.js
+++ b/fields/types/embedly/EmbedlyField.js
@@ -9,6 +9,7 @@ module.exports = Field.create({
 	displayName: 'EmbedlyField',
 	statics: {
 		type: 'Embedly',
+		getDefaultValue: () => ({}),
 	},
 
 	// always defers to renderValue; there is no form UI for this field

--- a/fields/types/markdown/MarkdownField.js
+++ b/fields/types/markdown/MarkdownField.js
@@ -113,6 +113,7 @@ module.exports = Field.create({
 	displayName: 'MarkdownField',
 	statics: {
 		type: 'Markdown',
+		getDefaultValue: () => ({}),
 	},
 
 	// override `shouldCollapse` to check the markdown field correctly


### PR DESCRIPTION
With the changes in #3393, the fields were fixed except for the Markdown and the Embedly
field.