### PR TITLE
removed call to populate createdBy and updatedBy fields in api/item/get

### DIFF
--- a/admin/server/api/item/get.js
+++ b/admin/server/api/item/get.js
@@ -17,14 +17,6 @@ module.exports = function (req, res) {
 		return res.status(401).json({ error: 'fields must be undefined, a string, or an array' });
 	}
 
-	if (req.list.tracking && req.list.tracking.createdBy) {
-		query.populate(req.list.tracking.createdBy);
-	}
-
-	if (req.list.tracking && req.list.tracking.updatedBy) {
-		query.populate(req.list.tracking.updatedBy);
-	}
-
 	query.exec(function (err, item) {
 
 		if (err) return res.status(500).json({ err: 'database error', detail: err });


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Remove the 2 calls which populate createdBy and updatedBy 


## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.
No, this was too hard.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


