### PR TITLE
Handle mongo error in ensureTextIndex

### DIFF
--- a/lib/list/ensureTextIndex.js
+++ b/lib/list/ensureTextIndex.js
@@ -43,10 +43,18 @@ function ensureTextIndex (callback) {
 	};
 
 	collection.getIndexes(function (err, indexes) {
-		if (err) throw err;  // Not sure what else to do here..
+		if (err) {
+			if (err.code === 26) {
+				// if the database doesn't exist, we'll get error code 26 "no database" here
+				// that's fine, we just default the indexes object so the new text index
+				// gets created when the database is connected.
+				indexes = {};
+			} else {
+				// otherwise, we've had an unexpected error, so we throw it
+				throw err;
+			}
+		}
 		var indexNames = Object.keys(indexes);
-		// debug('indexes', indexes);
-		// debug('indexNames', indexNames);
 
 		// Search though the
 		for (var i = 0; i < indexNames.length; i++) {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Checks for error code 26  in the collection.getIndexes callback. Defaults indexes object so the new text index gets created when the database is connected.

## Related issues (if any)
#3334 
#3180

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


Setting `searchUsesTextIndex: true` on a Model would cause keystone to
crash on first launch while initialising the database.