### PR TITLE
Fixed the validateRequiredInput in the DateTime type.

### DIFF
--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -36,7 +36,7 @@ boolean.prototype.validateInput = function (data, callback) {
 
 boolean.prototype.validateRequiredInput = function (item, data, callback) {
 	var value = this.getValueFromData(data);
-	var result = typeof (value) === 'boolean' || typeof (item.get(this.path)) === 'boolean';
+	var result = (value && value !== 'false') || item.get(this.path) ? true : false;
 	utils.defer(callback, result);
 };
 

--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -36,7 +36,7 @@ boolean.prototype.validateInput = function (data, callback) {
 
 boolean.prototype.validateRequiredInput = function (item, data, callback) {
 	var value = this.getValueFromData(data);
-	var result = (value && value !== 'false') || item.get(this.path) ? true : false;
+	var result = typeof (value) === 'boolean' || typeof (item.get(this.path)) === 'boolean';
 	utils.defer(callback, result);
 };
 

--- a/fields/types/datetime/DatetimeType.js
+++ b/fields/types/datetime/DatetimeType.js
@@ -3,7 +3,6 @@ var DateType = require('../date/DateType');
 var FieldType = require('../Type');
 var util = require('util');
 var utils = require('keystone-utils');
-var TextType = require('../text/TextType');
 
 // ISO_8601 is needed for the automatically created createdAt and updatedAt fields
 var parseFormats = ['YYYY-MM-DD', 'YYYY-MM-DD h:m:s a', 'YYYY-MM-DD h:m a', 'YYYY-MM-DD H:m:s', 'YYYY-MM-DD H:m', 'YYYY-MM-DD h:mm:s a Z', moment.ISO_8601];
@@ -40,8 +39,6 @@ datetime.prototype.moment = DateType.prototype.moment;
 datetime.prototype.parse = DateType.prototype.parse;
 datetime.prototype.addFilterToQuery = DateType.prototype.addFilterToQuery;
 
-datetime.prototype.validateRequiredInput = TextType.prototype.validateRequiredInput;
-
 /**
  * Get the value from a data object; may be simple or a pair of fields
  */
@@ -58,6 +55,16 @@ datetime.prototype.getInputFromData = function (data) {
 	}
 
 	return this.getValueFromData(data);
+};
+
+
+datetime.prototype.validateRequiredInput = function (item, data, callback) {
+	var value = this.getInputFromData(data);
+	var result = !!value;
+	if (value === undefined && item.get(this.path)) {
+		result = true;
+	}
+	utils.defer(callback, result);
 };
 
 /**


### PR DESCRIPTION
## Description of changes
Fixed the data extraction from <fieldName>_date and <fieldName>_time and the subsequenct validation.


## Related issues (if any)
#3460 

## Testing

- [X ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


…Fixes #3460.