### PR TITLE
Fixed the multiple calls to open event in openDataseConnection. #3474

### DIFF
--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -43,7 +43,7 @@ module.exports = function openDatabaseConnection (callback) {
 		keystone.mongoose.connect(keystone.get('mongo'), keystone.get('mongo options'));
 	}
 
-	keystone.mongoose.connection.on('error', function (err) {
+	keystone.mongoose.connection.once('error', function (err) {
 
 		if (keystone.get('logger')) {
 			console.log('------------------------------------------------');
@@ -58,7 +58,7 @@ module.exports = function openDatabaseConnection (callback) {
 			throw new Error('KeystoneJS (' + keystone.get('name') + ') failed to start - Check that you are running `mongod` in a separate process.');
 		}
 
-	}).on('open', function () {
+	}).once('open', function () {
 
 		debug('mongo connection open');
 		mongoConnectionOpen = true;


### PR DESCRIPTION
## Description of changes
Chamged the .on to .once on the error and open event in openDatabaseConnection.

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


