### PR TITLE
[WIP] Add item to uploadfile

### DIFF
--- a/fields/types/file/FileType.js
+++ b/fields/types/file/FileType.js
@@ -47,7 +47,7 @@ file.prototype.upload = function (item, file, callback) {
 	var field = this;
 	// TODO; Validate there is actuall a file to upload
 	debug('[%s.%s] Uploading file for item %s:', this.list.key, this.path, item.id, file);
-	this.storage.uploadFile(file, function (err, result) {
+	this.storage.uploadFile(file, item, function (err, result) {
 		if (err) return callback(err);
 		debug('[%s.%s] Uploaded file for item %s with result:', field.list.key, field.path, item.id, result);
 		item.set(field.path, result);

--- a/lib/storage/adapters/fs/index.js
+++ b/lib/storage/adapters/fs/index.js
@@ -89,7 +89,10 @@ FSAdapter.prototype.pathForFile = function (filename) {
 	in the field value. The file argument must be an object as per the [multer
 	file information spec](https://github.com/expressjs/multer#file-information)
 */
-FSAdapter.prototype.uploadFile = function (file, callback) {
+FSAdapter.prototype.uploadFile = function (file, item, callback) {
+  if (typeof item === 'function') {
+    callback = item;
+  }
 	debug('Uploading file', file);
 	var options = this.options;
 	this.getFilename(file, function (err, filename) {

--- a/lib/storage/adapters/fs/index.js
+++ b/lib/storage/adapters/fs/index.js
@@ -90,9 +90,9 @@ FSAdapter.prototype.pathForFile = function (filename) {
 	file information spec](https://github.com/expressjs/multer#file-information)
 */
 FSAdapter.prototype.uploadFile = function (file, item, callback) {
-  if (typeof item === 'function') {
-    callback = item;
-  }
+	if (typeof item === 'function') {
+		callback = item;
+	}
 	debug('Uploading file', file);
 	var options = this.options;
 	this.getFilename(file, function (err, filename) {


### PR DESCRIPTION
## Description of changes
Changing the uploadFile signature to pass item information.  There are obviously changes required in the individual storage adapter repos, but this can serve as a starting point for discussion.  

To Be Updated

- [x] keystone-storage-adapter-fs
- [x] keystone-storage-adapter-s3
- [ ] keystone-storage-adapter-azure
- [ ] keystone-storage-namefunctions?

## Related issues (if any)
Currently, you don't have access to item information when generating filenames or any other purpose.

