### PR TITLE
test(e2e): use improved po api

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-react": "5.2.2",
     "istanbul": "0.4.5",
     "keystone-email": "1.0.5",
-    "keystone-nightwatch-e2e": "^0.1.8",
+    "keystone-nightwatch-e2e": "^0.1.9",
     "mocha": "3.1.0",
     "must": "0.13.2",
     "proxyquire": "1.7.10",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "eslint-plugin-react": "5.2.2",
     "istanbul": "0.4.5",
     "keystone-email": "1.0.5",
-    "keystone-nightwatch-e2e": "^0.1.7",
+    "keystone-nightwatch-e2e": "^0.1.8",
     "mocha": "3.1.0",
     "must": "0.13.2",
     "proxyquire": "1.7.10",

--- a/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 	},
@@ -9,6 +9,6 @@ module.exports = {
 		browser.end();
 	},
 	'Signin page should show correctly': function (browser) {
-		browser.adminUISignin.assertUI();
+		browser.adminUISigninScreen.assertUI();
 	},
 };

--- a/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uiTestSigninView.js
@@ -2,7 +2,8 @@ module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
 		browser.adminUISigninScreen = browser.page.adminUISignin();
-		browser.adminUIApp.gotoHomeScreen();
+
+		browser.adminUIApp.gotoSigninScreen();
 		browser.adminUIApp.waitForSigninScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninRedirect.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 
 		browser.url(browser.adminUIApp.url + 'users');
 		browser.adminUIApp.waitForSigninScreen();
@@ -12,7 +12,7 @@ module.exports = {
 			end();
 	},
 	'AdminUI should allow users to login and redirect to custom url': function (browser) {
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForListScreen();
 		browser.assert.urlEquals(browser.adminUIApp.url + 'users');
 	},

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
@@ -10,7 +10,7 @@ module.exports = {
 		browser.end();
 	},
 	'Signin page should allow users to login': function (browser) {
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	'Signin page should be presented upon signout': function (browser) {

--- a/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
+++ b/test/e2e/adminUI/tests/group001Login/uxTestSigninView.js
@@ -3,7 +3,7 @@ module.exports = {
 		browser.adminUIApp = browser.page.adminUIApp();
 		browser.adminUISigninScreen = browser.page.adminUISignin();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
 		browser.adminUIApp.waitForSigninScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uiTestHomeView.js
@@ -1,13 +1,13 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIHomeScreen = browser.page.adminUIHomeScreen();
 
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
 		browser.adminUIApp.waitForHomeScreen();
 	},

--- a/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
@@ -61,13 +61,10 @@ module.exports = {
 
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': {value: 'Name Field Test'},
-				'fieldA': {firstName: 'First', lastName: 'Last'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{name: 'name', input: { value: 'Name Field Test' }, modelTestConfig: NameModelTestConfig,},
+			{name: 'fieldA', input: { firstName: 'First', lastName: 'Last' }, modelTestConfig: NameModelTestConfig,},
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 

--- a/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
+++ b/test/e2e/adminUI/tests/group002Home/uxTestHomeView.js
@@ -3,7 +3,7 @@ var NameModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig'
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIHomeScreen = browser.page.adminUIHomeScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
@@ -12,7 +12,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
 		browser.adminUIApp.waitForHomeScreen();
 	},

--- a/test/e2e/adminUI/tests/group003List/uiTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uiTestListView.js
@@ -3,20 +3,21 @@ var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig'
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
+
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
 		browser.adminUIApp.waitForHomeScreen();
 
-		browser.adminUIApp.click('@accessMenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'access', list: 'users'}).waitForListScreen();
 	},
 	after: function (browser) {
 		browser.adminUIApp.signout();

--- a/test/e2e/adminUI/tests/group003List/uiTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uiTestListView.js
@@ -1,4 +1,4 @@
-var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
 
 module.exports = {
 	before: function (browser) {
@@ -8,6 +8,7 @@ module.exports = {
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
 
 		browser.adminUIApp.gotoSigninScreen();
 
@@ -69,46 +70,46 @@ module.exports = {
 	},
 	'List screen user item must show a name': function (browser) {
 		browser.adminUIListScreen.assertItemFieldUIVisible([
-			{ row: 1, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 2, name: 'name',},
+			{ row: 2, column: 2, name: 'name',},
 		]);
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'e2e member', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 2, name: 'name', value: 'e2e user', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 2, name: 'name', value: 'e2e member',},
+			{ row: 2, column: 2, name: 'name', value: 'e2e user',},
 		]);
 	},
 	'List screen user item must show an email': function (browser) {
 		browser.adminUIListScreen.assertItemFieldUIVisible([
-			{ row: 1, column: 3, name: 'email', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 3, name: 'email', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 3, name: 'email',},
+			{ row: 2, column: 3, name: 'email',},
 		]);
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 3, name: 'email', value: 'member@test.e2e', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 3, name: 'email', value: 'user@test.e2e', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 3, name: 'email', value: 'member@test.e2e',},
+			{ row: 2, column: 3, name: 'email', value: 'user@test.e2e',},
 		]);
 	},
 	'List screen user item must have a Is Admin column': function (browser) {
 		browser.adminUIListScreen.assertItemFieldUIVisible([
-			{ row: 1, column: 4, name: 'isAdmin', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 4, name: 'isAdmin', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 4, name: 'isAdmin',},
+			{ row: 2, column: 4, name: 'isAdmin',},
 		]);
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 4, name: 'isAdmin', value: 'false', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 4, name: 'isAdmin', value: 'true', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 4, name: 'isAdmin', value: 'false',},
+			{ row: 2, column: 4, name: 'isAdmin', value: 'true',},
 		]);
 	},
 	'List screen user item must have a Is Member column': function (browser) {
 		browser.adminUIListScreen.assertItemFieldUIVisible([
-			{ row: 1, column: 5, name: 'isMember', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 5, name: 'isMember', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 5, name: 'isMember',},
+			{ row: 2, column: 5, name: 'isMember',},
 		]);
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 5, name: 'isMember', value: 'true', modelTestConfig: UserModelTestConfig, },
-			{ row: 2, column: 5, name: 'isMember', value: 'false', modelTestConfig: UserModelTestConfig, },
+			{ row: 1, column: 5, name: 'isMember', value: 'true',},
+			{ row: 2, column: 5, name: 'isMember', value: 'false',},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group003List/uxTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uxTestListView.js
@@ -28,13 +28,10 @@ module.exports = {
 
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': { value: 'Name Field Test 1' },
-				'fieldA': { firstName: 'First 1', lastName: 'Last 1' },
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, },
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 
@@ -55,13 +52,10 @@ module.exports = {
 
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': { value: 'Name Field Test 2' },
-				'fieldA': { firstName: 'First 2', lastName: 'Last 2' },
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 2' }, modelTestConfig: NameModelTestConfig, },
+			{ name: 'fieldA', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, },
+		]);
 
 		// TODO: refactor
 		browser.adminUIInitialFormScreen.section.form

--- a/test/e2e/adminUI/tests/group003List/uxTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uxTestListView.js
@@ -3,16 +3,17 @@ var NameModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig'
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
+
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
 		browser.adminUIApp.waitForHomeScreen();
 	},
@@ -21,7 +22,7 @@ module.exports = {
 		browser.end();
 	},
 	'List view should allow users to create a new list item': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickCreateItemButton();
 
@@ -39,7 +40,7 @@ module.exports = {
 
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 1 Name');
 
@@ -48,7 +49,7 @@ module.exports = {
 		]);
 	},
 	'List view should allow users to create more new list items': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickCreateItemButton();
 
@@ -68,7 +69,7 @@ module.exports = {
 
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 2 Names');
 
@@ -78,7 +79,7 @@ module.exports = {
 		]);
 	},
 	'List view should allow users to browse an item by clicking the item name': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
 			{ row: 1, column: 2, name: 'name', modelTestConfig: NameModelTestConfig, }
@@ -87,7 +88,7 @@ module.exports = {
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'List view should allow users to browse back to list view from an item view by using the crum links': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
 			{ row: 1, column: 2, name: 'name', modelTestConfig: NameModelTestConfig, }
@@ -101,7 +102,7 @@ module.exports = {
 		browser.adminUIApp.waitForListScreen();
 	},
 	'List view should allow users to search for items': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		// TODO: refactor
 		browser.adminUIListScreen
@@ -146,7 +147,7 @@ module.exports = {
 		]);
 	},
 	'List view should allow users to delete last item': function (browser) {
-		browser.adminUIApp.click('@fieldListsMenu').click('@nameListSubmenu').waitForListScreen();
+		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickDeleteItemIcon([
 			{ row: 1, column: 1 }

--- a/test/e2e/adminUI/tests/group003List/uxTestListView.js
+++ b/test/e2e/adminUI/tests/group003List/uxTestListView.js
@@ -1,4 +1,4 @@
-var NameModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig');
 
 module.exports = {
 	before: function (browser) {
@@ -8,6 +8,10 @@ module.exports = {
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
+
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
 
 		browser.adminUIApp.gotoSigninScreen();
 
@@ -29,8 +33,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, },
-			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, },
+			{ name: 'name', input: { value: 'Name Field Test 1' },},
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -42,7 +46,7 @@ module.exports = {
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 1 Name');
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1', modelTestConfig: NameModelTestConfig }
+			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1', }
 		]);
 	},
 	'List view should allow users to create more new list items': function (browser) {
@@ -53,8 +57,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 2' }, modelTestConfig: NameModelTestConfig, },
-			{ name: 'fieldA', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, },
+			{ name: 'name', input: { value: 'Name Field Test 2' },},
+			{ name: 'fieldA', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
 
 		// TODO: refactor
@@ -68,15 +72,15 @@ module.exports = {
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 2 Names');
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1', modelTestConfig: NameModelTestConfig, },
-			{ row: 2, column: 2, name: 'name', value: 'Name Field Test 2', modelTestConfig: NameModelTestConfig, }
+			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1',},
+			{ row: 2, column: 2, name: 'name', value: 'Name Field Test 2',}
 		]);
 	},
 	'List view should allow users to browse an item by clicking the item name': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
-			{ row: 1, column: 2, name: 'name', modelTestConfig: NameModelTestConfig, }
+			{ row: 1, column: 2, name: 'name',}
 		]);
 
 		browser.adminUIApp.waitForItemScreen();
@@ -85,7 +89,7 @@ module.exports = {
 		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
-			{ row: 1, column: 2, name: 'name', modelTestConfig: NameModelTestConfig, }
+			{ row: 1, column: 2, name: 'name',}
 		]);
 
 		browser.adminUIApp.waitForItemScreen();
@@ -107,7 +111,7 @@ module.exports = {
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 1 Name');
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 2', modelTestConfig: NameModelTestConfig, },
+			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 2',},
 		]);
 	},
 	'List view should allow users to clear search filter': function (browser) {
@@ -118,8 +122,8 @@ module.exports = {
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 2 Names');
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1', modelTestConfig: NameModelTestConfig, },
-			{ row: 2, column: 2, name: 'name', value: 'Name Field Test 2', modelTestConfig: NameModelTestConfig, },
+			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 1',},
+			{ row: 2, column: 2, name: 'name', value: 'Name Field Test 2',},
 		]);
 	},
 	'List view should allow users to delete items': function (browser) {
@@ -137,7 +141,7 @@ module.exports = {
 		browser.adminUIListScreen.assertPageItemCountTextEquals('Showing 1 Name');
 
 		browser.adminUIListScreen.assertItemFieldValueEquals([
-			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 2', modelTestConfig: NameModelTestConfig, },
+			{ row: 1, column: 2, name: 'name', value: 'Name Field Test 2',},
 		]);
 	},
 	'List view should allow users to delete last item': function (browser) {

--- a/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
@@ -3,21 +3,21 @@ var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig'
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
+
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
-		browser.adminUIApp
-			.waitForHomeScreen()
-			.click('@accessMenu')
-			.waitForListScreen();
+		browser.adminUIApp.waitForHomeScreen();
+
+		browser.adminUIApp.openList({section: 'access', list: 'User'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
 			{ row: 2, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, }

--- a/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uiTestItemView.js
@@ -1,4 +1,4 @@
-var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
 
 module.exports = {
 	before: function (browser) {
@@ -8,6 +8,8 @@ module.exports = {
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
+
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
 
 		browser.adminUIApp.gotoSigninScreen();
 
@@ -20,7 +22,7 @@ module.exports = {
 		browser.adminUIApp.openList({section: 'access', list: 'User'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
-			{ row: 2, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, }
+			{ row: 2, column: 2, name: 'name',}
 		]);
 
 		browser.adminUIApp.waitForItemScreen();

--- a/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
@@ -6,22 +6,22 @@ var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig'
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
 		browser.adminUIResetConfirmationScreen = browser.page.adminUIResetConfirmation();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
+
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
-		browser.adminUIApp
-			.waitForHomeScreen()
-			.click('@accessMenu')
-			.waitForListScreen();
+		browser.adminUIApp.waitForHomeScreen();
+
+		browser.adminUIApp.openList({section: 'access', list: 'User'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
 			{ row: 2, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, }

--- a/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
@@ -38,18 +38,13 @@ module.exports = {
 
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 1', lastName: 'Last 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 1', lastName: 'Last 1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: UserModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: UserModelTestConfig, },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
@@ -61,47 +56,35 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 	},
 	'Item screen should allow saving an item with changes': function (browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 2', lastName: 'Last 2'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 2', lastName: 'Last 2'},
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+		]);
+		
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+		]);
+		
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 	},
 	'Item screen should allow resetting an item with changes': function (browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 3', lastName: 'Last 3'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 3', lastName: 'Last 3'},
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' }, modelTestConfig: UserModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' }, modelTestConfig: UserModelTestConfig, },
+		]);
 
 		browser.adminUIItemScreen.reset();
 		browser.adminUIApp.waitForResetConfirmationScreen();
 		browser.adminUIResetConfirmationScreen.reset();
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: UserModelTestConfig,
-			fields: {
-				'name': {firstName: 'First 2', lastName: 'Last 2'},
-			}
-		});
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+		]);
 	},
 	'Item screen should allow deleting an item': function (browser) {
 		browser.adminUIItemScreen.delete();

--- a/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
+++ b/test/e2e/adminUI/tests/group004Item/uxTestItemView.js
@@ -1,7 +1,7 @@
 // TODO:  Currently the tests here only fill in the name field of the user list form.  That's because the other
 //		  fields in the user list do not have corresponding page object support, yet.  When they do revisit filling
 //		  all the fields.
-var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
 
 module.exports = {
 	before: function (browser) {
@@ -12,6 +12,10 @@ module.exports = {
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 		browser.adminUIDeleteConfirmation = browser.page.adminUIDeleteConfirmation();
 		browser.adminUIResetConfirmationScreen = browser.page.adminUIResetConfirmation();
+
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
 
 		browser.adminUIApp.gotoSigninScreen();
 
@@ -24,7 +28,7 @@ module.exports = {
 		browser.adminUIApp.openList({section: 'access', list: 'User'});
 
 		browser.adminUIListScreen.clickItemFieldValue([
-			{ row: 2, column: 2, name: 'name', modelTestConfig: UserModelTestConfig, }
+			{ row: 2, column: 2, name: 'name',}
 		]);
 
 		browser.adminUIApp.waitForItemScreen();
@@ -39,11 +43,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -57,24 +61,24 @@ module.exports = {
 	},
 	'Item screen should allow saving an item with changes': function (browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
-		
+
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
-		
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 	},
 	'Item screen should allow resetting an item with changes': function (browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' },},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 3', lastName: 'Last 3' },},
 		]);
 
 		browser.adminUIItemScreen.reset();
@@ -83,7 +87,7 @@ module.exports = {
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: UserModelTestConfig, },
+			{ name: 'name', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
 	},
 	'Item screen should allow deleting an item': function (browser) {

--- a/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
+++ b/test/e2e/adminUI/tests/group005Fields/commonFieldTestUtils.js
@@ -1,15 +1,16 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
 
-		browser.adminUIApp.gotoHomeScreen();
+		browser.adminUIApp.gotoSigninScreen();
+
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 
 		browser.adminUIApp.waitForHomeScreen();
 	},

--- a/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
@@ -9,10 +9,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: BooleanModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: BooleanModelTestConfig, },
+		]);
 	},
 	'restoring test state': function(browser) {
 		browser.adminUIInitialFormScreen.cancel();
@@ -20,63 +20,55 @@ module.exports = {
 	},
 	'Boolean field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'boolean'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
+
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: {
-				'name': {value: 'Boolean Field Test 1'},
-				'fieldA': {value: 'true'},
-				'fieldD': {value: 'Test'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: {
-				'name': {value: 'Boolean Field Test 1'},
-				'fieldA': {value: 'true'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: {
-				'name': {value: 'Boolean Field Test 1'},
-				'fieldA': {value: 'true'},
-			}
-		})
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+		]);
 	},
 	'Boolean field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: BooleanModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: BooleanModelTestConfig, },
+		]);
 	},
 	'Boolean field should have its default value if hidden': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: [{name: 'fieldD'}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldD', modelTestConfig: BooleanModelTestConfig, },
+		]);
 	},
 	'Boolean field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: {
-				'fieldB': {value: 'false'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: {value: 'false'}, modelTestConfig: BooleanModelTestConfig, }
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: BooleanModelTestConfig,
-			fields: {
-				'name': {value: 'Boolean Field Test 1'},
-				'fieldA': {value: 'true'},
-				'fieldB': {value: 'false'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldB', input: { value: 'false' }, modelTestConfig: BooleanModelTestConfig, },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Boolean field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'boolean'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -22,7 +23,6 @@ module.exports = {
 		browser.adminUIApp.openList({section: 'fields', list: 'boolean'});
 
 		browser.adminUIListScreen.clickCreateItemButton();
-
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
@@ -39,17 +39,18 @@ module.exports = {
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
-		]);
 	},
 	'Boolean field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: BooleanModelTestConfig, }, 
 			{ name: 'fieldA', modelTestConfig: BooleanModelTestConfig, }, 
 			{ name: 'fieldB', modelTestConfig: BooleanModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
 		]);
 	},
 	'Boolean field should have its default value if hidden': function(browser) {
@@ -64,7 +65,9 @@ module.exports = {
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs([
 			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
 			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },

--- a/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testBooleanField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var BooleanModelTestConfig = require('../../../modelTestConfig/BooleanModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/BooleanModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Boolean field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'boolean'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: BooleanModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', },
+			{ name: 'fieldA', },
 		]);
 	},
 	'restoring test state': function(browser) {
@@ -26,15 +31,15 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'true' }, },
+			{ name: 'fieldD', input: { value: 'Test' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'true' }, },
+			{ name: 'fieldD', input: { value: 'Test' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -42,25 +47,25 @@ module.exports = {
 	},
 	'Boolean field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: BooleanModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: BooleanModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', },
+			{ name: 'fieldA', },
+			{ name: 'fieldB', },
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldD', input: { value: 'Test' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'true' }, },
+			{ name: 'fieldD', input: { value: 'Test' }, },
 		]);
 	},
 	'Boolean field should have its default value if hidden': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldD', modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'fieldD', },
 		]);
 	},
 	'Boolean field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: {value: 'false'}, modelTestConfig: BooleanModelTestConfig, }
+			{ name: 'fieldB', input: {value: 'false'}, }
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -69,9 +74,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Boolean Field Test 1' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'true' }, modelTestConfig: BooleanModelTestConfig, },
-			{ name: 'fieldB', input: { value: 'false' }, modelTestConfig: BooleanModelTestConfig, },
+			{ name: 'name', input: { value: 'Boolean Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'true' }, },
+			{ name: 'fieldB', input: { value: 'false' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var CloudinaryImageModelTestConfig = require('../../../modelTestConfig/CloudinaryImageModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/CloudinaryImageModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'CloudinaryImage field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImage'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,11 +29,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -37,13 +42,13 @@ module.exports = {
 	},
 	'CloudinaryImage field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CloudinaryImageModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: CloudinaryImageModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageField.js
@@ -6,48 +6,44 @@ module.exports = {
 	after: fieldTests.after,
 	'CloudinaryImage field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImage'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: CloudinaryImageModelTestConfig,
-			fields: [{name: 'name'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CloudinaryImageModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'CloudinaryImage field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImage'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: CloudinaryImageModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImage Field Test 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: CloudinaryImageModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImage Field Test 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: CloudinaryImageModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImage Field Test 1'},
-			}
-		})
 	},
 	'CloudinaryImage field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: CloudinaryImageModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: CloudinaryImageModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: CloudinaryImageModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImage Field Test 1' }, modelTestConfig: CloudinaryImageModelTestConfig, },
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var CloudinaryImageMultipleModelTestConfig = require('../../../modelTestConfig/CloudinaryImageMultipleModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/CloudinaryImageMultipleModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'CloudinaryImageMultiple field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImageMultiple'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,11 +29,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -36,13 +41,13 @@ module.exports = {
 	},
 	'CloudinaryImageMultiple field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCloudinaryImageMultipleField.js
@@ -6,48 +6,43 @@ module.exports = {
 	after: fieldTests.after,
 	'CloudinaryImageMultiple field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImageMultiple'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: CloudinaryImageMultipleModelTestConfig,
-			fields: [{name: 'name'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'CloudinaryImageMultiple field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'CloudinaryImageMultiple'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: CloudinaryImageMultipleModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: CloudinaryImageMultipleModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: CloudinaryImageMultipleModelTestConfig,
-			fields: {
-				'name': {value: 'CloudinaryImageMultiple Field Test 1'},
-			}
-		})
 	},
 	'CloudinaryImageMultiple field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: CloudinaryImageMultipleModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'CloudinaryImageMultiple Field Test 1' }, modelTestConfig: CloudinaryImageMultipleModelTestConfig, },
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCodeField.js
@@ -6,74 +6,65 @@ module.exports = {
 	after: fieldTests.after,
 	'Code field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Code'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: CodeModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CodeModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: CodeModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Code field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Code'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: CodeModelTestConfig,
-			fields: {
-				'name': {value: 'Code Field Test 1'},
-				'fieldA': {value: 'Some test code for field A'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: CodeModelTestConfig,
-			fields: {
-				'name': {value: 'Code Field Test 1'},
-				'fieldA': {value: 'Some test code for field A'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: CodeModelTestConfig,
-			fields: {
-				'name': {value: 'Code Field Test 1'},
-				'fieldA': {value: 'Some test code for field A'},
-			}
-		})
 	},
 	'Code field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: CodeModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: CodeModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: CodeModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: CodeModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+		]);
 	},
 	'Code field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: CodeModelTestConfig,
-			fields: {
-				'fieldB': {value: 'Some test code for field B'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'Some test code for field B' }, modelTestConfig: CodeModelTestConfig, },
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: CodeModelTestConfig,
-			fields: {
-				'name': {value: 'Code Field Test 1'},
-				'fieldA': {value: 'Some test code for field A'},
-				'fieldB': {value: 'Some test code for field B'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldB', input: { value: 'Some test code for field B' }, modelTestConfig: CodeModelTestConfig, },
+		]);
 	},
 	'restoring test state': function(browser) {
-		browser.adminUIInitialFormScreen.cancel();
-		browser.adminUIApp.waitForListScreen();
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testCodeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testCodeField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var CodeModelTestConfig = require('../../../modelTestConfig/CodeModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/CodeModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Code field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Code'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CodeModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name', input: { value: 'Code Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test code for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name', input: { value: 'Code Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test code for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Code field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: CodeModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: CodeModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name', input: { value: 'Code Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test code for field A' },},
 		]);
 	},
 	'Code field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'Some test code for field B' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'fieldB', input: { value: 'Some test code for field B' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Code Field Test 1' }, modelTestConfig: CodeModelTestConfig, },
-			{ name: 'fieldA', input: { value: 'Some test code for field A' }, modelTestConfig: CodeModelTestConfig, },
-			{ name: 'fieldB', input: { value: 'Some test code for field B' }, modelTestConfig: CodeModelTestConfig, },
+			{ name: 'name', input: { value: 'Code Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test code for field A' },},
+			{ name: 'fieldB', input: { value: 'Some test code for field B' },},
 		]);
 	},
 	'restoring test state': function(browser) {

--- a/test/e2e/adminUI/tests/group005Fields/testColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testColorField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var ColorModelTestConfig = require('../../../modelTestConfig/ColorModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/ColorModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Color field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Color'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: ColorModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
-			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name', input: { value: 'Color Field Test 1' },},
+			{ name: 'fieldA', input: { value: '#002147' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
-			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name', input: { value: 'Color Field Test 1' },},
+			{ name: 'fieldA', input: { value: '#002147' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Color field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: ColorModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: ColorModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
-			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name', input: { value: 'Color Field Test 1' },},
+			{ name: 'fieldA', input: { value: '#002147' },},
 		]);
 	},
 	'Color field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: '#f8e71c' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldB', input: { value: '#f8e71c' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
-			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
-			{ name: 'fieldB', input: { value: '#f8e71c' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'name', input: { value: 'Color Field Test 1' },},
+			{ name: 'fieldA', input: { value: '#002147' },},
+			{ name: 'fieldB', input: { value: '#f8e71c' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testColorField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testColorField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Color field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Color'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: ColorModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: ColorModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: ColorModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Color field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Color'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: ColorModelTestConfig,
-			fields: {
-				'name': {value: 'Color Field Test 1'},
-				'fieldA': {value: '#002147'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: ColorModelTestConfig,
-			fields: {
-				'name': {value: 'Color Field Test 1'},
-				'fieldA': {value: '#002147'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: ColorModelTestConfig,
-			fields: {
-				'name': {value: 'Color Field Test 1'},
-				'fieldA': {value: '#002147'},
-			}
-		})
 	},
 	'Color field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: ColorModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: ColorModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: ColorModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: ColorModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+		]);
 	},
 	'Color field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: ColorModelTestConfig,
-			fields: {
-				'fieldB': {value: '#f8e71c'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: '#f8e71c' }, modelTestConfig: ColorModelTestConfig, },
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: ColorModelTestConfig,
-			fields: {
-				'name': {value: 'Color Field Test 1'},
-				'fieldA': {value: '#002147'},
-				'fieldB': {value: '#f8e71c'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Color Field Test 1' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldA', input: { value: '#002147' }, modelTestConfig: ColorModelTestConfig, },
+			{ name: 'fieldB', input: { value: '#f8e71c' }, modelTestConfig: ColorModelTestConfig, },
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var DateArrayModelTestConfig = require('../../../modelTestConfig/DateArrayModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/DateArrayModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'DateArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'DateArray'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,11 +29,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'DateArray Field Test 1' },},
 		]);
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'DateArray Field Test 1' },},
 		]);
 		*/
 
@@ -37,52 +42,52 @@ module.exports = {
 	},
 	'DateArray field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DateArrayModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: DateArrayModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'DateArray Field Test 1' },},
 		]);
 		*/
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { 'dateInputs': ['date1'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', options: { 'dateInputs': ['date1'] },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { 'dateInputs': ['date1', 'date2'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', options: { 'dateInputs': ['date1', 'date2'] },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldB', options: { 'dateInputs': ['date1', 'date2'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', options: { 'dateInputs': ['date1', 'date2'] },},
 		]);
 	},
 	'DateArray field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldA', input: {date1: '2016-01-01', date2: '2016-01-02'}, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', input: {date1: '2016-01-01', date2: '2016-01-02'},},
 		]);
 
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: {date1: '2016-01-03', date2: '2016-01-04'}, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', input: {date1: '2016-01-03', date2: '2016-01-04'},},
 		]);
 
 		// Drop focus on the date field so the popup disappears.
@@ -97,9 +102,9 @@ module.exports = {
 
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
-			{ name: 'fieldB', input: { date1: '2016-01-01', date2: '2016-01-02' }, modelTestConfig: DateArrayModelTestConfig, }, 
-			{ name: 'fieldB', input: { date1: '2016-01-03', date2: '2016-01-04' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'DateArray Field Test 1' },},
+			{ name: 'fieldB', input: { date1: '2016-01-01', date2: '2016-01-02' },},
+			{ name: 'fieldB', input: { date1: '2016-01-03', date2: '2016-01-04' },},
 		]);
 		*/
 	},

--- a/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateArrayField.js
@@ -6,111 +6,85 @@ module.exports = {
 	after: fieldTests.after,
 	'DateArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'DateArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: [{name: 'name'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'DateArray field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'DateArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'name': {value: 'DateArray Field Test 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'name': {value: 'DateArray Field Test 1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
 		*/
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'name': {value: 'DateArray Field Test 1'},
-			}
-		});
-		*/
 	},
 	'DateArray field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'dateInputs': ['date1']}
-			}],
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'dateInputs': ['date1', 'date2']}
-			}],
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: [{
-				name: 'fieldB',
-				options: {'dateInputs': ['date1', 'date2']}
-			}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+		*/
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { 'dateInputs': ['date1'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { 'dateInputs': ['date1', 'date2'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', click: 'addButton', modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldB', options: { 'dateInputs': ['date1', 'date2'] }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
 	},
 	'DateArray field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldA': {date1: '2016-01-01', date2: '2016-01-02'}
-			}
-		});
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'fieldB': {date1: '2016-01-03', date2: '2016-01-04'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldA', input: {date1: '2016-01-01', date2: '2016-01-02'}, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: {date1: '2016-01-03', date2: '2016-01-04'}, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
+
 		// Drop focus on the date field so the popup disappears.
 		browser.execute(function() {
 			document.activeElement.blur();
@@ -118,16 +92,15 @@ module.exports = {
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DateArrayModelTestConfig,
-			fields: {
-				'name': {value: 'DateArray Field Test 1'},
-				'fieldA': {date1: '2016-01-01', date2: '2016-01-02'},
-				'fieldB': {date1: '2016-01-03', date2: '2016-01-04'},
-			}
-		});
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'DateArray Field Test 1' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', input: { date1: '2016-01-01', date2: '2016-01-02' }, modelTestConfig: DateArrayModelTestConfig, }, 
+			{ name: 'fieldB', input: { date1: '2016-01-03', date2: '2016-01-04' }, modelTestConfig: DateArrayModelTestConfig, }, 
+		]);
 		*/
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var DateModelTestConfig = require('../../../modelTestConfig/DateModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/DateModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Date field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Date'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Date Field Test 1' },},
+			{ name: 'fieldA', input: { value: '2016-01-01' },},
 		]);
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Date Field Test 1' },},
+			{ name: 'fieldA', input: { value: '2016-01-01' },},
 		]);
 		*/
 		browser.adminUIInitialFormScreen.save();
@@ -39,21 +44,21 @@ module.exports = {
 	},
 	'Date field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Date Field Test 1' },},
+			{ name: 'fieldA', input: { value: '2016-01-01' },},
 		]);
 		*/
 	},
 	'Date field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: '2016-01-02' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: '2016-01-02' },},
 		]);
 
 		// Drop focus on the date field so the popup disappears.
@@ -68,9 +73,9 @@ module.exports = {
 
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
-			{ name: 'fieldB', input: { value: '2016-01-02' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Date Field Test 1' },},
+			{ name: 'fieldA', input: { value: '2016-01-01' },},
+			{ name: 'fieldB', input: { value: '2016-01-02' },},
 		]);
 		*/
 	},

--- a/test/e2e/adminUI/tests/group005Fields/testDateField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDateField.js
@@ -6,79 +6,72 @@ module.exports = {
 	after: fieldTests.after,
 	'Date field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Date'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: DateModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: DateModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Date field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Date'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: DateModelTestConfig,
-			fields: {
-				'name': {value: 'Date Field Test 1'},
-				'fieldA': {value: '2016-01-01'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+		]);
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: DateModelTestConfig,
-			fields: {
-				'name': {value: 'Date Field Test 1'},
-				'fieldA': {value: '2016-01-01'},
-			}
-		});
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+		]);
 		*/
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DateModelTestConfig,
-			fields: {
-				'name': {value: 'Date Field Test 1'},
-				'fieldA': {value: '2016-01-01'},
-			}
-		})
-		*/
 	},
 	'Date field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DateModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: DateModelTestConfig, }, 
+		]);
+
+		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+		]);
+		*/
 	},
 	'Date field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: DateModelTestConfig,
-			fields: {
-				'fieldB': {value: '2016-01-02'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: '2016-01-02' }, modelTestConfig: DateModelTestConfig, }, 
+		]);
+
 		// Drop focus on the date field so the popup disappears.
 		browser.execute(function() {
 			document.activeElement.blur();
 		});
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DateModelTestConfig,
-			fields: {
-				'name': {value: 'Date Field Test 1'},
-				'fieldA': {value: '2016-01-01'},
-				'fieldB': {value: '2016-01-02'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Date Field Test 1' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '2016-01-01' }, modelTestConfig: DateModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: '2016-01-02' }, modelTestConfig: DateModelTestConfig, }, 
+		]);
 		*/
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
@@ -2,80 +2,77 @@ var fieldTests = require('./commonFieldTestUtils.js');
 var DatetimeModelTestConfig = require('../../../modelTestConfig/DatetimeModelTestConfig');
 
 module.exports = {
-	'@disabled': true, // TODO:  https://github.com/keystonejs/keystone/issues/3330
+	//'@disabled': true, // TODO:  https://github.com/keystonejs/keystone/issues/3330
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Datetime field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Datetime'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: DatetimeModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Datetime field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Datetime'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: {
-				'name': {value: 'Datetime Field Test 1'},
-				'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
-			}
-		});
-		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: {
-				'name': {value: 'Datetime Field Test 1'},
-				'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
-			}
-		});
-		*/
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			/* https://github.com/keystonejs/keystone/issues/3330
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, },
+			*/ 
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			/* https://github.com/keystonejs/keystone/issues/3330
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			*/
+		]);
+	
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: {
-				'name': {value: 'Datetime Field Test 1'},
-				'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
-			}
-		})
-		*/
 	},
 	'Datetime field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: DatetimeModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			/* https://github.com/keystonejs/keystone/issues/3330
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			*/
+		]);
 	},
 	'Datetime field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: {
-				'fieldB': {date: '2016-01-02', time: '12:00:00 am'}
-			}
-		});
+		/* https://github.com/keystonejs/keystone/issues/3330
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+		]);
+		*/
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		/* TODO Pending fix of timezone issues which are causing Travis CI to fail
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: DatetimeModelTestConfig,
-			fields: {
-				'name': {value: 'Datetime Field Test 1'},
-				'fieldA': {date: '2016-01-01', time: '12:00:00 am'},
-				'fieldB': {date: '2016-01-02', time: '12:00:00 am'}
-			}
-		})
-		*/
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			/* https://github.com/keystonejs/keystone/issues/3330
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			*/
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testDatetimeField.js
@@ -1,9 +1,14 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var DatetimeModelTestConfig = require('../../../modelTestConfig/DatetimeModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/DatetimeModelTestConfig');
 
 module.exports = {
 	//'@disabled': true, // TODO:  https://github.com/keystonejs/keystone/issues/3330
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Datetime field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Datetime'});
@@ -12,8 +17,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DatetimeModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -26,39 +31,39 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Datetime Field Test 1' },},
 			/* https://github.com/keystonejs/keystone/issues/3330
-			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, },
-			*/ 
-		]);
-		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
-			/* https://github.com/keystonejs/keystone/issues/3330
-			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' },},
 			*/
 		]);
-	
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Datetime Field Test 1' },},
+			/* https://github.com/keystonejs/keystone/issues/3330
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' },},
+			*/
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Datetime field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: DatetimeModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: DatetimeModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Datetime Field Test 1' },},
 			/* https://github.com/keystonejs/keystone/issues/3330
-			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' },},
 			*/
 		]);
 	},
 	'Datetime field can be filled via the edit form': function(browser) {
 		/* https://github.com/keystonejs/keystone/issues/3330
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' },},
 		]);
 		*/
 
@@ -68,10 +73,10 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Datetime Field Test 1' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Datetime Field Test 1' },},
 			/* https://github.com/keystonejs/keystone/issues/3330
-			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
-			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' }, modelTestConfig: DatetimeModelTestConfig, }, 
+			{ name: 'fieldA', input: { date: '2016-01-01', time: '12:00:00 am' },},
+			{ name: 'fieldB', input: { date: '2016-01-02', time: '12:00:00 am' },},
 			*/
 		]);
 	},

--- a/test/e2e/adminUI/tests/group005Fields/testEmailField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testEmailField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var EmailModelTestConfig = require('../../../modelTestConfig/EmailModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/EmailModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Email field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Email'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Email Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'user@example1.com' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Email Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'user@example1.com' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Email field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Email Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'user@example1.com' },},
 		]);
 	},
 	'Email field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'user@example2.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'user@example2.com' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
-			{ name: 'fieldB', input: { value: 'user@example2.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Email Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'user@example1.com' },},
+			{ name: 'fieldB', input: { value: 'user@example2.com' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testEmailField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testEmailField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Email field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Email'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: EmailModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: EmailModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Email field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Email'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: EmailModelTestConfig,
-			fields: {
-				'name': {value: 'Email Field Test 1'},
-				'fieldA': {value: 'user@example1.com'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: EmailModelTestConfig,
-			fields: {
-				'name': {value: 'Email Field Test 1'},
-				'fieldA': {value: 'user@example1.com'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: EmailModelTestConfig,
-			fields: {
-				'name': {value: 'Email Field Test 1'},
-				'fieldA': {value: 'user@example1.com'},
-			}
-		})
 	},
 	'Email field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: EmailModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: EmailModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+		]);
 	},
 	'Email field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: EmailModelTestConfig,
-			fields: {
-				'fieldB': {value: 'user@example2.com'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'user@example2.com' }, modelTestConfig: EmailModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: EmailModelTestConfig,
-			fields: {
-				'name': {value: 'Email Field Test 1'},
-				'fieldA': {value: 'user@example1.com'},
-				'fieldB': {value: 'user@example2.com'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Email Field Test 1' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'user@example1.com' }, modelTestConfig: EmailModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'user@example2.com' }, modelTestConfig: EmailModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testFileField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testFileField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var FileModelTestConfig = require('../../../modelTestConfig/FileModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/FileModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'File field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'File'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,10 +29,10 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'name', input: { value: 'File Field Test 1' },},
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'name', input: { value: 'File Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -35,13 +40,13 @@ module.exports = {
 	},
 	'File field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: FileModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: FileModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'name', input: { value: 'File Field Test 1' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testFileField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testFileField.js
@@ -6,48 +6,42 @@ module.exports = {
 	after: fieldTests.after,
 	'File field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'File'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: FileModelTestConfig,
-			fields: [{name: 'name'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: FileModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'File field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'File'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: FileModelTestConfig,
-			fields: {
-				'name': {value: 'File Field Test 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: FileModelTestConfig,
-			fields: {
-				'name': {value: 'File Field Test 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: FileModelTestConfig,
-			fields: {
-				'name': {value: 'File Field Test 1'},
-			}
-		})
 	},
 	'File field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: FileModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: FileModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: FileModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'File Field Test 1' }, modelTestConfig: FileModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var GeoPointModelTestConfig = require('../../../modelTestConfig/GeoPointModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/GeoPointModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'GeoPoint field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'GeoPoint'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' },},
+			{ name: 'fieldA', input: { lat: '123', lng: '456' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' },},
+			{ name: 'fieldA', input: { lat: '123', lng: '456' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'GeoPoint field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' },},
+			{ name: 'fieldA', input: { lat: '123', lng: '456' },},
 		]);
 	},
 	'GeoPoint field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { lat: '789', lng: '246' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldB', input: { lat: '789', lng: '246' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
-			{ name: 'fieldB', input: { lat: '789', lng: '246' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' },},
+			{ name: 'fieldA', input: { lat: '123', lng: '456' },},
+			{ name: 'fieldB', input: { lat: '789', lng: '246' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testGeoPointField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'GeoPoint field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'GeoPoint'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'GeoPoint field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'GeoPoint'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: {
-				'name': {value: 'GeoPoint Field Test 1'},
-				'fieldA': {lat: '123', lng: '456'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: {
-				'name': {value: 'GeoPoint Field Test 1'},
-				'fieldA': {lat: '123', lng: '456'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: {
-				'name': {value: 'GeoPoint Field Test 1'},
-				'fieldA': {lat: '123', lng: '456'},
-			}
-		})
 	},
 	'GeoPoint field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
 	},
 	'GeoPoint field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: {
-				'fieldB': {lat: '789', lng: '246'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { lat: '789', lng: '246' }, modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: GeoPointModelTestConfig,
-			fields: {
-				'name': {value: 'GeoPoint Field Test 1'},
-				'fieldA': {lat: '123', lng: '456'},
-				'fieldB': {lat: '789', lng: '246'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'GeoPoint Field Test 1' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldA', input: { lat: '123', lng: '456' }, modelTestConfig: GeoPointModelTestConfig, }, 
+			{ name: 'fieldB', input: { lat: '789', lng: '246' }, modelTestConfig: GeoPointModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Html field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Html'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: HtmlModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Html field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Html'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: {
-				'name': {value: 'Html Field Test 1'},
-				'fieldA': {value: 'Some test html code for field A'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: {
-				'name': {value: 'Html Field Test 1'},
-				'fieldA': {value: 'Some test html code for field A'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: {
-				'name': {value: 'Html Field Test 1'},
-				'fieldA': {value: 'Some test html code for field A'},
-			}
-		})
 	},
 	'Html field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: HtmlModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+		]);
 	},
 	'Html field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: {
-				'fieldB': {value: 'Some test html code for field B'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'Some test html code for field B' }, modelTestConfig: HtmlModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: HtmlModelTestConfig,
-			fields: {
-				'name': {value: 'Html Field Test 1'},
-				'fieldA': {value: 'Some test html code for field A'},
-				'fieldB': {value: 'Some test html code for field B'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'Some test html code for field B' }, modelTestConfig: HtmlModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testHtmlField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var HtmlModelTestConfig = require('../../../modelTestConfig/HtmlModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/HtmlModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Html field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Html'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Html Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Html Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Html field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Html Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' },},
 		]);
 	},
 	'Html field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'Some test html code for field B' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'Some test html code for field B' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Html Field Test 1' }, modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'Some test html code for field A' }, modelTestConfig: HtmlModelTestConfig, }, 
-			{ name: 'fieldB', input: { value: 'Some test html code for field B' }, modelTestConfig: HtmlModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Html Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'Some test html code for field A' },},
+			{ name: 'fieldB', input: { value: 'Some test html code for field B' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testKeyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testKeyField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var KeyModelTestConfig = require('../../../modelTestConfig/KeyModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/KeyModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Key field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Key'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'A test key for field A' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Key Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'A test key for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'A test key for field A' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Key Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'A test key for field A' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Key field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Key Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' },},
 		]);
 	},
 	'Key field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'A test key for field B' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'A test key for field B' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' }, modelTestConfig: KeyModelTestConfig, }, 
-			{ name: 'fieldB', input: { value: 'a-test-key-for-field-b' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Key Field Test 1' },},
+			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' },},
+			{ name: 'fieldB', input: { value: 'a-test-key-for-field-b' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testKeyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testKeyField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Key field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Key'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: KeyModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: KeyModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Key field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Key'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: KeyModelTestConfig,
-			fields: {
-				'name': {value: 'Key Field Test 1'},
-				'fieldA': {value: 'A test key for field A'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: KeyModelTestConfig,
-			fields: {
-				'name': {value: 'Key Field Test 1'},
-				'fieldA': {value: 'A test key for field A'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'A test key for field A' }, modelTestConfig: KeyModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'A test key for field A' }, modelTestConfig: KeyModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: KeyModelTestConfig,
-			fields: {
-				'name': {value: 'Key Field Test 1'},
-				'fieldA': {value: 'a-test-key-for-field-a'},
-			}
-		})
 	},
 	'Key field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: KeyModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: KeyModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' }, modelTestConfig: KeyModelTestConfig, }, 
+		]);
 	},
 	'Key field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: KeyModelTestConfig,
-			fields: {
-				'fieldB': {value: 'A test key for field B'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'A test key for field B' }, modelTestConfig: KeyModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: KeyModelTestConfig,
-			fields: {
-				'name': {value: 'Key Field Test 1'},
-				'fieldA': {value: 'a-test-key-for-field-a'},
-				'fieldB': {value: 'a-test-key-for-field-b'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Key Field Test 1' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: 'a-test-key-for-field-a' }, modelTestConfig: KeyModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: 'a-test-key-for-field-b' }, modelTestConfig: KeyModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testLocationField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testLocationField.js
@@ -6,194 +6,153 @@ module.exports = {
 	after: fieldTests.after,
 	'Location field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Location'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: LocationModelTestConfig,
-			fields: [
-				{name: 'name'},
-				{
-					name: 'fieldA',
-					options: {showMore: false}
-				}
-			],
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', options: { showMore: false }, modelTestConfig: LocationModelTestConfig, }, 
+		]);
 
-		browser.adminUIInitialFormScreen.clickFieldUI({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'showMore'},
-			}
-		});
+		browser.adminUIInitialFormScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+		]);
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: LocationModelTestConfig,
-			fields: [
-				{name: 'name'},
-				{
-					name: 'fieldA',
-					options: {showMore: true}
-				}
-			],
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Location field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Location'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.clickFieldUI({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'showMore'},
-			}
-		});
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'name': {value: 'Location Field Test 1'},
-				'fieldA': {
-					'number': 'Field A',
-					'name': 'Building A',
-					'street1': 'Street A',
-					'street2': 'Town A',
-					'suburb': 'Suburb A',
-					'state': 'State A',
-					'postcode': 'AAA AAA',
-					'country': 'AAA',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'name': {value: 'Location Field Test 1'},
-				'fieldA': {
-					'number': 'Field A',
-					'name': 'Building A',
-					'street1': 'Street A',
-					'street2': 'Town A',
-					'suburb': 'Suburb A',
-					'state': 'State A',
-					'postcode': 'AAA AAA',
-					'country': 'AAA',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+		]);
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', input: {
+									'number': 'Field A',
+									'name': 'Building A',
+									'street1': 'Street A',
+									'street2': 'Town A',
+									'suburb': 'Suburb A',
+									'state': 'State A',
+									'postcode': 'AAA AAA',
+									'country': 'AAA',
+									'geoLat': '123',
+									'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', input: {
+									'number': 'Field A',
+									'name': 'Building A',
+									'street1': 'Street A',
+									'street2': 'Town A',
+									'suburb': 'Suburb A',
+									'state': 'State A',
+									'postcode': 'AAA AAA',
+									'country': 'AAA',
+									'geoLat': '123',
+									'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'name': {value: 'Location Field Test 1'},
-				'fieldA': {
-					'number': 'Field A',
-					'name': 'Building A',
-					'street1': 'Street A',
-					'street2': 'Town A',
-					'suburb': 'Suburb A',
-					'state': 'State A',
-					'postcode': 'AAA AAA',
-					'country': 'AAA',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-			}
-		})
 	},
 	'Location field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: LocationModelTestConfig,
-			fields: [
-				{
-					name: 'fieldA',
-					options: {showMore: true}
-				},
-				{
-					name: 'fieldB',
-					options: {showMore: false}
-				}
-			],
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'showMore'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: LocationModelTestConfig,
-			fields: [
-				{
-					name: 'fieldA',
-					options: {showMore: true}
-				},
-				{
-					name: 'fieldB',
-					options: {showMore: true}
-				}
-			],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldB', options: { showMore: false }, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', input: {
+									'number': 'Field A',
+									'name': 'Building A',
+									'street1': 'Street A',
+									'street2': 'Town A',
+									'suburb': 'Suburb A',
+									'state': 'State A',
+									'postcode': 'AAA AAA',
+									'country': 'AAA',
+									'geoLat': '123',
+									'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldB', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+		]);
 	},
 	'Location field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'fieldB': {
-					'number': 'Field B',
-					'name': 'Building B',
-					'street1': 'Street B',
-					'street2': 'Town B',
-					'suburb': 'Suburb B',
-					'state': 'State B',
-					'postcode': 'BBB BBB',
-					'country': 'BBB',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldB', input: {
+										'number': 'Field B',
+										'name': 'Building B',
+										'street1': 'Street B',
+										'street2': 'Town B',
+										'suburb': 'Suburb B',
+										'state': 'State B',
+										'postcode': 'BBB BBB',
+										'country': 'BBB',
+										'geoLat': '123',
+										'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: LocationModelTestConfig,
-			fields: {
-				'name': {value: 'Location Field Test 1'},
-				'fieldA': {
-					'number': 'Field A',
-					'name': 'Building A',
-					'street1': 'Street A',
-					'street2': 'Town A',
-					'suburb': 'Suburb A',
-					'state': 'State A',
-					'postcode': 'AAA AAA',
-					'country': 'AAA',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-				'fieldB': {
-					'number': 'Field B',
-					'name': 'Building B',
-					'street1': 'Street B',
-					'street2': 'Town B',
-					'suburb': 'Suburb B',
-					'state': 'State B',
-					'postcode': 'BBB BBB',
-					'country': 'BBB',
-					'geoLat': '123',
-					'geoLng': '123'
-				},
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldA', input: {
+									'number': 'Field A',
+									'name': 'Building A',
+									'street1': 'Street A',
+									'street2': 'Town A',
+									'suburb': 'Suburb A',
+									'state': 'State A',
+									'postcode': 'AAA AAA',
+									'country': 'AAA',
+									'geoLat': '123',
+									'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'fieldB', input: {
+										'number': 'Field B',
+										'name': 'Building B',
+										'street1': 'Street B',
+										'street2': 'Town B',
+										'suburb': 'Suburb B',
+										'state': 'State B',
+										'postcode': 'BBB BBB',
+										'country': 'BBB',
+										'geoLat': '123',
+										'geoLng': '123'
+			}, modelTestConfig: LocationModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testLocationField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testLocationField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var LocationModelTestConfig = require('../../../modelTestConfig/LocationModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/LocationModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Location field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Location'});
@@ -11,17 +16,17 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldA', options: { showMore: false }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA', options: { showMore: false },},
 		]);
 
 		browser.adminUIInitialFormScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+			{ name: 'fieldA', click: 'showMore',}
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA', options: { showMore: true },},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -34,11 +39,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+			{ name: 'fieldA', click: 'showMore',}
 		]);
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Location Field Test 1' },},
 			{ name: 'fieldA', input: {
 									'number': 'Field A',
 									'name': 'Building A',
@@ -50,11 +55,11 @@ module.exports = {
 									'country': 'AAA',
 									'geoLat': '123',
 									'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+			},},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Location Field Test 1' },},
 			{ name: 'fieldA', input: {
 									'number': 'Field A',
 									'name': 'Building A',
@@ -66,7 +71,7 @@ module.exports = {
 									'country': 'AAA',
 									'geoLat': '123',
 									'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+			},},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -74,13 +79,13 @@ module.exports = {
 	},
 	'Location field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldB', options: { showMore: false }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA', options: { showMore: true },},
+			{ name: 'fieldB', options: { showMore: false },},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Location Field Test 1' },},
 			{ name: 'fieldA', input: {
 									'number': 'Field A',
 									'name': 'Building A',
@@ -92,22 +97,22 @@ module.exports = {
 									'country': 'AAA',
 									'geoLat': '123',
 									'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+			},},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', click: 'showMore', modelTestConfig: LocationModelTestConfig, }
+			{ name: 'fieldB', click: 'showMore',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldA', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
-			{ name: 'fieldB', options: { showMore: true }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA', options: { showMore: true },},
+			{ name: 'fieldB', options: { showMore: true },},
 		]);
 	},
 	'Location field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Location Field Test 1' },},
 			{ name: 'fieldB', input: {
 										'number': 'Field B',
 										'name': 'Building B',
@@ -119,7 +124,7 @@ module.exports = {
 										'country': 'BBB',
 										'geoLat': '123',
 										'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+			},},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -128,7 +133,7 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Location Field Test 1' }, modelTestConfig: LocationModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Location Field Test 1' },},
 			{ name: 'fieldA', input: {
 									'number': 'Field A',
 									'name': 'Building A',
@@ -140,19 +145,19 @@ module.exports = {
 									'country': 'AAA',
 									'geoLat': '123',
 									'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+			},},
 			{ name: 'fieldB', input: {
-										'number': 'Field B',
-										'name': 'Building B',
-										'street1': 'Street B',
-										'street2': 'Town B',
-										'suburb': 'Suburb B',
-										'state': 'State B',
-										'postcode': 'BBB BBB',
-										'country': 'BBB',
-										'geoLat': '123',
-										'geoLng': '123'
-			}, modelTestConfig: LocationModelTestConfig, }, 
+									'number': 'Field B',
+									'name': 'Building B',
+									'street1': 'Street B',
+									'street2': 'Town B',
+									'suburb': 'Suburb B',
+									'state': 'State B',
+									'postcode': 'BBB BBB',
+									'country': 'BBB',
+									'geoLat': '123',
+									'geoLng': '123'
+			},},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var MarkdownModelTestConfig = require('../../../modelTestConfig/MarkdownModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/MarkdownModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Markdown field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Markdown'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,22 +30,22 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' },},
 		]);
 
 		browser.adminUIInitialFormScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, }
+			{ name: 'fieldA', click: 'previewToggle',}
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -48,19 +53,19 @@ module.exports = {
 	},
 	'Markdown field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' },},
 		]);
 	},
 	'Markdown field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -69,20 +74,20 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' },},
+			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, },
-			{ name: 'fieldB', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, },
+			{ name: 'fieldA', click: 'previewToggle',},
+			{ name: 'fieldB', click: 'previewToggle',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
-			{ name: 'fieldB', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Markdown Field Test 1' },},
+			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' },},
+			{ name: 'fieldB', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMarkdownField.js
@@ -6,96 +6,83 @@ module.exports = {
 	after: fieldTests.after,
 	'Markdown field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Markdown'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Markdown field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Markdown'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {md: 'Some __test__ markdown for **field A**'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {md: 'Some __test__ markdown for **field A**'},
-			}
-		});
-		browser.adminUIInitialFormScreen.clickFieldUI({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'previewToggle'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, }
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {md: 'Some __test__ markdown for **field A**'},
-			}
-		})
 	},
 	'Markdown field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
 	},
 	'Markdown field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'fieldB': {md: 'Some __test__ markdown for **field B**'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {md: 'Some __test__ markdown for **field A**'},
-				'fieldB': {md: 'Some __test__ markdown for **field B**'}
-			}
-		});
-		/* TODO Work out why this was breaking travis, and re-implement
-		See https://travis-ci.org/keystonejs/keystone/builds/130040822#L2215
-		browser.adminUIItemScreen.section.form.section.markdownList.section.fieldA.togglePreview();
-		browser.adminUIItemScreen.section.form.section.markdownList.section.fieldB.togglePreview();
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: MarkdownModelTestConfig,
-			fields: {
-				'name': {value: 'Markdown Field Test 1'},
-				'fieldA': {html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n'},
-				'fieldB': {html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n'}
-			}
-		});
-		*/
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { md: 'Some __test__ markdown for **field A**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldB', input: { md: 'Some __test__ markdown for **field B**' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, },
+			{ name: 'fieldB', click: 'previewToggle', modelTestConfig: MarkdownModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Markdown Field Test 1' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldA', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
+			{ name: 'fieldB', input: { html: '<p>Some <strong>test</strong> markdown for <strong>field A</strong></p>\n' }, modelTestConfig: MarkdownModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Money field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Money'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: MoneyModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Money field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Money'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: {
-				'name': {value: 'Money Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: {
-				'name': {value: 'Money Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: {
-				'name': {value: 'Money Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		})
 	},
 	'Money field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: MoneyModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+		]);
 	},
 	'Money field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: {
-				'fieldB': {value: '2'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: MoneyModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: MoneyModelTestConfig,
-			fields: {
-				'name': {value: 'Money Field Test 1'},
-				'fieldA': {value: '1'},
-				'fieldB': {value: '2'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: MoneyModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testMoneyField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var MoneyModelTestConfig = require('../../../modelTestConfig/MoneyModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/MoneyModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Money field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Money'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Money Field Test 1' },},
+			{ name: 'fieldA', input: { value: '1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Money Field Test 1' },},
+			{ name: 'fieldA', input: { value: '1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Money field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Money Field Test 1' },},
+			{ name: 'fieldA', input: { value: '1' },},
 		]);
 	},
 	'Money field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'fieldB', input: { value: '2' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Money Field Test 1' }, modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: MoneyModelTestConfig, }, 
-			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: MoneyModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Money Field Test 1' },},
+			{ name: 'fieldA', input: { value: '1' },},
+			{ name: 'fieldB', input: { value: '2' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNameField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var NameModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/NameModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Name field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,13 +30,13 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Name Field Test 1' },},
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Name Field Test 1' },},
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -39,19 +44,19 @@ module.exports = {
 	},
 	'Name field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Name Field Test 1' },},
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' },},
 		]);
 	},
 	'Name field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -60,9 +65,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
-			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'name', input: { value: 'Name Field Test 1' },},
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' },},
+			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNameField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNameField.js
@@ -6,70 +6,63 @@ module.exports = {
 	after: fieldTests.after,
 	'Name field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: NameModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: NameModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Name field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Name'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': {value: 'Name Field Test 1'},
-				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': {value: 'Name Field Test 1'},
-				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': {value: 'Name Field Test 1'},
-				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
-			}
-		})
 	},
 	'Name field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NameModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: NameModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+		]);
 	},
 	'Name field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'fieldB': {firstName: 'First 2', lastName: 'Last 2'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NameModelTestConfig,
-			fields: {
-				'name': {value: 'Name Field Test 1'},
-				'fieldA': {firstName: 'First 1', lastName: 'Last 1'},
-				'fieldB': {firstName: 'First 2', lastName: 'Last 2'}
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Name Field Test 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldA', input: { firstName: 'First 1', lastName: 'Last 1' }, modelTestConfig: NameModelTestConfig, }, 
+			{ name: 'fieldB', input: { firstName: 'First 2', lastName: 'Last 2' }, modelTestConfig: NameModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var NumberArrayModelTestConfig = require('../../../modelTestConfig/NumberArrayModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/NumberArrayModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'NumberArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'NumberArray'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,11 +29,11 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' },},
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -36,46 +41,46 @@ module.exports = {
 	},
 	'NumberArray field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: NumberArrayModelTestConfig, }, 
-			{ name: 'fieldA', modelTestConfig: NumberArrayModelTestConfig, }, 
-			{ name: 'fieldB', modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name',},
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+			{ name: 'fieldA', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { 'numberInputs': ['number1'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldA', options: { 'numberInputs': ['number1'] },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+			{ name: 'fieldA', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { 'numberInputs': ['number1', 'number2'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldA', options: { 'numberInputs': ['number1', 'number2'] },},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
-			{ name: 'fieldB', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+			{ name: 'fieldB', click: 'addButton',},
+			{ name: 'fieldB', click: 'addButton',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldB', options: { 'numberInputs': ['number1', 'number2'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldB', options: { 'numberInputs': ['number1', 'number2'] },},
 		]);
 	},
 	'NumberArray field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldA', input: { number1: '1', number2: '2' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldA', input: { number1: '1', number2: '2' },},
 		]);
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { number1: '3', number2: '4' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldB', input: { number1: '3', number2: '4' },},
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -84,9 +89,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
-			{ name: 'fieldA', input: { number1: '1', number2: '2' }, modelTestConfig: NumberArrayModelTestConfig, }, 
-			{ name: 'fieldB', input: { number1: '3', number2: '4' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' },},
+			{ name: 'fieldA', input: { number1: '1', number2: '2' },},
+			{ name: 'fieldB', input: { number1: '3', number2: '4' },},
 		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberArrayField.js
@@ -6,117 +6,87 @@ module.exports = {
 	after: fieldTests.after,
 	'NumberArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'NumberArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: [{name: 'name'}]
-		});
-	},
-	'restoring test state': function(browser) {
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'NumberArray field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'NumberArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'name': {value: 'NumberArray Field Test 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'name': {value: 'NumberArray Field Test 1'},
-			}
-		});
+
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'name': {value: 'NumberArray Field Test 1'},
-			}
-		})
 	},
 	'NumberArray field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'numberInputs': ['number1']}
-			}],
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'numberInputs': ['number1', 'number2']}
-			}],
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: [{
-				name: 'fieldB',
-				options:{'numberInputs': ['number1', 'number2']}
-			}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldA', modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldB', modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { 'numberInputs': ['number1'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { 'numberInputs': ['number1', 'number2'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+			{ name: 'fieldB', click: 'addButton', modelTestConfig: NumberArrayModelTestConfig, },
+		]);
+
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldB', options: { 'numberInputs': ['number1', 'number2'] }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
 	},
 	'NumberArray field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldA': {number1: '1', number2: '2'}
-			}
-		});
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'fieldB': {number1: '3', number2: '4'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldA', input: { number1: '1', number2: '2' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { number1: '3', number2: '4' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NumberArrayModelTestConfig,
-			fields: {
-				'name': {value: 'NumberArray Field Test 1'},
-				'fieldA': {number1: '1', number2: '2'},
-				'fieldB': {number1: '3', number2: '4'},
-			}
-		})
+
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'NumberArray Field Test 1' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldA', input: { number1: '1', number2: '2' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+			{ name: 'fieldB', input: { number1: '3', number2: '4' }, modelTestConfig: NumberArrayModelTestConfig, }, 
+		]);
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNumberField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberField.js
@@ -10,10 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: NumberModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: NumberModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: NumberModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,57 +24,42 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: NumberModelTestConfig,
-			fields: {
-				'name': {value: 'Number Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: NumberModelTestConfig,
-			fields: {
-				'name': {value: 'Number Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Number field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: NumberModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: NumberModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NumberModelTestConfig,
-			fields: {
-				'name': {value: 'Number Field Test 1'},
-				'fieldA': {value: '1'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+		])
 	},
 	'Number field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: NumberModelTestConfig,
-			fields: {
-				'fieldB': {value: '2'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: NumberModelTestConfig },
+		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: NumberModelTestConfig,
-			fields: {
-				'name': {value: 'Number Field Test 1'},
-				'fieldA': {value: '1'},
-				'fieldB': {value: '2'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: NumberModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNumberField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var NumberModelTestConfig = require('../../../modelTestConfig/NumberModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/NumberModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Number field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Number'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: NumberModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: NumberModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA',}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'name', input: { value: 'Number Field Test 1' }, },
+			{ name: 'fieldA', input: { value: '1' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'name', input: { value: 'Number Field Test 1' }, },
+			{ name: 'fieldA', input: { value: '1' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,18 +43,18 @@ module.exports = {
 	},
 	'Number field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', modelTestConfig: NumberModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: NumberModelTestConfig, }
+			{ name: 'fieldA',},
+			{ name: 'fieldB',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'name', input: { value: 'Number Field Test 1' }, },
+			{ name: 'fieldA', input: { value: '1' }, },
 		])
 	},
 	'Number field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'fieldB', input: { value: '2' }, },
 		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
@@ -57,9 +62,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Number Field Test 1' }, modelTestConfig: NumberModelTestConfig },
-			{ name: 'fieldA', input: { value: '1' }, modelTestConfig: NumberModelTestConfig },
-			{ name: 'fieldB', input: { value: '2' }, modelTestConfig: NumberModelTestConfig },
+			{ name: 'name', input: { value: 'Number Field Test 1' }, },
+			{ name: 'fieldA', input: { value: '1' }, },
+			{ name: 'fieldB', input: { value: '2' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testNumberField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testNumberField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Number field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Number'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -13,15 +14,16 @@ module.exports = {
 			modelTestConfig: NumberModelTestConfig,
 			fields: [{name: 'name'}, {name: 'fieldA'}]
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Number field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Number'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: NumberModelTestConfig,
 			fields: {
@@ -36,8 +38,15 @@ module.exports = {
 				'fieldA': {value: '1'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+	},
+	'Number field should show correctly in the edit form': function(browser) {
+		browser.adminUIItemScreen.assertFieldUIVisible({
+			modelTestConfig: NumberModelTestConfig,
+			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
+		});
 
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: NumberModelTestConfig,
@@ -46,12 +55,6 @@ module.exports = {
 				'fieldA': {value: '1'},
 			}
 		})
-	},
-	'Number field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: NumberModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
 	},
 	'Number field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
@@ -62,7 +65,9 @@ module.exports = {
 		});
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: NumberModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
@@ -1,9 +1,14 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var PasswordModelTestConfig = require('../../../modelTestConfig/PasswordModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/PasswordModelTestConfig');
 
 module.exports = {
 	// '@disabled': true,  // TODO: enable after https://github.com/keystonejs/keystone/issues/3428 is fixed
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Password field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Password'});
@@ -12,8 +17,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: PasswordModelTestConfig, },
-			{ name: 'fieldA', options: { passwordShown: true },  modelTestConfig: PasswordModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA', options: { passwordShown: true }, }
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -26,40 +31,40 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
-			{ name: 'fieldA', input: {value: 'password1', confirm: 'wrongPassword1'}, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'name', input: { value: 'Password Field Test 1' }, },
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'wrongPassword1'}, },
 		]);
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIInitialFormScreen.assertFlashError("Passwords must match");
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, },
 		]);
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Password field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, },
-			{ name: 'fieldB', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, }
+			{ name: 'fieldA', options: { passwordShown: false }, },
+			{ name: 'fieldB', options: { passwordShown: false }, }
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'name', input: { value: 'Password Field Test 1' }, },
 		])
 	},
 	'Password field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', 'click': 'setPasswordButton', modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldB', 'click': 'setPasswordButton', },
 		]);
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, },
-			{ name: 'fieldB', options: { passwordShown: true },  modelTestConfig: PasswordModelTestConfig, }
+			{ name: 'fieldA', options: { passwordShown: false }, },
+			{ name: 'fieldB', options: { passwordShown: true }, }
 		]);
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: {value: 'password2', confirm: 'wrongPassword2'}, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldB', input: {value: 'password2', confirm: 'wrongPassword2'}, },
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -68,7 +73,7 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashError('Passwords must match');
 
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: {value: 'password2', confirm: 'password2'}, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldB', input: {value: 'password2', confirm: 'password2'}, },
 		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
@@ -76,7 +81,7 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'name', input: { value: 'Password Field Test 1' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
@@ -2,7 +2,7 @@ var fieldTests = require('./commonFieldTestUtils.js');
 var PasswordModelTestConfig = require('../../../modelTestConfig/PasswordModelTestConfig');
 
 module.exports = {
-	'@disabled': true,  // TODO: enable after https://github.com/keystonejs/keystone/issues/3428 is fixed
+	// '@disabled': true,  // TODO: enable after https://github.com/keystonejs/keystone/issues/3428 is fixed
 	before: fieldTests.before,
 	after: fieldTests.after,
 	'Password field should show correctly in the initial modal': function (browser) {
@@ -11,18 +11,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: [
-				{
-					name: 'name'
-				},
-				{
-					name: 'fieldA',
-					options: {passwordShown: true}, // To check for @value instead of @button
-				}
-			],
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: PasswordModelTestConfig, },
+			{ name: 'fieldA', options: { passwordShown: true },  modelTestConfig: PasswordModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -33,100 +25,58 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'name': {value: 'Password Field Test 1'},
-				'fieldA': {value: 'password1', confirm: 'wrongPassword1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'wrongPassword1'}, modelTestConfig: PasswordModelTestConfig },
+		]);
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIInitialFormScreen.assertFlashError("Passwords must match");
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'fieldA': {value: 'password1', confirm: 'password1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'name': {value: 'Password Field Test 1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, modelTestConfig: PasswordModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'fieldA', input: {value: 'password1', confirm: 'password1'}, modelTestConfig: PasswordModelTestConfig },
+		]);
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Password field should show correctly in the edit form': function(browser) {
-		browser.itemScreen.assertFieldUIVisible({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: [
-				{
-					name: 'fieldA',
-					options: {passwordShown: false}, // To check for @button instead of @value
-				},
-				{
-					name: 'fieldB',
-					options: {passwordShown: false}, // To check for @button instead of @value
-				}
-			],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, },
+			{ name: 'fieldB', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, }
+		]);
 
-		browser.itemScreen.assertFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'name': {value: 'Password Field Test 1'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
+		])
 	},
 	'Password field can be filled via the edit form': function(browser) {
-		browser.itemScreen.clickFieldUI({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'setPasswordButton'},
-			}
-		});
-		browser.itemScreen.assertFieldUIVisible({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: [
-				{
-					name: 'fieldA',
-					options: {passwordShown: false}, // To check for @button instead of @value
-				},
-				{
-					name: 'fieldB',
-					options: {passwordShown: true}, // To check for @value instead of @button
-				}
-			],
-		});
-		browser.itemScreen.fillFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'fieldB': {value: 'password2', confirm: 'wrongPassword2'}
-			}
-		});
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', 'click': 'setPasswordButton', modelTestConfig: PasswordModelTestConfig },
+		]);
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: { passwordShown: false },  modelTestConfig: PasswordModelTestConfig, },
+			{ name: 'fieldB', options: { passwordShown: true },  modelTestConfig: PasswordModelTestConfig, }
+		]);
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: {value: 'password2', confirm: 'wrongPassword2'}, modelTestConfig: PasswordModelTestConfig },
+		]);
 
-		browser.itemScreen.save();
+		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.itemScreen.assertFlashError('Passwords must match');
+		browser.adminUIItemScreen.assertFlashError('Passwords must match');
 
-		browser.itemScreen.fillFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'fieldB': {value: 'password2', confirm: 'password2'}
-			}
-		});
-		browser.itemScreen.save();
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: {value: 'password2', confirm: 'password2'}, modelTestConfig: PasswordModelTestConfig },
+		]);
+		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
-		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.itemScreen.assertFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'name': {value: 'Password Field Test 1'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Password Field Test 1' }, modelTestConfig: PasswordModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testPasswordField.js
@@ -7,6 +7,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Password field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Password'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -22,15 +23,16 @@ module.exports = {
 				}
 			],
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Password field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Password'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: PasswordModelTestConfig,
 			fields: {
@@ -54,13 +56,6 @@ module.exports = {
 		});
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.itemScreen.assertFieldInputs({
-			modelTestConfig: PasswordModelTestConfig,
-			fields: {
-				'name': {value: 'Password Field Test 1'},
-			}
-		})
 	},
 	'Password field should show correctly in the edit form': function(browser) {
 		browser.itemScreen.assertFieldUIVisible({
@@ -76,6 +71,13 @@ module.exports = {
 				}
 			],
 		});
+
+		browser.itemScreen.assertFieldInputs({
+			modelTestConfig: PasswordModelTestConfig,
+			fields: {
+				'name': {value: 'Password Field Test 1'},
+			}
+		})
 	},
 	'Password field can be filled via the edit form': function(browser) {
 		browser.itemScreen.clickFieldUI({
@@ -103,9 +105,12 @@ module.exports = {
 				'fieldB': {value: 'password2', confirm: 'wrongPassword2'}
 			}
 		});
+
 		browser.itemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.itemScreen.assertFlashError('Passwords must match');
+
 		browser.itemScreen.fillFieldInputs({
 			modelTestConfig: PasswordModelTestConfig,
 			fields: {
@@ -114,7 +119,9 @@ module.exports = {
 		});
 		browser.itemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.itemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.itemScreen.assertFieldInputs({
 			modelTestConfig: PasswordModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
@@ -10,10 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: RelationshipModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: RelationshipModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,58 +24,42 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: {
-				'name': {value: 'Relationship Field Test 1'},
-				'fieldA': {option: 'option1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: {
-				'name': {value: 'Relationship Field Test 1'},
-				'fieldA': {value: 'e2e member'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldA', input: { option: 'option1' }, modelTestConfig: RelationshipModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Relationship field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: [{name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldB', modelTestConfig: RelationshipModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: {
-				'name': {value: 'Relationship Field Test 1'},
-				'fieldA': {value: 'e2e member'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
+		])
 	},
 	'Relationship field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: {
-				'fieldB': {option: 'option2'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { option: 'option2' }, modelTestConfig: RelationshipModelTestConfig },
+		]);
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: {
-				'name': {value: 'Relationship Field Test 1'},
-				'fieldA': {value: 'e2e member'},
-				'fieldB': {value: 'e2e user'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldB', input: { value: 'e2e user' }, modelTestConfig: RelationshipModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Relationship field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Relationship'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -19,8 +20,10 @@ module.exports = {
 	},
 	'Relationship field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Relationship'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: RelationshipModelTestConfig,
 			fields: {
@@ -35,8 +38,15 @@ module.exports = {
 				'fieldA': {value: 'e2e member'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+	},
+	'Relationship field should show correctly in the edit form': function(browser) {
+		browser.adminUIItemScreen.assertFieldUIVisible({
+			modelTestConfig: RelationshipModelTestConfig,
+			fields: [{name: 'fieldB'}]
+		});
 
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: RelationshipModelTestConfig,
@@ -46,12 +56,6 @@ module.exports = {
 			}
 		})
 	},
-	'Relationship field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: RelationshipModelTestConfig,
-			fields: [{name: 'fieldB'}]
-		});
-	},
 	'Relationship field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
 			modelTestConfig: RelationshipModelTestConfig,
@@ -59,9 +63,12 @@ module.exports = {
 				'fieldB': {option: 'option2'}
 			}
 		});
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: RelationshipModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var RelationshipModelTestConfig = require('../../../modelTestConfig/RelationshipModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/RelationshipModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Relationship field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Relationship'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: RelationshipModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: RelationshipModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA',}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
-			{ name: 'fieldA', input: { option: 'option1' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, },
+			{ name: 'fieldA', input: { option: 'option1' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
-			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'e2e member' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,17 +43,17 @@ module.exports = {
 	},
 	'Relationship field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldB', modelTestConfig: RelationshipModelTestConfig, }
+			{ name: 'fieldB',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
-			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'e2e member' }, },
 		])
 	},
 	'Relationship field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { option: 'option2' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'fieldB', input: { option: 'option2' }, },
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -57,9 +62,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Relationship Field Test 1' }, modelTestConfig: RelationshipModelTestConfig },
-			{ name: 'fieldA', input: { value: 'e2e member' }, modelTestConfig: RelationshipModelTestConfig },
-			{ name: 'fieldB', input: { value: 'e2e user' }, modelTestConfig: RelationshipModelTestConfig },
+			{ name: 'name', input: { value: 'Relationship Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'e2e member' }, },
+			{ name: 'fieldB', input: { value: 'e2e user' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testSelectField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Select field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Select'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -19,15 +20,16 @@ module.exports = {
 				}
 			],
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Select field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Select'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: SelectModelTestConfig,
 			fields: {
@@ -42,16 +44,9 @@ module.exports = {
 				'fieldA': {value: 'One'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'name': {value: 'Select Field Test 1'},
-				'fieldA': {value: 'One'},
-			}
-		})
 	},
 	'Select field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible({
@@ -67,6 +62,14 @@ module.exports = {
 				}
 			],
 		});
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			modelTestConfig: SelectModelTestConfig,
+			fields: {
+				'name': {value: 'Select Field Test 1'},
+				'fieldA': {value: 'One'},
+			}
+		})
 	},
 	'Select field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
@@ -75,9 +78,12 @@ module.exports = {
 				'fieldB': {value: 'Two'}
 			}
 		});
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: SelectModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testSelectField.js
@@ -10,16 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: SelectModelTestConfig,
-			fields: [
-				{name: 'name'},
-				{
-					name: 'fieldA',
-					options: {'editForm': false}
-				}
-			],
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: SelectModelTestConfig, },
+			{ name: 'fieldA', options: {'placeholder': true}, modelTestConfig: SelectModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -30,67 +24,43 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'name': {value: 'Select Field Test 1'},
-				'fieldA': {value: 'One'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'name': {value: 'Select Field Test 1'},
-				'fieldA': {value: 'One'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Select field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: SelectModelTestConfig,
-			fields: [
-				{
-					name: 'fieldA',
-					options: {'editForm': true}
-				},
-				{
-					name: 'fieldB',
-					options: {'editForm': true}
-				}
-			],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: {'placeholder': false}, modelTestConfig: SelectModelTestConfig, },
+			{ name: 'fieldB', options: {'placeholder': true}, modelTestConfig: SelectModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'name': {value: 'Select Field Test 1'},
-				'fieldA': {value: 'One'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+		])
 	},
 	'Select field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'fieldB': {value: 'Two'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'Two' }, modelTestConfig: SelectModelTestConfig },
+		]);
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: SelectModelTestConfig,
-			fields: {
-				'name': {value: 'Select Field Test 1'},
-				'fieldA': {value: 'One'},
-				'fieldB': {value: 'Two'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Two' }, modelTestConfig: SelectModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testSelectField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testSelectField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var SelectModelTestConfig = require('../../../modelTestConfig/SelectModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/SelectModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Select field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Select'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: SelectModelTestConfig, },
-			{ name: 'fieldA', options: {'placeholder': true}, modelTestConfig: SelectModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA', options: {'placeholder': true},}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
-			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'name', input: { value: 'Select Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'One' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
-			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'name', input: { value: 'Select Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'One' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,18 +43,18 @@ module.exports = {
 	},
 	'Select field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: {'placeholder': false}, modelTestConfig: SelectModelTestConfig, },
-			{ name: 'fieldB', options: {'placeholder': true}, modelTestConfig: SelectModelTestConfig, }
+			{ name: 'fieldA', options: {'placeholder': false},},
+			{ name: 'fieldB', options: {'placeholder': true},}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
-			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'name', input: { value: 'Select Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'One' }, },
 		])
 	},
 	'Select field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'Two' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Two' }, },
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -58,9 +63,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Select Field Test 1' }, modelTestConfig: SelectModelTestConfig },
-			{ name: 'fieldA', input: { value: 'One' }, modelTestConfig: SelectModelTestConfig },
-			{ name: 'fieldB', input: { value: 'Two' }, modelTestConfig: SelectModelTestConfig },
+			{ name: 'name', input: { value: 'Select Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'One' }, },
+			{ name: 'fieldB', input: { value: 'Two' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'TextArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'TextArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -13,15 +14,16 @@ module.exports = {
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: [{name: 'name'}]
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'TextArray field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'TextArray'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {
@@ -34,26 +36,30 @@ module.exports = {
 				'name': {value: 'TextArray Field Test 1'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'name': {value: 'TextArray Field Test 1'},
-			}
-		})
 	},
 	'TextArray field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
 		});
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			modelTestConfig: TextArrayModelTestConfig,
+			fields: {
+				'name': {value: 'TextArray Field Test 1'},
+			}
+		})
+
 		browser.adminUIItemScreen.clickFieldUI({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {
 				'fieldA': {'click': 'addButton'},
 			}
 		});
+
 		browser.adminUIItemScreen.assertFieldUIVisible({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: [{
@@ -61,12 +67,14 @@ module.exports = {
 				options: {'textInputs': ['text1']}
 			}],
 		});
+
 		browser.adminUIItemScreen.clickFieldUI({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {
 				'fieldA': {'click': 'addButton'},
 			}
 		});
+
 		browser.adminUIItemScreen.assertFieldUIVisible({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: [{
@@ -74,18 +82,21 @@ module.exports = {
 				options: {'textInputs': ['text1', 'text2']}
 			}],
 		});
+
 		browser.adminUIItemScreen.clickFieldUI({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {
 				'fieldB': {'click': 'addButton'},
 			}
 		});
+
 		browser.adminUIItemScreen.clickFieldUI({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {
 				'fieldB': {'click': 'addButton'},
 			}
 		});
+
 		browser.adminUIItemScreen.assertFieldUIVisible({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: [{
@@ -109,7 +120,9 @@ module.exports = {
 		});
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: TextArrayModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var TextArrayModelTestConfig = require('../../../modelTestConfig/TextArrayModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/TextArrayModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'TextArray field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'TextArray'});
@@ -11,7 +16,7 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'name',},
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -24,10 +29,10 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -35,46 +40,46 @@ module.exports = {
 	},
 	'TextArray field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', modelTestConfig: TextArrayModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'fieldA',},
+			{ name: 'fieldB',},
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, },
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldA', 'click': 'addButton', },
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: {'textInputs': ['text1']}, modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'fieldA', options: {'textInputs': ['text1']},},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldA', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldA', 'click': 'addButton', },
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', options: {'textInputs': ['text1', 'text2']}, modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'fieldA', options: {'textInputs': ['text1', 'text2']},},
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldB', 'click': 'addButton', },
 		]);
 
 		browser.adminUIItemScreen.clickFieldUI([
-			{ name: 'fieldB', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldB', 'click': 'addButton', },
 		]);
 
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldB', options: {'textInputs': ['text1', 'text2']}, modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'fieldB', options: {'textInputs': ['text1', 'text2']},},
 		]);
 	},
 	'TextArray field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, modelTestConfig: TextArrayModelTestConfig },
-			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, },
+			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, },
 		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
@@ -82,8 +87,8 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, modelTestConfig: TextArrayModelTestConfig },
-			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, },
+			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextArrayField.js
@@ -10,10 +10,9 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: [{name: 'name'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: TextArrayModelTestConfig, },
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,112 +23,67 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'name': {value: 'TextArray Field Test 1'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'name': {value: 'TextArray Field Test 1'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'TextArray field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: TextArrayModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: TextArrayModelTestConfig, },
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'name': {value: 'TextArray Field Test 1'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'TextArray Field Test 1' }, modelTestConfig: TextArrayModelTestConfig },
+		]);
 
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+		]);
 
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'textInputs': ['text1']}
-			}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: {'textInputs': ['text1']}, modelTestConfig: TextArrayModelTestConfig, },
+		]);
 
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldA': {'click': 'addButton'},
-			}
-		});
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldA', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+		]);
 
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: [{
-				name: 'fieldA',
-				options: {'textInputs': ['text1', 'text2']}
-			}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', options: {'textInputs': ['text1', 'text2']}, modelTestConfig: TextArrayModelTestConfig, },
+		]);
 
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+		]);
 
-		browser.adminUIItemScreen.clickFieldUI({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldB': {'click': 'addButton'},
-			}
-		});
+		browser.adminUIItemScreen.clickFieldUI([
+			{ name: 'fieldB', 'click': 'addButton', modelTestConfig: TextArrayModelTestConfig },
+		]);
 
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: [{
-				name: 'fieldB',
-				options:{'textInputs': ['text1', 'text2']}
-			}],
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldB', options: {'textInputs': ['text1', 'text2']}, modelTestConfig: TextArrayModelTestConfig, },
+		]);
 	},
 	'TextArray field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldA': {text1: 'Test text 1', text2: 'Test text 2'}
-			}
-		});
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'fieldB': {text1: 'Test text 3', text2: 'Test text 4'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, modelTestConfig: TextArrayModelTestConfig },
+		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextArrayModelTestConfig,
-			fields: {
-				'name': {value: 'TextArray Field Test 1'},
-				'fieldA': {text1: 'Test text 1', text2: 'Test text 2'},
-				'fieldB': {text1: 'Test text 3', text2: 'Test text 4'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'fieldA', input: { text1: 'Test text 1', text2: 'Test text 2' }, modelTestConfig: TextArrayModelTestConfig },
+			{ name: 'fieldB', input: { text1: 'Test text 3', text2: 'Test text 4' }, modelTestConfig: TextArrayModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextField.js
@@ -10,10 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: TextModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: TextModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: TextModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,57 +24,42 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: TextModelTestConfig,
-			fields: {
-				'name': {value: 'Text Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: TextModelTestConfig,
-			fields: {
-				'name': {value: 'Text Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Text field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: TextModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: TextModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextModelTestConfig,
-			fields: {
-				'name': {value: 'Text Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+		])
 	},
 	'Text field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: TextModelTestConfig,
-			fields: {
-				'fieldB': {value: 'Some test text for field B'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextModelTestConfig },
+		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextModelTestConfig,
-			fields: {
-				'name': {value: 'Text Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-				'fieldB': {value: 'Some test text for field B'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var TextModelTestConfig = require('../../../modelTestConfig/TextModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/TextModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Text field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Text'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: TextModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: TextModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA',}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'name', input: { value: 'Text Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'name', input: { value: 'Text Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,18 +43,18 @@ module.exports = {
 	},
 	'Text field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', modelTestConfig: TextModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: TextModelTestConfig, }
+			{ name: 'fieldA',},
+			{ name: 'fieldB',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'name', input: { value: 'Text Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		])
 	},
 	'Text field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, },
 		]);
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
@@ -57,9 +62,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Text Field Test 1' }, modelTestConfig: TextModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextModelTestConfig },
-			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextModelTestConfig },
+			{ name: 'name', input: { value: 'Text Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Text field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Text'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -13,15 +14,16 @@ module.exports = {
 			modelTestConfig: TextModelTestConfig,
 			fields: [{name: 'name'}, {name: 'fieldA'}]
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Text field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Text'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: TextModelTestConfig,
 			fields: {
@@ -36,8 +38,15 @@ module.exports = {
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+	},
+	'Text field should show correctly in the edit form': function(browser) {
+		browser.adminUIItemScreen.assertFieldUIVisible({
+			modelTestConfig: TextModelTestConfig,
+			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
+		});
 
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: TextModelTestConfig,
@@ -46,12 +55,6 @@ module.exports = {
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		})
-	},
-	'Text field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
 	},
 	'Text field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
@@ -62,7 +65,9 @@ module.exports = {
 		});
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: TextModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
@@ -10,10 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: TextareaModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: TextareaModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,58 +24,43 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: {
-				'name': {value: 'Textarea Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: {
-				'name': {value: 'Textarea Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Textarea field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: TextareaModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: TextareaModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: {
-				'name': {value: 'Textarea Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+		])
 	},
 	'Textarea field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: {
-				'fieldB': {value: 'Some test text for field B'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextareaModelTestConfig },
+		]);
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: {
-				'name': {value: 'Textarea Field Test 1'},
-				'fieldA': {value: 'Some test text for field A'},
-				'fieldB': {value: 'Some test text for field B'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextareaModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Textarea field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Textarea'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -13,15 +14,16 @@ module.exports = {
 			modelTestConfig: TextareaModelTestConfig,
 			fields: [{name: 'name'}, {name: 'fieldA'}]
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Textarea field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Textarea'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: TextareaModelTestConfig,
 			fields: {
@@ -36,8 +38,15 @@ module.exports = {
 				'fieldA': {value: 'Some test text for field A'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+	},
+	'Textarea field should show correctly in the edit form': function(browser) {
+		browser.adminUIItemScreen.assertFieldUIVisible({
+			modelTestConfig: TextareaModelTestConfig,
+			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
+		});
 
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: TextareaModelTestConfig,
@@ -47,12 +56,6 @@ module.exports = {
 			}
 		})
 	},
-	'Textarea field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: TextareaModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
-	},
 	'Textarea field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
 			modelTestConfig: TextareaModelTestConfig,
@@ -60,9 +63,12 @@ module.exports = {
 				'fieldB': {value: 'Some test text for field B'}
 			}
 		});
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: TextareaModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testTextareaField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var TextareaModelTestConfig = require('../../../modelTestConfig/TextareaModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/TextareaModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Textarea field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Textarea'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: TextareaModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: TextareaModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA',}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,18 +43,18 @@ module.exports = {
 	},
 	'Textarea field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', modelTestConfig: TextareaModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: TextareaModelTestConfig, }
+			{ name: 'fieldA',},
+			{ name: 'fieldB',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
 		])
 	},
 	'Textarea field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, },
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -58,9 +63,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Textarea Field Test 1' }, modelTestConfig: TextareaModelTestConfig },
-			{ name: 'fieldA', input: { value: 'Some test text for field A' }, modelTestConfig: TextareaModelTestConfig },
-			{ name: 'fieldB', input: { value: 'Some test text for field B' }, modelTestConfig: TextareaModelTestConfig },
+			{ name: 'name', input: { value: 'Textarea Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'Some test text for field A' }, },
+			{ name: 'fieldB', input: { value: 'Some test text for field B' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testUrlField.js
@@ -10,10 +10,10 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.assertFieldUIVisible({
-			modelTestConfig: UrlModelTestConfig,
-			fields: [{name: 'name'}, {name: 'fieldA'}]
-		});
+		browser.adminUIInitialFormScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: UrlModelTestConfig, },
+			{ name: 'fieldA', modelTestConfig: UrlModelTestConfig, }
+		]);
 
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
@@ -24,58 +24,43 @@ module.exports = {
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
-		browser.adminUIInitialFormScreen.fillFieldInputs({
-			modelTestConfig: UrlModelTestConfig,
-			fields: {
-				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'http://www.example1.com'},
-			}
-		});
-		browser.adminUIInitialFormScreen.assertFieldInputs({
-			modelTestConfig: UrlModelTestConfig,
-			fields: {
-				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'http://www.example1.com'},
-			}
-		});
+		browser.adminUIInitialFormScreen.fillFieldInputs([
+			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+		]);
+		browser.adminUIInitialFormScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+		]);
 
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 	},
 	'Url field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: UrlModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'fieldA', modelTestConfig: UrlModelTestConfig, },
+			{ name: 'fieldB', modelTestConfig: UrlModelTestConfig, }
+		]);
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: UrlModelTestConfig,
-			fields: {
-				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'http://www.example1.com'},
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+		])
 	},
 	'Url field can be filled via the edit form': function(browser) {
-		browser.adminUIItemScreen.fillFieldInputs({
-			modelTestConfig: UrlModelTestConfig,
-			fields: {
-				'fieldB': {value: 'http://www.example2.com'}
-			}
-		});
+		browser.adminUIItemScreen.fillFieldInputs([
+			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, modelTestConfig: UrlModelTestConfig },
+		]);
 
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
 
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
-		browser.adminUIItemScreen.assertFieldInputs({
-			modelTestConfig: UrlModelTestConfig,
-			fields: {
-				'name': {value: 'Url Field Test 1'},
-				'fieldA': {value: 'http://www.example1.com'},
-				'fieldB': {value: 'http://www.example2.com'}
-			}
-		})
+		browser.adminUIItemScreen.assertFieldInputs([
+			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, modelTestConfig: UrlModelTestConfig },
+		])
 	},
 };

--- a/test/e2e/adminUI/tests/group005Fields/testUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testUrlField.js
@@ -6,6 +6,7 @@ module.exports = {
 	after: fieldTests.after,
 	'Url field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Url'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
 
@@ -13,15 +14,16 @@ module.exports = {
 			modelTestConfig: UrlModelTestConfig,
 			fields: [{name: 'name'}, {name: 'fieldA'}]
 		});
-	},
-	'restoring test state': function(browser) {
+
 		browser.adminUIInitialFormScreen.cancel();
 		browser.adminUIApp.waitForListScreen();
 	},
 	'Url field can be filled via the initial modal': function(browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Url'});
+
 		browser.adminUIListScreen.clickCreateItemButton();
 		browser.adminUIApp.waitForInitialFormScreen();
+
 		browser.adminUIInitialFormScreen.fillFieldInputs({
 			modelTestConfig: UrlModelTestConfig,
 			fields: {
@@ -36,8 +38,15 @@ module.exports = {
 				'fieldA': {value: 'http://www.example1.com'},
 			}
 		});
+
 		browser.adminUIInitialFormScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+	},
+	'Url field should show correctly in the edit form': function(browser) {
+		browser.adminUIItemScreen.assertFieldUIVisible({
+			modelTestConfig: UrlModelTestConfig,
+			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
+		});
 
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: UrlModelTestConfig,
@@ -47,12 +56,6 @@ module.exports = {
 			}
 		})
 	},
-	'Url field should show correctly in the edit form': function(browser) {
-		browser.adminUIItemScreen.assertFieldUIVisible({
-			modelTestConfig: UrlModelTestConfig,
-			fields: [{name: 'fieldA'}, {name: 'fieldB'}]
-		});
-	},
 	'Url field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs({
 			modelTestConfig: UrlModelTestConfig,
@@ -60,9 +63,12 @@ module.exports = {
 				'fieldB': {value: 'http://www.example2.com'}
 			}
 		});
+
 		browser.adminUIItemScreen.save();
 		browser.adminUIApp.waitForItemScreen();
+
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
+
 		browser.adminUIItemScreen.assertFieldInputs({
 			modelTestConfig: UrlModelTestConfig,
 			fields: {

--- a/test/e2e/adminUI/tests/group005Fields/testUrlField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testUrlField.js
@@ -1,8 +1,13 @@
 var fieldTests = require('./commonFieldTestUtils.js');
-var UrlModelTestConfig = require('../../../modelTestConfig/UrlModelTestConfig');
+var ModelTestConfig = require('../../../modelTestConfig/UrlModelTestConfig');
 
 module.exports = {
-	before: fieldTests.before,
+	before: function (browser) {
+		fieldTests.before(browser);
+		browser.adminUIInitialFormScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIItemScreen.setDefaultModelTestConfig(ModelTestConfig);
+		browser.adminUIListScreen.setDefaultModelTestConfig(ModelTestConfig);
+	},
 	after: fieldTests.after,
 	'Url field should show correctly in the initial modal': function (browser) {
 		browser.adminUIApp.openList({section: 'fields', list: 'Url'});
@@ -11,8 +16,8 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.assertFieldUIVisible([
-			{ name: 'name', modelTestConfig: UrlModelTestConfig, },
-			{ name: 'fieldA', modelTestConfig: UrlModelTestConfig, }
+			{ name: 'name',},
+			{ name: 'fieldA',}
 		]);
 
 		browser.adminUIInitialFormScreen.cancel();
@@ -25,12 +30,12 @@ module.exports = {
 		browser.adminUIApp.waitForInitialFormScreen();
 
 		browser.adminUIInitialFormScreen.fillFieldInputs([
-			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
-			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'name', input: { value: 'Url Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, },
 		]);
 		browser.adminUIInitialFormScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
-			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'name', input: { value: 'Url Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, },
 		]);
 
 		browser.adminUIInitialFormScreen.save();
@@ -38,18 +43,18 @@ module.exports = {
 	},
 	'Url field should show correctly in the edit form': function(browser) {
 		browser.adminUIItemScreen.assertFieldUIVisible([
-			{ name: 'fieldA', modelTestConfig: UrlModelTestConfig, },
-			{ name: 'fieldB', modelTestConfig: UrlModelTestConfig, }
+			{ name: 'fieldA',},
+			{ name: 'fieldB',}
 		]);
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
-			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'name', input: { value: 'Url Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, },
 		])
 	},
 	'Url field can be filled via the edit form': function(browser) {
 		browser.adminUIItemScreen.fillFieldInputs([
-			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, },
 		]);
 
 		browser.adminUIItemScreen.save();
@@ -58,9 +63,9 @@ module.exports = {
 		browser.adminUIItemScreen.assertFlashMessage('Your changes have been saved successfully');
 
 		browser.adminUIItemScreen.assertFieldInputs([
-			{ name: 'name', input: { value: 'Url Field Test 1' }, modelTestConfig: UrlModelTestConfig },
-			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, modelTestConfig: UrlModelTestConfig },
-			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, modelTestConfig: UrlModelTestConfig },
+			{ name: 'name', input: { value: 'Url Field Test 1' }, },
+			{ name: 'fieldA', input: { value: 'http://www.example1.com' }, },
+			{ name: 'fieldB', input: { value: 'http://www.example2.com' }, },
 		])
 	},
 };

--- a/test/e2e/adminUI/tests/group999FixMe/2382.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2382.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -10,7 +10,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/2898.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2898.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/2940.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2940.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/2941.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2941.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/2945.js
+++ b/test/e2e/adminUI/tests/group999FixMe/2945.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/3028.js
+++ b/test/e2e/adminUI/tests/group999FixMe/3028.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/3126.js
+++ b/test/e2e/adminUI/tests/group999FixMe/3126.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -10,7 +10,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
+++ b/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
@@ -1,7 +1,7 @@
 module.exports = {
 	before: function (browser) {
 		browser.adminUIApp = browser.page.adminUIApp();
-		browser.adminUISignin = browser.page.adminUISignin();
+		browser.adminUISigninScreen = browser.page.adminUISignin();
 		browser.adminUIListScreen = browser.page.adminUIListScreen();
 		browser.adminUIItemScreen = browser.page.adminUIItemScreen();
 		browser.adminUIInitialFormScreen = browser.page.adminUIInitialForm();
@@ -9,7 +9,7 @@ module.exports = {
 		browser.adminUIApp.gotoHomeScreen();
 		browser.adminUIApp.waitForSigninScreen();
 
-		browser.adminUISignin.signin();
+		browser.adminUISigninScreen.signin();
 		browser.adminUIApp.waitForHomeScreen();
 	},
 	after: function (browser) {

--- a/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
+++ b/test/e2e/adminUI/tests/group999FixMe/testDependsOnField_issue3068.js
@@ -47,7 +47,7 @@ module.exports = {
 			}
 		});
 
-		browser.adminUIInitialFormScreen.assertFieldUINotPresent({
+		browser.adminUIInitialFormScreen.assertFieldDOMNotPresent({
 			listName: 'DependsOn',
 			fields: ['dependent'],
 			args: {
@@ -90,7 +90,7 @@ module.exports = {
 		});
 
 		// The dependency condition is no longer met, field should not be visible.
-		browser.adminUIItemScreen.assertFieldUINotPresent({
+		browser.adminUIItemScreen.assertFieldDOMNotPresent({
 			listName: 'DependsOn',
 			fields: ['dependent'],
 			args: {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

These changes are all @webteckie really, I just finished off the refactoring so am making the PR. 

Following updates in the `keystone-nightwatch-e2e` package we've refactored keystone's tests to use the new API. @webteckie may be able to provide more details...

Travis _should_ pass.

## Related issues (if any)


## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

