### PR TITLE
test(e2e): Add chromedriver package to allow running tests in chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "devDependencies": {
     "browserify-middleware": "7.1.0",
+    "chromedriver": "^2.24.1",
     "codeclimate-test-reporter": "0.3.3",
     "core-assert": "0.2.0",
     "disc": "1.3.2",

--- a/test/e2e/adminUI/nightwatch-no-process.json
+++ b/test/e2e/adminUI/nightwatch-no-process.json
@@ -88,46 +88,9 @@
         "browserName": "chrome",
         "javascriptEnabled": true,
         "acceptSslCerts": true
-      }
-    },
-    "chrome-win32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
       },
       "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/win32/chromedriver.exe"
-      }
-    },
-    "chrome-mac32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/mac32/chromedriver"
-      }
-    },
-    "chrome-linux64": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/linux64/chromedriver"
-      }
-    },
-    "chrome-linux32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/linux32/chromedriver"
+        "webdriver.chrome.driver": "${CHROMEDRIVER_PATH}"
       }
     }
   }

--- a/test/e2e/adminUI/nightwatch.json
+++ b/test/e2e/adminUI/nightwatch.json
@@ -88,46 +88,9 @@
         "browserName": "chrome",
         "javascriptEnabled": true,
         "acceptSslCerts": true
-      }
-    },
-    "chrome-win32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
       },
       "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/win32/chromedriver.exe"
-      }
-    },
-    "chrome-mac32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/mac32/chromedriver"
-      }
-    },
-    "chrome-linux64": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/linux64/chromedriver"
-      }
-    },
-    "chrome-linux32": {
-      "desiredCapabilities": {
-        "browserName": "chrome",
-        "javascriptEnabled": true,
-        "acceptSslCerts": true
-      },
-      "cli_args": {
-        "webdriver.chrome.driver": "test/e2e/drivers/chrome/linux32/chromedriver"
+        "webdriver.chrome.driver": "${CHROMEDRIVER_PATH}"
       }
     }
   }

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -8,10 +8,12 @@ var moment = require('moment');
 var mongoose = require('mongoose');
 var path = require('path');
 var keystoneNightwatchE2e = require('keystone-nightwatch-e2e');
+var chromedriver = require('chromedriver');
 
 // Set app-specific env for nightwatch session
 process.env['SELENIUM_SERVER'] = keystoneNightwatchE2e.seleniumPath;
 process.env['PAGE_OBJECTS_PATH'] = keystoneNightwatchE2e.pageObjectsPath;
+process.env['CHROMEDRIVER_PATH'] = chromedriver.path;
 
 // determine the mongo uri and database name
 var dbName = '/e2e' + (process.env.KEYSTONEJS_PORT || 3000);


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->
## Description of changes

cc @webteckie Can you test this locally when you get a chance. Works fine for me....
## Related issues (if any)
## Testing
- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

…without having to manually download drivers.
