### PR TITLE
Fix relationship links

### DIFF
--- a/admin/client/App/screens/Item/index.js
+++ b/admin/client/App/screens/Item/index.js
@@ -39,7 +39,8 @@ var ItemView = React.createClass({
 	componentDidMount () {
 		// When we directly navigate to an item without coming from another client
 		// side routed page before, we need to select the list before initializing the item
-		if (!this.props.currentList) {
+		// We also need to update when the list id has changed
+		if (!this.props.currentList || this.props.currentList.id !== this.props.params.listId) {
 			this.props.dispatch(selectList(this.props.params.listId));
 		}
 		this.initializeItem(this.props.params.itemId);

--- a/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
+++ b/test/e2e/adminUI/tests/group005Fields/testRelationshipField.js
@@ -1,5 +1,6 @@
 var fieldTests = require('./commonFieldTestUtils.js');
 var ModelTestConfig = require('../../../modelTestConfig/RelationshipModelTestConfig');
+var UserModelTestConfig = require('../../../modelTestConfig/UserModelTestConfig');
 
 module.exports = {
 	before: function (browser) {
@@ -67,4 +68,15 @@ module.exports = {
 			{ name: 'fieldB', input: { value: 'e2e user' }, },
 		])
 	},
+	'Clicking on the relationship navigates to the relavent item': function (browser) {
+		browser.adminUIApp.openList({section: 'fields', list: 'Relationship'});
+		browser.adminUIApp.waitForListScreen();
+		browser.adminUIListScreen.clickItemFieldValue([
+			{ name: 'fieldA', row: 1, column: 3 }
+		]);
+		browser.adminUIApp.waitForItemScreen();
+		browser.adminUIItemScreen.assertFieldUIVisible([
+			{ name: 'name', modelTestConfig: UserModelTestConfig }
+		]);
+	}
 };


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Fixes #3528. The ItemView's `componentDidMount` function didn't take into account the fact that the `currentList` will have changed when navigating from a relationship link, since the list changes from e.g. 'post' to 'user'. I've updated the `componentDidMount` function to fix this. 

I've also added additional assertions to the relationship field test, which should ensure this doesn't re-occur. (cc @webteckie if you want to have a quick look, but test passes so pretty confident this is fine). 

## Related issues (if any)
#3528 

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

