### PR TITLE
Fix deleting items over multiple pages. Fixes #3541

### DIFF
--- a/admin/client/App/screens/Item/actions.js
+++ b/admin/client/App/screens/Item/actions.js
@@ -3,8 +3,11 @@ import {
 	LOAD_DATA,
 	DATA_LOADING_SUCCESS,
 	DATA_LOADING_ERROR,
-	DELETE_ITEM,
 } from './constants';
+
+import {
+	loadItems,
+} from '../List/actions';
 
 /**
  * Select an item
@@ -108,10 +111,7 @@ export function deleteItem (id, router) {
 			if (err) {
 				alert('Error deleting item, please try again!');
 			} else {
-				dispatch({
-					type: DELETE_ITEM,
-					id,
-				});
+				dispatch(loadItems());
 			}
 		});
 	};


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Fix issue #3541. Makes pagination work properly when items are deleted. 

Unfortunately, the local state/props don't know anything about the items from the other pages, so we have to do a full `loadItems()` from the server to fix this. 

## Related issues (if any)

#3541 

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


