### PR TITLE
Fix re-ordering over multiple pages. Fixes #3494

### DIFF
--- a/admin/client/App/screens/List/actions/dragdrop.js
+++ b/admin/client/App/screens/List/actions/dragdrop.js
@@ -71,7 +71,6 @@ export function moveItem (prevIndex, newIndex, options) {
 export function reorderItems (item, prevSortOrder, newSortOrder, goToPage) {
 	// // reset drag
 	// defaultDrag();
-
 	return (dispatch, getState) => {
 		if (goToPage) {
 			// TODO FIGURE OUT IF THIS IS A RACE CONDITION
@@ -97,7 +96,7 @@ export function reorderItems (item, prevSortOrder, newSortOrder, goToPage) {
 				if (err) {
 					dispatch(resetItems(item.id));
 					// return this.resetItems(this.findItemById[item.id]);
-				} else if (typeof items !== 'object' && items && items.results) {
+				} else {
 					dispatch(itemsLoaded(items));
 					dispatch(setRowAlert({
 						success: item.id,

--- a/admin/client/App/screens/List/components/ItemsTable/ItemsTableDragDropZoneTarget.js
+++ b/admin/client/App/screens/List/components/ItemsTable/ItemsTableDragDropZoneTarget.js
@@ -57,46 +57,39 @@ const dropTarget = {
 		const item = monitor.getItem();
 		item.goToPage = props.page;
 		item.prevSortOrder = item.sortOrder;
-		// if the new page is greater, we will place the item at the beginning of the page
-		// if the new page is less, we will place the item at the end of the page
+		// Work out the new sort order. If the new page is greater, we'll put it at the start of the page, and
+		// if it's smaller we'll put it at the end of the page.
 		item.newSortOrder = (targetPage < page) ? (targetPage * pageSize) : (targetPage * pageSize - (pageSize - 1));
-
 		return item;
 	},
+	/*
+	* TODO Work out if it's possible to implement this in a way that works.
 	hover (props, monitor, component) {
 		if (timeoutID) {
 			return;
 		}
-		const { page, currentPage, drag } = props;
-		const original = drag;
+		const { page, currentPage } = props;
 
 		// self
 		if (page === currentPage) {
 			return;
 		}
+
 		if (monitor.isOver()) {
 			timeoutID = setTimeout(() => {
-				const newIndex = (original.page === page) ? original.index : (currentPage < page) ? 0 : props.pageSize;
-				props.dispatch(setCurrentPage(page));
-				monitor.getItem().index = newIndex;
+				// If user hovers over the target for a while change the page.
+				// TODO Get this working. Currently, it looks like it's going to work, but when you
+				// drop onto a new page, no drop events are fired, and react-dnd doesn't have a way to
+				// manually force them to happen. Not sure what to do here.
+				props.dispatch(setCurrentPage(props.page));
+
 
 				clearTimeout(timeoutID);
 				timeoutID = false;
 			}, 750);
 		}
 	},
-	canDrop (props, monitor) {
-		// if we drop on a page target, move the item to the correct first or last position in the new page
-		// if we want to stop this behaviour set return false
-		if (!Keystone.devMode) return;
-
-		const original = props.drag;
-		// self
-		if (original.page === props.page) {
-			return false;
-		}
-		return true;
-	},
+	*/
 };
 /**
  * Specifies the props to inject into your component.


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Kudos to @mxstbr for helping out with this one. 

Reordering of pages just didn't work. There were multiple issues: 

 - Often an index was used as a sort order. This was wrong because index starts from 0 whereas sort order should start from 1. 

 - The logic when changing pages just did not work at all. It would cause lots of console errors. I think this is because of the new SPA stuff, and I don't think it's possible to get it working quite as it used to. 
Previously, you were able to drag and hover an item over a different page link, and it would drop that item into the new page for you. You now have to release the mouse (and actually drop the item onto the link) for anything to happen. 
In current master, if you try to do either, everything will completely break. 

- The index where the item dropped onto was also broken when changing pages. Again because of the +1 thing, I think. The way it works now (which I think is how was intended before) is that if you're changing from e.g. page 1 to page 2, it'll drop the item at the top of page 2. If you're going from page 2 to page 1, it'll drop it at the bottom of page 1.

- Trying to do more than one move per page refresh was broken. The local sortOrders were not updating at all, so say you move item 1 to position 2, and then change your mind and move it to position 3. The API requests should look like `change position 1 to 2` and then `change position 2 to 3`, whereas they actually looked like `change position 1 to 2` and then `change position 1 to 3`, because the sort orders hadn't updated locally. However, they had updated at the endpoint of the api call, so strange and unexpected things would happen. This was mainly due to the weird `if` clause in `dragdrop.js`. 

- Previously, as described in #3494, if you change the order on page 2, that item will actually change to a new position on page 1. This was because it was using indexes and pages and silly things. I now calculate the sortOrder properly, using the index, the current page, and the number of items on the page. This now works as it should. 


## Related issues (if any)
#3494

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


