### PR TITLE
Re-implement management mode "Select All", fixes #3374

### DIFF
--- a/admin/client/App/screens/List/components/ListManagement.js
+++ b/admin/client/App/screens/List/components/ListManagement.js
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Button, GlyphButton, InlineGroup as Group, InlineGroupSection as Section } from '../../../elemental';
+import { Button, GlyphButton, InlineGroup as Group, InlineGroupSection as Section, Spinner } from '../../../elemental';
 
 function ListManagement ({
 	checkedItemCount,
@@ -11,11 +11,12 @@ function ListManagement ({
 	itemsPerPage,
 	nodelete,
 	noedit,
+	selectAllItemsLoading,
 	...props,
 }) {
 	// do not render if there's no results
 	// or if edit/delete unavailable on the list
-	if (!itemCount || (nodelete /* && noedit */)) return null;
+	if (!itemCount || (nodelete && noedit)) return null;
 
 	const buttonNoteStyles = { color: '#999', fontWeight: 'normal' };
 
@@ -35,26 +36,27 @@ function ListManagement ({
 	);
 
 	// select buttons
-	// TODO: implement selecting all items across multiple pages
-	const selectAllButton = null; /* itemCount > itemsPerPage && (
+	const allVisibleButtonIsActive = checkedItemCount === itemCount;
+	const pageVisibleButtonIsActive = checkedItemCount === itemsPerPage;
+	const noneButtonIsActive = !checkedItemCount;
+	const selectAllButton = itemCount > itemsPerPage && (
 		<Section>
 			<Button
+				active={allVisibleButtonIsActive}
 				onClick={() => handleSelect('all')}
 				title="Select all rows (including those not visible)">
-				All <small style={buttonNoteStyles}>({itemCount})</small>
+				{selectAllItemsLoading ? <Spinner/> : 'All'} <small style={buttonNoteStyles}>({itemCount})</small>
 			</Button>
 		</Section>
-	); */
+	);
 
-	const allVisibleButtonIsActive = checkedItemCount === Math.min(itemCount, itemsPerPage);
-	const noneButtonIsActive = !checkedItemCount;
 	const selectButtons = isOpen ? (
 		<Section>
 			<Group contiguous>
 				{selectAllButton}
 				<Section>
-					<Button active={allVisibleButtonIsActive} onClick={() => handleSelect('visible')} title="Select all rows">
-						{itemCount > itemsPerPage ? 'All Visible ' : 'All '}
+					<Button active={pageVisibleButtonIsActive} onClick={() => handleSelect('visible')} title="Select all rows">
+						{itemCount > itemsPerPage ? 'Page ' : 'All '}
 						<small style={buttonNoteStyles}>({itemCount > itemsPerPage ? itemsPerPage : itemCount})</small>
 					</Button>
 				</Section>
@@ -101,6 +103,7 @@ ListManagement.propTypes = {
 	itemsPerPage: PropTypes.number,
 	nodelete: PropTypes.bool,
 	noedit: PropTypes.bool,
+	selectAllItemsLoading: PropTypes.bool,
 };
 
 module.exports = ListManagement;

--- a/admin/client/App/screens/List/index.js
+++ b/admin/client/App/screens/List/index.js
@@ -191,7 +191,7 @@ const ListView = React.createClass({
 		});
 	},
 	handleManagementSelect (selection) {
-		if (selection === 'all') this.checkAllTableItems();
+		if (selection === 'all') this.checkAllItems();
 		if (selection === 'none') this.uncheckAllTableItems();
 		if (selection === 'visible') this.checkAllTableItems();
 		return false;
@@ -209,7 +209,7 @@ const ListView = React.createClass({
 		);
 	},
 	renderManagement () {
-		const { checkedItems, manageMode } = this.state;
+		const { checkedItems, manageMode, selectAllItemsLoading } = this.state;
 		const { currentList } = this.props;
 
 		return (
@@ -223,6 +223,7 @@ const ListView = React.createClass({
 				itemsPerPage={this.props.lists.page.size}
 				nodelete={currentList.nodelete}
 				noedit={currentList.noedit}
+				selectAllItemsLoading={selectAllItemsLoading}
 			/>
 		);
 	},
@@ -326,6 +327,22 @@ const ListView = React.createClass({
 		});
 		this.setState({
 			checkedItems: checkedItems,
+		});
+	},
+	checkAllItems () {
+		const checkedItems = { ...this.state.checkedItems };
+		// Just in case this API call takes a long time, we'll update the select all button with
+		// a spinner.
+		this.setState({ selectAllItemsLoading: true });
+		var self = this;
+		this.props.currentList.loadItems({ expandRelationshipFilters: false, filters: {} }, function (err, data) {
+			data.results.forEach(item => {
+				checkedItems[item.id] = true;
+			});
+			self.setState({
+				checkedItems: checkedItems,
+				selectAllItemsLoading: false,
+			});
 		});
 	},
 	uncheckAllTableItems () {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

cc @mxstbr and @JedWatson, this fixes #3374. 

There's an inevitable API call in the code to list all the items. I toyed with making this call anyway and fully populating say `props.allItems`, but I figured in most cases that's a huge waste of resources (there are potentially lots of items). Instead, I make this call when the "Select All" button is clicked, and while the call is in progress I replace the text of the button with an ElementalUI Spinner. I think this is the best way to do this.

It all seems to work nicely IMO. 

## Related issues (if any)

#3374 

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


