### PR TITLE
Fix TinyMCE not showing bug in Html field when using new dependsOn format #3551

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -259,12 +259,6 @@ var EditForm = React.createClass({
 				if (typeof Fields[field.type] !== 'function') {
 					return React.createElement(InvalidFieldType, { type: field.type, path: field.path, key: field.path });
 				}
-				if (props.dependsOn) {
-					props.currentDependencies = {};
-					Object.keys(props.dependsOn).forEach(dep => {
-						props.currentDependencies[dep] = this.state.values[dep];
-					});
-				}
 				props.key = field.path;
 				if (index === 0 && this.state.focusFirstField) {
 					props.autoFocus = true;

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -4,11 +4,6 @@ import tinymce from 'tinymce';
 import { FormInput } from 'elemental';
 import evalDependsOn from '../../utils/evalDependsOn';
 
-/**
- * TODO:
- * - Remove dependency on underscore
- */
-
 var lastId = 0;
 
 function getId () {

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Field from '../Field';
 import React from 'react';
 import tinymce from 'tinymce';
@@ -36,7 +35,7 @@ module.exports = Field.create({
 		return {
 			id: getId(),
 			isFocused: false,
-      wysiwygActive: false,
+			wysiwygActive: false,
 		};
 	},
 
@@ -55,34 +54,34 @@ module.exports = Field.create({
 
 		this._currentValue = this.props.value;
 		tinymce.init(opts);
-    this.setState({ wysiwygActive: true });
+		this.setState({ wysiwygActive: true });
 	},
 
-  removeWysiwyg (state) {
-    removeTinyMCEInstance(tinymce.get(state.id));
-    this.setState({ wysiwygActive: false });
-  },
+	removeWysiwyg (state) {
+		removeTinyMCEInstance(tinymce.get(state.id));
+		this.setState({ wysiwygActive: false });
+	},
 
 	componentDidUpdate (prevProps, prevState) {
 		if (prevState.isCollapsed && !this.state.isCollapsed) {
 			this.initWysiwyg();
 		}
-    
-    if (this.props.wysiwyg) {
-      if (evalDependsOn(this.props.dependsOn, this.props.values) ) {
-        if (!this.state.wysiwygActive) {
-          this.initWysiwyg();
-        }
-      } else if (this.state.wysiwygActive) {
-        this.removeWysiwyg(prevState);
-      }
-    }
+
+		if (this.props.wysiwyg) {
+			if (evalDependsOn(this.props.dependsOn, this.props.values)) {
+				if (!this.state.wysiwygActive) {
+					this.initWysiwyg();
+				}
+			} else if (this.state.wysiwygActive) {
+				this.removeWysiwyg(prevState);
+			}
+		}
 	},
 
 	componentDidMount () {
-    if (evalDependsOn(this.props.dependsOn, this.props.values)) {
-      this.initWysiwyg();
-    }
+		if (evalDependsOn(this.props.dependsOn, this.props.values)) {
+			this.initWysiwyg();
+		}
 	},
 
 	componentWillReceiveProps (nextProps) {

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -4,6 +4,11 @@ import tinymce from 'tinymce';
 import { FormInput } from 'elemental';
 import evalDependsOn from '../../utils/evalDependsOn';
 
+/**
+ * TODO:
+ * - Remove dependency on underscore
+ */
+
 var lastId = 0;
 
 function getId () {
@@ -74,9 +79,7 @@ module.exports = Field.create({
 	},
 
 	componentDidMount () {
-		if (evalDependsOn(this.props.dependsOn, this.props.values)) {
-			this.initWysiwyg();
-		}
+		this.initWysiwyg();
 	},
 
 	componentWillReceiveProps (nextProps) {


### PR DESCRIPTION
Hey all,

This fixes the issue with TinyMCE not initing for fields using dependsOn with a format other than key>value. #3551 

Looks like the fix was fairly simple after all. 
Have switched the Html field to use evalDependsOn.
I've also removed the currentDependencies bit from EditForm as it doesn't appear to be used anywhere else.

Let me know what you think.

## Related issues (if any)

#3551 

