### PR TITLE
update handler handles having no req

### DIFF
--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -52,12 +52,12 @@ UpdateHandler.prototype.process = function (data, options, callback) {
 
 	// pass the user from the request by default
 	if (!options.user) {
-		options.user = this.req.user;
+		options.user = req && req.user;
 	}
 
 	// pass the uploaded files object from the request by default
 	if (!options.files) {
-		options.files = this.req.files;
+		options.files = req && req.files;
 	}
 
 	function flashErrors (err) {


### PR DESCRIPTION
Currently if `getUpdateHandler` is passed no arguments, it will cause
the process to fail in an error, as we later check req.user and
req.files.

This change means we will continue to return undefined unless there is
a req.user ora req.files, which was the previous behaviour.

Additionally, req is set as a variable earlier, so am checking the
function-local variable.
