### PR TITLE
clone Keystone.csrf.header before passing to xhr

### DIFF
--- a/admin/client/utils/List.js
+++ b/admin/client/utils/List.js
@@ -96,7 +96,7 @@ List.prototype.createItem = function (formData, callback) {
 		url: `${Keystone.adminPath}/api/${this.path}/create`,
 		responseType: 'json',
 		method: 'POST',
-		headers: Keystone.csrf.header,
+		headers: assign({}, Keystone.csrf.header),
 		body: formData,
 	}, (err, resp, data) => {
 		if (err) callback(err);
@@ -124,7 +124,7 @@ List.prototype.updateItem = function (id, formData, callback) {
 		url: `${Keystone.adminPath}/api/${this.path}/${id}`,
 		responseType: 'json',
 		method: 'POST',
-		headers: Keystone.csrf.header,
+		headers: assign({}, Keystone.csrf.header),
 		body: formData,
 	}, (err, resp, data) => {
 		if (err) return callback(err);
@@ -309,7 +309,7 @@ List.prototype.deleteItems = function (itemIds, callback) {
 	xhr({
 		url: url,
 		method: 'POST',
-		headers: Keystone.csrf.header,
+		headers: assign({}, Keystone.csrf.header),
 		json: {
 			ids: itemIds,
 		},
@@ -329,7 +329,7 @@ List.prototype.reorderItems = function (item, oldSortOrder, newSortOrder, pageOp
 	xhr({
 		url: url,
 		method: 'POST',
-		headers: Keystone.csrf.header,
+		headers: assign({}, Keystone.csrf.header),
 	}, (err, resp, body) => {
 		if (err) return callback(err);
 		try {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
clone `Keystone.csrf.header` before passing to `xhr` so that `xhr` can't cause side-effects by modifying this global object


## Related issues (if any)
#3545 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

Some e2e checks failed due to elements not becoming visible on / after login

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->