### PR TITLE
Don't cache relationship options, fixes #3598

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -191,7 +191,7 @@ module.exports = Field.create({
 			);
 		}
 
-		body.push(<Select multi={this.props.many} onChange={this.updateValue} name={this.props.path} asyncOptions={this.getOptions} value={this.state.expandedValues} />);
+		body.push(<Select multi={this.props.many} onChange={this.updateValue} name={this.props.path} asyncOptions={this.getOptions} value={this.state.expandedValues} cacheAsyncResults={false} />);
 
 		return body;
 	}


### PR DESCRIPTION
## Description of changes

disables caching on the select dropdown of relationship fields, fixing #3598
## Related issues (if any)

fixes #3598
## Testing
- [x] npm run test
- [x] npm run lint
