### PR TITLE
SSL: Make "force" actually work

### DIFF
--- a/server/initSslRedirect.js
+++ b/server/initSslRedirect.js
@@ -1,7 +1,9 @@
 module.exports = function (keystone, app) {
 	var portString;
 	function sslRedirect (req, res, next) {
-		if (!req.secure) {
+		if (req.secure) {
+			next();
+		} else {
 			// Don't redirect connections from localhost
 			if (req.ip === '127.0.0.1') {
 				return next();


### PR DESCRIPTION
## Description of changes

If you use `ssl: "force",`, your server will hang. Now, not any more.

@JedWatson 