### PR TITLE
[RFC] Adds optional customApp and customRouters arguments on start()

### DIFF
--- a/lib/core/initExpressApp.js
+++ b/lib/core/initExpressApp.js
@@ -1,12 +1,10 @@
-module.exports = function initExpressApp (customApp) {
+module.exports = function initExpressApp (app) {
 	if (this.app) return this;
+	if (!app) app = require('express')();
+	require('../../server/initLetsEncrypt')(this, app);
+	require('../../server/initSslRedirect')(this, app);
 	this.initDatabaseConfig();
 	this.initExpressSession(this.mongoose);
-	if (customApp) {
-		this.app = customApp;
-		require('../../server/createApp')(this);
-	} else {
-		this.app = require('../../server/createApp')(this);
-	}
+	this.app = app;
 	return this;
 };

--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -19,12 +19,16 @@ var async = require('async');
 
 var dashes = '\n------------------------------------------------\n';
 
-function start (events) {
+function start (events, customApp, customRouters) {
 
 	if (typeof events === 'function') {
 		events = { onStart: events };
 	}
 	if (!events) events = {};
+	// Default optional customApp and customRouters args to false.
+	// initExpressApp() and createApp() provide sensible fallbacks.
+	if (!customApp) customApp = false;
+	if (!customRouters) customRouters = false;
 
 	function fireEvent (name) {
 		if (typeof events[name] === 'function') {
@@ -44,8 +48,8 @@ function start (events) {
 		}
 	});
 
-	this.initExpressApp();
-
+	this.initExpressApp(customApp);
+	require('../../server/createApp')(this, customRouters);
 	var keystone = this;
 	var app = keystone.app;
 

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -5,21 +5,11 @@ var morgan = require('morgan');
 
 var language = require('../lib/middleware/language');
 
-module.exports = function createApp (keystone, express) {
+module.exports = function createApp (keystone, routers) {
 
-	if (!keystone.app) {
-		if (!express) {
-			express = require('express');
-		}
-		keystone.app = express();
-	}
+	if (!keystone.app) keystone.initExpressApp();
 
 	var app = keystone.app;
-	require('./initLetsEncrypt')(keystone, app);
-	require('./initSslRedirect')(keystone, app);
-
-	keystone.initDatabaseConfig();
-	keystone.initExpressSession(keystone.mongoose);
 
 	require('./initTrustProxy')(keystone, app);
 	require('./initViewEngine')(keystone, app);
@@ -120,24 +110,40 @@ module.exports = function createApp (keystone, express) {
 	});
 
 	// Configure application routes
-	var appRouter = keystone.get('routes');
-	if (typeof appRouter === 'function') {
-		if (appRouter.length === 3) {
+	if (!routers) routers = keystone.get('routes');
+	if (typeof routers === 'function') {
+		if (routers.length === 3) {
 			// new:
 			//    var myRouter = new express.Router();
 			//    myRouter.get('/', (req, res) => res.send('hello world'));
 			//    keystone.set('routes', myRouter);
-			app.use(appRouter);
+			app.use(routers);
 		} else {
 			// old:
 			//    var initRoutes = function (app) {
 			//      app.get('/', (req, res) => res.send('hello world'));
 			//    }
 			//    keystone.set('routes', initRoutes);
-			appRouter(app);
+			routers(app);
 		}
+	} else if (typeof routers === 'object') {
+		// new:
+		// 	The path property sets the mount path of the router.
+		// 			var MyRouters = [
+		// 				{
+		// 					path: '/',
+		// 					js: MyRouter,
+		// 				}, {
+		// 					path: '/example',
+		// 					js: ExampleRouter,
+		// 				},
+		// 			]
+		routers.forEach(function (router) {
+			if (typeof router.js === 'function' && router.js.length === 3 && router.path) {
+				app.use(router.path, router.js);
+			}
+		});
 	}
-
 
 	require('./bindRedirectsHandler')(keystone, app);
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->
## Description of changes

keystone.start() can now take a custom express app and one or multiple custom express routers as its second and third argument respectively. 

I tried to change as little code as possible. However, I propose to move more of the functionality of createApp() to initExpressApp() and eventually rename createApp() to initExpressRouters() or something more adequate.

Also note, for advanced setups it will be necessary that createApp() is a public API. If you want me to do that, and to move it over to lib/core, I can do that in this or in a dedicated PR.  

I will create a PR for keystone-test-project if this goes through. 
## Related issues

#2861
[keystone-test-project/#15](https://github.com/keystonejs/keystone-test-project/pull/15/files)
## Testing
- [x] `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->
