### PR TITLE
File link instead of name only

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -68,10 +68,13 @@ module.exports = Field.create({
 	hasExisting () {
 		return this.props.value && !!this.props.value.filename;
 	},
-	getFilename () {
+	getFilename (href) {
 		return this.state.userSelectedFile
 			? this.state.userSelectedFile.name
-			: this.props.value.filename;
+			: href
+				? <a href={this.props.value.url} target="_blank">{this.props.value.filename}</a>
+				: this.props.value.filename;
+			//: this.props.value.filename;
 	},
 
 	// ==============================


### PR DESCRIPTION
## Description of changes

A quick fix to have the filename as a link. This doesn't solve the missing format function but at least we can click the filename and download or watch the file in a new tab.

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.