### PR TITLE
Webpackify Enable HMR for Signin & Fix react-hot-loader >= v3.0.0-beta.6

### DIFF
--- a/admin/client/Signin/Signin.js
+++ b/admin/client/Signin/Signin.js
@@ -135,4 +135,4 @@ var SigninView = React.createClass({
 });
 
 
-module.exports = SigninView;
+export default SigninView;

--- a/admin/client/Signin/index.js
+++ b/admin/client/Signin/index.js
@@ -8,17 +8,31 @@
 import qs from 'qs';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Signin from './Signin';
+import OrigSignin from './Signin';
+
+let Signin = OrigSignin;
 
 const params = qs.parse(window.location.search.replace(/^\?/, ''));
 
-ReactDOM.render(
-	<Signin
-		brand={Keystone.brand}
-		from={params.from}
-		logo={Keystone.logo}
-		user={Keystone.user}
-		userCanAccessKeystone={Keystone.userCanAccessKeystone}
-	/>,
-	document.getElementById('signin-view')
-);
+const doRender = () => {
+	ReactDOM.render(
+		<Signin
+			brand={Keystone.brand}
+			from={params.from}
+			logo={Keystone.logo}
+			user={Keystone.user}
+			userCanAccessKeystone={Keystone.userCanAccessKeystone}
+		/>,
+		document.getElementById('signin-view')
+	);
+};
+
+// Support hot reloading
+if (module.hot) {
+	module.hot.accept('./Signin', () => {
+		Signin = require('./Signin').default;
+		doRender();
+	});
+}
+
+doRender();

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "proxyquire": "1.7.10",
     "react-addons-test-utils": "15.4.1",
     "react-engine": "4.2.0",
-    "react-hot-loader": "^3.0.0-beta.2",
+    "react-hot-loader": "^3.0.0-beta.6",
     "raw-loader": "^0.5.1",
     "react-alt-text": "2.0.0",
     "react-color": "2.9.0",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -108,7 +108,6 @@ export const getHot = (options = {}) => {
 	const { adminPath = '/keystone' } = options;
 	const hmrPath = `${adminPath}/__webpack_hmr`.replace('//', '/');
 	const hotStuff = [
-		'react-hot-loader/patch',
 		`webpack-hot-middleware/client?path=${hmrPath}`,
 	];
 	const base = getBase(options);


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
 * Enable HMR for Signin
 * Fix react-hot-loader >= v3.0.0-beta.6


## Related issues (if any)

 * #3360 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

