### PR TITLE
ListType: reset list when no value is submitted, cast objects with nu…

### DIFF
--- a/fields/types/list/ListType.js
+++ b/fields/types/list/ListType.js
@@ -185,17 +185,19 @@ list.prototype.updateItem = function (item, data, files, callback) {
 
 	var field = this;
 	var values = this.getValueFromData(data);
-	// Don't update the value when it is undefined
-	if (values === undefined) {
-		return utils.defer(callback);
-	}
-	// Reset the value when null or an empty string is provided
-	if (values === null || values === '') {
+	// Reset the value when no value or null or an empty string is provided
+	if (values === undefined || values === null || values === '') {
 		values = [];
 	}
-	// Wrap non-array values in an array
 	if (!Array.isArray(values)) {
-		values = [values];
+		if (typeof values === 'object' && values[0] !== undefined) {
+			// Cast an object with numeric keys to an array
+			values.length = Object.getOwnPropertyNames(values).length;
+			values = Array.prototype.slice.call(values);
+		} else {
+			// Wrap non-array values in an array
+			values = [values];
+		}
 	}
 	// NOTE - this method will overwrite the entire array, which is less specific
 	// than it could be. Concurrent saves could lead to race conditions, but we


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

1. Reset list when no value is submitted. This allows user to empty out a list.
2. Cast objects with numeric keys to array. This works around an unchangeable setting in `multer` that causes submitted arrays of 22 items or more to be parsed as objects instead of arrays.


## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


…meric keys to array