### PR TITLE
Fix RelatedItemsList.js never loading related items

### DIFF
--- a/admin/client/App/screens/Item/components/RelatedItemsList/RelatedItemsList.js
+++ b/admin/client/App/screens/Item/components/RelatedItemsList/RelatedItemsList.js
@@ -131,7 +131,7 @@ const RelatedItemsList = React.createClass({
 		return (
 			<div className="Relationship">
 				<h3 className="Relationship__link"><Link to={listHref}>{this.props.refList.label}</Link></h3>
-				{this.state.items ? this.renderItems() : loadingElement}
+				{this.props.items ? this.renderItems() : loadingElement}
 			</div>
 		);
 	},


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

`RelatedItemList.js` was broken because of a `this.state` instead of `this.props` causing it to always render the loading element rather than `renderItems()`.

Kudos to @cnkcheung3 for suggesting the fix in his issue report: #3739.

## Related issues (if any)

Fixes #3739. 

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->


