### PR TITLE
WYSIWYG Editor doesn't refresh for dependsOn

### DIFF
--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -54,7 +54,9 @@ module.exports = Field.create({
 
 		this._currentValue = this.props.value;
 		tinymce.init(opts);
-		this.setState({ wysiwygActive: true });
+		if (evalDependsOn(this.props.dependsOn, this.props.values)) {
+			this.setState({ wysiwygActive: true });
+		}
 	},
 
 	removeWysiwyg (state) {


### PR DESCRIPTION
## Description of changes

Show WYSIWYG Editor when it depends on a dependsOn field. Ensure no other WYSIWYG Editors are corrupted under this condition.

## Related issues (if any)

Fixes #3551
Related #3554

## Testing

- [X] Please confirm `npm run test-all` ran successfully.