### PR TITLE
Allow HTTP/2 with letsencrypt

### DIFF
--- a/server/startSecureServer.js
+++ b/server/startSecureServer.js
@@ -30,7 +30,7 @@ module.exports = function (keystone, app, created, callback) {
 	var options = keystone.get('https server options') || {};
 	if (options.NPNProtocols && options.NPNProtocols.length === 1 && options.NPNProtocols[0] === 'http/1.1') {
 		// Remove default value so spdy can use its own better ones
-        delete options.NPNProtocols
+		delete options.NPNProtocols;
 	}
 
 	if (keystone.get('ssl cert') && fs.existsSync(keystone.getPath('ssl cert'))) {

--- a/server/startSecureServer.js
+++ b/server/startSecureServer.js
@@ -28,6 +28,11 @@ module.exports = function (keystone, app, created, callback) {
 	var sniFunc;
 
 	var options = keystone.get('https server options') || {};
+	if (options.NPNProtocols && options.NPNProtocols.length === 1 && options.NPNProtocols[0] === 'http/1.1') {
+		// Remove default value so spdy can use its own better ones
+        delete options.NPNProtocols
+	}
+
 	if (keystone.get('ssl cert') && fs.existsSync(keystone.getPath('ssl cert'))) {
 		options.cert = fs.readFileSync(keystone.getPath('ssl cert'));
 	}


### PR DESCRIPTION
For some reason, `letsencrypt` forces the `NPNProtocols` option, which inhibits `spdy` from offering HTTP/2.
