### PR TITLE
Allow pre:admin configuration.

### DIFF
--- a/server/createApp.js
+++ b/server/createApp.js
@@ -83,6 +83,9 @@ module.exports = function createApp (keystone, express) {
 	// unless the headless option is set (which disables the Admin UI),
 	// bind the Admin UI's Dynamic Router
 	if (!keystone.get('headless')) {
+		if (typeof keystone.get('pre:admin') === 'function') {
+			keystone.get('pre:admin')(app);
+		}
 		app.use(function (req, res, next) {
 			keystone.callHook('pre:admin', req, res, next);
 		});


### PR DESCRIPTION
## Description of changes
Allow pre:admin configuration. This allow more flexibility to customise admin UI flow.
For example we want to limit the api request body size of admin UI, we will need to create our own express and pass to keystone. Although this work but not the best way to do it. pre:admin middleware configuration will allow more precise setup.
