### PR TITLE
write keystone bundles to disk

### DIFF
--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -33,13 +33,29 @@ function buildFieldTypesStream (fieldTypes) {
 }
 
 module.exports = function createStaticRouter (keystone) {
+	var keystoneHash = keystone.createKeystoneHash();
+	var writeToDisk = keystone.get('cache admin bundles');
 	var router = express.Router();
 
 	/* Prepare browserify bundles */
 	var bundles = {
-		fields: browserify(buildFieldTypesStream(keystone.fieldTypes), 'FieldTypes'),
-		signin: browserify('./Signin/index.js'),
-		admin: browserify('./App/index.js'),
+		fields: browserify({
+			stream: buildFieldTypesStream(keystone.fieldTypes),
+			expose: 'FieldTypes',
+			file: './FieldTypes.js',
+			hash: keystoneHash,
+			writeToDisk: writeToDisk,
+		}),
+		signin: browserify({
+			file: './Signin/index.js',
+			hash: keystoneHash,
+			writeToDisk: writeToDisk,
+		}),
+		admin: browserify({
+			file: './App/index.js',
+			hash: keystoneHash,
+			writeToDisk: writeToDisk,
+		}),
 	};
 
 	// prebuild static resources on the next tick in keystone dev mode; this

--- a/admin/server/middleware/browserify.js
+++ b/admin/server/middleware/browserify.js
@@ -26,19 +26,37 @@ function logError (file, err) {
 	console.log(ts() + chalk.red('error building ' + chalk.underline(file) + ':') + '\n' + err.message);
 }
 
-module.exports = function (file, name) {
+module.exports = function (opts) {
+	var stream = opts.stream;
+	var expose = opts.expose;
+	var file = opts.file;
+	var hash = opts.hash;
+	var writeToDisk = opts.writeToDisk;
+
 	var b;
 	var building = false;
 	var queue = [];
-	var ready;
 	var src;
-	var logName = typeof file === 'string' ? file.replace(/^\.\//, '') : name;
+	var etag;
+
+	var logName = file.replace(/^\.\//, '');
 	var fileName = logName;
-	if (fileName.substr(-3) !== '.js') fileName += '.js';
+	var outputFilename = path.resolve(path.join(__dirname, '../../bundles/js', hash + '-' + fileName));
+
+	function updateBundle (newSrc) {
+		src = newSrc;
+		etag = crypto.createHash('md5').update(src).digest('hex').slice(0, 6);
+	}
+
 	function writeBundle (buff) {
-		if (devWriteBundles) {
-			fs.outputFile(path.resolve(path.join(__dirname, '../../bundles/js', fileName)), buff, 'utf8');
+		if (devWriteBundles || writeToDisk) {
+			fs.outputFile(outputFilename, buff, 'utf8', function (err) {
+				if (err) {
+					return logError(fileName, err);
+				}
+			});
 		}
+
 		if (devWriteDisc) {
 			var discFile = fileName.replace('.js', '.html');
 			require('disc').bundle(buff, function (err, html) {
@@ -51,6 +69,7 @@ module.exports = function (file, name) {
 			});
 		}
 	}
+
 	function build () {
 		if (building) return;
 		building = true;
@@ -67,59 +86,75 @@ module.exports = function (file, name) {
 		if (devWriteDisc) {
 			opts.fullPaths = true;
 		}
-		if (name) {
+
+		if (stream) {
 			b = browserify(opts);
-			b.require(file, { expose: name });
+			b.require(stream, { expose: expose });
 		} else {
 			b = browserify(file, opts);
 		}
+
 		b.transform(babelify);
 		b.exclude('FieldTypes');
 		packages.forEach(function (i) {
 			b.exclude(i);
 		});
+
 		if (devMode) {
 			b = watchify(b, { poll: 500 });
 		}
+
 		b.bundle(function (err, buff) {
 			if (err) return logError(logName, err);
-			src = buff;
-			ready = true;
+			updateBundle(buff);
 			queue.forEach(function (reqres) {
 				send.apply(null, reqres);
 			});
 			writeBundle(buff);
 		});
+
 		b.on('update', function () {
 			b.bundle(function (err, buff) {
 				if (err) return logError(logName, err);
 				else logRebuild(logName);
-				src = buff;
+				updateBundle(buff);
 				writeBundle(buff);
 			});
 		});
 	}
+
 	function serve (req, res) {
-		if (!ready) {
-			build();
-			queue.push([req, res]);
-			return;
+		if (src) {
+			return send(req, res);
 		}
-		send(req, res);
+
+		fs.readFile(outputFilename, function (err, data) {
+			if (data) {
+				updateBundle(data);
+				if (devMode) {
+					build();
+				}
+				send(req, res);
+			} else {
+				queue.push([req, res]);
+				build();
+			}
+		});
 	}
+
 	function send (req, res) {
 		res.setHeader('Content-Type', 'application/javascript');
-		var etag = crypto.createHash('md5').update(src).digest('hex').slice(0, 6);
+
 		if (req.get && (etag === req.get('If-None-Match'))) {
 			res.status(304);
 			res.end();
-		}
-		else {
-			res.setHeader('ETag', etag);
-			res.setHeader('Vary', 'Accept-Encoding');
+		} else {
+			res.set('ETag', etag);
+			res.set('Vary', 'Accept-Encoding');
 			res.send(src);
 		}
 	}
+
 	return {
 		serve: serve,
 		build: build,

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ var Keystone = function () {
 		'model prefix': null,
 		'module root': moduleRoot,
 		'frame guard': 'sameorigin',
+		'cache admin bundles': true,
 	};
 	this._redirects = {};
 
@@ -124,6 +125,7 @@ Keystone.prototype.populateRelated = require('./lib/core/populateRelated');
 Keystone.prototype.redirect = require('./lib/core/redirect');
 Keystone.prototype.start = require('./lib/core/start');
 Keystone.prototype.wrapHTMLError = require('./lib/core/wrapHTMLError');
+Keystone.prototype.createKeystoneHash = require('./lib/core/createKeystoneHash');
 
 /* Deprecation / Change warnings for 0.4 */
 Keystone.prototype.routes = function () {

--- a/lib/core/createKeystoneHash.js
+++ b/lib/core/createKeystoneHash.js
@@ -1,0 +1,15 @@
+var crypto = require('crypto');
+var forEach = require('lodash/forEach');
+
+function createKeystoneHash () {
+	var hash = crypto.createHash('md5');
+	hash.update(this.version);
+
+	forEach(this.lists, function (list, key) {
+		hash.update(JSON.stringify(list.getOptions()));
+	});
+
+	return hash.digest('hex').slice(0, 6);
+}
+
+module.exports = createKeystoneHash;


### PR DESCRIPTION
presented for comment



this will expose a keystone config option that will allow a developer to
tell keystone to write (admin.js, fields.js, signin.js, packages.js) to
a file in the static directory

this means that keystone won't need to recompile these files between
server boots. this brings the boot time down from 20s on every launch to
around 3-5s if the files are already compiled and available. this
additional mode is compatible with the previous strategy of storing each
bundle in a variable in the closure which it will still do in order to
enable the watchify workflow.

if the user does not enable this mode, it only uses the previous
strategy.




- [*] eslint passed
- [*] npm test passed

I still need to get e2e to run on my machine.