### PR TITLE
Manually launch sauce connect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,3 +83,5 @@ addons:
     - mongodb-3.2-precise
     packages:
     - mongodb-org-server
+  jwt:
+    secure: EDmMTTPbjAwagS9jR5G9yMa7cyO3gdNuQGQ53NEcBKbM7CfUq+mtlyF1XGaLo8n9VseRgtw2RbxqztUgER3irlWpQu82t6DIJylYJpGy2oiAFimN2xp94p3HGatuCF4BMkRVBUvbtvmfFpZf4HKT5nup1MGvKVrUyZuQPObm9rQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '6'
 env:
   global:
+    - SAUCE_USERNAME=jstockwin1
     - KEYSTONE_PREBUILD_ADMIN=true
   matrix:
     - JOB=lint-and-test-cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,43 +9,31 @@ env:
 matrix:
   include:
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group006Fields
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group005Item
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group004List
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group003Home
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group002App
     - node_js: '6'
-      addons:
-        sauce_connect: true
       script:
         - npm run test-e2e-saucelabs-group
       env:

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "react-addons-test-utils": "15.4.1",
     "react-engine": "4.2.0",
     "rimraf": "2.5.4",
+    "sauce-connect-launcher": "^1.1.1",
     "sinon": "1.17.6",
     "superagent": "3.1.0",
     "supertest": "2.0.1",


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Hopefully, this should start SauceConnect manually, rather than relying on travis. It enables useful things like being able to retry the connection if it fails! Let's see if travis passes. cc:// @webteckie @bassjacob 

If Travis starts playing nicer with Sauce Connect then maybe we'll switch back to the old way.

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

