### PR TITLE
Ensure travis fails if e2e fails

### DIFF
--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -194,16 +194,18 @@ function start() {
 
 	], function(err) {
 		var exitProcess = false;
+		var exitCode = 0;
 		if (err) {
 			console.error([moment().format('HH:mm:ss:SSS')] + ' e2e: ' + err);
 			exitProcess = true;
+			exitCode = 1;
 		}
 		if (runTests) {
 			exitProcess = true;
 		}
 		if (exitProcess) {
 			console.error([moment().format('HH:mm:ss:SSS')] + ' e2e: exiting');
-			process.exit();
+			process.exit(exitCode);
 		}
 	});
 }


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

cc @webteckie @bassjacob 

Sauce connect is currently failing due to the maintennence on their end. 

However, this didn't fail the build. See ([here](https://travis-ci.org/keystonejs/keystone/jobs/189969564)).

This PR fixes that. The build is [currently failing](https://travis-ci.org/keystonejs/keystone/builds/189974543) due to saucelabs being down, but that's kinda the point at the moment. 


We'll check re-run the build later to make sure it really is just saucelabs downtime, but this should be merged regardless. 

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

