### PR TITLE
Replacing DB connection error event listener; allows recovery after DB connection failure

### DIFF
--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -45,7 +45,7 @@ module.exports = function openDatabaseConnection (callback) {
 
 	keystone.mongoose.connection.on('error', function (err) {
 
-		// The DB connection has been established previously and this a ValidationError cased by restrictions Mongoose is enforcing on the field value
+		// The DB connection has been established previously and this a ValidationError caused by restrictions Mongoose is enforcing on the field value
 		// We can ignore these here; they'll also be picked up by the 'error' event listener on the model; see /lib/list/register.js
 		if (mongoConnectionOpen && err && err.name === 'ValidationError') return;
 

--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -43,20 +43,24 @@ module.exports = function openDatabaseConnection (callback) {
 		keystone.mongoose.connect(keystone.get('mongo'), keystone.get('mongo options'));
 	}
 
-	keystone.mongoose.connection.once('error', function (err) {
+	keystone.mongoose.connection.on('error', function (err) {
 
-		if (keystone.get('logger')) {
-			console.log('------------------------------------------------');
-			console.log('Mongo Error:\n');
-			console.log(err);
-		}
+		// The DB connection has been established previously and this a ValidationError cased by restrictions Mongoose is enforcing on the field value
+		// We can ignore these here; they'll also be picked up by the 'error' event listener on the model; see /lib/list/register.js
+		if (mongoConnectionOpen && err && err.name === 'ValidationError') return;
 
-		if (mongoConnectionOpen) {
-			if (err.name === 'ValidationError') return;
-			throw err;
-		} else {
+		// Alternatively, the error is legitimate; output it
+		console.error('------------------------------------------------');
+		console.error('Mongoose connection "error" event fired with:');
+		console.error(err);
+
+		// There's been an error establishing the initial connection, ie. Keystone is attempting to start
+		if (!mongoConnectionOpen) {
 			throw new Error('KeystoneJS (' + keystone.get('name') + ') failed to start - Check that you are running `mongod` in a separate process.');
 		}
+
+		// Otherwise rethrow the initial error
+		throw err;
 
 	}).once('open', function () {
 


### PR DESCRIPTION
## Description of changes

Replaces the `.once()` listener for the Mongoose connection 'error' event with a sensible, permanent listener. This provides logging of failures and causes the thread to fail properly if the DB connection drops and cannot be reestablished automatically. 

The previous listener created an issue whereby a failed DB connection could put Keystone into a state where request without DB interaction would work as normal but request requiring DB interaction would hang until express timed them out. This state would occur without any error being logged and, because the app hadn't actually crashed, thread monitoring tools (ie. forever, pm2, etc.) wouldn't automatically restart it.

## Related issues (if any)

Can't find any git issues but seen real-world issues from this. Has been reported in the Keystone Slack.

## Testing

`npm run test-all` ran successfully.
