### PR TITLE
Feature/healthchecks

### DIFF
--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -1,7 +1,6 @@
 var bodyParser = require('body-parser');
 var express = require('express');
 var multer = require('multer');
-var safeRequire = require('../../../lib/safeRequire');
 
 module.exports = function createDynamicRouter (keystone) {
 	// ensure keystone nav has been initialised

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -26,22 +26,8 @@ module.exports = function createDynamicRouter (keystone) {
 		next();
 	});
 
-	var healthcheckConfig = keystone.get('healthchecks');
-	if (healthcheckConfig) {
-		var endpoint = '/server-health';
-		var healthcheck = safeRequire('keystone-healthchecks', 'healthchecks');
-
-		if (healthcheckConfig === true) {
-			var userListName = keystone.get('user model');
-			var userModel = keystone.list(userListName).model;
-			var canQueryMongo = healthcheck.healthchecks.canQueryMongo(userModel);
-
-			healthcheckConfig = {
-				canQueryMongo: canQueryMongo,
-			};
-		}
-
-		router.use(endpoint, healthcheck.createRoute(healthcheckConfig));
+	if (keystone.get('healthchecks')) {
+		router.use('/server-health', require('./createHealthchecksHandler')(keystone));
 	}
 
 	// Init API request helpers

--- a/admin/server/app/createHealthchecksHandler.js
+++ b/admin/server/app/createHealthchecksHandler.js
@@ -1,3 +1,5 @@
+var safeRequire = require('../../../lib/safeRequire');
+
 function createHealthchecksHandler (keystone) {
 	var healthcheck = safeRequire('keystone-healthchecks', 'healthchecks');
 	var healthcheckConfig = keystone.get('healthchecks');
@@ -8,11 +10,11 @@ function createHealthchecksHandler (keystone) {
 		// user model. This validates we can successfully query the database.
 		if (keystone.get('user model')) {
 			var User = keystone.list(keystone.get('user model'));
-			healthcheckConfig.canQueryUsers = healthcheck.healthchecks.canQueryList(User);
+			healthcheckConfig.canQueryUsers = healthcheck.healthchecks.canQueryListFactory(User);
 		}
 	}
 
-	router.use(endpoint, healthcheck.createRoute(healthcheckConfig));
+	return healthcheck.createRoute(healthcheckConfig);
 }
 
 module.exports = createHealthchecksHandler;

--- a/admin/server/app/createHealthchecksHandler.js
+++ b/admin/server/app/createHealthchecksHandler.js
@@ -1,0 +1,18 @@
+function createHealthchecksHandler (keystone) {
+	var healthcheck = safeRequire('keystone-healthchecks', 'healthchecks');
+	var healthcheckConfig = keystone.get('healthchecks');
+
+	if (healthcheckConfig === true) {
+		healthcheckConfig = {};
+		// By default, we simply bind the user model healthcheck if there is a
+		// user model. This validates we can successfully query the database.
+		if (keystone.get('user model')) {
+			var User = keystone.list(keystone.get('user model'));
+			healthcheckConfig.canQueryUsers = healthcheck.healthchecks.canQueryList(User);
+		}
+	}
+
+	router.use(endpoint, healthcheck.createRoute(healthcheckConfig));
+}
+
+module.exports = createHealthchecksHandler;

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,5 +1,6 @@
 var keystone = require('../index');
 var utils = require('keystone-utils');
+var safeRequire = require('../lib/safeRequire');
 
 /**
  * Email Class
@@ -69,16 +70,7 @@ var Email = function (options) {
 	}
 
 	// Try to use the keystone-email package and throw if it hasn't been installed
-	var KeystoneEmail;
-	try {
-		KeystoneEmail = require('keystone-email');
-	} catch (err) {
-		if (err.code === 'MODULE_NOT_FOUND') {
-			throw new Error('The "keystone-email" package needs to be installed to send emails');
-		} else {
-			throw err;
-		}
-	}
+	var KeystoneEmail = safeRequire('keystone-email', 'keystone to send emails');
 
 	// Create the new email instance with the template name and options
 	var templateName = options.templateName;

--- a/lib/email.js
+++ b/lib/email.js
@@ -1,6 +1,5 @@
 var keystone = require('../index');
 var utils = require('keystone-utils');
-var safeRequire = require('../lib/safeRequire');
 
 /**
  * Email Class
@@ -70,7 +69,16 @@ var Email = function (options) {
 	}
 
 	// Try to use the keystone-email package and throw if it hasn't been installed
-	var KeystoneEmail = safeRequire('keystone-email', 'keystone to send emails');
+	var KeystoneEmail;
+	try {
+		KeystoneEmail = require('keystone-email');
+	} catch (err) {
+		if (err.code === 'MODULE_NOT_FOUND') {
+			throw new Error('The "keystone-email" package needs to be installed to send emails');
+		} else {
+			throw err;
+		}
+	}
 
 	// Create the new email instance with the template name and options
 	var templateName = options.templateName;

--- a/lib/safeRequire.js
+++ b/lib/safeRequire.js
@@ -1,0 +1,12 @@
+module.exports = function safeRequire (library, feature) {
+	try {
+		return require(library);
+	} catch (error) {
+		if (error.code === 'MODULE_NOT_FOUND') {
+			console.error('\nTo use', feature, 'install', library);
+			process.exit(1);
+		}
+
+		throw error;
+	}
+};

--- a/lib/safeRequire.js
+++ b/lib/safeRequire.js
@@ -3,8 +3,7 @@ module.exports = function safeRequire (library, feature) {
 		return require(library);
 	} catch (error) {
 		if (error.code === 'MODULE_NOT_FOUND') {
-			console.error('\nTo use', feature, 'install', library);
-			process.exit(1);
+			throw new Error('\nTo use ' + feature + ' install ' + library);
 		}
 
 		throw error;

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "core-assert": "0.2.1",
     "disc": "1.3.2",
     "enzyme": "2.7.0",
-    "enzyme": "2.6.0",
     "eslint": "3.13.1",
     "eslint-config-keystone": "3.0.0",
     "eslint-config-keystone-react": "1.0.0",

--- a/test/unit/lib/safeRequire.js
+++ b/test/unit/lib/safeRequire.js
@@ -1,0 +1,31 @@
+const demand = require('must');
+const proxyquire = require('proxyquire');
+const safeRequire = require('../../../lib/safeRequire');
+
+describe('safeRequire', function () {
+	describe('given a library that is not installed', function () {
+		beforeEach(function () {
+			this.oldExit = process.exit;
+			process.exit = status => demand(status).eql(1);
+		});
+
+		afterEach(function () {
+			process.exit = this.oldExit;
+		});
+
+		it('throws an error highlighting that the library is not installed', function () {
+			try {
+				safeRequire('foobarbaz', 'foobarbaz', true);
+			} catch (e) {
+				demand(e.message).contain('foobarbaz');
+			}
+		});
+	});
+
+	describe('given a library that exists', function () {
+		it('returns the required library', function () {
+			const localDemand = safeRequire('must');
+			localDemand(1).eql(1);
+		});
+	});
+});


### PR DESCRIPTION
## Description of changes
Adds an optional healthcheck endpoint at `/keystone/server-health` using the new [keystone-healthchecks](https://github.com/keystonejs/keystone-healthchecks) library.

It adds a healthcheck endpoint, and will add healthchecks in the following way:

if `keystone.get('healthchecks') === true` it will use a default keystone healthcheck that asserts that the mongodb database is able to be queried.

otherwise, it will try and use `keystone.get('healthchecks')` as an object, and pass it straight to the healthchecks module.

## Testing

- [x] npm run test