### PR TITLE
fix(0.12 regression): remove arrow functions

### DIFF
--- a/lib/list/updateItem.js
+++ b/lib/list/updateItem.js
@@ -75,7 +75,9 @@ function updateItem (item, data, options, callback) {
 
 	// Strip out noedit fields
 	if (!ignoreNoEdit) {
-		fields = fields.filter(i => !i.noedit);
+		fields = fields.filter(function (i) {
+			return !i.noedit;
+		});
 	}
 
 	// you can optionally require fields that aren't required in the schema

--- a/test/unit/lib/safeRequire.js
+++ b/test/unit/lib/safeRequire.js
@@ -6,7 +6,9 @@ describe('safeRequire', function () {
 	describe('given a library that is not installed', function () {
 		beforeEach(function () {
 			this.oldExit = process.exit;
-			process.exit = status => demand(status).eql(1);
+			process.exit = function (status) {
+				return demand(status).eql(1);
+			}
 		});
 
 		afterEach(function () {


### PR DESCRIPTION
remove some arrow functions that break 0.12 compat



https://github.com/keystonejs/keystone/commit/978b1ea2fbc725ca0d39f04edcbfebbfa1b4f311#commitcomment-20526321


- [ ] Please confirm `npm run test-all` ran successfully.