### PR TITLE
Minor improvement to the handling of text indexes

### DIFF
--- a/lib/list/ensureTextIndex.js
+++ b/lib/list/ensureTextIndex.js
@@ -89,7 +89,9 @@ function ensureTextIndex (callback) {
 			}
 
 			// It's a text index but not one of ours; nothing we can do
-			debug('Existing text index \'' + existingIndexName + '\' in \'' + list.key + '\' not recognised; no action taken');
+			console.error('list.ensureTextIndex() failed to update the existing text index \'' + existingIndexName + '\' for the \'' + list.key + '\' list.');
+			console.error('The existing index wasn\'t automatically created by ensureTextIndex() so will not be replaced.');
+			console.error('This may lead to unexpected behaviour when performing text searches on the this list.');
 			return;
 		}
 

--- a/lib/list/getSearchFilters.js
+++ b/lib/list/getSearchFilters.js
@@ -27,10 +27,11 @@ function getSearchFilters (search, add) {
 	search = String(search || '').trim();
 
 	if (search.length) {
-		// Use the text index if both a) it's enabled by the list and b) we have one
-		// If searchUsesTextIndex is true AND the list defines it's own custom text index this might not behave as expected.
-		// In this scenario you'll also get an error when the list is register()'ed though so hopefully someone will have noticed that..
-		if (this.options.searchUsesTextIndex && this.declaresTextIndex()) {
+		// Use the text index the behaviour is enabled by the list schema
+		// Usually, when searchUsesTextIndex is true, list.register() will maintain an index using ensureTextIndex()
+		// However, it's possible for searchUsesTextIndex to be true while there is an existing text index on the collection that *isn't* described in the list schema
+		// If this occurs, an error will be reported when list.register() is called and the existing index will not be replaced, meaning it will be used here
+		if (this.options.searchUsesTextIndex) {
 			filters.$text = { $search: search };
 		}
 		else {


### PR DESCRIPTION
Addresses the (hopefully?) unusual case where `searchUsesTextIndex` is enabled for a list but the collection has an existing text index that *isn't* described by the list. In this scenario, ensureTextIndex() will log the issue to stderr and the text search will use the existing index. This might produce unexpected search behaviour.. or might be exactly what the app builder intended; we don't know.

## Description of changes

Removes the requirement for the Mongoose list to define (either manually or automatically) a text index for a text index to be utilised. Allows existing text indexes on the collection to be used.

## Testing

> OK. 1790  total assertions passed. (17m 3s)