### PR TITLE
Added option to use custom signin and signout functions

### DIFF
--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -35,9 +35,11 @@ module.exports = function createDynamicRouter (keystone) {
 
 	// #1: Session API
 	// TODO: this should respect keystone auth options
+	var SignIn = typeof keystone.get('signin') === 'function' ? keystone.get('signin') : require('../api/session/signin');
+	var SignOut = typeof keystone.get('signout') === 'function' ? keystone.get('signout') : require('../api/session/signout');
 	router.get('/api/session', require('../api/session/get'));
-	router.post('/api/session/signin', require('../api/session/signin'));
-	router.post('/api/session/signout', require('../api/session/signout'));
+	router.post('/api/session/signin', SignIn);
+	router.post('/api/session/signout', SignOut);
 
 	// #2: Session Routes
 	// Bind auth middleware (generic or custom) to * routes, allowing


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Added option to use custom signin and signout functions by setting `'signin'` and `'signout'` to functions in `keystone.init({})`


## Related issues (if any)


## Testing
Tests dosen't seem to be working on windows 10 with a clean install (see #3945). At least all tests that runs is passing.

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

