### PR TITLE
Passing `req` to signin hooks to make it possible to add custom validation

### DIFF
--- a/admin/server/api/session/signin.js
+++ b/admin/server/api/session/signin.js
@@ -13,12 +13,12 @@ function signin (req, res) {
 	var emailRegExp = new RegExp('^' + utils.escapeRegExp(req.body.email) + '$', 'i');
 	User.model.findOne({ email: emailRegExp }).exec(function (err, user) {
 		if (user) {
-			keystone.callHook(user, 'pre:signin', function (err) {
+			keystone.callHook(user, 'pre:signin', req, function (err) {
 				if (err) return res.status(500).json({ error: 'pre:signin error', detail: err });
 				user._.password.compare(req.body.password, function (err, isMatch) {
 					if (isMatch) {
 						session.signinWithUser(user, req, res, function () {
-							keystone.callHook(user, 'post:signin', function (err) {
+							keystone.callHook(user, 'post:signin', req, function (err) {
 								if (err) return res.status(500).json({ error: 'post:signin error', detail: err });
 								res.json({ success: true, user: user });
 							});


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Passing `req` to signin hooks. This makes it possible to ie validate the users against a third part, for example Microsoft Active Directory or AWS Cognito, by taking the credentials from `req.body`.

## Related issues (if any)
Closes #3944 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->