### PR TITLE
Geopoint validation should succeed if an array with undefined values

### DIFF
--- a/fields/types/geopoint/GeoPointType.js
+++ b/fields/types/geopoint/GeoPointType.js
@@ -51,7 +51,7 @@ geopoint.prototype.format = function (item) {
 geopoint.prototype.validateInput = function (data, callback) {
 	var value = this.getValueFromData(data);
 	var result = false;
-	if (value === undefined || value === null || value === '' || (Array.isArray(value) && value.join('') === '')) {
+	if (value === undefined || value === null || value === '' || (Array.isArray(value) && value.length === 2 && value.join('') === '')) {
 		result = true;
 	} else {
 		if (Array.isArray(value)) {

--- a/fields/types/geopoint/GeoPointType.js
+++ b/fields/types/geopoint/GeoPointType.js
@@ -51,7 +51,7 @@ geopoint.prototype.format = function (item) {
 geopoint.prototype.validateInput = function (data, callback) {
 	var value = this.getValueFromData(data);
 	var result = false;
-	if (value === undefined || value === null || value === '') {
+	if (value === undefined || value === null || value === '' || (Array.isArray(value) && value.join('') === '')) {
 		result = true;
 	} else {
 		if (Array.isArray(value)) {

--- a/fields/types/geopoint/test/type.js
+++ b/fields/types/geopoint/test/type.js
@@ -92,7 +92,7 @@ exports.testFieldType = function (List) {
 			});
 		});
 
-		it('should validate string array input with undefined values', function (done) {
+		it('should validate string array input with empty string values', function (done) {
 			List.fields.geo.validateInput({
 				geo: ['', ''],
 			}, function (result) {

--- a/fields/types/geopoint/test/type.js
+++ b/fields/types/geopoint/test/type.js
@@ -92,6 +92,33 @@ exports.testFieldType = function (List) {
 			});
 		});
 
+		it('should validate string array input with undefined values', function (done) {
+			List.fields.geo.validateInput({
+				geo: ['', ''],
+			}, function (result) {
+				demand(result).be.true();
+				done();
+			});
+		});
+
+		it('should invalidate string array input with more than two items', function (done) {
+			List.fields.geo.validateInput({
+				geo: ['', '', ''],
+			}, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
+		it('should invalidate string array input with less than two items', function (done) {
+			List.fields.geo.validateInput({
+				geo: [''],
+			}, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
 		it('should invalidate numeric array input with more than two items', function (done) {
 			List.fields.geo.validateInput({
 				geo: [1, 2, 3],


### PR DESCRIPTION
## Description of changes
The geopoint field type input validation currently  returns `true` if a value is either `undefined`, `null`, or an empty string. It should also accept an array with undefined values.

## Related issues (if any)
N/A

## Testing
- [x] Please confirm `npm run test-all` ran successfully.