### PR TITLE
Moved the check for keystone readiness for e2e to kne.

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "react-engine": "4.2.1",
     "rimraf": "2.5.4",
     "sinon": "1.17.7",
-    "superagent": "3.4.1",
     "supertest": "3.0.0",
     "uglify-js": "2.7.5",
     "updtr": "0.2.3",

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -2,7 +2,6 @@ var async = require('async');
 var keystone = require('../..');
 var ReactEngine = require('react-engine');
 var engine = ReactEngine.server.create({});
-var request = require('superagent');
 var moment = require('moment');
 var mongoose = require('mongoose');
 var path = require('path');
@@ -35,27 +34,6 @@ function dropTestDatabase(done) {
 			done(err);
 		}
 	});
-}
-
-// Function that checks if keystone is ready before starting testing
-function checkKeystoneReady (done) {
-	async.retry({
-		times: 10,
-		interval: 3000
-	}, function(done, result) {
-		console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: checking if KeystoneJS ready for request');
-		request
-			.get('http://' + keystone.get('host') + ':' + keystone.get('port') + '/keystone')
-			.end(done);
-	}, function (err, result) {
-		if (!err) {
-			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: KeystoneJS Ready!');
-			done();
-		} else {
-			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: KeystoneJS does not appear ready!');
-			done(err);
-		}
-	})
 }
 
 // Function that starts the e2e common framework
@@ -174,10 +152,6 @@ function start() {
 
 		function (cb) {
 			runKeystone(cb);
-		},
-
-		function (cb) {
-			checkKeystoneReady(cb);
 		},
 
 		function (cb) {


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
This change moved the check for keystone readiness for e2e testing to the kne framework.


## Related issues (if any)
N/A

## Testing

- [X] Please confirm `npm run test-all` ran successfully.

