### PR TITLE
Fix path bug with ks-editable

### DIFF
--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -217,7 +217,7 @@ Content.prototype.editable = function (user, options) {
 
 		var data = {
 			type: 'list',
-			path: keystone.get('admin path') + '/' + list.path,
+			path: list.getAdminURL(),
 			singular: list.singular,
 			plural: list.plural,
 		};


### PR DESCRIPTION
## Description of changes

The path returned by `Content.prototype.editable` is now an absolute-path reference. This fixes broken links when used with `ks-editable` on a page whose pathname has slashes.

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

I didn't run the E2E tests. I'm hoping you'll forgive me and that this change is small enough not to warrant it. I did test that it worked in a project of mine.

