### PR TITLE
Update money field for update in numeraljs

### DIFF
--- a/fields/types/money/MoneyType.js
+++ b/fields/types/money/MoneyType.js
@@ -38,8 +38,8 @@ money.prototype.addFilterToQuery = NumberType.prototype.addFilterToQuery;
 money.prototype.format = function (item, format) {
 	if (this.currency) {
 		try {
-			numeral.language(this.currency, require('numeral/languages/' + this.currency));
-			numeral.language(this.currency);
+			numeral.locale(this.currency, require('numeral/locales/' + this.currency));
+			numeral.locale(this.currency);
 		} catch (err) {
 			throw new Error('FieldType.Money: options.currency failed to load.');
 		}

--- a/fields/types/money/Readme.md
+++ b/fields/types/money/Readme.md
@@ -13,13 +13,13 @@ Input should either be a valid `Number`, or a string that can be converted to a 
 
 ## Options
 
-`format` `String` - formats the stored value using [numeraljs](http://numeraljs.com/).
+`format` `String` - formats the stored value using [numeraljs](http://numeraljs.com/). Defaults to `'$0,0.00'`
 
 ```js
 { type: Types.Money, format: '$0,0.00' }
 ```
 
-`currency` `String` - loads a predefined object of settings for a specific language, the language must exist as a .js in numeral/languages folder.
+`currency` `String` - loads a predefined object of settings for a specific language, the language must exist as a .js in numeral/locales folder.
 
 ```js
 { type: Types.Money, currency: 'en-gb' }

--- a/fields/types/money/test/type.js
+++ b/fields/types/money/test/type.js
@@ -9,6 +9,8 @@ exports.initList = function (List) {
 			money: { type: MoneyType },
 		},
 		noFormat: { type: MoneyType, format: false },
+		withCurrency: { type: MoneyType, currency: 'en-gb' },
+		withCustomFormat: { type: MoneyType, format: '($ 0.00 a)' },
 	});
 };
 
@@ -87,6 +89,16 @@ exports.testFieldType = function (List) {
 			demand(testItem._.noFormat.format()).be(1234);
 			testItem.noFormat = -244;
 			demand(testItem._.noFormat.format()).be(-244);
+		});
+		it('should format at an item when .currency was provided as an option', function () {
+			var testItem = new List.model();
+			testItem.withCurrency = 1234;
+			demand(testItem._.withCurrency.format()).be('£1,234.00');
+		});
+		it('should format at an item with a .format option that is not the default', function () {
+			var testItem = new List.model();
+			testItem.withCustomFormat = 1234;
+			demand(testItem._.withCustomFormat.format()).be('£ 1.23 k');
 		});
 	});
 


### PR DESCRIPTION
In numeraljs 2.0.0, language was renamed to locale, and language
function and folder has been deprecated.

This fixes this, and adds test of the format method.