### PR TITLE
Use same query object to perform count and query

### DIFF
--- a/lib/list/paginate.js
+++ b/lib/list/paginate.js
@@ -20,7 +20,6 @@ function paginate (options, callback) {
 	options = options || {};
 
 	var query = model.find(options.filters, options.optionalExpression);
-	var countQuery = model.find(options.filters);
 
 	query._original_exec = query.exec;
 	query._original_sort = query.sort;
@@ -47,7 +46,7 @@ function paginate (options, callback) {
 	};
 
 	query.exec = function (callback) {
-		countQuery.count(function (err, count) {
+		query.count(function (err, count) {
 			if (err) callback(err);
 
 			query.find().limit(resultsPerPage).skip(skip);


### PR DESCRIPTION
This fixes a bug where people were modifying the query after creation,
but this was not being applied to countQuery so the count would be
wrong.

Fixes #4056