### PR TITLE
change import to use importer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 var _ = require('lodash');
 var express = require('express');
-var fs = require('fs');
 var grappling = require('grappling-hook');
 var path = require('path');
 var utils = require('keystone-utils');
+var importer = require('./lib/core/importer');
 
 /**
  * Don't use process.cwd() as it breaks module encapsulation
@@ -112,7 +112,7 @@ Keystone.prototype.prefixModel = function (key) {
 Keystone.prototype.createItems = require('./lib/core/createItems');
 Keystone.prototype.createRouter = require('./lib/core/createRouter');
 Keystone.prototype.getOrphanedLists = require('./lib/core/getOrphanedLists');
-Keystone.prototype.importer = require('./lib/core/importer');
+Keystone.prototype.importer = importer;
 Keystone.prototype.init = require('./lib/core/init');
 Keystone.prototype.initDatabaseConfig = require('./lib/core/initDatabaseConfig');
 Keystone.prototype.initExpressApp = require('./lib/core/initExpressApp');
@@ -173,36 +173,7 @@ keystone.utils = utils;
  */
 
 Keystone.prototype.import = function (dirname) {
-
-	var initialPath = path.join(this.get('module root'), dirname);
-
-	var doImport = function (fromPath) {
-
-		var imported = {};
-
-		fs.readdirSync(fromPath).forEach(function (name) {
-
-			var fsPath = path.join(fromPath, name);
-			var info = fs.statSync(fsPath);
-
-			// recur
-			if (info.isDirectory()) {
-				imported[name] = doImport(fsPath);
-			} else {
-				// only import files that we can `require`
-				var ext = path.extname(name);
-				var base = path.basename(name, ext);
-				if (require.extensions[ext]) {
-					imported[base] = require(fsPath);
-				}
-			}
-
-		});
-
-		return imported;
-	};
-
-	return doImport(initialPath);
+	return importer(this.get('module root'))(dirname);
 };
 
 


### PR DESCRIPTION
To make it easier to maintain the code, make import rely on creating a
new importer, and then calling it.