### PR TITLE
Implemented timezone fix for fields that use the 'Date' type

### DIFF
--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -43,20 +43,22 @@ module.exports = Field.create({
 			value: value,
 		});
 	},
-	moment (value) {
-		var m = moment(value);
-		if (this.props.isUTC) m.utc();
-		return m;
+	toMoment (value) {
+		if (this.props.isUTC) {
+			return moment.utc(value);
+		} else {
+			return moment(value);
+		}
 	},
 	isValid (value) {
-		return this.moment(value, this.inputFormat).isValid();
+		return this.toMoment(value, this.inputFormat).isValid();
 	},
 	format (value) {
-		return value ? this.moment(value).format(this.props.formatString) : '';
+		return value ? this.toMoment(value).format(this.props.formatString) : '';
 	},
 	setToday () {
 		this.valueChanged({
-			value: this.moment(new Date()).format(this.props.inputFormat),
+			value: this.toMoment(new Date()).format(this.props.inputFormat),
 		});
 	},
 	renderValue () {
@@ -67,10 +69,11 @@ module.exports = Field.create({
 		);
 	},
 	renderField () {
-		let value = this.moment(this.props.value);
-		value = this.props.value && value.isValid()
-			? value.format(this.props.inputFormat)
+		var dateAsMoment = this.toMoment(this.props.value);
+		var value = this.props.value && dateAsMoment.isValid()
+			? dateAsMoment.format(this.props.inputFormat)
 			: this.props.value;
+
 		return (
 			<Group>
 				<Section grow>

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -19,6 +19,16 @@ function date (list, path, options) {
 
 	this.yearRange = options.yearRange;
 	this.isUTC = options.utc || false;
+
+	/*
+	 * This offset is used to determine whether or not a stored date is probably corrupted or not.
+	 * If the date/time stored plus this offset equals a time close to midnight for that day, that
+	 * resulting date/time will be provided via the getData method instead of the one that is stored.
+	 * By default this timezone offset matches the offset of the keystone server. Using the default
+	 * setting is highly recommended.
+	 */
+	this.timezoneUtcOffsetMinutes = options.timezoneUtcOffsetMinutes || moment().utcOffset();
+
 	if (this.formatString && typeof this.formatString !== 'string') {
 		throw new Error('FieldType.Date: options.format must be a string.');
 	}
@@ -113,6 +123,49 @@ date.prototype.validateInput = function (data, callback) {
 		result = this.parse(value).isValid();
 	}
 	utils.defer(callback, result);
+};
+
+/**
+ *
+ * Retrives the date as a 'Javascript Date'.
+ *
+ * Note: If the JS date retrieved is UTC and has a time other than midnight,
+ * it has likely become corrupted. In this instance, the below code will
+ * attempt to add the server offset to it to fix the date.
+ */
+date.prototype.getData = function (item) {
+	var value = item.get(this.path);
+	var momentDate = this.isUTC ? moment.utc(value) : moment(value);
+
+	if (this.isUTC) {
+		if (momentDate.format('HH:mm:ss:SSS') !== '00:00:00:000') {
+			// Time is NOT midnight. So, let's try and add the server timezone offset
+			// to convert it (back?) to the original intended time. Since we don't know
+			// if the time was recorded during daylight savings time or not, allow +/-
+			// 1 hour leeway.
+
+			var adjustedMomentDate = moment.utc(momentDate);
+
+			// Add the server the time so that it is within +/- 1 hour of midnight.
+			adjustedMomentDate.add(this.timezoneUtcOffsetMinutes, 'minutes');
+
+			// Add 1 hour to the time so then we know any valid date/time would be between
+			// 00:00 and 02:00 on the correct day
+			adjustedMomentDate.add(1, 'hours'); // So
+			var timeAsNumber = Number(adjustedMomentDate.format('HHmmssSSS'));
+			if (timeAsNumber >= 0 && timeAsNumber <= 20000000) {
+				// Time is close enough to midnight so extract the date with a zeroed (ie. midnight) time value
+				return adjustedMomentDate.startOf('day').toDate();
+			} else {
+				// Seems that that adding the server time offset didn't produce a time
+				// that is close enough to midnight. Therefore, let's use the date/time
+				// as-is
+				return momentDate.toDate();
+			}
+		}
+	}
+
+	return momentDate.toDate();
 };
 
 /**


### PR DESCRIPTION
## Description of changes

This change fixes two bugs on keystone 4.0.0-beta.5:

- If using a field with type “Date” (ie. Types.Date) in the model without the UTC option turned on AND the keystone users are in different timezone(s) to where the server is running, dates may be recorded inaccurately. Specifically, when the user clicks on the save button for a form that contains a date, the date saved (and subsequently displayed) may be the date for one day before the date intended to be saved.

- If using a field with type “Date” (ie. Types.Date) in the model with the UTC option turned on, the incorrect date may be displayed upon selecting a new date from the date picker. Specifically, whenever the user selects a new date, the date for the day immediately before that date would be displayed. Clicking on save at that point would cause that incorrect date to be saved. This happens irrespective of the configured timezone(s).


## Related issues (if any)

https://github.com/keystonejs/keystone/issues/1702
https://github.com/keystonejs/keystone/issues/4082

## Notes

For the fix to take effect, the UTC option for the DateType field must be set.

ie. change:
```
publishedDate: { type: Types.Date },
```
to
```
publishedDate: { type: Types.Date, utc: true },
```
