### PR TITLE
respects `cloudinary secure` setting in admin

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -95,7 +95,7 @@ module.exports = Field.create({
 				crop: 'fit',
 				height: height,
 				format: 'jpg',
-				secure: !!keystone.get('cloudinary secure')
+				secure: !!Keystone.get('cloudinary secure'),
 			});
 		}
 

--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -95,6 +95,7 @@ module.exports = Field.create({
 				crop: 'fit',
 				height: height,
 				format: 'jpg',
+				secure: !!keystone.get('cloudinary secure')
 			});
 		}
 

--- a/fields/types/cloudinaryimages/CloudinaryImagesField.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesField.js
@@ -21,6 +21,7 @@ const SUPPORTED_REGEX = new RegExp(/^image\/|application\/pdf|application\/posts
 const RESIZE_DEFAULTS = {
 	crop: 'fit',
 	format: 'jpg',
+	secure: !!keystone.get('cloudinary secure')
 };
 
 let uploadInc = 1000;

--- a/fields/types/cloudinaryimages/CloudinaryImagesField.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesField.js
@@ -21,7 +21,7 @@ const SUPPORTED_REGEX = new RegExp(/^image\/|application\/pdf|application\/posts
 const RESIZE_DEFAULTS = {
 	crop: 'fit',
 	format: 'jpg',
-	secure: !!keystone.get('cloudinary secure')
+	secure: !!Keystone.get('cloudinary secure'),
 };
 
 let uploadInc = 1000;


### PR DESCRIPTION
This is the same as #2427, extending the fix to the builtin uploader.

## Description of changes

Ensures cloudinary images are rendered with https on the admin when `cloudinary secure` is set.

## Related issues (if any)

#2427

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

I ran `npm test` successfully - when I tried to run the e2e tests they would hang on *Starting Selenium server...*.