### PR TITLE
Deprecate currency setting, fixes #4060

### DIFF
--- a/fields/types/money/MoneyType.js
+++ b/fields/types/money/MoneyType.js
@@ -9,7 +9,9 @@ var util = require('util');
  * @api public
  */
 function money (list, path, options) {
-	this.currency = options.currency;
+	if (options.currency) {
+		throw new Error('The currency option from money has been deprecated. Provide a formatString instead');
+	}
 	this._nativeType = Number;
 	this._underscoreMethods = ['format'];
 	this._properties = ['currency'];
@@ -36,14 +38,6 @@ money.prototype.addFilterToQuery = NumberType.prototype.addFilterToQuery;
  * Formats the field value
  */
 money.prototype.format = function (item, format) {
-	if (this.currency) {
-		try {
-			numeral.language(this.currency, require('numeral/languages/' + this.currency));
-			numeral.language(this.currency);
-		} catch (err) {
-			throw new Error('FieldType.Money: options.currency failed to load.');
-		}
-	}
 	if (format || this._formatString) {
 		return (typeof item.get(this.path) === 'number') ? numeral(item.get(this.path)).format(format || this._formatString) : '';
 	} else {

--- a/fields/types/money/Readme.md
+++ b/fields/types/money/Readme.md
@@ -19,12 +19,6 @@ Input should either be a valid `Number`, or a string that can be converted to a 
 { type: Types.Money, format: '$0,0.00' }
 ```
 
-`currency` `String` - loads a predefined object of settings for a specific language, the language must exist as a .js in numeral/languages folder.
-
-```js
-{ type: Types.Money, currency: 'en-gb' }
-```
-
 ## Underscore Methods
 
 `format(string)` - formats the stored value using [numeraljs](http://numeraljs.com/). Set to `false` to disable automatic formatting.


### PR DESCRIPTION
numeral uses a global state, which makes setting of currency dangerous, as it may cause unintended consequences, particularly because number also uses its format method.

As it does not use the ISOstandard, switching to `toLocaleString` is breaking.

For 4, deprecate currency as an option. For 5, likely deprecate the money field.