### PR TITLE
hardcoded delimiter for admin ui

### DIFF
--- a/admin/server/routes/index.js
+++ b/admin/server/routes/index.js
@@ -87,7 +87,7 @@ module.exports = function IndexRoute (req, res) {
 		locals.cloudinaryScript = cloudinary.cloudinary_js_config();
 	};
 
-	ejs.renderFile(templatePath, locals, {}, function (err, str) {
+	ejs.renderFile(templatePath, locals, { delimiter: '%' }, function (err, str) {
 		if (err) {
 			console.error('Could not render Admin UI Index Template:', err);
 			return res.status(500).send(keystone.wrapHTMLError('Error Rendering Admin UI', err.message));

--- a/admin/server/routes/signin.js
+++ b/admin/server/routes/signin.js
@@ -19,7 +19,7 @@ module.exports = function SigninRoute (req, res) {
 		userCanAccessKeystone: !!(req.user && req.user.canAccessKeystone),
 	};
 	locals.csrf.header[keystone.security.csrf.CSRF_HEADER_KEY] = keystone.security.csrf.getToken(req, res);
-	ejs.renderFile(templatePath, locals, {}, function (err, str) {
+	ejs.renderFile(templatePath, locals, { delimiter: '%' }, function (err, str) {
 		if (err) {
 			console.error('Could not render Admin UI Signin Template:', err);
 			return res.status(500).send(keystone.wrapHTMLError('Error Rendering Signin', err.message));


### PR DESCRIPTION
## Description of changes
Hardcoded ejs delimiter to prevent keystone from being affected by a custom global delimiter based on @thejameskyle's suggestion 😀.

## Related issues (if any)
This PR attempts to fix #4093 

## Testing

E2E tests are not passing. I believe this may be to do with how I've got my environment configured vs the changes I've made?

Versions:
Node: `v7.6.0`
NPM: `4.1.2`
Mongodb: `3.4.3` (installed via brew `1.1.11`)

Running `npm run test-all` produces this output:

```
------------------------------------------------
KeystoneJS Started:
e2e is ready on http://localhost:3000
------------------------------------------------

22:01:10:420 e2e: KeystoneJS Started Successfully
22:01:10:420 e2e: checking if KeystoneJS ready for request
GET /keystone/ 302 3.764 ms
GET /keystone/signin 200 5.316 ms
22:01:10:464 e2e: KeystoneJS Ready!
22:01:10:464 e2e: starting tests...
22:01:10:465 kne: starting...
22:01:10:465 kne: running nightwatch...
nightwatch settings:
	Nightwatch Environment: default
	Nightwatch Start Selenium: true
	Browser Name: chrome
	Browser Version: latest
	SauceLabs Tunnel Id: undefined
	ChromeDriver: /Users/matthewlynch/Projects/keystone/node_modules/chromedriver/lib/chromedriver/chromedriver
	geckoDriver: /Users/matthewlynch/Projects/keystone/node_modules/geckodriver/geckodriver
Starting selenium server... Mongoose model 'index-single-done' event fired on 'NumberArray' for index:
 { createdBy: 1 } 
With error:
 connection 11 to localhost:27017 closed MongoError: connection 11 to localhost:27017 closed
    at Function.MongoError.create (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/error.js:29:11)
    at Socket.<anonymous> (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/connection/connection.js:200:22)
    at Object.onceWrapper (events.js:291:19)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:189:7)
    at TCP._handle.close [as _onclose] (net.js:501:12)
Mongoose model 'index' event fired on 'NumberArray' with error:
 connection 11 to localhost:27017 closed MongoError: connection 11 to localhost:27017 closed
    at Function.MongoError.create (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/error.js:29:11)
    at Socket.<anonymous> (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/connection/connection.js:200:22)
    at Object.onceWrapper (events.js:291:19)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:189:7)
    at TCP._handle.close [as _onclose] (net.js:501:12)
Mongoose model 'index-single-done' event fired on 'Date' for index:
 { createdBy: 1 } 
With error:
 24: Too many open files MongoError: 24: Too many open files
    at Function.MongoError.create (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/error.js:31:11)
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb/lib/db.js:1083:80
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/connection/pool.js:455:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
Mongoose model 'index' event fired on 'Date' with error:
 24: Too many open files MongoError: 24: Too many open files
    at Function.MongoError.create (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/error.js:31:11)
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb/lib/db.js:1083:80
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/connection/pool.js:455:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
Mongoose model 'index-single-done' event fired on 'TextArray' for index:
 { createdBy: 1 } 
With error:
 24: Too many open files MongoError: 24: Too many open files
    at Function.MongoError.create (/Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/error.js:31:11)
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb/lib/db.js:1083:80
    at /Users/matthewlynch/Projects/keystone/node_modules/mongodb-core/lib/connection/pool.js:455:18
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)

....
```

Thanks for taking a look! 