### PR TITLE
fix paginate to return on count error

### DIFF
--- a/lib/list/paginate.js
+++ b/lib/list/paginate.js
@@ -48,7 +48,7 @@ function paginate (options, callback) {
 
 	query.exec = function (callback) {
 		countQuery.count(function (err, count) {
-			if (err) callback(err);
+			if (err) return callback(err);
 
 			query.find().limit(resultsPerPage).skip(skip);
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Bug fix on paginate method to return callback when count query returns an error.


## Related issues (if any)


## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

