### PR TITLE
Make file field a link when it has a href

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -126,7 +126,7 @@ module.exports = Field.create({
 		return (
 			<div>
 				{(this.hasFile() && !this.state.removeExisting) ? (
-					<FileChangeMessage href={href} target="_blank">
+					<FileChangeMessage component={href ? 'a' : 'span'} href={href} target="_blank">
 						{this.getFilename()}
 					</FileChangeMessage>
 				) : null}


### PR DESCRIPTION
If you have specified `schema: { url: true }` in your storage adapter, admin ui will now make the span into a link. If not, then it will just be a span like before. 

Cheers