### PR TITLE
Cloudinary admin url update: fixes #2724

### DIFF
--- a/fields/components/columns/CloudinaryImageSummary.js
+++ b/fields/components/columns/CloudinaryImageSummary.js
@@ -58,7 +58,8 @@ var CloudinaryImageSummary = React.createClass({
 	},
 	renderImageThumbnail () {
 		if (!this.props.image) return;
-		const url = this.props.image.url.replace(/image\/upload/, `image/upload/c_thumb,g_face,h_${IMAGE_SIZE},w_${IMAGE_SIZE}`);
+		const startingUrl = this.props.secure ? this.props.image.secure_url : this.props.image.url;
+		const url = startingUrl.replace(/image\/upload/, `image/upload/c_thumb,g_face,h_${IMAGE_SIZE},w_${IMAGE_SIZE}`);
 		return <img src={url} style={imageStyle} className="img-load" />;
 	},
 	render () {

--- a/fields/types/cloudinaryimage/CloudinaryImageColumn.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageColumn.js
@@ -15,7 +15,7 @@ var CloudinaryImageColumn = React.createClass({
 
 		return (
 			<ItemsTableValue field={this.props.col.type}>
-				<CloudinaryImageSummary label="dimensions" image={value} />
+				<CloudinaryImageSummary label="dimensions" image={value} secure={this.props.col.field.secure} />
 			</ItemsTableValue>
 		);
 

--- a/fields/types/cloudinaryimage/CloudinaryImageField.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageField.js
@@ -95,6 +95,7 @@ module.exports = Field.create({
 				crop: 'fit',
 				height: height,
 				format: 'jpg',
+				secure: this.props.secure,
 			});
 		}
 

--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -277,6 +277,21 @@ cloudinaryimage.prototype.getData = function (item) {
 	return typeof value === 'object' ? value : {};
 };
 
+cloudinaryimage.prototype._originalGetOptions = cloudinaryimage.prototype.getOptions;
+
+cloudinaryimage.prototype.getOptions = function () {
+	this._originalGetOptions();
+	// We are performing the check here, so that if cloudinary secure is added
+	// to keystone after the model is registered, it will still be respected.
+	// Setting secure overrides default `cloudinary secure`
+	if ('secure' in this.options) {
+		this.__options.secure = this.options.secure;
+	} else if (keystone.get('cloudinary secure')) {
+		this.__options.secure = keystone.get('cloudinary secure');
+	}
+	return this.__options;
+};
+
 /**
  * Detects whether the field has been modified
  */

--- a/fields/types/cloudinaryimages/CloudinaryImagesColumn.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesColumn.js
@@ -19,7 +19,7 @@ var CloudinaryImagesColumn = React.createClass({
 		const items = [];
 		for (let i = 0; i < 3; i++) {
 			if (!value[i]) break;
-			items.push(<CloudinaryImageSummary key={'image' + i} image={value[i]} />);
+			items.push(<CloudinaryImageSummary key={'image' + i} image={value[i]} secure={this.props.col.field.secure} />);
 		}
 		if (value.length > 3) {
 			items.push(<span key="more" style={moreIndicatorStyle}>[...{value.length - 3} more]</span>);
@@ -29,7 +29,7 @@ var CloudinaryImagesColumn = React.createClass({
 	renderValue (value) {
 		if (!value || !Object.keys(value).length) return;
 
-		return <CloudinaryImageSummary image={value} />;
+		return <CloudinaryImageSummary image={value} secure={this.props.col.field.secure} />;
 
 	},
 	render () {

--- a/fields/types/cloudinaryimages/CloudinaryImagesField.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesField.js
@@ -51,11 +51,13 @@ module.exports = Field.create({
 				imageSourceSmall: cloudinaryResize(img.public_id, {
 					...RESIZE_DEFAULTS,
 					height: 90,
+					secure: props.secure,
 				}),
 				imageSourceLarge: cloudinaryResize(img.public_id, {
 					...RESIZE_DEFAULTS,
 					height: 600,
 					width: 900,
+					secure: props.secure,
 				}),
 			}, index);
 		}) : [];
@@ -215,7 +217,7 @@ module.exports = Field.create({
 		}
 	},
 	renderLightbox () {
-		const { value } = this.props;
+		const { value, secure } = this.props;
 		if (!value || !value.length) return;
 
 		const images = value.map(image => ({
@@ -223,6 +225,7 @@ module.exports = Field.create({
 				...RESIZE_DEFAULTS,
 				height: 600,
 				width: 900,
+				secure,
 			}),
 		}));
 

--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -219,6 +219,22 @@ cloudinaryimages.prototype.inputIsValid = function (data) { // eslint-disable-li
 	return true;
 };
 
+
+cloudinaryimages.prototype._originalGetOptions = cloudinaryimages.prototype.getOptions;
+
+cloudinaryimages.prototype.getOptions = function () {
+	this._originalGetOptions();
+	// We are performing the check here, so that if cloudinary secure is added
+	// to keystone after the model is registered, it will still be respected.
+	// Setting secure overrides default `cloudinary secure`
+	if ('secure' in this.options) {
+		this.__options.secure = this.options.secure;
+	} else if (keystone.get('cloudinary secure')) {
+		this.__options.secure = keystone.get('cloudinary secure');
+	}
+	return this.__options;
+};
+
 /**
  * Updates the value for this field in the item from a data object
  */


### PR DESCRIPTION
Changes:
Cloudinary fields pass down `secure` property with their `getOptions`
call.

When a url is created by the admin UI, the secure property is added. This is handled at each location an image is referenced.