### PR TITLE
Update z-index of color chooser

### DIFF
--- a/fields/types/color/ColorField.js
+++ b/fields/types/color/ColorField.js
@@ -135,7 +135,7 @@ const classes = {
 		marginTop: 10,
 		position: 'absolute',
 		left: 0,
-		zIndex: 2,
+		zIndex: 500,
 	},
 	swatch: {
 		borderRadius: 1,


### PR DESCRIPTION
The previous z-index of 2 was not enough for the popover to appear above the "Save" form footer, which has z-index: 99. I changed it to 500: i guess it can be on top of everything, because it can be opened and closed at will.

I saw there's a few z-index related issues, but I don't think there is one about this specific issue. If I missed it, I'm sorry.

Also, I didn't run any tests, because, well, I changed 5 characters...