### PR TITLE
Pagination totals fix

### DIFF
--- a/lib/list/paginate.js
+++ b/lib/list/paginate.js
@@ -20,7 +20,6 @@ function paginate (options, callback) {
 	options = options || {};
 
 	var query = model.find(options.filters, options.optionalExpression);
-	var countQuery = model.find(options.filters);
 
 	query._original_exec = query.exec;
 	query._original_sort = query.sort;
@@ -47,7 +46,7 @@ function paginate (options, callback) {
 	};
 
 	query.exec = function (callback) {
-		countQuery.count(function (err, count) {
+		query.count(function (err, count) {
 			if (err) callback(err);
 
 			query.find().limit(resultsPerPage).skip(skip);

--- a/test/unit/lib/list/pagination.js
+++ b/test/unit/lib/list/pagination.js
@@ -116,7 +116,19 @@ describe('When paginating results', function () {
 
 		});
 	});
-
+	
+	describe('with .where clause supplied by the user', function() {
+		it('should return the correct total', function(done) {
+			Post.paginate({page: 1, perPage: 2}).where('content').equals("keyword").exec(function (err, results){
+				if(err){
+					return done(err);
+				}
+				assert.equal(results.total, 1);
+				done();
+			});
+		});
+	});
+	
 	describe('with an optional expression', function () {
 		it('should return results plus query metadata and pagination metadata', function (done) {
 


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

Changed how pagination total is calculated to fix it being incorrect when .where() clauses are added to the query.
Added a unit test to ensure .where clauses are calculated into the count returned.

## Related issues (if any)

[4253](https://github.com/keystonejs/keystone/issues/4253)

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

I made the change in a vm without a desktop environment so I'm unable to run the e2e tests.
npm run test-unit and npm run test-admin complete with no errors.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

