### PR TITLE
RelationshipType: fix crash on prev null data

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -228,8 +228,8 @@ relationship.prototype.updateItem = function (item, data, callback) {
 
 	// Are we handling a many relationship or just one value?
 	if (this.many) {
-		var arr = item.get(this.path);
-		var _old = arr.map(function (i) { return String(i); });
+		var arr = item.get(this.path) || [];
+		var _old = arr.map(String);
 		var _new = value;
 		if (!utils.isArray(_new)) {
 			_new = String(_new || '').split(',');


### PR DESCRIPTION
This can happen when you add a multi relationship to an existing model


