### PR TITLE
Depopulate

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -90,6 +90,10 @@ relationship.prototype.addToSchema = function (schema) {
  * Gets the field's data from an Item, as used by the React components
  */
 relationship.prototype.getData = function (item) {
+    if (item.populated(this.path)) {
+        item.depopulate('this.path');
+    }
+
 	var value = item.get(this.path);
 	if (this.many) {
 		return Array.isArray(value) ? value : [];
@@ -218,7 +222,7 @@ relationship.prototype.inputIsValid = function (data, required, item) {
  */
 relationship.prototype.updateItem = function (item, data, callback) {
 	if (item.populated(this.path)) {
-		throw new Error('fieldTypes.relationship.updateItem() Error - You cannot update populated relationships.');
+		item.depopulate('this.path');
 	}
 
 	var value = this.getValueFromData(data);

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-router-redux": "4.0.8",
     "react-select": "1.0.0-rc.1",
     "redux": "3.6.0",
-    "redux-saga": "0.14.3",
+    "redux-saga": "0.14.8",
     "redux-thunk": "2.2.0",
     "sanitize-filename": "1.6.1",
     "scmp": "1.0.2",


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

call item.depopulate before updateItem and getData when a relationship is populated in order to support document population.

This came up in our use case where there was a pre-find hook that populated certain fields.

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

