### PR TITLE
Fix for views location default

### DIFF
--- a/server/initViewEngine.js
+++ b/server/initViewEngine.js
@@ -7,7 +7,7 @@ module.exports = function initViewEngine (keystone, app) {
 	}
 
 	// Set location of view templates and view engine
-	app.set('views', keystone.getPath('views') || path.sep + 'views');
+	app.set('views', keystone.getPath('views') || 'views');
 	app.set('view engine', keystone.get('view engine'));
 
 	var customView = keystone.get('view');


### PR DESCRIPTION
## Description of changes

The current default location of views for a Keystone app is `path.sep + 'views'`. Unfortunately this resolves to the root of the filesystem, rather than a folder in your project called `views`.

This change updates the default so that the default option for `views` is just `views`, which will resolve to a folder in your current project, rather than a folder at `/views`.

This is a breaking change in that if anyone was relying on their views folder genuinely living at `/views` and was using the default, that'll no longer work. The likelihood of that breakage affecting anyone is low in my mind because I doubt people would have done that, but I've seen stranger things, so it'd be best to document the breakage.

## Related issues (if any)

I did not lodge an issue for this change, and have not reviewed existing issues to see if one exists for this problem.

## Testing

- [ ] `npm run test-all` did not run successfully on my development machine, reporting

```
Cannot find module '@ljharb/eslint-config'
Referenced from: /Users/kevin/Development/packages/keystone/www/node_modules/array.prototype.find/.eslintrc
```

But I do not know how to resolve this error with the tests.
