### PR TITLE
Fix issue with Admin UI: Switching page to referenced model

### DIFF
--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -98,7 +98,15 @@ module.exports = Field.create({
 				value: null,
 			});
 		};
-		values = Array.isArray(values) ? values : values.split(',');
+
+        if (Array.isArray(values)) {
+            values = values;
+        } else if (typeof values === 'string') {
+            values = values.split(',');
+        } else {
+            values = [];
+        }
+
 		const cachedValues = values.map(i => this._itemsCache[i]).filter(i => i);
 		if (cachedValues.length === values.length) {
 			this.setState({


### PR DESCRIPTION
Fix issue with Admin UI: Switching page to referenced model (temporary) breaks app.

Issue was happening because to `loadValue` was passing object, and because of this was failing in ternary operator :
```
values = Array.isArray(values) ? values : values.split(',');
```

changed this ti check if really string or array and only then use split if this param is type of string. In other case set empty array.

Tried to use this instead of npm package: for me it resolves issue described in https://github.com/keystonejs/keystone/issues/3696

But for me occurs another one when use repository from my github : occurs warnings in browser console of admin page
```
[Violation] Forced reflow while executing JavaScript took 35ms
```
I think this because in my repository is missing bundles which are there when install from npm and are placed in `keystone/admin/js` folder .
Could anybody please prepare me this bundles?
