### PR TITLE
Update maxAge of cookie to reflect time in milliseconds

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -55,7 +55,7 @@ function signinWithUser (user, req, res, onSuccess) {
 			var cookieOpts = _.defaults({}, keystone.get('cookie signin options'), {
 				signed: true,
 				httpOnly: true,
-				maxAge: 10 * 24 * 60 * 60,
+				maxAge: 10 * 24 * 60 * 60 * 1000,
 			});
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}


### PR DESCRIPTION
maxAge is in milliseconds. The value was missing a multiplication that made the cookie expire after about 15 minute and not 10 day, as I believe the author intended. This was felt mainly on mobile devices where the browser closes frequently.