### PR TITLE
Add support for custom Octicons in admin nav sections

### DIFF
--- a/admin/client/App/screens/Home/index.js
+++ b/admin/client/App/screens/Home/index.js
@@ -62,7 +62,7 @@ var HomeView = React.createClass({
 							{/* Render nav with sections */}
 							{Keystone.nav.sections.map((navSection) => {
 								return (
-									<Section key={navSection.key} id={navSection.key} label={navSection.label}>
+									<Section key={navSection.key} id={navSection.key} label={navSection.label} icon={navSection.icon}>
 										<Lists
 											counts={this.props.counts}
 											lists={navSection.lists}

--- a/lib/core/initNav.js
+++ b/lib/core/initNav.js
@@ -32,10 +32,14 @@ module.exports = function initNav (sections) {
 		if (typeof section === 'string') {
 			section = [section];
 		}
+    var icon = section.icon || null;
 		section = {
-			lists: section,
+			lists: section.lists || section,
 			label: nav.flat ? keystone.list(section[0]).label : utils.keyToLabel(key),
 		};
+    if (icon) {
+      section.icon = icon;
+    }
 		section.key = key;
 		section.lists = _.map(section.lists, function (i) {
 			if (typeof i === 'string') {


### PR DESCRIPTION
This pull request adds support for the ability to specify custom icon classes to associate with Admin UI nav sections, i.e. those configured by `keystone.set('nav', ...)`.

[I proposed this feature not too long ago](https://keystonejs.canny.io/feature-requests/p/admin-ui-nav-icons) but didn't realize then what an easy change it would be (the feature is basically already "built in" and just needed a tweak to "enable" it).

To use this feature, instead of writing
```
keystone.set('nav', {
    'small animals': ['mice', 'rats']
});
```

you can instead write 
```
keystone.set('nav', {
    'small animals': {
        lists: ['mice', 'rats'],
        icon: 'octicon octicon-squirrel'
});
```
which will override the default 'bullet' icon. All previous behaviours are left intact (bullet is still default if no icon provided, component still "auto-selects" an icon based on list name).

The auto-selecting behaviour struck me as a bit presumptuous; this pull request hopes to address that by opening it up completely.
