### PR TITLE
Feature/location google maps

### DIFF
--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -16,7 +16,7 @@ function location (list, path, options) {
 
 	this._underscoreMethods = ['format', 'googleLookup', 'kmFrom', 'milesFrom'];
 	this._fixedSize = 'full';
-	this._properties = ['enableMapsAPI'];
+	this._properties = ['enableMapsAPI', 'map', 'height', 'browserApiKey'];
 	this.enableMapsAPI = (options.enableImprove === true || (options.enableImprove !== false && keystone.get('google server api key'))) ? true : false;
 
 	// Throw on invalid options in 4.0 (remove for 5.0)
@@ -44,6 +44,10 @@ function location (list, path, options) {
 	if (!this.requiredPaths) {
 		this.requiredPaths = ['street1', 'suburb'];
 	}
+	// Should display as a Google Map
+	this.map = options.map || false;
+	this.browserApiKey = this.map ? keystone.get('google api key') : null;
+	this.height = options.height || 300;
 
 	location.super_.call(this, list, path, options);
 }

--- a/fields/types/location/Readme.md
+++ b/fields/types/location/Readme.md
@@ -38,6 +38,18 @@ Google Places integration requires the `google api key` option to be set for Key
 
 `geo` `Array` longitude, latitude
 
+`map` `Boolean` - Show Google Map view and select coordinates by clicking on it. Right click removes the mark. Requires the `google api key`.
+
+```js
+{ type: Types.Location, map: true }
+```
+
+`height` `Number` - Show Google Map view height. By default it is `300`.
+
+```js
+{ type: Types.Location, map: true, height: 400 }
+```
+
 > Important: as per the MongoDB convention, the order for the geo array must be lng, lat which is the opposite of the order used by Google's API.
 
 ## Underscore methods

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-dnd-html5-backend": "2.2.4",
     "react-dom": "15.4.2",
     "react-domify": "0.2.6",
+    "react-google-maps": "6.3.0",
     "react-images": "0.5.2",
     "react-markdown": "2.4.5",
     "react-redux": "5.0.3",


### PR DESCRIPTION
## Description of changes

Added a Google Map view for `Location` field.

* It requires `google api key` for displaying it.
* Built with https://github.com/tomchentw/react-google-maps.
* Supports lazy and asynchronous loading of the vendor google maps scripts.
* Left click marks a spot and sets the lat/lng attributes.
* Right click on any place removes the marked spot.

![preview](https://user-images.githubusercontent.com/7570744/28491544-b2f8c070-6ec1-11e7-8e61-9a6da5febe6c.png)

## Related issues (if any)
I think not.

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

This test is not passing on my machine. Maybe I have not the correct setup.

```txt
1) language must allow Accept-Language selection:

      AssertionError: "en-US" must be equivalent to "zh-CN"
      + expected - actual

      -en-US
      +zh-CN

      at Context.<anonymous> (test/unit/lib/middleware/language.js:79:34)
```
