### PR TITLE
FileField UI bug

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -52,6 +52,8 @@ module.exports = Field.create({
 		return this.props.collapse && !this.hasExisting();
 	},
 	componentWillUpdate (nextProps) {
+		// Return if no value
+		if (!this.props.value) return
 		// Show the new filename when it's finished uploading
 		if (this.props.value.filename !== nextProps.value.filename) {
 			this.setState(buildInitialState(nextProps));


### PR DESCRIPTION
I ran into a bug with larger files, where a render is called before the value is ready. `cannot read filename of undefined`. Please see this PR https://github.com/keystonejs/keystone/pull/3282

<img width="551" alt="screen shot 2017-07-28 at 12 29 50 pm" src="https://user-images.githubusercontent.com/6100364/28700020-7c3f8e64-7390-11e7-8b96-5cc0839e0074.png">