### PR TITLE
Fix: model with required field that defaults to 0 can't be saved

### DIFF
--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -36,7 +36,7 @@ boolean.prototype.validateInput = function (data, callback) {
 
 boolean.prototype.validateRequiredInput = function (item, data, callback) {
 	var value = this.getValueFromData(data);
-	var result = (value && value !== 'false') || item.get(this.path) ? true : false;
+	var result = (value && value !== 'false') || typeof item.get(this.path) === 'boolean' ? true : false;
 	utils.defer(callback, result);
 };
 

--- a/fields/types/number/NumberType.js
+++ b/fields/types/number/NumberType.js
@@ -39,7 +39,7 @@ number.prototype.validateInput = function (data, callback) {
 number.prototype.validateRequiredInput = function (item, data, callback) {
 	var value = this.getValueFromData(data);
 	var result = !!(value || typeof value === 'number');
-	if (value === undefined && item.get(this.path)) {
+	if (value === undefined && typeof item.get(this.path) === 'number') {
 		result = true;
 	}
 	utils.defer(callback, result);


### PR DESCRIPTION
## Description of changes

This pull request fixes a bug that makes it impossible to create a document if the associated model has a **numeric** field that's **required** and has a **default** value of **zero**.

This minimal model reproduces the problem:

```js
var keystone = require("keystone")

var DocumentList = new keystone.List("Document", {
  schema: {collection: "documents"}
})

DocumentList.add({
  num: {type: Number, required: true, default: 0}
})

DocumentList.register()
```

Attempting to create such a document in Keystone gives an error: "Num is required".

The problem, as you might guess, is that zero is a falsy value in JavaScript. The affected check in KeystoneJS code is supposed to check if the getter returns a value, but instead it checks if it returns a **truthy** value. The fix is a simple one-liner.

Obviously the same problem also occurs with boolean fields which default to false.

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

One test fails. It looks unrelated to my changes, though.

> 1) language must allow Accept-Language selection:
>
>     AssertionError: "en-US" must be equivalent to "zh-CN"
>     \+ expected - actual
>
>     -en-US
>     \+zh-CN
>
>     at Context.\<anonymous\> (test\unit\lib\middleware\language.js:79:34)


