### PR TITLE
it should be a <a/>

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -126,7 +126,7 @@ module.exports = Field.create({
 		return (
 			<div>
 				{(this.hasFile() && !this.state.removeExisting) ? (
-					<FileChangeMessage href={href} target="_blank">
+					<FileChangeMessage href={href} target="_blank" component:"a">
 						{this.getFilename()}
 					</FileChangeMessage>
 				) : null}


### PR DESCRIPTION
it should be a <a/>

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

