### PR TITLE
Fix - basic filtering on a relationship field

### DIFF
--- a/admin/client/App/screens/Item/reducer.js
+++ b/admin/client/App/screens/Item/reducer.js
@@ -39,6 +39,7 @@ function item (state = initialState, action) {
 				loading: true,
 			});
 		case DATA_LOADING_SUCCESS:
+			Keystone.item = action.data; // Fix keystone filter
 			return assign({}, state, {
 				data: action.data,
 				loading: false,

--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -1,7 +1,7 @@
 var async = require('async');
 var assign = require('object-assign');
 var listToArray = require('list-to-array');
-var Mongoose = require('mongoose');
+
 module.exports = function (req, res) {
 	var where = {};
 	var fields = req.query.fields;
@@ -23,26 +23,7 @@ module.exports = function (req, res) {
 		try { filters = JSON.parse(req.query.filters); }
 		catch (e) { } // eslint-disable-line no-empty
 	}
-	let priorQuery;
-	if (typeof filters === 'object' && !req.query.expandRelationshipFields) {
-		Object.keys(filters)
-		.map(path => {
-			const relationship = req.list.relationshipFields.find(relationship => relationship.path === path);
-			const RefModel = req.keystone.lists[relationship.options.ref];
-			if (RefModel) {
-				Object.keys(RefModel.fields)
-				.reduce((acc, fieldName) => {
-					const field = RefModel.fields[fieldName];
-					if (req.list.key === field.options.ref) {
-						priorQuery = { Model: RefModel, find: toFind({ valueFilters: req.query.filters, filters: field.filters }) };
-					}
-
-				});
-			}
-		});
-	}
-
-	if (typeof filters === 'object' && req.query.expandRelationshipFields) {
+	if (typeof filters === 'object') {
 		assign(where, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
@@ -60,32 +41,16 @@ module.exports = function (req, res) {
 	var sort = req.list.expandSort(req.query.sort);
 	async.waterfall([
 		function (next) {
-			if (!priorQuery) {
-				return next(null);
-			}
-			priorQuery.Model.model.find(priorQuery.find)
-			.then(results => {
-				const ids = results.map(r => Mongoose.Types.ObjectId(r.id)); // return id's for $in query
-				assign(where, Object.keys(req.query.filters)
-				.reduce((acc, key) => {
-					if (!req.query.filters[key]) return acc;
-					return Object.assign({}, { [key]: { $in: ids } });
-				}, {}));
-				next(null);
-			});
-		},
-		function (next) {
 			if (!includeCount) {
 				return next(null, 0);
 			}
-			query.find(where);
 			query.count(next);
 		},
 		function (count, next) {
 			if (!includeResults) {
 				return next(null, count, []);
 			}
-			query.find(where);
+			query.find();
 			query.limit(Number(req.query.limit) || 100);
 			query.skip(Number(req.query.skip) || 0);
 			if (sort.string) {
@@ -113,18 +78,3 @@ module.exports = function (req, res) {
 		});
 	});
 };
-
-// INPUT:
-// valueFilters { domain: { value: 'bobsyouruncle.com``' }}
-// OUTPUT:
-// { domain: 'bobsyouruncle.com' }
-function toFind ({ valueFilters, filters }) {
-	return Object.keys(valueFilters)
-	.reduce((acc, k) => {
-		if (!filters[k]) return acc;
-		const value = valueFilters[k].value;
-		const key = filters[k].replace(/:/g, '');
-		return Object.assign({}, acc, { [key]: value });
-		// { key: 'futurism' }
-	}, {});
-}

--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -24,7 +24,7 @@ module.exports = function (req, res) {
 		catch (e) { } // eslint-disable-line no-empty
 	}
 	let priorQuery;
-	if (typeof filters === 'object') {
+	if (typeof filters === 'object' && !req.query.expandRelationshipFields) {
 		Object.keys(filters)
 		.map(path => {
 			const relationship = req.list.relationshipFields.find(relationship => relationship.path === path);
@@ -40,6 +40,10 @@ module.exports = function (req, res) {
 				});
 			}
 		});
+	}
+
+	if (typeof filters === 'object' && req.query.expandRelationshipFields) {
+		assign(where, req.list.addFiltersToQuery(filters));
 	}
 	if (req.query.search) {
 		assign(where, req.list.addSearchToQuery(req.query.search));

--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -68,7 +68,7 @@ module.exports = Field.create({
 				}
 
 				// check if filtering by id and item was already saved
-				if (fieldName === ':_id' && Keystone.item) {
+				if (fieldName === '_id' && Keystone.item) {
 					filters[key] = Keystone.item.id;
 					return;
 				}


### PR DESCRIPTION
```js
var Site = new keystone.List('Site', {
	defaultColumns: 'name, description',
	track: true,
});

Site.add({
	featuredTags: {
		type: Types.Relationship,
		ref: 'Tag',
		many: true,
		filters: { site: ':key' }
	}
})

var Tag = new keystone.List('Tag', {
	autokey: { from: 'name', path: 'key' },
	defaultColumns: 'name|200',
	track: true,
});
Tag.add({
	name: { type: String, required: true, index: true },
	vocalSite: { type: Types.Relationship, ref: 'Site', initial: true },
});
```

bug: relationship list options do not display a subset of a collection based on relationship.

I found that the $in query being passed into ```.find``` was an array of strings and not an array of object id's. this is not supported by mongodbs $in aggregation.

When visiting a Site in the keystone edit view, show a subset of tags to display for that site.

expected:
```js
{ site: {$in: [ObjectId("59194faf1a8f016b5d2a74e2")] }}
``` 

actual:
```js
{ site: {$in: ['geeks']}}
```
Fix:
I found that the admin ui never had access to keystone.item as its now moved to redux. this fix populates the keystone.item property and allows for filtering by id.

This fix is a minimal change and is currently being used in production.

more work could be done to pull the current item by using connect from redux instead and passing the item down to the Keystone.item check replacing the global keystone usage.


