### PR TITLE
Fix Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,11 @@ matrix:
         - npm run test-admin
       env:
         - JOB=unit_tests_node_4
-    - node_js: '0.12'
-      script:
-        - npm run test-admin
-      env:
-        - JOB=unit_tests_node_0.12
+#    - node_js: '0.12'
+#      script:
+#        - npm run test-admin
+#      env:
+#        - JOB=unit_tests_node_0.12
 
 before_script:
 - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,7 @@ script:
 sudo: required
 notifications:
   email:
-  - jed@keystonejs.com
-  slack:
-    secure: AqayzYjoHTlwE85pgB0h5yqpyBDWbdrpiXKXhb8tSqWPKi6unhkfZ4r11kQRowoDQXb+fue9367u+lJ9lKBfMv+SSFnKY+OccasfrW6JwJ8Wi258aB7bjcSP9kUtUfvbbvPSwQjY6Z8+9TlMxP6kyabeZ69SGnhnaJNt+vbAJzc=
+  - chris.troutner@gmail.com
 services:
 - mongodb
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,11 +54,7 @@ matrix:
         - npm run test-admin
       env:
         - JOB=unit_tests_node_4
-#    - node_js: '0.12'
-#      script:
-#        - npm run test-admin
-#      env:
-#        - JOB=unit_tests_node_0.12
+
 
 before_script:
 - sleep 15
@@ -68,7 +64,9 @@ script:
 sudo: required
 notifications:
   email:
-  - chris.troutner@gmail.com
+  - jed@keystonejs.com
+  slack:
+    secure: AqayzYjoHTlwE85pgB0h5yqpyBDWbdrpiXKXhb8tSqWPKi6unhkfZ4r11kQRowoDQXb+fue9367u+lJ9lKBfMv+SSFnKY+OccasfrW6JwJ8Wi258aB7bjcSP9kUtUfvbbvPSwQjY6Z8+9TlMxP6kyabeZ69SGnhnaJNt+vbAJzc=
 services:
 - mongodb
 git:


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

I am submitting the PR at the request of @jstockwin. The Travis CI build has broken because Yarn no longer supports Node v0.12. The changes in this PR comment out the v0.12 tests, and get the Travis build to pass.

## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

I have successfully passed all tests in Travis CI using the fork submitted in this PR.

 -->

