### PR TITLE
fix:module-name in import statement in EditForm.js

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -15,7 +15,7 @@ import theme from '../../../../theme';
 
 import { Button, LoadingButton } from '../../../elemental';
 import AlertMessages from '../../../shared/AlertMessages';
-import ConfirmationDialog from './../../../shared/ConfirmationDialog';
+import ConfirmationDialog from '../../../shared/ConfirmationDialog';
 
 import FormHeading from './FormHeading';
 import AltText from './AltText';


### PR DESCRIPTION
## Description of changes
Fix the `ConfirmationDialog` import statement in Editform. It works fine but the extra `./` is extraneous and redundant.