### PR TITLE
Fixed overwrite in Adapters.FS

### DIFF
--- a/lib/storage/adapters/fs/index.js
+++ b/lib/storage/adapters/fs/index.js
@@ -97,7 +97,9 @@ FSAdapter.prototype.uploadFile = function (file, callback) {
 		filename = sanitize(filename);
 		debug('Uploading file with filename: %s', filename);
 		var uploadPath = path.resolve(options.path, filename);
-		fs.move(file.path, uploadPath, function (err) {
+		var fsOptions = {};
+		fsOptions.clobber = options.whenExists === 'overwrite';
+		fs.move(file.path, uploadPath, fsOptions, function (err) {
 			if (err) return callback(err);
 
 			// TODO: Chmod the file.


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

This change solves an issue that would prevent keystone.Storage.Adapters.FS from overwriting a file when `whenExists == 'overwrite'`. For example, previously the below configuration would return an `EEXIST` error when the file path being written already exists.

```js
const storage = new keystone.Storage({
  adapter: keystone.Storage.Adapters.FS,
  fs: {
    path: path,
    publicPath: path,
    whenExists: 'overwrite',
    generateFilename: keystone.Storage.contentHashFilename,
  }
});
```

This issue is resolved by enabling the `clobber` option in [`fs-extra.move`](https://github.com/jprichardson/node-fs-extra/tree/1.0.0#movesrc-dest-options-callback).

_Note: If updating to later versions of fs-extra the `clobber` option must be changed to `overwrite`._

## Related issues (if any)

#4245 (See comment 2)

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

_Same tests pass/fail as do in current master branch._

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

