### PR TITLE
Now 'signin redirect' option can be a function again

### DIFF
--- a/admin/server/routes/signin.js
+++ b/admin/server/routes/signin.js
@@ -5,13 +5,17 @@ var templatePath = path.resolve(__dirname, '../templates/signin.html');
 
 module.exports = function SigninRoute (req, res) {
 	var keystone = req.keystone;
+	var signinRedirect = keystone.get('signin redirect');
+	if (req.user && typeof signinRedirect === 'function') {
+		return signinRedirect(req.user, req, res);
+	}
 	var UserList = keystone.list(keystone.get('user model'));
 	var locals = {
 		adminPath: '/' + keystone.get('admin path'),
 		brand: keystone.get('brand'),
 		csrf: { header: {} },
 		logo: keystone.get('signin logo'),
-		redirect: keystone.get('signin redirect'),
+		redirect: signinRedirect,
 		user: req.user ? {
 			id: req.user.id,
 			name: UserList.getDocumentName(req.user) || '(no name)',

--- a/docs/documentation/Configuration/Database-Options.md
+++ b/docs/documentation/Configuration/Database-Options.md
@@ -109,17 +109,21 @@ A `href` string to use for the 'back to (site name)' link in the header of the A
 
 A `href` to bounce visitors to when they fail the default auth check (e.g. not signed in). Defaults to `/keystone/signin`, only used when `auth` is set to `true`/
 
-<h4 data-primitive-type="String"><code>signin redirect</code></h4>
+<h4 data-primitive-type="String|Function"><code>signin redirect</code></h4>
 
 A `href` to bounce visitors to after they successfully sign in via the built-in signin route. Defaults to `/keystone`.
+
+If it's a function, it will be invoked with parameters `user`, `req` and `res` and should handle the redirect autonomously.
 
 <h4 data-primitive-type="String"><code>signout url</code></h4>
 
 A `href` for the signout link in the top right of the UI. Defaults to `/keystone/signout` if `auth` is set to `true`
 
-<h4 data-primitive-type="String"><code>signout redirect</code></h4>
+<h4 data-primitive-type="String|Function"><code>signout redirect</code></h4>
 
 A `href` to bounce visitors to after they successfully sign out via the built-in sign out route. Defaults to `/keystone`
+
+If it's a function, it will be invoked with parameters `req` and `res` and should handle the redirect autonomously.
 
 
 For more information about setting up and using database models with Keystone, see the [database guide](/database/).


### PR DESCRIPTION
## Description of changes
This pull request restores the Keystone 0.3 functionality to set the `signin redirect` option as a function. It didn't work in Keystone 4 any more.

This functionality is useful to customize the page you are redirect to after successful login, especially for not admin users.

The documentation has been updated either for the `signin redirect` option and for the `signout redirect` option.

Note: for the `signout redirect` option this functionality was already developed, but the documentation was not aligned.

## Related issues (if any)
#4449
#4469

## Testing

- [x] Please confirm `npm run test-all` ran successfully.


