### PR TITLE
#4480 - Added listening for ctrl+s in EditForm

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -91,7 +91,12 @@ var EditForm = React.createClass({
 		values[event.path] = event.value;
 		this.setState({ values });
 	},
-
+	handleKeyPress (event) {
+		if (event.ctrlKey && event.key === 's') {
+			event.preventDefault();
+			this.updateItem();
+		}
+	},
 	toggleDeleteDialog () {
 		this.setState({
 			deleteDialogIsOpen: !this.state.deleteDialogIsOpen,
@@ -370,7 +375,10 @@ var EditForm = React.createClass({
 	},
 	render () {
 		return (
-			<form ref="editForm" className="EditForm-container">
+			<form
+				ref="editForm"
+				className="EditForm-container"
+				onKeyPress={this.handleKeyPress}>
 				{(this.state.alerts) ? <AlertMessages alerts={this.state.alerts} /> : null}
 				<Grid.Row>
 					<Grid.Col large="three-quarters">


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Added a listener for keypress event on the EditForm component. This listener checks that ctrl+s keys are pressed and if so, triggers the updateItem (save) function.


## Related issues (if any)
#4480 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

