### PR TITLE
specify icon for admin sections

### DIFF
--- a/admin/client/App/screens/Home/components/Section.js
+++ b/admin/client/App/screens/Home/components/Section.js
@@ -3,7 +3,7 @@ import getRelatedIconClass from '../utils/getRelatedIconClass';
 
 class Section extends React.Component {
 	render () {
-		const iconClass = this.props.icon || getRelatedIconClass(this.props.id);
+		const iconClass = this.props.icon ? `octicon octicon-${this.props.icon}` : getRelatedIconClass(this.props.id);
 		return (
 			<div className="dashboard-group" data-section-label={this.props.label}>
 				<div className="dashboard-group__heading">

--- a/admin/client/App/screens/Home/index.js
+++ b/admin/client/App/screens/Home/index.js
@@ -62,7 +62,7 @@ var HomeView = React.createClass({
 							{/* Render nav with sections */}
 							{Keystone.nav.sections.map((navSection) => {
 								return (
-									<Section key={navSection.key} id={navSection.key} label={navSection.label}>
+									<Section key={navSection.key} id={navSection.key} label={navSection.label} icon={navSection.icon}>
 										<Lists
 											counts={this.props.counts}
 											lists={navSection.lists}

--- a/docs/documentation/Configuration/Project-Options.md
+++ b/docs/documentation/Configuration/Project-Options.md
@@ -53,6 +53,16 @@ keystone.set('nav', {
 });
 ```
 
+If you want to specify the icon, use an object (you will find the icon name [here](https://octicons.github.com)):
+
+```javascript
+keystone.set('nav', {
+  posts: ['posts', 'post-categories'],
+  galleries: {icon: 'rocket', lists: ['galleries', 'enquiries']},
+  users: 'users'
+};
+```
+
 <h4 data-primitive-type="String"><code>csv field delimiter</code></h4>
 
 Allow you to choose a custom field delimiter to be used for CSV export instead of the default comma.

--- a/lib/core/initNav.js
+++ b/lib/core/initNav.js
@@ -28,14 +28,25 @@ module.exports = function initNav (sections) {
 		});
 	}
 
-	_.forEach(sections, function (section, key) {
-		if (typeof section === 'string') {
-			section = [section];
+	_.forEach(sections, function (spec, key) {
+		var lists;
+		if (typeof spec === 'string') {
+			lists = [spec];
 		}
-		section = {
-			lists: section,
-			label: nav.flat ? keystone.list(section[0]).label : utils.keyToLabel(key),
+		else if (Array.isArray(spec)) {
+			lists = spec;
+		}
+		else {
+			lists = spec.paths;
+		}
+
+		var section = {
+			lists: lists,
+			label: nav.flat ? keystone.list(spec[0]).label : utils.keyToLabel(key),
 		};
+		if (spec.icon) {
+			section.icon = spec.icon;
+		}
 		section.key = key;
 		section.lists = _.map(section.lists, function (i) {
 			if (typeof i === 'string') {


### PR DESCRIPTION
## Description of changes
specify icons for admin sections

To specify an admin icon, use an object (you will find the icon name [here](https://octicons.github.com)):
```javascript
keystone.set('nav', {
  posts: ['posts', 'post-categories'],
  galleries: {icon: 'rocket', lists: ['galleries', 'enquiries']},
  users: 'users'
};
```
## Related issues (if any)
#4382 
not looked sufficiently enough for a similar issue (wont do it again)
this pr is slighty different + doc

## Testing
- [ ] Please confirm `npm run test-all` ran successfully.
9 tests failing with mongodb, I dont see how this could be related to this commit