### PR TITLE
Option for todayButton

### DIFF
--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -29,6 +29,7 @@ module.exports = Field.create({
 		onChange: React.PropTypes.func,
 		path: React.PropTypes.string,
 		value: React.PropTypes.string,
+		todayButton: React.PropTypes.string,
 	},
 
 	getDefaultProps () {
@@ -74,6 +75,7 @@ module.exports = Field.create({
 			? dateAsMoment.format(this.props.inputFormat)
 			: this.props.value;
 
+if (this.props.todayButton) {
 		return (
 			<Group>
 				<Section grow>
@@ -90,6 +92,21 @@ module.exports = Field.create({
 				</Section>
 			</Group>
 		);
+ } else {
+	 	return (
+			<Group>
+				<Section grow>
+					<DateInput
+						format={this.props.inputFormat}
+						name={this.getInputName(this.props.path)}
+						onChange={this.valueChanged}
+						ref="dateInput"
+						value={value}
+					/>
+				</Section>
+			</Group>
+		);
+ }
 	},
 
 });


### PR DESCRIPTION
Make the Today Button optional

Everyone does not need the Today Button. It should be made optional

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Adds a new option for Date
todayButton: true or false


## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

