### PR TITLE
(feat) implements image thumbnails for the File type

### DIFF
--- a/fields/types/Type.js
+++ b/fields/types/Type.js
@@ -29,6 +29,7 @@ var DEFAULT_OPTION_KEYS = [
 	'collapse',
 	'dependsOn',
 	'autoCleanup',
+	'thumb',
 ];
 
 /**

--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -32,11 +32,11 @@ module.exports = Field.create({
 		label: PropTypes.string,
 		note: PropTypes.string,
 		path: PropTypes.string.isRequired,
+		thumb: PropTypes.bool,
 		value: PropTypes.shape({
 			filename: PropTypes.string,
 			// TODO: these are present but not used in the UI,
 			//       should we start using them?
-			// showThumbnail: PropTypes.bool
 			// filetype: PropTypes.string,
 			// originalname: PropTypes.string,
 			// path: PropTypes.string,
@@ -81,9 +81,6 @@ module.exports = Field.create({
 	isImage () {
 		const href = this.props.value ? this.props.value.url : undefined;
 		return href && href.match(/\.(jpeg|jpg|gif|png|svg)$/i) != null;
-	},
-	showThumb () {
-		return this.props.value && this.props.value.showthumb;
 	},
 
 	// ==============================
@@ -216,14 +213,13 @@ module.exports = Field.create({
 		);
 	},
 	renderUI () {
-		const { label, note, path } = this.props;
+		const { label, note, path, thumb } = this.props;
 		const isImage = this.isImage();
 		const hasFile = this.hasFile();
-		const showThumb = this.showThumb();
 
 		const previews = (
-			<div style={(isImage && showThumb) ? { marginBottom: '1em' } : null}>
-				{isImage && showThumb && this.renderImagePreview()}
+			<div style={(isImage && thumb) ? { marginBottom: '1em' } : null}>
+				{isImage && thumb && this.renderImagePreview()}
 				{hasFile && this.renderFileNameAndChangeMessage()}
 			</div>
 		);

--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -14,6 +14,7 @@ import {
 } from '../../../admin/client/App/elemental';
 import FileChangeMessage from '../../components/FileChangeMessage';
 import HiddenFileInput from '../../components/HiddenFileInput';
+import ImageThumbnail from '../../components/ImageThumbnail';
 
 let uploadInc = 1000;
 
@@ -35,6 +36,7 @@ module.exports = Field.create({
 			filename: PropTypes.string,
 			// TODO: these are present but not used in the UI,
 			//       should we start using them?
+			// showThumbnail: PropTypes.bool
 			// filetype: PropTypes.string,
 			// originalname: PropTypes.string,
 			// path: PropTypes.string,
@@ -72,6 +74,16 @@ module.exports = Field.create({
 		return this.state.userSelectedFile
 			? this.state.userSelectedFile.name
 			: this.props.value.filename;
+	},
+	getFileUrl () {
+		return this.props.value && this.props.value.url;
+	},
+	isImage () {
+		const href = this.props.value ? this.props.value.url : undefined;
+		return href && href.match(/\.(jpeg|jpg|gif|png|svg)$/i) != null;
+	},
+	showThumb () {
+		return this.props.value && this.props.value.showthumb;
 	},
 
 	// ==============================
@@ -190,23 +202,45 @@ module.exports = Field.create({
 			return null;
 		}
 	},
+	renderImagePreview () {
+		const imageSource = this.getFileUrl();
+		return (
+			<ImageThumbnail
+				component="a"
+				href={imageSource}
+				target="__blank"
+				style={{ float: 'left', marginRight: '1em', maxWidth: '50%' }}
+			>
+				<img src={imageSource} style={{ 'max-height': 100, 'max-width': '100%' }} />
+			</ImageThumbnail>
+		);
+	},
 	renderUI () {
 		const { label, note, path } = this.props;
-		const buttons = (
-			<div style={this.hasFile() ? { marginTop: '1em' } : null}>
-				<Button onClick={this.triggerFileBrowser}>
-					{this.hasFile() ? 'Change' : 'Upload'} File
-				</Button>
-				{this.hasFile() && this.renderClearButton()}
+		const isImage = this.isImage();
+		const hasFile = this.hasFile();
+		const showThumb = this.showThumb();
+
+		const previews = (
+			<div style={(isImage && showThumb) ? { marginBottom: '1em' } : null}>
+				{isImage && showThumb && this.renderImagePreview()}
+				{hasFile && this.renderFileNameAndChangeMessage()}
 			</div>
 		);
-
+		const buttons = (
+			<div style={hasFile ? { marginTop: '1em' } : null}>
+				<Button onClick={this.triggerFileBrowser}>
+					{hasFile ? 'Change' : 'Upload'} File
+				</Button>
+				{hasFile && this.renderClearButton()}
+			</div>
+		);
 		return (
 			<div data-field-name={path} data-field-type="file">
 				<FormField label={label} htmlFor={path}>
 					{this.shouldRenderField() ? (
 						<div>
-							{this.hasFile() && this.renderFileNameAndChangeMessage()}
+							{previews}
 							{buttons}
 							<HiddenFileInput
 								key={this.state.uploadFieldPath}
@@ -218,7 +252,7 @@ module.exports = Field.create({
 						</div>
 					) : (
 						<div>
-							{this.hasFile()
+							{hasFile
 								? this.renderFileNameAndChangeMessage()
 								: <FormInput noedit>no file</FormInput>}
 						</div>

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -29,6 +29,7 @@ var SCHEMA_TYPES = {
 	path: String,           // the path (e.g directory) the file is stored in; not the full path to the file
 	originalname: String,   // the original (uploaded) name of the file; useful when filename generated
 	url: String,            // publicly accessible URL of the stored file
+	showthumb: Boolean,			// Whether to attempt to load an image thumbnail
 };
 
 /**
@@ -43,6 +44,7 @@ var SCHEMA_FIELD_DEFAULTS = {
 	path: false,
 	originalname: false,
 	url: false,
+	showthumb: false,
 };
 
 // TODO: We could support custom schema mappings for backwards compatibilty
@@ -122,6 +124,10 @@ function normalizeFile (file, schema, callback) {
 	if (!file.originalname) {
 		file.originalname = file.name
 			|| (file.path) ? path.parse(file.path).base : 'unnamedfile';
+	}
+
+	if (!file.showthumb) {
+		file.showthumb = schema.showthumb;
 	}
 
 	if (schema.size && !file.size) {

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -29,7 +29,6 @@ var SCHEMA_TYPES = {
 	path: String,           // the path (e.g directory) the file is stored in; not the full path to the file
 	originalname: String,   // the original (uploaded) name of the file; useful when filename generated
 	url: String,            // publicly accessible URL of the stored file
-	showthumb: Boolean,			// Whether to attempt to load an image thumbnail
 };
 
 /**
@@ -44,7 +43,6 @@ var SCHEMA_FIELD_DEFAULTS = {
 	path: false,
 	originalname: false,
 	url: false,
-	showthumb: false,
 };
 
 // TODO: We could support custom schema mappings for backwards compatibilty
@@ -124,10 +122,6 @@ function normalizeFile (file, schema, callback) {
 	if (!file.originalname) {
 		file.originalname = file.name
 			|| (file.path) ? path.parse(file.path).base : 'unnamedfile';
-	}
-
-	if (!file.showthumb) {
-		file.showthumb = schema.showthumb;
 	}
 
 	if (schema.size && !file.size) {


### PR DESCRIPTION
Implements an image thumbnail for type `File`. Depends on a new schema property called `showThumb`. This improves upon the existing PR's in place that have stalled.

CSS has been implemented to ensure larger format images don't break layout.

Intent is to keep this simple for now until more complex solutions re: image middleware are sorted.

Master currently has e2e and unit tests failing from a prior merge. Can these be resolved so I can rebase?

@JedWatson