### PR TITLE
Fix: TextType - Over-length value validates when both max and min spe…

### DIFF
--- a/fields/types/text/TextType.js
+++ b/fields/types/text/TextType.js
@@ -25,7 +25,7 @@ text.prototype.validateInput = function (data, callback) {
 	if (max && typeof value === 'string') {
 		result = value.length < max;
 	}
-	if (min && typeof value === 'string') {
+	if (result && min && typeof value === 'string') {
 		result = value.length > min;
 	}
 	utils.defer(callback, result);

--- a/fields/types/text/test/type.js
+++ b/fields/types/text/test/type.js
@@ -14,6 +14,11 @@ exports.initList = function (List) {
 			type: String,
 			min: 10,
 		},
+		minMaxChar: {
+			type: String,
+			min: 10,
+			max: 20,
+		},
 	});
 };
 
@@ -146,6 +151,20 @@ exports.testFieldType = function (List) {
 
 		it('should invalidate string shorter than min characters', function (done) {
 			List.fields.minChar.validateInput({ minChar: 'Short' }, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
+		it('should invalidate string shorter than min characters when both min and max are specified', function (done) {
+			List.fields.minMaxChar.validateInput({ minMaxChar: 'Short' }, function (result) {
+				demand(result).be.false();
+				done();
+			});
+		});
+
+		it('should invalidate string longer than max characters when both min and max are specified', function (done) {
+			List.fields.minMaxChar.validateInput({ minMaxChar: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit' }, function (result) {
 				demand(result).be.false();
 				done();
 			});


### PR DESCRIPTION
…cified #4536

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Change validation logic for TextType to ensure an overlength string is invalidated when both max and min are specified.
Tests to support

## Related issues (if any)
#4536 

## Testing

- [x] Please confirm `npm run test-all` ran successfully.
No new failures. 7 failed tests in unrelated areas, all pre-existing.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

