### PR TITLE
Fix for known security vulnerability in marked 0.3.6 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "letsencrypt-express": "2.0.6",
     "list-to-array": "1.1.0",
     "lodash": "4.17.4",
-    "marked": "0.3.6",
+    "marked": "0.3.9",
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
     "moment": "2.18.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,9 +4455,9 @@ map-obj@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-marked@0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+marked@0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.9.tgz#54ce6a57e720c3ac6098374ec625fcbcc97ff290"
 
 material-colors@^1.2.1:
   version "1.2.5"


### PR DESCRIPTION
## Description of changes
Github found a known security vulnerability in one of our dependencies, which was fixed with a patch upgrade, so this moves keystone's dependency to the recommended version.

## Testing
- [x] `npm run test-all` ran successfully