### PR TITLE
Optional filtering functionality

### DIFF
--- a/lib/core/importer.js
+++ b/lib/core/importer.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var debug = require('debug')('keystone:core:importer');
 var path = require('path');
-
+var minimatch = require('minimatch');
 /**
  * Returns a function that looks in a specified path relative to the current
  * directory, and returns all .js modules in it (recursively).
@@ -19,7 +19,7 @@ var path = require('path');
  * @api public
  */
 
-function dispatchImporter (rel__dirname) {
+function dispatchImporter (rel__dirname, filters) {
 
 	function importer (from) {
 		debug('importing ', from);
@@ -27,9 +27,14 @@ function dispatchImporter (rel__dirname) {
 		var joinPath = function () {
 			return '.' + path.sep + path.join.apply(path, arguments);
 		};
-
 		var fsPath = joinPath(path.relative(process.cwd(), rel__dirname), from);
 		fs.readdirSync(fsPath).forEach(function (name) {
+			var matchingVar = 'match';
+			var excludingVar = 'exclude';
+			var isMatch = true;
+			if (this.filters) {
+				isMatch = filters[matchingVar] ? true : false;
+			}
 			var info = fs.statSync(path.join(fsPath, name));
 			debug('recur');
 			if (info.isDirectory()) {
@@ -39,12 +44,27 @@ function dispatchImporter (rel__dirname) {
 				var ext = path.extname(name);
 				var base = path.basename(name, ext);
 				if (require.extensions[ext]) {
+					if (this.filters)
+					{
+						if (isMatch || (!isMatch && !minimatch(name, this.filters[excludingVar])))
+						{
+							imported[base] = require(path.join(rel__dirname, from, name));
+						}
+					}
+					else
+					{
+						imported[base] = require(path.join(rel__dirname, from, name));
+					}
+				}
+				else if (this.filters && isMatch && minimatch(name, this.filters[matchingVar]))
+				{
 					imported[base] = require(path.join(rel__dirname, from, name));
-				} else {
+				}
+				else {
 					debug('cannot require ', ext);
 				}
 			}
-		});
+		}, { filters: filters });
 
 		return imported;
 	}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "marked": "0.3.6",
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
+	"minimatch": "^3.0.4",
     "moment": "2.18.1",
     "mongoose": "4.9.2",
     "morgan": "1.9.0",


### PR DESCRIPTION
This is a functionality in response to issue number 3690. Using keystone.importer we can pass the parameters for excluding or including a particular sort of file. Object like {"match":"*.js"} will be used to include a file with js extension. Object like {"exclude":"*.js"} will exclude this kind of file when importing from a directory.