### PR TITLE
Added session max age cookie to match keystone.uid cookie expiry

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -57,6 +57,7 @@ function signinWithUser (user, req, res, onSuccess) {
 				httpOnly: true,
 				maxAge: 10 * 24 * 60 * 60 * 1000,
 			});
+			req.session.cookie.maxAge = cookieOpts.maxAge;
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
     "moment": "2.18.1",
-    "mongoose": "4.9.2",
+    "mongoose": "4.13.12",
     "morgan": "1.9.0",
     "multer": "0.1.8",
     "numeral": "2.0.6",


### PR DESCRIPTION
## Description of changes
Add the session max age cookie (defaults to name this.sid) to match the expiry of the keystone.uid cookie. This correctly then expires when the keystone.uid cookie expires forcing the user to need to re-authenticate.

## Related issues (if any)

As described in Issue #4494 

## Testing

npm test run-all doesn't work - fails on **npm test && npm run test-e2e-bg** but this occurred before the change was made, so it's likely my env causing build issues. 

