### PR TITLE
replace knox git dependency with knox-s3

### DIFF
--- a/admin/server/api/s3.js
+++ b/admin/server/api/s3.js
@@ -5,7 +5,7 @@ TODO: Needs Review and Spec
 module.exports = {
 
 	upload: function (req, res) {
-		var knox = require('knox');
+		var knox = require('knox-s3');
 		var keystone = req.keystone;
 		var Types = keystone.Field.Types;
 

--- a/fields/types/s3file/S3FileType.js
+++ b/fields/types/s3file/S3FileType.js
@@ -68,7 +68,7 @@ Object.defineProperty(s3file.prototype, 's3config', {
  */
 s3file.prototype.addToSchema = function (schema) {
 
-	var knox = require('knox');
+	var knox = require('knox-s3');
 	var field = this;
 
 	var paths = this.paths = {
@@ -333,7 +333,7 @@ s3file.prototype.generateHeaders = function (item, file, callback) {
  */
 s3file.prototype.uploadFile = function (item, file, update, callback) {
 
-	var knox = require('knox');
+	var knox = require('knox-s3');
 	var field = this;
 	var path = field.options.s3path ? field.options.s3path + '/' : '';
 	var prefix = field.options.datePrefix ? moment().format(field.options.datePrefix) + '-' : '';

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "kerberos": "0.0.23",
     "keystone-storage-namefunctions": "1.1.1",
     "keystone-utils": "0.4.0",
-    "knox": "keystonejs/knox",
+    "knox-s3": "0.9.5",
     "less-middleware": "2.2.1",
     "letsencrypt-express": "2.0.6",
     "list-to-array": "1.1.0",


### PR DESCRIPTION
## Description of changes

This PR fixes #4573. An issue where keystone fails to install in environments without git. It replaces [keystonejs/knox](https://github.com/keystonejs/knox) with [knox-s3](https://www.npmjs.com/package/knox-s3), which are currently identical, save for the fact that knox-s3 is published to npm.

**¡¡¡ IMPORTANTE !!! - PR keystonejs/keystone-storage-adapter-s3#32 must be merged and published to npm BEFORE this is merged.**

If not, I believe issue #4498 will re-occur. This issue was originally fixed by switching to keystonejs/knox in PR #4453. I think the storage adapter picked up the knox update automatically because the same package name is used in both places, even though its package.json was not updated. If keystone is updated to use knox-s3 without the adapter being updated, I think the adapter will fall back to using the old broken knox dependency.

Pinging @vitalbone 

## Related issues (if any)

* #4573
* #4498

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

I did not run the tests. I hope that's OK.
