### PR TITLE
Adding in the missing DayPicker-WeekdaysRow

### DIFF
--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -116,7 +116,7 @@
 }
 
 .DayPicker-WeekdaysRow {
-	display: tahle-row;
+	display: table-row;
 }
 
 .DayPicker-Weekday {

--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -113,9 +113,10 @@
 
 .DayPicker-Weekdays {
 	display: table-header-group;
-	// > div {
-	//	 display: table-row;
-	// }
+}
+
+.DayPicker-WeekdaysRow {
+	display: tahle-row;
 }
 
 .DayPicker-Weekday {


### PR DESCRIPTION
## Description of changes
Updating the admin.less file as it is currently missing the DayPicker-WeekdaysRow. Since this class is missing, the days are not aligning correctly with the calendar below


## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.