### PR TITLE
clean up and collect docs into one place

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ know. We'll help you get started, rather than adding it to the queue.
 (with regards to formatting, etc)
 * You can also run `npm run lint`
 but please ensure there are not more violations than before your changes.
-* All new features and changes need documentation. They live over at the  [Keystone-site](https://github.com/keystonejs/keystonejs-site) repo.
+* All new features and changes need documentation, so ensure they are 
+documented extensively under 
+[docs](https://github.com/keystonejs/keystone/tree/master/docs) when implemented.
 * We have three translations so far,
 please read our [Documentation Translation  Guidelines](https://github.com/keystonejs/keystone/wiki/Documentation-Translation-Guidelines).
 


### PR DESCRIPTION
documentation is is currently spread out all over the place and is often outdated. after what i gathered @Noviny started collecting all documentation into a (new) website hosted here: http://keystonejs.netlify.com/documentation   

i think that's a good solution to keeping things organised and clean.
i want to help, so i'm wondering: what is the current situation? what needs to be done? do we merge this site into the main site (http://keystonejs.com/) when it's more ready or is it meant to live by itself on a different domain?

this is the first commit of cleaning something up, and i hope to commit more to this pull, once i know a bit more about the help needed.