### PR TITLE
Clearer Dropdown and Popout behaviour

### DIFF
--- a/packages/admin-ui/client/components/Popout.js
+++ b/packages/admin-ui/client/components/Popout.js
@@ -34,17 +34,17 @@ const Footer = styled(Bar)({
 });
 
 // Other
-export const DisclosureArrow = styled.span`
-  border-left: 0.3em solid transparent;
-  border-right: 0.3em solid transparent;
-  border-top: 0.3em solid;
-  display: inline-block;
-  height: 0px;
-  margin-left: 0.33em;
-  margin-top: -0.125em;
-  vertical-align: middle;
-  width: 0px;
-`;
+export const DisclosureArrow = styled.span(({ size = '0.3em' }) => ({
+  borderLeft: `${size} solid transparent`,
+  borderRight: `${size} solid transparent`,
+  borderTop: `${size} solid`,
+  display: 'inline-block',
+  height: 0,
+  marginLeft: '0.33em',
+  marginTop: '-0.125em',
+  verticalAlign: 'middle',
+  width: 0,
+}));
 
 type Props = { buttonLabel: string };
 
@@ -56,9 +56,16 @@ export const Popout = ({
   headerBefore,
   headerTitle,
   target,
-}: Props) => (
-  <PopoutModal
-    content={
+}: Props) => {
+  const defaultTarget = (
+    <Button>
+      {buttonLabel}
+      <DisclosureArrow />
+    </Button>
+  );
+
+  return (
+    <PopoutModal target={target || defaultTarget}>
       <Fragment>
         <Header>
           {headerBefore}
@@ -68,13 +75,6 @@ export const Popout = ({
         <Body>{children}</Body>
         {footerContent ? <Footer>{footerContent}</Footer> : null}
       </Fragment>
-    }
-  >
-    {target || (
-      <Button>
-        {buttonLabel}
-        <DisclosureArrow />
-      </Button>
-    )}
-  </PopoutModal>
-);
+    </PopoutModal>
+  );
+};

--- a/packages/admin-ui/client/pages/List/FieldAwareSelect.js
+++ b/packages/admin-ui/client/pages/List/FieldAwareSelect.js
@@ -28,7 +28,14 @@ export default class FieldAwareSelect extends Component<SelectProps> {
   };
 
   render() {
-    const { components, fields, onChange, value, ...props } = this.props;
+    const {
+      components,
+      fields,
+      innerRef,
+      onChange,
+      value,
+      ...props
+    } = this.props;
 
     // Convert the fields data into the format react-select expects.
     const options = fields.map(({ label, path }) => ({ label, value: path }));
@@ -57,6 +64,7 @@ export default class FieldAwareSelect extends Component<SelectProps> {
         isClearable={false}
         menuIsOpen
         menuShouldScrollIntoView={false}
+        ref={innerRef}
         styles={selectStyles}
         tabSelectsValue={false}
         components={{

--- a/packages/admin-ui/client/pages/List/SortSelect.js
+++ b/packages/admin-ui/client/pages/List/SortSelect.js
@@ -1,9 +1,32 @@
 import React, { Component } from 'react';
+import styled from 'react-emotion';
 import { ChevronDownIcon, ChevronUpIcon } from '@keystonejs/icons';
 import { colors } from '@keystonejs/ui/src/theme';
 
 import FieldAwareSelect, { type SelectProps } from './FieldAwareSelect';
 import { OptionPrimitive } from './components';
+
+export const SortButton = styled.button(({ isActive }) => {
+  const overStyles = {
+    color: colors.primary,
+    textDecoration: 'underline',
+  };
+  const activeStyles = isActive ? overStyles : null;
+  return {
+    background: 0,
+    border: 0,
+    outline: 0,
+    color: 'inherit',
+    cursor: 'pointer',
+    display: 'inline-block',
+    fontSize: 'inherit',
+    fontWeight: 'inherit',
+    verticalAlign: 'baseline',
+
+    ':hover, :focus': overStyles,
+    ...activeStyles,
+  };
+});
 
 export const SortOption = ({
   altIsDown,

--- a/packages/admin-ui/client/pages/List/index.js
+++ b/packages/admin-ui/client/pages/List/index.js
@@ -18,7 +18,7 @@ import Nav from '../../components/Nav';
 import { Popout, DisclosureArrow } from '../../components/Popout';
 
 import ColumnSelect from './ColumnSelect';
-import SortSelect from './SortSelect';
+import SortSelect, { SortButton } from './SortSelect';
 
 const getQueryArgs = args => {
   const queryArgs = Object.keys(args).map(
@@ -239,13 +239,11 @@ class ListPage extends Component {
                         </Note>
                       }
                       target={
-                        <span
-                          css={{ color: colors.primary, cursor: 'pointer' }}
-                        >
+                        <SortButton>
                           {' '}
                           {sortBy.label.toLowerCase()}
-                          <DisclosureArrow />
-                        </span>
+                          <DisclosureArrow size="0.25em" />
+                        </SortButton>
                       }
                     >
                       <SortSelect

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Modals.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Modals.js
@@ -10,6 +10,13 @@ export default class ModalGuide extends Component {
   toggleDialog = () => {
     this.setState(state => ({ dialogIsOpen: !state.dialogIsOpen }));
   };
+  handleDropdownClick = ({ data }) => {
+    console.log(`You selected "${data.content}", yum!`);
+  };
+  handleDialogKeyDown = ({ key }) => {
+    if (key !== 'Escape') return;
+    this.setState({ dialogIsOpen: false });
+  };
   render() {
     const { dialogIsOpen } = this.state;
     return (
@@ -18,35 +25,34 @@ export default class ModalGuide extends Component {
 
         <h4>Dropdowns</h4>
         <Dropdown
+          target={<Button>Show menu</Button>}
           // selectClosesMenu={false}
           items={[
             { to: '/admin', content: 'Home' },
-            { content: 'Macaroon', onClick: console.log },
-            { content: 'Cupcake', onClick: console.log },
-            { content: 'Liquorice', onClick: console.log },
-            { content: 'Cookie', onClick: console.log },
-            { content: 'Cake', onClick: console.log },
+            { content: 'Macaroon', onClick: this.handleDropdownClick },
+            { content: 'Cupcake', onClick: this.handleDropdownClick },
+            { content: 'Liquorice', onClick: this.handleDropdownClick },
+            { content: 'Cookie', onClick: this.handleDropdownClick },
+            { content: 'Cake', onClick: this.handleDropdownClick },
           ]}
-        >
-          <Button>Show menu</Button>
-        </Dropdown>
+        />
 
         <h4>Popouts</h4>
         <FlexGroup justify="space-between">
-          <Popout content={<PopoutContent>Left</PopoutContent>}>
-            <Button>Left</Button>
+          <Popout target={<Button>Left</Button>}>
+            <PopoutContent>Left</PopoutContent>
           </Popout>
-          <Popout content={<PopoutContent>Intermediate Left</PopoutContent>}>
-            <Button>Intermediate Left</Button>
+          <Popout target={<Button>Intermediate Left</Button>}>
+            <PopoutContent>Intermediate Left</PopoutContent>
           </Popout>
-          <Popout content={<PopoutContent>Middle</PopoutContent>}>
-            <Button>Middle</Button>
+          <Popout target={<Button>Middle</Button>}>
+            <PopoutContent>Middle</PopoutContent>
           </Popout>
-          <Popout content={<PopoutContent>Intermediate Right</PopoutContent>}>
-            <Button>Intermediate Right</Button>
+          <Popout target={<Button>Intermediate Right</Button>}>
+            <PopoutContent>Intermediate Right</PopoutContent>
           </Popout>
-          <Popout content={<PopoutContent>Right</PopoutContent>}>
-            <Button>Right</Button>
+          <Popout target={<Button>Right</Button>}>
+            <PopoutContent>Right</PopoutContent>
           </Popout>
         </FlexGroup>
 
@@ -54,6 +60,7 @@ export default class ModalGuide extends Component {
         <Button onClick={this.toggleDialog}>Open Dialog</Button>
         <Dialog
           isOpen={dialogIsOpen}
+          onKeyDown={this.handleDialogKeyDown}
           onClose={this.toggleDialog}
           heading="Dialog"
           footer={

--- a/packages/ui/src/primitives/modals/FocusTrap.js
+++ b/packages/ui/src/primitives/modals/FocusTrap.js
@@ -8,8 +8,8 @@ export type FocusTarget = HTMLElement | string | Fn;
 type Fn = (*) => void;
 type Props = {
   children: Element<*>,
-  active?: boolean,
-  paused?: boolean,
+  isActive?: boolean,
+  isPaused?: boolean,
   options: {
     /* A function that will be called when the focus trap activates. */
     onActivate?: Fn,
@@ -60,8 +60,8 @@ export default class FocusTrap extends Component<Props> {
   focusTrap: Object;
   previouslyFocusedElement: HTMLElement;
   static defaultProps = {
-    active: true,
-    paused: false,
+    isActive: true,
+    isPaused: false,
     options: {},
   };
   componentWillMount() {
@@ -71,8 +71,9 @@ export default class FocusTrap extends Component<Props> {
   }
 
   componentDidMount() {
-    const { active, options, paused } = this.props;
+    const { isActive, options, isPaused } = this.props;
 
+    // Objects as defaultProps don't merge, set and spread here instead
     const defaultOptions = {
       escapeDeactivates: false,
       fallbackFocus: this.boundary,
@@ -82,20 +83,20 @@ export default class FocusTrap extends Component<Props> {
 
     this.focusTrap = this.createFocusTrap(this.boundary, createOptions);
 
-    if (active) this.focusTrap.activate();
-    if (paused) this.focusTrap.pause();
+    if (isActive) this.focusTrap.activate();
+    if (isPaused) this.focusTrap.pause();
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.active && !this.props.active) {
+    if (prevProps.isActive && !this.props.isActive) {
       this.focusTrap.deactivate();
-    } else if (!prevProps.active && this.props.active) {
+    } else if (!prevProps.isActive && this.props.isActive) {
       this.focusTrap.activate();
     }
 
-    if (prevProps.paused && !this.props.paused) {
+    if (prevProps.isPaused && !this.props.isPaused) {
       this.focusTrap.unpause();
-    } else if (!prevProps.paused && this.props.paused) {
+    } else if (!prevProps.isPaused && this.props.isPaused) {
       this.focusTrap.pause();
     }
   }

--- a/packages/ui/src/primitives/modals/dropdown.js
+++ b/packages/ui/src/primitives/modals/dropdown.js
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import { Link } from 'react-router-dom';
 
 import { borderRadius, colors, gridSize } from '../../theme';
+import FocusTrap from './FocusTrap';
 import { SlideDown } from './transitions';
 import withModalHandlers, { type CloseType } from './withModalHandlers';
 
@@ -56,7 +57,7 @@ type ItemType = {
   href?: string,
   onClick?: (*) => void,
 };
-type ClickArgs = { onClick?: MouseEvent => void };
+type ClickArgs = { onClick?: ({ event: MouseEvent, data: Object }) => void };
 type Props = {
   children: Element<*>,
   close: CloseType,
@@ -87,10 +88,12 @@ class Dropdown extends Component<Props> {
     document.removeEventListener('keydown', this.handleKeyDown, false);
   }
 
-  handleItemClick = ({ onClick }: ClickArgs) => (event: MouseEvent) => {
+  handleItemClick = ({ onClick, ...data }: ClickArgs) => (
+    event: MouseEvent
+  ) => {
     const { close, selectClosesMenu } = this.props;
     if (selectClosesMenu) close({ returnFocus: true });
-    if (onClick) onClick(event);
+    if (onClick) onClick({ event, data });
   };
   handleKeyDown = (event: KeyboardEvent) => {
     const { key, target } = event;
@@ -147,22 +150,27 @@ class Dropdown extends Component<Props> {
     const { items, style } = this.props;
 
     return (
-      <Menu
-        innerRef={this.getMenu}
-        onMouseLeave={this.handleMenuLeave}
-        style={style}
-      >
-        {items.map(({ content, ...rest }, idx) => (
-          <Item
-            {...rest}
-            onClick={this.handleItemClick(rest)}
-            onMouseOver={this.handleMouseOver}
-            key={idx}
-          >
-            {content}
-          </Item>
-        ))}
-      </Menu>
+      <FocusTrap options={{ clickOutsideDeactivates: true }}>
+        <Menu
+          innerRef={this.getMenu}
+          onMouseLeave={this.handleMenuLeave}
+          style={style}
+        >
+          {items.map((item, idx) => {
+            const { content, ...rest } = item;
+            return (
+              <Item
+                {...rest}
+                onClick={this.handleItemClick(item)}
+                onMouseOver={this.handleMouseOver}
+                key={idx}
+              >
+                {content}
+              </Item>
+            );
+          })}
+        </Menu>
+      </FocusTrap>
     );
   }
 }

--- a/packages/ui/src/primitives/modals/popout.js
+++ b/packages/ui/src/primitives/modals/popout.js
@@ -1,10 +1,11 @@
 // @flow
 
-import React, { Component, type Element, type Node } from 'react';
+import React, { Component, type Element } from 'react';
 import styled from 'react-emotion';
 import { createPortal } from 'react-dom';
 
 import { borderRadius, gridSize } from '../../theme';
+import FocusTrap from './FocusTrap';
 import { SlideDown } from './transitions';
 import withModalHandlers, { type CloseType } from './withModalHandlers';
 
@@ -62,10 +63,10 @@ const Arrow = styled.div`
 type Props = {
   children: Element<*>,
   close: CloseType,
-  content: Node,
   defaultIsOpen: boolean,
   getModalRef: HTMLElement => void,
   style: Object,
+  target: Element<*>,
   targetNode: HTMLElement,
   width: number,
 };
@@ -130,7 +131,7 @@ class Popout extends Component<Props, State> {
   };
 
   render() {
-    const { content, getModalRef, style, width } = this.props;
+    const { children, getModalRef, style, width } = this.props;
     let { leftOffset, topOffset, arrowLeftOffset } = this.state;
 
     return document.body
@@ -142,10 +143,12 @@ class Popout extends Component<Props, State> {
             width={width}
             style={style} // style comes from Transition
           >
-            <WrapperInner>
-              <Arrow left={arrowLeftOffset} />
-              {content}
-            </WrapperInner>
+            <FocusTrap options={{ clickOutsideDeactivates: true }}>
+              <WrapperInner>
+                <Arrow left={arrowLeftOffset} />
+                {children}
+              </WrapperInner>
+            </FocusTrap>
           </Wrapper>,
           document.body
         )

--- a/packages/ui/src/primitives/modals/withModalHandlers.js
+++ b/packages/ui/src/primitives/modals/withModalHandlers.js
@@ -11,7 +11,7 @@ import NodeResolver from 'react-node-resolver';
 
 export type CloseType = ({ returnFocus: boolean }) => void;
 type Props = {
-  children: Element<*>,
+  target: Element<*>,
   defaultIsOpen: boolean,
 };
 type State = { isOpen: boolean };
@@ -92,14 +92,14 @@ export default function withModalHandlers(
     };
 
     render() {
-      const { children } = this.props;
+      const { target } = this.props;
       const { isOpen } = this.state;
       const cloneProps = isOpen ? { isActive: true } : {};
 
       return (
         <Fragment>
           <NodeResolver innerRef={this.getTarget}>
-            {cloneElement(children, cloneProps)}
+            {cloneElement(target, cloneProps)}
           </NodeResolver>
           <Transition in={isOpen}>
             <WrappedComponent


### PR DESCRIPTION
- new prop `target`: an element to trigger the dialog
- children prop behaves as expected
- employ FocusTrap for both to avoid fuzzy tab behaviour