### PR TITLE
Add tests for graphql schemas for Lists

### DIFF
--- a/packages/core/List/index.js
+++ b/packages/core/List/index.js
@@ -85,6 +85,7 @@ module.exports = class List {
       plural: this.plural,
       path: this.path,
       listQueryName: this.listQueryName,
+      listQueryMetaName: this.listQueryMetaName,
       itemQueryName: this.itemQueryName,
       createMutationName: this.createMutationName,
       updateMutationName: this.updateMutationName,
@@ -101,7 +102,7 @@ module.exports = class List {
     const fieldTypes = this.fields
       .map(i => i.getGraphqlTypes())
       .filter(i => i)
-      .join('\n     ');
+      .join('\n      ');
     const updateArgs = this.fields
       .map(i => i.getGraphqlUpdateArgs())
       .filter(i => i)
@@ -125,38 +126,36 @@ module.exports = class List {
       input ${this.key}CreateInput {
         ${createArgs}
       }
-      ${fieldTypes}
-    `;
+      ${fieldTypes}`;
   }
   getAdminGraphqlQueries() {
     const queryArgs = this.fields
       .map(i => i.getGraphqlQueryArgs())
       .filter(i => i)
       .map(i => i.split(/\n\s+/g).join('\n          '))
-      .join('\n          # New field');
+      .join('\n          # New field\n          ');
     const commonArgs = `
           search: String
           sort: String
 
           # Pagination
           first: Int
-          skip: Int
-    `;
+          skip: Int`;
     // TODO: Group field filters under filter: FilterInput
     return `
-        ${this.listQueryName}(
-          ${commonArgs}
+        ${this.listQueryName}(${commonArgs}
+
           # Field Filters
           ${queryArgs}
         ): [${this.key}]
+
         ${this.itemQueryName}(id: String!): ${this.key}
 
-        ${this.listQueryMetaName}(
-          ${commonArgs}
+        ${this.listQueryMetaName}(${commonArgs}
+
           # Field Filters
           ${queryArgs}
-        ): _QueryMeta
-    `;
+        ): _QueryMeta`;
   }
   getAdminQueryResolvers() {
     return {
@@ -179,8 +178,7 @@ module.exports = class List {
         ): ${this.key}
         ${this.deleteManyMutationName}(
           ids: [String!]
-        ): ${this.key}
-    `;
+        ): ${this.key}`;
   }
   getAdminMutationResolvers() {
     return {

--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -1,8 +1,20 @@
 const { Mongoose } = require('mongoose');
 const List = require('../List');
 
+class MockAdminMeta {
+}
+
 class MockType {
+  constructor(name) {
+    this.name = name;
+  }
   addToMongooseSchema = jest.fn();
+  getAdminMeta = () => new MockAdminMeta();
+  getGraphqlSchema = () => `${this.name}_schema`;
+  getGraphqlTypes = () => `${this.name}_types`;
+  getGraphqlUpdateArgs = () => `${this.name}_update_args`;
+  getGraphqlCreateArgs = () => `${this.name}_create_args`;
+  getGraphqlQueryArgs = () => `${this.name}_query_args`;
 };
 
 const config = {
@@ -66,4 +78,153 @@ describe('new List()', () => {
       }
     });
   });
+});
+
+describe('getAdminMeta()', () => {
+  test('adminMeta() - Smoke test', () => {
+    const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+    const adminMeta = list.getAdminMeta();
+    expect(adminMeta).not.toBeNull();
+  });
+
+  test('getAdminMeta() - labels', () => {
+    const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+    const adminMeta = list.getAdminMeta();
+
+    expect(adminMeta.key).toEqual('Test');
+    expect(adminMeta.label).toEqual('Tests');
+    expect(adminMeta.singular).toEqual('Test');
+    expect(adminMeta.plural).toEqual('Tests');
+    expect(adminMeta.path).toEqual('tests');
+    expect(adminMeta.itemQueryName).toEqual('Test');
+    expect(adminMeta.listQueryName).toEqual('allTests');
+    expect(adminMeta.listQueryMetaName).toEqual('_allTestsMeta');
+    expect(adminMeta.deleteMutationName).toEqual('deleteTest');
+    expect(adminMeta.deleteManyMutationName).toEqual('deleteTests');
+    expect(adminMeta.updateMutationName).toEqual('updateTest');
+    expect(adminMeta.createMutationName).toEqual('createTest');
+  });
+
+  test('getAdminMeta() - fields', () => {
+    const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+    const adminMeta = list.getAdminMeta();
+
+    expect(adminMeta.fields).toHaveLength(2);
+    expect(adminMeta.fields[0]).toBeInstanceOf(MockAdminMeta);
+    expect(adminMeta.fields[1]).toBeInstanceOf(MockAdminMeta);
+  });
+
+  test('getAdminMeta() - views', () => {
+    const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+    const adminMeta = list.getAdminMeta();
+
+    expect(adminMeta.views).toEqual({
+      name: {
+        viewType1: 'viewPath1',
+        viewType2: 'viewPath2',
+      },
+      email: {
+        viewType3: 'viewPath3',
+        viewType4: 'viewPath4',
+      }
+    });
+  });
+});
+
+
+test('getAdminGraphqlTypes()', () => {
+  const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+  const types = list.getAdminGraphqlTypes();
+
+  expect(types).toEqual(`
+      type Test {
+        id: String
+        name_schema
+        email_schema
+      }
+      input TestUpdateInput {
+        name_update_args
+        email_update_args
+      }
+      input TestCreateInput {
+        name_create_args
+        email_create_args
+      }
+      name_types
+      email_types`);
+});
+
+test('getAdminGraphqlQueries()', () => {
+  const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+  const queries = list.getAdminGraphqlQueries();
+
+  expect(queries).toEqual(`
+        allTests(
+          search: String
+          sort: String
+
+          # Pagination
+          first: Int
+          skip: Int
+
+          # Field Filters
+          name_query_args
+          # New field
+          email_query_args
+        ): [Test]
+
+        Test(id: String!): Test
+
+        _allTestsMeta(
+          search: String
+          sort: String
+
+          # Pagination
+          first: Int
+          skip: Int
+
+          # Field Filters
+          name_query_args
+          # New field
+          email_query_args
+        ): _QueryMeta`);
+});
+
+test('getAdminGraphqlMutations()', () => {
+  const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+  const mutations = list.getAdminGraphqlMutations();
+
+  expect(mutations).toEqual(`
+        createTest(
+          data: TestUpdateInput
+        ): Test
+        updateTest(
+          id: String!
+          data: TestUpdateInput
+        ): Test
+        deleteTest(
+          id: String!
+        ): Test
+        deleteTests(
+          ids: [String!]
+        ): Test`);
+});
+
+test('getAdminQueryResolvers()', () => {
+  const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+  const resolvers = list.getAdminQueryResolvers();
+
+  expect(resolvers['Test']).toBeInstanceOf(Function);
+  expect(resolvers['allTests']).toBeInstanceOf(Function);
+  expect(resolvers['_allTestsMeta']).toBeInstanceOf(Function);
+});
+
+test('getAdminMutationResolvers()', () => {
+  const list = new List('Test', config, { mongoose: new Mongoose(), lists: [] });
+  const resolvers = list.getAdminMutationResolvers();
+
+  expect(resolvers['createTest']).toBeInstanceOf(Function);
+  expect(resolvers['updateTest']).toBeInstanceOf(Function);
+  expect(resolvers['deleteTest']).toBeInstanceOf(Function);
+  expect(resolvers['deleteTests']).toBeInstanceOf(Function);
 });


### PR DESCRIPTION
Adds more tests. Cleans up the schema structure for easier reading/testing.