### PR TITLE
Smooth scroll speed adjustment for Admin UI

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -38,11 +38,16 @@ function getNameFromData (data) {
 }
 
 function smoothScrollTop () {
-	if (document.body.scrollTop || document.documentElement.scrollTop) {
-		window.scrollBy(0, -50);
-		var timeOut = setTimeout(smoothScrollTop, 20);
-	}	else {
-		clearTimeout(timeOut);
+	var position = window.scrollY || window.pageYOffset;
+	var speed = position / 10;
+
+	if (position > 1) {
+		var newPosition = position - speed;
+
+		window.scrollTo(0, newPosition);
+		window.requestAnimationFrame(smoothScrollTop);
+	} else {
+		window.scrollTo(0, 0);
 	}
 }
 


### PR DESCRIPTION
## Description of changes

Addressing request from my colleagues (content publishers) to speed up smooth scroll when form is updated and form happens to be quite long (page hight). Current speed is 50px with timeout 20ms is static and sometimes it takes up to 10-15 seconds to wait for smooth scroll to complete. Update takes current scrollY position into consideration to calculate the speed, hence the bigger scrolllY value, the higher smooth scroll speed, slowing down as it approaches top of the page.

## Related issues (if any)

Haven't found any.

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

Test fails with error `15:14 Unexpected token =` in `website/templates/template-doc-layout.js`. 
It was there before development started. Error is caused by class method notation being wrong. 
I decided to leave as is because it's not related to my issue.