### PR TITLE
Admin UI tests with Cypress

### DIFF
--- a/cypress/integration/test_project_spec.js
+++ b/cypress/integration/test_project_spec.js
@@ -1,7 +1,124 @@
-describe('Test Project Smoke Tests', function() {
-  it('Should be able to access welcome message /', function() {
+describe('Test Project Smoke Tests', () => {
+  it('Should be able to access welcome message /', () => {
     cy.visit('http://localhost:3000/');
 
     cy.get('body').should('contain', 'Welcome');
+  });
+
+  it('Should be able to click through to admin page.', () => {
+    cy.visit('http://localhost:3000/');
+
+    cy.contains('Open').click();
+
+    cy.url().should('include', '/admin');
+  });
+});
+
+describe('Nav Bar', () => {
+  // Testing links which should open in a new tab is a bit tricky in Cypress.
+  // The discussion at this page lists some of the details.
+  // https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__tab-handling-links/cypress/integration/tab_handling_anchor_links_spec.js
+  [
+    { text: 'Dashboard', target: '/admin' },
+    { text: 'Users', target: '/admin/users' },
+    { text: 'Posts', target: '/admin/posts' },
+    { text: 'Post Categories', target: '/admin/post-categories' },
+    {
+      text: 'GitHub',
+      target: 'https://github.com/keystonejs/keystone-5',
+      newTab: true,
+    },
+    { text: 'Graphiql', target: '/admin/graphiql', newTab: true },
+    { text: 'Style Guide', target: '/admin/style-guide' },
+    { text: 'Sign Out', target: '/admin/signin' },
+  ].forEach(({ text, target, newTab = false }) => {
+    it(`${newTab ? 'Check' : 'Click'} ${text}`, () => {
+      cy.visit('http://localhost:3000/admin');
+
+      cy
+        .get('nav')
+        .contains(text)
+        .should('have.attr', 'href', target);
+      if (newTab) {
+        cy
+          .get('nav')
+          .contains(text)
+          .should('have.attr', 'target', '_blank');
+      } else {
+        cy
+          .get('nav')
+          .contains(text)
+          .click();
+        cy.url().should('include', target);
+      }
+    });
+  });
+});
+
+describe('Home page', () => {
+  [
+    { text: 'Users', target: 'users' },
+    { text: 'Posts', target: 'posts' },
+    { text: 'Post Categories', target: 'post-categories' },
+  ].forEach(({ text, target }) => {
+    it(`Click through to list page - ${text}`, () => {
+      cy.visit('http://localhost:3000/admin');
+      cy
+        .contains(`Show ${text}`)
+        .should('have.attr', 'href', `/admin/${target}`)
+        .should('have.attr', 'title', `Show ${text}`)
+        .click();
+
+      cy.url().should('include', target);
+    });
+  });
+
+  it('Create list buttons exists', () => {
+    cy.visit('http://localhost:3000/admin');
+
+    [{ text: 'User' }, { text: 'Post' }, { text: 'Post Category' }].forEach(
+      ({ text }) => {
+        cy
+          .contains('button', `Create ${text}`)
+          .should('have.attr', 'title', `Create ${text}`);
+      }
+    );
+  });
+
+  it('Ensure Create Modal opens, has the correct fields, and Cancels', () => {
+    cy.visit('http://localhost:3000/admin');
+
+    [
+      {
+        text: 'User',
+        labels: [
+          'Name',
+          'Email',
+          'Password',
+          'Twitterid',
+          'Twitterusername',
+          'Company',
+        ],
+      },
+      {
+        text: 'Post',
+        labels: ['Name', 'Slug', 'Status', 'Author', 'Categories'],
+      },
+      { text: 'Post Category', labels: ['Name', 'Slug'] },
+    ].forEach(({ text, labels }) => {
+      cy.contains('button', `Create ${text}`).click();
+      cy
+        .contains('div', `Create ${text} Dialog`)
+        .contains('h3', `Create ${text}`);
+      cy.contains('div', `Create ${text} Dialog`).contains('button', 'Create');
+      labels.forEach(label => {
+        cy.contains('div[data-selector="field-container"]', label);
+      });
+      cy
+        .contains('div', `Create ${text} Dialog`)
+        .contains('button', 'Cancel')
+        .click();
+      cy.contains('div', `Create ${text} Dialog`).should('not.exist');
+    });
   });
 });

--- a/packages/admin-ui/client/components/Nav.js
+++ b/packages/admin-ui/client/components/Nav.js
@@ -47,16 +47,23 @@ const Nav = props => {
         })}
       </NavGroup>
       <NavGroup>
-        <PrimaryNavItem target="_blank" href={GITHUB_PROJECT}>
+        <PrimaryNavItem target="_blank" href={GITHUB_PROJECT} title="GitHub">
           <MarkGithubIcon />
+          <A11yText>GitHub</A11yText>
         </PrimaryNavItem>
         <NavSeparator />
-        <PrimaryNavItem target="_blank" href={graphiqlPath}>
+        <PrimaryNavItem
+          target="_blank"
+          href={graphiqlPath}
+          title="Graphiql Console"
+        >
           <TerminalIcon />
+          <A11yText>Graphiql Console</A11yText>
         </PrimaryNavItem>
         <NavSeparator />
-        <PrimaryNavItem to={`${adminPath}/style-guide`}>
+        <PrimaryNavItem to={`${adminPath}/style-guide`} title="Style Guide">
           <TelescopeIcon />
+          <A11yText>Style Guide</A11yText>
         </PrimaryNavItem>
         <NavSeparator />
         <PrimaryNavItem to={`${adminPath}/signin`} title="Sign Out">

--- a/packages/admin-ui/client/pages/Home/index.js
+++ b/packages/admin-ui/client/pages/Home/index.js
@@ -71,15 +71,18 @@ class HomePage extends Component {
                           {isSmall => (
                             <Cell width={isSmall ? 6 : 3}>
                               <Box
+                                title={`Show ${list.label}`}
                                 to={`${adminPath}/${list.path}`}
                                 onMouseEnter={this.selectActive(key)}
                                 onMouseLeave={this.deselectActive}
                                 onFocus={this.selectActive(key)}
                                 onBlur={this.deselectActive}
                               >
+                                <A11yText>Show {list.label}</A11yText>
                                 <Name isHover={isActive}>{list.label}</Name>
                                 <Count meta={listMeta} />
                                 <CreateButton
+                                  title={`Create ${list.singular}`}
                                   isHover={isActive}
                                   onClick={this.openCreateModal(key)}
                                 >

--- a/packages/ui/src/primitives/fields.js
+++ b/packages/ui/src/primitives/fields.js
@@ -1,10 +1,14 @@
 import styled from 'react-emotion';
 import { colors } from '../theme';
+import { withSelector } from './misc';
 
-export const FieldContainer = styled.div({
-  display: 'flex',
-  marginBottom: 8,
-});
+export const FieldContainer = withSelector(
+  'field-container',
+  styled.div({
+    display: 'flex',
+    marginBottom: 8,
+  })
+);
 
 export const FieldLabel = styled.label({
   color: colors.N60,

--- a/packages/ui/src/primitives/misc.js
+++ b/packages/ui/src/primitives/misc.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'react-emotion';
 
 export const A11yText = styled.span({
@@ -10,3 +11,10 @@ export const A11yText = styled.span({
   whiteSpace: 'nowrap',
   width: 1,
 });
+
+// This function wraps a component and adds a `data-selector` attribue
+// which can be used by test system to select DOM elements.
+export const withSelector = (id, WrappedComponent) =>
+  process.env.NODE_ENV === 'production'
+    ? WrappedComponent
+    : props => <WrappedComponent data-selector={id} {...props} />;

--- a/packages/ui/src/primitives/modals/dialog.js
+++ b/packages/ui/src/primitives/modals/dialog.js
@@ -10,6 +10,7 @@ import { Fade, SlideUp, withTransitionState } from './transitions';
 import { Blanket } from './common';
 import { colors } from '../../theme';
 import { alpha } from '../../theme/color-utils';
+import { A11yText } from '../misc';
 
 const outerGutter = 40;
 const innerGutter = 20;
@@ -114,6 +115,7 @@ class ModalDialog extends PureComponent<Props> {
           <Positioner width={width}>
             <FocusTrap options={{ initialFocus }}>
               <Dialog>
+                <A11yText>{heading} Dialog</A11yText>
                 {heading ? (
                   <Header>
                     <Title>{heading}</Title>


### PR DESCRIPTION
This PR implements tests of current admin UI for `test-project`. It includes some minor tweaks to the UI to make it more testable.

A helper component wrapper `withSelector` is added, which allows particular component types to have a `data-selector` added to them in development mode. This allows the test systems to perform DOM selection without coupling to the CSS selectors.