### PR TITLE
Add support for test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ To run the unit tests, run the script
 
 Unit tests for each package can be found in `packages/<package>/tests` and following the naming pattern `<module>.test.js`.
 
+To see test coverage of the files touched by the unit tests, run
+
+`bolt jest --coverage`
+
+To see test coverage of the entire mono-repo, including files which have zero test coverage, use the special script
+
+`bolt coverage`
+
 ### End to end tests
 
 Keystone tests end to end functionality with the help of [Cypress](https://www.cypress.io/). To run these tests, you first need to start the `test-project` application by running

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "cypress:open": "cypress open",
     "lint": "yarn prettier_lint && yarn eslint",
     "test": "yarn lint && yarn jest",
-    "test:all": "yarn test && yarn cypress:run"
+    "test:all": "yarn test && yarn cypress:run",
+    "coverage": "jest --coverage --collectCoverageFrom=packages/**/*.{js}"
   },
   "dependencies": {
     "apollo-cache-inmemory": "^1.1.12",

--- a/packages/admin-ui/tests/server/AdminUI.test.js
+++ b/packages/admin-ui/tests/server/AdminUI.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+const AdminUI = require('../../server/AdminUI.js');
+
+const keystone = {
+  session: {
+    validate: () => jest.fn(),
+  },
+  getAdminSchema: jest.fn(),
+  getAdminMeta: jest.fn(),
+};
+const adminPath = 'admin_path';
+const cookieSecret = 'cookiesecret';
+
+test('new AdminUI() - smoke test', () => {
+  const adminUI = new AdminUI(keystone, { adminPath });
+  expect(adminUI).not.toBe(null);
+
+  expect(adminUI.keystone).toEqual(keystone);
+});
+
+describe('Add Middleware', () => {
+  test('Smoke test', () => {
+    const adminUI = new AdminUI(keystone, { adminPath });
+
+    expect(adminUI.createSessionMiddleware({ cookieSecret })).not.toBe(null);
+    expect(adminUI.createGraphQLMiddleware()).not.toBe(null);
+    expect(adminUI.createDevMiddleware()).not.toBe(null);
+  });
+});

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -1,0 +1,58 @@
+import FieldController from '../Controller';
+
+const config = {
+  path: 'path',
+  label: 'label',
+  type: 'type',
+  list: 'list',
+  adminMeta: 'adminMeta',
+  defaultValue: 'default',
+};
+
+describe('new Controller()', () => {
+  test('new Controller() - Smoke test', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    expect(controller).not.toBeNull();
+
+    expect(controller.config).toEqual(config);
+    expect(controller.label).toEqual('label');
+    expect(controller.type).toEqual('type');
+    expect(controller.list).toEqual('list');
+    expect(controller.adminMeta).toEqual('adminMeta');
+  });
+});
+
+test('getQueryFragment()', () => {
+  const controller = new FieldController(config, 'list', 'adminMeta');
+
+  const value = controller.getQueryFragment();
+  expect(value).toEqual('path');
+});
+
+describe('getValue()', () => {
+  test('getValue() - path exists', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    let value = controller.getValue({ path: 'some_value' });
+    expect(value).toEqual('some_value');
+  });
+
+  test('getValue() - path does not exist', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    const value = controller.getValue({});
+    expect(value).toEqual('');
+  });
+});
+
+describe('getInitialData()', () => {
+  test('getInitialData() - Default defined', () => {
+    const controller = new FieldController(config, 'list', 'adminMeta');
+    const value = controller.getInitialData();
+    expect(value).toEqual('default');
+  });
+
+  test('getInitialData() - No default', () => {
+    const controller = new FieldController({}, 'list', 'adminMeta');
+    const value = controller.getInitialData();
+    expect(value).toEqual('');
+  });
+});

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -1,0 +1,178 @@
+const Field = require('../Implementation');
+
+const config = {
+  label: 'config label',
+  defaultValue: 'default',
+};
+
+const args = {
+  getListByKey: {},
+  listKey: {},
+};
+
+describe('new Implementation()', () => {
+  test('new Implementation() - Smoke test', () => {
+    const impl = new Field(
+      'path',
+      {},
+      {
+        getListByKey: {},
+        listKey: {},
+      }
+    );
+    expect(impl).not.toBeNull();
+    expect(impl.path).toEqual('path');
+    expect(impl.config).toEqual({});
+    expect(impl.getListByKey).toEqual({});
+    expect(impl.listKey).toEqual({});
+    expect(impl.label).toEqual('Path');
+  });
+
+  test('new Implementation - label from config', () => {
+    const impl = new Field('path', config, args);
+    expect(impl.label).toEqual('config label');
+  });
+});
+
+test('addToMongooseSchema()', () => {
+  const impl = new Field('path', config, args);
+
+  expect(() => {
+    impl.addToMongooseSchema();
+  }).toThrow(Error);
+});
+
+test('getGraphqlSchema()', () => {
+  const impl = new Field('path', config, args);
+
+  // By default graphQLType is undefined and getGraphqlSchema should throw an Error.
+  expect(impl.graphQLType).toBe(undefined);
+  expect(() => {
+    impl.getGraphqlSchema();
+  }).toThrowError(Error);
+
+  // Setting graphQLType should cause the method to return a valid value.
+  impl.graphQLType = 'graphQL type';
+  const value = impl.getGraphqlSchema();
+  expect(value).toEqual('path: graphQL type');
+});
+
+test('getGraphqlAuxiliaryTypes()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryTypes();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlAuxiliaryTypeResolvers()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryTypeResolvers();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlAuxiliaryQueries()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryQueries();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlAuxiliaryQueryResolvers()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryQueryResolvers();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlAuxiliaryMutations()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryMutations();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlAuxiliaryMutationResolvers()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlAuxiliaryMutationResolvers();
+  expect(value).toBe(undefined);
+});
+
+test('createFieldPreHook()', () => {
+  const impl = new Field('path', config, args);
+
+  const data = { a: 1 };
+  const value = impl.createFieldPreHook(data);
+  expect(value).toEqual(data);
+});
+
+test('createFieldPostHook()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.createFieldPostHook();
+  expect(value).toBe(undefined);
+});
+
+test('updateFieldPreHook()', () => {
+  const impl = new Field('path', config, args);
+
+  const data = { a: 1 };
+  const value = impl.updateFieldPreHook(data);
+  expect(value).toEqual(data);
+});
+
+test('updateFieldPostHook()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.updateFieldPostHook();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlQueryArgs()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlQueryArgs();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlUpdateArgs()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlUpdateArgs();
+  expect(value).toBe(undefined);
+});
+
+test('getGraphqlFieldResolvers()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getGraphqlFieldResolvers();
+  expect(value).toBe(undefined);
+});
+
+test('getQueryConditions()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getQueryConditions();
+  expect(value).toEqual([]);
+});
+
+test('getAdminMeta()', () => {
+  const impl = new Field('path', config, args);
+
+  const value = impl.getAdminMeta();
+  expect(value).toEqual({
+    label: 'config label',
+    path: 'path',
+    type: 'Field',
+    defaultValue: 'default',
+  });
+});
+
+test('extendAdminMeta()', () => {
+  const impl = new Field('path', config, args);
+
+  const meta = { a: 1 };
+  const value = impl.extendAdminMeta(meta);
+  expect(value).toEqual(meta);
+});


### PR DESCRIPTION
Coverage information can be obtained by running

`bolt jest --coverage`

This only provide info about the files which `jest` touches. Files with zero coverage are not included. To see complete coverage, this PR adds a new script

`bolt coverage`

which covers all files in the repo.

The PR also adds some new smoke tests for the admin UI and fields interface.
