### PR TITLE
Ensure auxiliary queries/mutations are unique

### DIFF
--- a/packages/core/Keystone/index.js
+++ b/packages/core/Keystone/index.js
@@ -87,12 +87,16 @@ module.exports = class Keystone {
     // Deduping here avoids that problem.
     listTypes = unique(listTypes);
 
-    let queries = flatten(
-      this.listsArray.map(list => list.getAdminGraphqlQueries())
-    ).map(trim);
-    let mutations = flatten(
-      this.listsArray.map(list => list.getAdminGraphqlMutations())
-    ).map(trim);
+    let queries = unique(
+      flatten(this.listsArray.map(list => list.getAdminGraphqlQueries())).map(
+        trim
+      )
+    );
+    let mutations = unique(
+      flatten(this.listsArray.map(list => list.getAdminGraphqlMutations())).map(
+        trim
+      )
+    );
     const typeDefs = `
       type Query {
         ${queries.join('')}


### PR DESCRIPTION
Noticed an error when enabling CloudinaryImage types on multiple lists - it was incorrectly trying to insert the global upload mutation multiple times.

Note that I don't agree with what prettier has done here, but 🤷‍♂️ it works.