### PR TITLE
Update cors.js

### DIFF
--- a/lib/middleware/cors.js
+++ b/lib/middleware/cors.js
@@ -29,6 +29,9 @@ module.exports = function (keystone) {
 		if (keystone.get('cors allow headers') !== false) {
 			res.header('Access-Control-Allow-Headers', keystone.get('cors allow headers') || 'Content-Type, Authorization');
 		}
+		if (keystone.get('cors allow credentials') !== false) {
+			res.header('Access-Control-Allow-Credentials', 'true');
+		}
 
 		next();
 	};


### PR DESCRIPTION
Add Access-Control-Allow-Credentials header to cors middleware #4380
https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Allow-Credentials

The only valid value for this header is true, so I've not added in a "keystone.get('cors allow credentials')" bit like in the 'methods' and 'headers' settings.

Hopefully that seems ok!

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

