### PR TITLE
Fix integration tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,17 +58,18 @@ jobs:
       - image: circleci/node:carbon
       - image: mongo:3.4.4
 
-    working_directory: ~/repo
+    working_directory: /home/circleci/repo
 
     steps:
       - checkout
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          - v1-dependencies-
+          - v3-dependencies-{{ checksum "yarn.lock" }}
       - run: sudo apt-get install xvfb libgtk2.0-0 libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2
       - run: sudo yarn global add bolt
-      - run: bolt
+      - run:
+          name: Bolt - Install packages
+          command: CYPRESS_CACHE_FOLDER=$CIRCLE_WORKING_DIRECTORY/node_modules/cypress/.cache/ bolt
       - run:
           name: Starting test project
           command: yarn test:server:start
@@ -79,11 +80,11 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v3-dependencies-{{ checksum "yarn.lock" }}
 
       - run:
           name: Running E2E tests
-          command: yarn cypress:run --reporter junit --reporter-options "mochaFile=reports/junit/cypress-results.xml"
+          command: CYPRESS_CACHE_FOLDER=$CIRCLE_WORKING_DIRECTORY/node_modules/cypress/.cache/ yarn cypress:run --reporter junit --reporter-options "mochaFile=reports/junit/cypress-results.xml"
 
       - store_artifacts:
           path: cypress/videos


### PR DESCRIPTION
The new version of Cypress installs its binary application in a global cache

https://github.com/cypress-io/cypress/issues/1300

This causes builds on circleCI to fail, as they cannot find the install on a fresh machine.

This PR updates our config file to put this cache within the `node_modules` directory so that the package cache mechanism works correctly.