### PR TITLE
Fix #4652: Remove EOL Node releases from Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,6 @@ matrix:
         - npm run test-admin
       env:
         - JOB=unit_tests_node_6
-    - node_js: '5'
-      script:
-        - npm run test-admin
-      env:
-        - JOB=unit_tests_node_5
-    - node_js: '4'
-      script:
-        - npm run test-admin
-      env:
-        - JOB=unit_tests_node_4
 
 
 before_script:


### PR DESCRIPTION
## Description of change

Remove EOL Node releases (4,5) from Travis testing

## Related issues (if any)

#4652

## Testing

- [ x ] Please confirm `npm run test-all` ran successfully.
