### PR TITLE
show color swatch on color field

### DIFF
--- a/fields/types/color/ColorField.js
+++ b/fields/types/color/ColorField.js
@@ -9,6 +9,7 @@ import {
 	InlineGroupSection as Section,
 } from '../../../admin/client/App/elemental';
 import transparentSwatch from './transparent-swatch';
+import coloredSwatch from './colored-swatch';
 import theme from '../../../admin/client/theme';
 
 const ColorField = Field.create({
@@ -61,7 +62,8 @@ const ColorField = Field.create({
 		return (this.props.value) ? (
 			<span
 				className={className}
-				style={{ backgroundColor: this.props.value }}
+				style={{ color: this.props.value }}
+				dangerouslySetInnerHTML={{ __html: coloredSwatch }}
 			/>
 		) : (
 			<span
@@ -139,10 +141,11 @@ const classes = {
 	},
 	swatch: {
 		borderRadius: 1,
-		boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.1)',
+		boxShadow: '0 0 0 1px rgba(0,0,0,0.1)',
 		display: 'block',
-		height: '100%',
-		width: '100%',
+		' svg': {
+			display: 'block',
+		},
 	},
 };
 

--- a/fields/types/color/colored-swatch.js
+++ b/fields/types/color/colored-swatch.js
@@ -1,0 +1,7 @@
+module.exports = (
+	`<svg width="24" height="24" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+		<g fill="currentColor">
+			<rect x="0" y="0" width="24" height="24" />
+		</g>
+	</svg>`
+);


### PR DESCRIPTION
## Description of changes
Fixes the display of the color swatch in Color FieldType

Before: 
![image](https://user-images.githubusercontent.com/814227/41699092-616cb06c-7565-11e8-95a5-f13b4619628a.png)

After: 
![screen shot 2018-06-21 at 3 06 39 pm](https://user-images.githubusercontent.com/814227/41699047-1eced2b2-7565-11e8-8fc9-687f19155ede.png)

## Related issues (if any)
Fixes issue: https://github.com/keystonejs/keystone/issues/4074

## Testing

- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

