### PR TITLE
Provides a fix for a bug in Safari where XHR form submission fails wh…

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -127,13 +127,13 @@ var EditForm = React.createClass({
 
 		// Fix for Safari where XHR form submission fails when input[type=file] is empty
 		// https://stackoverflow.com/questions/49614091/safari-11-1-ajax-xhr-form-submission-fails-when-inputtype-file-is-empty
-		editForm.querySelectorAll("input[type='file']").each(function () {
+		$(editForm).find("input[type='file']").each(function () {
 			if ($(this).get(0).files.length === 0) { $(this).prop('disabled', true); }
 		});
 
 		const formData = new FormData(editForm);
 
-		editForm.querySelectorAll("input[type='file']").each(function () {
+		$(editForm).find("input[type='file']").each(function () {
 			if ($(this).get(0).files.length === 0) { $(this).prop('disabled', false); }
 		});
 

--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -124,7 +124,18 @@ var EditForm = React.createClass({
 	updateItem () {
 		const { data, list } = this.props;
 		const editForm = this.refs.editForm;
+
+		// Fix for Safari where XHR form submission fails when input[type=file] is empty
+		// https://stackoverflow.com/questions/49614091/safari-11-1-ajax-xhr-form-submission-fails-when-inputtype-file-is-empty
+		editForm.querySelectorAll("input[type='file']").each(function () {
+			if ($(this).get(0).files.length === 0) { $(this).prop('disabled', true); }
+		});
+
 		const formData = new FormData(editForm);
+
+		editForm.querySelectorAll("input[type='file']").each(function () {
+			if ($(this).get(0).files.length === 0) { $(this).prop('disabled', false); }
+		});
 
 		// Show loading indicator
 		this.setState({


### PR DESCRIPTION
…en input[type=file] is empty

## Description of changes
Fixes issue with uploading any type of file in the Keystone admin interface in Safari (https://github.com/keystonejs/keystone/issues/4656).
I closely observed the behavior of the associated POST requests and eventually found the solution to be caused by a problem described here: https://stackoverflow.com/questions/49614091/safari-11-1-ajax-xhr-form-submission-fails-when-inputtype-file-is-empty.
Applied the cross-browser solution that's listed at the StackOverflow question.

## Related issues (if any)
N/A

## Testing
Linting passes. 
Further testing:
```
  952 passing (8s)
  1 pending
  1 failing

  1) FieldType: Markdown: Filter "before all" hook:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```