### PR TITLE
[FIX] Make required respect dependsOn on Relationship fields too

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -72,9 +72,9 @@ relationship.prototype.addToSchema = function (schema) {
 	var def = {
 		type: this._nativeType,
 		ref: this.options.ref,
-		index: (this.options.index ? true : false),
-		required: (this.options.required ? true : false),
-		unique: (this.options.unique ? true : false),
+		index: (this.options.index ? this.options.index : false),
+		required: (this.options.required ? this.options.required : false),
+		unique: (this.options.unique ? this.options.unique : false),
 	};
 	this.paths = {
 		refList: this.options.refListPath || this.path + 'RefList',

--- a/test/models/DependsOn.js
+++ b/test/models/DependsOn.js
@@ -11,6 +11,7 @@ DependsOn.add({
 	title: { type: String, required: true, default: '' },
 	state: { type: Types.Select, options: 'draft, published, archived', default: 'draft' },
 	publishedDate: { type: Types.Date, dependsOn: {state: 'published'}, required: true, initial: false },
+	relativeDependsOn: { type: Types.Relationship, ref: 'DependsOn', dependsOn: {state: 'published'}, required: true, initial: false },
 });
 
 DependsOn.register();

--- a/test/unit/lib/list/dependsOn.js
+++ b/test/unit/lib/list/dependsOn.js
@@ -10,26 +10,24 @@ var DependsOn = keystone.list('DependsOn');
 describe('Test dependsOn and required', function () {
 
 	it('Ignore required if evalDependsOn is not `true` by setting `state` to `draft`', function (done) {
-		// remove any Post documents
+		// remove any DependsOn documents
 		DependsOn.model.find({}).remove(function (error) {
 			if (error) {
 				done(error);
 			}
 
-			var newPost = new DependsOn.model({
+			var newDependsOn = new DependsOn.model({
 				title: 'new post',
 				state: 'draft'
 			});
 
-			newPost.save(done);
+			newDependsOn.save(done);
 
 		});
 	});
 
-
-
 	it('Save will fail if `state` set to `published` and `publishedDate` is not defined', function (done) {
-		// remove any Post documents
+		// remove any DependsOn documents
 		DependsOn.model.find({}).remove(function (error) {
 			if (error) {
 				done(error);
@@ -39,13 +37,15 @@ describe('Test dependsOn and required', function () {
 			const backupLog = console.error;
 			console.error = () => null;
 
-			var newPost = new DependsOn.model({
+			var newDependsOn = new DependsOn.model({
 				title: 'new post',
 				state: 'published',
 				publishedDate: undefined,
 			});
+			
+			newDependsOn.relativeDependsOn = newDependsOn._id;
 
-			newPost.save(function (err) {
+			newDependsOn.save(function (err) {
 				demand(err).be.a.object();
 
 				console.error = backupLog;
@@ -55,20 +55,51 @@ describe('Test dependsOn and required', function () {
 
 	});
 
-	it('Save will succeed if `state` set to `published` and `publishedDate` is defined', function (done) {
-
-		// remove any Post documents
+	it('Save will fail if `state` set to `published` and `relativeDependsOn` is not defined', function (done) {
+		// remove any DependsOn documents
 		DependsOn.model.find({}).remove(function (error) {
 			if (error) {
 				done(error);
 			}
 
-			var newPost = new DependsOn.model({
+			// suppressing console log output
+			const backupLog = console.error;
+			console.error = () => null;
+
+			var newDependsOn = new DependsOn.model({
 				title: 'new post',
 				state: 'published',
-				publishedDate: new Date()
+				publishedDate: new Date(),
+				relativeDependsOn: undefined,
 			});
-			newPost.save(done);
+
+			newDependsOn.save(function (err) {
+				demand(err).be.a.object();
+
+				console.error = backupLog;
+				done();
+			});
+		});
+
+	});
+
+	it('Save will succeed if `state` set to `published` and `publishedDate` and `relativeDependsOn` are defined', function (done) {
+
+		// remove any DependsOn documents
+		DependsOn.model.find({}).remove(function (error) {
+			if (error) {
+				done(error);
+			}
+
+			var newDependsOn = new DependsOn.model({
+				title: 'new post',
+				state: 'published',
+				publishedDate: new Date(),
+			});
+			
+			newDependsOn.relativeDependsOn = newDependsOn._id;
+			
+			newDependsOn.save(done);
 
 		});
 	});


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes

Fixes a bug: work done by https://github.com/keystonejs/keystone/pull/2200 did not apply to Relationship fields.

## Testing

<!-- List browser version(s) any admin UI changes were tested in -->

- [x] Please confirm you've added test coverage for this change.
- [x] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

