### PR TITLE
Include keystone.version in startup message

### DIFF
--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -55,7 +55,7 @@ function start (events) {
 
 		var ssl = keystone.get('ssl');
 		var unixSocket = keystone.get('unix socket');
-		var startupMessages = ['KeystoneJS Started:'];
+		var startupMessages = [`KeystoneJS ${keystone.version} started:`];
 
 		async.parallel([
 			// HTTP Server

--- a/lib/core/start.js
+++ b/lib/core/start.js
@@ -55,7 +55,7 @@ function start (events) {
 
 		var ssl = keystone.get('ssl');
 		var unixSocket = keystone.get('unix socket');
-		var startupMessages = [`KeystoneJS ${keystone.version} started:`];
+		var startupMessages = [`KeystoneJS v${keystone.version} started:`];
 
 		async.parallel([
 			// HTTP Server


### PR DESCRIPTION
## Description of changes

Include `keystone.version` in startup message

## Testing

Only changes startup message. Uses template literal for readability so requires Node 4+.