### PR TITLE
Remove unused title markdown from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
----
-title: KeystoneJS
----
-
 ![KeystoneJS](http://keystonejs.com/images/logo.svg)
 ===================================
 


### PR DESCRIPTION
## Description of changes

Remove unused title markdown from README.md. This was added in 0c8bfa1 (initial Gatsby commit) but appears to be unused (and a tag fugly).

## Testing

Checked Gatsby docs for reference to README.md and confirmed this change doesn't appear to affect anything.

Gatsby title comes from `website/gatsby-config`: https://github.com/keystonejs/keystone/blob/master/website/gatsby-config.js#L3