### PR TITLE
Enhance numeric fields

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -79,7 +79,7 @@ var EditForm = React.createClass({
 				props.isValid = false;
 			}
 		}
-		props.value = this.state.values[field.path];
+		props.value = this.state.values[field.path] || field.defaultValue;
 		props.values = this.state.values;
 		props.onChange = this.handleChange;
 		props.mode = 'edit';

--- a/fields/mixins/ArrayField.js
+++ b/fields/mixins/ArrayField.js
@@ -59,7 +59,9 @@ module.exports = {
 		var updatedValues = this.state.values;
 		var updateIndex = updatedValues.indexOf(i);
 		var newValue = event.value || event.target.value;
-		updatedValues[updateIndex].value = this.cleanInput ? this.cleanInput(newValue) : newValue;
+		if (this.isValid === undefined || this.isValid(newValue)) {
+			updatedValues[updateIndex].value = this.cleanInput ? this.cleanInput(newValue) : newValue;
+		}
 		this.setState({
 			values: updatedValues,
 		});

--- a/fields/types/numberarray/NumberArrayField.js
+++ b/fields/types/numberarray/NumberArrayField.js
@@ -10,8 +10,8 @@ module.exports = Field.create({
 
 	mixins: [ArrayFieldMixin],
 
-	cleanInput (input) {
-		return input.replace(/[^\d]/g, '');
+	isValid (input) {
+		return /^-?\d*\.?\d*$/.test(input);
 	},
 
 });

--- a/test/e2e/adminUI/tests/group006Fields/testNumberArrayField.js
+++ b/test/e2e/adminUI/tests/group006Fields/testNumberArrayField.js
@@ -122,4 +122,54 @@ module.exports = {
 			],
 		});
 	},
+	'NumberArray field can save negative values': function (browser) {
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldA', input: { number1: '1', number2: '-2' }, },
+			],
+		});
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldB', input: { number1: '3', number2: '-4' }, },
+			],
+		});
+
+		browser.adminUIItemScreen.save();
+		browser.adminUIApp.waitForItemScreen();
+
+		browser.adminUIItemScreen.assertElementTextEquals({ element: '@flashMessage', text: 'Your changes have been saved successfully' });
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			fields: [
+				{ name: 'name', input: { value: 'NumberArray Field Test 1' }, },
+				{ name: 'fieldA', input: { number1: '1', number2: '-2' }, },
+				{ name: 'fieldB', input: { number1: '3', number2: '-4' }, },
+			],
+		});
+	},
+	'NumberArray field can save decimal values': function (browser) {
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldA', input: { number1: '1', number2: '2.5' }, },
+			],
+		});
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldB', input: { number1: '3', number2: '4.5' }, },
+			],
+		});
+
+		browser.adminUIItemScreen.save();
+		browser.adminUIApp.waitForItemScreen();
+
+		browser.adminUIItemScreen.assertElementTextEquals({ element: '@flashMessage', text: 'Your changes have been saved successfully' });
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			fields: [
+				{ name: 'name', input: { value: 'NumberArray Field Test 1' }, },
+				{ name: 'fieldA', input: { number1: '1', number2: '2.5' }, },
+				{ name: 'fieldB', input: { number1: '3', number2: '4.5' }, },
+			],
+		});
+	}
 };

--- a/test/e2e/adminUI/tests/group006Fields/testNumberField.js
+++ b/test/e2e/adminUI/tests/group006Fields/testNumberField.js
@@ -81,4 +81,42 @@ module.exports = {
 			],
 		})
 	},
+	'Number field should save negative values': function (browser) {
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldB', input: { value: '-5' }, },
+			],
+		});
+		browser.adminUIItemScreen.save();
+		browser.adminUIApp.waitForItemScreen();
+
+		browser.adminUIItemScreen.assertElementTextEquals({ element: '@flashMessage', text: 'Your changes have been saved successfully' });
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			fields: [
+				{ name: 'name', input: { value: 'Number Field Test 1' }, },
+				{ name: 'fieldA', input: { value: '1' }, },
+				{ name: 'fieldB', input: { value: '-5' }, },
+			],
+		});
+	},
+	'Number field should save decimal values': function (browser) {
+		browser.adminUIItemScreen.fillFieldInputs({
+			fields: [
+				{ name: 'fieldB', input: { value: '4.5' }, },
+			],
+		});
+		browser.adminUIItemScreen.save();
+		browser.adminUIApp.waitForItemScreen();
+
+		browser.adminUIItemScreen.assertElementTextEquals({ element: '@flashMessage', text: 'Your changes have been saved successfully' });
+
+		browser.adminUIItemScreen.assertFieldInputs({
+			fields: [
+				{ name: 'name', input: { value: 'Number Field Test 1' }, },
+				{ name: 'fieldA', input: { value: '1' }, },
+				{ name: 'fieldB', input: { value: '4.5' }, },
+			],
+		});
+	}
 };


### PR DESCRIPTION
## Description of changes

This PR will enhance the functionality and tests for `NumberField` and `NumberArrayField`.

1) In `EditForm` it was possible to write any characters to an empty `NumberField`. This was caused by the uncontrolled React component as the default value for the field was not used and the `value` was therefore `undefined` for the empty fields. It behaves now similarly to `CreateForm`.

2) `NumberArrayField` now saves decimal values properly (#4564). This is done by adding a new optional `isValid` function to array fields. If the function exists and returns `false`, the state is not modified and the user input is omitted.

3) `NumberArrayField` now also saves negative values properly. `NumberArrayField` uses now the same regular expression as `NumberField` to check whether the input is valid.

4) Tests for both numeric fields now have test cases for negative and decimal values.


## Related issues (if any)

#4564 

## Testing

Tested with Firefox 61, Chromium 66

- [x] Please confirm you've added (or verified) test coverage for this change.
- [x] Please confirm `npm run test-all` ran successfully.
