### PR TITLE
 Upgrade Mongoose to 4.13.14

### DIFF
--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -32,6 +32,7 @@ module.exports = function openDatabaseConnection (callback) {
 				rs_name: replicaData.db.replicaSetOptions.rs_name,
 				readPreference: replicaData.db.replicaSetOptions.readPreference,
 			},
+			useMongoClient: true,
 		};
 
 		debug('connecting to replica set');
@@ -40,7 +41,9 @@ module.exports = function openDatabaseConnection (callback) {
 	} else {
 		debug('connecting to mongo');
 		keystone.initDatabaseConfig();
-		keystone.mongoose.connect(keystone.get('mongo'), keystone.get('mongo options'));
+		var mongo_options = keystone.get('mongo options') || {};
+		mongo_options.useMongoClient = true;
+		keystone.mongoose.connect(keystone.get('mongo'), mongo_options);
 	}
 
 	keystone.mongoose.connection.on('error', function (err) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
     "moment": "2.19.3",
-    "mongoose": "4.9.2",
+    "mongoose": "4.13.14",
     "morgan": "1.9.0",
     "multer": "0.1.8",
     "numeral": "2.0.6",

--- a/test/pretest.js
+++ b/test/pretest.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 var mongoUri = 'mongodb://localhost/test';
 
 function dropTestDatabase(done) {
-	mongoose.connect(mongoUri,function (err) {
+	mongoose.connect(mongoUri, { useMongoClient: true }, function (err) {
 		if (!err) {
 			mongoose.connection.db.dropDatabase(function (err) {
 				mongoose.connection.close(function (err) {


### PR DESCRIPTION
## Description of changes
  - Upgrade Mongoose to 4.13.14: https://github.com/Automattic/mongoose/blob/master/History.md#41314--2018-05-25
  - Add useMongoClient per http://thecodebarbarian.com/mongoose-4.11-use-mongo-client.html

## Related issues (if any)

## Testing
 - [x] List browser version(s) any admin UI changes were tested in: Chrome 67.0.3396.99, Firefox 61.0
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.
