### PR TITLE
Add pointer to Keystone 4 beta/RC release notes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 KeystoneJS is maintained by [@JedWatson](https://github.com/JedWatson) and an amazing team of contributors. All contributions are given credit here except for Jed's.
 
+Release notes for Keystone 4 beta & release candidates can be found on the [GitHub releases]( https://github.com/keystonejs/keystone/releases) page.
+
+Changes for production releases are included below.
 
 ## v0.3.22 / 2016-07-22
 


### PR DESCRIPTION
## Description of changes

Add pointer to 4.x beta/RC release notes, which differ in format and detail from the current history.

Since the current history doesn't include any previous beta/RC releases, it probably makes sense to either resume adding with 4.0.0 GA or to reset HISTORY.md to be specific to the 4.x release series (with a pointer to the older history on GitHub).

In the interim, the 4.x history should be more discoverable.

## Related issues (if any)
 #4481 

## Testing
n/a
