### PR TITLE
Replace / with . to delimiter the file extension

### DIFF
--- a/docs/Getting Started/Setting-Up/part-3.md
+++ b/docs/Getting Started/Setting-Up/part-3.md
@@ -123,7 +123,7 @@ The keystone importer gives us a function that allows us to reduce a folder and 
 
 We then call `importRoutes` with the directory we want to import, and attach it to an object at `routes.views`. Finally, we can now provide `routes.views.index` as the second argument for our `app.get` function call.
 
-This is a bit heavyweight for a single route, but makes it easy to add new routes, without requiring a litany of requirements of every file as you go along. We're going to need some content in `routes/views/index/js` for this to run now.
+This is a bit heavyweight for a single route, but makes it easy to add new routes, without requiring a litany of requirements of every file as you go along. We're going to need some content in `routes/views/index.js` for this to run now.
 
 #### `routes/views/index.js`
 


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Updated the filename to read index.js in the Step 3 of the documentation

## Related issues (if any)


## Testing

Its a documentation change, no need for test cases

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

