### PR TITLE
#4589: Update to Mongoose 5.0

### DIFF
--- a/admin/server/api/counts.js
+++ b/admin/server/api/counts.js
@@ -4,7 +4,7 @@ module.exports = function (req, res) {
 	var keystone = req.keystone;
 	var counts = {};
 	async.each(keystone.lists, function (list, next) {
-		list.model.count(function (err, count) {
+		list.model.countDocuments(function (err, count) {
 			counts[list.key] = count;
 			next(err);
 		});

--- a/admin/server/api/list/get.js
+++ b/admin/server/api/list/get.js
@@ -44,7 +44,7 @@ module.exports = function (req, res) {
 			if (!includeCount) {
 				return next(null, 0);
 			}
-			query.count(next);
+			query.countDocuments(next);
 		},
 		function (count, next) {
 			if (!includeResults) {

--- a/docs/Getting Started/yo-generator.md
+++ b/docs/Getting Started/yo-generator.md
@@ -41,7 +41,7 @@ keystone.init({
   'view engine': 'pug',
 
   'auto update': true,
-  'mongo': 'mongodb://localhost/my-project',
+  'mongo': 'mongodb://localhost:27017/my-project',
 
   'session': true,
   'auth': true,

--- a/docs/documentation/Configuration/Database-Options.md
+++ b/docs/documentation/Configuration/Database-Options.md
@@ -6,7 +6,7 @@ The following options control your database configuration and user models / auth
 
 The url for your MongoDB connection.
 
-You should typically set this to `process.env.MONGO_URI || "mongodb://localhost/your-db"`, which will cause it to default to localhost unless a MONGO_URI is explicitly provided in the environment.
+You should typically set this to `process.env.MONGO_URI || "mongodb://localhost:27017/your-db"`, which will cause it to default to localhost unless a MONGO_URI is explicitly provided in the environment. mongodb port is required, default 27017
 
 <h4 data-primitive-type="String"><code>model prefix</code></h4>
 

--- a/fields/types/markdown/MarkdownType.js
+++ b/fields/types/markdown/MarkdownType.js
@@ -1,4 +1,5 @@
 var FieldType = require('../Type');
+var keystone = require('../../../');
 var marked = require('marked');
 var sanitizeHtml = require('sanitize-html');
 var TextType = require('../text/TextType');
@@ -51,6 +52,14 @@ markdown.prototype.addToSchema = function (schema) {
 	var sanitizeOptions = this.sanitizeOptions;
 
 	var setMarkdown = function (value) {
+
+		// Need to check if `this` is a document, because in mongoose 5 setters will also run on queries,
+		// in which case `this` will be amongoose query object.
+		// in that case we need to return the value as is
+		if (!(this instanceof keystone.mongoose.Document)) {
+			return value;
+		}
+
 		// Clear if saving invalid value
 		if (typeof value !== 'string') {
 			this.set(paths.md, undefined);

--- a/index.js
+++ b/index.js
@@ -86,7 +86,6 @@ var Keystone = function () {
 
 	// init mongoose
 	this.set('mongoose', require('mongoose'));
-	this.mongoose.Promise = require('es6-promise').Promise;
 
 	// Attach middleware packages, bound to this instance
 	this.middleware = {

--- a/lib/core/initExpressSession.js
+++ b/lib/core/initExpressSession.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 var session = require('express-session');
 var cookieParser = require('cookie-parser');
 var debug = require('debug')('keystone:core:initExpressSession');
-var Promise = require('es6-promise').Promise;
+// var Promise = require('es6-promise').Promise;
 var safeRequire = require('../safeRequire');
 
 module.exports = function initExpressSession (mongoose) {

--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -32,7 +32,6 @@ module.exports = function openDatabaseConnection (callback) {
 				rs_name: replicaData.db.replicaSetOptions.rs_name,
 				readPreference: replicaData.db.replicaSetOptions.readPreference,
 			},
-			useMongoClient: true,
 		};
 
 		debug('connecting to replica set');
@@ -42,7 +41,6 @@ module.exports = function openDatabaseConnection (callback) {
 		debug('connecting to mongo');
 		keystone.initDatabaseConfig();
 		var mongo_options = keystone.get('mongo options') || {};
-		mongo_options.useMongoClient = true;
 		keystone.mongoose.connect(keystone.get('mongo'), mongo_options);
 	}
 

--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -32,6 +32,7 @@ module.exports = function openDatabaseConnection (callback) {
 				rs_name: replicaData.db.replicaSetOptions.rs_name,
 				readPreference: replicaData.db.replicaSetOptions.readPreference,
 			},
+			useNewUrlParser: true,
 		};
 
 		debug('connecting to replica set');
@@ -41,6 +42,7 @@ module.exports = function openDatabaseConnection (callback) {
 		debug('connecting to mongo');
 		keystone.initDatabaseConfig();
 		var mongo_options = keystone.get('mongo options') || {};
+		mongo_options.useNewUrlParser = true;
 		keystone.mongoose.connect(keystone.get('mongo'), mongo_options);
 	}
 

--- a/lib/list/paginate.js
+++ b/lib/list/paginate.js
@@ -47,7 +47,7 @@ function paginate (options, callback) {
 	};
 
 	query.exec = function (callback) {
-		countQuery.count(function (err, count) {
+		countQuery.countDocuments(function (err, count) {
 			if (err) return callback(err);
 
 			query.find().limit(resultsPerPage).skip(skip);

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "method-override": "2.3.10",
     "mime-types": "2.1.15",
     "moment": "2.19.3",
-    "mongoose": "4.13.14",
+    "mongoose": "5.2.2",
     "morgan": "1.9.0",
     "multer": "0.1.8",
     "numeral": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "elemental": "0.6.1",
     "embedly": "2.1.0",
     "errorhandler": "1.5.0",
-    "es6-promise": "4.1.1",
     "express": "4.16.1",
     "express-request-language": "1.1.12",
     "express-session": "1.15.6",

--- a/test/e2e/server.js
+++ b/test/e2e/server.js
@@ -14,13 +14,13 @@ process.env.KNE_EXCLUDE_TEST_PATHS = 'test/e2e/adminUI/tests/group006Fields/comm
 
 // determine the mongo uri and database name
 var dbName = '/e2e' + (process.env.KEYSTONEJS_PORT || 3000);
-var mongoUri = 'mongodb://' + (process.env.KEYSTONEJS_HOST || 'localhost') + dbName;
+var mongoUri = 'mongodb://' + (process.env.KEYSTONEJS_HOST || 'localhost')  + ':27017' + dbName;
 
 // Function that drops the test database before starting testing
 function dropTestDatabase(done) {
 	console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: dropping test database: ' + mongoUri);
 
-	mongoose.connect(mongoUri,function(err){
+	mongoose.connect(mongoUri, { useNewUrlParser: true },function(err){
 		if (!err) {
 			mongoose.connection.db.dropDatabase(function (err) {
 				if (!err) {

--- a/test/helpers/getMongooseConnection.js
+++ b/test/helpers/getMongooseConnection.js
@@ -1,4 +1,4 @@
 var mongoose = require('mongoose');
 
-mongoose.connect('mongodb://localhost/test');
+mongoose.connect('mongodb://localhost:27017/test', { useNewUrlParser: true });
 module.exports = mongoose;

--- a/test/helpers/getMongooseConnection.js
+++ b/test/helpers/getMongooseConnection.js
@@ -1,3 +1,4 @@
 var mongoose = require('mongoose');
 
-module.exports = mongoose.connect('mongodb://localhost/test');
+mongoose.connect('mongodb://localhost/test');
+module.exports = mongoose;

--- a/test/pretest.js
+++ b/test/pretest.js
@@ -2,7 +2,7 @@ var mongoose = require('mongoose');
 var mongoUri = 'mongodb://localhost/test';
 
 function dropTestDatabase(done) {
-	mongoose.connect(mongoUri, { useMongoClient: true }, function (err) {
+	mongoose.connect(mongoUri, function (err) {
 		if (!err) {
 			mongoose.connection.db.dropDatabase(function (err) {
 				mongoose.connection.close(function (err) {

--- a/test/pretest.js
+++ b/test/pretest.js
@@ -1,8 +1,8 @@
 var mongoose = require('mongoose');
-var mongoUri = 'mongodb://localhost/test';
+var mongoUri = 'mongodb://localhost:27017/test';
 
 function dropTestDatabase(done) {
-	mongoose.connect(mongoUri, function (err) {
+	mongoose.connect(mongoUri, { useNewUrlParser: true }, function (err) {
 		if (!err) {
 			mongoose.connection.db.dropDatabase(function (err) {
 				mongoose.connection.close(function (err) {


### PR DESCRIPTION
## Description of changes
updated mongoose to 5.2, with mongodb connection useNewUrlParser option. Also updated collection.count deprecation notice which asks to use countDocuments instead of count. this breaks away from mongoose 5.0. requires 5.2 and above. 

## Related issues (if any)
#4589 

## Testing

 - [x] List browser version(s) any admin UI changes were tested in
    - tested in Chrome browser on mac, no change to admin ui
 - [x] Please confirm you've added (or verified) test coverage for this change.
    - no code coverage change
 - [x] Please confirm `npm run test-all` ran successfully.
