### PR TITLE
Fix broken links in part-2.md

### DIFF
--- a/docs/Getting Started/Setting-Up/part-2.md
+++ b/docs/Getting Started/Setting-Up/part-2.md
@@ -239,6 +239,6 @@ learn more about:
 - [configuring keystone](/documentation/configuration)
 - [importing models](/api/methods/import)
 - [list of keystone fields](/api/field)
-- [keystone field options](/api/fields/options)
-- [update scripts](/documentation/application-updates)
+- [keystone field options](/api/field/options)
+- [update scripts](/documentation/database/application-updates)
 - [virtuals and schema methods](/api/list/schema)


### PR DESCRIPTION
The links for "keystone field options" and "update scripts" were broken.

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Fixed links at the bottom of the page for "keystone field options" and "update scripts"

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

