### PR TITLE
Add new extend query params option

### DIFF
--- a/docs/documentation/Configuration/Server-Options.md
+++ b/docs/documentation/Configuration/Server-Options.md
@@ -97,6 +97,10 @@ Optional config options that will be passed to the morgan middleware; see [githu
 
 Set this to enable processing of the HTTP request `X-Forwarded-For` header. Extracted IP addresses will be available as the array `req.ips` ([see docs here](http://expressjs.com/en/api.html)).
 
+<h4 data-primitive-type="Boolean"><code>extend query params</code></h4>
+
+Optional config option to disable extending request query parameters; see [docs here](https://www.npmjs.com/package/body-parser#extended) for more information. If this is set to `false`, the value in `req.query` for each request parameter will always be a string or an array of strings. Defaults to `true`, ie. a value for the parameter can also be an object depending on the input. 
+
 ### Exposes `onHttpServerCreated` event
 
 ```javascript

--- a/server/bindBodyParser.js
+++ b/server/bindBodyParser.js
@@ -9,7 +9,9 @@ module.exports = function bindBodyParser (keystone, app) {
 		bodyParserParams.limit = keystone.get('file limit');
 	}
 	app.use(bodyParser.json(bodyParserParams));
-	bodyParserParams.extended = true;
+	if (keystone.get('extend query params') !== false) {
+		bodyParserParams.extended = true;
+	}
 	app.use(bodyParser.urlencoded(bodyParserParams));
 	if (keystone.get('handle uploads')) {
 		uploads.configure(app, keystone.get('multer options'));


### PR DESCRIPTION
## Description of changes

Adds a new optional config option `extend query params` which can be set to `false` to ensure that `req.query` will contain only string values.

Currently, GETting a page /mypage?a[r]=1 produces `{a: {r: 1}}` instead of a plain string which can crash the site if an object was not expected.

## Related issues (if any)

#4541 

## Testing

This does not affect the Admin UI as the default has not been changed and for the Admin UI this option is set elsewhere. There was not any suitable tests to extend to cover this feature.
