### PR TITLE
Links to demo.keystonejs.com should use http

### DIFF
--- a/website/src/pages/components/home/CommunityResponse.js
+++ b/website/src/pages/components/home/CommunityResponse.js
@@ -30,7 +30,7 @@ export default class ValueProps extends Component {
 
 				</Row>
 				<div>
-					<Link to="/getting-started" style={{ color: 'white' }}>Get Started</Link> <a href="https://demo.keystonejs.com" style={{ color: 'white' }}>Try the Demo</a>
+					<Link to="/getting-started" style={{ color: 'white' }}>Get Started</Link> <a href="http://demo.keystonejs.com" style={{ color: 'white' }}>Try the Demo</a>
 				</div>
 			</Container>
 		);

--- a/website/src/pages/components/home/header/Header.js
+++ b/website/src/pages/components/home/header/Header.js
@@ -25,7 +25,7 @@ export default class Header extends Component {
 						<h1 className={compose(styles.intro__title)}>Node.js CMS & web application platform</h1>
 						<p className={compose(styles.intro__lead)}>Keystone is an open source framework for developing database-driven websites, applications, and APIs in Node.js. Built on Express and MongoDB.</p>
 						<div className={compose(styles.home_header_buttons)}>
-							<Link to="/getting-started" className={compose(styles.button_home, styles.button_home_primary)}>Get Started</Link> <a href="https://demo.keystonejs.com" className={compose(styles.button_home, styles.button_home_inverse)}>Try the Demo</a>
+							<Link to="/getting-started" className={compose(styles.button_home, styles.button_home_primary)}>Get Started</Link> <a href="http://demo.keystonejs.com" className={compose(styles.button_home, styles.button_home_inverse)}>Try the Demo</a>
 						</div>
 						<ul className={compose(styles.list_links)}>
 							<li className={compose(styles.list_item)}>Current Version {version}</li>


### PR DESCRIPTION
## Description of changes

Change https to http

## Related issues (if any)

https://github.com/keystonejs/keystone-demo/issues/88 (Add SSL certificate for demo.keystonejs.com)
