### PR TITLE
Bumped version on website to v0.3.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ coverage
 coverage.html
 .cover*
 lib-cov
+website/.cache
+website/public
 
 docs/_dist
 admin/public/styles/auth.css

--- a/website/index.html
+++ b/website/index.html
@@ -30,8 +30,8 @@
         <div class="home-header-buttons"><a href="/getting-started" title="KeystoneJS getting started guide" class="btn btn-lg btn-primary"><span class="hidden-xs">Get Started</span><span class="visible-xs">Start</span></a><a href="http://demo.keystonejs.com" target="_blank" title="Demo Website (new window)" class="btn btn-lg btn-link hidden-xs">Try the demo</a></div>
         <ul class="home-header-list-links">
           <li><a href="/docs" title="KeystoneJS Documentation">Read the Documentation</a></li>
-          <li>Current version 0.3.17</li>
-          <li><a href="https://github.com/keystonejs/keystone/blob/master/HISTORY.md" target="_blank" title="View Changelog on GitHub">What's new</a></li>
+          <li>Current version 0.3.22</li>
+          <li><a href="https://github.com/keystonejs/keystone/blob/v0.3-docs/HISTORY.md" target="_blank" title="View Changelog on GitHub">What's new</a></li>
           <li>Free and open source (MIT)</li>
         </ul>
         <ul class="home-header-list-social">


### PR DESCRIPTION
- Bumped version number to v0.3.22 on home page
- Changed "What's new" button to link to v0.3-docs branch