### PR TITLE
Add Netlify redirects for v3 paths to v4 equivalents

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -26,5 +26,6 @@ module.exports = {
 				pathToConfigModule: 'utils/typography',
 			},
 		},
+		'gatsby-plugin-netlify',
 	],
 };

--- a/website/package.json
+++ b/website/package.json
@@ -10,6 +10,7 @@
     "gatsby": "^1.9.247",
     "gatsby-link": "^1.6.40",
     "gatsby-plugin-glamor": "^1.6.13",
+    "gatsby-plugin-netlify": "^1.0.21",
     "gatsby-plugin-react-helmet": "^2.0.10",
     "gatsby-plugin-twitter": "^1.0.20",
     "gatsby-plugin-typography": "^1.7.18",

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,0 +1,9 @@
+# Netlify redirects for Keystone v0.3 docs urls
+# See: https://www.netlify.com/docs/redirects/
+
+# V3 urls that have V4 equivalents
+/docs/*	   /documentation/:splat
+/guide     /getting-started
+
+# V3 urls that don't have V4 equivalents yet
+/examples  https://v3.keystonejs.com/examples  302


### PR DESCRIPTION
## Description of changes

Add some Netlify redirects for v3 paths in v4 docs

## Related issues (if any)

#4734

## Testing

Tested `_redirects` via https://play.netlify.com/redirects but these aren't testable locally.