### PR TITLE
Fixed a typo in Project-Options.md

### DIFF
--- a/docs/documentation/Configuration/Project-Options.md
+++ b/docs/documentation/Configuration/Project-Options.md
@@ -7,7 +7,7 @@ The following options control the branding, navigation and default export settin
 
 The name of the KeystoneJS application
 
-<h4 data-primitive-type="String"><code>name</code></h4>
+<h4 data-primitive-type="String"><code>brand</code></h4>
 
 Displayed in the top left hand corner of the Admin UI
 


### PR DESCRIPTION
The `name` option appears twice, instead of the 2nd being `brand`.

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

