### PR TITLE
Relationship Values not clearing via admin API

### DIFF
--- a/fields/types/relationship/RelationshipType.js
+++ b/fields/types/relationship/RelationshipType.js
@@ -222,10 +222,7 @@ relationship.prototype.updateItem = function (item, data, callback) {
 	}
 
 	var value = this.getValueFromData(data);
-	if (value === undefined) {
-		return process.nextTick(callback);
-	}
-
+	
 	// Are we handling a many relationship or just one value?
 	if (this.many) {
 		var arr = item.get(this.path);
@@ -244,7 +241,7 @@ relationship.prototype.updateItem = function (item, data, callback) {
 		if (value && value !== item.get(this.path)) {
 			// If it's set and has changed, I do.
 			item.set(this.path, value);
-		} else if (!value && item.get(this.path)) {
+		} else if ((value === undefined || !value) && item.get(this.path))  {
 			// If it's not set and it was set previously, I need to clear.
 			item.set(this.path, null);
 		}

--- a/lib/session.js
+++ b/lib/session.js
@@ -57,6 +57,7 @@ function signinWithUser (user, req, res, onSuccess) {
 				httpOnly: true,
 				maxAge: 10 * 24 * 60 * 60 * 1000,
 			});
+			req.session.cookie.maxAge = cookieOpts.maxAge;
 			res.cookie('keystone.uid', userToken, cookieOpts);
 		}
 		onSuccess(user);


### PR DESCRIPTION

When removing a relationship value in the admin API, the value wasn't clearing because there was a check forvalue === undefined which resulted in the update ignoring that change.

Tested and confirmed to be working


