### PR TITLE
Removing 'frontmatter' from raw HTML files

### DIFF
--- a/website/docs.html
+++ b/website/docs.html
@@ -1,6 +1,3 @@
----
-permalink: /docs/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/docs_configuration.html
+++ b/website/docs_configuration.html
@@ -1,6 +1,3 @@
----
-permalink: /docs/configuration/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/docs_database.html
+++ b/website/docs_database.html
@@ -1,6 +1,3 @@
----
-permalink: /docs/database/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/docs_getting-started.html
+++ b/website/docs_getting-started.html
@@ -1,6 +1,3 @@
----
-permalink: /docs/getting-started/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/examples.html
+++ b/website/examples.html
@@ -1,6 +1,3 @@
----
-permalink: /examples/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -1,6 +1,3 @@
----
-permalink: /getting-started/
----
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/website/guide.html
+++ b/website/guide.html
@@ -1,6 +1,3 @@
----
-permalink: /guide/
----
 <!DOCTYPE html>
 <html>
   <head>

--- a/website/guide_config.html
+++ b/website/guide_config.html
@@ -1,6 +1,3 @@
----
-permalink: /guide/config/
----
 <!DOCTYPE html>
 <html>
   <head>

--- a/website/guide_data.html
+++ b/website/guide_data.html
@@ -1,6 +1,3 @@
----
-permalink: /guide/data/
----
 <!DOCTYPE html>
 <html>
   <head>

--- a/website/zh.html
+++ b/website/zh.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_docs.html
+++ b/website/zh_docs.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/docs/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_docs_configuration.html
+++ b/website/zh_docs_configuration.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/docs/configuration/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_docs_database.html
+++ b/website/zh_docs_database.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/docs/database/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_docs_getting-started.html
+++ b/website/zh_docs_getting-started.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/docs/getting-started/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_examples.html
+++ b/website/zh_examples.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/examples/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>

--- a/website/zh_getting-started.html
+++ b/website/zh_getting-started.html
@@ -1,6 +1,3 @@
----
-permalink: /zh/getting-started/
----
 <!DOCTYPE html>
 <html lang="zh">
   <head>


### PR DESCRIPTION
## Description of changes
Removing content from HTML files that is above the DOCTYPE declaration, as it is being rendered on the page.

Example: "---permalink: /zh/---"