### PR TITLE
Show helpful errors when using native field types

### DIFF
--- a/packages/core/List/index.js
+++ b/packages/core/List/index.js
@@ -19,6 +19,25 @@ const labelToPath = str =>
 
 const labelToClass = str => str.replace(/\s+/g, '');
 
+const isNativeType = type => [Boolean, String, Number].includes(type);
+
+const throwNativeTypeError = (type, listKey, fieldPath) => {
+  switch (type) {
+    case Boolean:
+      throw new Error(
+        `Field '${fieldPath}' on list '${listKey}' is set to type Boolean, a native JavaScript type. Instead, try 'Checkbox' from the @keystonejs/fields package.`
+      );
+    case String:
+      throw new Error(
+        `Field '${fieldPath}' on list '${listKey}' is set to type String, a native JavaScript type. Instead, try 'Text' from the @keystonejs/fields package.`
+      );
+    case Number:
+      throw new Error(
+        `Field '${fieldPath}' on list '${listKey}' is set to type Number, a native JavaScript type. Instead, try 'Integer', or 'Float' from the @keystonejs/fields package.`
+      );
+  }
+};
+
 module.exports = class List {
   constructor(key, config, { getListByKey, adapter }) {
     this.key = key;
@@ -60,6 +79,11 @@ module.exports = class List {
     this.fields = config.fields
       ? Object.keys(config.fields).map(path => {
           const { type, ...fieldSpec } = config.fields[path];
+
+          if (isNativeType(type)) {
+            throwNativeTypeError(type, key, path);
+          }
+
           const implementation = type.implementation;
           return new implementation(path, fieldSpec, {
             getListByKey,

--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -313,3 +313,29 @@ test('getAdminMutationResolvers()', () => {
   expect(resolvers['deleteTest']).toBeInstanceOf(Function);
   expect(resolvers['deleteTests']).toBeInstanceOf(Function);
 });
+
+describe('Throws error when using native type', () => {
+  const adapter = new MockAdapter();
+  test('Boolean', () => {
+    expect(
+      () =>
+        new List('Test', { fields: { foo: { type: Boolean } } }, { adapter })
+    ).toThrow(
+      "Field 'foo' on list 'Test' is set to type Boolean, a native JavaScript type. Instead, try 'Checkbox' from the @keystonejs/fields package."
+    );
+  });
+  test('String', () => {
+    expect(
+      () => new List('Test', { fields: { foo: { type: String } } }, { adapter })
+    ).toThrow(
+      "Field 'foo' on list 'Test' is set to type String, a native JavaScript type. Instead, try 'Text' from the @keystonejs/fields package."
+    );
+  });
+  test('Number', () => {
+    expect(
+      () => new List('Test', { fields: { foo: { type: Number } } }, { adapter })
+    ).toThrow(
+      "Field 'foo' on list 'Test' is set to type Number, a native JavaScript type. Instead, try 'Integer', or 'Float' from the @keystonejs/fields package."
+    );
+  });
+});


### PR DESCRIPTION
Fixes #180

I spent a while debugging why I was getting weird seemingly unrelated errors until I saw I was using a `Boolean` type instead of a `Checkbox` type.

This PR provides a more useful error.