### PR TITLE
Consistently use the truthiness of array elements when filtering arrays

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,6 +1,7 @@
 # Authentication
 
-*Note on terminology*:
+_Note on terminology_:
+
 - _Authentication_ refers to a user identifying themselves.
   Within this document, we abbreviate _Authentication_ to _Auth_.
 - _Access Control_ refers to the specific actions an authenticated or anonymous

--- a/packages/access-control/index.js
+++ b/packages/access-control/index.js
@@ -7,7 +7,7 @@ const validateGranularConfigTypes = (longHandAccess, validationError) => {
 
       return validationError(type, accessType);
     })
-    .filter(error => !!error);
+    .filter(error => error);
 
   if (errors.length) {
     throw new Error(errors.join('\n'));

--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -310,7 +310,7 @@ class MongooseListAdapter extends BaseListAdapter {
               )
             )
             // If anything gets removed, we clear it out here
-            .filter(Boolean)
+            .filter(item => item)
         );
       });
   }

--- a/packages/admin-ui/client/apolloClient.js
+++ b/packages/admin-ui/client/apolloClient.js
@@ -79,7 +79,7 @@ class BoostClientWithUplaod extends ApolloClient {
     });
 
     const link = ApolloLink.from(
-      [errorLink, requestHandler, stateLink, httpLink].filter(x => !!x)
+      [errorLink, requestHandler, stateLink, httpLink].filter(x => x)
     );
 
     // super hacky, we will fix the types eventually

--- a/packages/core/List/index.js
+++ b/packages/core/List/index.js
@@ -196,7 +196,7 @@ module.exports = class List {
   getAdminGraphqlTypes() {
     const fieldSchemas = this.fields
       // If it's globally set to false, makes sense to never show it
-      .filter(field => !!field.access.read)
+      .filter(field => field.access.read)
       .map(field => field.getGraphqlSchema())
       .join('\n          ');
 
@@ -206,7 +206,7 @@ module.exports = class List {
 
     const updateArgs = this.fields
       // If it's globally set to false, makes sense to never let it be updated
-      .filter(field => !!field.access.update)
+      .filter(field => field.access.update)
       .map(field => field.getGraphqlUpdateArgs())
       .filter(i => i)
       .map(i => i.split(/\n\s+/g).join('\n          '))
@@ -215,7 +215,7 @@ module.exports = class List {
 
     const createArgs = this.fields
       // If it's globally set to false, makes sense to never let it be created
-      .filter(field => !!field.access.create)
+      .filter(field => field.access.create)
       .map(i => i.getGraphqlCreateArgs())
       .filter(i => i)
       .map(i => i.split(/\n\s+/g).join('\n          '))
@@ -224,7 +224,7 @@ module.exports = class List {
 
     const queryArgs = this.fields
       // If it's globally set to false, makes sense to never show it
-      .filter(field => !!field.access.read)
+      .filter(field => field.access.read)
       .map(field => {
         const fieldQueryArgs = field
           .getGraphqlQueryArgs()
@@ -237,7 +237,7 @@ module.exports = class List {
 
         return `# ${field.constructor.name} field\n          ${fieldQueryArgs}`;
       })
-      .filter(Boolean)
+      .filter(i => i)
       .join('\n\n          ');
 
     const types = [
@@ -316,7 +316,7 @@ module.exports = class List {
     const queries = this.fields
       .map(field => field.getGraphqlAuxiliaryQueries())
       // Filter out any empty elements
-      .filter(Boolean);
+      .filter(query => query);
 
     // If `read` is either `true`, or a function (we don't care what the result
     // of the function is, that'll get executed at a later time)
@@ -544,7 +544,7 @@ module.exports = class List {
     }
 
     const fieldResolvers = this.fields
-      .filter(field => !!field.access.read)
+      .filter(field => field.access.read)
       .reduce(
         (resolvers, field) => ({
           ...resolvers,
@@ -625,7 +625,7 @@ module.exports = class List {
       `);
     }
 
-    return mutations.filter(Boolean);
+    return mutations.filter(mutation => mutation);
   }
 
   throwIfAccessDeniedOnFields({
@@ -815,7 +815,7 @@ module.exports = class List {
 
     if (access.id || access.id_in) {
       const accessControlIdsAllowed = unique(
-        [].concat(access.id, access.id_in).filter(Boolean)
+        [].concat(access.id, access.id_in).filter(id => id)
       );
 
       idFilters.id_in = intersection(accessControlIdsAllowed, uniqueIds);
@@ -825,7 +825,7 @@ module.exports = class List {
 
     if (access.id_not || access.id_not_in) {
       const accessControlIdsDisallowed = unique(
-        [].concat(access.id_not, access.id_not_in).filter(Boolean)
+        [].concat(access.id_not, access.id_not_in).filter(id => id)
       );
 
       idFilters.id_not_in = intersection(accessControlIdsDisallowed, uniqueIds);

--- a/packages/fields/types/Relationship/views/Cell.js
+++ b/packages/fields/types/Relationship/views/Cell.js
@@ -8,7 +8,7 @@ export default ({ data, field, Link }) => {
   return (
     <Fragment>
       {(Array.isArray(data) ? data : [data])
-        .filter(Boolean)
+        .filter(item => item)
         .map((item, index) => (
           <Fragment key={item.id}>
             {!!index ? ', ' : ''}

--- a/packages/ui/src/primitives/layout.js
+++ b/packages/ui/src/primitives/layout.js
@@ -80,7 +80,7 @@ export const FlexGroup = ({
 }: FlexGroupProps) => {
   const gutter = spacing / 2;
   const length = Children.count(children);
-  const childArray = Children.toArray(children).filter(Boolean); // filter out null and undefined children
+  const childArray = Children.toArray(children).filter(child => child); // filter out null and undefined children
 
   return (
     <Tag


### PR DESCRIPTION
Always use the pattern `x.filter(a => a)` when filtering out items from an array, rather than `x.filter(a => !!a)` or `x.filter(Boolean)`.

Cherry picks these changes from #200 in order to simplify the review of that PR in the future.