### PR TITLE
Simplify uses of Object.assign

### DIFF
--- a/packages/admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/admin-ui/client/components/UpdateManyItemsModal.js
@@ -5,6 +5,7 @@ import { Button } from '@keystonejs/ui/src/primitives/buttons';
 import { Drawer } from '@keystonejs/ui/src/primitives/modals';
 import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Select } from '@keystonejs/ui/src/primitives/filters';
+import { omit } from '@keystonejs/utils';
 
 import FieldTypes from '../FIELD_TYPES';
 
@@ -78,11 +79,7 @@ class UpdateManyModal extends Component {
   getOptions = () => {
     const { list } = this.props;
     // remove the `options` key from select type fields
-    return list.fields.map(f => {
-      let field = Object.assign({}, f);
-      delete field.options;
-      return field;
-    });
+    return list.fields.map(f => omit(f, ['options']));
   };
   render() {
     const { isLoading, isOpen, items, list } = this.props;

--- a/projects/access-control/index.js
+++ b/projects/access-control/index.js
@@ -64,7 +64,7 @@ function createListWithStaticAccess(access) {
       foo: { type: Text },
       zip: { type: Text },
       ...fieldAccessVariations.reduce(
-        (memo, variation) => Object.assign(memo, createField(variation)),
+        (memo, variation) => ({ ...memo, ...createField(variation) }),
         {}
       ),
     },
@@ -89,7 +89,7 @@ function createListWithImperativeAccess(access) {
       foo: { type: Text },
       zip: { type: Text },
       ...fieldAccessVariations.reduce(
-        (memo, variation) => Object.assign(memo, createField(variation)),
+        (memo, variation) => ({ ...memo, ...createField(variation) }),
         {}
       ),
     },

--- a/projects/login/index.js
+++ b/projects/login/index.js
@@ -53,9 +53,7 @@ server.app.get('/api/session', (req, res) => {
     userId: req.session.keystoneItemId,
   };
   if (req.user) {
-    Object.assign(data, {
-      name: req.user.name,
-    });
+    data.name = req.user.name;
   }
   res.json(data);
 });

--- a/projects/twitter-login/custom-fields/SecurePassword/index.js
+++ b/projects/twitter-login/custom-fields/SecurePassword/index.js
@@ -1,9 +1,10 @@
 const path = require('path');
 const DefaultPasswordField = require('@keystonejs/fields').Password;
 
-module.exports = Object.assign({}, DefaultPasswordField, {
+module.exports = {
+  ...DefaultPasswordField,
   type: 'Password',
   views: {
     Field: path.resolve(__dirname, './views/Field'),
   },
-});
+};


### PR DESCRIPTION
Use the spread operator (`...`) rather than the more verbose `Object.assign` when working with objects.

Breaks out some of the changes in #200 to simplify the review of that PR.