### PR TITLE
Create Nested Relationships from create/update mutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "yarn lint:prettier && yarn lint:eslint",
     "start": "cd projects/basic && yarn start",
     "test": "yarn lint && yarn test:unit && yarn cypress:run",
-    "test:unit": "NODE_ENV=test jest",
+    "test:unit": "DISABLE_LOGGING=true NODE_ENV=test jest",
     "test:unit:debug": "NODE_ENV=test node --inspect-brk `which jest` --runInBand"
   },
   "dependencies": {
@@ -73,6 +73,7 @@
     "mongoose": "<5.1.0",
     "oauth-libre": "^0.9.17",
     "octicons": "^7.2.0",
+    "p-settle": "^2.1.0",
     "passport": "^0.4.0",
     "passport-twitter": "^1.0.4",
     "pino": "5.0.0-rc.4",
@@ -95,6 +96,7 @@
     "react-select": "^2.0.0-beta.6",
     "react-toast-notifications": "^1.2.0",
     "react-transition-group": "^2.3.1",
+    "testcheck": "^1.0.0-rc.2",
     "to-pascal-case": "^1.0.0",
     "webpack": "^4.5.0",
     "webpack-dev-middleware": "^3.1.2"

--- a/packages/core/auth/Password.js
+++ b/packages/core/auth/Password.js
@@ -20,11 +20,15 @@ class PasswordAuthStrategy {
   async validate({ username, password }) {
     const list = this.getList();
     const { usernameField, passwordField } = this.config;
-    const item = await list.adapter.findOne({
-      [usernameField]: username,
-      [passwordField]: password,
-    });
-    return item ? { success: true, list, item } : { success: false };
+    try {
+      const item = await list.adapter.findOne({
+        [usernameField]: username,
+        [passwordField]: password,
+      });
+      return item ? { success: true, list, item } : { success: false };
+    } catch (error) {
+      return { success: false, error };
+    }
   }
 }
 

--- a/packages/fields/Implementation.js
+++ b/packages/fields/Implementation.js
@@ -64,32 +64,37 @@ class Field {
    * the result to store in `avatar`
    *
    * @param data {Mixed} The data received from the query
-   * @param item {Object} The existing version of the item
    * @param path {String} The path of the field in the item
+   * @param context {Mixed} The GraphQL Context object for the current request
    */
-  createFieldPreHook(data) {
+  // eslint-disable-next-line no-unused-vars
+  createFieldPreHook(data, path, context) {
     return data;
   }
   /*
    * @param data {Mixed} The data as saved & read from the DB
-   * @param item {Object} The existing version of the item
    * @param path {String} The path of the field in the item
+   * @param item {Object} The existing version of the item
+   * @param context {Mixed} The GraphQL Context object for the current request
    */
-  createFieldPostHook() {}
+  createFieldPostHook(data, path, item, context) {} // eslint-disable-line no-unused-vars
   /*
    * @param data {Mixed} The data received from the query
-   * @param item {Object} The existing version of the item
    * @param path {String} The path of the field in the item
+   * @param item {Object} The existing version of the item
+   * @param context {Mixed} The GraphQL Context object for the current request
    */
-  updateFieldPreHook(data) {
+  // eslint-disable-next-line no-unused-vars
+  updateFieldPreHook(data, path, item, context) {
     return data;
   }
   /*
    * @param data {Mixed} The data as saved & read from the DB
-   * @param item {Object} The existing version of the item
    * @param path {String} The path of the field in the item
+   * @param item {Object} The existing version of the item
+   * @param context {Mixed} The GraphQL Context object for the current request
    */
-  updateFieldPostHook() {}
+  updateFieldPostHook(data, path, item, context) {} // eslint-disable-line no-unused-vars
 
   getGraphqlQueryArgs() {}
   getGraphqlCreateArgs() {}

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -13,10 +13,12 @@
     "@keystonejs/icons": "^1.0.0",
     "@keystonejs/ui": "^5.0.0",
     "@keystonejs/utils": "^1.0.0",
+    "apollo-errors": "^1.9.0",
     "apollo-upload-server": "^5.0.0",
     "cuid": "^2.1.1",
     "graphql-tag": "^2.8.0",
     "mongoose": "<5.1.0",
+    "p-settle": "^2.1.0",
     "react-apollo": "^2.1.3"
   }
 }

--- a/packages/fields/types/Relationship/Controller.js
+++ b/packages/fields/types/Relationship/Controller.js
@@ -14,12 +14,31 @@ export default class RelationshipController extends FieldController {
       }
     `;
   };
+
+  dataToRelationshipInput = (data, pathKey) => {
+    if (data.id && data.create) {
+      throw new Error(
+        `Cannot provide both an id and create data when linking ${
+          this.list.key
+        }.${pathKey} to a ${this.config.ref}`
+      );
+    }
+
+    if (data.id) {
+      return { id: data.id };
+    }
+
+    return { create: data };
+  };
+
   getValue = data => {
     const { many, path } = this.config;
     if (!data[path]) {
       return many ? [] : null;
     }
-    return many ? data[path].map(i => i.id) : data[path].id;
+    return many
+      ? data[path].map(value => this.dataToRelationshipInput(value, path))
+      : this.dataToRelationshipInput(data[path], path);
   };
   getInitialData = () => {
     const { defaultValue, many } = this.config;

--- a/packages/fields/types/Relationship/graphqlErrors.js
+++ b/packages/fields/types/Relationship/graphqlErrors.js
@@ -1,0 +1,10 @@
+const { createError } = require('apollo-errors');
+
+module.exports = {
+  ParameterError: createError('ParameterError', {
+    message: 'Incorrect paramters supplied',
+    options: {
+      showPath: true,
+    },
+  }),
+};

--- a/packages/fields/types/Relationship/tests/implementation.test.js
+++ b/packages/fields/types/Relationship/tests/implementation.test.js
@@ -1,3 +1,4 @@
+const gql = require('graphql-tag');
 const Relationship = require('../').implementation;
 
 class MockFieldAdapter {}
@@ -18,25 +19,82 @@ function createRelationship({ path, config = {} }) {
 }
 
 describe('Type Generation', () => {
-  test('IDs for relationship fields in create args', () => {
-    const relMany = createRelationship({ path: 'foo', config: { many: true } });
-    expect(relMany.getGraphqlCreateArgs()).toEqual('foo: [ID]');
+  test('inputs for relationship fields in create args', () => {
+    const relMany = createRelationship({
+      path: 'foo',
+      config: { many: true, ref: 'Zip' },
+    });
+    expect(relMany.getGraphqlCreateArgs()).toEqual(
+      'foo: [ZipRelationshipInput]'
+    );
 
     const relSingle = createRelationship({
       path: 'foo',
-      config: { many: false },
+      config: { many: false, ref: 'Zip' },
     });
-    expect(relSingle.getGraphqlCreateArgs()).toEqual('foo: ID');
+    expect(relSingle.getGraphqlCreateArgs()).toEqual(
+      'foo: ZipRelationshipInput'
+    );
   });
 
-  test('IDs for relationship fields in update args', () => {
-    const relMany = createRelationship({ path: 'foo', config: { many: true } });
-    expect(relMany.getGraphqlUpdateArgs()).toEqual('foo: [ID]');
+  test('inputs for relationship fields in update args', () => {
+    const relMany = createRelationship({
+      path: 'foo',
+      config: { many: true, ref: 'Zip' },
+    });
+    expect(relMany.getGraphqlUpdateArgs()).toEqual(
+      'foo: [ZipRelationshipInput]'
+    );
 
     const relSingle = createRelationship({
       path: 'foo',
-      config: { many: false },
+      config: { many: false, ref: 'Zip' },
     });
-    expect(relSingle.getGraphqlUpdateArgs()).toEqual('foo: ID');
+    expect(relSingle.getGraphqlUpdateArgs()).toEqual(
+      'foo: ZipRelationshipInput'
+    );
+  });
+
+  test('relationship LinkOrCreate input', () => {
+    const relationship = createRelationship({
+      path: 'foo',
+      config: { many: false, ref: 'Zip' },
+    });
+
+    // We're testing the AST is as we expect it to be
+    expect(gql(relationship.getGraphqlAuxiliaryTypes())).toMatchObject({
+      definitions: [
+        {
+          kind: 'InputObjectTypeDefinition',
+          name: {
+            value: 'ZipRelationshipInput',
+          },
+          fields: [
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                value: 'id',
+              },
+              type: {
+                name: {
+                  value: 'ID',
+                },
+              },
+            },
+            {
+              kind: 'InputValueDefinition',
+              name: {
+                value: 'create',
+              },
+              type: {
+                name: {
+                  value: 'ZipCreateInput',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
   });
 });

--- a/packages/fields/types/Relationship/views/Field.js
+++ b/packages/fields/types/Relationship/views/Field.js
@@ -11,6 +11,7 @@ import {
 import { Select } from '@keystonejs/ui/src/primitives/filters';
 import { ShieldIcon } from '@keystonejs/icons';
 import { colors } from '@keystonejs/ui/src/theme';
+import { pick } from '@keystonejs/utils';
 
 const getGraphqlQuery = refList => {
   // TODO: How can we replace this with field.Controller.getQueryFragment()?
@@ -82,7 +83,7 @@ export default class RelationshipField extends Component {
               if (error) return 'Error';
 
               const options = data[refList.listQueryName].map(listData => ({
-                value: listData,
+                value: pick(listData, ['id']),
                 label: listData._label_, // eslint-disable-line no-underscore-dangle
               }));
 

--- a/packages/server/WebServer/graphqlErrors.js
+++ b/packages/server/WebServer/graphqlErrors.js
@@ -1,0 +1,10 @@
+const { createError } = require('apollo-errors');
+
+module.exports = {
+  NestedError: createError('NestedError', {
+    message: 'Nested errors occured',
+    options: {
+      showPath: true,
+    },
+  }),
+};

--- a/packages/server/WebServer/initConfig.js
+++ b/packages/server/WebServer/initConfig.js
@@ -1,8 +1,6 @@
 const { fixConfigKeys, checkRequiredConfig } = require('@keystonejs/utils');
 
-const requiredConfig = {
-  'cookie secret': 'You must provide a unique cookie secret to enable sessions',
-};
+const requiredConfig = {};
 
 const defaultConfig = {
   port: process.env.PORT || 3000,

--- a/projects/basic/cypress/integration/add-edit-delete-data.js
+++ b/projects/basic/cypress/integration/add-edit-delete-data.js
@@ -33,10 +33,37 @@ describe('Adding data', () => {
 
       cy.get('form[role="dialog"] button[appearance="create"]').click();
 
+      cy.location('pathname').should('match', new RegExp(`${url}/.+`));
+
       Object.keys(data).forEach(item => {
         cy.get(`#${item}`).should('have.value', data[item]);
       });
     });
+  });
+
+  it(`Adds relationship items`, () => {
+    const url = '/admin/posts';
+    cy.visit(url);
+
+    cy.server();
+    cy.route('/admin/posts/*').as('newPost');
+
+    cy.get('button[appearance="create"]').click();
+
+    cy.get('#ks-input-name').type('My post');
+    cy.get('#ks-input-slug').type('mypost');
+    cy.get('#ks-input-author').click({ force: true });
+    cy.get('#ks-input-author').type('John Doe{downarrow}{enter}', {
+      force: true,
+    });
+
+    cy.get('form[role="dialog"] button[appearance="create"]').click();
+
+    cy.location('pathname').should('match', new RegExp(`${url}/.+`));
+
+    cy.get('#ks-input-name').should('have.value', 'My post');
+    cy.get('#ks-input-slug').should('have.value', 'mypost');
+    cy.get('#react-select-ks-input-author').should('contain', 'John Doe');
   });
 });
 
@@ -80,6 +107,50 @@ describe('Editing data', () => {
       cy.get('button[type="submit"][appearance="primary"]').click();
       cy.get(`nav a:contains("${section}")`).click();
       cy.get('body').should('contain', field.newValue);
+    });
+  });
+
+  it(`Updates relationship items`, () => {
+    const url = '/admin/posts';
+    cy.visit(url);
+
+    cy.server();
+    cy.route('/admin/posts/*').as('newPost');
+
+    cy.get(`a:contains("My post"):first`).click();
+
+    cy.location('pathname').then(path => {
+      cy.get('#ks-input-author').click({ force: true });
+
+      // Clear any value that might be there
+      cy.get('#ks-input-author').type('{backspace}{esc}', { force: true });
+
+      // save
+      cy.get('button[type="submit"][appearance="primary"]').click();
+
+      // Then reload the page
+      cy.visit(path);
+
+      // Assert that the field is empty
+      cy.get('#react-select-ks-input-author').should('contain', 'Select...');
+
+      // Select the first item
+      cy.get('#ks-input-author').click({ force: true });
+      cy.get('#ks-input-author').type('{downarrow}{enter}', { force: true });
+      cy.get('#react-select-ks-input-author').then(([authorInput]) => {
+        const userText = authorInput.textContent.replace(
+          /.*option (.*), selected.*/,
+          '$1'
+        );
+
+        // save
+        cy.get('button[type="submit"][appearance="primary"]').click();
+
+        // Then reload the page
+        cy.visit(path);
+
+        cy.get('#react-select-ks-input-author').should('contain', userText);
+      });
     });
   });
 });

--- a/projects/basic/package.json
+++ b/projects/basic/package.json
@@ -28,11 +28,13 @@
     "react": "^16.3.1"
   },
   "devDependencies": {
+    "@keystonejs/utils": "^1.0.0",
     "cypress": "^3.0.2",
     "execa": "0.10.0",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
-    "start-server-and-test": "^1.5.0"
+    "start-server-and-test": "^1.5.0",
+    "testcheck": "^1.0.0-rc.2"
   }
 }

--- a/projects/basic/tests/relationships/nested-create/many.test.js
+++ b/projects/basic/tests/relationships/nested-create/many.test.js
@@ -1,0 +1,1058 @@
+const { gen, sampleOne } = require('testcheck');
+
+const { Text, Relationship } = require('@keystonejs/fields');
+const { resolveAllKeys, mapKeys } = require('@keystonejs/utils');
+
+const { setupServer, graphqlRequest } = require('./util');
+
+const alphanumGenerator = gen.alphaNumString.notEmpty();
+
+let server;
+
+beforeAll(() => {
+  server = setupServer({
+    name: 'Tests relationship field nested create many',
+    createLists: keystone => {
+      keystone.createList('Note', {
+        fields: {
+          content: { type: Text },
+        },
+      });
+
+      keystone.createList('User', {
+        fields: {
+          username: { type: Text },
+          notes: { type: Relationship, ref: 'Note', many: true },
+        },
+      });
+
+      keystone.createList('NoteNoRead', {
+        fields: {
+          content: { type: Text },
+        },
+        access: {
+          read: () => false,
+        },
+      });
+
+      keystone.createList('UserToNotesNoRead', {
+        fields: {
+          username: { type: Text },
+          notes: { type: Relationship, ref: 'NoteNoRead', many: true },
+        },
+      });
+
+      keystone.createList('NoteNoCreate', {
+        fields: {
+          content: { type: Text },
+        },
+        access: {
+          create: () => false,
+        },
+      });
+
+      keystone.createList('UserToNotesNoCreate', {
+        fields: {
+          username: { type: Text },
+          notes: { type: Relationship, ref: 'NoteNoCreate', many: true },
+        },
+      });
+    },
+  });
+
+  server.keystone.connect();
+});
+
+function create(list, item) {
+  return server.keystone.getListByKey(list).adapter.create(item);
+}
+
+afterAll(() =>
+  resolveAllKeys(
+    mapKeys(server.keystone.adapters, adapter =>
+      adapter.dropDatabase().then(() => adapter.close())
+    )
+  ));
+
+beforeEach(() =>
+  // clean the db
+  resolveAllKeys(
+    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())
+  ));
+
+describe('no access control', () => {
+  test('link nested from within create mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+
+    // Create an item to link against
+    const createNote = await create('Note', { content: noteContent });
+
+    // Create an item that does the linking
+    const createUserOneNote = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: {
+            username: "A thing",
+            notes: [{ id: "${createNote.id}" }]
+          }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUserOneNote.body.data).toMatchObject({
+      createUser: { id: expect.any(String) },
+    });
+    expect(createUserOneNote.body).not.toHaveProperty('errors');
+
+    // Create an item that does the linking
+    const createUserManyNotes = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: {
+            username: "A thing",
+            notes: [{ id: "${createNote.id}" }, { id: "${createNote.id}" }]
+          }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUserManyNotes.body.data).toMatchObject({
+      createUser: { id: expect.any(String) },
+    });
+    expect(createUserManyNotes.body).not.toHaveProperty('errors');
+  });
+
+  test('create nested from within create mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+    const noteContent2 = sampleOne(alphanumGenerator);
+    const noteContent3 = sampleOne(alphanumGenerator);
+
+    // Create an item that does the nested create
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: {
+            username: "A thing",
+            notes: [{ create: { content: "${noteContent}" } }]
+          }) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body).not.toHaveProperty('errors');
+    expect(createUser.body.data).toMatchObject({
+      createUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: expect.any(String),
+            content: noteContent,
+          },
+        ],
+      },
+    });
+
+    // Create an item that does the nested create
+    const createUserManyNotes = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: {
+            username: "A thing",
+            notes: [{ create: { content: "${noteContent2}" } }, { create: { content: "${noteContent3}" } }]
+          }) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(createUserManyNotes.body).not.toHaveProperty('errors');
+    expect(createUserManyNotes.body.data).toMatchObject({
+      createUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: expect.any(String),
+            content: noteContent2,
+          },
+          {
+            id: expect.any(String),
+            content: noteContent3,
+          },
+        ],
+      },
+    });
+
+    // Sanity check that the items are actually created
+    const {
+      body: {
+        data: { allNotes },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          allNotes(where: { id_in: [${createUserManyNotes.body.data.createUser.notes
+            .map(({ id }) => `"${id}"`)
+            .join(',')}] }) {
+            id
+            content
+          }
+        }
+    `,
+    });
+
+    expect(allNotes).toHaveLength(
+      createUserManyNotes.body.data.createUser.notes.length
+    );
+  });
+
+  test('link AND create nested from within create mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+    const noteContent2 = sampleOne(alphanumGenerator);
+
+    // Create an item to link against
+    const createNote = await create('Note', { content: noteContent });
+
+    // Create an item that does the linking
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: {
+            username: "A thing",
+            notes: [{ id: "${
+              createNote.id
+            }" }, { create: { content: "${noteContent2}" } }]
+          }) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body.data).toMatchObject({
+      createUser: {
+        id: expect.any(String),
+        notes: [
+          { id: expect.any(String), content: noteContent },
+          { id: expect.any(String), content: noteContent2 },
+        ],
+      },
+    });
+    expect(createUser.body).not.toHaveProperty('errors');
+
+    // Sanity check that the items are actually created
+    const {
+      body: {
+        data: { allNotes },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          allNotes(where: { id_in: [${createUser.body.data.createUser.notes
+            .map(({ id }) => `"${id}"`)
+            .join(',')}] }) {
+            id
+            content
+          }
+        }
+    `,
+    });
+
+    expect(allNotes).toHaveLength(createUser.body.data.createUser.notes.length);
+  });
+
+  test('link nested from within update mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+    const noteContent2 = sampleOne(alphanumGenerator);
+
+    // Create an item to link against
+    const createNote = await create('Note', { content: noteContent });
+    const createNote2 = await create('Note', { content: noteContent2 });
+
+    // Create an item to update
+    const createUser = await create('User', { username: 'A thing' });
+
+    // Update the item and link the relationship field
+    const updateUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateUser(
+            id: "${createUser.id}"
+            data: {
+              username: "A thing",
+              notes: [{ id: "${createNote.id}" }]
+            }
+          ) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(updateUser.body.data).toMatchObject({
+      updateUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: expect.any(String),
+            content: noteContent,
+          },
+        ],
+      },
+    });
+    expect(updateUser.body).not.toHaveProperty('errors');
+
+    // Update the item and link multiple relationship fields
+    const { body } = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateUser(
+            id: "${createUser.id}"
+            data: {
+              username: "A thing",
+              notes: [{ id: "${createNote.id}" }, { id: "${createNote2.id}" }]
+            }
+          ) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(body.data).toMatchObject({
+      updateUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: createNote.id,
+            content: noteContent,
+          },
+          {
+            id: createNote2.id,
+            content: noteContent2,
+          },
+        ],
+      },
+    });
+    expect(body).not.toHaveProperty('errors');
+  });
+
+  test('create nested from within update mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+    const noteContent2 = sampleOne(alphanumGenerator);
+
+    // Create an item to update
+    const createUser = await create('User', { username: 'A thing' });
+
+    // Update an item that does the nested create
+    const updateUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateUser(
+            id: "${createUser.id}"
+            data: {
+              username: "A thing",
+              notes: [{ create: { content: "${noteContent}" } }]
+            }
+          ) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(updateUser.body).not.toHaveProperty('errors');
+    expect(updateUser.body.data).toMatchObject({
+      updateUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: expect.any(String),
+            content: noteContent,
+          },
+        ],
+      },
+    });
+
+    const updateUserManyNotes = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateUser(
+            id: "${createUser.id}"
+            data: {
+              username: "A thing",
+              notes: [{ create: { content: "${noteContent}" } }, { create: { content: "${noteContent2}" } }]
+            }
+          ) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(updateUserManyNotes.body).not.toHaveProperty('errors');
+    expect(updateUserManyNotes.body.data).toMatchObject({
+      updateUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: expect.any(String),
+            content: noteContent,
+          },
+          {
+            id: expect.any(String),
+            content: noteContent2,
+          },
+        ],
+      },
+    });
+
+    // Sanity check that the items are actually created
+    const {
+      body: {
+        data: { allNotes },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          allNotes(where: { id_in: [${updateUserManyNotes.body.data.updateUser.notes
+            .map(({ id }) => `"${id}"`)
+            .join(',')}] }) {
+            id
+            content
+          }
+        }
+    `,
+    });
+
+    expect(allNotes).toHaveLength(
+      updateUserManyNotes.body.data.updateUser.notes.length
+    );
+  });
+
+  test('link & create nested from within update mutation', async () => {
+    const noteContent = sampleOne(alphanumGenerator);
+    const noteContent2 = sampleOne(alphanumGenerator);
+
+    // Create an item to link against
+    const createNote = await create('Note', { content: noteContent });
+
+    // Create an item to update
+    const createUser = await create('User', { username: 'A thing' });
+
+    // Update the item and link the relationship field
+    const { body } = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateUser(
+            id: "${createUser.id}"
+            data: {
+              username: "A thing",
+              notes: [{ id: "${
+                createNote.id
+              }" }, { create: { content: "${noteContent2}" } }]
+            }
+          ) {
+            id
+            notes {
+              id
+              content
+            }
+          }
+        }
+    `,
+    });
+
+    expect(body.data).toMatchObject({
+      updateUser: {
+        id: expect.any(String),
+        notes: [
+          {
+            id: createNote.id,
+            content: noteContent,
+          },
+          {
+            id: expect.any(String),
+            content: noteContent2,
+          },
+        ],
+      },
+    });
+    expect(body).not.toHaveProperty('errors');
+
+    // Sanity check that the items are actually created
+    const {
+      body: {
+        data: { allNotes },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          allNotes(where: { id_in: [${body.data.updateUser.notes
+            .map(({ id }) => `"${id}"`)
+            .join(',')}] }) {
+            id
+            content
+          }
+        }
+    `,
+    });
+
+    expect(allNotes).toHaveLength(body.data.updateUser.notes.length);
+  });
+});
+
+describe('errors on incomplete data', () => {
+  test('when neither id or create data passed', async () => {
+    // Create an item that does the linking
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: { notes: [{}] }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body).toHaveProperty('data.createUser', null);
+    expect(createUser.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createUser', 'notes', 0],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test('when neither id or create data passed for only some', async () => {
+    // Create an item that does the linking
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: { notes: [
+            { create: { content: "foo" } },
+            {}
+          ] }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body).toHaveProperty('data.createUser', null);
+    expect(createUser.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createUser', 'notes', 1],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test('when both id and create data passed', async () => {
+    // Create an item that does the linking
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: { notes: [{ id: "abc123", create: { content: "foo" } }] }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body).toHaveProperty('data.createUser', null);
+    expect(createUser.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createUser', 'notes', 0],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test('when both id and create data passed for only some', async () => {
+    // Create an item that does the linking
+    const createUser = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createUser(data: { notes: [
+            { create: { content: "bar" } },
+            { id: "abc123", create: { content: "foo" } }
+          ] }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createUser.body).toHaveProperty('data.createUser', null);
+    expect(createUser.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createUser', 'notes', 1],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+});
+
+describe('with access control', () => {
+  describe('read: false on related list', () => {
+    test('does not throw when link nested from within create mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNoteNoRead = await create('NoteNoRead', {
+        content: noteContent,
+      });
+
+      // Create an item that does the linking
+      const createUserOneNote = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createUserToNotesNoRead(data: {
+              username: "A thing",
+              notes: [{ id: "${createNoteNoRead.id}" }]
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(createUserOneNote.body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw when create nested from within create mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item that does the nested create
+      const createUserToNotesNoRead = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createUserToNotesNoRead(data: {
+              username: "A thing",
+              notes: [{ create: { content: "${noteContent}" } }]
+            }) {
+              id
+              notes {
+                id
+                content
+              }
+            }
+          }
+      `,
+      });
+
+      expect(createUserToNotesNoRead.body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw when link AND create nested from within create mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+      const noteContent2 = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNoteNoRead = await create('NoteNoRead', {
+        content: noteContent,
+      });
+
+      // Create an item that does the linking
+      const createUser = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createUserToNotesNoRead(data: {
+              username: "A thing",
+              notes: [{ id: "${
+                createNoteNoRead.id
+              }" }, { create: { content: "${noteContent2}" } }]
+            }) {
+              id
+              notes {
+                id
+              }
+            }
+          }
+      `,
+      });
+
+      expect(createUser.body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw when link nested from within update mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNote = await create('NoteNoRead', { content: noteContent });
+
+      // Create an item to update
+      const createUser = await create('UserToNotesNoRead', {
+        username: 'A thing',
+      });
+
+      // Update the item and link the relationship field
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateUserToNotesNoRead(
+              id: "${createUser.id}"
+              data: {
+                username: "A thing",
+                notes: [{ id: "${createNote.id}" }]
+              }
+            ) {
+              id
+              notes {
+                id
+                content
+              }
+            }
+          }
+      `,
+      });
+
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw when create nested from within update mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to update
+      const createUser = await create('UserToNotesNoRead', {
+        username: 'A thing',
+      });
+
+      // Update an item that does the nested create
+      const updateUserToNotesNoRead = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateUserToNotesNoRead(
+              id: "${createUser.id}"
+              data: {
+                username: "A thing",
+                notes: [{ create: { content: "${noteContent}" } }]
+              }
+            ) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(updateUserToNotesNoRead.body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw when link & create nested from within update mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+      const noteContent2 = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNote = await create('NoteNoRead', { content: noteContent });
+
+      // Create an item to update
+      const createUser = await create('UserToNotesNoRead', {
+        username: 'A thing',
+      });
+
+      // Update the item and link the relationship field
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateUserToNotesNoRead(
+              id: "${createUser.id}"
+              data: {
+                username: "A thing",
+                notes: [{ id: "${
+                  createNote.id
+                }" }, { create: { content: "${noteContent2}" } }]
+              }
+            ) {
+              id
+              notes {
+                id
+                content
+              }
+            }
+          }
+      `,
+      });
+
+      expect(body).not.toHaveProperty('errors');
+    });
+  });
+
+  describe('create: false on related list', () => {
+    test('does not throw when link nested from within create mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNoteNoCreate = await create('NoteNoCreate', {
+        content: noteContent,
+      });
+
+      // Create an item that does the linking
+      const createUserOneNote = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createUserToNotesNoCreate(data: {
+              username: "A thing",
+              notes: [{ id: "${createNoteNoCreate.id}" }]
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(createUserOneNote.body).not.toHaveProperty('errors');
+    });
+
+    test('throws error when creating nested within create mutation', async () => {
+      const userName = sampleOne(alphanumGenerator);
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item that does the nested create
+      const createUserToNotesNoCreate = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createUserToNotesNoCreate(data: {
+              username: "${userName}",
+              notes: [{ create: { content: "${noteContent}" } }]
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      // Assert it throws an access denied error
+      expect(createUserToNotesNoCreate.body).toHaveProperty(
+        'data.createUserToNotesNoCreate',
+        null
+      );
+      expect(createUserToNotesNoCreate.body.errors).toMatchObject([
+        {
+          name: 'NestedError',
+          data: {
+            errors: [
+              {
+                path: ['createUserToNotesNoCreate', 'notes', 0, 'create'],
+                name: 'AccessDeniedError',
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Confirm it didn't insert either of the records anyway
+      const {
+        body: {
+          data: { allNoteNoCreates, allUserToNotesNoCreates },
+        },
+      } = await graphqlRequest({
+        server,
+        query: `
+          query {
+            allNoteNoCreates(where: { content: "${noteContent}" }) {
+              id
+              content
+            }
+            allUserToNotesNoCreates(where: { username: "${userName}" }) {
+              id
+              username
+            }
+          }
+      `,
+      });
+
+      expect(allNoteNoCreates).toMatchObject([]);
+      expect(allUserToNotesNoCreates).toMatchObject([]);
+    });
+
+    test('does not throw when link nested from within update mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to link against
+      const createNote = await create('NoteNoCreate', { content: noteContent });
+
+      // Create an item to update
+      const createUser = await create('UserToNotesNoCreate', {
+        username: 'A thing',
+      });
+
+      // Update the item and link the relationship field
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateUserToNotesNoCreate(
+              id: "${createUser.id}"
+              data: {
+                username: "A thing",
+                notes: [{ id: "${createNote.id}" }]
+              }
+            ) {
+              id
+              notes {
+                id
+                content
+              }
+            }
+          }
+      `,
+      });
+
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('throws error when creating nested within update mutation', async () => {
+      const noteContent = sampleOne(alphanumGenerator);
+
+      // Create an item to update
+      const createUserToNotesNoCreate = await create('UserToNotesNoCreate', {
+        username: 'A thing',
+      });
+
+      // Update an item that does the nested create
+      const updateUserToNotesNoCreate = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateUserToNotesNoCreate(
+              id: "${createUserToNotesNoCreate.id}"
+              data: {
+                username: "A thing",
+                notes: { create: { content: "${noteContent}" } }
+              }
+            ) {
+              id
+            }
+          }
+      `,
+      });
+
+      // Assert it throws an access denied error
+      expect(updateUserToNotesNoCreate.body).toHaveProperty(
+        'data.updateUserToNotesNoCreate',
+        null
+      );
+      expect(updateUserToNotesNoCreate.body.errors).toMatchObject([
+        {
+          name: 'NestedError',
+          data: {
+            errors: [
+              {
+                path: ['updateUserToNotesNoCreate', 'notes', 0, 'create'],
+                name: 'AccessDeniedError',
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Confirm it didn't insert the record anyway
+      const {
+        body: {
+          data: { allNoteNoCreates },
+        },
+      } = await graphqlRequest({
+        server,
+        query: `
+          query {
+            allNoteNoCreates(where: { content: "${noteContent}" }) {
+              id
+              content
+            }
+          }
+      `,
+      });
+
+      expect(allNoteNoCreates).toMatchObject([]);
+    });
+  });
+});

--- a/projects/basic/tests/relationships/nested-create/singular.test.js
+++ b/projects/basic/tests/relationships/nested-create/singular.test.js
@@ -1,0 +1,698 @@
+const { gen, sampleOne } = require('testcheck');
+const { Text, Relationship } = require('@keystonejs/fields');
+const { resolveAllKeys, mapKeys } = require('@keystonejs/utils');
+
+const { setupServer, graphqlRequest } = require('./util');
+
+let server;
+
+beforeAll(() => {
+  server = setupServer({
+    name: 'Tests relationship field nested create singular',
+    createLists: keystone => {
+      keystone.createList('Group', {
+        fields: {
+          name: { type: Text },
+        },
+      });
+
+      keystone.createList('Event', {
+        fields: {
+          title: { type: Text },
+          group: { type: Relationship, ref: 'Group' },
+        },
+      });
+
+      keystone.createList('GroupNoRead', {
+        fields: {
+          name: { type: Text },
+        },
+        access: {
+          read: () => false,
+        },
+      });
+
+      keystone.createList('EventToGroupNoRead', {
+        fields: {
+          title: { type: Text },
+          group: { type: Relationship, ref: 'GroupNoRead' },
+        },
+      });
+
+      keystone.createList('GroupNoCreate', {
+        fields: {
+          name: { type: Text },
+        },
+        access: {
+          create: () => false,
+        },
+      });
+
+      keystone.createList('EventToGroupNoCreate', {
+        fields: {
+          title: { type: Text },
+          group: { type: Relationship, ref: 'GroupNoCreate' },
+        },
+      });
+    },
+  });
+
+  server.keystone.connect();
+});
+
+function create(list, item) {
+  return server.keystone.getListByKey(list).adapter.create(item);
+}
+
+afterAll(() =>
+  resolveAllKeys(
+    mapKeys(server.keystone.adapters, adapter =>
+      adapter.dropDatabase().then(() => adapter.close())
+    )
+  ));
+
+beforeEach(() =>
+  // clean the db
+  resolveAllKeys(
+    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())
+  ));
+
+describe('no access control', () => {
+  test('link nested from within create mutation', async () => {
+    const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+    // Create an item to link against
+    const createGroup = await create('Group', { name: groupName });
+
+    // Create an item that does the linking
+    const { body } = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createEvent(data: {
+            title: "A thing",
+            group: { id: "${createGroup.id}" }
+          }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(body.data).toMatchObject({
+      createEvent: { id: expect.any(String) },
+    });
+    expect(body).not.toHaveProperty('errors');
+  });
+
+  test('create nested from within create mutation', async () => {
+    const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+    // Create an item that does the nested create
+    const createEvent = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createEvent(data: {
+            title: "A thing",
+            group: { create: { name: "${groupName}" } }
+          }) {
+            id
+            group {
+              id
+              name
+            }
+          }
+        }
+    `,
+    });
+
+    expect(createEvent.body).not.toHaveProperty('errors');
+    expect(createEvent.body.data).toMatchObject({
+      createEvent: {
+        id: expect.any(String),
+        group: {
+          id: expect.any(String),
+          name: groupName,
+        },
+      },
+    });
+
+    const {
+      body: {
+        data: { Group },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          Group(where: { id: "${
+            createEvent.body.data.createEvent.group.id
+          }" }) {
+            id
+            name
+          }
+        }
+    `,
+    });
+
+    expect(Group).toMatchObject({
+      id: createEvent.body.data.createEvent.group.id,
+      name: groupName,
+    });
+  });
+
+  test('link nested from within update mutation', async () => {
+    const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+    // Create an item to link against
+    const createGroup = await create('Group', { name: groupName });
+
+    // Create an item to update
+    const {
+      body: {
+        data: { createEvent },
+      },
+    } = await graphqlRequest({
+      server,
+      query: 'mutation { createEvent(data: { title: "A thing", }) { id } }',
+    });
+
+    // Update the item and link the relationship field
+    const { body } = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateEvent(
+            id: "${createEvent.id}"
+            data: {
+              title: "A thing",
+              group: { id: "${createGroup.id}" }
+            }
+          ) {
+            id
+            group {
+              id
+              name
+            }
+          }
+        }
+    `,
+    });
+
+    expect(body.data).toMatchObject({
+      updateEvent: {
+        id: expect.any(String),
+        group: {
+          id: expect.any(String),
+          name: groupName,
+        },
+      },
+    });
+    expect(body).not.toHaveProperty('errors');
+  });
+
+  test('create nested from within update mutation', async () => {
+    const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+    // Create an item to update
+    const createEvent = await create('Event', { title: 'A thing' });
+
+    // Update an item that does the nested create
+    const updateEvent = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          updateEvent(
+            id: "${createEvent.id}"
+            data: {
+              title: "A thing",
+              group: { create: { name: "${groupName}" } }
+            }
+          ) {
+            id
+            group {
+              id
+              name
+            }
+          }
+        }
+    `,
+    });
+
+    expect(updateEvent.body).not.toHaveProperty('errors');
+    expect(updateEvent.body.data).toMatchObject({
+      updateEvent: {
+        id: expect.any(String),
+        group: {
+          id: expect.any(String),
+          name: groupName,
+        },
+      },
+    });
+
+    const {
+      body: {
+        data: { Group },
+      },
+    } = await graphqlRequest({
+      server,
+      query: `
+        query {
+          Group(where: { id: "${
+            updateEvent.body.data.updateEvent.group.id
+          }" }) {
+            id
+            name
+          }
+        }
+    `,
+    });
+
+    expect(Group).toMatchObject({
+      id: updateEvent.body.data.updateEvent.group.id,
+      name: groupName,
+    });
+  });
+});
+
+describe('errors on incomplete data', () => {
+  test('when neither id or create data passed', async () => {
+    // Create an item that does the linking
+    const createEvent = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createEvent(data: { group: {} }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createEvent.body).toHaveProperty('data.createEvent', null);
+    expect(createEvent.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createEvent', 'group'],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test('when both id and create data passed', async () => {
+    // Create an item that does the linking
+    const createEvent = await graphqlRequest({
+      server,
+      query: `
+        mutation {
+          createEvent(data: { group: { id: "abc123", create: { name: "foo" } } }) {
+            id
+          }
+        }
+    `,
+    });
+
+    expect(createEvent.body).toHaveProperty('data.createEvent', null);
+    expect(createEvent.body.errors).toMatchObject([
+      {
+        name: 'NestedError',
+        data: {
+          errors: [
+            {
+              path: ['createEvent', 'group'],
+              name: 'ParameterError',
+            },
+          ],
+        },
+      },
+    ]);
+  });
+});
+
+describe('with access control', () => {
+  describe('read: false on related list', () => {
+    test('does not throw error when linking nested within create mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to link against
+      const createGroupNoRead = await create('GroupNoRead', {
+        name: groupName,
+      });
+
+      // Create an item that does the linking
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createEventToGroupNoRead(data: {
+              title: "A thing",
+              group: { id: "${createGroupNoRead.id}" }
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(body.data).toMatchObject({
+        createEventToGroupNoRead: { id: expect.any(String) },
+      });
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw error when creating nested within create mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item that does the nested create
+      const createEventToGroupNoRead = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createEventToGroupNoRead(data: {
+              title: "A thing",
+              group: { create: { name: "${groupName}" } }
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(createEventToGroupNoRead.body).not.toHaveProperty('errors');
+      expect(createEventToGroupNoRead.body.data).toMatchObject({
+        createEventToGroupNoRead: { id: expect.any(String) },
+      });
+    });
+
+    test('does not throw error when linking nested within update mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to link against
+      const createGroupNoRead = await create('GroupNoRead', {
+        name: groupName,
+      });
+
+      // Create an item to update
+      const {
+        body: {
+          data: { createEventToGroupNoRead },
+        },
+      } = await graphqlRequest({
+        server,
+        query:
+          'mutation { createEventToGroupNoRead(data: { title: "A thing", }) { id } }',
+      });
+
+      // Update the item and link the relationship field
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateEventToGroupNoRead(
+              id: "${createEventToGroupNoRead.id}"
+              data: {
+                title: "A thing",
+                group: { id: "${createGroupNoRead.id}" }
+              }
+            ) {
+              id
+              group {
+                id
+                name
+              }
+            }
+          }
+      `,
+      });
+
+      expect(body.data).toMatchObject({
+        updateEventToGroupNoRead: {
+          id: expect.any(String),
+          group: {
+            id: expect.any(String),
+            name: groupName,
+          },
+        },
+      });
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('does not throw error when creating nested within update mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to update
+      const createEventToGroupNoRead = await create('EventToGroupNoRead', {
+        title: 'A thing',
+      });
+
+      // Update an item that does the nested create
+      const updateEventToGroupNoRead = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateEventToGroupNoRead(
+              id: "${createEventToGroupNoRead.id}"
+              data: {
+                title: "A thing",
+                group: { create: { name: "${groupName}" } }
+              }
+            ) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(updateEventToGroupNoRead.body).not.toHaveProperty('errors');
+      expect(updateEventToGroupNoRead.body.data).toMatchObject({
+        updateEventToGroupNoRead: { id: expect.any(String) },
+      });
+    });
+  });
+
+  describe('create: false on related list', () => {
+    test('does not throw error when linking nested within create mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to link against
+      // We can't use the graphQL query here (it's `create: () => false`)
+      const { id } = await create('GroupNoCreate', { name: groupName });
+
+      // Create an item that does the linking
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createEventToGroupNoCreate(data: {
+              title: "A thing",
+              group: { id: "${id}" }
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      expect(body.data).toMatchObject({
+        createEventToGroupNoCreate: { id: expect.any(String) },
+      });
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('throws error when creating nested within create mutation', async () => {
+      const alphaNumGenerator = gen.alphaNumString.notEmpty();
+      const eventName = sampleOne(alphaNumGenerator);
+      const groupName = sampleOne(alphaNumGenerator);
+
+      // Create an item that does the nested create
+      const createEventToGroupNoCreate = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            createEventToGroupNoCreate(data: {
+              title: "${eventName}",
+              group: { create: { name: "${groupName}" } }
+            }) {
+              id
+            }
+          }
+      `,
+      });
+
+      // Assert it throws an access denied error
+      expect(createEventToGroupNoCreate.body).toHaveProperty(
+        'data.createEventToGroupNoCreate',
+        null
+      );
+      expect(createEventToGroupNoCreate.body.errors).toMatchObject([
+        {
+          name: 'NestedError',
+          data: {
+            errors: [
+              {
+                path: ['createEventToGroupNoCreate', 'group', 'create'],
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Confirm it didn't insert either of the records anyway
+      const {
+        body: {
+          data: { allGroupNoCreates },
+        },
+      } = await graphqlRequest({
+        server,
+        query: `
+          query {
+            allGroupNoCreates(where: { name: "${groupName}" }) {
+              id
+              name
+            }
+          }
+      `,
+      });
+
+      expect(allGroupNoCreates).toMatchObject([]);
+
+      // Confirm it didn't insert either of the records anyway
+      const {
+        body: {
+          data: { allEventToGroupNoCreates },
+        },
+      } = await graphqlRequest({
+        server,
+        query: `
+          query {
+            allEventToGroupNoCreates(where: { title: "${eventName}" }) {
+              id
+              title
+            }
+          }
+      `,
+      });
+
+      expect(allEventToGroupNoCreates).toMatchObject([]);
+    });
+
+    test('does not throw error when linking nested within update mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to link against
+      // We can't use the graphQL query here (it's `create: () => false`)
+      const createGroupNoCreate = await create('GroupNoCreate', {
+        name: groupName,
+      });
+
+      // Create an item to update
+      const createEventToGroupNoCreate = await create('EventToGroupNoCreate', {
+        title: 'A Thing',
+      });
+
+      // Update the item and link the relationship field
+      const { body } = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateEventToGroupNoCreate(
+              id: "${createEventToGroupNoCreate.id}"
+              data: {
+                title: "A thing",
+                group: { id: "${createGroupNoCreate.id}" }
+              }
+            ) {
+              id
+              group {
+                id
+                name
+              }
+            }
+          }
+      `,
+      });
+
+      expect(body.data).toMatchObject({
+        updateEventToGroupNoCreate: {
+          id: expect.any(String),
+          group: {
+            id: expect.any(String),
+            name: groupName,
+          },
+        },
+      });
+      expect(body).not.toHaveProperty('errors');
+    });
+
+    test('throws error when creating nested within update mutation', async () => {
+      const groupName = sampleOne(gen.alphaNumString.notEmpty());
+
+      // Create an item to update
+      const createEventToGroupNoCreate = await create('EventToGroupNoCreate', {
+        title: 'A thing',
+      });
+
+      // Update an item that does the nested create
+      const updateEventToGroupNoCreate = await graphqlRequest({
+        server,
+        query: `
+          mutation {
+            updateEventToGroupNoCreate(
+              id: "${createEventToGroupNoCreate.id}"
+              data: {
+                title: "A thing",
+                group: { create: { name: "${groupName}" } }
+              }
+            ) {
+              id
+            }
+          }
+      `,
+      });
+
+      // Assert it throws an access denied error
+      expect(updateEventToGroupNoCreate.body).toHaveProperty(
+        'data.updateEventToGroupNoCreate',
+        null
+      );
+      expect(updateEventToGroupNoCreate.body.errors).toMatchObject([
+        {
+          name: 'NestedError',
+          data: {
+            errors: [
+              {
+                path: ['updateEventToGroupNoCreate', 'group', 'create'],
+              },
+            ],
+          },
+        },
+      ]);
+
+      // Confirm it didn't insert the record anyway
+      const {
+        body: {
+          data: { allGroupNoCreates },
+        },
+      } = await graphqlRequest({
+        server,
+        query: `
+          query {
+            allGroupNoCreates(where: { name: "${groupName}" }) {
+              id
+              name
+            }
+          }
+      `,
+      });
+
+      expect(allGroupNoCreates).toMatchObject([]);
+    });
+  });
+});

--- a/projects/basic/tests/relationships/nested-create/util.js
+++ b/projects/basic/tests/relationships/nested-create/util.js
@@ -1,0 +1,35 @@
+const supertest = require('supertest');
+const { Keystone } = require('@keystonejs/core');
+const { WebServer } = require('@keystonejs/server');
+const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
+
+function setupServer({ name, createLists = () => {} }) {
+  const keystone = new Keystone({
+    name,
+    adapter: new MongooseAdapter(),
+    defaultAccess: { list: true, field: true },
+  });
+
+  createLists(keystone);
+
+  const server = new WebServer(keystone, {
+    apiPath: '/admin/api',
+    graphiqlPath: '/admin/graphiql',
+  });
+
+  return { keystone, server };
+}
+
+function graphqlRequest({ server, query }) {
+  return supertest(server.server.app)
+    .post('/admin/api')
+    .set('Accept', 'application/json')
+    .send({ query })
+    .set('Accept', 'application/json')
+    .expect(200);
+}
+
+module.exports = {
+  setupServer,
+  graphqlRequest,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5697,7 +5697,7 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
-p-limit@^1.1.0:
+p-limit@^1.1.0, p-limit@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   dependencies:
@@ -5712,6 +5712,17 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-reflect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-1.0.0.tgz#f4fa1ee1bb546d8eb3ec0321148dfe0a79137bb8"
+
+p-settle@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-settle/-/p-settle-2.1.0.tgz#5b7161f45f92a3d2e17098dca8ce6bb0d51099ea"
+  dependencies:
+    p-limit "^1.2.0"
+    p-reflect "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -7333,6 +7344,10 @@ test-exclude@^4.2.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+testcheck@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/testcheck/-/testcheck-1.0.0-rc.2.tgz#11356a25b84575efe0b0857451e85b5fa74ee4e4"
 
 text-table@~0.2.0:
   version "0.2.0"


### PR DESCRIPTION
Implements and closes #186.

_This PR is [best viewed with whitespace off](https://github.com/keystonejs/keystone-5/pull/207/files?w=1)._

## Example

```javascript
keystone.addList('User', {
  fields: {
    posts: { type: Relationship, ref: 'Post', many: true },
    org: { type: Relationship, ref: 'Org' },
  }
});

keystone.addList('Org', {
  fields: {
    name: { type: Text },
  }
});

keystone.addList('Post', {
  fields: {
    title: { type: Text },
  }
});
```

Generates the following schema:

```graphql
input CreatePostInput { title: String }

input CreateOrgInput { name: String }

# NOTE: Can't pass both id AND create
input PostRelationshipInput { id: ID, create: CreatePostInput }

# NOTE: Can't pass both id AND create
input OrgRelationshipInput { id: ID, create: CreateOrgInput }

input CreateUserInput {
  posts: [PostRelationshipInput]
  org: OrgRelationshipInput
}
input UpdateUserInput {
  posts: [PostRelationshipInput]
  org: OrgRelationshipInput
}

type Mutation {
  createUser(data: CreateUserInput): User
}
```

So now we can do fun queries like this:

```graphql
mutation {
  createUser(data: {
    org: { create: { name: "Thinkmill" } },
    posts: [
      { create: { title: "How to be awesome" } },
      { create: { title: "React is life" } }
    ]
  }) {
    id
    org { id name }
    posts { id title }
  }
}
```
Which will create the new `Org`, 2 new `Post`s, associate their ids as the relationships, then return the whole result:

```javascript
{
  id: "abc123",
  org: { id: "def345", name: "Thinkmill" },
  posts: [
    { id: "ghi567", title: "How to be awesome" },
    { id: "xyz789", title: "React is life" }
  ]
}
```

And it's possible to link existing records (and mix linking & creating!):

```graphql
mutation {
  createUser(data: {
    org: { id: "def345" }, # Link the Thinkmill Org ID
    posts: [
      { create: { title: "GraphQL is pretty alright!" } },
      { id: "ghi567" } # Link the "How to be awesome" post
    ]
  }) {
    id
    org { id name }
    posts { id title }
  }
}
```
Which will return something like:

```javascript
{
  id: "098wer",
  org: { id: "def345", name: "Thinkmill" },
  posts: [
    { id: "xyz789", title: "React is life" },
    { id: "654yui", title: "GraphQL is pretty alright!" }
  ]
}
```

The same can be done when using the `updateX` mutation 👍 