### PR TITLE
Lock mongoose version to stop corrupt IDs

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",
     "mkdirp": "^0.5.1",
-    "mongoose": "^5.0.14",
+    "mongoose": "<5.1.0",
     "oauth-libre": "^0.9.17",
     "octicons": "^7.2.0",
     "passport": "^0.4.0",

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "@keystonejs/utils": "^1.0.0",
     "@keystonejs/core": "^5.0.0",
-    "mongoose": "^5.0.14"
+    "mongoose": "<5.1.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
     "apollo-upload-server": "^5.0.0",
     "graphql-tools": "^3.0.0",
     "graphql-type-json": "^0.2.1",
-    "mongoose": "^5.0.14",
+    "mongoose": "<5.1.0",
     "oauth-libre": "^0.9.17",
     "passport": "^0.4.0",
     "passport-twitter": "^1.0.4",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -16,7 +16,7 @@
     "apollo-upload-server": "^5.0.0",
     "cuid": "^2.1.1",
     "graphql-tag": "^2.8.0",
-    "mongoose": "^5.0.14",
+    "mongoose": "<5.1.0",
     "react-apollo": "^2.1.3"
   }
 }

--- a/projects/access-control/package.json
+++ b/projects/access-control/package.json
@@ -32,7 +32,7 @@
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
-    "mongoose": "^5.0.14",
+    "mongoose": "<5.1.0",
     "start-server-and-test": "^1.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,7 +779,7 @@ async@2.1.4:
   dependencies:
     lodash "^4.14.0"
 
-async@2.6.1, async@^2.1.4, async@^2.5, async@^2.6:
+async@^2.1.4, async@^2.5, async@^2.6:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -4690,9 +4690,9 @@ junit-merge@^1.3.0:
     mkdirp "^0.5.1"
     xmldoc "^1.1.0"
 
-kareem@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"
+kareem@2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.0.7.tgz#8d260366a4df4236ceccec318fcf10c17c5beb22"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -5255,35 +5255,32 @@ moment@2.x.x, "moment@>= 2.9.0", moment@^2.19:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
-mongodb-core@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.0.tgz#af91f36fd560ed785f4e61e694432df4d3698aad"
+mongodb-core@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.0.8.tgz#8d401f4eab6056c0d874a3d5844a4844f761d4d7"
   dependencies:
     bson "~1.0.4"
     require_optional "^1.0.1"
-  optionalDependencies:
-    saslprep "^1.0.0"
 
-mongodb@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.1.tgz#c018c4b277614e8b1e08426d5bcbe1a7e5cdbd74"
+mongodb@3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.0.8.tgz#2c1daecac9a0ec2de2f2aea4dc97d76ae70f8951"
   dependencies:
-    mongodb-core "3.1.0"
+    mongodb-core "3.0.8"
 
 mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
 
-mongoose@^5.0.14:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.2.4.tgz#52b3385bee9420cf6bbd7e4ebfb211523c37a9e3"
+mongoose@<5.1.0:
+  version "5.0.18"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.0.18.tgz#2d04c70f0800959b4c8180e5e70db13bc18d3826"
   dependencies:
-    async "2.6.1"
+    async "2.1.4"
     bson "~1.0.5"
-    kareem "2.2.1"
+    kareem "2.0.7"
     lodash.get "4.4.2"
-    mongodb "3.1.1"
-    mongodb-core "3.1.0"
+    mongodb "3.0.8"
     mongoose-legacy-pluralize "1.0.2"
     mpath "0.4.1"
     mquery "3.0.0"
@@ -6786,10 +6783,6 @@ sane@^2.0.0:
     watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.2.3"
-
-saslprep@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.1.tgz#b644e0ba25b156b652f3cb90df7542f896049ba6"
 
 sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"


### PR DESCRIPTION
Refs #209 

`mongoose@5.1.0` introduced a change which results in corrupted ids being returned.

Dom, Tom, and myself have spent hours investigating and cannot figure out what's actually wrong, so the workaround is to fix at the version prior to that change.

This is also causing tests to fail in some cases.