### PR TITLE
Update prettier to use printWidth: 100 (up from default of 80)

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-  singleQuote: true,
-  trailingComma: 'es5',
-};

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -93,8 +93,7 @@ keystone.createList('User', {
       access: {
         // 2.
         read: false,
-        update: ({ item, authentication }) =>
-          item.id === authentication.item.id,
+        update: ({ item, authentication }) => item.id === authentication.item.id,
       },
     },
   },
@@ -634,8 +633,7 @@ keystone.createList('User', {
   },
   admin: {
     // below, admin gets super access
-    createFields: auth =>
-      auth.item.isAdmin ? true : ['name', 'email', 'password'],
+    createFields: auth => (auth.item.isAdmin ? true : ['name', 'email', 'password']),
     readFields: auth => (auth.item.isAdmin ? true : ['name', 'email']),
     updateFields: auth => (auth.item.isAdmin ? true : ['email']),
   },

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
   "prettier": {
     "proseWrap": "preserve",
     "singleQuote": true,
-    "trailingComma": "es5"
+    "trailingComma": "es5",
+    "printWidth": 100
   },
   "bolt": {
     "workspaces": [

--- a/packages/access-control/index.js
+++ b/packages/access-control/index.js
@@ -109,12 +109,7 @@ module.exports = {
     });
   },
 
-  parseFieldAccess({
-    listKey,
-    fieldKey,
-    defaultAccess,
-    access = defaultAccess,
-  }) {
+  parseFieldAccess({ listKey, fieldKey, defaultAccess, access = defaultAccess }) {
     const accessTypes = ['create', 'read', 'update'];
 
     return parseAccess({
@@ -181,14 +176,7 @@ module.exports = {
     return result;
   },
 
-  testFieldAccessControl({
-    access,
-    listKey,
-    fieldKey,
-    item,
-    operation,
-    authentication,
-  }) {
+  testFieldAccessControl({ access, listKey, fieldKey, item, operation, authentication }) {
     if (typeof access[operation] !== 'function') {
       return access[operation];
     }

--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -56,8 +56,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
     if (debugMongoose()) {
       this.mongoose.set('debug', true);
     }
-    this.listAdapterClass =
-      this.listAdapterClass || this.defaultListAdapterClass;
+    this.listAdapterClass = this.listAdapterClass || this.defaultListAdapterClass;
   }
 
   connect(to, config) {
@@ -157,18 +156,12 @@ class MongooseListAdapter extends BaseListAdapter {
     // depth instead of passing it through to the individual fields and back
     // again?
     if (depthGuard > 1) {
-      throw new Error(
-        'Nesting where args deeper than 1 level is not currently supported'
-      );
+      throw new Error('Nesting where args deeper than 1 level is not currently supported');
     }
 
     return this.fieldAdapters.reduce(
       (conds, fieldAdapater) => {
-        const fieldConditions = fieldAdapater.getQueryConditions(
-          args,
-          this,
-          depthGuard + 1
-        );
+        const fieldConditions = fieldAdapater.getQueryConditions(args, this, depthGuard + 1);
 
         if (fieldConditions && !Array.isArray(fieldConditions)) {
           console.warn(
@@ -321,9 +314,7 @@ class MongooseListAdapter extends BaseListAdapter {
 
 class MongooseFieldAdapter extends BaseFieldAdapter {
   addToMongooseSchema() {
-    throw new Error(
-      `Field type [${this.fieldName}] does not implement addToMongooseSchema()`
-    );
+    throw new Error(`Field type [${this.fieldName}] does not implement addToMongooseSchema()`);
   }
 
   getQueryConditions() {

--- a/packages/admin-ui/client/apolloClient.js
+++ b/packages/admin-ui/client/apolloClient.js
@@ -25,9 +25,7 @@ class BoostClientWithUplaod extends ApolloClient {
         : new InMemoryCache();
 
     const stateLink =
-      config && config.clientState
-        ? withClientState({ ...config.clientState, cache })
-        : false;
+      config && config.clientState ? withClientState({ ...config.clientState, cache }) : false;
 
     const errorLink =
       config && config.onError
@@ -78,9 +76,7 @@ class BoostClientWithUplaod extends ApolloClient {
       credentials: 'same-origin',
     });
 
-    const link = ApolloLink.from(
-      [errorLink, requestHandler, stateLink, httpLink].filter(x => x)
-    );
+    const link = ApolloLink.from([errorLink, requestHandler, stateLink, httpLink].filter(x => x));
 
     // super hacky, we will fix the types eventually
     super({ cache, link });

--- a/packages/admin-ui/client/components/AnimateHeight.js
+++ b/packages/admin-ui/client/components/AnimateHeight.js
@@ -50,13 +50,7 @@ export default class AnimateHeight extends Component<Props, State> {
     }
   };
   render() {
-    const {
-      autoScroll,
-      children,
-      initialHeight,
-      render,
-      ...props
-    } = this.props;
+    const { autoScroll, children, initialHeight, render, ...props } = this.props;
     const { height, isTransitioning } = this.state;
     const overflow = isTransitioning ? 'hidden' : null;
 

--- a/packages/admin-ui/client/components/ConnectivityListener.js
+++ b/packages/admin-ui/client/components/ConnectivityListener.js
@@ -45,11 +45,7 @@ class ConnectivityListener extends Component {
     const content = (
       <div>
         <strong>{isOnline ? 'Online' : 'Offline'}</strong>
-        <div>
-          {isOnline
-            ? 'Editing is available again'
-            : 'Changes you make may not be saved'}
-        </div>
+        <div>{isOnline ? 'Editing is available again' : 'Changes you make may not be saved'}</div>
       </div>
     );
 

--- a/packages/admin-ui/client/components/CreateItemModal.js
+++ b/packages/admin-ui/client/components/CreateItemModal.js
@@ -67,9 +67,7 @@ class CreateItemModal extends Component {
       },
     });
   };
-  formComponent = props => (
-    <form autoComplete="off" onSubmit={this.onCreate} {...props} />
-  );
+  formComponent = props => <form autoComplete="off" onSubmit={this.onCreate} {...props} />;
   render() {
     const { isLoading, isOpen, list } = this.props;
     const { item } = this.state;
@@ -87,11 +85,7 @@ class CreateItemModal extends Component {
             <Button appearance="create" type="submit">
               {isLoading ? 'Loading...' : 'Create'}
             </Button>
-            <Button
-              appearance="warning"
-              variant="subtle"
-              onClick={this.onClose}
-            >
+            <Button appearance="warning" variant="subtle" onClick={this.onClose}>
               Cancel
             </Button>
           </Fragment>
@@ -124,11 +118,7 @@ export default class CreateItemModalWithMutation extends Component {
     return (
       <Mutation mutation={list.createMutation}>
         {(createItem, { loading }) => (
-          <CreateItemModal
-            createItem={createItem}
-            isLoading={loading}
-            {...this.props}
-          />
+          <CreateItemModal createItem={createItem} isLoading={loading} {...this.props} />
         )}
       </Mutation>
     );

--- a/packages/admin-ui/client/components/DeleteItemModal.js
+++ b/packages/admin-ui/client/components/DeleteItemModal.js
@@ -23,8 +23,7 @@ export default class DeleteItemModal extends Component {
           return (
             <Confirm isOpen={isOpen} onKeyDown={this.onKeyDown}>
               <p style={{ marginTop: 0 }}>
-                Are you sure you want to delete{' '}
-                <strong>{item.name || item.id}</strong>?
+                Are you sure you want to delete <strong>{item.name || item.id}</strong>?
               </p>
               <footer>
                 <Button

--- a/packages/admin-ui/client/components/DeleteManyItemsModal.js
+++ b/packages/admin-ui/client/components/DeleteManyItemsModal.js
@@ -23,8 +23,7 @@ export default class DeleteManyModal extends Component {
           return (
             <Confirm isOpen={isOpen} onKeyDown={this.onKeyDown}>
               <p style={{ marginTop: 0 }}>
-                Are you sure you want to delete{' '}
-                <strong>{list.formatCount(itemIds)}</strong>?
+                Are you sure you want to delete <strong>{list.formatCount(itemIds)}</strong>?
               </p>
               <footer>
                 <Button

--- a/packages/admin-ui/client/components/ListTable.js
+++ b/packages/admin-ui/client/components/ListTable.js
@@ -141,16 +141,10 @@ class ListDisplayRow extends Component {
             return <BodyCell key={path} />;
           }
 
-          if (
-            itemErrors[path] instanceof Error &&
-            itemErrors[path].name === 'AccessDeniedError'
-          ) {
+          if (itemErrors[path] instanceof Error && itemErrors[path].name === 'AccessDeniedError') {
             return (
               <BodyCell key={path}>
-                <ShieldIcon
-                  title={itemErrors[path].message}
-                  css={{ color: colors.N10 }}
-                />
+                <ShieldIcon title={itemErrors[path].message} css={{ color: colors.N10 }} />
                 <A11yText>{itemErrors[path].message}</A11yText>
               </BodyCell>
             );
@@ -164,14 +158,7 @@ class ListDisplayRow extends Component {
             const LinkComponent = ({ children, ...data }) => (
               <ItemLink to={link(data)}>{children}</ItemLink>
             );
-            content = (
-              <Cell
-                list={list}
-                data={item[path]}
-                field={field}
-                Link={LinkComponent}
-              />
-            );
+            content = <Cell list={list} data={item[path]} field={field} Link={LinkComponent} />;
           } else {
             content = item[path];
           }
@@ -179,9 +166,7 @@ class ListDisplayRow extends Component {
           return (
             <BodyCell key={path}>
               {!index ? (
-                <ItemLink to={link({ path: list.path, id: item.id })}>
-                  {content}
-                </ItemLink>
+                <ItemLink to={link({ path: list.path, id: item.id })}>{content}</ItemLink>
               ) : (
                 content
               )}
@@ -328,10 +313,7 @@ export default class ListTable extends Component {
             ))}
           </tr>
         </thead>
-        <tbody
-          onMouseUp={this.stopRowSelectOnEnter}
-          onMouseLeave={this.stopRowSelectOnEnter}
-        >
+        <tbody onMouseUp={this.stopRowSelectOnEnter} onMouseLeave={this.stopRowSelectOnEnter}>
           {items.map(
             (item, itemIndex) =>
               isManaging ? (

--- a/packages/admin-ui/client/components/ModalDialog.js
+++ b/packages/admin-ui/client/components/ModalDialog.js
@@ -51,9 +51,7 @@ export const ModalProvider = ({ children }: Props) => (
     {children}
 
     <Subscribe to={[ModalState]}>
-      {({ state }) => (
-        <TransitionGroup component={null}>{state.activeDialog}</TransitionGroup>
-      )}
+      {({ state }) => <TransitionGroup component={null}>{state.activeDialog}</TransitionGroup>}
     </Subscribe>
   </Provider>
 );

--- a/packages/admin-ui/client/components/Nav.js
+++ b/packages/admin-ui/client/components/Nav.js
@@ -23,14 +23,7 @@ const GITHUB_PROJECT = 'https://github.com/keystonejs/keystone-5';
 
 const Nav = props => {
   const {
-    adminMeta: {
-      withAuth,
-      getListByKey,
-      listKeys,
-      adminPath,
-      graphiqlPath,
-      signoutPath,
-    },
+    adminMeta: { withAuth, getListByKey, listKeys, adminPath, graphiqlPath, signoutPath },
     location,
   } = props;
   return (
@@ -58,20 +51,12 @@ const Nav = props => {
       <NavGroup>
         {ENABLE_DEV_FEATURES ? (
           <Fragment>
-            <PrimaryNavItem
-              target="_blank"
-              href={GITHUB_PROJECT}
-              title="GitHub"
-            >
+            <PrimaryNavItem target="_blank" href={GITHUB_PROJECT} title="GitHub">
               <MarkGithubIcon />
               <A11yText>GitHub</A11yText>
             </PrimaryNavItem>
             <NavSeparator />
-            <PrimaryNavItem
-              target="_blank"
-              href={graphiqlPath}
-              title="Graphiql Console"
-            >
+            <PrimaryNavItem target="_blank" href={graphiqlPath} title="Graphiql Console">
               <TerminalIcon />
               <A11yText>Graphiql Console</A11yText>
             </PrimaryNavItem>

--- a/packages/admin-ui/client/components/Popout.js
+++ b/packages/admin-ui/client/components/Popout.js
@@ -1,11 +1,6 @@
 // @flow
 
-import React, {
-  Fragment,
-  type ComponentType,
-  type Node,
-  type Ref,
-} from 'react';
+import React, { Fragment, type ComponentType, type Node, type Ref } from 'react';
 import styled from 'react-emotion';
 
 import { Button } from '@keystonejs/ui/src/primitives/buttons';

--- a/packages/admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/admin-ui/client/components/UpdateManyItemsModal.js
@@ -3,11 +3,7 @@ import gql from 'graphql-tag';
 import { Mutation } from 'react-apollo';
 import { Button } from '@keystonejs/ui/src/primitives/buttons';
 import { Drawer } from '@keystonejs/ui/src/primitives/modals';
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Select } from '@keystonejs/ui/src/primitives/filters';
 
 import FieldTypes from '../FIELD_TYPES';
@@ -105,11 +101,7 @@ class UpdateManyModal extends Component {
             <Button appearance="primary" onClick={this.onUpdate}>
               {isLoading ? 'Loading...' : 'Update'}
             </Button>
-            <Button
-              appearance="warning"
-              variant="subtle"
-              onClick={this.onClose}
-            >
+            <Button appearance="warning" variant="subtle" onClick={this.onClose}>
               Cancel
             </Button>
           </Fragment>
@@ -157,11 +149,7 @@ export default class UpdateManyModalWithMutation extends Component {
     return (
       <Mutation mutation={updateMutation}>
         {(updateItem, { loading }) => (
-          <UpdateManyModal
-            updateItem={updateItem}
-            isLoading={loading}
-            {...this.props}
-          />
+          <UpdateManyModal updateItem={updateItem} isLoading={loading} {...this.props} />
         )}
       </Mutation>
     );

--- a/packages/admin-ui/client/index.js
+++ b/packages/admin-ui/client/index.js
@@ -36,11 +36,7 @@ const Keystone = () => (
                     path={`${adminPath}/style-guide/:page?`}
                     render={() => <StyleGuidePage {...adminMeta} />}
                   />
-                  <Route
-                    exact
-                    path={`${adminPath}`}
-                    render={() => <HomePage {...adminMeta} />}
-                  />
+                  <Route exact path={`${adminPath}`} render={() => <HomePage {...adminMeta} />} />
                   <Route
                     path={`${adminPath}/:listKey`}
                     render={({
@@ -56,13 +52,7 @@ const Keystone = () => (
                           <Route
                             exact
                             path={`${adminPath}/:list`}
-                            render={() => (
-                              <ListPage
-                                key={listKey}
-                                list={list}
-                                {...adminMeta}
-                              />
-                            )}
+                            render={() => <ListPage key={listKey} list={list} {...adminMeta} />}
                           />
                           <Route
                             exact
@@ -80,9 +70,7 @@ const Keystone = () => (
                               />
                             )}
                           />
-                          <Route
-                            render={() => <InvalidRoutePage {...adminMeta} />}
-                          />
+                          <Route render={() => <InvalidRoutePage {...adminMeta} />} />
                         </Switch>
                       ) : (
                         <ListNotFoundPage listKey={listKey} {...adminMeta} />

--- a/packages/admin-ui/client/pages/Home/components.js
+++ b/packages/admin-ui/client/pages/Home/components.js
@@ -83,7 +83,8 @@ export const Count = ({ meta }) => {
     </div>
   ) : (
     <div css={{ fontSize: '0.85em' }}>
-      {count} Item{count !== 1 ? 's' : ''}
+      {count} Item
+      {count !== 1 ? 's' : ''}
     </div>
   );
 };

--- a/packages/admin-ui/client/pages/Item/Footer.js
+++ b/packages/admin-ui/client/pages/Item/Footer.js
@@ -77,8 +77,7 @@ export default class Footer extends Component {
     const viewY = window.scrollY + window.innerHeight;
 
     const newSize = getWindowSize();
-    const sizeChanged =
-      newSize.x !== this.windowSize.x || newSize.y !== this.windowSize.y;
+    const sizeChanged = newSize.x !== this.windowSize.x || newSize.y !== this.windowSize.y;
     this.windowSize = newSize;
 
     const newState = {

--- a/packages/admin-ui/client/pages/Item/index.js
+++ b/packages/admin-ui/client/pages/Item/index.js
@@ -14,23 +14,14 @@ import DocTitle from '../../components/DocTitle';
 import PageError from '../../components/PageError';
 import PageLoading from '../../components/PageLoading';
 import Footer from './Footer';
-import {
-  TriangleLeftIcon,
-  CheckIcon,
-  ClippyIcon,
-  PlusIcon,
-} from '@keystonejs/icons';
+import { TriangleLeftIcon, CheckIcon, ClippyIcon, PlusIcon } from '@keystonejs/icons';
 import { Container, FlexGroup } from '@keystonejs/ui/src/primitives/layout';
 import { A11yText, H1 } from '@keystonejs/ui/src/primitives/typography';
 import { Button, IconButton } from '@keystonejs/ui/src/primitives/buttons';
 import { Alert } from '@keystonejs/ui/src/primitives/alert';
 import { AutocompleteCaptor } from '@keystonejs/ui/src/primitives/forms';
 import { colors, gridSize } from '@keystonejs/ui/src/theme';
-import {
-  deconstructErrorsToDataShape,
-  toastItemSuccess,
-  toastError,
-} from '../../util';
+import { deconstructErrorsToDataShape, toastItemSuccess, toastError } from '../../util';
 
 import { resolveAllKeys } from '@keystonejs/utils';
 import isEqual from 'lodash.isequal';
@@ -181,18 +172,9 @@ const ItemDetails = withRouter(
       const { itemHasChanged, resetRequested } = this.state;
 
       return resetRequested ? (
-        <div
-          css={{ display: 'flex', alignItems: 'center', marginLeft: gridSize }}
-        >
-          <div css={{ fontSize: '0.9rem', marginRight: gridSize }}>
-            Are you sure?
-          </div>
-          <Button
-            appearance="danger"
-            autoFocus
-            onClick={this.onReset}
-            variant="ghost"
-          >
+        <div css={{ display: 'flex', alignItems: 'center', marginLeft: gridSize }}>
+          <div css={{ fontSize: '0.9rem', marginRight: gridSize }}>Are you sure?</div>
+          <Button appearance="danger" autoFocus onClick={this.onReset} variant="ghost">
             Reset
           </Button>
           <Button variant="subtle" onClick={this.hideConfirmResetMessage}>
@@ -330,11 +312,7 @@ const ItemDetails = withRouter(
             <H1>
               <TitleLink to={listHref}>{list.label}</TitleLink>: {item.name}
             </H1>
-            <IconButton
-              appearance="create"
-              icon={PlusIcon}
-              onClick={this.openCreateModal}
-            >
+            <IconButton appearance="create" icon={PlusIcon} onClick={this.openCreateModal}>
               Create
             </IconButton>
           </FlexGroup>
@@ -407,25 +385,18 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey, toastManager }) => {
           // (ie; there could be partial data + partial errors)
           if (
             error &&
-            (!data ||
-              !data[list.itemQueryName] ||
-              !Object.keys(data[list.itemQueryName]).length)
+            (!data || !data[list.itemQueryName] || !Object.keys(data[list.itemQueryName]).length)
           ) {
             return (
               <Fragment>
                 <DocTitle>{list.singular} not found</DocTitle>
-                <ItemNotFound
-                  adminPath={adminPath}
-                  errorMessage={error.message}
-                  list={list}
-                />
+                <ItemNotFound adminPath={adminPath} errorMessage={error.message} list={list} />
               </Fragment>
             );
           }
 
           const item = data[list.itemQueryName];
-          const itemErrors =
-            deconstructErrorsToDataShape(error)[list.itemQueryName] || {};
+          const itemErrors = deconstructErrorsToDataShape(error)[list.itemQueryName] || {};
 
           return item ? (
             <main>
@@ -434,10 +405,7 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey, toastManager }) => {
               </DocTitle>
               <Container id="toast-boundary">
                 <Mutation mutation={list.updateMutation}>
-                  {(
-                    updateItem,
-                    { loading: updateInProgress, error: updateError }
-                  ) => {
+                  {(updateItem, { loading: updateInProgress, error: updateError }) => {
                     if (updateError) {
                       const [title, ...rest] = updateError.message.split(/\:/);
                       const toastContent = rest.length ? (

--- a/packages/admin-ui/client/pages/List/ColumnSelect.js
+++ b/packages/admin-ui/client/pages/List/ColumnSelect.js
@@ -6,13 +6,7 @@ import { OptionPrimitive } from '@keystonejs/ui/src/primitives/filters';
 import { POPOUT_GUTTER } from '../../components/Popout';
 import FieldSelect, { type FieldSelectProps } from './FieldSelect';
 
-export const ColumnOption = ({
-  children,
-  isFocused,
-  isSelected,
-  selectProps,
-  ...props
-}) => {
+export const ColumnOption = ({ children, isFocused, isSelected, selectProps, ...props }) => {
   const { removeIsAllowed } = selectProps;
 
   let Icon;
@@ -26,9 +20,7 @@ export const ColumnOption = ({
   return (
     <OptionPrimitive isFocused={isFocused} isSelected={isSelected} {...props}>
       <span>{children}</span>
-      {isSelected && !removeIsAllowed ? null : (
-        <Icon css={{ color: iconColor }} />
-      )}
+      {isSelected && !removeIsAllowed ? null : <Icon css={{ color: iconColor }} />}
     </OptionPrimitive>
   );
 };

--- a/packages/admin-ui/client/pages/List/DataProvider.js
+++ b/packages/admin-ui/client/pages/List/DataProvider.js
@@ -14,9 +14,7 @@ const getQueryArgs = ({ filters, ...args }) => {
     argName => `${argName}: ${JSON.stringify(args[argName])}`
   );
   if (filters) {
-    const filterArgs = filters.map(filter =>
-      filter.field.getFilterGraphQL(filter)
-    );
+    const filterArgs = filters.map(filter => filter.field.getFilterGraphQL(filter));
     if (filterArgs.length) {
       queryArgs.push(`where: { ${filterArgs.join(', ')} }`);
     }
@@ -125,10 +123,7 @@ class ListPageDataProvider extends Component<Props, State> {
     let filters = this.state.filters.slice(0);
 
     const updateIndex = filters.findIndex(i => {
-      return (
-        i.field.path === updatedFilter.field.path &&
-        i.type === updatedFilter.type
-      );
+      return i.field.path === updatedFilter.field.path && i.type === updatedFilter.type;
     });
 
     filters.splice(updateIndex, 1, updatedFilter);
@@ -147,15 +142,11 @@ class ListPageDataProvider extends Component<Props, State> {
 
     // Ensure that the displayed fields maintain their original sortDirection
     // when they're added/removed
-    const fields = this.props.list.fields.filter(field =>
-      selectedFields.includes(field)
-    );
+    const fields = this.props.list.fields.filter(field => selectedFields.includes(field));
 
     // Reset `sortBy` if we were ordering by a field which has been removed.
     const { sortBy } = this.state;
-    const newSort = fields.includes(sortBy.field)
-      ? sortBy
-      : { ...sortBy, field: fields[0] };
+    const newSort = fields.includes(sortBy.field) ? sortBy : { ...sortBy, field: fields[0] };
 
     this.setState({ fields, sortBy: newSort });
   };
@@ -180,15 +171,7 @@ class ListPageDataProvider extends Component<Props, State> {
 
   render() {
     const { children, list } = this.props;
-    const {
-      currentPage,
-      fields,
-      filters,
-      pageSize,
-      search,
-      skip,
-      sortBy,
-    } = this.state;
+    const { currentPage, fields, filters, pageSize, search, skip, sortBy } = this.state;
 
     const orderBy = `${sortBy.field.path}_${sortBy.direction}`;
     const first = pageSize;
@@ -212,9 +195,7 @@ class ListPageDataProvider extends Component<Props, State> {
             // (ie; there could be partial data + partial errors)
             if (
               error &&
-              (!data ||
-                !data[list.listQueryName] ||
-                !Object.keys(data[list.listQueryName]).length)
+              (!data || !data[list.listQueryName] || !Object.keys(data[list.listQueryName]).length)
             ) {
               let message = error.message;
 
@@ -226,8 +207,7 @@ class ListPageDataProvider extends Component<Props, State> {
                 error.networkError.result.errors &&
                 error.networkError.result.errors[0]
               ) {
-                message =
-                  error.networkError.result.errors[0].message || message;
+                message = error.networkError.result.errors[0].message || message;
               }
 
               // Special case for when trying to access a non-existent list or a
@@ -243,8 +223,7 @@ class ListPageDataProvider extends Component<Props, State> {
               );
             }
 
-            const itemsErrors =
-              deconstructErrorsToDataShape(error)[list.listQueryName] || [];
+            const itemsErrors = deconstructErrorsToDataShape(error)[list.listQueryName] || [];
 
             // Leave the old values intact while new data is loaded
             if (!loading) {

--- a/packages/admin-ui/client/pages/List/Filters/ActiveFilters.js
+++ b/packages/admin-ui/client/pages/List/Filters/ActiveFilters.js
@@ -22,12 +22,7 @@ type Props = {
   onUpdate: FilterType => void,
 };
 
-export default function ActiveFilters({
-  filterList,
-  onClear,
-  onRemove,
-  onUpdate,
-}: Props) {
+export default function ActiveFilters({ filterList, onClear, onRemove, onUpdate }: Props) {
   if (!ENABLE_DEV_FEATURES) return null;
 
   return (
@@ -42,11 +37,7 @@ export default function ActiveFilters({
                   onChange={onUpdate}
                   filter={filter}
                   target={
-                    <Pill
-                      appearance="primary"
-                      onRemove={onRemove(filter)}
-                      style={pillStyle}
-                    >
+                    <Pill appearance="primary" onRemove={onRemove(filter)} style={pillStyle}>
                       {label}
                     </Pill>
                   }

--- a/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -1,11 +1,7 @@
 import React, { Component, createRef } from 'react';
 import { Transition, TransitionGroup } from 'react-transition-group';
 
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  AlertIcon,
-} from '@keystonejs/icons';
+import { ChevronLeftIcon, ChevronRightIcon, AlertIcon } from '@keystonejs/icons';
 import { colors, gridSize } from '@keystonejs/ui/src/theme';
 import { A11yText } from '@keystonejs/ui/src/primitives/typography';
 import { Alert } from '@keystonejs/ui/src/primitives/alert';
@@ -31,8 +27,7 @@ const EventCatcher = props => (
 );
 
 export const FieldOption = ({ children, ...props }) => {
-  let iconColor =
-    !props.isFocused && !props.isSelected ? colors.N40 : 'currentColor';
+  let iconColor = !props.isFocused && !props.isSelected ? colors.N40 : 'currentColor';
 
   return (
     <OptionPrimitive {...props}>

--- a/packages/admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -48,12 +48,7 @@ export default class EditFilterPopout extends Component<Props, State> {
     const headerTitle = filter.field.getFilterLabel(filter);
 
     return (
-      <PopoutForm
-        target={target}
-        headerTitle={headerTitle}
-        onSubmit={this.onSubmit}
-        showFooter
-      >
+      <PopoutForm target={target} headerTitle={headerTitle} onSubmit={this.onSubmit} showFooter>
         {({ ref, recalcHeight }) => (
           <div ref={ref} style={{ padding: POPOUT_GUTTER }}>
             <Filter

--- a/packages/admin-ui/client/pages/List/ListDetails.js
+++ b/packages/admin-ui/client/pages/List/ListDetails.js
@@ -2,19 +2,9 @@ import React, { Component, createRef, Fragment } from 'react';
 import styled from 'react-emotion';
 import { withRouter } from 'react-router-dom';
 
-import {
-  FoldIcon,
-  PlusIcon,
-  SearchIcon,
-  UnfoldIcon,
-  XIcon,
-} from '@keystonejs/icons';
+import { FoldIcon, PlusIcon, SearchIcon, UnfoldIcon, XIcon } from '@keystonejs/icons';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
-import {
-  Container,
-  FlexGroup,
-  CONTAINER_WIDTH,
-} from '@keystonejs/ui/src/primitives/layout';
+import { Container, FlexGroup, CONTAINER_WIDTH } from '@keystonejs/ui/src/primitives/layout';
 import { A11yText, Kbd, H1 } from '@keystonejs/ui/src/primitives/typography';
 import { Button, IconButton } from '@keystonejs/ui/src/primitives/buttons';
 import { LoadingSpinner } from '@keystonejs/ui/src/primitives/loading';
@@ -76,11 +66,7 @@ const Search = ({ children, hasValue, isFetching, onClear, onSubmit }) => {
           },
         }}
       >
-        {isLoading ? (
-          <LoadingSpinner size={16} />
-        ) : (
-          <Icon onClick={hasValue ? onClear : null} />
-        )}
+        {isLoading ? <LoadingSpinner size={16} /> : <Icon onClick={hasValue ? onClear : null} />}
       </div>
     </form>
   );
@@ -208,7 +194,9 @@ class ListDetails extends Component<Props, State> {
     if (search && search.length) {
       return (
         <span>
-          No {list.plural.toLowerCase()} found matching &ldquo;{search}&rdquo;
+          No {list.plural.toLowerCase()} found matching &ldquo;
+          {search}
+          &rdquo;
         </span>
       );
     }
@@ -267,12 +255,7 @@ class ListDetails extends Component<Props, State> {
       search,
       sortBy,
     } = this.props;
-    const {
-      isFullWidth,
-      isManaging,
-      selectedItems,
-      showCreateModal,
-    } = this.state;
+    const { isFullWidth, isManaging, selectedItems, showCreateModal } = this.state;
 
     const searchId = 'list-search-input';
 
@@ -344,11 +327,7 @@ class ListDetails extends Component<Props, State> {
             {this.renderExpandButton()}
             <ToolbarSeparator />
             {list.access.create ? (
-              <IconButton
-                appearance="create"
-                icon={PlusIcon}
-                onClick={this.openCreateModal}
-              >
+              <IconButton appearance="create" icon={PlusIcon} onClick={this.openCreateModal}>
                 Create
               </IconButton>
             ) : null}

--- a/packages/admin-ui/client/pages/List/SortSelect.js
+++ b/packages/admin-ui/client/pages/List/SortSelect.js
@@ -32,18 +32,8 @@ export const SortButton = styled.button(({ isActive }) => {
   };
 });
 
-export const SortOption = ({
-  altIsDown,
-  children,
-  isFocused,
-  isSelected,
-  ...props
-}) => {
-  const Icon = isSelected
-    ? ChevronUpIcon
-    : altIsDown
-      ? ChevronUpIcon
-      : ChevronDownIcon;
+export const SortOption = ({ altIsDown, children, isFocused, isSelected, ...props }) => {
+  const Icon = isSelected ? ChevronUpIcon : altIsDown ? ChevronUpIcon : ChevronDownIcon;
   const iconColor = !isFocused && !isSelected ? colors.N40 : 'currentColor';
 
   return (
@@ -103,9 +93,7 @@ export default class SortSelect extends Component<Props, State> {
     onChange({ field, direction });
     popoutRef.current.close();
   };
-  enhancedOption = props => (
-    <SortOption altIsDown={this.state.altIsDown} {...props} />
-  );
+  enhancedOption = props => <SortOption altIsDown={this.state.altIsDown} {...props} />;
   getOptions = () => {
     const { fields } = this.props;
     return fields.map(({ options, ...field }) => field);

--- a/packages/admin-ui/client/pages/ListNotFound.js
+++ b/packages/admin-ui/client/pages/ListNotFound.js
@@ -9,7 +9,11 @@ const ListNotFoundPage = ({ listKey, adminPath }) => (
   <Fragment>
     <Nav />
     <PageError Icon={IssueOpenedIcon}>
-      <p>The list &ldquo;{listKey}&rdquo; doesn&apos;t exist</p>
+      <p>
+        The list &ldquo;
+        {listKey}
+        &rdquo; doesn&apos;t exist
+      </p>
       <Button to={adminPath} variant="ghost">
         Go Home
       </Button>

--- a/packages/admin-ui/client/pages/Signin.js
+++ b/packages/admin-ui/client/pages/Signin.js
@@ -86,9 +86,7 @@ class SigninPage extends Component {
       <Container>
         <Alerts>
           {error ? (
-            <Alert appearance="danger">
-              Your username and password were incorrect
-            </Alert>
+            <Alert appearance="danger">Your username and password were incorrect</Alert>
           ) : null}
         </Alerts>
         <Form method="post" onSubmit={this.onSubmit}>
@@ -128,11 +126,7 @@ class SigninPage extends Component {
 }
 
 export default ({ sessionPath, signinPath, signoutPath }) => (
-  <SessionProvider
-    signinPath={signinPath}
-    signoutPath={signoutPath}
-    sessionPath={sessionPath}
-  >
+  <SessionProvider signinPath={signinPath} signoutPath={signoutPath} sessionPath={sessionPath}>
     {props => <SigninPage {...props} />}
   </SessionProvider>
 );

--- a/packages/admin-ui/client/pages/Signout.js
+++ b/packages/admin-ui/client/pages/Signout.js
@@ -81,11 +81,7 @@ const SignedOutPage = ({ isLoading, isSignedIn, signinPath, signOut }) => {
 };
 
 export default ({ signinPath, signoutPath, sessionPath }) => (
-  <SessionProvider
-    signinPath={signinPath}
-    signoutPath={signoutPath}
-    sessionPath={sessionPath}
-  >
+  <SessionProvider signinPath={signinPath} signoutPath={signoutPath} sessionPath={sessionPath}>
     {props => <SignedOutPage signinPath={signinPath} {...props} />}
   </SessionProvider>
 );

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Alerts.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Alerts.js
@@ -9,20 +9,17 @@ const AlertGuide = () => (
     <h4>Variant: Subtle</h4>
     <FlexGroup isVertical>
       <Alert appearance="info">
-        <code>info</code>: Amet soufflé chocolate bar sugar plum topping sweet
-        jelly jujubes.
+        <code>info</code>: Amet soufflé chocolate bar sugar plum topping sweet jelly jujubes.
       </Alert>
       <Alert appearance="danger">
-        <code>danger</code>: Dessert gummi bears pudding cheesecake oat cake
-        carrot cake pastry jelly beans jelly-o.
+        <code>danger</code>: Dessert gummi bears pudding cheesecake oat cake carrot cake pastry
+        jelly beans jelly-o.
       </Alert>
       <Alert appearance="warning">
-        <code>warning</code>: Croissant candy biscuit bear claw cotton candy
-        sugar plum.
+        <code>warning</code>: Croissant candy biscuit bear claw cotton candy sugar plum.
       </Alert>
       <Alert appearance="success">
-        <code>success</code>: Bear claw chocolate cheesecake candy canes
-        soufflé.
+        <code>success</code>: Bear claw chocolate cheesecake candy canes soufflé.
       </Alert>
     </FlexGroup>
     <h4>Variant: Bold</h4>
@@ -31,8 +28,7 @@ const AlertGuide = () => (
         <code>info</code>: Jujubes gummies candy liquorice biscuit soufflé.
       </Alert>
       <Alert appearance="danger" variant="bold">
-        <code>danger</code>: Tiramisu cupcake brownie soufflé toffee cake sweet
-        roll candy soufflé.
+        <code>danger</code>: Tiramisu cupcake brownie soufflé toffee cake sweet roll candy soufflé.
       </Alert>
       <Alert appearance="warning" variant="bold">
         <code>warning</code>: Bear claw dessert cake jelly beans cake.

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Badges.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Badges.js
@@ -3,26 +3,15 @@ import React, { Fragment } from 'react';
 import { Badge } from '@keystonejs/ui/src/primitives/badge';
 import { FlexGroup } from '@keystonejs/ui/src/primitives/layout';
 
-const appearances = [
-  'default',
-  'primary',
-  'created',
-  'warning',
-  'danger',
-  'inverted',
-];
+const appearances = ['default', 'primary', 'created', 'warning', 'danger', 'inverted'];
 const BadgeGuide = () => (
   <Fragment>
     <h2>Badges</h2>
     <h4>Variant: Subtle</h4>
-    <FlexGroup>
-      {appearances.map(a => <Badge value={55} appearance={a} key={a} />)}
-    </FlexGroup>
+    <FlexGroup>{appearances.map(a => <Badge value={55} appearance={a} key={a} />)}</FlexGroup>
     <h4>Variant: Bold</h4>
     <FlexGroup>
-      {appearances.map(a => (
-        <Badge value={55} variant="bold" appearance={a} key={a} />
-      ))}
+      {appearances.map(a => <Badge value={55} variant="bold" appearance={a} key={a} />)}
     </FlexGroup>
   </Fragment>
 );

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Buttons.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Buttons.js
@@ -1,17 +1,7 @@
 import React, { Component, Fragment } from 'react';
 
-import {
-  AlertIcon,
-  DashboardIcon,
-  PencilIcon,
-  PlusIcon,
-  MegaphoneIcon,
-} from '@keystonejs/icons';
-import {
-  Button,
-  IconButton,
-  LoadingButton,
-} from '@keystonejs/ui/src/primitives/buttons';
+import { AlertIcon, DashboardIcon, PencilIcon, PlusIcon, MegaphoneIcon } from '@keystonejs/icons';
+import { Button, IconButton, LoadingButton } from '@keystonejs/ui/src/primitives/buttons';
 import { FlexGroup } from '@keystonejs/ui/src/primitives/layout';
 
 export default class ButtonGuide extends Component {

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Fields.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Fields.js
@@ -1,10 +1,6 @@
 import React, { Fragment } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import {
   Checkbox,
   CheckboxGroup,

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Layout.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Layout.js
@@ -19,18 +19,9 @@ const LayoutGuide = () => (
   <Fragment>
     <h2>Flex Group</h2>
     <FlexGroupExample heading="Default" groupProps={{ growIndexes: [1] }} />
-    <FlexGroupExample
-      heading="Contiguous"
-      groupProps={{ isContiguous: true, growIndexes: [1] }}
-    />
-    <FlexGroupExample
-      heading="Inline"
-      groupProps={{ isInline: true, growIndexes: [1] }}
-    />
-    <FlexGroupExample
-      heading="Justify"
-      groupProps={{ justify: 'space-between' }}
-    />
+    <FlexGroupExample heading="Contiguous" groupProps={{ isContiguous: true, growIndexes: [1] }} />
+    <FlexGroupExample heading="Inline" groupProps={{ isInline: true, growIndexes: [1] }} />
+    <FlexGroupExample heading="Justify" groupProps={{ justify: 'space-between' }} />
   </Fragment>
 );
 

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Loading.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Loading.js
@@ -3,10 +3,7 @@ import styled from 'react-emotion';
 
 import { colors } from '@keystonejs/ui/src/theme';
 import { FlexGroup } from '@keystonejs/ui/src/primitives/layout';
-import {
-  LoadingIndicator,
-  LoadingSpinner,
-} from '@keystonejs/ui/src/primitives/loading';
+import { LoadingIndicator, LoadingSpinner } from '@keystonejs/ui/src/primitives/loading';
 
 const LoadingBox = styled.div(({ on, size }) => ({
   alignItems: 'center',
@@ -39,13 +36,7 @@ export default class ProgressGuide extends Component<*, State> {
         <h2>Loading</h2>
         <FlexGroup style={{ marginBottom: '1em' }}>
           <div css={{ alignItems: 'center', display: 'flex' }}>
-            <input
-              type="range"
-              min="4"
-              max="16"
-              value={size}
-              onChange={this.handleSize}
-            />
+            <input type="range" min="4" max="16" value={size} onChange={this.handleSize} />
           </div>
           <div>
             {appearances.map(a => (

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Modals.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Modals.js
@@ -68,39 +68,31 @@ export default class ModalGuide extends Component {
               <Button appearance="primary" onClick={this.toggleDialog}>
                 Do Thing
               </Button>
-              <Button
-                appearance="warning"
-                variant="subtle"
-                onClick={this.toggleDialog}
-              >
+              <Button appearance="warning" variant="subtle" onClick={this.toggleDialog}>
                 Cancel
               </Button>
             </Fragment>
           }
         >
           <p>
-            Cupcake ipsum dolor. Sit amet gummi bears toffee. Dessert danish
-            fruitcake cupcake powder pie soufflé macaroon cake.
+            Cupcake ipsum dolor. Sit amet gummi bears toffee. Dessert danish fruitcake cupcake
+            powder pie soufflé macaroon cake.
           </p>
           <p>
-            Icing cheesecake topping. Jelly jujubes lemon drops tart jujubes.
-            Biscuit jujubes jelly-o chupa chups tiramisu. Fruitcake brownie
-            donut.
+            Icing cheesecake topping. Jelly jujubes lemon drops tart jujubes. Biscuit jujubes
+            jelly-o chupa chups tiramisu. Fruitcake brownie donut.
           </p>
           <p>
-            Soufflé chocolate bar tart sweet. Gummies sweet roll danish sesame
-            snaps danish liquorice apple pie pie. Apple pie donut pudding dragée
-            gummies soufflé powder.
+            Soufflé chocolate bar tart sweet. Gummies sweet roll danish sesame snaps danish
+            liquorice apple pie pie. Apple pie donut pudding dragée gummies soufflé powder.
           </p>
           <p>
-            Chocolate bear claw dragée fruitcake liquorice. Caramels wafer
-            fruitcake brownie caramels jelly. Tiramisu jelly-o jelly pastry bear
-            claw gummies.
+            Chocolate bear claw dragée fruitcake liquorice. Caramels wafer fruitcake brownie
+            caramels jelly. Tiramisu jelly-o jelly pastry bear claw gummies.
           </p>
           <p>
-            Liquorice jelly-o icing oat cake oat cake halvah tootsie roll.
-            Fruitcake caramels danish tart gingerbread candy macaroon
-            gingerbread sweet. Sugar plum fruitcake wafer.
+            Liquorice jelly-o icing oat cake oat cake halvah tootsie roll. Fruitcake caramels danish
+            tart gingerbread candy macaroon gingerbread sweet. Sugar plum fruitcake wafer.
           </p>
         </Dialog>
       </Fragment>

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Pills.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Pills.js
@@ -18,12 +18,7 @@ const PillGuide = () => (
     <h4>Variant: Bold</h4>
     <FlexGroup>
       {appearances.map(a => (
-        <Pill
-          variant="bold"
-          appearance={a.toLowerCase()}
-          key={a}
-          onRemove={console.log}
-        >
+        <Pill variant="bold" appearance={a.toLowerCase()} key={a} onRemove={console.log}>
           {a}
         </Pill>
       ))}

--- a/packages/admin-ui/client/pages/StyleGuide/Icons.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Icons.js
@@ -75,20 +75,16 @@ export default class IconsGuide extends Component {
     return (
       <Fragment>
         {altIsDown ? (
-          <Instructions>
-            Click an icon to copy its import code to your clipboard.
-          </Instructions>
+          <Instructions>Click an icon to copy its import code to your clipboard.</Instructions>
         ) : (
           <Instructions>
-            Click an icon to copy its name to your clipboard. Hold{' '}
-            <Kbd>⌥ option</Kbd> to copy the import code.
+            Click an icon to copy its name to your clipboard. Hold <Kbd>⌥ option</Kbd> to copy the
+            import code.
           </Instructions>
         )}
         <Grid gap={16}>
           {Object.keys(icons).map(name => {
-            const importText = altIsDown
-              ? `import { ${name} } from '@keystonejs/icons';`
-              : name;
+            const importText = altIsDown ? `import { ${name} } from '@keystonejs/icons';` : name;
             const isCopied = copyText === importText;
             const Icon = isCopied ? icons.CheckIcon : icons[name];
             return (
@@ -97,16 +93,12 @@ export default class IconsGuide extends Component {
                   <IconContainer>
                     <Icon
                       css={{
-                        fill: isCopied
-                          ? `${colors.create} !important`
-                          : 'inherit',
+                        fill: isCopied ? `${colors.create} !important` : 'inherit',
                         width: 24,
                         height: 24,
                       }}
                     />
-                    <IconName className="icon-text">
-                      {isCopied ? 'Copied!' : name}
-                    </IconName>
+                    <IconName className="icon-text">{isCopied ? 'Copied!' : name}</IconName>
                   </IconContainer>
                 </CopyToClipboard>
               </Cell>

--- a/packages/admin-ui/client/pages/StyleGuide/index.js
+++ b/packages/admin-ui/client/pages/StyleGuide/index.js
@@ -8,10 +8,7 @@ import IconsGuide from './Icons';
 import PaletteGuide from './Palette';
 
 import { Container, FlexGroup } from '@keystonejs/ui/src/primitives/layout';
-import {
-  SecondaryNav,
-  SecondaryNavItem,
-} from '@keystonejs/ui/src/primitives/navigation';
+import { SecondaryNav, SecondaryNavItem } from '@keystonejs/ui/src/primitives/navigation';
 import { H1 } from '@keystonejs/ui/src/primitives/typography';
 
 const pages = ['components', 'palette', 'icons'];
@@ -45,20 +42,9 @@ export default withRouter(
           <Container css={{ paddingBottom: 200 }}>
             <H1>Style Guide: {upCase(currentPage)}</H1>
             <Switch>
-              <Route
-                exact
-                path={`${adminPath}/style-guide/palette`}
-                component={PaletteGuide}
-              />
-              <Route
-                exact
-                path={`${adminPath}/style-guide/icons`}
-                component={IconsGuide}
-              />
-              <Route
-                path={`${adminPath}/style-guide/components`}
-                component={ComponentsGuide}
-              />
+              <Route exact path={`${adminPath}/style-guide/palette`} component={PaletteGuide} />
+              <Route exact path={`${adminPath}/style-guide/icons`} component={IconsGuide} />
+              <Route path={`${adminPath}/style-guide/components`} component={ComponentsGuide} />
               <Route>
                 <Redirect to={`${adminPath}/style-guide/components`} />
               </Route>

--- a/packages/admin-ui/client/util.js
+++ b/packages/admin-ui/client/util.js
@@ -11,9 +11,7 @@ export const deconstructErrorsToDataShape = error => {
     error.graphQLErrors
       // Comes from the backend. Specific to Keystone, so shouldn't
       // give false positives with regular GraphQL errors
-      .filter(
-        gqlError => gqlError.name && gqlError.name === 'AccessDeniedError'
-      )
+      .filter(gqlError => gqlError.name && gqlError.name === 'AccessDeniedError')
       .forEach(gqlError => {
         // Set the gqlError message to the path as reported by the graphql
         // gqlError

--- a/packages/admin-ui/server/AdminUI.js
+++ b/packages/admin-ui/server/AdminUI.js
@@ -102,9 +102,7 @@ module.exports = class AdminUI {
 
   setAuthStrategy(authStrategy) {
     if (authStrategy.authType !== 'password') {
-      throw new Error(
-        'Keystone 5 Admin currently only supports the `PasswordAuthStrategy`'
-      );
+      throw new Error('Keystone 5 Admin currently only supports the `PasswordAuthStrategy`');
     }
 
     this.authStrategy = authStrategy;
@@ -115,12 +113,7 @@ module.exports = class AdminUI {
 
     // Listen to POST events for form signin form submission (GET falls through
     // to the webpack server(s))
-    app.post(
-      this.config.signinPath,
-      bodyParser.json(),
-      bodyParser.urlencoded(),
-      this.signin
-    );
+    app.post(this.config.signinPath, bodyParser.json(), bodyParser.urlencoded(), this.signin);
 
     // Listen to both POST and GET events, and always sign the user out.
     app.use(this.config.signoutPath, this.signout);
@@ -185,9 +178,7 @@ module.exports = class AdminUI {
       // app.use(adminMiddleware);
       app.use((req, res, next) => {
         // TODO: Better security, should check some property of the user
-        return req.user
-          ? secureMiddleware(req, res, next)
-          : publicMiddleware(req, res, next);
+        return req.user ? secureMiddleware(req, res, next) : publicMiddleware(req, res, next);
       });
 
       this.stopDevServer = () => {

--- a/packages/admin-ui/server/env.js
+++ b/packages/admin-ui/server/env.js
@@ -1,7 +1,4 @@
-exports.mode =
-  process.env.NODE_ENV === 'production' ? 'production' : 'development';
+exports.mode = process.env.NODE_ENV === 'production' ? 'production' : 'development';
 
 exports.enableDevFeatures =
-  process.env.ENABLE_DEV_FEATURES === 'true'
-    ? true
-    : !(exports.mode === 'production');
+  process.env.ENABLE_DEV_FEATURES === 'true' ? true : !(exports.mode === 'production');

--- a/packages/core/Keystone/index.js
+++ b/packages/core/Keystone/index.js
@@ -102,9 +102,7 @@ module.exports = class Keystone {
     return { lists, name };
   }
   getAdminSchema() {
-    let listTypes = flatten(
-      this.listsArray.map(list => list.getAdminGraphqlTypes())
-    ).map(trim);
+    let listTypes = flatten(this.listsArray.map(list => list.getAdminGraphqlTypes())).map(trim);
 
     listTypes.push(`
       # NOTE: Can be JSON, or a Boolean/Int/String
@@ -152,14 +150,10 @@ module.exports = class Keystone {
     listTypes = unique(listTypes);
 
     let queries = unique(
-      flatten(this.listsArray.map(list => list.getAdminGraphqlQueries())).map(
-        trim
-      )
+      flatten(this.listsArray.map(list => list.getAdminGraphqlQueries())).map(trim)
     );
     let mutations = unique(
-      flatten(this.listsArray.map(list => list.getAdminGraphqlMutations())).map(
-        trim
-      )
+      flatten(this.listsArray.map(list => list.getAdminGraphqlMutations())).map(trim)
     );
     const typeDefs = `
       type Query {
@@ -219,14 +213,8 @@ module.exports = class Keystone {
       Query: {
         // Order is also important here, any TypeQuery's defined by types
         // shouldn't be able to override list-level queries
-        ...this.listsArray.reduce(
-          (acc, i) => ({ ...i.getAuxiliaryQueryResolvers(), ...acc }),
-          {}
-        ),
-        ...this.listsArray.reduce(
-          (acc, i) => ({ ...i.getAdminQueryResolvers(), ...acc }),
-          {}
-        ),
+        ...this.listsArray.reduce((acc, i) => ({ ...i.getAuxiliaryQueryResolvers(), ...acc }), {}),
+        ...this.listsArray.reduce((acc, i) => ({ ...i.getAdminQueryResolvers(), ...acc }), {}),
       },
 
       Mutation: {
@@ -234,10 +222,7 @@ module.exports = class Keystone {
           (acc, i) => ({ ...i.getAuxiliaryMutationResolvers(), ...acc }),
           {}
         ),
-        ...this.listsArray.reduce(
-          (acc, i) => ({ ...i.getAdminMutationResolvers(), ...acc }),
-          {}
-        ),
+        ...this.listsArray.reduce((acc, i) => ({ ...i.getAdminMutationResolvers(), ...acc }), {}),
       },
     };
 
@@ -255,13 +240,7 @@ module.exports = class Keystone {
     return this.lists[listKey].getAccessControl({ operation, authentication });
   }
 
-  getFieldAccessControl({
-    item,
-    listKey,
-    fieldKey,
-    operation,
-    authentication,
-  }) {
+  getFieldAccessControl({ item, listKey, fieldKey, operation, authentication }) {
     return this.lists[listKey].getFieldAccessControl({
       item,
       fieldKey,
@@ -280,9 +259,7 @@ module.exports = class Keystone {
         Object.keys(data).reduce(
           (memo, list) => ({
             ...memo,
-            [list]: Promise.all(
-              data[list].map(item => this.createItem(list, item))
-            ),
+            [list]: Promise.all(data[list].map(item => this.createItem(list, item))),
           }),
           {}
         )
@@ -292,19 +269,12 @@ module.exports = class Keystone {
     const cleanupItems = createdItems =>
       Promise.all(
         Object.keys(createdItems).map(listKey =>
-          Promise.all(
-            createdItems[listKey].map(({ id }) =>
-              this.lists[listKey].adapter.delete(id)
-            )
-          )
+          Promise.all(createdItems[listKey].map(({ id }) => this.lists[listKey].adapter.delete(id)))
         )
       );
 
     // 1. Split it apart
-    const { relationships, data } = unmergeRelationships(
-      this.lists,
-      itemsToCreate
-    );
+    const { relationships, data } = unmergeRelationships(this.lists, itemsToCreate);
     // 2. Create the items
     // NOTE: Only works if all relationships fields are non-"required"
     const createdItems = await createItems(data);
@@ -312,11 +282,7 @@ module.exports = class Keystone {
     let createdRelationships;
     try {
       // 3. Create the relationships
-      createdRelationships = await createRelationships(
-        this.lists,
-        relationships,
-        createdItems
-      );
+      createdRelationships = await createRelationships(this.lists, relationships, createdItems);
     } catch (error) {
       // 3.5. If creation of relationships didn't work, unwind the createItems
       cleanupItems(createdItems);

--- a/packages/core/Keystone/relationship-utils.js
+++ b/packages/core/Keystone/relationship-utils.js
@@ -121,9 +121,7 @@ const unmergeRelationships = (lists, input) => {
 };
 
 const relateTo = async ({ relatedTo, relatedFrom }) => {
-  if (
-    isManyRelationship({ list: relatedFrom.list, fieldKey: relatedFrom.field })
-  ) {
+  if (isManyRelationship({ list: relatedFrom.list, fieldKey: relatedFrom.field })) {
     return relateToManyItems({ relatedTo, relatedFrom });
   } else {
     return relateToOneItem({ relatedTo, relatedFrom });
@@ -138,21 +136,16 @@ const throwRelateError = ({ relatedTo, relatedFrom, isMany }) => {
 
 const relateToOneItem = async ({ relatedTo, relatedFrom }) => {
   // Use where clause provided in original data to find related item
-  const relatedToItems = await relatedTo.list.adapter.itemsQuery(
-    relatedTo.conditions
-  );
+  const relatedToItems = await relatedTo.list.adapter.itemsQuery(relatedTo.conditions);
 
   // Sanity checking
   if (!relatedToItems || !relatedToItems.length) {
     throwRelateError({ relatedTo, relatedFrom, isMany: false });
   }
 
-  const updateResult = await relatedFrom.list.adapter.update(
-    relatedFrom.item.id,
-    {
-      [relatedFrom.field]: relatedToItems[0].id,
-    }
-  );
+  const updateResult = await relatedFrom.list.adapter.update(relatedFrom.item.id, {
+    [relatedFrom.field]: relatedToItems[0].id,
+  });
 
   return updateResult[relatedFrom.field];
 };
@@ -163,9 +156,7 @@ const relateToManyItems = async ({ relatedTo, relatedFrom }) => {
   if (Array.isArray(relatedTo.conditions)) {
     // Use where clause provided in original data to find related item
     relatedToItems = await Promise.all(
-      relatedTo.conditions.map(condition =>
-        relatedTo.list.adapter.itemsQuery(condition)
-      )
+      relatedTo.conditions.map(condition => relatedTo.list.adapter.itemsQuery(condition))
     );
 
     // Grab the first result of each
@@ -177,9 +168,7 @@ const relateToManyItems = async ({ relatedTo, relatedFrom }) => {
     }
   } else {
     // Use where clause provided in original data to find related item
-    relatedToItems = await relatedTo.list.adapter.itemsQuery(
-      relatedTo.conditions
-    );
+    relatedToItems = await relatedTo.list.adapter.itemsQuery(relatedTo.conditions);
   }
 
   // Sanity checking
@@ -187,12 +176,9 @@ const relateToManyItems = async ({ relatedTo, relatedFrom }) => {
     throwRelateError({ relatedTo, relatedFrom, isMany: true });
   }
 
-  const updateResult = await relatedFrom.list.adapter.update(
-    relatedFrom.item.id,
-    {
-      [relatedFrom.field]: relatedToItems.map(({ id }) => id),
-    }
-  );
+  const updateResult = await relatedFrom.list.adapter.update(relatedFrom.item.id, {
+    [relatedFrom.field]: relatedToItems.map(({ id }) => id),
+  });
 
   return updateResult[relatedFrom.field];
 };

--- a/packages/core/Keystone/relationship-utils.test.js
+++ b/packages/core/Keystone/relationship-utils.test.js
@@ -9,11 +9,7 @@ describe('mergeRelationships', () => {
   test('merges relationships', () => {
     const merged = mergeRelationships(
       {
-        User: [
-          { name: 'Jess', id: 1 },
-          { name: 'Tici', id: 2 },
-          { name: 'Lauren', id: 3 },
-        ],
+        User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
         Post: [
           { title: 'Hello world', id: 'abc123' },
           { title: 'Foo Article', id: 'def789' },
@@ -30,11 +26,7 @@ describe('mergeRelationships', () => {
     );
 
     expect(merged).toEqual({
-      User: [
-        { name: 'Jess', id: 1 },
-        { name: 'Tici', id: 2 },
-        { name: 'Lauren', id: 3 },
-      ],
+      User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
       Post: [
         { title: 'Hello world', id: 'abc123', author: 1 },
         { title: 'Foo Article', id: 'def789', author: 3 },
@@ -46,11 +38,7 @@ describe('mergeRelationships', () => {
   test('merges sparse relationships', () => {
     const merged = mergeRelationships(
       {
-        User: [
-          { name: 'Jess', id: 1 },
-          { name: 'Tici', id: 2 },
-          { name: 'Lauren', id: 3 },
-        ],
+        User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
         Post: [
           { title: 'Hello world', id: 'abc123' },
           { title: 'Foo Article', id: 'def789' },
@@ -66,11 +54,7 @@ describe('mergeRelationships', () => {
     );
 
     expect(merged).toEqual({
-      User: [
-        { name: 'Jess', id: 1 },
-        { name: 'Tici', id: 2 },
-        { name: 'Lauren', id: 3 },
-      ],
+      User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
       Post: [
         { title: 'Hello world', id: 'abc123', author: 1 },
         { title: 'Foo Article', id: 'def789' },
@@ -82,11 +66,7 @@ describe('mergeRelationships', () => {
   test('ignores unknown sparse relationships', () => {
     const merged = mergeRelationships(
       {
-        User: [
-          { name: 'Jess', id: 1 },
-          { name: 'Tici', id: 2 },
-          { name: 'Lauren', id: 3 },
-        ],
+        User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
         Post: [
           { title: 'Hello world', id: 'abc123' },
           { title: 'Foo Article', id: 'def789' },
@@ -103,11 +83,7 @@ describe('mergeRelationships', () => {
     );
 
     expect(merged).toEqual({
-      User: [
-        { name: 'Jess', id: 1 },
-        { name: 'Tici', id: 2 },
-        { name: 'Lauren', id: 3 },
-      ],
+      User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
       Post: [
         { title: 'Hello world', id: 'abc123', author: 1 },
         { title: 'Foo Article', id: 'def789' },
@@ -119,11 +95,7 @@ describe('mergeRelationships', () => {
   test('supports many-relationships', () => {
     const merged = mergeRelationships(
       {
-        User: [
-          { name: 'Jess', id: 1 },
-          { name: 'Tici', id: 2 },
-          { name: 'Lauren', id: 3 },
-        ],
+        User: [{ name: 'Jess', id: 1 }, { name: 'Tici', id: 2 }, { name: 'Lauren', id: 3 }],
         Post: [
           { title: 'Hello world', id: 'abc123' },
           { title: 'Foo Article', id: 'def789' },
@@ -190,11 +162,7 @@ describe('unmergeRelationships', () => {
 
     expect(data).toEqual({
       User: [{ name: 'Jess' }, { name: 'Tici' }, { name: 'Lauren' }],
-      Post: [
-        { title: 'Hello world' },
-        { title: 'Foo Article' },
-        { title: 'A Thinking!' },
-      ],
+      Post: [{ title: 'Hello world' }, { title: 'Foo Article' }, { title: 'A Thinking!' }],
     });
 
     expect(relationships).toEqual({
@@ -269,20 +237,12 @@ describe('unmergeRelationships', () => {
         { name: 'Tici' },
         { name: 'Lauren' },
       ],
-      Post: [
-        { title: 'Hello world' },
-        { title: 'Foo Article' },
-        { title: 'A Thinking!' },
-      ],
+      Post: [{ title: 'Hello world' }, { title: 'Foo Article' }, { title: 'A Thinking!' }],
     });
 
     expect(data).toEqual({
       User: [{ name: 'Jess' }, { name: 'Tici' }, { name: 'Lauren' }],
-      Post: [
-        { title: 'Hello world' },
-        { title: 'Foo Article' },
-        { title: 'A Thinking!' },
-      ],
+      Post: [{ title: 'Hello world' }, { title: 'Foo Article' }, { title: 'A Thinking!' }],
     });
 
     expect(relationships).toEqual({
@@ -297,35 +257,21 @@ describe('unmergeRelationships', () => {
       User: [
         {
           name: 'Jess',
-          posts: [
-            { where: { title: 'Hello world' } },
-            { where: { title: 'Foo Article' } },
-          ],
+          posts: [{ where: { title: 'Hello world' } }, { where: { title: 'Foo Article' } }],
         },
       ],
-      Post: [
-        { title: 'Hello world' },
-        { title: 'Foo Article' },
-        { title: 'A Thinking!' },
-      ],
+      Post: [{ title: 'Hello world' }, { title: 'Foo Article' }, { title: 'A Thinking!' }],
     });
 
     expect(data).toEqual({
       User: [{ name: 'Jess' }],
-      Post: [
-        { title: 'Hello world' },
-        { title: 'Foo Article' },
-        { title: 'A Thinking!' },
-      ],
+      Post: [{ title: 'Hello world' }, { title: 'Foo Article' }, { title: 'A Thinking!' }],
     });
 
     expect(relationships).toEqual({
       User: {
         0: {
-          posts: [
-            { where: { title: 'Hello world' } },
-            { where: { title: 'Foo Article' } },
-          ],
+          posts: [{ where: { title: 'Hello world' } }, { where: { title: 'Foo Article' } }],
         },
       },
     });
@@ -431,11 +377,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       Post: {
@@ -479,9 +421,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    await expect(
-      createRelationships(lists, relationships, createdItems)
-    ).rejects.toThrow(
+    await expect(createRelationships(lists, relationships, createdItems)).rejects.toThrow(
       /Attempted to relate .* to a .*, but no .* matched the conditions .*/
     );
   });
@@ -526,11 +466,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       Post: {
@@ -574,12 +510,9 @@ describe('createRelationships', () => {
     };
 
     // Mocking the database calls
-    lists.Post.adapter.itemsQuery.mockImplementation(
-      ({ where: { title_starts_with } }) =>
-        // Grab all the matching 'starts_with' items
-        createdItems.Post.filter(post =>
-          post.title.startsWith(title_starts_with)
-        )
+    lists.Post.adapter.itemsQuery.mockImplementation(({ where: { title_starts_with } }) =>
+      // Grab all the matching 'starts_with' items
+      createdItems.Post.filter(post => post.title.startsWith(title_starts_with))
     );
 
     lists.User.adapter.update.mockImplementation((id, data) => ({
@@ -588,11 +521,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       User: {
@@ -605,10 +534,7 @@ describe('createRelationships', () => {
     const relationships = {
       User: {
         1: {
-          posts: [
-            { where: { title: 'Hello Things' } },
-            { where: { title: 'Kaboom' } },
-          ],
+          posts: [{ where: { title: 'Hello Things' } }, { where: { title: 'Kaboom' } }],
         },
       },
     };
@@ -652,11 +578,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       User: {
@@ -710,11 +632,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       User: {
@@ -727,10 +645,7 @@ describe('createRelationships', () => {
     const relationships = {
       User: {
         1: {
-          posts: [
-            { where: { title: 'Nope' } },
-            { where: { title: 'Double Nope' } },
-          ],
+          posts: [{ where: { title: 'Nope' } }, { where: { title: 'Double Nope' } }],
         },
       },
     };
@@ -771,9 +686,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    expect(
-      createRelationships(lists, relationships, createdItems)
-    ).rejects.toThrow(
+    expect(createRelationships(lists, relationships, createdItems)).rejects.toThrow(
       /Attempted to relate .* to .*, but no .* matched the conditions .*/
     );
   });
@@ -808,11 +721,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({});
   });
@@ -847,11 +756,7 @@ describe('createRelationships', () => {
       ...data,
     }));
 
-    const updatedRelationships = await createRelationships(
-      lists,
-      relationships,
-      createdItems
-    );
+    const updatedRelationships = await createRelationships(lists, relationships, createdItems);
 
     expect(updatedRelationships).toEqual({
       Post: {},

--- a/packages/core/Keystone/session.js
+++ b/packages/core/Keystone/session.js
@@ -1,10 +1,6 @@
 const noop = () => undefined;
 
-const validate = keystone => ({ valid = noop, invalid = noop }) => async (
-  req,
-  res,
-  next
-) => {
+const validate = keystone => ({ valid = noop, invalid = noop }) => async (req, res, next) => {
   if (!req.session || !req.session.keystoneItemId) {
     invalid({ req, reason: 'empty' });
     return next();

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -85,10 +85,7 @@ There is 2 ways to write the relationship query:
 
 ```javascript
 keystone.createItems({
-  User: [
-    { name: 'Ticiana' },
-    { name: 'Lauren', posts: { where: { title_contains: 'React' } } },
-  ],
+  User: [{ name: 'Ticiana' }, { name: 'Lauren', posts: { where: { title_contains: 'React' } } }],
   Post: [
     { title: 'Hello Everyone' },
     { title: 'Talking about React' },

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -9,8 +9,7 @@ class BaseKeystoneAdapter {
   }
 
   newListAdapter(key, config = {}) {
-    const listAdapterClass =
-      config.listAdapterClass || this.config.listAdapterClass;
+    const listAdapterClass = config.listAdapterClass || this.config.listAdapterClass;
     const adapter = new listAdapterClass(key, this, config);
     this.prepareListAdapter(adapter);
     this.listAdapters[key] = adapter;
@@ -29,13 +28,7 @@ class BaseListAdapter {
   }
 
   newFieldAdapter(fieldAdapterClass, name, path, getListByKey, config) {
-    const adapter = new fieldAdapterClass(
-      name,
-      path,
-      this,
-      getListByKey,
-      config
-    );
+    const adapter = new fieldAdapterClass(name, path, this, getListByKey, config);
     this.prepareFieldAdapter(adapter);
     this.fieldAdapters.push(adapter);
     return adapter;

--- a/packages/core/tests/Keystone.test.js
+++ b/packages/core/tests/Keystone.test.js
@@ -229,10 +229,7 @@ describe('Keystone.createItems()', () => {
 
     expect(createdItems).toEqual({
       User: [{ id: 1, name: 'Jess' }, { id: 2, name: 'Lauren' }],
-      Post: [
-        { id: 3, title: 'Hello world', author: 2 },
-        { id: 4, title: 'Goodbye', author: 1 },
-      ],
+      Post: [{ id: 3, title: 'Hello world', author: 2 }, { id: 4, title: 'Goodbye', author: 1 }],
     });
   });
 

--- a/packages/fields/Implementation.js
+++ b/packages/fields/Implementation.js
@@ -1,8 +1,5 @@
 const inflection = require('inflection');
-const {
-  parseFieldAccess,
-  testFieldAccessControl,
-} = require('@keystonejs/access-control');
+const { parseFieldAccess, testFieldAccessControl } = require('@keystonejs/access-control');
 
 class Field {
   constructor(
@@ -33,9 +30,7 @@ class Field {
 
   getGraphqlSchema() {
     if (!this.graphQLType) {
-      throw new Error(
-        `Field type [${this.constructor.name}] does not implement graphQLType`
-      );
+      throw new Error(`Field type [${this.constructor.name}] does not implement graphQLType`);
     }
     return `${this.path}: ${this.graphQLType}`;
   }

--- a/packages/fields/tests/fields.test.js
+++ b/packages/fields/tests/fields.test.js
@@ -49,9 +49,7 @@ export const matchFilter = (app, filter, fields, target, done, sortkey) => {
   filter = filter ? `(${filter})` : '';
   const snippet = `allTests ${filter} ${fields}`;
   runQuery(app, snippet, data => {
-    const value = sortkey
-      ? sorted(data.allTests || [], i => i[sortkey])
-      : data.allTests;
+    const value = sortkey ? sorted(data.allTests || [], i => i[sortkey]) : data.allTests;
     expect(value).toEqual(target);
     done();
   });

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -11,12 +11,7 @@ export const getTestFields = () => {
 };
 
 export const initItems = () => {
-  return [
-    { name: 'person1' },
-    { name: 'person2' },
-    { name: 'person3' },
-    { name: 'person4' },
-  ];
+  return [{ name: 'person1' }, { name: 'person2' }, { name: 'person3' }, { name: 'person4' }];
 };
 
 const getIDs = async keystone => {
@@ -69,11 +64,7 @@ export const filterTests = (app, keystone) => {
   test('Filter: id', async done => {
     const IDs = await getIDs(keystone);
     const id = IDs['person2'];
-    match(
-      `where: { id: "${id}" }`,
-      [{ id: IDs['person2'], name: 'person2' }],
-      done
-    );
+    match(`where: { id: "${id}" }`, [{ id: IDs['person2'], name: 'person2' }], done);
   });
 
   test('Filter: id_not', async done => {
@@ -96,10 +87,7 @@ export const filterTests = (app, keystone) => {
     const id3 = IDs['person3'];
     match(
       `where: { id_in: ["${id2}", "${id3}"] }`,
-      [
-        { id: IDs['person2'], name: 'person2' },
-        { id: IDs['person3'], name: 'person3' },
-      ],
+      [{ id: IDs['person2'], name: 'person2' }, { id: IDs['person3'], name: 'person3' }],
       done
     );
   });
@@ -118,10 +106,7 @@ export const filterTests = (app, keystone) => {
     const id3 = IDs['person3'];
     match(
       `where: { id_not_in: ["${id2}", "${id3}"] }`,
-      [
-        { id: IDs['person1'], name: 'person1' },
-        { id: IDs['person4'], name: 'person4' },
-      ],
+      [{ id: IDs['person1'], name: 'person1' }, { id: IDs['person4'], name: 'person4' }],
       done
     );
   });

--- a/packages/fields/types/Checkbox/filterTests.js
+++ b/packages/fields/types/Checkbox/filterTests.js
@@ -60,11 +60,7 @@ export const filterTests = app => {
   });
 
   test('Filter: enabled false', done => {
-    match(
-      'where: { enabled: false }',
-      [{ name: 'person2', enabled: false }],
-      done
-    );
+    match('where: { enabled: false }', [{ name: 'person2', enabled: false }], done);
   });
 
   test('Filter: enabled_not true', done => {

--- a/packages/fields/types/Checkbox/views/Field.js
+++ b/packages/fields/types/Checkbox/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 
 // TODO: use pretty checkboxes - these only work in a CheckGroup situation.
 // import { Checkbox } from '@keystonejs/ui/src/primitives/forms';

--- a/packages/fields/types/CloudinaryImage/Implementation.js
+++ b/packages/fields/types/CloudinaryImage/Implementation.js
@@ -67,10 +67,7 @@ class CloudinaryImage extends File {
         return {
           publicUrl: this.config.adapter.publicUrl(itemValues),
           publicUrlTransformed: ({ transformation }) =>
-            this.config.adapter.publicUrlTransformed(
-              itemValues,
-              transformation
-            ),
+            this.config.adapter.publicUrlTransformed(itemValues, transformation),
           ...itemValues,
         };
       },
@@ -78,9 +75,7 @@ class CloudinaryImage extends File {
   }
   getGraphqlAuxiliaryMutations() {
     return `
-      uploadCloudinaryImage(file: ${this.getFileUploadType()}!): ${
-      this.graphQLType
-    }
+      uploadCloudinaryImage(file: ${this.getFileUploadType()}!): ${this.graphQLType}
     `;
   }
   getGraphqlAuxiliaryMutationResolvers() {

--- a/packages/fields/types/CloudinaryImage/index.js
+++ b/packages/fields/types/CloudinaryImage/index.js
@@ -1,8 +1,5 @@
 const path = require('path');
-const {
-  CloudinaryImage,
-  MongoCloudinaryImageInterface,
-} = require('./Implementation');
+const { CloudinaryImage, MongoCloudinaryImageInterface } = require('./Implementation');
 
 module.exports = {
   type: 'CloudinaryImage',

--- a/packages/fields/types/CloudinaryImage/views/Field.js
+++ b/packages/fields/types/CloudinaryImage/views/Field.js
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { AlertIcon, ShieldIcon } from '@keystonejs/icons';
 import { HiddenInput } from '@keystonejs/ui/src/primitives/forms';
 import { Lozenge } from '@keystonejs/ui/src/primitives/lozenge';
@@ -199,11 +195,7 @@ export default class FileField extends Component {
     const { changeStatus, isLoading } = this.state;
 
     return (
-      <LoadingButton
-        onClick={this.openFileBrowser}
-        isLoading={isLoading}
-        variant="ghost"
-      >
+      <LoadingButton onClick={this.openFileBrowser} isLoading={isLoading} variant="ghost">
         {uploadButtonLabel({ status: changeStatus })}
       </LoadingButton>
     );
@@ -242,8 +234,7 @@ export default class FileField extends Component {
     const isEmpty = changeStatus === 'empty';
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
-      itemErrors[field.path] instanceof Error &&
-      itemErrors[field.path].name === 'AccessDeniedError'
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
 
     return (
@@ -310,9 +301,7 @@ export default class FileField extends Component {
 // Styled Components
 // ==============================
 
-const Wrapper = props => (
-  <div css={{ alignItems: 'flex-start', display: 'flex' }} {...props} />
-);
+const Wrapper = props => <div css={{ alignItems: 'flex-start', display: 'flex' }} {...props} />;
 const Content = props => <div css={{ flex: 1, minWidth: 0 }} {...props} />;
 const Image = props => (
   <div

--- a/packages/fields/types/File/Implementation.js
+++ b/packages/fields/types/File/Implementation.js
@@ -89,12 +89,7 @@ class File extends Implementation {
       return null;
     }
 
-    const {
-      stream,
-      filename: originalFilename,
-      mimetype,
-      encoding,
-    } = await uploadData;
+    const { stream, filename: originalFilename, mimetype, encoding } = await uploadData;
 
     if (!stream && previousData) {
       // TODO: FIXME: Handle when stream is null. Can happen when:
@@ -189,10 +184,7 @@ class MongoFileInterface extends MongooseFieldAdapter {
     }
     const not_starts_with = `${this.path}_not_starts_with`;
     if (not_starts_with in args) {
-      const not_starts_with_rx = new RegExp(
-        `^${esc(args[not_starts_with])}`,
-        rx_cs
-      );
+      const not_starts_with_rx = new RegExp(`^${esc(args[not_starts_with])}`, rx_cs);
       conditions.push({ $not: not_starts_with_rx });
     }
     const ends_with = `${this.path}_ends_with`;
@@ -202,10 +194,7 @@ class MongoFileInterface extends MongooseFieldAdapter {
     }
     const not_ends_with = `${this.path}_not_ends_with`;
     if (not_ends_with in args) {
-      const not_ends_with_rx = new RegExp(
-        `${esc(args[not_ends_with])}$`,
-        rx_cs
-      );
+      const not_ends_with_rx = new RegExp(`${esc(args[not_ends_with])}$`, rx_cs);
       conditions.push({ $not: not_ends_with_rx });
     }
     const is_in = `${this.path}_in`;

--- a/packages/fields/types/File/views/Field.js
+++ b/packages/fields/types/File/views/Field.js
@@ -1,11 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { AlertIcon, ShieldIcon } from '@keystonejs/icons';
 import { HiddenInput } from '@keystonejs/ui/src/primitives/forms';
 import { Lozenge } from '@keystonejs/ui/src/primitives/lozenge';
@@ -177,9 +173,7 @@ export default class FileField extends Component {
     const { file } = this.getFile();
 
     // avoid jank during FileReader processing keeping the old image in place
-    return file && file.mimetype && file.mimetype.includes('image')
-      ? file.publicUrl
-      : dataURI;
+    return file && file.mimetype && file.mimetype.includes('image') ? file.publicUrl : dataURI;
   };
   getInputRef = ref => {
     this.inputRef = ref;
@@ -194,11 +188,7 @@ export default class FileField extends Component {
     const { changeStatus, isLoading } = this.state;
 
     return (
-      <LoadingButton
-        onClick={this.openFileBrowser}
-        isLoading={isLoading}
-        variant="ghost"
-      >
+      <LoadingButton onClick={this.openFileBrowser} isLoading={isLoading} variant="ghost">
         {uploadButtonLabel({ status: changeStatus })}
       </LoadingButton>
     );
@@ -236,8 +226,7 @@ export default class FileField extends Component {
     const showStatusMessage = ['removed', 'updated'].includes(changeStatus);
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
-      itemErrors[field.path] instanceof Error &&
-      itemErrors[field.path].name === 'AccessDeniedError'
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
 
     return (
@@ -271,9 +260,7 @@ export default class FileField extends Component {
                   <ErrorInfo>{errorMessage}</ErrorInfo>
                 ) : file ? (
                   <FlexGroup isInline growIndexes={[0]}>
-                    <MetaInfo href={file.publicUrl}>
-                      {file.filename || file.name}
-                    </MetaInfo>
+                    <MetaInfo href={file.publicUrl}>{file.filename || file.name}</MetaInfo>
                     {showStatusMessage ? (
                       <ChangeInfo status={changeStatus}>
                         {statusMessage({ status: changeStatus })}
@@ -306,9 +293,7 @@ export default class FileField extends Component {
 // Styled Components
 // ==============================
 
-const Wrapper = props => (
-  <div css={{ alignItems: 'flex-start', display: 'flex' }} {...props} />
-);
+const Wrapper = props => <div css={{ alignItems: 'flex-start', display: 'flex' }} {...props} />;
 const Content = props => <div css={{ flex: 1, minWidth: 0 }} {...props} />;
 const Image = props => (
   <div

--- a/packages/fields/types/Float/views/Field.js
+++ b/packages/fields/types/Float/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
 
 export default class TextField extends Component {

--- a/packages/fields/types/Integer/filterTests.js
+++ b/packages/fields/types/Integer/filterTests.js
@@ -95,11 +95,7 @@ export const filterTests = app => {
   test('Filter: count_lte', done => {
     match(
       'where: { count_lte: 2 }',
-      [
-        { name: 'person1', count: 0 },
-        { name: 'person2', count: 1 },
-        { name: 'person3', count: 2 },
-      ],
+      [{ name: 'person1', count: 0 }, { name: 'person2', count: 1 }, { name: 'person3', count: 2 }],
       done
     );
   });
@@ -137,11 +133,7 @@ export const filterTests = app => {
   test('Filter: count_in', done => {
     match(
       'where: { count_in: [0, 1, 2] }',
-      [
-        { name: 'person1', count: 0 },
-        { name: 'person2', count: 1 },
-        { name: 'person3', count: 2 },
-      ],
+      [{ name: 'person1', count: 0 }, { name: 'person2', count: 1 }, { name: 'person3', count: 2 }],
       done
     );
   });
@@ -155,11 +147,7 @@ export const filterTests = app => {
   });
 
   test('Filter: count_in null', done => {
-    match(
-      'where: { count_in: [null] }',
-      [{ name: 'person5', count: null }],
-      done
-    );
+    match('where: { count_in: [null] }', [{ name: 'person5', count: null }], done);
   });
 
   test('Filter: count_not_in null', done => {

--- a/packages/fields/types/Integer/views/Field.js
+++ b/packages/fields/types/Integer/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
 
 export default class TextField extends Component {

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -35,9 +35,7 @@ class MongoPasswordInterface extends MongooseFieldAdapter {
     const conditions = [];
     const is_set = `${this.path}_is_set`;
     if (is_set in args) {
-      conditions.push(
-        args[is_set] ? { $nin: [null, ''] } : { $in: [null, ''] }
-      );
+      conditions.push(args[is_set] ? { $nin: [null, ''] } : { $in: [null, ''] });
     }
     return conditions;
   }

--- a/packages/fields/types/Password/filterTests.js
+++ b/packages/fields/types/Password/filterTests.js
@@ -60,19 +60,12 @@ export const filterTests = app => {
   test('Filter: is_set - true', done => {
     match(
       'where: { password_is_set: true }',
-      [
-        { name: 'person1', password: 'pass1' },
-        { name: 'person3', password: 'pass3' },
-      ],
+      [{ name: 'person1', password: 'pass1' }, { name: 'person3', password: 'pass3' }],
       done
     );
   });
 
   test('Filter: is_set - false', done => {
-    match(
-      'where: { password_is_set: false }',
-      [{ name: 'person2', password: '' }],
-      done
-    );
+    match('where: { password_is_set: false }', [{ name: 'person2', password: '' }], done);
   });
 };

--- a/packages/fields/types/Password/views/Field.js
+++ b/packages/fields/types/Password/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
 
 export default class PasswordField extends Component {

--- a/packages/fields/types/Relationship/Controller.js
+++ b/packages/fields/types/Relationship/Controller.js
@@ -18,9 +18,9 @@ export default class RelationshipController extends FieldController {
   dataToRelationshipInput = (data, pathKey) => {
     if (data.id && data.create) {
       throw new Error(
-        `Cannot provide both an id and create data when linking ${
-          this.list.key
-        }.${pathKey} to a ${this.config.ref}`
+        `Cannot provide both an id and create data when linking ${this.list.key}.${pathKey} to a ${
+          this.config.ref
+        }`
       );
     }
 

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -12,13 +12,7 @@ const { Implementation } = require('../../Implementation');
 const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 const { ParameterError } = require('./graphqlErrors');
 
-function relationFilterPipeline({
-  path,
-  query,
-  many,
-  refListAdapter,
-  joinPathName,
-}) {
+function relationFilterPipeline({ path, query, many, refListAdapter, joinPathName }) {
   return [
     {
       // JOIN
@@ -49,12 +43,7 @@ function relationFilterPipeline({
   ];
 }
 
-function postAggregateMutationFactory({
-  path,
-  many,
-  joinPathName,
-  refListAdapter,
-}) {
+function postAggregateMutationFactory({ path, many, joinPathName, refListAdapter }) {
   // Recreate Mongoose instances of the sub items every time to allow for
   // further operations to be performed on those sub items via Mongoose.
   return item => {
@@ -66,9 +55,7 @@ function postAggregateMutationFactory({
 
     if (many) {
       joinedItems = item[path].map(itemId => {
-        const joinedItemIndex = item[joinPathName].findIndex(({ _id }) =>
-          _id.equals(itemId)
-        );
+        const joinedItemIndex = item[joinPathName].findIndex(({ _id }) => _id.equals(itemId));
 
         if (joinedItemIndex === -1) {
           return itemId;
@@ -188,10 +175,7 @@ class Relationship extends Implementation {
         });
       }
 
-      if (
-        !input.id &&
-        (!input.create || Object.keys(input.create).length === 0)
-      ) {
+      if (!input.id && (!input.create || Object.keys(input.create).length === 0)) {
         throw new ParameterError({
           message: `Must provide one of 'id' or 'create' data when linking ${
             this.listKey
@@ -209,10 +193,7 @@ class Relationship extends Implementation {
 
       // Create related item. Will check for access control itself, no need to
       // do anything extra here.
-      const { id } = await this.getListByKey(ref).createMutation(
-        input.create,
-        context
-      );
+      const { id } = await this.getListByKey(ref).createMutation(input.create, context);
       return id;
     };
 
@@ -256,9 +237,7 @@ class Relationship extends Implementation {
 
     if (errored.length) {
       const error = new Error(
-        `Unable to create ${errored.length} new ${ref} as set on ${
-          this.listKey
-        }.${fieldKey}`
+        `Unable to create ${errored.length} new ${ref} as set on ${this.listKey}.${fieldKey}`
       );
 
       // Setup the correct path on the nested error objects
@@ -311,14 +290,10 @@ class Relationship extends Implementation {
     // }
     return `
       input ${this.config.ref}RelationshipInput {
-        # Provide an id to link to an existing ${
-          this.config.ref
-        }. Cannot be set if 'create' set.
+        # Provide an id to link to an existing ${this.config.ref}. Cannot be set if 'create' set.
         id: ID
 
-        # Provide data to create a new ${
-          this.config.ref
-        }. Cannot be set if 'id' set.
+        # Provide data to create a new ${this.config.ref}. Cannot be set if 'id' set.
         create: ${this.config.ref}CreateInput
       }
     `;
@@ -377,10 +352,7 @@ class MongoSelectInterface extends MongooseFieldAdapter {
 
     if (this.path in args) {
       const refListAdapter = this.getListByKey(this.config.ref).adapter;
-      const filters = refListAdapter.itemsQueryConditions(
-        args[this.path],
-        depthGuard
-      );
+      const filters = refListAdapter.itemsQueryConditions(args[this.path], depthGuard);
 
       const query = {
         $and: filters,

--- a/packages/fields/types/Relationship/tests/implementation.test.js
+++ b/packages/fields/types/Relationship/tests/implementation.test.js
@@ -24,17 +24,13 @@ describe('Type Generation', () => {
       path: 'foo',
       config: { many: true, ref: 'Zip' },
     });
-    expect(relMany.getGraphqlCreateArgs()).toEqual(
-      'foo: [ZipRelationshipInput]'
-    );
+    expect(relMany.getGraphqlCreateArgs()).toEqual('foo: [ZipRelationshipInput]');
 
     const relSingle = createRelationship({
       path: 'foo',
       config: { many: false, ref: 'Zip' },
     });
-    expect(relSingle.getGraphqlCreateArgs()).toEqual(
-      'foo: ZipRelationshipInput'
-    );
+    expect(relSingle.getGraphqlCreateArgs()).toEqual('foo: ZipRelationshipInput');
   });
 
   test('inputs for relationship fields in update args', () => {
@@ -42,17 +38,13 @@ describe('Type Generation', () => {
       path: 'foo',
       config: { many: true, ref: 'Zip' },
     });
-    expect(relMany.getGraphqlUpdateArgs()).toEqual(
-      'foo: [ZipRelationshipInput]'
-    );
+    expect(relMany.getGraphqlUpdateArgs()).toEqual('foo: [ZipRelationshipInput]');
 
     const relSingle = createRelationship({
       path: 'foo',
       config: { many: false, ref: 'Zip' },
     });
-    expect(relSingle.getGraphqlUpdateArgs()).toEqual(
-      'foo: ZipRelationshipInput'
-    );
+    expect(relSingle.getGraphqlUpdateArgs()).toEqual('foo: ZipRelationshipInput');
   });
 
   test('relationship LinkOrCreate input', () => {

--- a/packages/fields/types/Relationship/views/Cell.js
+++ b/packages/fields/types/Relationship/views/Cell.js
@@ -7,16 +7,14 @@ export default ({ data, field, Link }) => {
   const refList = field.adminMeta.getListByKey(field.config.ref);
   return (
     <Fragment>
-      {(Array.isArray(data) ? data : [data])
-        .filter(item => item)
-        .map((item, index) => (
-          <Fragment key={item.id}>
-            {!!index ? ', ' : ''}
-            <Link path={refList.path} id={item.id}>
-              {item._label_ /* eslint-disable-line no-underscore-dangle */}
-            </Link>
-          </Fragment>
-        ))}
+      {(Array.isArray(data) ? data : [data]).filter(item => item).map((item, index) => (
+        <Fragment key={item.id}>
+          {!!index ? ', ' : ''}
+          <Link path={refList.path} id={item.id}>
+            {item._label_ /* eslint-disable-line no-underscore-dangle */}
+          </Link>
+        </Fragment>
+      ))}
     </Fragment>
   );
 };

--- a/packages/fields/types/Relationship/views/Field.js
+++ b/packages/fields/types/Relationship/views/Field.js
@@ -3,11 +3,7 @@ import React, { Component } from 'react';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Select } from '@keystonejs/ui/src/primitives/filters';
 import { ShieldIcon } from '@keystonejs/icons';
 import { colors } from '@keystonejs/ui/src/theme';
@@ -40,8 +36,7 @@ export default class RelationshipField extends Component {
     const query = getGraphqlQuery(refList);
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
-      itemErrors[field.path] instanceof Error &&
-      itemErrors[field.path].name === 'AccessDeniedError'
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
 
     const selectProps =
@@ -93,15 +88,10 @@ export default class RelationshipField extends Component {
                 if (many) {
                   if (!Array.isArray(item[field.path])) value = [];
                   value = item[field.path]
-                    .map(
-                      i => options.filter(option => option.value.id === i.id)[0]
-                    )
+                    .map(i => options.filter(option => option.value.id === i.id)[0])
                     .filter(i => i);
                 } else if (item[field.path]) {
-                  value =
-                    options.filter(
-                      i => i.value.id === item[field.path].id
-                    )[0] || null;
+                  value = options.filter(i => i.value.id === item[field.path].id)[0] || null;
                 }
               }
 
@@ -110,9 +100,7 @@ export default class RelationshipField extends Component {
                   autoFocus={autoFocus}
                   isMulti={many}
                   value={value}
-                  placeholder={
-                    canRead ? undefined : itemErrors[field.path].message
-                  }
+                  placeholder={canRead ? undefined : itemErrors[field.path].message}
                   getOptionValue={option => option.value.id}
                   options={options}
                   onChange={this.onChange}

--- a/packages/fields/types/Select/Controller.js
+++ b/packages/fields/types/Select/Controller.js
@@ -24,9 +24,7 @@ export default class SelectController extends FieldController {
       key = `${this.path}_not`;
     }
 
-    const value = isMulti
-      ? options.map(x => x.value).join(',')
-      : options[0].value;
+    const value = isMulti ? options.map(x => x.value).join(',') : options[0].value;
 
     return `${key}: ${value}`;
   };
@@ -35,9 +33,7 @@ export default class SelectController extends FieldController {
   };
   formatFilter = ({ value }) => {
     if (!value.options.length) {
-      return value.inverted
-        ? `${this.label} is set`
-        : `${this.label} has no value`;
+      return value.inverted ? `${this.label} is set` : `${this.label} has no value`;
     }
     if (value.options.length > 1) {
       const values = value.options.map(i => i.label).join(', ');

--- a/packages/fields/types/Select/Implementation.js
+++ b/packages/fields/types/Select/Implementation.js
@@ -7,9 +7,7 @@ function initOptions(options) {
   if (typeof options === 'string') optionsArray = options.split(/\,\s*/);
   if (!Array.isArray(optionsArray)) return null;
   return optionsArray.map(i => {
-    return typeof i === 'string'
-      ? { value: i, label: inflection.humanize(i) }
-      : i;
+    return typeof i === 'string' ? { value: i, label: inflection.humanize(i) } : i;
   });
 }
 

--- a/packages/fields/types/Select/filterTests.js
+++ b/packages/fields/types/Select/filterTests.js
@@ -56,11 +56,7 @@ export const filterTests = app => {
   });
 
   test('Filter: company', done => {
-    match(
-      'where: { company: thinkmill }',
-      [{ company: 'thinkmill', name: 'a' }],
-      done
-    );
+    match('where: { company: thinkmill }', [{ company: 'thinkmill', name: 'a' }], done);
   });
 
   test('Filter: company_not', done => {

--- a/packages/fields/types/Select/views/Field.js
+++ b/packages/fields/types/Select/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Select } from '@keystonejs/ui/src/primitives/filters';
 import { ShieldIcon } from '@keystonejs/icons';
 import { colors } from '@keystonejs/ui/src/theme';
@@ -19,8 +15,7 @@ export default class SelectField extends Component {
     const value = field.options.filter(i => i.value === item[field.path])[0];
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
-      itemErrors[field.path] instanceof Error &&
-      itemErrors[field.path].name === 'AccessDeniedError'
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
 
     const selectProps =

--- a/packages/fields/types/Select/views/Filter.js
+++ b/packages/fields/types/Select/views/Filter.js
@@ -1,12 +1,7 @@
 // @flow
 
 import React, { Component, Fragment, type Ref } from 'react';
-import {
-  OptionRenderer,
-  Radio,
-  RadioGroup,
-  Select,
-} from '@keystonejs/ui/src/primitives/filters';
+import { OptionRenderer, Radio, RadioGroup, Select } from '@keystonejs/ui/src/primitives/filters';
 import { gridSize } from '@keystonejs/ui/src/theme';
 
 const EventCatcher = props => (
@@ -18,9 +13,7 @@ const EventCatcher = props => (
     {...props}
   />
 );
-const SelectWrapper = props => (
-  <div css={{ marginTop: gridSize * 2 }} {...props} />
-);
+const SelectWrapper = props => <div css={{ marginTop: gridSize * 2 }} {...props} />;
 
 type Props = { field: Object, innerRef: Ref<*>, onChange: Event => void };
 type State = { inverted: boolean };

--- a/packages/fields/types/Text/Implementation.js
+++ b/packages/fields/types/Text/Implementation.js
@@ -85,10 +85,7 @@ class MongoTextInterface extends MongooseFieldAdapter {
     }
     const not_starts_with = `${this.path}_not_starts_with`;
     if (not_starts_with in args) {
-      const not_starts_with_rx = new RegExp(
-        `^${esc(args[not_starts_with])}`,
-        rx_cs
-      );
+      const not_starts_with_rx = new RegExp(`^${esc(args[not_starts_with])}`, rx_cs);
       conditions.push({ $not: not_starts_with_rx });
     }
     const ends_with = `${this.path}_ends_with`;
@@ -98,10 +95,7 @@ class MongoTextInterface extends MongooseFieldAdapter {
     }
     const not_ends_with = `${this.path}_not_ends_with`;
     if (not_ends_with in args) {
-      const not_ends_with_rx = new RegExp(
-        `${esc(args[not_ends_with])}$`,
-        rx_cs
-      );
+      const not_ends_with_rx = new RegExp(`${esc(args[not_ends_with])}$`, rx_cs);
       conditions.push({ $not: not_ends_with_rx });
     }
     const is_in = `${this.path}_in`;

--- a/packages/fields/types/Text/filterTests.js
+++ b/packages/fields/types/Text/filterTests.js
@@ -34,19 +34,11 @@ export const filterTests = app => {
   };
 
   test('No filter', done => {
-    match(
-      undefined,
-      ['', 'ITEM 5 - end', 'item 1', 'item 2 - end', 'thing 4 - END'],
-      done
-    );
+    match(undefined, ['', 'ITEM 5 - end', 'item 1', 'item 2 - end', 'thing 4 - END'], done);
   });
 
   test('Empty filter', done => {
-    match(
-      'where: { }',
-      ['', 'ITEM 5 - end', 'item 1', 'item 2 - end', 'thing 4 - END'],
-      done
-    );
+    match('where: { }', ['', 'ITEM 5 - end', 'item 1', 'item 2 - end', 'thing 4 - END'], done);
   });
 
   test('Filter: name', done => {
@@ -62,11 +54,7 @@ export const filterTests = app => {
   });
 
   test('Filter: name (case-sensitive) (hit)', done => {
-    match(
-      'where: { name: "thing 4 - END", name_case_sensitive: true }',
-      ['thing 4 - END'],
-      done
-    );
+    match('where: { name: "thing 4 - END", name_case_sensitive: true }', ['thing 4 - END'], done);
   });
 
   test('Filter: name_not (case-sensitive) (hit)', done => {
@@ -78,11 +66,7 @@ export const filterTests = app => {
   });
 
   test('Filter: name (case-sensitive) (miss)', done => {
-    match(
-      'where: { name: "thing 4 - end", name_case_sensitive: true }',
-      [],
-      done
-    );
+    match('where: { name: "thing 4 - end", name_case_sensitive: true }', [], done);
   });
 
   test('Filter: name_not (case-sensitive) (miss)', done => {
@@ -94,19 +78,11 @@ export const filterTests = app => {
   });
 
   test('Filter: starts_with', done => {
-    match(
-      'where: { name_starts_with: "item" }',
-      ['ITEM 5 - end', 'item 1', 'item 2 - end'],
-      done
-    );
+    match('where: { name_starts_with: "item" }', ['ITEM 5 - end', 'item 1', 'item 2 - end'], done);
   });
 
   test('Filter: not_starts_with', done => {
-    match(
-      'where: { name_not_starts_with: "item" }',
-      ['', 'thing 4 - END'],
-      done
-    );
+    match('where: { name_not_starts_with: "item" }', ['', 'thing 4 - END'], done);
   });
 
   test('Filter: starts_with (case-sensitive)', done => {
@@ -154,11 +130,7 @@ export const filterTests = app => {
   });
 
   test('Filter: contains', done => {
-    match(
-      'where: { name_contains: "item" }',
-      ['ITEM 5 - end', 'item 1', 'item 2 - end'],
-      done
-    );
+    match('where: { name_contains: "item" }', ['ITEM 5 - end', 'item 1', 'item 2 - end'], done);
   });
 
   test('Filter: not_contains', done => {

--- a/packages/fields/types/Text/views/Field.js
+++ b/packages/fields/types/Text/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
 import { ShieldIcon } from '@keystonejs/icons';
 import { colors } from '@keystonejs/ui/src/theme';
@@ -19,8 +15,7 @@ export default class TextField extends Component {
     const value = item[field.path] || '';
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
-      itemErrors[field.path] instanceof Error &&
-      itemErrors[field.path].name === 'AccessDeniedError'
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
 
     return (

--- a/packages/file-adapters/cloudinary.js
+++ b/packages/file-adapters/cloudinary.js
@@ -2,15 +2,12 @@ const cloudinary = require('cloudinary');
 
 function uploadStream(stream, options) {
   return new Promise((resolve, reject) => {
-    const cloudinaryStream = cloudinary.v2.uploader.upload_stream(
-      options,
-      (error, result) => {
-        if (error) {
-          return reject(error);
-        }
-        resolve(result);
+    const cloudinaryStream = cloudinary.v2.uploader.upload_stream(options, (error, result) => {
+      if (error) {
+        return reject(error);
       }
-    );
+      resolve(result);
+    });
 
     stream.pipe(cloudinaryStream);
   });
@@ -19,9 +16,7 @@ function uploadStream(stream, options) {
 module.exports = class CloudinaryAdapter {
   constructor(options) {
     if (!options.cloudName || !options.apiKey || !options.apiSecret) {
-      throw new Error(
-        'CloudinaryAdapter requires cloudName, apiKey, and apiSecret'
-      );
+      throw new Error('CloudinaryAdapter requires cloudName, apiKey, and apiSecret');
     }
     this.cloudName = options.cloudName;
     this.apiKey = options.apiKey;

--- a/packages/icons/build/template.js
+++ b/packages/icons/build/template.js
@@ -1,11 +1,4 @@
-const template = ({
-  componentName,
-  height,
-  width,
-  viewBox,
-  ariaHidden,
-  svgContents,
-}) => `
+const template = ({ componentName, height, width, viewBox, ariaHidden, svgContents }) => `
 import React, { Component } from 'react';
 
 class ${componentName} extends Component {

--- a/packages/icons/index.js
+++ b/packages/icons/index.js
@@ -55,9 +55,7 @@ export { default as FileDirectoryIcon } from './icons/FileDirectory';
 export { default as FileMediaIcon } from './icons/FileMedia';
 export { default as FilePdfIcon } from './icons/FilePdf';
 export { default as FileSubmoduleIcon } from './icons/FileSubmodule';
-export {
-  default as FileSymlinkDirectoryIcon,
-} from './icons/FileSymlinkDirectory';
+export { default as FileSymlinkDirectoryIcon } from './icons/FileSymlinkDirectory';
 export { default as FileSymlinkFileIcon } from './icons/FileSymlinkFile';
 export { default as FileIcon } from './icons/File';
 export { default as FileZipIcon } from './icons/FileZip';

--- a/packages/server/WebServer/graphql.js
+++ b/packages/server/WebServer/graphql.js
@@ -3,10 +3,7 @@ const bodyParser = require('body-parser');
 const fastMemoize = require('fast-memoize');
 const { apolloUploadExpress } = require('apollo-upload-server');
 const { graphqlExpress, graphiqlExpress } = require('apollo-server-express');
-const {
-  formatError,
-  isInstance: isApolloErrorInstance,
-} = require('apollo-errors');
+const { formatError, isInstance: isApolloErrorInstance } = require('apollo-errors');
 const cuid = require('cuid');
 const logger = require('@keystonejs/logger');
 
@@ -14,10 +11,7 @@ const { NestedError } = require('./graphqlErrors');
 
 const graphqlLogger = logger('graphql');
 
-module.exports = function createGraphQLMiddleware(
-  keystone,
-  { apiPath, graphiqlPath }
-) {
+module.exports = function createGraphQLMiddleware(keystone, { apiPath, graphiqlPath }) {
   const app = express();
 
   // add the Admin GraphQL API
@@ -40,17 +34,15 @@ module.exports = function createGraphQLMiddleware(
         });
       });
 
-      const getFieldAccessControlForUser = fastMemoize(
-        (listKey, fieldKey, item, operation) => {
-          return keystone.getFieldAccessControl({
-            item,
-            listKey,
-            fieldKey,
-            operation,
-            authentication: { item: req.user, listKey: req.authedListKey },
-          });
-        }
-      );
+      const getFieldAccessControlForUser = fastMemoize((listKey, fieldKey, item, operation) => {
+        return keystone.getFieldAccessControl({
+          item,
+          listKey,
+          fieldKey,
+          operation,
+          authentication: { item: req.user, listKey: req.authedListKey },
+        });
+      });
 
       return {
         schema,

--- a/packages/server/WebServer/index.js
+++ b/packages/server/WebServer/index.js
@@ -36,8 +36,7 @@ module.exports = class WebServer {
           return next();
         }
 
-        const authHeader =
-          req.headers.authorization || req.headers.Authorization;
+        const authHeader = req.headers.authorization || req.headers.Authorization;
 
         if (!authHeader) {
           return next();
@@ -47,9 +46,7 @@ module.exports = class WebServer {
 
         if (type !== 'Bearer') {
           // TODO: Use logger
-          console.warn(
-            `Got Authorization header of type ${type}, but expected Bearer`
-          );
+          console.warn(`Got Authorization header of type ${type}, but expected Bearer`);
           return next();
         }
 
@@ -113,9 +110,7 @@ module.exports = class WebServer {
       config: { port },
     } = this;
 
-    app.get('/', (req, res) =>
-      res.sendFile(path.resolve(__dirname, './default.html'))
-    );
+    app.get('/', (req, res) => res.sendFile(path.resolve(__dirname, './default.html')));
 
     app.listen(port, () => {
       console.log(`KeystoneJS 5 ready on port ${port}`);

--- a/packages/ui/src/primitives/alert.js
+++ b/packages/ui/src/primitives/alert.js
@@ -41,13 +41,8 @@ type Props = {
 
 export const Alert = styled.div(({ appearance, variant }: Props) => ({
   backgroundColor:
-    variant === 'bold'
-      ? boldBackgroundColor[appearance]
-      : subtleBackgroundColor[appearance],
-  color:
-    variant === 'bold'
-      ? boldTextColor[appearance]
-      : subtleTextColor[appearance],
+    variant === 'bold' ? boldBackgroundColor[appearance] : subtleBackgroundColor[appearance],
+  color: variant === 'bold' ? boldTextColor[appearance] : subtleTextColor[appearance],
   borderRadius,
   display: 'flex',
   fontWeight: variant === 'bold' ? 500 : null,
@@ -55,10 +50,7 @@ export const Alert = styled.div(({ appearance, variant }: Props) => ({
   padding: '0.9em 1.2em',
 
   '& a': {
-    color:
-      variant === 'bold'
-        ? boldTextColor[appearance]
-        : subtleTextColor[appearance],
+    color: variant === 'bold' ? boldTextColor[appearance] : subtleTextColor[appearance],
     textDecoration: 'underline',
   },
 }));

--- a/packages/ui/src/primitives/badge.js
+++ b/packages/ui/src/primitives/badge.js
@@ -40,15 +40,10 @@ const subtleTextColor = {
 
 const BadgeElement = styled.div(({ appearance, variant }) => ({
   backgroundColor:
-    variant === 'bold'
-      ? boldBackgroundColor[appearance]
-      : subtleBackgroundColor[appearance],
+    variant === 'bold' ? boldBackgroundColor[appearance] : subtleBackgroundColor[appearance],
   borderRadius: '2em',
   boxSizing: 'border-box',
-  color:
-    variant === 'bold'
-      ? boldTextColor[appearance]
-      : subtleTextColor[appearance],
+  color: variant === 'bold' ? boldTextColor[appearance] : subtleTextColor[appearance],
   display: 'inline-block',
   fontSize: 12,
   fontWeight: 500,

--- a/packages/ui/src/primitives/buttons/loading.js
+++ b/packages/ui/src/primitives/buttons/loading.js
@@ -27,12 +27,7 @@ type Loading = ButtonProps & {
   isLoading: boolean,
   indicatorVariant: 'spinner' | 'dots',
 };
-export const LoadingButton = ({
-  children,
-  indicatorVariant,
-  isLoading,
-  ...props
-}: Loading) => {
+export const LoadingButton = ({ children, indicatorVariant, isLoading, ...props }: Loading) => {
   const appearance = getAppearance(props.appearance);
   const textCSS = isLoading ? { visibility: 'hidden' } : null;
   const isSpinner = indicatorVariant === 'spinner';

--- a/packages/ui/src/primitives/buttons/primitives.js
+++ b/packages/ui/src/primitives/buttons/primitives.js
@@ -6,11 +6,7 @@ import withPseudoState from 'react-pseudo-state';
 
 import { gridSize } from '../../theme';
 import { buttonAndInputBase } from '../forms';
-import {
-  makeSubtleVariant,
-  makeGhostVariant,
-  makeBoldVariant,
-} from './variants';
+import { makeSubtleVariant, makeGhostVariant, makeBoldVariant } from './variants';
 
 const SPACING_OPTION = {
   comfortable: `${gridSize}px ${gridSize * 1.5}px`,
@@ -99,15 +95,7 @@ const ButtonElement = (props: ButtonProps) => {
   const variant = makeVariant(props);
   if (rest.to) return <Link innerRef={innerRef} css={variant} {...rest} />;
   if (rest.href) return <a ref={innerRef} css={variant} {...rest} />;
-  return (
-    <button
-      type="button"
-      disabled={isDisabled}
-      ref={innerRef}
-      css={variant}
-      {...rest}
-    />
-  );
+  return <button type="button" disabled={isDisabled} ref={innerRef} css={variant} {...rest} />;
 };
 
 ButtonElement.defaultProps = {

--- a/packages/ui/src/primitives/buttons/variants.js
+++ b/packages/ui/src/primitives/buttons/variants.js
@@ -114,13 +114,7 @@ export function makeGhostVariant({ appearance, isDisabled }) {
 // Bold
 // ------------------------------
 
-export function makeBoldVariant({
-  appearance,
-  isDisabled,
-  isActive,
-  isHover,
-  isFocus,
-}) {
+export function makeBoldVariant({ appearance, isDisabled, isActive, isHover, isFocus }) {
   const { bg, border, focusRing, text } = boldAppearance[appearance];
   const bgTop = lighten(bg, 10);
   const bgBottom = darken(bg, 10);
@@ -128,21 +122,16 @@ export function makeBoldVariant({
   const borderBottom = darken(border, 16);
   const activeBg = darken(bg, 12);
   const textShadow =
-    appearance === 'default'
-      ? '0 1px 0 rgba(255, 255, 255, 0.5)'
-      : '0 -1px 0 rgba(0, 0, 0, 0.25)';
+    appearance === 'default' ? '0 1px 0 rgba(255, 255, 255, 0.5)' : '0 -1px 0 rgba(0, 0, 0, 0.25)';
 
   const hoverAndFocus =
     isHover || isFocus
       ? {
-          borderColor: `${darken(borderTop, 8)} ${darken(border, 8)} ${darken(
-            borderBottom,
+          borderColor: `${darken(borderTop, 8)} ${darken(border, 8)} ${darken(borderBottom, 8)}`,
+          background: `linear-gradient(to bottom, ${lighten(bgTop, 10)} 0%, ${lighten(
+            bgBottom,
             8
-          )}`,
-          background: `linear-gradient(to bottom, ${lighten(
-            bgTop,
-            10
-          )} 0%, ${lighten(bgBottom, 8)} 100%)`,
+          )} 100%)`,
         }
       : null;
   const hoverStyles = isHover
@@ -162,10 +151,7 @@ export function makeBoldVariant({
   const activeStyles = isActive
     ? {
         background: activeBg,
-        borderColor: `${darken(border, 24)} ${darken(border, 16)} ${darken(
-          border,
-          12
-        )}`,
+        borderColor: `${darken(border, 24)} ${darken(border, 16)} ${darken(border, 12)}`,
         boxShadow: 'inset 0 1px 2px rgba(0, 0, 0, 0.12)',
       }
     : null;
@@ -173,9 +159,7 @@ export function makeBoldVariant({
   return {
     backgroundColor: bgBottom,
     backgroundRepeat: 'repeat-x',
-    background: isDisabled
-      ? null
-      : `linear-gradient(to bottom, ${bgTop} 0%, ${bgBottom} 100%)`,
+    background: isDisabled ? null : `linear-gradient(to bottom, ${bgTop} 0%, ${bgBottom} 100%)`,
     borderColor: isDisabled ? null : `${borderTop} ${border} ${borderBottom}`,
     color: text,
     fontWeight: 500,

--- a/packages/ui/src/primitives/filters.js
+++ b/packages/ui/src/primitives/filters.js
@@ -121,23 +121,15 @@ const ControlLabel = ({ isChecked, isDisabled, ...props }) => {
 const StretchGroup = props => <FlexGroup stretch {...props} />;
 
 // checkbox
-export const CheckboxGroup = props => (
-  <_CheckboxGroup component={StretchGroup} {...props} />
-);
+export const CheckboxGroup = props => <_CheckboxGroup component={StretchGroup} {...props} />;
 const ButtonCheckbox = props => (
   <CheckboxPrimitive components={{ Label: ControlLabel }} {...props} />
 );
-export const Checkbox = props => (
-  <_Checkbox component={ButtonCheckbox} {...props} />
-);
+export const Checkbox = props => <_Checkbox component={ButtonCheckbox} {...props} />;
 
 // radio
-export const RadioGroup = props => (
-  <_RadioGroup component={StretchGroup} {...props} />
-);
-const ButtonRadio = props => (
-  <RadioPrimitive components={{ Label: ControlLabel }} {...props} />
-);
+export const RadioGroup = props => <_RadioGroup component={StretchGroup} {...props} />;
+const ButtonRadio = props => <RadioPrimitive components={{ Label: ControlLabel }} {...props} />;
 export const Radio = props => <_Radio component={ButtonRadio} {...props} />;
 
 // ==============================

--- a/packages/ui/src/primitives/forms/Controls.js
+++ b/packages/ui/src/primitives/forms/Controls.js
@@ -1,10 +1,5 @@
 // @flow
-import React, {
-  Component,
-  type ComponentType,
-  type Node,
-  type Ref,
-} from 'react';
+import React, { Component, type ComponentType, type Node, type Ref } from 'react';
 import styled from 'react-emotion';
 import {
   CheckboxGroup as ReactCheckboxGroup,
@@ -66,61 +61,59 @@ type IconProps = {
   isDisabled: boolean,
   isFocused: boolean,
 };
-const Icon = styled.div(
-  ({ isDisabled, isFocused, checked, isActive }: IconProps) => {
-    // background
-    let bg = colors.N05;
-    if (isDisabled && checked) {
-      bg = colors.B.D20;
-    } else if (isDisabled) {
-      bg = colors.N10;
-    } else if (isActive) {
-      bg = checked ? colors.B.D10 : colors.N10;
-    } else if (isFocused && !checked) {
-      bg = 'white';
-    } else if (checked) {
-      bg = colors.B.base;
-    }
-
-    // fill
-    let fill = 'white';
-    if (isDisabled && checked) {
-      fill = colors.N70;
-    } else if (!checked) {
-      fill = 'transparent';
-    }
-
-    // stroke
-    let innerStroke = isFocused ? colors.B.L20 : colors.N30;
-    let innerStrokeWidth = 1;
-    if (checked) {
-      innerStroke = isActive ? colors.B.D20 : colors.B.base;
-    }
-    let outerStroke = 'transparent';
-    let outerStrokeWidth = 1;
-    if (isFocused && !isActive) {
-      outerStroke = colors.B.A20;
-      outerStrokeWidth = 5;
-    }
-
-    return {
-      color: bg,
-      fill,
-      lineHeight: 0,
-
-      // awkwardly apply the focus ring
-      '& .outer-stroke': {
-        transition: 'stroke 0.2s ease-in-out',
-        stroke: outerStroke,
-        strokeWidth: outerStrokeWidth,
-      },
-      '& .inner-stroke': {
-        stroke: innerStroke,
-        strokeWidth: innerStrokeWidth,
-      },
-    };
+const Icon = styled.div(({ isDisabled, isFocused, checked, isActive }: IconProps) => {
+  // background
+  let bg = colors.N05;
+  if (isDisabled && checked) {
+    bg = colors.B.D20;
+  } else if (isDisabled) {
+    bg = colors.N10;
+  } else if (isActive) {
+    bg = checked ? colors.B.D10 : colors.N10;
+  } else if (isFocused && !checked) {
+    bg = 'white';
+  } else if (checked) {
+    bg = colors.B.base;
   }
-);
+
+  // fill
+  let fill = 'white';
+  if (isDisabled && checked) {
+    fill = colors.N70;
+  } else if (!checked) {
+    fill = 'transparent';
+  }
+
+  // stroke
+  let innerStroke = isFocused ? colors.B.L20 : colors.N30;
+  let innerStrokeWidth = 1;
+  if (checked) {
+    innerStroke = isActive ? colors.B.D20 : colors.B.base;
+  }
+  let outerStroke = 'transparent';
+  let outerStrokeWidth = 1;
+  if (isFocused && !isActive) {
+    outerStroke = colors.B.A20;
+    outerStrokeWidth = 5;
+  }
+
+  return {
+    color: bg,
+    fill,
+    lineHeight: 0,
+
+    // awkwardly apply the focus ring
+    '& .outer-stroke': {
+      transition: 'stroke 0.2s ease-in-out',
+      stroke: outerStroke,
+      strokeWidth: outerStrokeWidth,
+    },
+    '& .inner-stroke': {
+      stroke: innerStroke,
+      strokeWidth: innerStrokeWidth,
+    },
+  };
+});
 
 const defaultComponents = { Wrapper, Label, Text };
 
@@ -277,9 +270,7 @@ export const CheckboxPrimitive = ({ innerRef, ...props }: Props) => (
 export const Checkbox = (props: Props) => (
   <ReactCheckbox component={CheckboxPrimitive} {...props} />
 );
-export const CheckboxGroup = (props: Props) => (
-  <ReactCheckboxGroup {...props} />
-);
+export const CheckboxGroup = (props: Props) => <ReactCheckboxGroup {...props} />;
 export const RadioPrimitive = ({ innerRef, ...props }: Props) => (
   <Control
     ref={innerRef}
@@ -292,7 +283,5 @@ export const RadioPrimitive = ({ innerRef, ...props }: Props) => (
     {...props}
   />
 );
-export const Radio = (props: Props) => (
-  <ReactRadio component={RadioPrimitive} {...props} />
-);
+export const Radio = (props: Props) => <ReactRadio component={RadioPrimitive} {...props} />;
 export const RadioGroup = (props: Props) => <ReactRadioGroup {...props} />;

--- a/packages/ui/src/primitives/forms/index.js
+++ b/packages/ui/src/primitives/forms/index.js
@@ -64,11 +64,7 @@ export const Input = ({ innerRef, isMultiline, ...props }: InputProps) => {
     },
   };
   return isMultiline ? (
-    <textarea
-      ref={innerRef}
-      css={{ ...css, lineHeight: 'inherit', height: 'auto' }}
-      {...props}
-    />
+    <textarea ref={innerRef} css={{ ...css, lineHeight: 'inherit', height: 'auto' }} {...props} />
   ) : (
     <input ref={innerRef} css={css} {...props} />
   );
@@ -117,9 +113,7 @@ export const selectStyles = {
   }),
 };
 
-export const Select = (props: *) => (
-  <ReactSelect styles={selectStyles} isClearable {...props} />
-);
+export const Select = (props: *) => <ReactSelect styles={selectStyles} isClearable {...props} />;
 
 // Hidden Input
 // ------------------------------

--- a/packages/ui/src/primitives/layout.js
+++ b/packages/ui/src/primitives/layout.js
@@ -53,12 +53,7 @@ type FlexGroupProps = {
   isContiguous: boolean,
   isInline: boolean,
   isVertical: boolean,
-  justify:
-    | 'space-between'
-    | 'space-around'
-    | 'center'
-    | 'flex-end'
-    | 'flex-start',
+  justify: 'space-between' | 'space-around' | 'center' | 'flex-end' | 'flex-start',
   wrap: boolean,
   spacing: number,
   stretch: boolean,
@@ -163,9 +158,7 @@ export const Grid = ({
 }: GridProps) => {
   const templateRows = rows ? { gridTemplateRows: rows } : {};
   const templateAreas = areas ? { gridTemplateAreas: formatAreas(areas) } : {};
-  const gridTemplateColumns = Number.isInteger(columns)
-    ? `repeat(${columns}, 1fr)`
-    : columns;
+  const gridTemplateColumns = Number.isInteger(columns) ? `repeat(${columns}, 1fr)` : columns;
 
   return (
     <div
@@ -198,14 +191,7 @@ type CellProps = {
   width: number,
 };
 
-export const Cell = ({
-  area,
-  height = 1,
-  left,
-  top,
-  width = 1,
-  ...props
-}: CellProps) => (
+export const Cell = ({ area, height = 1, left, top, width = 1, ...props }: CellProps) => (
   <div
     css={{
       alignContent: 'space-around',

--- a/packages/ui/src/primitives/loading.js
+++ b/packages/ui/src/primitives/loading.js
@@ -46,10 +46,7 @@ const Dot = styled.span(({ appearance, delay = 0, isOffset }: DotProps) => ({
   verticalAlign: 'top',
   width: '1em',
 }));
-export const LoadingIndicator = ({
-  appearance = 'default',
-  size = 4,
-}: LoadingIndicatorProps) => (
+export const LoadingIndicator = ({ appearance = 'default', size = 4 }: LoadingIndicatorProps) => (
   <DotsContainer size={size}>
     <Dot appearance={appearance} />
     <Dot appearance={appearance} delay={160} isOffset />
@@ -92,10 +89,7 @@ const SpinnerSatellite = styled.div(({ color, size }) => ({
   top: 0,
 }));
 
-export const LoadingSpinner = ({
-  appearance = 'default',
-  size = 16,
-}: LoadingIndicatorProps) => {
+export const LoadingSpinner = ({ appearance = 'default', size = 16 }: LoadingIndicatorProps) => {
   const color = appearanceColor[appearance];
 
   return (

--- a/packages/ui/src/primitives/lozenge.js
+++ b/packages/ui/src/primitives/lozenge.js
@@ -67,14 +67,9 @@ export const Lozenge = styled.div(({ appearance, variant, crop }: Props) => {
   return {
     border: '1px solid transparent',
     backgroundColor:
-      variant === 'bold'
-        ? boldBackgroundColor[appearance]
-        : subtleBackgroundColor[appearance],
+      variant === 'bold' ? boldBackgroundColor[appearance] : subtleBackgroundColor[appearance],
     borderColor: variant === 'bold' ? null : subtleBorderColor[appearance],
-    color:
-      variant === 'bold'
-        ? boldTextColor[appearance]
-        : subtleTextColor[appearance],
+    color: variant === 'bold' ? boldTextColor[appearance] : subtleTextColor[appearance],
     borderRadius,
     display: 'inline-block',
     fontSize: '0.85em',

--- a/packages/ui/src/primitives/modals/FocusTrap.js
+++ b/packages/ui/src/primitives/modals/FocusTrap.js
@@ -120,10 +120,6 @@ export default class FocusTrap extends Component<Props> {
   };
 
   render() {
-    return (
-      <NodeResolver innerRef={this.getBoundary}>
-        {this.props.children}
-      </NodeResolver>
-    );
+    return <NodeResolver innerRef={this.getBoundary}>{this.props.children}</NodeResolver>;
   }
 }

--- a/packages/ui/src/primitives/modals/confirm.js
+++ b/packages/ui/src/primitives/modals/confirm.js
@@ -1,12 +1,6 @@
 // @flow
 
-import React, {
-  Fragment,
-  PureComponent,
-  type ComponentType,
-  type Ref,
-  type Node,
-} from 'react';
+import React, { Fragment, PureComponent, type ComponentType, type Ref, type Node } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'react-emotion';
 import ScrollLock from 'react-scrolllock';
@@ -36,12 +30,7 @@ type DialogElementProps = {
   innerRef?: Ref<*>,
   width: number,
 };
-const Dialog = ({
-  component: Tag,
-  innerRef,
-  width,
-  ...props
-}: DialogElementProps) => (
+const Dialog = ({ component: Tag, innerRef, width, ...props }: DialogElementProps) => (
   <Tag
     ref={innerRef}
     role="alertdialog"
@@ -49,8 +38,7 @@ const Dialog = ({
       backgroundColor: 'white',
       borderBottomRightRadius: borderRadius,
       borderBottomLeftRadius: borderRadius,
-      boxShadow:
-        '0 0 0 1px rgba(0, 0, 0, 0.175), 0 3px 8px rgba(0, 0, 0, 0.175)',
+      boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.175), 0 3px 8px rgba(0, 0, 0, 0.175)',
       display: 'flex',
       flexDirection: 'column',
       maxHeight: '100%',
@@ -95,14 +83,7 @@ class ModalConfirm extends PureComponent<Props> {
     if (this.props.onKeyDown) this.props.onKeyDown(e);
   };
   render() {
-    const {
-      attachTo,
-      children,
-      component,
-      onClose,
-      width,
-      ...transitionProps
-    } = this.props;
+    const { attachTo, children, component, onClose, width, ...transitionProps } = this.props;
 
     return createPortal(
       <Fragment>

--- a/packages/ui/src/primitives/modals/dialog.js
+++ b/packages/ui/src/primitives/modals/dialog.js
@@ -140,10 +140,7 @@ class ModalDialog extends PureComponent<Props> {
     return createPortal(
       <Fragment>
         <Fade {...transitionProps}>
-          <Blanket
-            onClick={closeOnBlanketClick ? onClose : undefined}
-            isTinted
-          />
+          <Blanket onClick={closeOnBlanketClick ? onClose : undefined} isTinted />
         </Fade>
         <SlideUp {...transitionProps}>
           <Positioner width={width}>

--- a/packages/ui/src/primitives/modals/drawer.js
+++ b/packages/ui/src/primitives/modals/drawer.js
@@ -138,10 +138,7 @@ class ModalDialog extends PureComponent<Props> {
     return createPortal(
       <Fragment>
         <Fade {...transitionProps}>
-          <Blanket
-            onClick={closeOnBlanketClick ? onClose : undefined}
-            isTinted
-          />
+          <Blanket onClick={closeOnBlanketClick ? onClose : undefined} isTinted />
         </Fade>
         <SlideInHorizontal slideInFrom={slideInFrom} {...transitionProps}>
           <Positioner slideInFrom={slideInFrom} width={width}>

--- a/packages/ui/src/primitives/modals/dropdown.js
+++ b/packages/ui/src/primitives/modals/dropdown.js
@@ -88,9 +88,7 @@ class Dropdown extends Component<Props> {
     document.removeEventListener('keydown', this.handleKeyDown, false);
   }
 
-  handleItemClick = ({ onClick, ...data }: ClickArgs) => (
-    event: MouseEvent
-  ) => {
+  handleItemClick = ({ onClick, ...data }: ClickArgs) => (event: MouseEvent) => {
     const { close, selectClosesMenu } = this.props;
     if (selectClosesMenu) close({ returnFocus: true });
     if (onClick) onClick({ event, data });
@@ -151,11 +149,7 @@ class Dropdown extends Component<Props> {
 
     return (
       <FocusTrap options={{ clickOutsideDeactivates: true }}>
-        <Menu
-          innerRef={this.getMenu}
-          onMouseLeave={this.handleMenuLeave}
-          style={style}
-        >
+        <Menu innerRef={this.getMenu} onMouseLeave={this.handleMenuLeave} style={style}>
           {items.map((item, idx) => {
             const { content, ...rest } = item;
             return (

--- a/packages/ui/src/primitives/modals/popout.js
+++ b/packages/ui/src/primitives/modals/popout.js
@@ -102,8 +102,7 @@ class Popout extends Component<Props, State> {
     let isAlignedRight = false;
 
     // handle right aligned
-    const spaceOnRight =
-      window.innerWidth - (leftOffset + width + CHROME_GUTTER);
+    const spaceOnRight = window.innerWidth - (leftOffset + width + CHROME_GUTTER);
     if (spaceOnRight < 0) {
       leftOffset = leftOffset + spaceOnRight;
       isAlignedRight = true;

--- a/packages/ui/src/primitives/modals/transitions.js
+++ b/packages/ui/src/primitives/modals/transitions.js
@@ -17,20 +17,10 @@ type ProviderProps = {
   isOpen: boolean,
 };
 
-export const TransitionProvider = ({
-  children,
-  isOpen,
-  ...props
-}: ProviderProps) => (
+export const TransitionProvider = ({ children, isOpen, ...props }: ProviderProps) => (
   <TransitionGroup component={null}>
     {isOpen ? (
-      <Transition
-        appear
-        mountOnEnter
-        unmountOnExit
-        timeout={transitionDurationMs}
-        {...props}
-      >
+      <Transition appear mountOnEnter unmountOnExit timeout={transitionDurationMs} {...props}>
         {state => children(state)}
       </Transition>
     ) : null}

--- a/packages/ui/src/primitives/modals/withModalHandlers.js
+++ b/packages/ui/src/primitives/modals/withModalHandlers.js
@@ -1,12 +1,6 @@
 // @flow
 
-import React, {
-  cloneElement,
-  Component,
-  Fragment,
-  type ComponentType,
-  type Element,
-} from 'react';
+import React, { cloneElement, Component, Fragment, type ComponentType, type Element } from 'react';
 import NodeResolver from 'react-node-resolver';
 import { TransitionProvider } from './transitions';
 
@@ -98,15 +92,9 @@ export default function withModalHandlers(
 
       return (
         <Fragment>
-          <NodeResolver innerRef={this.getTarget}>
-            {cloneElement(target, cloneProps)}
-          </NodeResolver>
+          <NodeResolver innerRef={this.getTarget}>{cloneElement(target, cloneProps)}</NodeResolver>
 
-          <TransitionProvider
-            isOpen={isOpen}
-            onEntered={onOpen}
-            onExited={onClose}
-          >
+          <TransitionProvider isOpen={isOpen} onEntered={onOpen} onExited={onClose}>
             {transitionState => (
               <Transition transitionState={transitionState}>
                 <WrappedComponent

--- a/packages/ui/src/primitives/navigation/pagination/Page.js
+++ b/packages/ui/src/primitives/navigation/pagination/Page.js
@@ -24,22 +24,11 @@ type PageProps = PagePrimitiveProps & {
 // remove props that will create react DOM warnings
 // ------------------------------
 
-const PagePrimitive = ({
-  isDisabled,
-  isSelected,
-  ...props
-}: PagePrimitiveProps) => {
+const PagePrimitive = ({ isDisabled, isSelected, ...props }: PagePrimitiveProps) => {
   const current = isSelected ? 'page' : null;
   if (props.to) return <Link aria-current={current} {...props} />;
   if (props.href) return <a aria-current={current} {...props} />;
-  return (
-    <button
-      type="button"
-      disabled={isDisabled}
-      aria-current={current}
-      {...props}
-    />
-  );
+  return <button type="button" disabled={isDisabled} aria-current={current} {...props} />;
 };
 PagePrimitive.defaultProps = {
   isDisabled: false,
@@ -49,51 +38,49 @@ PagePrimitive.defaultProps = {
 // Primitive
 // ------------------------------
 
-const PageElement = styled(PagePrimitive)(
-  ({ isDisabled, isSelected }: PageProps) => {
-    const disabledStyles = isDisabled
-      ? {
-          color: colors.N40,
+const PageElement = styled(PagePrimitive)(({ isDisabled, isSelected }: PageProps) => {
+  const disabledStyles = isDisabled
+    ? {
+        color: colors.N40,
+        cursor: 'default',
+      }
+    : null;
+  const selectedStyles = isSelected
+    ? {
+        '&, &:hover, &:focus': {
+          backgroundColor: colors.N10,
+          borderColor: 'transparent',
+          color: colors.N80,
           cursor: 'default',
-        }
-      : null;
-    const selectedStyles = isSelected
-      ? {
-          '&, &:hover, &:focus': {
-            backgroundColor: colors.N10,
-            borderColor: 'transparent',
-            color: colors.N80,
-            cursor: 'default',
-            zIndex: 2,
-          },
-        }
-      : null;
+          zIndex: 2,
+        },
+      }
+    : null;
 
-    return {
-      appearance: 'none',
-      background: 0,
-      border: '1px solid transparent',
-      borderRadius: 3,
-      color: colors.N60,
-      cursor: 'pointer',
-      fontSize: 'inherit',
-      marginRight: '.1em',
-      padding: '0.25em 0.7em',
-      position: 'relative',
-      textDecoration: 'none',
+  return {
+    appearance: 'none',
+    background: 0,
+    border: '1px solid transparent',
+    borderRadius: 3,
+    color: colors.N60,
+    cursor: 'pointer',
+    fontSize: 'inherit',
+    marginRight: '.1em',
+    padding: '0.25em 0.7em',
+    position: 'relative',
+    textDecoration: 'none',
 
-      '&:hover, &:focus': {
-        backgroundColor: 'white',
-        borderColor: colors.N20,
-        color: colors.N80,
-        outline: 'none',
-      },
+    '&:hover, &:focus': {
+      backgroundColor: 'white',
+      borderColor: colors.N20,
+      color: colors.N80,
+      outline: 'none',
+    },
 
-      ...selectedStyles,
-      ...disabledStyles,
-    };
-  }
-);
+    ...selectedStyles,
+    ...disabledStyles,
+  };
+});
 
 export default class Page extends Component {
   onClick = () => {

--- a/packages/ui/src/primitives/navigation/pagination/Pagination.js
+++ b/packages/ui/src/primitives/navigation/pagination/Pagination.js
@@ -10,14 +10,7 @@ import type { CountArgs, CountFormat, LabelType, OnChangeType } from './types';
 function ariaPageLabelFn(page: number) {
   return `Go to page ${page}`;
 }
-function countFormatterFn({
-  end,
-  pageSize,
-  plural,
-  singular,
-  start,
-  total,
-}: CountArgs) {
+function countFormatterFn({ end, pageSize, plural, singular, start, total }: CountArgs) {
   let count = '';
 
   if (!total) {
@@ -78,14 +71,7 @@ class Pagination extends Component<PaginationProps> {
   };
 
   renderCount() {
-    let {
-      countFormatter,
-      displayCount,
-      pageSize,
-      plural,
-      singular,
-      total,
-    } = this.props;
+    let { countFormatter, displayCount, pageSize, plural, singular, total } = this.props;
 
     if (!displayCount) return null;
 
@@ -143,12 +129,7 @@ class Pagination extends Component<PaginationProps> {
     // go to first
     if (minPage > 1) {
       pages.push(
-        <Page
-          aria-label={ariaPageLabel(1)}
-          key="page_start"
-          onClick={onChange}
-          value={1}
-        >
+        <Page aria-label={ariaPageLabel(1)} key="page_start" onClick={onChange} value={1}>
           {moreCharacter}
         </Page>
       );

--- a/packages/ui/src/primitives/pill.js
+++ b/packages/ui/src/primitives/pill.js
@@ -67,10 +67,7 @@ const PillButton = styled.button(({ appearance, variant }: Props) => {
       variant === 'bold'
         ? boldBackgroundColor[appearance].default
         : subtleBackgroundColor[appearance].default,
-    color:
-      variant === 'bold'
-        ? boldTextColor[appearance]
-        : subtleTextColor[appearance],
+    color: variant === 'bold' ? boldTextColor[appearance] : subtleTextColor[appearance],
     alignItems: 'center',
     border: 0,
     cursor: 'pointer',
@@ -114,25 +111,14 @@ const PillButton = styled.button(({ appearance, variant }: Props) => {
   };
 });
 
-export const Pill = ({
-  appearance,
-  children,
-  onClick,
-  onRemove,
-  variant,
-  ...props
-}: Props) => {
+export const Pill = ({ appearance, children, onClick, onRemove, variant, ...props }: Props) => {
   return (
     <PillWrapper {...props}>
       <PillButton appearance={appearance} variant={variant} onClick={onClick}>
         {children}
       </PillButton>
       {onRemove ? (
-        <PillButton
-          appearance={appearance}
-          variant={variant}
-          onClick={onRemove}
-        >
+        <PillButton appearance={appearance} variant={variant} onClick={onRemove}>
           <XIcon css={{ height: 12 }} />
         </PillButton>
       ) : null}

--- a/packages/ui/src/primitives/typography.js
+++ b/packages/ui/src/primitives/typography.js
@@ -17,8 +17,7 @@ export const Kbd = styled.kbd({
   backgroundColor: colors.N05,
   border: `1px solid ${colors.N20}`,
   borderRadius: 3,
-  boxShadow:
-    '0 1px 1px rgba(0, 0, 0, 0.12), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset',
+  boxShadow: '0 1px 1px rgba(0, 0, 0, 0.12), 0 2px 0 0 rgba(255, 255, 255, 0.7) inset',
   display: 'inline-block',
   fontFamily: 'Monaco, monospace',
   fontSize: '0.85em',

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -4,8 +4,7 @@ const camelize = (exports.camelize = str =>
     return index == 0 ? match.toLowerCase() : match.toUpperCase();
   }));
 
-exports.getType = thing =>
-  Object.prototype.toString.call(thing).replace(/\[object (.*)\]/, '$1');
+exports.getType = thing => Object.prototype.toString.call(thing).replace(/\[object (.*)\]/, '$1');
 
 exports.fixConfigKeys = (config, remapKeys = {}) => {
   const rtn = {};
@@ -22,8 +21,7 @@ exports.checkRequiredConfig = (config, requiredKeys = {}) => {
   });
 };
 
-exports.escapeRegExp = str =>
-  str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+exports.escapeRegExp = str => str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 
 exports.mapKeys = (obj, func) =>
   Object.entries(obj).reduce(
@@ -47,10 +45,7 @@ exports.intersection = (array1, array2) =>
   exports.unique(array1.filter(value => array2.includes(value)));
 
 exports.pick = (obj, keys) =>
-  keys.reduce(
-    (result, key) => (key in obj ? { ...result, [key]: obj[key] } : result),
-    {}
-  );
+  keys.reduce((result, key) => (key in obj ? { ...result, [key]: obj[key] } : result), {});
 
 exports.omit = (obj, keys) =>
   exports.pick(obj, Object.keys(obj).filter(value => !keys.includes(value)));

--- a/projects/access-control/cypress/integration/field/admin-ui.js
+++ b/projects/access-control/cypress/integration/field/admin-ui.js
@@ -42,26 +42,22 @@ describe('Access Control Fields > Admin UI', () => {
       });
 
       it('shows creatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ create, read }) => create && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('exist'));
-          });
+        fieldAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('exist'));
+        });
       });
 
       // Skipped until Admin UI is created to exclude these fields
       it.skip('does not show non-creatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ create, read }) => !create && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
-          });
+        fieldAccessVariations.filter(({ create, read }) => !create && read).forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
+        });
       });
     }
 
@@ -127,36 +123,31 @@ describe('Access Control Fields > Admin UI', () => {
       const queryName = `all${listName}s`;
 
       before(() => {
-        cy.graphql_query(
-          '/admin/api',
-          `query { ${queryName}(first: 1) { id } }`
-        ).then(({ data }) => {
-          cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
-          cy.get('form').should('exist');
-        });
+        cy.graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`).then(
+          ({ data }) => {
+            cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
+            cy.get('form').should('exist');
+          }
+        );
       });
 
       it('shows updatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ update, read }) => update && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('exist'));
-          });
+        fieldAccessVariations.filter(({ update, read }) => update && read).forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('exist'));
+        });
       });
 
       // Skipped until Admin UI hides these fields
       it.skip('does not show non-updatable inputs', () => {
-        fieldAccessVariations
-          .filter(({ update, read }) => !update && read)
-          .forEach(access => {
-            const field = getFieldName(access);
-            cy.get(`label[for="ks-input-${field}"]`)
-              .should('exist')
-              .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
-          });
+        fieldAccessVariations.filter(({ update, read }) => !update && read).forEach(access => {
+          const field = getFieldName(access);
+          cy.get(`label[for="ks-input-${field}"]`)
+            .should('exist')
+            .then(() => cy.get(`#ks-input-${field}`).should('not.exist'));
+        });
       });
     }
 

--- a/projects/access-control/cypress/integration/field/graphql.js
+++ b/projects/access-control/cypress/integration/field/graphql.js
@@ -27,10 +27,7 @@ const imperativeCollection = listNameToCollectionName(imperativeList);
 const identity = val => val;
 
 const arrayToObject = (items, keyedBy, mapFn = identity) =>
-  items.reduce(
-    (memo, item) => Object.assign(memo, { [item[keyedBy]]: mapFn(item) }),
-    {}
-  );
+  items.reduce((memo, item) => Object.assign(memo, { [item[keyedBy]]: mapFn(item) }), {});
 
 describe('Access Control, Field, GraphQL', () => {
   describe('Schema', () => {
@@ -118,10 +115,7 @@ describe('Access Control, Field, GraphQL', () => {
               `${staticList}WhereInput.inputFields.${name}`
             );
           } else {
-            expect(
-              types,
-              `WhereInput.${name} doesn't exist`
-            ).to.not.have.deep.property(
+            expect(types, `WhereInput.${name} doesn't exist`).to.not.have.deep.property(
               `${staticList}WhereInput.inputFields.${name}`
             );
           }
@@ -135,10 +129,7 @@ describe('Access Control, Field, GraphQL', () => {
               `${staticList}CreateInput.inputFields.${name}`
             );
           } else {
-            expect(
-              types,
-              `CreateInput.${name} doesn't exist`
-            ).to.not.have.deep.property(
+            expect(types, `CreateInput.${name} doesn't exist`).to.not.have.deep.property(
               `${staticList}CreateInput.inputFields.${name}`
             );
           }
@@ -152,10 +143,7 @@ describe('Access Control, Field, GraphQL', () => {
               `${staticList}CreateInput.inputFields.${name}`
             );
           } else {
-            expect(
-              types,
-              `CreateInput.${name} doesn't exist`
-            ).to.not.have.deep.property(
+            expect(types, `CreateInput.${name} doesn't exist`).to.not.have.deep.property(
               `${staticList}CreateInput.inputFields.${name}`
             );
           }
@@ -176,9 +164,7 @@ describe('Access Control, Field, GraphQL', () => {
         it(`${JSON.stringify(access)} on ${imperativeList}`, () => {
           const name = getFieldName(access);
 
-          expect(types, 'types').to.have.deep.property(
-            `${imperativeList}.fields`
-          );
+          expect(types, 'types').to.have.deep.property(`${imperativeList}.fields`);
 
           const fields = types[imperativeList].fields;
 
@@ -251,16 +237,12 @@ describe('Access Control, Field, GraphQL', () => {
           const fieldName = getFieldName(access);
 
           it(`all allowed: ${JSON.stringify(access)}`, () => {
-            cy.graphql_query(
-              '/admin/api',
-              `query { ${allQueryName} { id ${fieldName} } }`
-            ).then(({ data, errors }) => {
-              expect(errors, 'no errors querying all').to.equal(undefined);
-              expect(
-                data[allQueryName],
-                'data when querying all'
-              ).to.have.length.greaterThan(0);
-            });
+            cy.graphql_query('/admin/api', `query { ${allQueryName} { id ${fieldName} } }`).then(
+              ({ data, errors }) => {
+                expect(errors, 'no errors querying all').to.equal(undefined);
+                expect(data[allQueryName], 'data when querying all').to.have.length.greaterThan(0);
+              }
+            );
           });
 
           it(`singular allowed: ${JSON.stringify(access)}`, () => {
@@ -271,16 +253,13 @@ describe('Access Control, Field, GraphQL', () => {
               cy
                 .graphql_query(
                   '/admin/api',
-                  `query { ${singleQueryName}(where: { id: "${
-                    item.id
-                  }" }) { id ${fieldName} } }`
+                  `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`
                 )
                 .then(({ data, errors }) => {
                   expect(errors, 'no errors querying all').to.equal(undefined);
-                  expect(
-                    data[singleQueryName],
-                    'data when querying all'
-                  ).to.have.property(fieldName);
+                  expect(data[singleQueryName], 'data when querying all').to.have.property(
+                    fieldName
+                  );
                 })
             );
           });
@@ -348,10 +327,7 @@ describe('Access Control, Field, GraphQL', () => {
                 '/admin/api',
                 `mutation { ${createMutationName}(data: { ${fieldName}: "bar" }) { id } }`
               ).then(({ data, errors }) => {
-                expect(data, 'create mutation denied').to.have.property(
-                  createMutationName,
-                  null
-                );
+                expect(data, 'create mutation denied').to.have.property(createMutationName, null);
 
                 expect(errors, 'create mutation denied').to.have.deep.property(
                   '[0].name',
@@ -378,16 +354,14 @@ describe('Access Control, Field, GraphQL', () => {
             const fieldName = getFieldName(access);
 
             it(`all allowed: ${JSON.stringify(access)}`, () => {
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id ${fieldName} } }`
-              ).then(({ data, errors }) => {
-                expect(errors, 'no errors querying all').to.equal(undefined);
-                expect(
-                  data[allQueryName],
-                  'data when querying all'
-                ).to.have.length.greaterThan(0);
-              });
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id ${fieldName} } }`).then(
+                ({ data, errors }) => {
+                  expect(errors, 'no errors querying all').to.equal(undefined);
+                  expect(data[allQueryName], 'data when querying all').to.have.length.greaterThan(
+                    0
+                  );
+                }
+              );
             });
 
             it(`singular allowed: ${JSON.stringify(access)}`, () => {
@@ -398,18 +372,13 @@ describe('Access Control, Field, GraphQL', () => {
                 cy
                   .graphql_query(
                     '/admin/api',
-                    `query { ${singleQueryName}(where: { id: "${
-                      item.id
-                    }" }) { id ${fieldName} } }`
+                    `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`
                   )
                   .then(({ data, errors }) => {
-                    expect(errors, 'no errors querying all').to.equal(
-                      undefined
+                    expect(errors, 'no errors querying all').to.equal(undefined);
+                    expect(data[singleQueryName], 'data when querying all').to.have.property(
+                      fieldName
                     );
-                    expect(
-                      data[singleQueryName],
-                      'data when querying all'
-                    ).to.have.property(fieldName);
                   })
               );
             });
@@ -419,28 +388,22 @@ describe('Access Control, Field, GraphQL', () => {
             const fieldName = getFieldName(access);
 
             it(`all denied: ${JSON.stringify(access)}`, () => {
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id ${fieldName} } }`
-              ).then(({ data, errors }) => {
-                // All the items are returned
-                expect(
-                  data[allQueryName],
-                  'denied query all'
-                ).to.have.length.greaterThan(0);
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id ${fieldName} } }`).then(
+                ({ data, errors }) => {
+                  // All the items are returned
+                  expect(data[allQueryName], 'denied query all').to.have.length.greaterThan(0);
 
-                // But there should be an error per item (because we don't
-                // have access to the field)
-                expect(errors, 'denied query all').to.have.length.greaterThan(
-                  0
-                );
+                  // But there should be an error per item (because we don't
+                  // have access to the field)
+                  expect(errors, 'denied query all').to.have.length.greaterThan(0);
 
-                // And the values of the fields we don't have access to are
-                // null
-                data[allQueryName].forEach(item =>
-                  expect(item[fieldName], 'denied query all').to.equal(null)
-                );
-              });
+                  // And the values of the fields we don't have access to are
+                  // null
+                  data[allQueryName].forEach(item =>
+                    expect(item[fieldName], 'denied query all').to.equal(null)
+                  );
+                }
+              );
             });
 
             it(`singular denied: ${JSON.stringify(access)}`, () => {
@@ -451,9 +414,7 @@ describe('Access Control, Field, GraphQL', () => {
                 cy
                   .graphql_query(
                     '/admin/api',
-                    `query { ${singleQueryName}(where: { id: "${
-                      item.id
-                    }" }) { id ${fieldName} } }`
+                    `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`
                   )
                   .then(({ data, errors }) => {
                     expect(data, 'read singular denied').to.have.deep.property(
@@ -461,21 +422,18 @@ describe('Access Control, Field, GraphQL', () => {
                       null
                     );
 
-                    expect(
-                      errors,
-                      'read singular denied'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'read singular denied'
-                    ).to.have.deep.property(
+                    expect(errors, 'read singular denied').to.have.deep.property(
+                      '[0].name',
+                      'AccessDeniedError'
+                    );
+                    expect(errors, 'read singular denied').to.have.deep.property(
                       '[0].message',
                       'You do not have access to this resource'
                     );
-                    expect(
-                      errors,
-                      'read singular denied'
-                    ).to.have.deep.property('[0].path[0]', singleQueryName);
+                    expect(errors, 'read singular denied').to.have.deep.property(
+                      '[0].path[0]',
+                      singleQueryName
+                    );
                   })
               );
             });
@@ -501,9 +459,7 @@ describe('Access Control, Field, GraphQL', () => {
                     }", data: { ${fieldName}: "bar" }) { id } }`
                   )
                   .then(({ data, errors }) => {
-                    expect(errors, 'update mutation Errors').to.equal(
-                      undefined
-                    );
+                    expect(errors, 'update mutation Errors').to.equal(undefined);
                     expect(
                       data[updateMutationName],
                       `updateMutation data.${updateMutationName}`
@@ -534,21 +490,18 @@ describe('Access Control, Field, GraphQL', () => {
                       null
                     );
 
-                    expect(
-                      errors,
-                      'update mutation denied'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'update mutation denied'
-                    ).to.have.deep.property(
+                    expect(errors, 'update mutation denied').to.have.deep.property(
+                      '[0].name',
+                      'AccessDeniedError'
+                    );
+                    expect(errors, 'update mutation denied').to.have.deep.property(
                       '[0].message',
                       'You do not have access to this resource'
                     );
-                    expect(
-                      errors,
-                      'update mutation denied'
-                    ).to.have.deep.property('[0].path[0]', updateMutationName);
+                    expect(errors, 'update mutation denied').to.have.deep.property(
+                      '[0].path[0]',
+                      updateMutationName
+                    );
                   })
               );
             });
@@ -577,30 +530,27 @@ describe('Access Control, Field, GraphQL', () => {
     stayLoggedIn('su');
 
     it('current user query returns user info', () => {
-      cy.graphql_query(
-        '/admin/api',
-        '{ authenticatedUser { id yesRead noRead } }'
-      ).then(({ data, errors }) => {
-        expect(data).to.have.deep.property('authenticatedUser.id');
-        expect(data).to.have.deep.property('authenticatedUser.yesRead', 'yes');
-        expect(data).to.have.deep.property('authenticatedUser.noRead', null);
-        expect(errors).to.have.length(1);
-        expect(errors, 'authenticatedUser read denied').to.have.deep.property(
-          '[0].name',
-          'AccessDeniedError'
-        );
-        expect(errors, 'authenticatedUser read denied').to.have.deep.property(
-          '[0].message',
-          'You do not have access to this resource'
-        );
-        expect(errors, 'authenticatedUser read denied').to.have.deep.property(
-          '[0].path'
-        );
-        expect(errors[0].path, 'authenticatedUser read denied').to.deep.equal([
-          'authenticatedUser',
-          'noRead',
-        ]);
-      });
+      cy.graphql_query('/admin/api', '{ authenticatedUser { id yesRead noRead } }').then(
+        ({ data, errors }) => {
+          expect(data).to.have.deep.property('authenticatedUser.id');
+          expect(data).to.have.deep.property('authenticatedUser.yesRead', 'yes');
+          expect(data).to.have.deep.property('authenticatedUser.noRead', null);
+          expect(errors).to.have.length(1);
+          expect(errors, 'authenticatedUser read denied').to.have.deep.property(
+            '[0].name',
+            'AccessDeniedError'
+          );
+          expect(errors, 'authenticatedUser read denied').to.have.deep.property(
+            '[0].message',
+            'You do not have access to this resource'
+          );
+          expect(errors, 'authenticatedUser read denied').to.have.deep.property('[0].path');
+          expect(errors[0].path, 'authenticatedUser read denied').to.deep.equal([
+            'authenticatedUser',
+            'noRead',
+          ]);
+        }
+      );
     });
   });
 

--- a/projects/access-control/cypress/integration/list/admin-ui.js
+++ b/projects/access-control/cypress/integration/list/admin-ui.js
@@ -24,9 +24,7 @@ describe('Access Control Lists > Admin UI', () => {
       stayLoggedIn('su');
 
       listAccessVariations.filter(({ read }) => !read).forEach(access => {
-        it(`is not visible when not readable: ${JSON.stringify(
-          access
-        )}`, () => {
+        it(`is not visible when not readable: ${JSON.stringify(access)}`, () => {
           const name = getStaticListName(access);
           const slug = `${name.toLowerCase()}s`;
 
@@ -52,10 +50,7 @@ describe('Access Control Lists > Admin UI', () => {
 
           cy.visit(`/admin/${slug}`);
 
-          cy.get('body').should(
-            'not.contain',
-            `The list “${slug}” doesn't exist`
-          );
+          cy.get('body').should('not.contain', `The list “${slug}” doesn't exist`);
           cy.get('body h1').should('contain', prettyName);
         });
       });
@@ -74,10 +69,7 @@ describe('Access Control Lists > Admin UI', () => {
 
           cy.visit(`admin/${slug}`);
 
-          cy.get('body').should(
-            'not.contain',
-            'You do not have access to this resource'
-          );
+          cy.get('body').should('not.contain', 'You do not have access to this resource');
           cy.get('body h1').should('contain', prettyName);
 
           // TODO: Check for list of items too
@@ -98,10 +90,7 @@ describe('Access Control Lists > Admin UI', () => {
           cy.visit(`admin/${slug}`);
 
           // But shows an error on attempt to read
-          cy.get('body').should(
-            'contain',
-            'You do not have access to this resource'
-          );
+          cy.get('body').should('contain', 'You do not have access to this resource');
 
           // TODO: Check no items shown too
         });
@@ -121,10 +110,7 @@ describe('Access Control Lists > Admin UI', () => {
 
           cy.visit(`admin/${slug}`);
 
-          cy.get('body').should(
-            'not.contain',
-            'You do not have access to this resource'
-          );
+          cy.get('body').should('not.contain', 'You do not have access to this resource');
           cy.get('body h1').should('contain', prettyName);
 
           // TODO: Check for list of items too
@@ -145,10 +131,7 @@ describe('Access Control Lists > Admin UI', () => {
           cy.visit(`admin/${slug}`);
 
           // But shows an error on attempt to read
-          cy.get('body').should(
-            'contain',
-            'You do not have access to this resource'
-          );
+          cy.get('body').should('contain', 'You do not have access to this resource');
 
           // TODO: Check no items shown too
         });
@@ -160,9 +143,7 @@ describe('Access Control Lists > Admin UI', () => {
         stayLoggedIn('su');
 
         listAccessVariations.filter(({ read }) => read).forEach(access => {
-          it(`shows items when readable & admin: ${JSON.stringify(
-            access
-          )}`, () => {
+          it(`shows items when readable & admin: ${JSON.stringify(access)}`, () => {
             const name = getDeclarativeListName(access);
             const prettyName = prettyListName(name);
             const slug = listSlug(name);
@@ -171,10 +152,7 @@ describe('Access Control Lists > Admin UI', () => {
 
             cy.visit(`admin/${slug}`);
 
-            cy.get('body').should(
-              'not.contain',
-              'You do not have access to this resource'
-            );
+            cy.get('body').should('not.contain', 'You do not have access to this resource');
             cy.get('body h1').should('contain', prettyName);
 
             // TODO: Check for list of items too
@@ -186,9 +164,7 @@ describe('Access Control Lists > Admin UI', () => {
         stayLoggedIn('reader');
 
         listAccessVariations.filter(({ read }) => read).forEach(access => {
-          it(`does not show items when readable & not admin: ${JSON.stringify(
-            access
-          )}`, () => {
+          it(`does not show items when readable & not admin: ${JSON.stringify(access)}`, () => {
             const name = getDeclarativeListName(access);
             const prettyName = prettyListName(name);
             const slug = listSlug(name);
@@ -199,10 +175,7 @@ describe('Access Control Lists > Admin UI', () => {
             cy.visit(`admin/${slug}`);
 
             // But shows an error on attempt to read
-            cy.get('body').should(
-              'contain',
-              'You do not have access to this resource'
-            );
+            cy.get('body').should('contain', 'You do not have access to this resource');
 
             // TODO: Check no items shown too
           });
@@ -217,77 +190,59 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ create, read }) => create && read)
-        .forEach(access => {
-          it(`shows create option when creatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+        it(`shows create option when creatable (list view): ${JSON.stringify(access)}`, () => {
+          const name = getStaticListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            cy.get('button[appearance="create"]').should('exist');
-          });
-
-          it(`shows create option when creatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) =>
-                cy
-                  .visit(`/admin/${slug}/${data[queryName][0].id}`)
-                  .then(() =>
-                    cy.get('button[appearance="create"]').should('exist')
-                  )
-              );
-          });
+          cy.get('button[appearance="create"]').should('exist');
         });
 
-      listAccessVariations
-        .filter(({ create, read }) => !create && read)
-        .forEach(access => {
-          it(`does not show create option when not creatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const slug = listSlug(name);
+        it(`shows create option when creatable (item view): ${JSON.stringify(access)}`, () => {
+          const name = getStaticListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
-
-            cy.get('button[appearance="create"]').should('not.exist');
-          });
-
-          it(`does not show create option when not creatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) =>
-                cy
-                  .visit(`/admin/${slug}/${data[queryName][0].id}`)
-                  .then(() =>
-                    cy.get('button[appearance="create"]').should('not.exist')
-                  )
-              );
-          });
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) =>
+              cy
+                .visit(`/admin/${slug}/${data[queryName][0].id}`)
+                .then(() => cy.get('button[appearance="create"]').should('exist'))
+            );
         });
+      });
+
+      listAccessVariations.filter(({ create, read }) => !create && read).forEach(access => {
+        it(`does not show create option when not creatable (list view): ${JSON.stringify(
+          access
+        )}`, () => {
+          const name = getStaticListName(access);
+          const slug = listSlug(name);
+
+          cy.visit(`admin/${slug}`);
+
+          cy.get('button[appearance="create"]').should('not.exist');
+        });
+
+        it(`does not show create option when not creatable (item view): ${JSON.stringify(
+          access
+        )}`, () => {
+          const name = getStaticListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
+
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) =>
+              cy
+                .visit(`/admin/${slug}/${data[queryName][0].id}`)
+                .then(() => cy.get('button[appearance="create"]').should('not.exist'))
+            );
+        });
+      });
     });
 
     describe('imperative', () => {
@@ -295,45 +250,34 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ create, read }) => create && read)
-        .forEach(access => {
-          it(`shows create option when creatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getImperativeListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+        it(`shows create option when creatable (list view): ${JSON.stringify(access)}`, () => {
+          const name = getImperativeListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            // Always shows create button, regardless of dynamic permission result.
-            // ie; The UI has no way of executing the graphql-side permission
-            // query, so must always show the option until the user submits a
-            // graphql request.
-            cy.get('button[appearance="create"]').should('exist');
-          });
-
-          it(`shows create option when creatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getImperativeListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) =>
-                cy
-                  .visit(`/admin/${slug}/${data[queryName][0].id}`)
-                  .then(() =>
-                    cy.get('button[appearance="create"]').should('exist')
-                  )
-              );
-          });
+          // Always shows create button, regardless of dynamic permission result.
+          // ie; The UI has no way of executing the graphql-side permission
+          // query, so must always show the option until the user submits a
+          // graphql request.
+          cy.get('button[appearance="create"]').should('exist');
         });
+
+        it(`shows create option when creatable (item view): ${JSON.stringify(access)}`, () => {
+          const name = getImperativeListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
+
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) =>
+              cy
+                .visit(`/admin/${slug}/${data[queryName][0].id}`)
+                .then(() => cy.get('button[appearance="create"]').should('exist'))
+            );
+        });
+      });
     });
 
     describe('declarative', () => {
@@ -341,45 +285,34 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ create, read }) => create && read)
-        .forEach(access => {
-          it(`shows create option when creatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getDeclarativeListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+        it(`shows create option when creatable (list view): ${JSON.stringify(access)}`, () => {
+          const name = getDeclarativeListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            // Always shows create button, regardless of dynamic permission result.
-            // ie; The UI has no way of executing the graphql-side permission
-            // query, so must always show the option until the user submits a
-            // graphql request.
-            cy.get('button[appearance="create"]').should('exist');
-          });
-
-          it(`shows create option when creatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getDeclarativeListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) =>
-                cy
-                  .visit(`/admin/${slug}/${data[queryName][0].id}`)
-                  .then(() =>
-                    cy.get('button[appearance="create"]').should('exist')
-                  )
-              );
-          });
+          // Always shows create button, regardless of dynamic permission result.
+          // ie; The UI has no way of executing the graphql-side permission
+          // query, so must always show the option until the user submits a
+          // graphql request.
+          cy.get('button[appearance="create"]').should('exist');
         });
+
+        it(`shows create option when creatable (item view): ${JSON.stringify(access)}`, () => {
+          const name = getDeclarativeListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
+
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) =>
+              cy
+                .visit(`/admin/${slug}/${data[queryName][0].id}`)
+                .then(() => cy.get('button[appearance="create"]').should('exist'))
+            );
+        });
+      });
     });
   });
 
@@ -397,73 +330,59 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ update, read }) => update && read)
-        .forEach(access => {
-          it(`shows update option when updatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ update, read }) => update && read).forEach(access => {
+        it(`shows update option when updatable (list view): ${JSON.stringify(access)}`, () => {
+          const name = getStaticListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            cy.get('button[data-test-name="manage"]').click();
-            cy.get('button[data-test-name="update"]').should('exist');
-          });
-
-          it(`shows update option when updatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) => {
-                cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
-                // TODO: Check for "Save Changes" & "Reset Changes" buttons
-              });
-          });
+          cy.get('button[data-test-name="manage"]').click();
+          cy.get('button[data-test-name="update"]').should('exist');
         });
 
-      listAccessVariations
-        .filter(({ update, read }) => !update && read)
-        .forEach(access => {
-          it(`does not show update option when not updatable (list view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const slug = listSlug(name);
+        it(`shows update option when updatable (item view): ${JSON.stringify(access)}`, () => {
+          const name = getStaticListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
-
-            cy.get('button[data-test-name="manage"]').click();
-            cy.get('button[data-test-name="update"]').should('not.exist');
-          });
-
-          it(`does not show input fields when not updatable (item view): ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getStaticListName(access);
-            const queryName = `all${name}s`;
-            const slug = listSlug(name);
-
-            return cy
-              .graphql_query(
-                '/admin/api',
-                `query { ${queryName}(first: 1) { id } }`
-              )
-              .then(({ data }) => {
-                cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
-                // TODO: Check for "Save Changes" & "Reset Changes" buttons
-              });
-          });
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) => {
+              cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
+              // TODO: Check for "Save Changes" & "Reset Changes" buttons
+            });
         });
+      });
+
+      listAccessVariations.filter(({ update, read }) => !update && read).forEach(access => {
+        it(`does not show update option when not updatable (list view): ${JSON.stringify(
+          access
+        )}`, () => {
+          const name = getStaticListName(access);
+          const slug = listSlug(name);
+
+          cy.visit(`admin/${slug}`);
+
+          cy.get('button[data-test-name="manage"]').click();
+          cy.get('button[data-test-name="update"]').should('not.exist');
+        });
+
+        it(`does not show input fields when not updatable (item view): ${JSON.stringify(
+          access
+        )}`, () => {
+          const name = getStaticListName(access);
+          const queryName = `all${name}s`;
+          const slug = listSlug(name);
+
+          return cy
+            .graphql_query('/admin/api', `query { ${queryName}(first: 1) { id } }`)
+            .then(({ data }) => {
+              cy.visit(`/admin/${slug}/${data[queryName][0].id}`);
+              // TODO: Check for "Save Changes" & "Reset Changes" buttons
+            });
+        });
+      });
     });
 
     describe('imperative', () => {
@@ -471,24 +390,20 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ create, read }) => create && read)
-        .forEach(access => {
-          it(`shows create option when creatable: ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getImperativeListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+        it(`shows create option when creatable: ${JSON.stringify(access)}`, () => {
+          const name = getImperativeListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            // Always shows create button, regardless of dynamic permission result.
-            // ie; The UI has no way of executing the graphql-side permission
-            // query, so must always show the option until the user submits a
-            // graphql request.
-            cy.get('button[appearance="create"]').should('exist');
-          });
+          // Always shows create button, regardless of dynamic permission result.
+          // ie; The UI has no way of executing the graphql-side permission
+          // query, so must always show the option until the user submits a
+          // graphql request.
+          cy.get('button[appearance="create"]').should('exist');
         });
+      });
     });
 
     describe('declarative', () => {
@@ -496,24 +411,20 @@ describe('Access Control Lists > Admin UI', () => {
 
       // NOTE: We only check lists that are readable as we've checked that
       // non-readable lists show access denied above
-      listAccessVariations
-        .filter(({ create, read }) => create && read)
-        .forEach(access => {
-          it(`shows create option when creatable: ${JSON.stringify(
-            access
-          )}`, () => {
-            const name = getDeclarativeListName(access);
-            const slug = listSlug(name);
+      listAccessVariations.filter(({ create, read }) => create && read).forEach(access => {
+        it(`shows create option when creatable: ${JSON.stringify(access)}`, () => {
+          const name = getDeclarativeListName(access);
+          const slug = listSlug(name);
 
-            cy.visit(`admin/${slug}`);
+          cy.visit(`admin/${slug}`);
 
-            // Always shows create button, regardless of dynamic permission result.
-            // ie; The UI has no way of executing the graphql-side permission
-            // query, so must always show the option until the user submits a
-            // graphql request.
-            cy.get('button[appearance="create"]').should('exist');
-          });
+          // Always shows create button, regardless of dynamic permission result.
+          // ie; The UI has no way of executing the graphql-side permission
+          // query, so must always show the option until the user submits a
+          // graphql request.
+          cy.get('button[appearance="create"]').should('exist');
         });
+      });
     });
   });
 

--- a/projects/access-control/cypress/integration/list/graphql.js
+++ b/projects/access-control/cypress/integration/list/graphql.js
@@ -177,80 +177,68 @@ describe('Access Control, List, GraphQL', () => {
         });
 
         describe('create', () => {
-          listAccessVariations
-            .filter(({ create }) => !create)
-            .forEach(access => {
-              it(`denied: ${JSON.stringify(access)}`, () => {
-                const createMutationName = `create${getImperativeListName(
-                  access
-                )}`;
+          listAccessVariations.filter(({ create }) => !create).forEach(access => {
+            it(`denied: ${JSON.stringify(access)}`, () => {
+              const createMutationName = `create${getImperativeListName(access)}`;
 
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', createMutationName);
-                });
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  createMutationName
+                );
               });
             });
+          });
         });
 
         describe('query', () => {
           listAccessVariations.filter(({ read }) => !read).forEach(access => {
             it(`'all' denied: ${JSON.stringify(access)}`, () => {
               const allQueryName = `all${getImperativeListName(access)}s`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id } }`
-              ).then(({ errors }) => {
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].name',
-                  'AccessDeniedError'
-                );
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].message',
-                  'You do not have access to this resource'
-                );
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].path[0]',
-                  allQueryName
-                );
-              });
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                ({ errors }) => {
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    allQueryName
+                  );
+                }
+              );
             });
 
             it(`meta denied: ${JSON.stringify(access)}`, () => {
               const metaName = `_all${getImperativeListName(access)}sMeta`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${metaName} { count } }`
-              ).then(({ errors }) => {
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].name',
-                  'AccessDeniedError'
-                );
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].message',
-                  'You do not have access to this resource'
-                );
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].path[0]',
-                  metaName
-                );
-              });
+              cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(
+                ({ errors }) => {
+                  expect(errors, 'meta Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'meta Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'meta Errors').to.have.deep.property('[0].path[0]', metaName);
+                }
+              );
             });
 
             it(`single denied: ${JSON.stringify(access)}`, () => {
@@ -277,96 +265,74 @@ describe('Access Control, List, GraphQL', () => {
         });
 
         describe('update', () => {
-          listAccessVariations
-            .filter(({ update }) => !update)
-            .forEach(access => {
-              it(`denies: ${JSON.stringify(access)}`, () => {
-                const updateMutationName = `update${getImperativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', updateMutationName);
-                });
+          listAccessVariations.filter(({ update }) => !update).forEach(access => {
+            it(`denies: ${JSON.stringify(access)}`, () => {
+              const updateMutationName = `update${getImperativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  updateMutationName
+                );
               });
             });
+          });
         });
 
         describe('delete', () => {
-          listAccessVariations
-            .filter(access => !access.delete)
-            .forEach(access => {
-              it(`single denied: ${JSON.stringify(access)}`, () => {
-                const deleteMutationName = `delete${getImperativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', deleteMutationName);
-                });
-              });
-
-              it(`multi denied: ${JSON.stringify(access)}`, () => {
-                const multiDeleteMutationName = `delete${getImperativeListName(
-                  access
-                )}s`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].path[0]',
-                    multiDeleteMutationName
-                  );
-                });
+          listAccessVariations.filter(access => !access.delete).forEach(access => {
+            it(`single denied: ${JSON.stringify(access)}`, () => {
+              const deleteMutationName = `delete${getImperativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  deleteMutationName
+                );
               });
             });
+
+            it(`multi denied: ${JSON.stringify(access)}`, () => {
+              const multiDeleteMutationName = `delete${getImperativeListName(access)}s`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  multiDeleteMutationName
+                );
+              });
+            });
+          });
         });
       });
 
@@ -374,56 +340,46 @@ describe('Access Control, List, GraphQL', () => {
         stayLoggedIn('su');
 
         describe('create', () => {
-          listAccessVariations
-            .filter(({ create }) => create)
-            .forEach(access => {
-              it(`allowed: ${JSON.stringify(access)}`, () => {
-                const createMutationName = `create${getImperativeListName(
-                  access
-                )}`;
+          listAccessVariations.filter(({ create }) => create).forEach(access => {
+            it(`allowed: ${JSON.stringify(access)}`, () => {
+              const createMutationName = `create${getImperativeListName(access)}`;
 
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                ).then(({ data, errors }) => {
-                  expect(errors, 'create mutation Errors').to.equal(undefined);
-                  expect(
-                    data[createMutationName],
-                    `createMutation data.${createMutationName}`
-                  ).to.have.property('id');
-                });
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+              ).then(({ data, errors }) => {
+                expect(errors, 'create mutation Errors').to.equal(undefined);
+                expect(
+                  data[createMutationName],
+                  `createMutation data.${createMutationName}`
+                ).to.have.property('id');
               });
             });
+          });
         });
 
         describe('query', () => {
           listAccessVariations.filter(({ read }) => read).forEach(access => {
             it(`'all' allowed: ${JSON.stringify(access)}`, () => {
               const allQueryName = `all${getImperativeListName(access)}s`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id } }`
-              ).then(({ data, errors }) => {
-                expect(errors, 'allQuery Errors').to.equal(undefined);
-                expect(
-                  data[allQueryName],
-                  `allQuery data.${allQueryName}`
-                ).to.have.property('length');
-              });
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                ({ data, errors }) => {
+                  expect(errors, 'allQuery Errors').to.equal(undefined);
+                  expect(data[allQueryName], `allQuery data.${allQueryName}`).to.have.property(
+                    'length'
+                  );
+                }
+              );
             });
 
             it(`meta allowed: ${JSON.stringify(access)}`, () => {
               const metaName = `_all${getImperativeListName(access)}sMeta`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${metaName} { count } }`
-              ).then(({ data, errors }) => {
-                expect(errors, 'meta Errors').to.equal(undefined);
-                expect(
-                  data[metaName].count,
-                  `meta data.${metaName}.count`
-                ).to.be.gte(0);
-              });
+              cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(
+                ({ data, errors }) => {
+                  expect(errors, 'meta Errors').to.equal(undefined);
+                  expect(data[metaName].count, `meta data.${metaName}.count`).to.be.gte(0);
+                }
+              );
             });
 
             it(`single allowed: ${JSON.stringify(access)}`, () => {
@@ -433,160 +389,125 @@ describe('Access Control, List, GraphQL', () => {
                 `query { ${singleQueryName}(where: { id: "${FAKE_ID}" }) { id } }`
               ).then(({ data, errors }) => {
                 expect(errors, 'single query Errors').to.equal(undefined);
-                expect(
-                  data[singleQueryName],
-                  `meta data.${singleQueryName}`
-                ).to.equal(null);
+                expect(data[singleQueryName], `meta data.${singleQueryName}`).to.equal(null);
               });
             });
           });
         });
 
         describe('update', () => {
-          listAccessVariations
-            .filter(({ update }) => update)
-            .forEach(access => {
-              it(`allowed: ${JSON.stringify(access)}`, () => {
-                const updateMutationName = `update${getImperativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
-                ).then(({ errors }) => {
-                  // It errors because it's a fake ID.
-                  // That's ok, as long as it's not an AccessDeniedError.
-                  // We test that updates actually work elsewhere.
-                  expect(
-                    errors[0],
-                    'update mutation Errors'
-                  ).to.not.have.ownProperty('name');
-                  expect(
-                    errors[0],
-                    'update mutation Errors'
-                  ).to.not.have.property(
-                    'message',
-                    'You do not have access to this resource'
-                  );
-                });
+          listAccessVariations.filter(({ update }) => update).forEach(access => {
+            it(`allowed: ${JSON.stringify(access)}`, () => {
+              const updateMutationName = `update${getImperativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
+              ).then(({ errors }) => {
+                // It errors because it's a fake ID.
+                // That's ok, as long as it's not an AccessDeniedError.
+                // We test that updates actually work elsewhere.
+                expect(errors[0], 'update mutation Errors').to.not.have.ownProperty('name');
+                expect(errors[0], 'update mutation Errors').to.not.have.property(
+                  'message',
+                  'You do not have access to this resource'
+                );
               });
             });
+          });
         });
 
         describe('delete', () => {
-          listAccessVariations
-            .filter(access => access.delete)
-            .forEach(access => {
-              it(`single allowed: ${JSON.stringify(access)}`, () => {
-                const deleteMutationName = `delete${getImperativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                ).then(({ data, errors }) => {
-                  expect(errors, 'delete mutation Errors').to.equal(undefined);
-                  expect(data, 'deleteMutation data').to.have.ownProperty(
-                    deleteMutationName
-                  );
-                });
-              });
-
-              it(`multi allowed: ${JSON.stringify(access)}`, () => {
-                const multiDeleteMutationName = `delete${getImperativeListName(
-                  access
-                )}s`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
-                ).then(({ data, errors }) => {
-                  expect(errors, 'delete mutation Errors').to.equal(undefined);
-                  expect(data, 'deleteMutation data').to.have.ownProperty(
-                    multiDeleteMutationName
-                  );
-                });
+          listAccessVariations.filter(access => access.delete).forEach(access => {
+            it(`single allowed: ${JSON.stringify(access)}`, () => {
+              const deleteMutationName = `delete${getImperativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+              ).then(({ data, errors }) => {
+                expect(errors, 'delete mutation Errors').to.equal(undefined);
+                expect(data, 'deleteMutation data').to.have.ownProperty(deleteMutationName);
               });
             });
+
+            it(`multi allowed: ${JSON.stringify(access)}`, () => {
+              const multiDeleteMutationName = `delete${getImperativeListName(access)}s`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
+              ).then(({ data, errors }) => {
+                expect(errors, 'delete mutation Errors').to.equal(undefined);
+                expect(data, 'deleteMutation data').to.have.ownProperty(multiDeleteMutationName);
+              });
+            });
+          });
         });
 
         describe('disallowed', () => {
           before(() => cy.visit('/admin'));
 
           describe('create', () => {
-            listAccessVariations
-              .filter(({ create }) => !create)
-              .forEach(access => {
-                it(`denied: ${JSON.stringify(access)}`, () => {
-                  const createMutationName = `create${getImperativeListName(
-                    access
-                  )}`;
+            listAccessVariations.filter(({ create }) => !create).forEach(access => {
+              it(`denied: ${JSON.stringify(access)}`, () => {
+                const createMutationName = `create${getImperativeListName(access)}`;
 
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', createMutationName);
-                  });
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    createMutationName
+                  );
                 });
               });
+            });
           });
 
           describe('query', () => {
             listAccessVariations.filter(({ read }) => !read).forEach(access => {
               it(`'all' denied: ${JSON.stringify(access)}`, () => {
                 const allQueryName = `all${getImperativeListName(access)}s`;
-                cy.graphql_query(
-                  '/admin/api',
-                  `query { ${allQueryName} { id } }`
-                ).then(({ errors }) => {
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].name',
-                    'AccessDeniedError'
-                  );
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].path[0]',
-                    allQueryName
-                  );
-                });
+                cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                  ({ errors }) => {
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].name',
+                      'AccessDeniedError'
+                    );
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].message',
+                      'You do not have access to this resource'
+                    );
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].path[0]',
+                      allQueryName
+                    );
+                  }
+                );
               });
 
               it(`meta denied: ${JSON.stringify(access)}`, () => {
                 const metaName = `_all${getImperativeListName(access)}sMeta`;
-                cy.graphql_query(
-                  '/admin/api',
-                  `query { ${metaName} { count } }`
-                ).then(({ errors }) => {
-                  expect(errors, 'meta Errors').to.have.deep.property(
-                    '[0].name',
-                    'AccessDeniedError'
-                  );
-                  expect(errors, 'meta Errors').to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(errors, 'meta Errors').to.have.deep.property(
-                    '[0].path[0]',
-                    metaName
-                  );
-                });
+                cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(
+                  ({ errors }) => {
+                    expect(errors, 'meta Errors').to.have.deep.property(
+                      '[0].name',
+                      'AccessDeniedError'
+                    );
+                    expect(errors, 'meta Errors').to.have.deep.property(
+                      '[0].message',
+                      'You do not have access to this resource'
+                    );
+                    expect(errors, 'meta Errors').to.have.deep.property('[0].path[0]', metaName);
+                  }
+                );
               });
 
               it(`single denied: ${JSON.stringify(access)}`, () => {
@@ -613,96 +534,74 @@ describe('Access Control, List, GraphQL', () => {
           });
 
           describe('update', () => {
-            listAccessVariations
-              .filter(({ update }) => !update)
-              .forEach(access => {
-                it(`denies: ${JSON.stringify(access)}`, () => {
-                  const updateMutationName = `update${getImperativeListName(
-                    access
-                  )}`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', updateMutationName);
-                  });
+            listAccessVariations.filter(({ update }) => !update).forEach(access => {
+              it(`denies: ${JSON.stringify(access)}`, () => {
+                const updateMutationName = `update${getImperativeListName(access)}`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    updateMutationName
+                  );
                 });
               });
+            });
           });
 
           describe('delete', () => {
-            listAccessVariations
-              .filter(access => !access.delete)
-              .forEach(access => {
-                it(`single denied: ${JSON.stringify(access)}`, () => {
-                  const deleteMutationName = `delete${getImperativeListName(
-                    access
-                  )}`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', deleteMutationName);
-                  });
-                });
-
-                it(`multi denied: ${JSON.stringify(access)}`, () => {
-                  const multiDeleteMutationName = `delete${getImperativeListName(
-                    access
-                  )}s`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].path[0]',
-                      multiDeleteMutationName
-                    );
-                  });
+            listAccessVariations.filter(access => !access.delete).forEach(access => {
+              it(`single denied: ${JSON.stringify(access)}`, () => {
+                const deleteMutationName = `delete${getImperativeListName(access)}`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    deleteMutationName
+                  );
                 });
               });
+
+              it(`multi denied: ${JSON.stringify(access)}`, () => {
+                const multiDeleteMutationName = `delete${getImperativeListName(access)}s`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    multiDeleteMutationName
+                  );
+                });
+              });
+            });
           });
         });
       });
@@ -713,80 +612,68 @@ describe('Access Control, List, GraphQL', () => {
         before(() => cy.visit('/admin'));
 
         describe('create', () => {
-          listAccessVariations
-            .filter(({ create }) => create)
-            .forEach(access => {
-              it(`denied: ${JSON.stringify(access)}`, () => {
-                const createMutationName = `create${getDeclarativeListName(
-                  access
-                )}`;
+          listAccessVariations.filter(({ create }) => create).forEach(access => {
+            it(`denied: ${JSON.stringify(access)}`, () => {
+              const createMutationName = `create${getDeclarativeListName(access)}`;
 
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'create mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', createMutationName);
-                });
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'create mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  createMutationName
+                );
               });
             });
+          });
         });
 
         describe('query', () => {
           listAccessVariations.filter(({ read }) => read).forEach(access => {
             it(`'all' denied: ${JSON.stringify(access)}`, () => {
               const allQueryName = `all${getDeclarativeListName(access)}s`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id } }`
-              ).then(({ errors }) => {
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].name',
-                  'AccessDeniedError'
-                );
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].message',
-                  'You do not have access to this resource'
-                );
-                expect(errors, 'allQuery Errors').to.have.deep.property(
-                  '[0].path[0]',
-                  allQueryName
-                );
-              });
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                ({ errors }) => {
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'allQuery Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    allQueryName
+                  );
+                }
+              );
             });
 
             it(`meta denied: ${JSON.stringify(access)}`, () => {
               const metaName = `_all${getDeclarativeListName(access)}sMeta`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${metaName} { count } }`
-              ).then(({ errors }) => {
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].name',
-                  'AccessDeniedError'
-                );
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].message',
-                  'You do not have access to this resource'
-                );
-                expect(errors, 'meta Errors').to.have.deep.property(
-                  '[0].path[0]',
-                  metaName
-                );
-              });
+              cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(
+                ({ errors }) => {
+                  expect(errors, 'meta Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'meta Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'meta Errors').to.have.deep.property('[0].path[0]', metaName);
+                }
+              );
             });
 
             it(`single denied: ${JSON.stringify(access)}`, () => {
@@ -813,96 +700,74 @@ describe('Access Control, List, GraphQL', () => {
         });
 
         describe('update', () => {
-          listAccessVariations
-            .filter(({ update }) => update)
-            .forEach(access => {
-              it(`denied: ${JSON.stringify(access)}`, () => {
-                const updateMutationName = `update${getDeclarativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'update mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', updateMutationName);
-                });
+          listAccessVariations.filter(({ update }) => update).forEach(access => {
+            it(`denied: ${JSON.stringify(access)}`, () => {
+              const updateMutationName = `update${getDeclarativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'update mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  updateMutationName
+                );
               });
             });
+          });
         });
 
         describe('delete', () => {
-          listAccessVariations
-            .filter(access => access.delete)
-            .forEach(access => {
-              it(`single denied: ${JSON.stringify(access)}`, () => {
-                const deleteMutationName = `delete${getDeclarativeListName(
-                  access
-                )}`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].path[0]', deleteMutationName);
-                });
-              });
-
-              it(`multiple denied: ${JSON.stringify(access)}`, () => {
-                const multiDeleteMutationName = `delete${getDeclarativeListName(
-                  access
-                )}s`;
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
-                ).then(({ errors }) => {
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(
-                    errors,
-                    'delete mutation Errors'
-                  ).to.have.deep.property(
-                    '[0].path[0]',
-                    multiDeleteMutationName
-                  );
-                });
+          listAccessVariations.filter(access => access.delete).forEach(access => {
+            it(`single denied: ${JSON.stringify(access)}`, () => {
+              const deleteMutationName = `delete${getDeclarativeListName(access)}`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  deleteMutationName
+                );
               });
             });
+
+            it(`multiple denied: ${JSON.stringify(access)}`, () => {
+              const multiDeleteMutationName = `delete${getDeclarativeListName(access)}s`;
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
+              ).then(({ errors }) => {
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].name',
+                  'AccessDeniedError'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'delete mutation Errors').to.have.deep.property(
+                  '[0].path[0]',
+                  multiDeleteMutationName
+                );
+              });
+            });
+          });
         });
       });
 
@@ -910,56 +775,46 @@ describe('Access Control, List, GraphQL', () => {
         stayLoggedIn('su');
 
         describe('create', () => {
-          listAccessVariations
-            .filter(({ create }) => create)
-            .forEach(access => {
-              it(`allowed: ${JSON.stringify(access)}`, () => {
-                const createMutationName = `create${getDeclarativeListName(
-                  access
-                )}`;
+          listAccessVariations.filter(({ create }) => create).forEach(access => {
+            it(`allowed: ${JSON.stringify(access)}`, () => {
+              const createMutationName = `create${getDeclarativeListName(access)}`;
 
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                ).then(({ data, errors }) => {
-                  expect(errors, 'create mutation Errors').to.equal(undefined);
-                  expect(
-                    data[createMutationName],
-                    `createMutation data.${createMutationName}`
-                  ).to.have.property('id');
-                });
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+              ).then(({ data, errors }) => {
+                expect(errors, 'create mutation Errors').to.equal(undefined);
+                expect(
+                  data[createMutationName],
+                  `createMutation data.${createMutationName}`
+                ).to.have.property('id');
               });
             });
+          });
         });
 
         describe('query', () => {
           listAccessVariations.filter(({ read }) => read).forEach(access => {
             it(`'all' allowed: ${JSON.stringify(access)}`, () => {
               const allQueryName = `all${getDeclarativeListName(access)}s`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${allQueryName} { id } }`
-              ).then(({ data, errors }) => {
-                expect(errors, 'allQuery Errors').to.equal(undefined);
-                expect(
-                  data[allQueryName],
-                  `allQuery data.${allQueryName}`
-                ).to.have.property('length');
-              });
+              cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                ({ data, errors }) => {
+                  expect(errors, 'allQuery Errors').to.equal(undefined);
+                  expect(data[allQueryName], `allQuery data.${allQueryName}`).to.have.property(
+                    'length'
+                  );
+                }
+              );
             });
 
             it(`meta allowed: ${JSON.stringify(access)}`, () => {
               const metaName = `_all${getDeclarativeListName(access)}sMeta`;
-              cy.graphql_query(
-                '/admin/api',
-                `query { ${metaName} { count } }`
-              ).then(({ data, errors }) => {
-                expect(errors, 'meta Errors').to.equal(undefined);
-                expect(
-                  data[metaName].count,
-                  `meta data.${metaName}.count`
-                ).to.be.gte(0);
-              });
+              cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(
+                ({ data, errors }) => {
+                  expect(errors, 'meta Errors').to.equal(undefined);
+                  expect(data[metaName].count, `meta data.${metaName}.count`).to.be.gte(0);
+                }
+              );
             });
 
             it(`single allowed: ${JSON.stringify(access)}`, () => {
@@ -972,9 +827,7 @@ describe('Access Control, List, GraphQL', () => {
                 return cy
                   .graphql_query(
                     '/admin/api',
-                    `query { ${singleQueryName}(where: { id: "${
-                      item.id
-                    }" }) { id } }`
+                    `query { ${singleQueryName}(where: { id: "${item.id}" }) { id } }`
                   )
                   .then(({ data, errors }) => {
                     expect(errors, 'single query Errors').to.equal(undefined);
@@ -986,304 +839,239 @@ describe('Access Control, List, GraphQL', () => {
               });
             });
 
-            it(`single denied when filtered out: ${JSON.stringify(
-              access
-            )}`, () => {
+            it(`single denied when filtered out: ${JSON.stringify(access)}`, () => {
               const singleQueryName = getDeclarativeListName(access);
               cy.graphql_query(
                 '/admin/api',
                 `query { ${singleQueryName}(where: { id: "${FAKE_ID}" }) { id } }`
               ).then(({ data, errors }) => {
                 expect(data, 'data').to.have.property(singleQueryName, null);
-                expect(errors, 'error name').to.have.deep.property(
-                  '[0].name',
-                  'AccessDeniedError'
-                );
+                expect(errors, 'error name').to.have.deep.property('[0].name', 'AccessDeniedError');
                 expect(errors, 'error message').to.have.deep.property(
                   '[0].message',
                   'You do not have access to this resource'
                 );
-                expect(errors, 'error path').to.have.deep.property(
-                  '[0].path[0]',
-                  singleQueryName
-                );
+                expect(errors, 'error path').to.have.deep.property('[0].path[0]', singleQueryName);
               });
             });
 
-            it(`all returns empty array when filtered out: ${JSON.stringify(
-              access
-            )}`, () => {
+            it(`all returns empty array when filtered out: ${JSON.stringify(access)}`, () => {
               const allQueryName = `all${getDeclarativeListName(access)}s`;
               cy.graphql_query(
                 '/admin/api',
                 `query { ${allQueryName}(where: { id_in: ["${FAKE_ID}", "${FAKE_ID_2}"] }) { id } }`
               ).then(({ data, errors }) => {
                 expect(errors, 'multi query denied Errors').to.equal(undefined);
-                expect(data, 'multi query denied data').to.have.property(
-                  allQueryName
-                );
-                expect(
-                  data[allQueryName],
-                  'multi query denied data'
-                ).to.deep.equal([]);
+                expect(data, 'multi query denied data').to.have.property(allQueryName);
+                expect(data[allQueryName], 'multi query denied data').to.deep.equal([]);
               });
             });
           });
         });
 
         describe('update', () => {
-          listAccessVariations
-            .filter(({ update }) => update)
-            .forEach(access => {
-              it(`allowed: ${JSON.stringify(access)}`, () => {
-                const list = getDeclarativeListName(access);
-                const collection = listNameToCollectionName(list);
+          listAccessVariations.filter(({ update }) => update).forEach(access => {
+            it(`allowed: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const collection = listNameToCollectionName(list);
 
-                cy.task('mongoFind', { collection, query: {} }).then(items => {
-                  // filter items for foo: 'Hello', then pick THAT id.
-                  const item = items.find(({ foo }) => foo === 'Hello');
-                  const updateMutationName = `update${list}`;
-
-                  return cy
-                    .graphql_mutate(
-                      '/admin/api',
-                      `mutation { ${updateMutationName}(id: "${
-                        item.id
-                      }", data: { zip: "bar" }) { id } }`
-                    )
-                    .then(({ data, errors }) => {
-                      expect(errors, 'update mutation Errors').to.equal(
-                        undefined
-                      );
-                      expect(
-                        data,
-                        'update mutation data'
-                      ).to.have.deep.property(
-                        `${updateMutationName}.id`,
-                        item.id
-                      );
-                      //expect(data, 'update mutation data').to.have.deep.property(
-                      //  `${updateMutationName}.zip`,
-                      //  'bar',
-                      //);
-                    });
-                });
-              });
-
-              it(`denied when filtered out: ${JSON.stringify(access)}`, () => {
-                const list = getDeclarativeListName(access);
+              cy.task('mongoFind', { collection, query: {} }).then(items => {
+                // filter items for foo: 'Hello', then pick THAT id.
+                const item = items.find(({ foo }) => foo === 'Hello');
                 const updateMutationName = `update${list}`;
 
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { zip: "bar" }) { id } }`
-                ).then(({ data, errors }) => {
-                  expect(data, 'data').to.have.property(
-                    updateMutationName,
-                    null
-                  );
-                  expect(errors, 'error name').to.have.deep.property(
-                    '[0].name',
-                    'AccessDeniedError'
-                  );
-                  expect(errors, 'error message').to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(errors, 'error path').to.have.deep.property(
-                    '[0].path[0]',
-                    updateMutationName
-                  );
-                });
+                return cy
+                  .graphql_mutate(
+                    '/admin/api',
+                    `mutation { ${updateMutationName}(id: "${
+                      item.id
+                    }", data: { zip: "bar" }) { id } }`
+                  )
+                  .then(({ data, errors }) => {
+                    expect(errors, 'update mutation Errors').to.equal(undefined);
+                    expect(data, 'update mutation data').to.have.deep.property(
+                      `${updateMutationName}.id`,
+                      item.id
+                    );
+                    //expect(data, 'update mutation data').to.have.deep.property(
+                    //  `${updateMutationName}.zip`,
+                    //  'bar',
+                    //);
+                  });
               });
             });
+
+            it(`denied when filtered out: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const updateMutationName = `update${list}`;
+
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { zip: "bar" }) { id } }`
+              ).then(({ data, errors }) => {
+                expect(data, 'data').to.have.property(updateMutationName, null);
+                expect(errors, 'error name').to.have.deep.property('[0].name', 'AccessDeniedError');
+                expect(errors, 'error message').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'error path').to.have.deep.property(
+                  '[0].path[0]',
+                  updateMutationName
+                );
+              });
+            });
+          });
         });
 
         describe('delete', () => {
-          listAccessVariations
-            .filter(access => access.delete)
-            .forEach(access => {
-              it(`single allowed: ${JSON.stringify(access)}`, () => {
-                const list = getDeclarativeListName(access);
-                const collection = listNameToCollectionName(list);
-                // First, insert an item that can be deleted
-                cy.task('mongoInsertOne', {
-                  collection,
-                  document: { foo: 'Hello', zip: 'zap' },
-                }).then(({ id }) => {
-                  const deleteMutationName = `delete${list}`;
-                  return cy
-                    .graphql_mutate(
-                      '/admin/api',
-                      `mutation { ${deleteMutationName}(id: "${id}") { id } }`
-                    )
-                    .then(({ data, errors }) => {
-                      expect(errors, 'delete mutation Errors').to.equal(
-                        undefined
-                      );
-                      expect(data, 'deleteMutation data').to.have.ownProperty(
-                        deleteMutationName
-                      );
-                      expect(data, 'deleteMutation id').to.have.deep.property(
-                        `${deleteMutationName}.id`,
-                        id
-                      );
-                    });
-                });
-              });
-
-              it(`single denied when filtered out: ${JSON.stringify(
-                access
-              )}`, () => {
-                const list = getDeclarativeListName(access);
+          listAccessVariations.filter(access => access.delete).forEach(access => {
+            it(`single allowed: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const collection = listNameToCollectionName(list);
+              // First, insert an item that can be deleted
+              cy.task('mongoInsertOne', {
+                collection,
+                document: { foo: 'Hello', zip: 'zap' },
+              }).then(({ id }) => {
                 const deleteMutationName = `delete${list}`;
-
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                ).then(({ data, errors }) => {
-                  expect(data, 'data').to.have.property(
-                    deleteMutationName,
-                    null
-                  );
-                  expect(errors, 'error name').to.have.deep.property(
-                    '[0].name',
-                    'AccessDeniedError'
-                  );
-                  expect(errors, 'error message').to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(errors, 'error path').to.have.deep.property(
-                    '[0].path[0]',
-                    deleteMutationName
-                  );
-                });
-              });
-
-              it(`multi allowed: ${JSON.stringify(access)}`, () => {
-                const list = getDeclarativeListName(access);
-                const collection = listNameToCollectionName(list);
-                // First, insert an item that can be deleted
-                cy.task('mongoInsertOne', {
-                  collection,
-                  document: { foo: 'Hello', zip: 'zap' },
-                }).then(({ id: id1 }) => {
-                  return cy
-                    .task('mongoInsertOne', {
-                      collection,
-                      document: { foo: 'Hello', zip: 'zing' },
-                    })
-                    .then(({ id: id2 }) => {
-                      const multiDeleteMutationName = `delete${list}s`;
-                      return cy
-                        .graphql_mutate(
-                          '/admin/api',
-                          `mutation { ${multiDeleteMutationName}(ids: ["${id1}", "${id2}"]) { id } }`
-                        )
-                        .then(({ data, errors }) => {
-                          expect(errors, 'delete mutation Errors').to.equal(
-                            undefined
-                          );
-                          expect(
-                            data,
-                            'deleteMutation data'
-                          ).to.have.ownProperty(multiDeleteMutationName);
-                        });
-                    });
-                });
-              });
-
-              it(`multi denied when filtered out: ${JSON.stringify(
-                access
-              )}`, () => {
-                const list = getDeclarativeListName(access);
-                const multiDeleteMutationName = `delete${list}s`;
-
-                cy.graphql_mutate(
-                  '/admin/api',
-                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}", "${FAKE_ID_2}"]) { id } }`
-                ).then(({ data, errors }) => {
-                  expect(errors, 'multi query denied Errors').to.equal(
-                    undefined
-                  );
-                  expect(data, 'multi query denied data').to.have.property(
-                    multiDeleteMutationName
-                  );
-                  expect(
-                    data[multiDeleteMutationName],
-                    'multi query denied data'
-                  ).to.deep.equal([]);
-                });
+                return cy
+                  .graphql_mutate(
+                    '/admin/api',
+                    `mutation { ${deleteMutationName}(id: "${id}") { id } }`
+                  )
+                  .then(({ data, errors }) => {
+                    expect(errors, 'delete mutation Errors').to.equal(undefined);
+                    expect(data, 'deleteMutation data').to.have.ownProperty(deleteMutationName);
+                    expect(data, 'deleteMutation id').to.have.deep.property(
+                      `${deleteMutationName}.id`,
+                      id
+                    );
+                  });
               });
             });
+
+            it(`single denied when filtered out: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const deleteMutationName = `delete${list}`;
+
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+              ).then(({ data, errors }) => {
+                expect(data, 'data').to.have.property(deleteMutationName, null);
+                expect(errors, 'error name').to.have.deep.property('[0].name', 'AccessDeniedError');
+                expect(errors, 'error message').to.have.deep.property(
+                  '[0].message',
+                  'You do not have access to this resource'
+                );
+                expect(errors, 'error path').to.have.deep.property(
+                  '[0].path[0]',
+                  deleteMutationName
+                );
+              });
+            });
+
+            it(`multi allowed: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const collection = listNameToCollectionName(list);
+              // First, insert an item that can be deleted
+              cy.task('mongoInsertOne', {
+                collection,
+                document: { foo: 'Hello', zip: 'zap' },
+              }).then(({ id: id1 }) => {
+                return cy
+                  .task('mongoInsertOne', {
+                    collection,
+                    document: { foo: 'Hello', zip: 'zing' },
+                  })
+                  .then(({ id: id2 }) => {
+                    const multiDeleteMutationName = `delete${list}s`;
+                    return cy
+                      .graphql_mutate(
+                        '/admin/api',
+                        `mutation { ${multiDeleteMutationName}(ids: ["${id1}", "${id2}"]) { id } }`
+                      )
+                      .then(({ data, errors }) => {
+                        expect(errors, 'delete mutation Errors').to.equal(undefined);
+                        expect(data, 'deleteMutation data').to.have.ownProperty(
+                          multiDeleteMutationName
+                        );
+                      });
+                  });
+              });
+            });
+
+            it(`multi denied when filtered out: ${JSON.stringify(access)}`, () => {
+              const list = getDeclarativeListName(access);
+              const multiDeleteMutationName = `delete${list}s`;
+
+              cy.graphql_mutate(
+                '/admin/api',
+                `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}", "${FAKE_ID_2}"]) { id } }`
+              ).then(({ data, errors }) => {
+                expect(errors, 'multi query denied Errors').to.equal(undefined);
+                expect(data, 'multi query denied data').to.have.property(multiDeleteMutationName);
+                expect(data[multiDeleteMutationName], 'multi query denied data').to.deep.equal([]);
+              });
+            });
+          });
         });
 
         describe('disallowed', () => {
           before(() => cy.visit('/admin'));
 
           describe('create', () => {
-            listAccessVariations
-              .filter(({ create }) => !create)
-              .forEach(access => {
-                it(`denied: ${JSON.stringify(access)}`, () => {
-                  const createMutationName = `create${getDeclarativeListName(
-                    access
-                  )}`;
+            listAccessVariations.filter(({ create }) => !create).forEach(access => {
+              it(`denied: ${JSON.stringify(access)}`, () => {
+                const createMutationName = `create${getDeclarativeListName(access)}`;
 
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'create mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', createMutationName);
-                  });
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${createMutationName}(data: { foo: "bar" }) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'create mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    createMutationName
+                  );
                 });
               });
+            });
           });
 
           describe('query', () => {
             listAccessVariations.filter(({ read }) => !read).forEach(access => {
               it(`'all' denied: ${JSON.stringify(access)}`, () => {
                 const allQueryName = `all${getDeclarativeListName(access)}s`;
-                cy.graphql_query(
-                  '/admin/api',
-                  `query { ${allQueryName} { id } }`
-                ).then(({ errors }) => {
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].name',
-                    'AccessDeniedError'
-                  );
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].message',
-                    'You do not have access to this resource'
-                  );
-                  expect(errors, 'allQuery Errors').to.have.deep.property(
-                    '[0].path[0]',
-                    allQueryName
-                  );
-                });
+                cy.graphql_query('/admin/api', `query { ${allQueryName} { id } }`).then(
+                  ({ errors }) => {
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].name',
+                      'AccessDeniedError'
+                    );
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].message',
+                      'You do not have access to this resource'
+                    );
+                    expect(errors, 'allQuery Errors').to.have.deep.property(
+                      '[0].path[0]',
+                      allQueryName
+                    );
+                  }
+                );
               });
 
               it(`meta denied: ${JSON.stringify(access)}`, () => {
                 const metaName = `_all${getDeclarativeListName(access)}sMeta`;
-                cy.graphql_query(
-                  '/admin/api',
-                  `query { ${metaName} { count } }`
-                ).then(result => {
+                cy.graphql_query('/admin/api', `query { ${metaName} { count } }`).then(result => {
                   const errors = result.errors;
                   expect(errors, 'meta Errors').to.have.deep.property(
                     '[0].name',
@@ -1293,10 +1081,7 @@ describe('Access Control, List, GraphQL', () => {
                     '[0].message',
                     'You do not have access to this resource'
                   );
-                  expect(errors, 'meta Errors').to.have.deep.property(
-                    '[0].path[0]',
-                    metaName
-                  );
+                  expect(errors, 'meta Errors').to.have.deep.property('[0].path[0]', metaName);
                 });
               });
 
@@ -1324,96 +1109,74 @@ describe('Access Control, List, GraphQL', () => {
           });
 
           describe('update', () => {
-            listAccessVariations
-              .filter(({ update }) => !update)
-              .forEach(access => {
-                it(`denies: ${JSON.stringify(access)}`, () => {
-                  const updateMutationName = `update${getDeclarativeListName(
-                    access
-                  )}`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'update mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', updateMutationName);
-                  });
+            listAccessVariations.filter(({ update }) => !update).forEach(access => {
+              it(`denies: ${JSON.stringify(access)}`, () => {
+                const updateMutationName = `update${getDeclarativeListName(access)}`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { foo: "bar" }) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'update mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    updateMutationName
+                  );
                 });
               });
+            });
           });
 
           describe('delete', () => {
-            listAccessVariations
-              .filter(access => !access.delete)
-              .forEach(access => {
-                it(`single denied: ${JSON.stringify(access)}`, () => {
-                  const deleteMutationName = `delete${getDeclarativeListName(
-                    access
-                  )}`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].path[0]', deleteMutationName);
-                  });
-                });
-
-                it(`multi denied: ${JSON.stringify(access)}`, () => {
-                  const multiDeleteMutationName = `delete${getDeclarativeListName(
-                    access
-                  )}s`;
-                  cy.graphql_mutate(
-                    '/admin/api',
-                    `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
-                  ).then(({ errors }) => {
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property('[0].name', 'AccessDeniedError');
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].message',
-                      'You do not have access to this resource'
-                    );
-                    expect(
-                      errors,
-                      'delete mutation Errors'
-                    ).to.have.deep.property(
-                      '[0].path[0]',
-                      multiDeleteMutationName
-                    );
-                  });
+            listAccessVariations.filter(access => !access.delete).forEach(access => {
+              it(`single denied: ${JSON.stringify(access)}`, () => {
+                const deleteMutationName = `delete${getDeclarativeListName(access)}`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    deleteMutationName
+                  );
                 });
               });
+
+              it(`multi denied: ${JSON.stringify(access)}`, () => {
+                const multiDeleteMutationName = `delete${getDeclarativeListName(access)}s`;
+                cy.graphql_mutate(
+                  '/admin/api',
+                  `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`
+                ).then(({ errors }) => {
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].name',
+                    'AccessDeniedError'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].message',
+                    'You do not have access to this resource'
+                  );
+                  expect(errors, 'delete mutation Errors').to.have.deep.property(
+                    '[0].path[0]',
+                    multiDeleteMutationName
+                  );
+                });
+              });
+            });
           });
         });
       });

--- a/projects/access-control/cypress/integration/util.js
+++ b/projects/access-control/cypress/integration/util.js
@@ -91,10 +91,7 @@ module.exports = {
 
   stayLoggedIn(level) {
     before(() =>
-      cy.loginToKeystone(
-        usersByLevel()[level][0].email,
-        usersByLevel()[level][0].password
-      )
+      cy.loginToKeystone(usersByLevel()[level][0].email, usersByLevel()[level][0].password)
     );
 
     beforeEach(() =>

--- a/projects/access-control/cypress/plugins/index.js
+++ b/projects/access-control/cypress/plugins/index.js
@@ -18,9 +18,7 @@ module.exports = async (on, config) => {
 
   const mongoose = new Mongoose();
   await mongoose.connect(
-    `mongodb://localhost/${inflection
-      .dasherize(process.env.PROJECT_NAME)
-      .toLowerCase()}`
+    `mongodb://localhost/${inflection.dasherize(process.env.PROJECT_NAME).toLowerCase()}`
   );
 
   const dbConnection = mongoose.connection.db;

--- a/projects/access-control/data.js
+++ b/projects/access-control/data.js
@@ -57,10 +57,7 @@ module.exports = Object.assign(
           Object.assign({ foo: 'Hello', zip: 'yo' }, generatedFieldData),
           Object.assign({ foo: 'Hi', zip: 'yo' }, generatedFieldData),
         ],
-        [getDeclarativeListName(access)]: [
-          { foo: 'Hello', zip: 'yo' },
-          { foo: 'Hi', zip: 'yo' },
-        ],
+        [getDeclarativeListName(access)]: [{ foo: 'Hello', zip: 'yo' }, { foo: 'Hi', zip: 'yo' }],
       }),
     {}
   )

--- a/projects/access-control/index.js
+++ b/projects/access-control/index.js
@@ -110,15 +110,9 @@ function createListWithDeclarativeAccess(access) {
     },
     access: {
       create: ({ authentication: { item, listKey } }) =>
-        access.create &&
-        listKey === 'User' &&
-        ['su', 'admin'].includes(item.level),
+        access.create && listKey === 'User' && ['su', 'admin'].includes(item.level),
       read: ({ authentication: { item, listKey } }) => {
-        if (
-          access.read &&
-          listKey === 'User' &&
-          ['su', 'admin'].includes(item.level)
-        ) {
+        if (access.read && listKey === 'User' && ['su', 'admin'].includes(item.level)) {
           return {
             // arbitrarily restrict the data to a single item (see data.js)
             foo_starts_with: 'Hello',
@@ -127,11 +121,7 @@ function createListWithDeclarativeAccess(access) {
         return false;
       },
       update: ({ authentication: { item, listKey } }) => {
-        if (
-          access.update &&
-          listKey === 'User' &&
-          ['su', 'admin'].includes(item.level)
-        ) {
+        if (access.update && listKey === 'User' && ['su', 'admin'].includes(item.level)) {
           return {
             // arbitrarily restrict the data to a single item (see data.js)
             foo_starts_with: 'Hello',
@@ -140,11 +130,7 @@ function createListWithDeclarativeAccess(access) {
         return false;
       },
       delete: ({ authentication: { item, listKey } }) => {
-        if (
-          access.delete &&
-          listKey === 'User' &&
-          ['su', 'admin'].includes(item.level)
-        ) {
+        if (access.delete && listKey === 'User' && ['su', 'admin'].includes(item.level)) {
           return {
             // arbitrarily restrict the data to a single item (see data.js)
             foo_starts_with: 'Hello',

--- a/projects/basic/cypress/integration/add-edit-delete-data.js
+++ b/projects/basic/cypress/integration/add-edit-delete-data.js
@@ -138,10 +138,7 @@ describe('Editing data', () => {
       cy.get('#ks-input-author').click({ force: true });
       cy.get('#ks-input-author').type('{downarrow}{enter}', { force: true });
       cy.get('#react-select-ks-input-author').then(([authorInput]) => {
-        const userText = authorInput.textContent.replace(
-          /.*option (.*), selected.*/,
-          '$1'
-        );
+        const userText = authorInput.textContent.replace(/.*option (.*), selected.*/, '$1');
 
         // save
         cy.get('button[type="submit"][appearance="primary"]').click();

--- a/projects/basic/cypress/integration/create-buttons_spec.js
+++ b/projects/basic/cypress/integration/create-buttons_spec.js
@@ -17,15 +17,9 @@ describe('Home page', () => {
 
   it('Create list buttons exists', () => {
     cy.visit('/admin');
-    [{ text: 'User' }, { text: 'Post' }, { text: 'Post Category' }].forEach(
-      ({ text }) => {
-        cy.contains('button', `Create ${text}`).should(
-          'have.attr',
-          'title',
-          `Create ${text}`
-        );
-      }
-    );
+    [{ text: 'User' }, { text: 'Post' }, { text: 'Post Category' }].forEach(({ text }) => {
+      cy.contains('button', `Create ${text}`).should('have.attr', 'title', `Create ${text}`);
+    });
   });
 
   it('Ensure Create Modal opens, has the correct fields, and Cancels', () => {
@@ -42,10 +36,7 @@ describe('Home page', () => {
       { text: 'Post Category', labels: ['Name', 'Slug'] },
     ].forEach(({ text, labels }) => {
       cy.contains('button', `Create ${text}`).click();
-      cy.contains('div', `Create ${text} Dialog`).contains(
-        'h3',
-        `Create ${text}`
-      );
+      cy.contains('div', `Create ${text} Dialog`).contains('h3', `Create ${text}`);
       cy.contains('div', `Create ${text} Dialog`).contains('button', 'Create');
       labels.forEach(label => {
         cy.contains('div[data-selector="field-container"]', label);
@@ -69,10 +60,7 @@ describe('Home page', () => {
         labels: ['Name', 'Email', 'Password', 'Company'],
       },
     ].forEach(({ text, labels }) => {
-      cy.contains('div', `Create ${text} Dialog`).contains(
-        'h3',
-        `Create ${text}`
-      );
+      cy.contains('div', `Create ${text} Dialog`).contains('h3', `Create ${text}`);
       cy.contains('div', `Create ${text} Dialog`).contains('button', 'Create');
       labels.forEach(label => {
         cy.contains('div[data-selector="field-container"]', label);

--- a/projects/basic/cypress/integration/local-file-upload_spec.js
+++ b/projects/basic/cypress/integration/local-file-upload_spec.js
@@ -18,10 +18,7 @@ describe('Adding a file', function() {
         const fileContent = `Some important content ${Math.random()}`;
         cy.visit(`/admin/users/${user.id}`);
         cy.writeFile('cypress/mock/upload.txt', fileContent);
-        cy.upload_file(
-          'input[name=attachment][type=file]',
-          '../mock/upload.txt'
-        );
+        cy.upload_file('input[name=attachment][type=file]', '../mock/upload.txt');
 
         // Setup to track XHR requests
         cy.server();
@@ -55,9 +52,7 @@ describe('Adding a file', function() {
           )
           .then(({ data: { User: { attachment } } }) => {
             // Assert the URL is visible in the admin UI
-            cy.contains(
-              `${attachment.publicUrl.split('/')[3].split('-')[1]}`
-            ).should('be.visible');
+            cy.contains(`${attachment.publicUrl.split('/')[3].split('-')[1]}`).should('be.visible');
 
             // Assert the file contents are what we uploaded
             cy.request(attachment.publicUrl)

--- a/projects/basic/index.js
+++ b/projects/basic/index.js
@@ -12,10 +12,7 @@ const {
   CloudinaryImage,
 } = require('@keystonejs/fields');
 const { WebServer } = require('@keystonejs/server');
-const {
-  CloudinaryAdapter,
-  LocalFileAdapter,
-} = require('@keystonejs/file-adapters');
+const { CloudinaryAdapter, LocalFileAdapter } = require('@keystonejs/file-adapters');
 
 const { port, staticRoute, staticPath, cloudinary } = require('./config');
 
@@ -68,9 +65,7 @@ keystone.createList('User', {
       ],
     },
     attachment: { type: File, adapter: fileAdapter },
-    ...(cloudinaryAdapter
-      ? { avatar: { type: CloudinaryImage, adapter: cloudinaryAdapter } }
-      : {}),
+    ...(cloudinaryAdapter ? { avatar: { type: CloudinaryImage, adapter: cloudinaryAdapter } } : {}),
   },
   labelResolver: item => `${item.name} <${item.email}>`,
 });
@@ -82,10 +77,7 @@ keystone.createList('Post', {
     status: {
       type: Select,
       defaultValue: 'draft',
-      options: [
-        { label: 'Draft', value: 'draft' },
-        { label: 'Published', value: 'published' },
-      ],
+      options: [{ label: 'Draft', value: 'draft' }, { label: 'Published', value: 'published' }],
     },
     author: {
       type: Relationship,

--- a/projects/basic/tests/relationships/nested-create/many.test.js
+++ b/projects/basic/tests/relationships/nested-create/many.test.js
@@ -69,16 +69,12 @@ function create(list, item) {
 
 afterAll(() =>
   resolveAllKeys(
-    mapKeys(server.keystone.adapters, adapter =>
-      adapter.dropDatabase().then(() => adapter.close())
-    )
+    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase().then(() => adapter.close()))
   ));
 
 beforeEach(() =>
   // clean the db
-  resolveAllKeys(
-    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())
-  ));
+  resolveAllKeys(mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())));
 
 describe('no access control', () => {
   test('link nested from within create mutation', async () => {
@@ -220,9 +216,7 @@ describe('no access control', () => {
     `,
     });
 
-    expect(allNotes).toHaveLength(
-      createUserManyNotes.body.data.createUser.notes.length
-    );
+    expect(allNotes).toHaveLength(createUserManyNotes.body.data.createUser.notes.length);
   });
 
   test('link AND create nested from within create mutation', async () => {
@@ -239,9 +233,7 @@ describe('no access control', () => {
         mutation {
           createUser(data: {
             username: "A thing",
-            notes: [{ id: "${
-              createNote.id
-            }" }, { create: { content: "${noteContent2}" } }]
+            notes: [{ id: "${createNote.id}" }, { create: { content: "${noteContent2}" } }]
           }) {
             id
             notes {
@@ -471,9 +463,7 @@ describe('no access control', () => {
     `,
     });
 
-    expect(allNotes).toHaveLength(
-      updateUserManyNotes.body.data.updateUser.notes.length
-    );
+    expect(allNotes).toHaveLength(updateUserManyNotes.body.data.updateUser.notes.length);
   });
 
   test('link & create nested from within update mutation', async () => {
@@ -495,9 +485,7 @@ describe('no access control', () => {
             id: "${createUser.id}"
             data: {
               username: "A thing",
-              notes: [{ id: "${
-                createNote.id
-              }" }, { create: { content: "${noteContent2}" } }]
+              notes: [{ id: "${createNote.id}" }, { create: { content: "${noteContent2}" } }]
             }
           ) {
             id
@@ -743,9 +731,7 @@ describe('with access control', () => {
           mutation {
             createUserToNotesNoRead(data: {
               username: "A thing",
-              notes: [{ id: "${
-                createNoteNoRead.id
-              }" }, { create: { content: "${noteContent2}" } }]
+              notes: [{ id: "${createNoteNoRead.id}" }, { create: { content: "${noteContent2}" } }]
             }) {
               id
               notes {
@@ -845,9 +831,7 @@ describe('with access control', () => {
               id: "${createUser.id}"
               data: {
                 username: "A thing",
-                notes: [{ id: "${
-                  createNote.id
-                }" }, { create: { content: "${noteContent2}" } }]
+                notes: [{ id: "${createNote.id}" }, { create: { content: "${noteContent2}" } }]
               }
             ) {
               id
@@ -911,10 +895,7 @@ describe('with access control', () => {
       });
 
       // Assert it throws an access denied error
-      expect(createUserToNotesNoCreate.body).toHaveProperty(
-        'data.createUserToNotesNoCreate',
-        null
-      );
+      expect(createUserToNotesNoCreate.body).toHaveProperty('data.createUserToNotesNoCreate', null);
       expect(createUserToNotesNoCreate.body.errors).toMatchObject([
         {
           name: 'NestedError',
@@ -1017,10 +998,7 @@ describe('with access control', () => {
       });
 
       // Assert it throws an access denied error
-      expect(updateUserToNotesNoCreate.body).toHaveProperty(
-        'data.updateUserToNotesNoCreate',
-        null
-      );
+      expect(updateUserToNotesNoCreate.body).toHaveProperty('data.updateUserToNotesNoCreate', null);
       expect(updateUserToNotesNoCreate.body.errors).toMatchObject([
         {
           name: 'NestedError',

--- a/projects/basic/tests/relationships/nested-create/singular.test.js
+++ b/projects/basic/tests/relationships/nested-create/singular.test.js
@@ -66,16 +66,12 @@ function create(list, item) {
 
 afterAll(() =>
   resolveAllKeys(
-    mapKeys(server.keystone.adapters, adapter =>
-      adapter.dropDatabase().then(() => adapter.close())
-    )
+    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase().then(() => adapter.close()))
   ));
 
 beforeEach(() =>
   // clean the db
-  resolveAllKeys(
-    mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())
-  ));
+  resolveAllKeys(mapKeys(server.keystone.adapters, adapter => adapter.dropDatabase())));
 
 describe('no access control', () => {
   test('link nested from within create mutation', async () => {
@@ -146,9 +142,7 @@ describe('no access control', () => {
       server,
       query: `
         query {
-          Group(where: { id: "${
-            createEvent.body.data.createEvent.group.id
-          }" }) {
+          Group(where: { id: "${createEvent.body.data.createEvent.group.id}" }) {
             id
             name
           }
@@ -259,9 +253,7 @@ describe('no access control', () => {
       server,
       query: `
         query {
-          Group(where: { id: "${
-            updateEvent.body.data.updateEvent.group.id
-          }" }) {
+          Group(where: { id: "${updateEvent.body.data.updateEvent.group.id}" }) {
             id
             name
           }
@@ -406,8 +398,7 @@ describe('with access control', () => {
         },
       } = await graphqlRequest({
         server,
-        query:
-          'mutation { createEventToGroupNoRead(data: { title: "A thing", }) { id } }',
+        query: 'mutation { createEventToGroupNoRead(data: { title: "A thing", }) { id } }',
       });
 
       // Update the item and link the relationship field

--- a/projects/login/cypress/integration/login_spec.js
+++ b/projects/login/cypress/integration/login_spec.js
@@ -28,10 +28,7 @@ describe('Testing Login', () => {
       // appear to be attached, so the form is not getting validated correctly
       cy.wait(250);
       cy.get('button[type="submit"]').click();
-      cy.get('body').should(
-        'contain',
-        'Your username and password were incorrect'
-      );
+      cy.get('body').should('contain', 'Your username and password were incorrect');
     });
 
     it('Does not log in with invalid credentials', () => {
@@ -46,10 +43,7 @@ describe('Testing Login', () => {
         .type('gibberish', { force: true });
 
       cy.get('button[type="submit"]').click();
-      cy.get('body').should(
-        'contain',
-        'Your username and password were incorrect'
-      );
+      cy.get('body').should('contain', 'Your username and password were incorrect');
     });
 
     it('Does not log in with invalid username', () => {
@@ -64,10 +58,7 @@ describe('Testing Login', () => {
         .type(PASSWORD, { force: true });
 
       cy.get('button[type="submit"]').click();
-      cy.get('body').should(
-        'contain',
-        'Your username and password were incorrect'
-      );
+      cy.get('body').should('contain', 'Your username and password were incorrect');
     });
 
     it('Does not log in with invalid password', () => {
@@ -82,10 +73,7 @@ describe('Testing Login', () => {
         .type('gibberish', { force: true });
 
       cy.get('button[type="submit"]').click();
-      cy.get('body').should(
-        'contain',
-        'Your username and password were incorrect'
-      );
+      cy.get('body').should('contain', 'Your username and password were incorrect');
     });
   });
 
@@ -144,12 +132,10 @@ describe('authenticated item', () => {
 
   describe('logged out', () => {
     it('current user query returns null', () => {
-      cy.graphql_query('/admin/api', '{ authenticatedUser { id } }').then(
-        ({ data, errors }) => {
-          expect(data).to.have.property('authenticatedUser', null);
-          expect(errors).to.equal(undefined);
-        }
-      );
+      cy.graphql_query('/admin/api', '{ authenticatedUser { id } }').then(({ data, errors }) => {
+        expect(data).to.have.property('authenticatedUser', null);
+        expect(errors).to.equal(undefined);
+      });
     });
   });
 
@@ -172,12 +158,10 @@ describe('authenticated item', () => {
     });
 
     it('current user query returns user info', () => {
-      cy.graphql_query('/admin/api', '{ authenticatedUser { id } }').then(
-        ({ data, errors }) => {
-          expect(data).to.have.deep.property('authenticatedUser.id');
-          expect(errors).to.equal(undefined);
-        }
-      );
+      cy.graphql_query('/admin/api', '{ authenticatedUser { id } }').then(({ data, errors }) => {
+        expect(data).to.have.deep.property('authenticatedUser.id');
+        expect(errors).to.equal(undefined);
+      });
     });
   });
 });

--- a/projects/login/index.js
+++ b/projects/login/index.js
@@ -60,35 +60,30 @@ server.app.get('/api/session', (req, res) => {
   res.json(data);
 });
 
-server.app.post(
-  '/signin',
-  bodyParser.json(),
-  bodyParser.urlencoded(),
-  async (req, res, next) => {
-    // Cleanup any previous session
-    await keystone.session.destroy(req);
+server.app.post('/signin', bodyParser.json(), bodyParser.urlencoded(), async (req, res, next) => {
+  // Cleanup any previous session
+  await keystone.session.destroy(req);
 
-    try {
-      const result = await keystone.auth.User.password.validate({
-        username: req.body.username,
-        password: req.body.password,
+  try {
+    const result = await keystone.auth.User.password.validate({
+      username: req.body.username,
+      password: req.body.password,
+    });
+    if (!result.success) {
+      return res.json({
+        success: false,
       });
-      if (!result.success) {
-        return res.json({
-          success: false,
-        });
-      }
-      await keystone.session.create(req, result);
-      res.json({
-        success: true,
-        itemId: result.item.id,
-        token: req.sessionID,
-      });
-    } catch (e) {
-      next(e);
     }
+    await keystone.session.create(req, result);
+    res.json({
+      success: true,
+      itemId: result.item.id,
+      token: req.sessionID,
+    });
+  } catch (e) {
+    next(e);
   }
-);
+});
 
 server.app.get('/signout', async (req, res, next) => {
   try {

--- a/projects/login/tests/auth-header.test.js
+++ b/projects/login/tests/auth-header.test.js
@@ -43,34 +43,29 @@ describe('Auth testing', () => {
     graphiqlPath: '/admin/graphiql',
   });
 
-  server.app.post(
-    '/signin',
-    bodyParser.json(),
-    bodyParser.urlencoded(),
-    async (req, res, next) => {
-      // Cleanup any previous session
-      await keystone.session.destroy(req);
+  server.app.post('/signin', bodyParser.json(), bodyParser.urlencoded(), async (req, res, next) => {
+    // Cleanup any previous session
+    await keystone.session.destroy(req);
 
-      try {
-        const result = await keystone.auth.User.password.validate({
-          username: req.body.username,
-          password: req.body.password,
+    try {
+      const result = await keystone.auth.User.password.validate({
+        username: req.body.username,
+        password: req.body.password,
+      });
+      if (!result.success) {
+        return res.json({
+          success: false,
         });
-        if (!result.success) {
-          return res.json({
-            success: false,
-          });
-        }
-        await keystone.session.create(req, result);
-        res.json({
-          success: true,
-          token: req.sessionID,
-        });
-      } catch (e) {
-        next(e);
       }
+      await keystone.session.create(req, result);
+      res.json({
+        success: true,
+        token: req.sessionID,
+      });
+    } catch (e) {
+      next(e);
     }
-  );
+  });
 
   function login(username, password) {
     return supertest(server.app)
@@ -89,14 +84,11 @@ describe('Auth testing', () => {
     keystone.connect();
   });
 
-  afterAll(() =>
-    resolveAllKeys(mapKeys(keystone.adapters, adapter => adapter.close())));
+  afterAll(() => resolveAllKeys(mapKeys(keystone.adapters, adapter => adapter.close())));
 
   beforeEach(async () => {
     // clean the db
-    await resolveAllKeys(
-      mapKeys(keystone.adapters, adapter => adapter.dropDatabase())
-    );
+    await resolveAllKeys(mapKeys(keystone.adapters, adapter => adapter.dropDatabase()));
     // seed the db
     await keystone.createItems(initialData);
   });

--- a/projects/twitter-login/custom-fields/SecurePassword/views/Field.js
+++ b/projects/twitter-login/custom-fields/SecurePassword/views/Field.js
@@ -1,10 +1,6 @@
 import React, { Component } from 'react';
 
-import {
-  FieldContainer,
-  FieldLabel,
-  FieldInput,
-} from '@keystonejs/ui/src/primitives/fields';
+import { FieldContainer, FieldLabel, FieldInput } from '@keystonejs/ui/src/primitives/fields';
 import { Input } from '@keystonejs/ui/src/primitives/forms';
 
 export default class PasswordField extends Component {
@@ -18,11 +14,7 @@ export default class PasswordField extends Component {
       <FieldContainer>
         <FieldLabel>{'🔐' + field.label}</FieldLabel>
         <FieldInput>
-          <Input
-            type="password"
-            value={item[field.path]}
-            onChange={this.onChange}
-          />
+          <Input type="password" value={item[field.path]} onChange={this.onChange} />
         </FieldInput>
       </FieldContainer>
     );

--- a/projects/twitter-login/index.js
+++ b/projects/twitter-login/index.js
@@ -11,18 +11,9 @@ const {
 } = require('@keystonejs/fields');
 const { WebServer } = require('@keystonejs/server');
 const PasswordAuthStrategy = require('@keystonejs/core/auth/Password');
-const {
-  CloudinaryAdapter,
-  LocalFileAdapter,
-} = require('@keystonejs/file-adapters');
+const { CloudinaryAdapter, LocalFileAdapter } = require('@keystonejs/file-adapters');
 
-const {
-  twitterAuthEnabled,
-  port,
-  staticRoute,
-  staticPath,
-  cloudinary,
-} = require('./config');
+const { twitterAuthEnabled, port, staticRoute, staticPath, cloudinary } = require('./config');
 const { configureTwitterAuth } = require('./twitter');
 
 const { DISABLE_AUTH } = process.env;
@@ -86,8 +77,7 @@ keystone.createList('User', {
       type: Password,
       access: {
         update: ({ item, authentication }) =>
-          authentication.listKey === this.listKey &&
-          item.id === authentication.item.id,
+          authentication.listKey === this.listKey && item.id === authentication.item.id,
       },
     },
     // TODO: Create a Twitter field type to encapsulate these
@@ -111,9 +101,7 @@ keystone.createList('User', {
       // its own access control setup
     },
     attachment: { type: File, adapter: fileAdapter },
-    ...(cloudinaryAdapter
-      ? { avatar: { type: CloudinaryImage, adapter: cloudinaryAdapter } }
-      : {}),
+    ...(cloudinaryAdapter ? { avatar: { type: CloudinaryImage, adapter: cloudinaryAdapter } } : {}),
   },
   labelResolver: item => `${item.name} <${item.email}>`,
 });
@@ -125,10 +113,7 @@ keystone.createList('Post', {
     status: {
       type: Select,
       defaultValue: 'draft',
-      options: [
-        { label: 'Draft', value: 'draft' },
-        { label: 'Published', value: 'published' },
-      ],
+      options: [{ label: 'Draft', value: 'draft' }, { label: 'Published', value: 'published' }],
     },
     author: {
       type: Relationship,
@@ -144,14 +129,11 @@ keystone.createList('Post', {
   access: {
     read: true,
     create: ({ item, authentication }) =>
-      authentication.listKey === authStrategy.listKey &&
-      item.user.id === authentication.item.id,
+      authentication.listKey === authStrategy.listKey && item.user.id === authentication.item.id,
     update: ({ item, authentication }) =>
-      authentication.listKey === authStrategy.listKey &&
-      item.user.id === authentication.item.id,
+      authentication.listKey === authStrategy.listKey && item.user.id === authentication.item.id,
     delete: ({ item, authentication }) =>
-      authentication.listKey === authStrategy.listKey &&
-      item.user.id === authentication.item.id,
+      authentication.listKey === authStrategy.listKey && item.user.id === authentication.item.id,
   },
 });
 
@@ -178,8 +160,7 @@ keystone.createList('Note', {
   },
   // All access to notes limited to authenticated person
   access: ({ item, authentication }) =>
-    authentication.listKey === authStrategy.listKey &&
-    item.user.id === authentication.item.id,
+    authentication.listKey === authStrategy.listKey && item.user.id === authentication.item.id,
 });
 
 const admin = new AdminUI(keystone, {


### PR DESCRIPTION
This PR updates `prettier` to use a maximum line length of `100`, up from the default of `80`. This saves us ~1.5KLOC, and should make the code more readable by having few instances where a single line gets broken out to 5-10 lines.

This setting is open to review in the future, particularly if any developers experience ongoing frustration due to lines being too long in certain dev environments.

This PR also removes the `.prettierrc.js` file, as this wasn't actually being used, leading to much confusion when trying to make these changes. The config for `prettier` currently lives in `package.json`. If anyone has strong opinions on this we can always break it out into a config file.