### PR TITLE
Decoupling list fields and GraphQL output fields

### DIFF
--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -27,7 +27,7 @@ class MockType {
     this.access = access;
   }
   getAdminMeta = () => new MockAdminMeta();
-  getGraphqlSchema = () => `${this.name}_schema`;
+  getGraphqlOutputFields = () => `${this.name}_schema`;
   getGraphqlAuxiliaryTypes = () => `${this.name}_types`;
   getGraphqlAuxiliaryQueries = () => {};
   getGraphqlAuxiliaryMutations = () => {};

--- a/packages/fields/Implementation.js
+++ b/packages/fields/Implementation.js
@@ -28,12 +28,9 @@ class Field {
     });
   }
 
-  getGraphqlSchema() {
-    if (!this.graphQLType) {
-      throw new Error(`Field type [${this.constructor.name}] does not implement graphQLType`);
-    }
-    return `${this.path}: ${this.graphQLType}`;
-  }
+  // Field types should replace this if they want to any fields to the output type
+  getGraphqlOutputFields() {}
+  getGraphqlOutputFieldResolvers() {}
 
   /**
    * Auxiliary Types are top-level types which a type may need or provide.
@@ -94,7 +91,7 @@ class Field {
   getGraphqlQueryArgs() {}
   getGraphqlCreateArgs() {}
   getGraphqlUpdateArgs() {}
-  getGraphqlFieldResolvers() {}
+
   getAdminMeta() {
     return this.extendAdminMeta({
       label: this.label,

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -50,21 +50,6 @@ test('addToMongooseSchema()', () => {
   }).toThrow(Error);
 });
 
-test('getGraphqlSchema()', () => {
-  const impl = new Field('path', config, args);
-
-  // By default graphQLType is undefined and getGraphqlSchema should throw an Error.
-  expect(impl.graphQLType).toBe(undefined);
-  expect(() => {
-    impl.getGraphqlSchema();
-  }).toThrowError(Error);
-
-  // Setting graphQLType should cause the method to return a valid value.
-  impl.graphQLType = 'graphQL type';
-  const value = impl.getGraphqlSchema();
-  expect(value).toEqual('path: graphQL type');
-});
-
 test('getGraphqlAuxiliaryTypes()', () => {
   const impl = new Field('path', config, args);
 
@@ -151,10 +136,10 @@ test('getGraphqlUpdateArgs()', () => {
   expect(value).toBe(undefined);
 });
 
-test('getGraphqlFieldResolvers()', () => {
+test('getGraphqlOutputFieldResolvers()', () => {
   const impl = new Field('path', config, args);
 
-  const value = impl.getGraphqlFieldResolvers();
+  const value = impl.getGraphqlOutputFieldResolvers();
   expect(value).toBe(undefined);
 });
 

--- a/packages/fields/types/CalendarDay/Implementation.js
+++ b/packages/fields/types/CalendarDay/Implementation.js
@@ -6,9 +6,13 @@ const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 class CalendarDay extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'String';
   }
 
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: String
+    `;
+  }
   getGraphqlQueryArgs() {
     return `
         ${this.path}: String

--- a/packages/fields/types/Checkbox/Implementation.js
+++ b/packages/fields/types/Checkbox/Implementation.js
@@ -4,7 +4,15 @@ const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 class Checkbox extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'Boolean';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: Boolean
+    `;
+  }
+  getGraphqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
   }
 
   getGraphqlQueryArgs() {

--- a/packages/fields/types/CloudinaryImage/Implementation.js
+++ b/packages/fields/types/CloudinaryImage/Implementation.js
@@ -3,7 +3,13 @@ const { File, MongoFileInterface } = require('../File/Implementation');
 class CloudinaryImage extends File {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'CloudinaryImage_File';
+    this.graphQLOutputType = 'CloudinaryImage_File';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: ${this.graphQLOutputType}
+    `;
   }
   extendAdminMeta(meta) {
     // Overwrite so we have only the original meta
@@ -51,13 +57,13 @@ class CloudinaryImage extends File {
         transformation: String
       }
 
-      extend type ${this.graphQLType} {
+      extend type ${this.graphQLOutputType} {
         publicUrlTransformed(transformation: CloudinaryImageFormat): String
       }
     `;
   }
   // Called on `User.avatar` for example
-  getGraphqlFieldResolvers() {
+  getGraphqlOutputFieldResolvers() {
     return {
       [this.path]: item => {
         const itemValues = item[this.path];
@@ -75,7 +81,7 @@ class CloudinaryImage extends File {
   }
   getGraphqlAuxiliaryMutations() {
     return `
-      uploadCloudinaryImage(file: ${this.getFileUploadType()}!): ${this.graphQLType}
+      uploadCloudinaryImage(file: ${this.getFileUploadType()}!): ${this.graphQLOutputType}
     `;
   }
   getGraphqlAuxiliaryMutationResolvers() {

--- a/packages/fields/types/File/Implementation.js
+++ b/packages/fields/types/File/Implementation.js
@@ -15,9 +15,14 @@ const {
 class File extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'File_File';
+    this.graphQLOutputType = 'File_File';
   }
 
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: ${this.graphQLOutputType}
+    `;
+  }
   extendAdminMeta(meta) {
     return {
       ...meta,
@@ -35,7 +40,7 @@ class File extends Implementation {
     return `
       scalar ${this.getFileUploadType()}
 
-      type ${this.graphQLType} {
+      type ${this.graphQLOutputType} {
         id: ID
         path: String
         filename: String
@@ -46,7 +51,7 @@ class File extends Implementation {
     `;
   }
   // Called on `User.avatar` for example
-  getGraphqlFieldResolvers() {
+  getGraphqlOutputFieldResolvers() {
     return {
       [this.path]: item => {
         const itemValues = item[this.path];
@@ -67,7 +72,7 @@ class File extends Implementation {
   }
   getGraphqlAuxiliaryMutations() {
     return `
-      uploadFile(file: ${this.getFileUploadType()}!): ${this.graphQLType}
+      uploadFile(file: ${this.getFileUploadType()}!): ${this.graphQLOutputType}
     `;
   }
   getGraphqlAuxiliaryMutationResolvers() {

--- a/packages/fields/types/Float/Implementation.js
+++ b/packages/fields/types/Float/Implementation.js
@@ -4,7 +4,15 @@ const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 class Float extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'Float';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: Float
+    `;
+  }
+  getGraphqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
   }
 
   getGraphqlQueryArgs() {

--- a/packages/fields/types/Integer/Implementation.js
+++ b/packages/fields/types/Integer/Implementation.js
@@ -4,7 +4,15 @@ const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 class Integer extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'Int';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: Int
+    `;
+  }
+  getGraphqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
   }
 
   getGraphqlQueryArgs() {

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -4,7 +4,12 @@ const { MongooseFieldAdapter } = require('@keystonejs/adapter-mongoose');
 class Password extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'String';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: String
+    `;
   }
   getGraphqlQueryArgs() {
     return `

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -107,7 +107,7 @@ class Relationship extends Implementation {
   constructor() {
     super(...arguments);
   }
-  getGraphqlSchema() {
+  getGraphqlOutputFields() {
     const { many, ref } = this.config;
     const type = many ? `[${ref}]` : ref;
     return `${this.path}: ${type}`;
@@ -137,7 +137,7 @@ class Relationship extends Implementation {
       `;
     }
   }
-  getGraphqlFieldResolvers() {
+  getGraphqlOutputFieldResolvers() {
     const { many, ref } = this.config;
     return {
       [this.path]: item => {

--- a/packages/fields/types/Select/Implementation.js
+++ b/packages/fields/types/Select/Implementation.js
@@ -16,9 +16,13 @@ class Select extends Implementation {
     super(...arguments);
     this.options = initOptions(config.options);
   }
-  getGraphqlSchema() {
+  getGraphqlOutputFields() {
     return `${this.path}: ${this.getTypeName()}`;
   }
+  getGraphqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
+  }
+
   getTypeName() {
     return `${this.listKey}${inflection.classify(this.path)}Type`;
   }

--- a/packages/fields/types/Text/Implementation.js
+++ b/packages/fields/types/Text/Implementation.js
@@ -5,7 +5,15 @@ const { escapeRegExp: esc } = require('@keystonejs/utils');
 class Text extends Implementation {
   constructor() {
     super(...arguments);
-    this.graphQLType = 'String';
+  }
+
+  getGraphqlOutputFields() {
+    return `
+      ${this.path}: String
+    `;
+  }
+  getGraphqlOutputFieldResolvers() {
+    return { [`${this.path}`]: item => item[this.path] };
   }
 
   getGraphqlQueryArgs() {


### PR DESCRIPTION
As per @jesstelford's [request](https://github.com/keystonejs/keystone-5/pull/237#discussion_r211135293).

Refactoring the application of ACLs to items and fields to allow for:
* List fields that add more than one GraphQL output fields field named differently than the field path
* List fields that add zero GraphQL output field

Also:
* Cleaned up some related naming in the field interface (`getGraphqlSchema` >> `getGraphqlOutputFields`)
* Made `getGraphqlOutputFieldResolvers()` explicit (for now) and refactored `graphQLType` out of most types. These are often not 1-to-1 with a field type.

