### PR TITLE
Fix a minor grammar error on one of the docs pages.

### DIFF
--- a/docs/api/List/index.md
+++ b/docs/api/List/index.md
@@ -33,4 +33,4 @@ A new list will be created with the following default options:
 
 It will merge the defaultOptions with the passed options, deferring to the passed options when both define it. While fields can be set up in the constructor, the common pattern is to use [.add()](/api/list/add) on the instance of the list.
 
-Once your list has been completed, you can need to call [.register()](/api/list/register).
+Once your list has been completed, you need to call [.register()](/api/list/register).


### PR DESCRIPTION
minor wording error fix

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

