### PR TITLE
Upgrade cypress from 3.0.2 to 3.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,14 +15,14 @@ x-job-setup: &job-setup
 # Download and cache dependencies
 x-restore-cache: &restore-cache
   keys:
-    - v7-dependencies-{{ checksum "yarn.lock" }}
+    - v8-dependencies-{{ checksum "yarn.lock" }}
       # fallback to using the latest cache if no exact match is found
-    - v7-dependencies-
+    - v8-dependencies-
 
 x-save-cache: &save-cache
   paths:
     - node_modules
-  key: v7-dependencies-{{ checksum "yarn.lock" }}
+  key: v8-dependencies-{{ checksum "yarn.lock" }}
 
 x-integration-steps: &integration-steps
   steps:

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "devDependencies": {
     "apollo-fetch": "^0.7.0",
-    "cypress": "^3.0.2",
+    "cypress": "^3.1.0",
     "eslint-plugin-cypress": "^2.0.1",
     "fast-memoize": "^2.4.0",
     "junit-merge": "^1.3.0",

--- a/projects/access-control/package.json
+++ b/projects/access-control/package.json
@@ -27,7 +27,7 @@
     "react": "^16.4.2"
   },
   "devDependencies": {
-    "cypress": "^3.0.2",
+    "cypress": "^3.1.0",
     "execa": "0.10.0",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",

--- a/projects/basic/package.json
+++ b/projects/basic/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@keystonejs/utils": "^1.0.0",
-    "cypress": "^3.0.2",
+    "cypress": "^3.1.0",
     "execa": "0.10.0",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",

--- a/projects/login/package.json
+++ b/projects/login/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@keystonejs/utils": "^1.0.0",
-    "cypress": "^3.0.2",
+    "cypress": "^3.1.0",
     "execa": "0.10.0",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,9 +774,9 @@ async@1.5, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+async@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
   dependencies:
     lodash "^4.14.0"
 
@@ -2297,9 +2297,9 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-cypress@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.0.2.tgz#90caef84c91bd52b9cdf123aa76213249a289694"
+cypress@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.1.0.tgz#b718ba64289b887c7ab7a7f09245d871a4a409ba"
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.3"
@@ -2324,13 +2324,13 @@ cypress@^3.0.2:
     executable "4.1.1"
     extract-zip "1.6.6"
     fs-extra "4.0.1"
-    getos "2.8.4"
+    getos "3.1.0"
     glob "7.1.2"
     is-ci "1.0.10"
     is-installed-globally "0.1.0"
     lazy-ass "1.6.0"
     listr "0.12.0"
-    lodash "4.17.4"
+    lodash "4.17.10"
     log-symbols "2.2.0"
     minimist "1.2.0"
     progress "1.1.8"
@@ -3444,11 +3444,11 @@ get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
-getos@2.8.4:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/getos/-/getos-2.8.4.tgz#7b8603d3619c28e38cb0fe7a4f63c3acb80d5163"
+getos@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/getos/-/getos-3.1.0.tgz#db3aa4df15a3295557ce5e81aa9e3e5cdfaa6567"
   dependencies:
-    async "2.1.4"
+    async "2.4.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -4917,11 +4917,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.17.10, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
Changelog for cypress is [here](https://docs.cypress.io/guides/references/changelog.html#3-1-0)

This is part of #206 