### PR TITLE
Upgrade prettier from 1.12 -> 1.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "passport-twitter": "^1.0.4",
     "pino": "5.0.0-rc.4",
     "pluralize": "^7.0.0",
-    "prettier": "^1.12.1",
+    "prettier": "^1.14.2",
     "prop-types": "^15.6.1",
     "raf-schd": "^4.0.0",
     "react": "^16.4.2",

--- a/packages/admin-ui/client/pages/StyleGuide/Components/Badges.js
+++ b/packages/admin-ui/client/pages/StyleGuide/Components/Badges.js
@@ -8,10 +8,16 @@ const BadgeGuide = () => (
   <Fragment>
     <h2>Badges</h2>
     <h4>Variant: Subtle</h4>
-    <FlexGroup>{appearances.map(a => <Badge value={55} appearance={a} key={a} />)}</FlexGroup>
+    <FlexGroup>
+      {appearances.map(a => (
+        <Badge value={55} appearance={a} key={a} />
+      ))}
+    </FlexGroup>
     <h4>Variant: Bold</h4>
     <FlexGroup>
-      {appearances.map(a => <Badge value={55} variant="bold" appearance={a} key={a} />)}
+      {appearances.map(a => (
+        <Badge value={55} variant="bold" appearance={a} key={a} />
+      ))}
     </FlexGroup>
   </Fragment>
 );

--- a/packages/ui/src/primitives/forms/DayPicker.js
+++ b/packages/ui/src/primitives/forms/DayPicker.js
@@ -145,7 +145,11 @@ export const DayPicker = (props: Props) => {
         </Header>
 
         <Body>
-          <WeekLabels>{WEEK_DAYS.map(d => <Day key={d}>{d}</Day>)}</WeekLabels>
+          <WeekLabels>
+            {WEEK_DAYS.map(d => (
+              <Day key={d}>{d}</Day>
+            ))}
+          </WeekLabels>
 
           {weeksInCurrentMonth.map((week, i) => (
             <WeekRow key={i}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6040,9 +6040,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.12.1:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
Changelog for prettier [here](https://prettier.io/blog/2018/07/29/1.14.0.html)

This is part of #206 