### PR TITLE
Include message in error reported by pino

### DIFF
--- a/packages/server/WebServer/graphql.js
+++ b/packages/server/WebServer/graphql.js
@@ -66,6 +66,7 @@ module.exports = function createGraphQLMiddleware(keystone, { apiPath, graphiqlP
         } else {
           if (error.extensions && error.extensions.exception) {
             const pinoError = {
+              message: error.message || error.msg,
               ...omit(error.extensions.exception, ['name', 'model']),
               path: error.path,
               stack: Array.isArray(error.extensions.exception.stacktrace)


### PR DESCRIPTION
Sometimes there isn't a `.message` field on `error.extensions.exception`, so we make sure to include one.

Output before this PR:

<img width="832" alt="screen shot 2018-08-31 at 11 45 22 am" src="https://user-images.githubusercontent.com/612020/44888264-7db81500-ad13-11e8-973c-b14dc689e608.png">


Output after this PR:

<img width="921" alt="screen shot 2018-08-31 at 11 45 32 am" src="https://user-images.githubusercontent.com/612020/44888266-801a6f00-ad13-11e8-8ac6-9e92d963a0a9.png">
