### PR TITLE
Remove unnecessary restriction around AND + other keys in mongo queries

### DIFF
--- a/packages/mongo-join-builder/query-parser.js
+++ b/packages/mongo-join-builder/query-parser.js
@@ -66,17 +66,19 @@ module.exports = options => {
     const isAND = isANDQuery(query);
     const queryKeys = Object.keys(query);
 
-    if (isAND && queryKeys.length > 1) {
-      throw new Error(`Cannot combine AND query with other keys. Got ${queryKeys.join(', ')}.`);
-    }
+    let pipeline = [];
+    let postJoinPipeline = [];
+    let relationships = {};
 
     if (isAND) {
-      return parseAND(query, pathSoFar);
-    }
+      const parsedAnd = parseAND(query, pathSoFar);
+      pipeline = parsedAnd.pipeline;
+      postJoinPipeline = parsedAnd.postJoinPipeline;
+      relationships = parsedAnd.relationships;
 
-    const pipeline = [];
-    const postJoinPipeline = [];
-    const relationships = {};
+      // remove the `AND` query from further processing
+      queryKeys.splice(queryKeys.indexOf('AND'), 1);
+    }
 
     queryKeys.forEach(key => {
       const value = query[key];

--- a/packages/mongo-join-builder/tests/query-parser.test.js
+++ b/packages/mongo-join-builder/tests/query-parser.test.js
@@ -271,12 +271,26 @@ describe('query parser', () => {
       };
       const parser = queryParser({ tokenizer: simpleTokenizer });
 
-      expect(() =>
-        parser({
+      parser({
+        AND: [{ name: 'foobar' }, { age_lte: 23 }],
+        age_gte: 20,
+      });
+
+      expect(simpleTokenizer.simple).toBeCalledTimes(3);
+      expect(simpleTokenizer.simple).toBeCalledWith({ name: 'foobar' }, 'name', ['AND', 0, 'name']);
+      expect(simpleTokenizer.simple).toBeCalledWith({ age_lte: 23 }, 'age_lte', [
+        'AND',
+        1,
+        'age_lte',
+      ]);
+      expect(simpleTokenizer.simple).toBeCalledWith(
+        {
           AND: [{ name: 'foobar' }, { age_lte: 23 }],
           age_gte: 20,
-        })
-      ).toThrow(Error);
+        },
+        'age_gte',
+        ['age_gte']
+      );
     });
 
     test('AND query with invalid query type', () => {


### PR DESCRIPTION
There's no need to have this restriction given a pipeline of filters are an implicit `$and` in mongo.

It was also messing with adding other modifiers to the query (like `first: 10`, etc).