### PR TITLE
Better error logging during async graphql tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "apollo-fetch": "^0.7.0",
     "cypress": "^3.1.0",
     "eslint-plugin-cypress": "^2.0.1",
+    "extract-stack": "^1.0.0",
     "fast-memoize": "^2.4.0",
     "junit-merge": "^1.3.0",
     "lodash.omitby": "^4.6.0",
@@ -137,6 +138,6 @@
     "pino-colada": "^1.4.4",
     "pm2": "^2.10.4",
     "start-server-and-test": "^1.5.0",
-    "supertest": "^3.1.0"
+    "supertest-light": "^1.0.2"
   }
 }

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -28,5 +28,8 @@
     "mongoose": "^5.2.7",
     "p-settle": "^2.1.0",
     "react-apollo": "^2.1.11"
+  },
+  "devDependencies": {
+    "supertest-light": "^1.0.2"
   }
 }

--- a/projects/basic/package.json
+++ b/projects/basic/package.json
@@ -33,11 +33,13 @@
     "cuid": "^2.1.1",
     "cypress": "^3.1.0",
     "execa": "0.10.0",
+    "extract-stack": "^1.0.0",
     "mocha": "^3.1.2",
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
     "pino-colada": "^1.4.4",
     "start-server-and-test": "^1.5.0",
+    "supertest-light": "^1.0.2",
     "testcheck": "^1.0.0-rc.2"
   }
 }

--- a/projects/basic/tests/util.js
+++ b/projects/basic/tests/util.js
@@ -1,4 +1,5 @@
-const supertest = require('supertest');
+const supertest = require('supertest-light');
+const extractStack = require('extract-stack');
 const { Keystone } = require('@keystonejs/core');
 const { WebServer } = require('@keystonejs/server');
 const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
@@ -21,12 +22,35 @@ function setupServer({ name, createLists = () => {} }) {
 }
 
 function graphqlRequest({ server, query }) {
+  const cleanedStack = extractStack(new Error())
+    .split('\n')
+    // Slice out the stackframe pointing to this function
+    .slice(1)
+    // Stick the stacktrace back together
+    .join('\n');
+
   return supertest(server.server.app)
-    .post('/admin/api')
     .set('Accept', 'application/json')
-    .send({ query })
-    .set('Accept', 'application/json')
-    .expect(200);
+    .post('/admin/api', { query })
+    .then(res => {
+      res.body = JSON.parse(res.text);
+      return res;
+    })
+    .then(res => {
+      if (res.statusCode && (res.statusCode < 200 || res.statusCode >= 300)) {
+        const error = new Error(
+          `Expected status "2XX", got ${res.statusCode} with body:` +
+            `\n${require('util').inspect(res.body || {}, { depth: null })}`
+        );
+
+        // Replace the stacktrace with the clean one we gathered and cleaned
+        // before this async process
+        error.stack = error.stack.replace(extractStack(error), cleanedStack);
+
+        throw error;
+      }
+      return res;
+    });
 }
 
 module.exports = {

--- a/projects/login/package.json
+++ b/projects/login/package.json
@@ -34,6 +34,7 @@
     "mocha-junit-reporter": "^1.17.0",
     "mocha-multi-reporters": "^1.1.7",
     "pino-colada": "^1.4.4",
-    "start-server-and-test": "^1.5.0"
+    "start-server-and-test": "^1.5.0",
+    "supertest-light": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,7 +2280,7 @@ compare-versions@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
 
-component-emitter@^1.2.0, component-emitter@^1.2.1:
+component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -2296,7 +2296,7 @@ concat-stream@1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -2349,10 +2349,6 @@ cookie-signature@^1.1.0:
 cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-
-cookiejar@^2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3430,6 +3426,10 @@ extract-files@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.0.0-beta.38"
 
+extract-stack@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/extract-stack/-/extract-stack-1.0.0.tgz#b97acaf9441eea2332529624b732fc5a1c8165fa"
+
 extract-zip@1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
@@ -3671,17 +3671,13 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.3.1, form-data@~2.3.1:
+form-data@~2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
-
-formidable@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5558,10 +5554,6 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
-mime@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-
 mime@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
@@ -6735,7 +6727,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@6.5.2, qs@^6.5.1, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -6988,7 +6980,7 @@ read@^1.0.4:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -7816,27 +7808,11 @@ subscriptions-transport-ws@^0.9.11:
     symbol-observable "^1.0.4"
     ws "^5.2.0"
 
-superagent@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.2.tgz#e4a11b9d047f7d3efeb3bbe536d9ec0021d16403"
+supertest-light@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/supertest-light/-/supertest-light-1.0.2.tgz#a2ffd4cfe06985bdc7f2d2b96880eea2c9ce9925"
   dependencies:
-    component-emitter "^1.2.0"
-    cookiejar "^2.1.0"
-    debug "^3.1.0"
-    extend "^3.0.0"
-    form-data "^2.3.1"
-    formidable "^1.1.1"
-    methods "^1.1.1"
-    mime "^1.4.1"
-    qs "^6.5.1"
-    readable-stream "^2.0.5"
-
-supertest@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.1.0.tgz#f9ebaf488e60f2176021ec580bdd23ad269e7bc6"
-  dependencies:
-    methods "~1.1.2"
-    superagent "3.8.2"
+    concat-stream "^1.6.2"
 
 supports-color@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
Took errors from this:

![screen shot 2018-09-04 at 12 53 47 pm](https://user-images.githubusercontent.com/612020/45007696-62664600-b042-11e8-9ce2-67c08b1c4698.png)

To this:

![screen shot 2018-09-04 at 12 52 43 pm](https://user-images.githubusercontent.com/612020/45007701-68f4bd80-b042-11e8-80b9-80d09e045bdd.png)

Improvements:

1. Stacktrace points to the actual test file
2. Outputs the body of the response
3. Got rid of `supertest` which is way over-engineered and has all sorts of crazy edge cases. Replaced with [`supertest-light`](https://github.com/rook2pawn/supertest-light/blob/master/index.js) which is only 79LOC.