### PR TITLE
Fix labels on fields in item view.

### DIFF
--- a/packages/fields/Implementation.js
+++ b/packages/fields/Implementation.js
@@ -11,7 +11,7 @@ class Field {
     this.config = config;
     this.getListByKey = getListByKey;
     this.listKey = listKey;
-    this.label = config.label || inflection.humanize(path);
+    this.label = config.label || inflection.humanize(inflection.underscore(path));
     this.adapter = listAdapter.newFieldAdapter(
       fieldAdapterClass,
       this.constructor.name,


### PR DESCRIPTION
This solution converts from `camelCase` to `under_score` before calling `inflection.humanize`. This means that the path `optionGroup` translates to the label. `Option group` 

https://www.npmjs.com/package/inflection

Fixes #338