### PR TITLE
add alt text to delete button

### DIFF
--- a/admin/client/App/screens/List/components/ListManagement.js
+++ b/admin/client/App/screens/List/components/ListManagement.js
@@ -35,7 +35,8 @@ function ListManagement ({
 				glyph="trashcan"
 				onClick={handleDelete}
 				position="left"
-				variant="link">
+				variant="link"
+				alt="delete">
 				Delete
 			</GlyphButton>
 		</Section>


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Adds alt text "delete" to delete item button

## Related issues (if any)
fixes #4717

## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

