### PR TITLE
Connect column sorting components to DataProvider

### DIFF
--- a/packages/admin-ui/client/pages/List/ListDetails.js
+++ b/packages/admin-ui/client/pages/List/ListDetails.js
@@ -417,6 +417,8 @@ class ListDetails extends Component<Props, State> {
                 onChange={query.refetch}
                 onSelect={this.handleItemSelect}
                 onSelectAll={this.handleItemSelectAll}
+                handleSortChange={handleSortChange}
+                sortBy={sortBy}
                 selectedItems={selectedItems}
                 noResultsMessage={this.getNoResultsMessage()}
               />


### PR DESCRIPTION
This PR connects the clickable column UI components to the data provider so that we can controller the `sortBy` state using the clickable columns.

Fixes #337 