### PR TITLE
Fix #4815: Typo in Getting started part 4 tutorial

### DIFF
--- a/docs/Getting Started/Setting-Up/part-4.md
+++ b/docs/Getting Started/Setting-Up/part-4.md
@@ -201,7 +201,7 @@ This leaves us with a file looking like:
 
 ```javascript
 var keystone = require('keystone');
-var Event = keystone.list('Event');
+var Event = keystone.List('Event');
 
 module.exports = function (req, res) {
   if (!req.body.name || !req.body.startTime || !req.body.endTime) {


### PR DESCRIPTION
## Description of changes

Fix #4815 (typo in example code for Getting Started, part 4)