### PR TITLE
Add support for filtering based on Relationships

### DIFF
--- a/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -167,7 +167,7 @@ export default class AddFilterPopout extends Component<Props, State> {
     const { field, filter, value } = this.state;
 
     event.preventDefault();
-    if (!filter) return;
+    if (!filter || value === null) return;
 
     onChange({ field, label: filter.label, type: filter.type, value });
   };

--- a/packages/admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -24,7 +24,7 @@ export default class EditFilterPopout extends Component<Props, State> {
   onSubmit = () => {
     const { filter, onChange } = this.props;
     const { value } = this.state;
-
+    if (value === null) return;
     onChange({
       field: filter.field,
       label: filter.label,

--- a/packages/fields/types/Relationship/Controller.js
+++ b/packages/fields/types/Relationship/Controller.js
@@ -14,6 +14,19 @@ export default class RelationshipController extends FieldController {
       }
     `;
   };
+  getFilterGraphQL = ({ type, value }) => {
+    if (type === 'contains') {
+      return `${this.path}_some: {id: "${value}"}`;
+    } else if (type === 'is') {
+      return `${this.path}: {id: "${value}"}`;
+    }
+  };
+  getFilterLabel = ({ label }) => {
+    return `${this.label} ${label.toLowerCase()}`;
+  };
+  formatFilter = ({ label, value }) => {
+    return `${this.getFilterLabel({ label })}: "${value}"`;
+  };
 
   // TODO: FIXME: This should be `set`, not `connect`
   buildRelateToOneInput = ({ id }) => ({ connect: { id } });
@@ -39,5 +52,25 @@ export default class RelationshipController extends FieldController {
     const { defaultValue, many } = this.config;
     return many ? defaultValue || [] : defaultValue || null;
   };
-  getFilterTypes = () => [];
+
+  getFilterTypes = () => {
+    const { many } = this.config;
+    if (many) {
+      return [
+        {
+          type: 'contains',
+          label: 'Contains',
+          getInitialValue: () => null,
+        },
+      ];
+    } else {
+      return [
+        {
+          type: 'is',
+          label: 'Is',
+          getInitialValue: () => null,
+        },
+      ];
+    }
+  };
 }

--- a/packages/fields/types/Relationship/index.js
+++ b/packages/fields/types/Relationship/index.js
@@ -8,6 +8,7 @@ module.exports = {
   views: {
     Controller: path.resolve(__dirname, './Controller'),
     Field: path.resolve(__dirname, './views/Field'),
+    Filter: path.resolve(__dirname, './views/Filter'),
     Cell: path.resolve(__dirname, './views/Cell'),
   },
   adapters: {

--- a/packages/fields/types/Relationship/views/Field.js
+++ b/packages/fields/types/Relationship/views/Field.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
-import { Query } from 'react-apollo';
 
 import { FieldContainer, FieldLabel, FieldInput } from '@voussoir/ui/src/primitives/fields';
-import { Select } from '@voussoir/ui/src/primitives/filters';
 import { ShieldIcon } from '@voussoir/icons';
 import { colors } from '@voussoir/ui/src/theme';
-import { pick } from '@voussoir/utils';
+
+import RelationshipSelect from './RelationshipSelect';
 
 export default class RelationshipField extends Component {
   onChange = option => {
@@ -20,20 +19,10 @@ export default class RelationshipField extends Component {
   render() {
     const { autoFocus, field, item, itemErrors, renderContext } = this.props;
     const { many } = field.config;
-    const refList = field.getRefList();
-    const query = refList.getBasicQuery();
     const htmlID = `ks-input-${field.path}`;
     const canRead = !(
       itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
     );
-
-    const selectProps =
-      renderContext === 'dialog'
-        ? {
-            menuPortalTarget: document.body,
-            menuShouldBlockScroll: true,
-          }
-        : null;
 
     return (
       <FieldContainer>
@@ -54,54 +43,16 @@ export default class RelationshipField extends Component {
           ) : null}
         </FieldLabel>
         <FieldInput>
-          <Query query={query}>
-            {({ data, error, loading }) => {
-              if (loading) {
-                return <Select key="loading" isDisabled isLoading={loading} />;
-              }
-              // TODO: better error UI
-              // TODO: Handle permission errors
-              // (ie; user has permission to read this relationship field, but
-              // not the related list, or some items on the list)
-              if (error) return 'Error';
-
-              const options = data[refList.gqlNames.listQueryName].map(listData => ({
-                value: pick(listData, ['id']),
-                label: listData._label_,
-              }));
-
-              let value = null;
-
-              if (canRead) {
-                if (many) {
-                  if (!Array.isArray(item[field.path])) value = [];
-                  value = item[field.path]
-                    .map(i => options.find(option => option.value.id === i.id))
-                    .filter(i => i);
-                } else if (item[field.path]) {
-                  value = options.find(i => i.value.id === item[field.path].id) || null;
-                }
-              }
-
-              return (
-                <Select
-                  autoFocus={autoFocus}
-                  isMulti={many}
-                  value={value}
-                  placeholder={canRead ? undefined : itemErrors[field.path].message}
-                  getOptionValue={option => option.value.id}
-                  options={options}
-                  onChange={this.onChange}
-                  id={`react-select-${htmlID}`}
-                  isClearable
-                  isLoading={loading}
-                  instanceId={htmlID}
-                  inputId={htmlID}
-                  {...selectProps}
-                />
-              );
-            }}
-          </Query>
+          <RelationshipSelect
+            autoFocus={autoFocus}
+            isMulti={many}
+            field={field}
+            item={item}
+            itemErrors={itemErrors}
+            renderContext={renderContext}
+            htmlID={htmlID}
+            onChange={this.onChange}
+          />
         </FieldInput>
       </FieldContainer>
     );

--- a/packages/fields/types/Relationship/views/Filter.js
+++ b/packages/fields/types/Relationship/views/Filter.js
@@ -1,0 +1,61 @@
+// @flow
+
+import React, { Component, type Ref } from 'react';
+import RelationshipSelect from './RelationshipSelect';
+
+type Props = {
+  field: Object,
+  filter: Object,
+  innerRef: Ref<*>,
+  onChange: Event => void,
+};
+const EventCatcher = props => (
+  <div
+    onClick={e => {
+      e.preventDefault();
+      e.stopPropagation();
+    }}
+    {...props}
+  />
+);
+
+export default class RelationshipFilterView extends Component<Props> {
+  componentDidUpdate(prevProps) {
+    const { filter } = this.props;
+    if (prevProps.filter !== filter) {
+      this.props.recalcHeight();
+    }
+  }
+  handleChange = option => {
+    const { onChange } = this.props;
+    if (option === null) {
+      onChange(null);
+    } else {
+      const { value } = option;
+      if (value) {
+        onChange(value.id);
+      }
+    }
+  };
+
+  render() {
+    const { filter, field, value } = this.props;
+    if (!filter) return null;
+
+    const htmlID = `ks-input-${field.path}`;
+    return (
+      <EventCatcher>
+        <RelationshipSelect
+          field={field}
+          item={null}
+          itemErrors={{}}
+          renderContext={null}
+          htmlID={htmlID}
+          onChange={this.handleChange}
+          value={value}
+          isMulti={false}
+        />
+      </EventCatcher>
+    );
+  }
+}

--- a/packages/fields/types/Relationship/views/RelationshipSelect.js
+++ b/packages/fields/types/Relationship/views/RelationshipSelect.js
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import { Query } from 'react-apollo';
+import { Select } from '@voussoir/ui/src/primitives/filters';
+import { pick } from '@voussoir/utils';
+
+export default class RelationshipSelect extends Component {
+  render() {
+    const {
+      innerRef,
+      autoFocus,
+      field,
+      item,
+      itemErrors,
+      renderContext,
+      htmlID,
+      onChange,
+      value,
+      isMulti,
+    } = this.props;
+    const refList = field.getRefList();
+    const query = refList.getBasicQuery();
+    const canRead = !(
+      itemErrors[field.path] instanceof Error && itemErrors[field.path].name === 'AccessDeniedError'
+    );
+    const selectProps = renderContext === 'dialog' ? { menuShouldBlockScroll: true } : null;
+
+    return (
+      <Query query={query}>
+        {({ data, error, loading }) => {
+          if (loading) {
+            return <Select key="loading" isDisabled isLoading={loading} />;
+          }
+          // TODO: better error UI
+          // TODO: Handle permission errors
+          // (ie; user has permission to read this relationship field, but
+          // not the related list, or some items on the list)
+          if (error) console.log('ERROR!!!', error);
+          if (error) return 'Error';
+
+          const options = data[refList.gqlNames.listQueryName].map(listData => ({
+            value: pick(listData, ['id']),
+            label: listData._label_,
+          }));
+
+          // Collect IDs to represent and convert them into a value.
+          let foo;
+          if (item && canRead) {
+            const fieldValue = item[field.path];
+            if (isMulti) {
+              foo = (Array.isArray(fieldValue) ? fieldValue : []).map(i => i.id);
+            } else if (fieldValue) {
+              foo = fieldValue.id;
+            }
+          } else if (value) {
+            foo = value;
+          }
+
+          let currentValue;
+          if (foo) {
+            currentValue = options.find(option => option.value.id === foo) || null;
+          }
+          return (
+            <Select
+              autoFocus={autoFocus}
+              isMulti={isMulti}
+              value={currentValue}
+              placeholder={canRead ? undefined : itemErrors[field.path].message}
+              getOptionValue={option => option.value.id}
+              options={options}
+              onChange={onChange}
+              id={`react-select-${htmlID}`}
+              isClearable
+              isLoading={loading}
+              instanceId={htmlID}
+              inputId={htmlID}
+              innerRef={innerRef}
+              menuPortalTarget={document.body}
+              {...selectProps}
+            />
+          );
+        }}
+      </Query>
+    );
+  }
+}


### PR DESCRIPTION
This begins to deal with #352.

The PR adds support for filtering based on the ID of the related item. Within the Admin UI, we factor out the `Select` component used for relationships fields in the `Item` view.
