### PR TITLE
Convert .filterTypes to .getFilterTypes()

### DIFF
--- a/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -121,17 +121,17 @@ export default class AddFilterPopout extends Component<Props, State> {
     const existingFieldFilters = this.getExistingFieldFilters(field);
 
     // bail quickly if possibly
-    if (field.filterTypes.length === existingFieldFilters.length) {
+    if (field.getFilterTypes().length === existingFieldFilters.length) {
       return [];
     }
 
     // create a diff of existing filters VS selected field filters
-    return field.filterTypes.filter(x => {
+    return field.getFilterTypes().filter(x => {
       return !existingFieldFilters.filter(y => y.type === x.type).length;
     });
   };
   hasAvailableFilterTypes = field => {
-    if (!field.filterTypes) return false;
+    if (!field.getFilterTypes()) return false;
     return Boolean(this.availableFieldFilterTypes(field).length);
   };
   doesNotHaveAvailableFilterTypes = field => {
@@ -193,7 +193,7 @@ export default class AddFilterPopout extends Component<Props, State> {
 
   getFieldOptions = () => {
     const { fields } = this.props;
-    return fields.filter(f => f.filterTypes && f.filterTypes.length);
+    return fields.filter(f => f.getFilterTypes() && f.getFilterTypes().length);
   };
   renderFieldSelect = ({ ref }) => {
     return (
@@ -238,7 +238,7 @@ export default class AddFilterPopout extends Component<Props, State> {
   };
   renderFilterUI = ({ ref, recalcHeight }) => {
     const { field, filter } = this.state;
-    const options = field.filterTypes;
+    const options = field.getFilterTypes();
 
     return (
       <Transition

--- a/packages/admin-ui/client/pages/List/url-state.js
+++ b/packages/admin-ui/client/pages/List/url-state.js
@@ -94,7 +94,7 @@ const parseFilter = (filter: [string, string], list): Filter | null => {
   let label;
   const field = list.fields.find(f => {
     if (key.indexOf(f.path) !== 0) return false;
-    const filterType = f.filterTypes.find(t => {
+    const filterType = f.getFilterTypes().find(t => {
       return key === `${f.path}_${t.type}`;
     });
     if (filterType) {

--- a/packages/fields/types/CalendarDay/Controller.js
+++ b/packages/fields/types/CalendarDay/Controller.js
@@ -14,7 +14,7 @@ export default class CalendarDayController extends FieldController {
   getValue = data => {
     return data[this.config.path];
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is exactly',

--- a/packages/fields/types/Checkbox/Controller.js
+++ b/packages/fields/types/Checkbox/Controller.js
@@ -13,7 +13,7 @@ export default class CheckboxController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is',

--- a/packages/fields/types/DateTime/Controller.js
+++ b/packages/fields/types/DateTime/Controller.js
@@ -14,7 +14,7 @@ export default class DateTimeController extends FieldController {
   getValue = data => {
     return data[this.config.path];
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is exactly',

--- a/packages/fields/types/File/Controller.js
+++ b/packages/fields/types/File/Controller.js
@@ -19,4 +19,5 @@ export default class FileController extends FieldController {
        publicUrl
     }
   `;
+  getFilterTypes = () => [];
 }

--- a/packages/fields/types/Float/Controller.js
+++ b/packages/fields/types/Float/Controller.js
@@ -23,7 +23,7 @@ export default class TextController extends FieldController {
       return null;
     }
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is exactly',

--- a/packages/fields/types/Integer/Controller.js
+++ b/packages/fields/types/Integer/Controller.js
@@ -23,7 +23,7 @@ export default class TextController extends FieldController {
       return null;
     }
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is exactly',

--- a/packages/fields/types/Password/Controller.js
+++ b/packages/fields/types/Password/Controller.js
@@ -14,7 +14,7 @@ export default class PasswordController extends FieldController {
   // Passwords don't expose their own value like most fields
   getQueryFragment = () => `${this.path}_is_set`;
 
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is_set',
       label: 'Is Set',

--- a/packages/fields/types/Relationship/Controller.js
+++ b/packages/fields/types/Relationship/Controller.js
@@ -39,4 +39,5 @@ export default class RelationshipController extends FieldController {
     const { defaultValue, many } = this.config;
     return many ? defaultValue || [] : defaultValue || null;
   };
+  getFilterTypes = () => [];
 }

--- a/packages/fields/types/Select/Controller.js
+++ b/packages/fields/types/Select/Controller.js
@@ -46,7 +46,7 @@ export default class SelectController extends FieldController {
       ? `${this.label} is not ${optionLabel}`
       : `${this.label} is ${optionLabel}`;
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'is',
       label: 'Matches',

--- a/packages/fields/types/Text/Controller.js
+++ b/packages/fields/types/Text/Controller.js
@@ -11,7 +11,7 @@ export default class TextController extends FieldController {
   formatFilter = ({ label, value }) => {
     return `${this.getFilterLabel({ label })}: "${value}"`;
   };
-  filterTypes = [
+  getFilterTypes = () => [
     {
       type: 'contains',
       label: 'Contains',


### PR DESCRIPTION
This PR converts the `FilterController` attribute `.filterTypes` into a method `.getFilterTypes)_`.

The motivation for this is the `Relationship` type, where a `many` relationship wants to have a `contains` filter, whereas the non-`many` relationships want to have an `is` filter.
