### PR TITLE
DOCS: Fix typo for TextArray Field

### DIFF
--- a/fields/types/textarray/Readme.md
+++ b/fields/types/textarray/Readme.md
@@ -1,6 +1,10 @@
-# Textarray Field
+# TextArray Field
 
 Stores an `Array` of `String` values in the model.
+
+```js
+{ type: Types.TextArray }
+```
 
 ## Options
 

--- a/website/data/navigation.js
+++ b/website/data/navigation.js
@@ -276,7 +276,7 @@ export const api = {
 				label: 'Textarea',
 				slug: '/textarea',
 			}, {
-				label: 'Textarray',
+				label: 'TextArray',
 				slug: '/textarray',
 			}, {
 				label: 'URL',


### PR DESCRIPTION
## Description of changes

Fixed typo + added example as per other docs pages.