### PR TITLE
Show selected styles in nav even if there is a search query

### DIFF
--- a/packages/admin-ui/client/components/Nav.js
+++ b/packages/admin-ui/client/components/Nav.js
@@ -53,7 +53,7 @@ const Nav = props => {
           if (maybeSearchParam) {
             href += maybeSearchParam;
           }
-          const isSelected = href === location.pathname;
+          const isSelected = href === location.pathname + location.search;
 
           return (
             <Fragment key={key}>


### PR DESCRIPTION
This makes it so that even if there is a search query in the url because the columns were changed, filters were the changed or etc. the button in the nav still shows that that list is selected.