### PR TITLE
Fixed incorrectly named API method label (fixes #4825)

### DIFF
--- a/website/data/navigation.js
+++ b/website/data/navigation.js
@@ -121,7 +121,7 @@ export const api = {
 			section: 'Methods',
 			slug: '/methods',
 			items: [{
-				label: 'openDatabaseConnection()',
+				label: 'closeDatabaseConnection()',
 				slug: '/close-database-connection',
 			}, {
 				label: 'createItems()',


### PR DESCRIPTION
Fixes the doc issue I noticed in #4825.
