### PR TITLE
Update options.md

### DIFF
--- a/docs/api/Field/options.md
+++ b/docs/api/Field/options.md
@@ -46,7 +46,7 @@ Displays an **+ add** link in the admin UI when the field has no value. Will com
 
 <h4 data-primitive-type="Object|Array"><code>dependsOn</code></h4>
 
-The field or header will only be displayed when the paths specified in the object match the current data for the item. You can target multiple values per path using an Array. The contents of dependsOn are passed to [expression match](npmjs.com/package/expression-match), if you want to form more complex queries.
+The field or header will only be displayed when the paths specified in the object match the current data for the item. You can target multiple values per path using an Array. The contents of dependsOn are passed to [expression match](http://npmjs.com/package/expression-match), if you want to form more complex queries.
 
 **Example**
 


### PR DESCRIPTION
Link is broken without `http://`

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

