### PR TITLE
Add _req_user to removed item so you can use this in the remove pre/p…

### DIFF
--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -38,6 +38,7 @@ module.exports = function (req, res) {
 			return res.apiError('database error', err);
 		}
 		async.forEachLimit(results, 10, function (item, next) {
+			item._req_user = req.user;
 			item.remove(function (err) {
 				if (err) return next(err);
 				deletedCount++;


### PR DESCRIPTION
…ost hook

As discussed in https://github.com/keystonejs/keystone/issues/1857 the remove pre/post hooks are "missing" the _req_user. I, amongst others, am using this object to handle some permissions. It's available in the updateHandler (in `create` and `update`) but missing in `remove`.

it's added on the updateHandler here: https://github.com/keystonejs/keystone/blob/d34f45662eb359e2cb18b397f2ffea21f9883141/lib/list/updateItem.js#L157

Remove doesn't use the updateHandler, so this is missing.

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

