### PR TITLE
Return a 500 error when `item.remove` fails

### DIFF
--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -44,7 +44,12 @@ module.exports = function (req, res) {
 				deletedIds.push(item.id);
 				next();
 			});
-		}, function () {
+		}, function (err) {
+			if (err) {
+				return res.apiError({
+					error: err.message,
+				});
+			}
 			return res.json({
 				success: true,
 				ids: deletedIds,

--- a/admin/server/api/list/delete.js
+++ b/admin/server/api/list/delete.js
@@ -45,11 +45,7 @@ module.exports = function (req, res) {
 				next();
 			});
 		}, function (err) {
-			if (err) {
-				return res.apiError({
-					error: err.message,
-				});
-			}
+			if (err) return res.apiError(err);
 			return res.json({
 				success: true,
 				ids: deletedIds,


### PR DESCRIPTION
Currently, errors from `item.remove` are not handled at all in the callback. This gives an empty 200 back to the frontend, which will do nothing with this response (no visual feedback on the error).
We should return an actual error. All suggestions on how to return this error Keystone style are welcome.

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

