### PR TITLE
fix: fields explorer invalid capitilisations

### DIFF
--- a/fields/types/datearray/test/explorer.js
+++ b/fields/types/datearray/test/explorer.js
@@ -1,6 +1,6 @@
 module.exports = {
-	Field: require('../DatearrayField'),
-	Filter: require('../DatearrayFilter'),
+	Field: require('../DateArrayField'),
+	Filter: require('../DateArrayFilter'),
 	section: 'Date',
 	spec: {
 		label: 'Datearray',

--- a/fields/types/geopoint/test/explorer.js
+++ b/fields/types/geopoint/test/explorer.js
@@ -1,6 +1,6 @@
 module.exports = {
-	Field: require('../GeopointField'),
-	Filter: require('../GeopointFilter'),
+	Field: require('../GeoPointField'),
+	Filter: require('../GeoPointFilter'),
 	section: 'Miscellaneous',
 	spec: {
 		label: 'Geopoint',

--- a/fields/types/numberarray/test/explorer.js
+++ b/fields/types/numberarray/test/explorer.js
@@ -1,6 +1,6 @@
 module.exports = {
-	Field: require('../NumberarrayField'),
-	Filter: require('../NumberarrayFilter'),
+	Field: require('../NumberArrayField'),
+	Filter: require('../NumberArrayFilter'),
 	section: 'Number',
 	spec: {
 		label: 'Numberarray',

--- a/fields/types/textarray/test/explorer.js
+++ b/fields/types/textarray/test/explorer.js
@@ -1,6 +1,6 @@
 module.exports = {
-	Field: require('../TextarrayField'),
-	Filter: require('../TextarrayFilter'),
+	Field: require('../TextArrayField'),
+	Filter: require('../TextArrayFilter'),
 	section: 'Text',
 	spec: {
 		label: 'Textarray',


### PR DESCRIPTION
There were a few invalid capitilisations stopping the fields explorer `npm run fields-explorer` from running correctly - haven't done any deeper testing yet
