### PR TITLE
Remove **/filterTests.js from .npmignore in packages which don't need it

### DIFF
--- a/packages/access-control/.npmignore
+++ b/packages/access-control/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/adapter-mongoose/.npmignore
+++ b/packages/adapter-mongoose/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/admin-ui/.npmignore
+++ b/packages/admin-ui/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/field-views-loader/.npmignore
+++ b/packages/field-views-loader/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/file-adapters/.npmignore
+++ b/packages/file-adapters/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/icons/.npmignore
+++ b/packages/icons/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/logger/.npmignore
+++ b/packages/logger/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/mongo-join-builder/.npmignore
+++ b/packages/mongo-join-builder/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/server/.npmignore
+++ b/packages/server/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/test-utils/.npmignore
+++ b/packages/test-utils/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/ui/.npmignore
+++ b/packages/ui/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -1,3 +1,2 @@
 **/*.md
 **/*.test.js
-**/filterTests.js


### PR DESCRIPTION
Closes #442 