### PR TITLE
RELEASING: Releasing 19 package(s)

### DIFF
--- a/packages/access-control/CHANGELOG.md
+++ b/packages/access-control/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @voussoir/access-control
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/utils@0.2.0
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/access-control/package.json
+++ b/packages/access-control/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@voussoir/access-control",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Jess Telford",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/utils": "^0.1.2"
+    "@voussoir/utils": "^0.2.0"
   }
 }

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @voussoir/adapter-mongoose
 
+## 0.3.0
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [minor] Support unique field constraint for mongoose adapter [750a83e](750a83e)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/core@0.3.0
+  - @voussoir/mongo-join-builder@0.1.3
+  - @voussoir/utils@0.2.0
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@voussoir/adapter-mongoose",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/logger": "^0.1.2",
-    "@voussoir/mongo-join-builder": "^0.1.2",
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/logger": "^0.1.3",
+    "@voussoir/mongo-join-builder": "^0.1.3",
+    "@voussoir/utils": "^0.2.0",
     "inflection": "^1.12.0",
     "mongodb-memory-server": "^2.4.3",
     "mongoose": "^5.3.3",

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @voussoir/admin-ui
 
+## 0.2.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [9c75136](9c75136)
+- [patch] Updated dependencies [750a83e](750a83e)
+  - @voussoir/fields@1.0.0
+  - @voussoir/utils@0.2.0
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@voussoir/admin-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/field-views-loader": "^0.1.2",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/icons": "^0.1.2",
-    "@voussoir/ui": "^0.2.0",
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/field-views-loader": "^0.1.3",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/icons": "^0.1.3",
+    "@voussoir/ui": "^0.2.1",
+    "@voussoir/utils": "^0.2.0",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",
     "apollo-link": "^1.2.3",

--- a/packages/arch/CHANGELOG.md
+++ b/packages/arch/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @arch-ui/core
 
+## 0.1.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.1.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/arch/package.json
+++ b/packages/arch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arch-ui/core",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "author": "Joss Mackison",
   "license": "MIT",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @voussoir/core
 
+## 0.3.0
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [minor] Support unique field constraint for mongoose adapter [750a83e](750a83e)
+- [patch] Surface errors that occur at the adapter level during a create mutation. [81641b2](81641b2)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/fields@1.0.0
+  - @voussoir/access-control@0.1.3
+  - @voussoir/utils@0.2.0
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@voussoir/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/access-control": "^0.1.2",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/logger": "^0.1.2",
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/access-control": "^0.1.3",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/logger": "^0.1.3",
+    "@voussoir/utils": "^0.2.0",
     "apollo-errors": "^1.9.0",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.8.0",

--- a/packages/field-views-loader/CHANGELOG.md
+++ b/packages/field-views-loader/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @voussoir/field-views-loader
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/field-views-loader/package.json
+++ b/packages/field-views-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voussoir/field-views-loader",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A webpack loader used to load all thew field views used in an app",
   "main": "index.js",
   "author": "Jed Watson",

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @voussoir/fields
 
+## 1.0.0
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [major] `Text` fields now default to case sensitive filtering. Insensitive filters available via the `_i` suffix (eg. `name: "Jane"` -vs- `name_i: "jane"`). This replaces the `${path}_case_sensitive` boolean that could previously be specified when using `Text` field filters. This is all covered in more detail in #359. [445b699](445b699)
+- [minor] Support unique field constraint for mongoose adapter [750a83e](750a83e)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/access-control@0.1.3
+  - @voussoir/adapter-mongoose@0.3.0
+  - @voussoir/utils@0.2.0
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,18 +1,18 @@
 {
   "name": "@voussoir/fields",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/access-control": "^0.1.2",
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/icons": "^0.1.2",
-    "@voussoir/logger": "^0.1.2",
-    "@voussoir/ui": "^0.2.0",
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/access-control": "^0.1.3",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/icons": "^0.1.3",
+    "@voussoir/logger": "^0.1.3",
+    "@voussoir/ui": "^0.2.1",
+    "@voussoir/utils": "^0.2.0",
     "apollo-errors": "^1.9.0",
     "bcrypt": "^3.0.0",
     "cuid": "^2.1.1",
@@ -35,7 +35,7 @@
     "react": "^16.5.2"
   },
   "devDependencies": {
-    "@voussoir/test-utils": "^0.0.0",
+    "@voussoir/test-utils": "^0.0.1",
     "cuid": "^2.1.1",
     "supertest-light": "^1.0.2"
   }

--- a/packages/file-adapters/CHANGELOG.md
+++ b/packages/file-adapters/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @voussoir/file-adapters
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/file-adapters/package.json
+++ b/packages/file-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voussoir/file-adapters",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Adapters for handling storage of the File type",
   "main": "index.js",
   "repository": "https://github.com/keystonejs/keystone-5.git",

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @voussoir/icons
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voussoir/icons",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Jed Watson",
   "license": "MIT",
   "main": "index.js",

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @voussoir/logger
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voussoir/logger",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {

--- a/packages/mongo-join-builder/CHANGELOG.md
+++ b/packages/mongo-join-builder/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @voussoir/mongo-join-builder
 
+## 0.1.3
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/utils@0.2.0
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/mongo-join-builder/package.json
+++ b/packages/mongo-join-builder/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@voussoir/mongo-join-builder",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Jess Telford",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/utils": "^0.2.0",
     "cuid": "^2.1.1"
   },
   "devDependencies": {

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @voussoir/server
 
+## 0.2.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [9c75136](9c75136)
+  - @voussoir/utils@0.2.0
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,26 +1,26 @@
 {
   "name": "@voussoir/server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/logger": "^0.1.2",
-    "@voussoir/utils": "^0.1.2",
-    "apollo-server-express": "^2.1.0",
+    "@voussoir/logger": "^0.1.3",
+    "@voussoir/utils": "^0.2.0",
     "apollo-errors": "^1.9.0",
+    "apollo-server-express": "^2.1.0",
     "body-parser": "^1.18.2",
-    "cuid": "^2.1.1",
     "cookie": "^0.3.1",
     "cookie-signature": "^1.1.0",
     "cors": "^2.8.4",
+    "cuid": "^2.1.1",
     "express": "^4.16.3",
     "express-pino-logger": "^4.0.0",
+    "express-session": "^1.15.6",
     "falsey": "^1.0.0",
     "fast-memoize": "^2.4.0",
-    "express-session": "^1.15.6",
     "graphql": "^0.13.2",
     "graphql-playground-html": "^1.6.0"
   }

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @voussoir/test-utils
+
+## 0.0.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@voussoir/test-utils",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/server": "^0.2.0",
-    "@voussoir/utils": "^0.1.2",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/server": "^0.2.1",
+    "@voussoir/utils": "^0.2.0",
     "extract-stack": "^1.0.0",
     "mongodb-memory-server": "^2.4.3",
     "p-finally": "^1.0.0",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,8 @@
 # @voussoir/ui
 
+## 0.2.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+
 ## 0.2.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@voussoir/ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@voussoir/icons": "^0.1.2",
+    "@voussoir/icons": "^0.1.3",
     "date-fns": "^1.29.0",
     "emotion": "^9.1.1",
     "focus-trap": "^2.4.3",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @voussoir/utils
 
+## 0.2.0
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [minor] Added createLazyDeferred method [9c75136](9c75136)
+
 ## 0.1.2
 
 - [patch] Rename readme files [a8b995e](a8b995e)

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voussoir/utils",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {

--- a/projects/access-control/CHANGELOG.md
+++ b/projects/access-control/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @voussoir/cypress-project-access-control
 
+## 1.0.2
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [9c75136](9c75136)
+- [patch] Updated dependencies [750a83e](750a83e)
+  - @voussoir/admin-ui@0.2.1
+  - @voussoir/core@0.3.0
+  - @voussoir/fields@1.0.0
+  - @voussoir/adapter-mongoose@0.3.0
+  - @voussoir/server@0.2.1
+  - @voussoir/utils@0.2.0
+
 ## 1.0.1
 
 - [patch] Updated dependencies [fed0cdc](fed0cdc)

--- a/projects/access-control/package.json
+++ b/projects/access-control/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voussoir/cypress-project-access-control",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
@@ -17,13 +17,13 @@
     "cypress:open": "if [ -f .env ]; then yarn prepare-test-server cypress:open:cmd; else echo \"\nError: Must create a projects/access-control/.env file.\nSee projects/access-control/.env.example for values\n\"; exit 1; fi"
   },
   "dependencies": {
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/admin-ui": "^0.2.0",
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/server": "^0.2.0",
-    "@voussoir/ui": "^0.2.0",
-    "@voussoir/utils": "^0.1.0",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/admin-ui": "^0.2.1",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/server": "^0.2.1",
+    "@voussoir/ui": "^0.2.1",
+    "@voussoir/utils": "^0.2.0",
     "dotenv-safe": "^6.0.0",
     "react": "^16.5.2"
   },

--- a/projects/basic/CHANGELOG.md
+++ b/projects/basic/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @voussoir/cypress-project-basic
 
+## 1.1.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [9c75136](9c75136)
+- [patch] Updated dependencies [750a83e](750a83e)
+  - @voussoir/admin-ui@0.2.1
+  - @voussoir/core@0.3.0
+  - @voussoir/fields@1.0.0
+  - @voussoir/adapter-mongoose@0.3.0
+  - @voussoir/server@0.2.1
+  - @voussoir/utils@0.2.0
+
 ## 1.1.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/projects/basic/package.json
+++ b/projects/basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voussoir/cypress-project-basic",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
@@ -17,20 +17,20 @@
     "cypress:open": "if [ -f .env ]; then yarn prepare-test-server cypress:open:cmd; else echo \"\nError: Must create a projects/basic/.env file.\nSee projects/basic/.env.example for values\n\"; exit 1; fi"
   },
   "dependencies": {
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/admin-ui": "^0.2.0",
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/file-adapters": "^0.1.0",
-    "@voussoir/server": "^0.2.0",
-    "@voussoir/ui": "^0.2.0",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/admin-ui": "^0.2.1",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/file-adapters": "^0.1.3",
+    "@voussoir/server": "^0.2.1",
+    "@voussoir/ui": "^0.2.1",
     "date-fns": "^1.29.0",
     "dotenv-safe": "^6.0.0",
     "react": "^16.5.2"
   },
   "devDependencies": {
-    "@voussoir/test-utils": "^0.0.0",
-    "@voussoir/utils": "^0.1.0",
+    "@voussoir/test-utils": "^0.0.1",
+    "@voussoir/utils": "^0.2.0",
     "cuid": "^2.1.1",
     "cypress": "^3.1.0",
     "execa": "1.0.0",

--- a/projects/login/CHANGELOG.md
+++ b/projects/login/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @voussoir/cypress-project-login
 
+## 1.1.1
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [9c75136](9c75136)
+- [patch] Updated dependencies [750a83e](750a83e)
+  - @voussoir/admin-ui@0.2.1
+  - @voussoir/core@0.3.0
+  - @voussoir/fields@1.0.0
+  - @voussoir/adapter-mongoose@0.3.0
+  - @voussoir/server@0.2.1
+  - @voussoir/utils@0.2.0
+
 ## 1.1.0
 
 - [minor] Add missing dependencies for which the mono-repo was hiding that they were missing [fed0cdc](fed0cdc)

--- a/projects/login/package.json
+++ b/projects/login/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voussoir/cypress-project-login",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
@@ -17,20 +17,20 @@
     "cypress:open": "if [ -f .env ]; then yarn prepare-test-server cypress:open:cmd; else echo \"\nError: Must create a projects/login/.env file.\nSee projects/login/.env.example for values\n\"; exit 1; fi"
   },
   "dependencies": {
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/admin-ui": "^0.2.0",
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/server": "^0.2.0",
-    "@voussoir/ui": "^0.2.0",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/admin-ui": "^0.2.1",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/server": "^0.2.1",
+    "@voussoir/ui": "^0.2.1",
     "body-parser": "^1.18.2",
     "cookie-signature": "^1.1.0",
     "dotenv-safe": "^6.0.0",
     "react": "^16.5.2"
   },
   "devDependencies": {
-    "@voussoir/test-utils": "^0.0.0",
-    "@voussoir/utils": "^0.1.0",
+    "@voussoir/test-utils": "^0.0.1",
+    "@voussoir/utils": "^0.2.0",
     "cuid": "^2.1.1",
     "cypress": "^3.1.0",
     "execa": "1.0.0",

--- a/projects/twitter-login/CHANGELOG.md
+++ b/projects/twitter-login/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @voussoir/cypress-project-twitter-login
 
+## 1.0.2
+- [patch] Bump all packages for Babel config fixes [d51c833](d51c833)
+- [patch] Updated dependencies [445b699](445b699)
+- [patch] Updated dependencies [750a83e](750a83e)
+  - @voussoir/admin-ui@0.2.1
+  - @voussoir/core@0.3.0
+  - @voussoir/fields@1.0.0
+  - @voussoir/adapter-mongoose@0.3.0
+
 ## 1.0.1
 
 - [patch] Updated dependencies [fed0cdc](fed0cdc)

--- a/projects/twitter-login/package.json
+++ b/projects/twitter-login/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@voussoir/cypress-project-twitter-login",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Jed Watson",
   "license": "MIT",
   "engines": {
@@ -13,13 +13,13 @@
     "cypress:run": "exit 0"
   },
   "dependencies": {
-    "@voussoir/adapter-mongoose": "^0.2.0",
-    "@voussoir/admin-ui": "^0.2.0",
-    "@voussoir/core": "^0.2.0",
-    "@voussoir/fields": "^0.2.0",
-    "@voussoir/file-adapters": "^0.1.0",
-    "@voussoir/server": "^0.2.0",
-    "@voussoir/ui": "^0.2.0",
+    "@voussoir/adapter-mongoose": "^0.3.0",
+    "@voussoir/admin-ui": "^0.2.1",
+    "@voussoir/core": "^0.3.0",
+    "@voussoir/fields": "^1.0.0",
+    "@voussoir/file-adapters": "^0.1.3",
+    "@voussoir/server": "^0.2.1",
+    "@voussoir/ui": "^0.2.1",
     "dotenv-safe": "^6.0.0",
     "react": "^16.5.2"
   },


### PR DESCRIPTION
Releases:
  @voussoir/access-control@0.1.3
  @voussoir/adapter-mongoose@0.3.0
  @voussoir/admin-ui@0.2.1
  @arch-ui/core@0.1.1
  @voussoir/core@0.3.0
  @voussoir/field-views-loader@0.1.3
  @voussoir/fields@1.0.0
  @voussoir/file-adapters@0.1.3
  @voussoir/icons@0.1.3
  @voussoir/logger@0.1.3
  @voussoir/mongo-join-builder@0.1.3
  @voussoir/server@0.2.1
  @voussoir/test-utils@0.0.1
  @voussoir/ui@0.2.1
  @voussoir/utils@0.2.0
  @voussoir/cypress-project-access-control@1.0.2
  @voussoir/cypress-project-basic@1.1.1
  @voussoir/cypress-project-login@1.1.1
  @voussoir/cypress-project-twitter-login@1.0.2

Dependents:
  []

Deleted:
  []

---
{"releases":[{"name":"@voussoir/access-control","commits":["d51c833","9c75136"],"version":"0.1.3"},{"name":"@voussoir/adapter-mongoose","commits":["d51c833","9c75136","750a83e"],"version":"0.3.0"},{"name":"@voussoir/admin-ui","commits":["d51c833","445b699","9c75136","750a83e"],"version":"0.2.1"},{"name":"@arch-ui/core","commits":["d51c833"],"version":"0.1.1"},{"name":"@voussoir/core","commits":["d51c833","445b699","9c75136","750a83e","81641b2"],"version":"0.3.0"},{"name":"@voussoir/field-views-loader","commits":["d51c833"],"version":"0.1.3"},{"name":"@voussoir/fields","commits":["d51c833","445b699","9c75136","750a83e"],"version":"1.0.0"},{"name":"@voussoir/file-adapters","commits":["d51c833"],"version":"0.1.3"},{"name":"@voussoir/icons","commits":["d51c833"],"version":"0.1.3"},{"name":"@voussoir/logger","commits":["d51c833"],"version":"0.1.3"},{"name":"@voussoir/mongo-join-builder","commits":["d51c833","9c75136"],"version":"0.1.3"},{"name":"@voussoir/server","commits":["d51c833","9c75136"],"version":"0.2.1"},{"name":"@voussoir/test-utils","commits":["d51c833"],"version":"0.0.1"},{"name":"@voussoir/ui","commits":["d51c833"],"version":"0.2.1"},{"name":"@voussoir/utils","commits":["d51c833","9c75136"],"version":"0.2.0"},{"name":"@voussoir/cypress-project-access-control","commits":["d51c833","445b699","9c75136","750a83e"],"version":"1.0.2"},{"name":"@voussoir/cypress-project-basic","commits":["d51c833","445b699","9c75136","750a83e"],"version":"1.1.1"},{"name":"@voussoir/cypress-project-login","commits":["d51c833","445b699","9c75136","750a83e"],"version":"1.1.1"},{"name":"@voussoir/cypress-project-twitter-login","commits":["d51c833","445b699","750a83e"],"version":"1.0.2"}],"changesets":[{"commit":"d51c833","summary":"Bump all packages for Babel config fixes"},{"commit":"445b699","summary":"`Text` fields now default to case sensitive filtering. Insensitive filters available via the `_i` suffix (eg. `name: \"Jane\"` -vs- `name_i: \"jane\"`). This replaces the `${path}_case_sensitive` boolean that could previously be specified when using `Text` field filters. This is all covered in more detail in #359."},{"commit":"9c75136","summary":"Added createLazyDeferred method"},{"commit":"750a83e","summary":"Support unique field constraint for mongoose adapter"},{"commit":"81641b2","summary":"Surface errors that occur at the adapter level during a create mutation."}]}
---

[skip ci]