### PR TITLE
Bug #4840 - Fix UTC DateColumn value display

### DIFF
--- a/fields/types/date/DateColumn.js
+++ b/fields/types/date/DateColumn.js
@@ -10,12 +10,19 @@ var DateColumn = React.createClass({
 		data: React.PropTypes.object,
 		linkTo: React.PropTypes.string,
 	},
+	toMoment (value) {
+		if (this.props.col.field.isUTC) {
+			return moment.utc(value);
+		} else {
+			return moment(value);
+		}
+	},
 	getValue () {
 		const value = this.props.data.fields[this.props.col.path];
 		if (!value) return null;
 
 		const format = (this.props.col.type === 'datetime') ? 'MMMM Do YYYY, h:mm:ss a' : 'MMMM Do YYYY';
-		return moment(value).format(format);
+		return this.toMoment(value).format(format);
 	},
 	render () {
 		const value = this.getValue();


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
- Added `toMoment()` method to allow Moment.js to use utc dates.
-Updated `getValue()` to use `toMoment()` for proper output of UTC dates.

## Related issues (if any)
https://github.com/keystonejs/keystone/issues/4840

## Testing

 - [All latest - Chrome, Fiexfox, IE11, Edge] List browser version(s) any admin UI changes were tested in:
 - [verified] Please confirm you've added (or verified) test coverage for this change.
 - [X] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

