### PR TITLE
Use require.resolve(path) instead of path.resolve(__dirname, path) in field types

### DIFF
--- a/packages/fields/types/CalendarDay/index.js
+++ b/packages/fields/types/CalendarDay/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { CalendarDay, MongoCalendarDayInterface } = require('./Implementation');
 
 module.exports = {
   type: 'CalendarDay',
   implementation: CalendarDay,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoCalendarDayInterface,

--- a/packages/fields/types/Checkbox/index.js
+++ b/packages/fields/types/Checkbox/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { Checkbox, MongoCheckboxInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Checkbox',
   implementation: Checkbox,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoCheckboxInterface,

--- a/packages/fields/types/CloudinaryImage/index.js
+++ b/packages/fields/types/CloudinaryImage/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { CloudinaryImage, MongoCloudinaryImageInterface } = require('./Implementation');
 
 module.exports = {
   type: 'CloudinaryImage',
   implementation: CloudinaryImage,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoCloudinaryImageInterface,

--- a/packages/fields/types/Color/index.js
+++ b/packages/fields/types/Color/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { Text, MongoTextInterface } = require('../Text/Implementation');
 
 module.exports = {
   type: 'Color',
   implementation: Text,
   views: {
-    Controller: path.resolve(__dirname, '../Text/Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Cell: path.resolve(__dirname, './views/Cell'),
-    Filter: path.resolve(__dirname, '../Text/views/Filter'),
+    Controller: require.resolve('../Text/Controller'),
+    Field: require.resolve('./views/Field'),
+    Cell: require.resolve('./views/Cell'),
+    Filter: require.resolve('../Text/views/Filter'),
   },
   adapters: {
     mongoose: MongoTextInterface,

--- a/packages/fields/types/DateTime/index.js
+++ b/packages/fields/types/DateTime/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { DateTime, MongoDateTimeInterface } = require('./Implementation');
 
 module.exports = {
   type: 'DateTime',
   implementation: DateTime,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoDateTimeInterface,

--- a/packages/fields/types/File/index.js
+++ b/packages/fields/types/File/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { File, MongoFileInterface } = require('./Implementation');
 
 module.exports = {
   type: 'File',
   implementation: File,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoFileInterface,

--- a/packages/fields/types/Float/index.js
+++ b/packages/fields/types/Float/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { Float, MongoFloatInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Float',
   implementation: Float,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
   },
   adapters: {
     mongoose: MongoFloatInterface,

--- a/packages/fields/types/Integer/index.js
+++ b/packages/fields/types/Integer/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { Integer, MongoIntegerInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Integer',
   implementation: Integer,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
   },
   adapters: {
     mongoose: MongoIntegerInterface,

--- a/packages/fields/types/Password/index.js
+++ b/packages/fields/types/Password/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { Password, MongoPasswordInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Password',
   implementation: Password,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
   },
   adapters: {
     mongoose: MongoPasswordInterface,

--- a/packages/fields/types/Relationship/index.js
+++ b/packages/fields/types/Relationship/index.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { Relationship, MongoSelectInterface } = require('./Implementation');
 
 module.exports = {
@@ -6,10 +5,10 @@ module.exports = {
   isRelationship: true, // Used internally for this special case
   implementation: Relationship,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoSelectInterface,

--- a/packages/fields/types/Select/index.js
+++ b/packages/fields/types/Select/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { Select, MongoSelectInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Select',
   implementation: Select,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoSelectInterface,

--- a/packages/fields/types/Text/index.js
+++ b/packages/fields/types/Text/index.js
@@ -1,13 +1,12 @@
-const path = require('path');
 const { Text, MongoTextInterface } = require('./Implementation');
 
 module.exports = {
   type: 'Text',
   implementation: Text,
   views: {
-    Controller: path.resolve(__dirname, './Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, './views/Filter'),
+    Controller: require.resolve('./Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('./views/Filter'),
   },
   adapters: {
     mongoose: MongoTextInterface,

--- a/packages/fields/types/Url/index.js
+++ b/packages/fields/types/Url/index.js
@@ -1,14 +1,13 @@
-const path = require('path');
 const { Text, MongoTextInterface } = require('../Text/Implementation');
 
 module.exports = {
   type: 'Url',
   implementation: Text,
   views: {
-    Controller: path.resolve(__dirname, '../Text/Controller'),
-    Field: path.resolve(__dirname, './views/Field'),
-    Filter: path.resolve(__dirname, '../Text/views/Filter'),
-    Cell: path.resolve(__dirname, './views/Cell'),
+    Controller: require.resolve('../Text/Controller'),
+    Field: require.resolve('./views/Field'),
+    Filter: require.resolve('../Text/views/Filter'),
+    Cell: require.resolve('./views/Cell'),
   },
   adapters: {
     mongoose: MongoTextInterface,


### PR DESCRIPTION
I was working on the docs for #372 and it seemed weird to use 1path.resolve(__dirname, path)1 to resolve a module when `require.resolve` is made for exactly this purpose and doesn't require passing in a directory or importing `path`.