### PR TITLE
File field thumb option support mimetype

### DIFF
--- a/fields/types/file/FileField.js
+++ b/fields/types/file/FileField.js
@@ -80,7 +80,8 @@ module.exports = Field.create({
 	},
 	isImage () {
 		const href = this.props.value ? this.props.value.url : undefined;
-		return href && href.match(/\.(jpeg|jpg|gif|png|svg)$/i) != null;
+		return (href && href.match(/\.(jpeg|jpg|gif|png|svg)$/i) != null) || 
+			(this.props.value.mimetype && this.props.value.mimetype.indexOf('image/') >=0 );
 	},
 
 	// ==============================


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes

Add checking image by mime type to isImage() function in File type

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->
