### PR TITLE
Consolidate mongoose schema pre/post hooks for field types

### DIFF
--- a/.changeset/45c75180/changes.json
+++ b/.changeset/45c75180/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@voussoir/adapter-mongoose", "type": "patch" },
+    { "name": "@voussoir/fields", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/45c75180/changes.md
+++ b/.changeset/45c75180/changes.md
@@ -1,0 +1,1 @@
+- Consolidate mongoose schema pre/post hooks for field types

--- a/packages/adapter-mongoose/CHANGELOG.md
+++ b/packages/adapter-mongoose/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @voussoir/adapter-mongoose
 
 ## 0.4.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
   - @voussoir/core@0.6.0

--- a/packages/admin-ui/CHANGELOG.md
+++ b/packages/admin-ui/CHANGELOG.md
@@ -1,8 +1,9 @@
 # @voussoir/admin-ui
 
 ## 0.5.0
+
 - [minor] 1d30a329"
-:
+  :
 
   - Cleanup vertical navigation, more separation between primary/secondary nav primitives
 

--- a/packages/apollo-helpers/CHANGELOG.md
+++ b/packages/apollo-helpers/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @voussoir/apollo-helpers
 
 ## 0.3.0
+
 - [minor] 7f64792:
 
   Add @voussoir/apollo-helpers package for cache busting goodness

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,12 +1,15 @@
 # @voussoir/core
 
 ## 0.6.0
+
 - [minor] d94b517:
 
-  Add _ksListsMeta query to gather type and relationship information
+  Add \_ksListsMeta query to gather type and relationship information
+
 - [minor] a3b995c:
 
-  Add _ksListsMeta query to gather type and relationship information
+  Add \_ksListsMeta query to gather type and relationship information
+
 - [patch] ca7ce46:
 
   Correctly hide fields from Relationships when not readable

--- a/packages/fields/CHANGELOG.md
+++ b/packages/fields/CHANGELOG.md
@@ -1,17 +1,21 @@
 # @voussoir/fields
 
 ## 1.3.0
+
 - [minor] d94b517:
 
-  Add _ksListsMeta query to gather type and relationship information
+  Add \_ksListsMeta query to gather type and relationship information
+
 - [minor] a3b995c:
 
-  Add _ksListsMeta query to gather type and relationship information
+  Add \_ksListsMeta query to gather type and relationship information
+
 - [patch] ca7ce46:
 
   Correctly hide fields from Relationships when not readable
+
 - Updated dependencies [1d30a329"
-]:
+  ]:
   - @voussoir/ui@0.4.0
 
 ## 1.2.0

--- a/packages/fields/types/DateTime/Implementation.js
+++ b/packages/fields/types/DateTime/Implementation.js
@@ -83,7 +83,7 @@ class MongoDateTimeInterface extends MongooseFieldAdapter {
     });
 
     // Updates the relevant value in the item provided (by referrence)
-    const toServerSide = item => {
+    this.addToServerHook(schema, item => {
       const datetimeString = item[field_path];
 
       if (
@@ -96,9 +96,8 @@ class MongoDateTimeInterface extends MongooseFieldAdapter {
       item[utc_field] = toDate(datetimeString);
       item[offset_field] = DateTime.fromISO(datetimeString, { setZone: true }).toFormat('ZZ');
       item[field_path] = undefined; // Never store this field
-    };
-
-    const toClientSide = item => {
+    });
+    this.addToClientHook(schema, item => {
       if (item[utc_field] && item[offset_field] === undefined) {
         return;
       }
@@ -117,76 +116,6 @@ class MongoDateTimeInterface extends MongooseFieldAdapter {
       item[field_path] = datetimeString;
       item[utc_field] = undefined;
       item[offset_field] = undefined;
-    };
-    schema.post('aggregate', function(result) {
-      result.forEach(r => toClientSide(r));
-    });
-
-    schema.post('find', function(result) {
-      result.forEach(r => toClientSide(r));
-    });
-    schema.post('findById', function(result) {
-      toClientSide(result);
-    });
-    schema.post('findOne', function(result) {
-      toClientSide(result);
-    });
-
-    // Attach various pre save/update hooks to convert the datetime value
-    schema.pre('save', function() {
-      toServerSide(this);
-    });
-
-    // These are "Query middleware"; they differ from "document" middleware..
-    // ".. `this` refers to the query object rather than the document being updated."
-    schema.pre('update', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateOne', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateMany', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('findOneAndUpdate', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-
-    // Model middleware
-    // Docs as second arg? (https://github.com/Automattic/mongoose/commit/3d62d3558c15ec852bdeaab1a5138b1853b4f7cb)
-    schema.pre('insertMany', function(next, docs) {
-      for (let doc of docs) {
-        toServerSide(doc);
-      }
-    });
-
-    // After saving, we return the result to the client, so we have to parse it
-    // back again
-    schema.post('save', function() {
-      toClientSide(this);
-    });
-
-    // These are "Query middleware"; they differ from "document" middleware..
-    // ".. `this` refers to the query object rather than the document being updated."
-    schema.post('update', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('updateOne', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('updateMany', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('findOneAndUpdate', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-
-    // Model middleware
-    // Docs as second arg? (https://github.com/Automattic/mongoose/commit/3d62d3558c15ec852bdeaab1a5138b1853b4f7cb)
-    schema.post('insertMany', function(next, docs) {
-      for (let doc of docs) {
-        toClientSide(doc);
-      }
     });
   }
 

--- a/packages/fields/types/Decimal/Implementation.js
+++ b/packages/fields/types/Decimal/Implementation.js
@@ -65,89 +65,17 @@ class MongoDecimalInterface extends MongooseFieldAdapter {
       },
     });
     // Updates the relevant value in the item provided (by referrence)
-    const toServerSide = item => {
+    this.addToServerHook(schema, item => {
       if (item[this.path] && typeof item[this.path] === 'string') {
         item[this.path] = mongoose.Types.Decimal128.fromString(item[this.path]);
       } else if (!item[this.path]) {
         item[this.path] = null;
       }
       // else: Must either be undefined or a Decimal128 object, so leave it alone.
-    };
-
-    const toClientSide = item => {
+    });
+    this.addToClientHook(schema, item => {
       if (item[this.path]) {
         item[this.path] = item[this.path].toString();
-      }
-    };
-
-    schema.post('aggregate', function(result) {
-      result.forEach(r => toClientSide(r));
-    });
-
-    schema.post('find', function(result) {
-      result.forEach(r => toClientSide(r));
-    });
-    schema.post('findById', function(result) {
-      toClientSide(result);
-    });
-    schema.post('findOne', function(result) {
-      toClientSide(result);
-    });
-
-    // Attach various pre save/update hooks to convert the decimal value
-    schema.pre('validate', function() {
-      toServerSide(this);
-    });
-
-    // These are "Query middleware"; they differ from "document" middleware..
-    // ".. `this` refers to the query object rather than the document being updated."
-    schema.pre('update', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateOne', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateMany', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-    schema.pre('findOneAndUpdate', function() {
-      toServerSide(this['_update'].$set || this['_update']);
-    });
-
-    // Model middleware
-    // Docs as second arg? (https://github.com/Automattic/mongoose/commit/3d62d3558c15ec852bdeaab1a5138b1853b4f7cb)
-    schema.pre('insertMany', function(next, docs) {
-      for (let doc of docs) {
-        toServerSide(doc);
-      }
-    });
-
-    // After saving, we return the result to the client, so we have to parse it
-    // back again
-    schema.post('save', function() {
-      toClientSide(this);
-    });
-
-    // These are "Query middleware"; they differ from "document" middleware..
-    // ".. `this` refers to the query object rather than the document being updated."
-    schema.post('update', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('updateOne', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('updateMany', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-    schema.post('findOneAndUpdate', function() {
-      toClientSide(this['_update'].$set || this['_update']);
-    });
-
-    // Model middleware
-    // Docs as second arg? (https://github.com/Automattic/mongoose/commit/3d62d3558c15ec852bdeaab1a5138b1853b4f7cb)
-    schema.post('insertMany', function(next, docs) {
-      for (let doc of docs) {
-        toClientSide(doc);
       }
     });
   }

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -94,7 +94,7 @@ class MongoPasswordInterface extends MongooseFieldAdapter {
     });
 
     // Updates the relevant value in the item provided (by referrence)
-    const hashFieldValue = async item => {
+    this.addToServerHook(schema, async item => {
       const list = this.getListByKey(this.listAdapter.key);
       const field = list.fieldsByPath[this.path];
       const plaintext = item[field.path];
@@ -107,34 +107,6 @@ class MongoPasswordInterface extends MongooseFieldAdapter {
         item[field.path] = await field.generateHash(plaintext);
       } else {
         item[field.path] = null;
-      }
-    };
-
-    // Attach various pre save/update hooks to hash the password value
-    schema.pre('save', async function() {
-      await hashFieldValue(this);
-    });
-
-    // These are "Query middleware"; they differ from "document" middleware..
-    // ".. `this` refers to the query object rather than the document being updated."
-    schema.pre('update', async function() {
-      await hashFieldValue(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateOne', async function() {
-      await hashFieldValue(this['_update'].$set || this['_update']);
-    });
-    schema.pre('updateMany', async function() {
-      await hashFieldValue(this['_update'].$set || this['_update']);
-    });
-    schema.pre('findOneAndUpdate', async function() {
-      await hashFieldValue(this['_update'].$set || this['_update']);
-    });
-
-    // Model middleware
-    // Docs as second arg? (https://github.com/Automattic/mongoose/commit/3d62d3558c15ec852bdeaab1a5138b1853b4f7cb)
-    schema.pre('insertMany', async function(next, docs) {
-      for (let doc of docs) {
-        await hashFieldValue(doc);
       }
     });
   }

--- a/packages/test-utils/CHANGELOG.md
+++ b/packages/test-utils/CHANGELOG.md
@@ -1,6 +1,7 @@
 # @voussoir/test-utils
 
 ## 0.1.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
   - @voussoir/adapter-mongoose@0.4.1

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,8 +1,9 @@
 # @voussoir/ui
 
 ## 0.4.0
+
 - [minor] 1d30a329"
-:
+  :
 
   - Cleanup vertical navigation, more separation between primary/secondary nav primitives
 

--- a/projects/access-control/CHANGELOG.md
+++ b/projects/access-control/CHANGELOG.md
@@ -1,10 +1,11 @@
 # @voussoir/cypress-project-access-control
 
 ## 1.1.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
 - Updated dependencies [1d30a329"
-]:
+  ]:
   - @voussoir/adapter-mongoose@0.4.1
   - @voussoir/test-utils@0.1.1
   - @voussoir/core@0.6.0

--- a/projects/basic/CHANGELOG.md
+++ b/projects/basic/CHANGELOG.md
@@ -1,10 +1,11 @@
 # @voussoir/cypress-project-basic
 
 ## 1.2.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
 - Updated dependencies [1d30a329"
-]:
+  ]:
   - @voussoir/adapter-mongoose@0.4.1
   - @voussoir/test-utils@0.1.1
   - @voussoir/core@0.6.0

--- a/projects/login/CHANGELOG.md
+++ b/projects/login/CHANGELOG.md
@@ -1,10 +1,11 @@
 # @voussoir/cypress-project-login
 
 ## 1.2.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
 - Updated dependencies [1d30a329"
-]:
+  ]:
   - @voussoir/adapter-mongoose@0.4.1
   - @voussoir/test-utils@0.1.1
   - @voussoir/core@0.6.0

--- a/projects/twitter-login/CHANGELOG.md
+++ b/projects/twitter-login/CHANGELOG.md
@@ -1,10 +1,11 @@
 # @voussoir/cypress-project-twitter-login
 
 ## 1.1.1
+
 - Updated dependencies [d94b517]:
 - Updated dependencies [a3b995c]:
 - Updated dependencies [1d30a329"
-]:
+  ]:
   - @voussoir/adapter-mongoose@0.4.1
   - @voussoir/core@0.6.0
   - @voussoir/fields@1.3.0


### PR DESCRIPTION
This PR adds `addToServerHook` and `addToClientHook` methods to `MongooseFieldAdapter`. This consolidates a large amount of duplicated code from the `fields` package and ensures that we are following consistent patterns for all types.