### PR TITLE
Fix markup typo in quick start docs.

### DIFF
--- a/docs/Getting Started/yo-generator.md
+++ b/docs/Getting Started/yo-generator.md
@@ -417,7 +417,7 @@ Keystone will also automatically generate `.css` or compressed `.min.css` files 
 
 Keystone includes an [Application Updates](/documentation/database/application-updates/) framework which can be used to apply one-off data changes against your database. Application update scripts can be convenient for seeding your database, transitioning existing data when models change, or running transformation scripts against your database. Since update scripts only run once per database, they are also very useful to ensure consistency across multiple deployments or environments.
 
-Keystone's automatic update functionality is enabled in `keystone.js` by the auto `update option`.
+Keystone's automatic update functionality is enabled in `keystone.js` by the `auto update` option.
 
 When the option is set to `true`, Keystone will scan the `updates` directory for `.js` files, each of which should export a method accepting a single argument:
 


### PR DESCRIPTION
The `auto update` field was highlighted incorrectly.

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [x] List browser version(s) any admin UI changes were tested in:
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

