### PR TITLE
Completed opening sentence

### DIFF
--- a/docs/api/List/model.md
+++ b/docs/api/List/model.md
@@ -1,6 +1,6 @@
 # Model
 
-Once you retrieve a list from Keystone, the [mongoose](http://mongoosejs.com/) methods can be accessed from.
+Once you retrieve a list from Keystone, the [mongoose](http://mongoosejs.com/) methods can be accessed from `.model`.
 
 Example:
 


### PR DESCRIPTION
The sentence "Once you retrieve a list from Keystone, the mongoose methods can be accessed from." seemed incomplete

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
The sentence "Once you retrieve a list from Keystone, the mongoose methods can be accessed from." of [this](https://keystonejs.com/api/list/model/) page seemed incomplete, so I added a simple ending.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

