### PR TITLE
Update the backlink processing queue API

### DIFF
--- a/.changeset/9c67d959/changes.json
+++ b/.changeset/9c67d959/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@voussoir/fields", "type": "minor" }], "dependents": [] }

--- a/.changeset/9c67d959/changes.md
+++ b/.changeset/9c67d959/changes.md
@@ -1,0 +1,1 @@
+- Update the backlink queue API

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -12,9 +12,8 @@ const {
 const { Implementation } = require('../../Implementation');
 const {
   nestedMutation,
-  processQueuedDisconnections,
-  processQueuedConnections,
-  tellForeignItemToDisconnect,
+  resolveBacklinks,
+  enqueueBacklinkOperations,
 } = require('./nested-mutations');
 
 class Relationship extends Implementation {
@@ -177,7 +176,7 @@ class Relationship extends Implementation {
     }
     const currentValue = item && item[this.path];
     const getItem = createdPromise || Promise.resolve(item);
-
+    context.queues = context.queues || {};
     return await nestedMutation({
       input,
       currentValue,
@@ -193,8 +192,7 @@ class Relationship extends Implementation {
 
   async afterChange(data, item, context) {
     // We have to wait to the post hook so we have the item's id to connect to!
-    await processQueuedDisconnections({ context });
-    await processQueuedConnections({ context });
+    await resolveBacklinks(context.queues, context);
   }
 
   beforeDelete(data, item, context) {
@@ -212,25 +210,20 @@ class Relationship extends Implementation {
     }
 
     const itemsToDisconnect = many ? data : [data];
-
-    itemsToDisconnect
-      // The data comes in as an ObjectId, so we have to convert it
-      .map(itemToDisconnect => itemToDisconnect.toString())
-      .forEach(itemToDisconnect => {
-        tellForeignItemToDisconnect({
-          context,
-          getItem: Promise.resolve(item),
-          local: {
-            list: this.getListByKey(this.listKey),
-            field: this,
-          },
-          foreign: {
-            list: refList,
-            field: refField,
-            id: itemToDisconnect,
-          },
-        });
-      });
+    context.queues = context.queues || {};
+    enqueueBacklinkOperations(
+      { disconnect: itemsToDisconnect.map(id => id.toString()) },
+      context.queues,
+      Promise.resolve(item),
+      {
+        list: this.getListByKey(this.listKey),
+        field: this,
+      },
+      {
+        list: refList,
+        field: refField,
+      }
+    );
 
     // TODO: Cascade _deletion_ of any related items (not just setting the
     // reference to null)
@@ -240,7 +233,7 @@ class Relationship extends Implementation {
 
   async afterDelete(fieldData, item, context) {
     // We have to wait to the post hook so we have the item's id to discconect.
-    await processQueuedDisconnections({ context });
+    await resolveBacklinks(context.queues, context);
   }
 
   get gqlAuxTypes() {


### PR DESCRIPTION
This PR updates the interfaces for the backlink processing queue.

`enqueueBacklinkOperations` takes an `operations` parameter with the shape { `[operation]`: [`id`] } }. e.g.

```js
{
  connect: [1, 2, 3],
  disconnect: [5, 6, 7]
}
```
`resolveBacklinks` processes both the `connect` and `disconnect` queue, so there is no longer a need to call a seperate function for each.

In future PRs, calls to `resolveBacklinks` will be most likely be hoisted into the list mutation resolver functions, and calls to `enqueueBacklinkOperations` will be hoisted out of `nestedMutation` and into the relevant relationship methods.