### PR TITLE
Split out Relationship.resolveBacklink from the afterChange hook

### DIFF
--- a/packages/core/List/index.js
+++ b/packages/core/List/index.js
@@ -17,7 +17,7 @@ const { parseListAccess } = require('@voussoir/access-control');
 
 const logger = require('@voussoir/logger');
 
-const { Text, Checkbox, Float } = require('@voussoir/fields');
+const { Text, Checkbox, Float, Relationship } = require('@voussoir/fields');
 
 const graphqlLogger = logger('graphql');
 const keystoneLogger = logger('keystone');
@@ -785,6 +785,9 @@ module.exports = class List {
       throw error;
     }
 
+    // Resolve backlinks
+    await Relationship.resolveBacklinks(context.queues, context);
+
     // After change
     await Promise.all(
       Object.keys(data).map(fieldPath =>
@@ -826,6 +829,9 @@ module.exports = class List {
     // Before change
 
     const newItem = await this.adapter.update(id, resolvedData);
+
+    // Resolve backlinks
+    await Relationship.resolveBacklinks(context.queues, context);
 
     // After change
     await Promise.all(
@@ -875,6 +881,9 @@ module.exports = class List {
     );
 
     const result = await this.adapter.delete(item.id);
+
+    // Resolve backlinks
+    await Relationship.resolveBacklinks(context.queues, context);
 
     // After delete
     await Promise.all(this.fields.map(field => field.afterDelete(item[field.path], item, context)));

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -10,11 +10,7 @@ const {
 } = mongoose;
 
 const { Implementation } = require('../../Implementation');
-const {
-  nestedMutation,
-  resolveBacklinks,
-  enqueueBacklinkOperations,
-} = require('./nested-mutations');
+const { nestedMutation, enqueueBacklinkOperations } = require('./nested-mutations');
 
 class Relationship extends Implementation {
   constructor() {
@@ -190,11 +186,6 @@ class Relationship extends Implementation {
     });
   }
 
-  async afterChange(data, item, context) {
-    // We have to wait to the post hook so we have the item's id to connect to!
-    await resolveBacklinks(context.queues, context);
-  }
-
   registerBacklink(data, item, context) {
     // Early out for null'd field
     if (!data) {
@@ -229,11 +220,6 @@ class Relationship extends Implementation {
     // reference to null)
     // Accept a config option for cascading: https://www.prisma.io/docs/1.4/reference/service-configuration/data-modelling-(sdl)-eiroozae8u/#the-@relation-directive
     // Beware of circular delete hooks!
-  }
-
-  async afterDelete(fieldData, item, context) {
-    // We have to wait to the post hook so we have the item's id to discconect.
-    await resolveBacklinks(context.queues, context);
   }
 
   get gqlAuxTypes() {

--- a/packages/fields/types/Relationship/index.js
+++ b/packages/fields/types/Relationship/index.js
@@ -1,4 +1,5 @@
 const { Relationship, MongoSelectInterface } = require('./Implementation');
+const { resolveBacklinks } = require('./nested-mutations');
 
 module.exports = {
   type: 'Relationship',
@@ -13,4 +14,5 @@ module.exports = {
   adapters: {
     mongoose: MongoSelectInterface,
   },
+  resolveBacklinks,
 };


### PR DESCRIPTION
This PR a) resolves backlinks before the `afterChange` hooks are called and b) ensures `resolveBacklinks` is only called once per mutation, since each call is operating on a shared queue.