### PR TITLE
Use existingItem as variable name in access control functions

### DIFF
--- a/.changeset/321b67d3/changes.json
+++ b/.changeset/321b67d3/changes.json
@@ -1,0 +1,9 @@
+{
+  "releases": [
+    { "name": "@voussoir/access-control", "type": "minor" },
+    { "name": "@voussoir/core", "type": "patch" }
+  ],
+  "dependents": [
+    { "name": "@voussoir/fields", "type": "patch", "dependencies": ["@voussoir/access-control"] }
+  ]
+}

--- a/.changeset/321b67d3/changes.md
+++ b/.changeset/321b67d3/changes.md
@@ -1,0 +1,1 @@
+- Rename the access control function parameter `item` to `existingItem`

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -86,14 +86,14 @@ keystone.createList('User', {
     email: {
       type: Email,
       // 1.
-      access: ({ item, authentication }) => item.id === authentication.item.id,
+      access: ({ existingItem, authentication }) => existingItem.id === authentication.item.id,
     },
     password: {
       type: Password,
       access: {
         // 2.
         read: false,
-        update: ({ item, authentication }) => item.id === authentication.item.id,
+        update: ({ existingItem, authentication }) => existingItem.id === authentication.item.id,
       },
     },
   },
@@ -183,12 +183,6 @@ type ListConfig = {
 ie; for a list `User`, it would match the input type `UserWhereInput`.
 
 `AccessInput` function parameter
-
-<!-- TODO:
-  Having keying the currently authenticated item as `item` makes unpacking it painful.
-  The access functions are already supplied an `item` argument.
-  See linting errors in the "Granular functions returning Boolean" secion.
--->
 
 - `authentication` describes the currently authenticated user.
   - `.item` is the details of the current user. Will be `undefined` for anonymous users.
@@ -385,7 +379,7 @@ type AccessInput = {
     item?: {},
     listKey?: string,
   },
-  item: {},
+  existingItem: {},
 };
 
 type StaticAccess = boolean;
@@ -416,7 +410,7 @@ only to modify it).
 - `authentication` describes the currently authenticated user.
   - `.item` is the details of the current user. Will be `undefined` for anonymous users.
   - `.listKey` is the list key of the currently authenticated user. Will be `undefined` for anonymous users.
-- `item` is the item this field belongs to.
+- `existingItem` is the existing item this field belongs to (undefined on create).
 
 When defining `StaticAccess`;
 
@@ -484,7 +478,7 @@ keystone.createList('User', {
   fields: {
     name: {
       type: Text,
-      access: ({ authentication: { item, listKey }, item }) => {
+      access: ({ authentication: { item, listKey }, existingItem }) => {
         return true;
       },
     },
@@ -501,11 +495,10 @@ include the field in the GraphQL Schema.
 
 ```js
 keystone.createList('User', {
-
   access: {
-    create: ({ authentication: { item, listKey }, item }) => true,
-    read: ({ authentication: { item, listKey }, item }) => true,
-    update: ({ authentication: { item, listKey }, item }) => true,
+    create: ({ authentication: { item, listKey }, existingItem }) => true,
+    read: ({ authentication: { item, listKey }, existingItem }) => true,
+    update: ({ authentication: { item, listKey }, existingItem }) => true,
   },
 
   fields: {
@@ -702,13 +695,13 @@ keystone.createList('User', {
     address: { type: Text },
     email: {
       type: Email,
-      access: ({ item, auth }) => item.id === auth.id,
+      access: ({ existingItem, auth }) => existingItem.id === auth.id,
     },
     password: {
       type: Password,
       access: {
         read: false,
-        update: ({ item, auth }) => item.id === auth.id,
+        update: ({ existingItem, auth }) => existingItem.id === auth.id,
       },
     },
   },
@@ -833,13 +826,13 @@ keystone.createList('User', {
     address: { type: Text },
     email: {
       type: Email,
-      access: ({ item, auth }) => item.id === auth.id,
+      access: ({ existingItem, auth }) => existingItem.id === auth.id,
     },
     password: {
       type: Password,
       access: {
         read: false,
-        update: ({ item, auth }) => item.id === auth.id,
+        update: ({ existingItem, auth }) => existingItem.id === auth.id,
       },
     },
   },

--- a/packages/access-control/index.js
+++ b/packages/access-control/index.js
@@ -146,14 +146,21 @@ module.exports = {
     return result;
   },
 
-  validateFieldAccessControl({ access, listKey, fieldKey, item, operation, authentication }) {
+  validateFieldAccessControl({
+    access,
+    listKey,
+    fieldKey,
+    existingItem,
+    operation,
+    authentication,
+  }) {
     let result;
     if (typeof access[operation] !== 'function') {
       result = access[operation];
     } else {
       result = access[operation]({
         authentication: authentication.item ? authentication : {},
-        item,
+        existingItem,
       });
     }
 

--- a/packages/core/Keystone/index.js
+++ b/packages/core/Keystone/index.js
@@ -307,16 +307,18 @@ module.exports = class Keystone {
       });
     });
 
-    const getFieldAccessControlForUser = fastMemoize((listKey, fieldKey, item, operation) => {
-      return validateFieldAccessControl({
-        access: this.lists[listKey].fieldsByPath[fieldKey].access,
-        item,
-        operation,
-        authentication: { item: user, listKey: authedListKey },
-        fieldKey,
-        listKey,
-      });
-    });
+    const getFieldAccessControlForUser = fastMemoize(
+      (listKey, fieldKey, existingItem, operation) => {
+        return validateFieldAccessControl({
+          access: this.lists[listKey].fieldsByPath[fieldKey].access,
+          existingItem,
+          operation,
+          authentication: { item: user, listKey: authedListKey },
+          fieldKey,
+          listKey,
+        });
+      }
+    );
 
     return {
       // req.user & req.authedListKey come from ../index.js

--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -62,8 +62,8 @@ class MockAdapter {
 
 const context = {
   getListAccessControlForUser: () => true,
-  getFieldAccessControlForUser: (listKey, fieldPath, item) =>
-    !(item.makeFalse && fieldPath === 'name'),
+  getFieldAccessControlForUser: (listKey, fieldPath, existingItem) =>
+    !(existingItem && existingItem.makeFalse && fieldPath === 'name'),
   authedItem: {
     id: 1,
   },


### PR DESCRIPTION
This changes the parameter name in access control functions from `item` to `existingItem`. This makes it consistent with the naming convention in the hooks system and highlights a bug in `createMutation`. The field access control was using an `existingItem` containing the default field values, rather than `undefined`. This PR fixes this bug.