### PR TITLE
Fixed dependsOn setting when applied to a boolean field set to false by default

### DIFF
--- a/fields/types/Field.js
+++ b/fields/types/Field.js
@@ -135,7 +135,7 @@ module.exports.create = function (spec) {
 		mixins: [Mixins.Collapse],
 		statics: {
 			getDefaultValue: function (field) {
-				return field.defaultValue || '';
+				return typeof field.defaultValue !== 'undefined' ? field.defaultValue : '';
 			},
 		},
 		render () {


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes

Returns a proper default value if `field.defaultValue` is set to `false`. The current code improperly returns empty string if `field.defaultValue` is set to `false`. This leads to an incorrect comparison with dependsOn pointing to a Boolean field. 

## Related issues (if any)

#4866 

## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

