### PR TITLE
Decouple backlink queue operations from nested mutation resolving

### DIFF
--- a/packages/fields/types/Relationship/backlinks.js
+++ b/packages/fields/types/Relationship/backlinks.js
@@ -1,0 +1,61 @@
+function _queueIdForOperation({ queue, foreign, local, done }) {
+  // The queueID encodes the full list/field path and ID of both the foreign and local fields
+  const f = info => `${info.list.key}.${info.field.path}.${info.id}`;
+  const queueId = `${f(local)}->${f(foreign)}`;
+
+  // It may have already been added elsewhere, so we don't want to add it again
+  if (!queue.has(queueId)) {
+    queue.set(queueId, { local, foreign: { id: foreign.id }, done });
+  }
+}
+
+function enqueueBacklinkOperations(operations, queues, getItem, local, foreign) {
+  Object.entries(operations).forEach(([operation, idsToOperateOn = []]) => {
+    queues[operation] = queues[operation] || new Map();
+    const queue = queues[operation];
+    // NOTE: We don't return this promises, we expect it to be fulfilled at a
+    // future date and don't want to wait for it now.
+    getItem.then(item => {
+      const _local = { ...local, id: item.id };
+      idsToOperateOn.forEach(id => {
+        const _foreign = { ...foreign, id };
+        // Enqueue the backlink operation (foreign -> local)
+        _queueIdForOperation({ queue, foreign: _local, local: _foreign, done: false });
+
+        // Effectively dequeue the forward link operation (local -> foreign)
+        // To avoid any circular updates with the above disconnect, we flag this
+        // item as having already been connected/disconnected
+        _queueIdForOperation({ queue, foreign: _foreign, local: _local, done: true });
+      });
+    });
+  });
+}
+
+async function resolveBacklinks(queues = {}, context) {
+  await Promise.all(
+    Object.entries(queues).map(async ([operation, queue]) => {
+      for (let queuedWork of queue.values()) {
+        if (queuedWork.done) {
+          continue;
+        }
+        // Flag it as handled so we don't try again in a nested update
+        // NOTE: We do this first before any other work below to avoid async issues
+        // To avoid issues with looping and Map()s, we directly set the value on the
+        // object as stored in the Map, and don't try to update the Map() itself.
+        queuedWork.done = true;
+
+        // Run update of local.path <operation>>> foreign.id
+        // NOTE: This relies on the user having `update` permissions on the local list.
+        const { local, foreign } = queuedWork;
+        const { path, config } = local.field;
+        const clause = { [path]: { [operation]: config.many ? [foreign] : foreign } };
+        await local.list.updateMutation(local.id, clause, context);
+      }
+    })
+  );
+}
+
+module.exports = {
+  enqueueBacklinkOperations,
+  resolveBacklinks,
+};

--- a/packages/fields/types/Relationship/index.js
+++ b/packages/fields/types/Relationship/index.js
@@ -1,5 +1,5 @@
 const { Relationship, MongoSelectInterface } = require('./Implementation');
-const { resolveBacklinks } = require('./nested-mutations');
+const { resolveBacklinks } = require('./backlinks');
 
 module.exports = {
   type: 'Relationship',

--- a/packages/fields/types/Relationship/nested-mutations.js
+++ b/packages/fields/types/Relationship/nested-mutations.js
@@ -5,64 +5,6 @@ const { ParameterError } = require('./graphqlErrors');
 
 const NESTED_MUTATIONS = ['create', 'connect', 'disconnect', 'disconnectAll'];
 
-/***  Queue operations ***/
-function _queueIdForOperation({ queue, foreign, local, done }) {
-  // The queueID encodes the full list/field path and ID of both the foreign and local fields
-  const f = info => `${info.list.key}.${info.field.path}.${info.id}`;
-  const queueId = `${f(local)}->${f(foreign)}`;
-
-  // It may have already been added elsewhere, so we don't want to add it again
-  if (!queue.has(queueId)) {
-    queue.set(queueId, { local, foreign: { id: foreign.id }, done });
-  }
-}
-
-function enqueueBacklinkOperations(operations, queues, getItem, local, foreign) {
-  Object.entries(operations).forEach(([operation, idsToOperateOn = []]) => {
-    queues[operation] = queues[operation] || new Map();
-    const queue = queues[operation];
-    // NOTE: We don't return this promises, we expect it to be fulfilled at a
-    // future date and don't want to wait for it now.
-    getItem.then(item => {
-      const _local = { ...local, id: item.id };
-      idsToOperateOn.forEach(id => {
-        const _foreign = { ...foreign, id };
-        // Enqueue the backlink operation (foreign -> local)
-        _queueIdForOperation({ queue, foreign: _local, local: _foreign, done: false });
-
-        // Effectively dequeue the forward link operation (local -> foreign)
-        // To avoid any circular updates with the above disconnect, we flag this
-        // item as having already been connected/disconnected
-        _queueIdForOperation({ queue, foreign: _foreign, local: _local, done: true });
-      });
-    });
-  });
-}
-
-async function resolveBacklinks(queues = {}, context) {
-  await Promise.all(
-    Object.entries(queues).map(async ([operation, queue]) => {
-      for (let queuedWork of queue.values()) {
-        if (queuedWork.done) {
-          continue;
-        }
-        // Flag it as handled so we don't try again in a nested update
-        // NOTE: We do this first before any other work below to avoid async issues
-        // To avoid issues with looping and Map()s, we directly set the value on the
-        // object as stored in the Map, and don't try to update the Map() itself.
-        queuedWork.done = true;
-
-        // Run update of local.path <operation>>> foreign.id
-        // NOTE: This relies on the user having `update` permissions on the local list.
-        const { local, foreign } = queuedWork;
-        const { path, config } = local.field;
-        const clause = { [path]: { [operation]: config.many ? [foreign] : foreign } };
-        await local.list.updateMutation(local.id, clause, context);
-      }
-    })
-  );
-}
-
 /*** Input validation  ***/
 const throwWithErrors = ({ message, errors }) => {
   const error = new Error(message);
@@ -126,30 +68,11 @@ const _runActions = async (action, targets, path) => {
   return [errors.length ? [] : results.map(({ value }) => value), errors];
 };
 
-const openDatabaseTransaction = () => {
-  // TODO: Implement transactions
-  return {
-    rollback: () => {},
-    commit: () => {},
-  };
-};
-
-async function toManyNestedMutation({
-  input,
-  currentValue,
-  refList,
-  refField,
-  context,
-  localField,
-  queueData,
-  target,
-}) {
-  // Convert the ObjectIds to strings
-  const idsToKeep = (currentValue || []).map(id => id.toString());
-
+async function resolveNestedMany({ input, currentValue, refList, context, localField, target }) {
+  // Disconnections
   let disconnectIds = [];
   if (input.disconnectAll) {
-    disconnectIds = [...idsToKeep];
+    disconnectIds = [...currentValue];
   } else if (input.disconnect) {
     // We want to avoid DB lookups where possible, so we split the input into
     // two halves; one with ids, and the other without ids
@@ -164,7 +87,7 @@ async function toManyNestedMutation({
     // This will resolve access control, etc for us.
     // In the future, when WhereUniqueInput accepts more than just an id,
     // this will also resolve those queries for us too.
-    const action = where => refList.itemQuery(where.id, context, refList.gqlNames.itemQueryName);
+    const action = where => refList.itemQuery(where, context, refList.gqlNames.itemQueryName);
     // We don't throw if any fail; we're only interested in the ones this user has
     // access to read (and hence remove from the list)
     const disconnectItems = (await pSettle((withoutId || []).map(action)))
@@ -175,11 +98,7 @@ async function toManyNestedMutation({
     disconnectIds.push(...disconnectItems.map(({ id }) => id));
   }
 
-  if (refField) {
-    const { queues, getItem, local, foreign } = queueData;
-    enqueueBacklinkOperations({ disconnect: disconnectIds }, queues, getItem, local, foreign);
-  }
-
+  // Connections
   let allConnectedIds = [];
   if (input.connect || input.create) {
     // This will resolve access control, etc for us.
@@ -207,14 +126,6 @@ async function toManyNestedMutation({
       .filter(itemConnected => itemConnected)
       .map(({ id }) => id);
 
-    if (refField) {
-      // At this point, we've not actually added the ID `idToConnect` to the
-      // field `localField` on list `localList`, just flagged it needing to be added.
-      // This is so any recursive checks don't attempt to do it again.
-      const { queues, getItem, local, foreign } = queueData;
-      enqueueBacklinkOperations({ connect: allConnectedIds }, queues, getItem, local, foreign);
-    }
-
     const allErrors = [...connectErrors, ...createErrors];
     if (allErrors.length) {
       const message = `Unable to create and/or connect ${allErrors.length} ${target}`;
@@ -222,37 +133,25 @@ async function toManyNestedMutation({
     }
   }
 
-  // When there are items to disconnect, we want to remove them from the 'to-keep array'
-  return [...idsToKeep.filter(id => !disconnectIds.includes(id)), ...allConnectedIds];
+  return { disconnect: disconnectIds, connect: allConnectedIds };
 }
 
-async function toSingleNestedMutation({
-  input,
-  currentValue,
-  localField,
-  refList,
-  refField,
-  context,
-  queueData,
-  target,
-}) {
-  let result = currentValue;
-
+async function resolveNestedSingle({ input, currentValue, localField, refList, context, target }) {
+  let result_ = {};
   if ((input.disconnect || input.disconnectAll) && currentValue) {
     let idToDisconnect;
     if (input.disconnectAll) {
-      idToDisconnect = currentValue.toString();
+      idToDisconnect = currentValue;
     } else if (input.disconnect.id) {
       idToDisconnect = input.disconnect.id;
     } else {
       try {
         // Support other unique fields for disconnection
-        const itemToDisconnect = await refList.itemQuery(
+        idToDisconnect = (await refList.itemQuery(
           input.disconnect,
           context,
           refList.gqlNames.itemQueryName
-        );
-        idToDisconnect = itemToDisconnect.id.toString();
+        )).id.toString();
       } catch (error) {
         // Maybe we don't have read access, or maybe the item doesn't exist
         // (recently deleted, or it's an erroneous value in the relationship field)
@@ -260,18 +159,9 @@ async function toSingleNestedMutation({
       }
     }
 
-    if (currentValue.toString() === idToDisconnect) {
+    if (currentValue === idToDisconnect) {
       // Found the item, so unset it
-      result = null;
-
-      if (refField) {
-        // At this point, we've not actually removed the ID `idToDisconnect`
-        // from the field `localField` on list `localList`, but instead flagged
-        // it for removal (by setting `result = null`).
-        const { queues, getItem, local, foreign } = queueData;
-        const disconnect = [idToDisconnect];
-        enqueueBacklinkOperations({ disconnect }, queues, getItem, local, foreign);
-      }
+      result_.disconnect = [idToDisconnect];
     }
   }
 
@@ -288,69 +178,36 @@ async function toSingleNestedMutation({
       const message = `Unable to ${operation} a ${target}`;
       throwWithErrors({ message, errors: [{ ...error, path: [localField.path, operation] }] });
     }
-    // Can happen when the input id doesn't exist / the user doesn't have read access
-    if (!item) {
-      return undefined;
-    }
 
-    if (refField) {
-      // At this point, we've not actually added the ID `item.id` to the
-      // field `localField` on list `localList`, just flagged it needing to be added.
-      // This is so any recursive checks don't attempt to do it again.
-      const { queues, getItem, local, foreign } = queueData;
-      enqueueBacklinkOperations({ connect: [item.id] }, queues, getItem, local, foreign);
+    // Might not exist if the input id doesn't exist / the user doesn't have read access
+    if (item) {
+      result_.connect = [item.id];
     }
-
-    return item.id;
   }
-
-  return result;
+  return result_;
 }
 
-async function nestedMutation({
-  input,
-  currentValue,
-  many,
-  getItem,
-  localList,
-  localField,
-  refList,
-  refField,
-  context,
-}) {
+/*
+ * Resolve the nested mutations and return the ids of items to be connected/disconnected
+ *
+ * Returns: { connect: [id], disconnect: [id]}
+ */
+async function resolveNested({ input, currentValue, many, listInfo, context }) {
+  const localList = listInfo.local.list;
+  const localField = listInfo.local.field;
+  const refList = listInfo.foreign.list;
   const target = `${localList.key}.${localField.path}<${refList.key}>`;
-  const cleanInput = cleanAndValidateInput({ input, many, localList, localField, refList, target });
-
-  const transaction = await openDatabaseTransaction();
-
-  try {
-    const queueData = {
-      queues: context.queues,
-      getItem,
-      local: { list: localList, field: localField },
-      foreign: { list: refList, field: refField },
-    };
-    const args = {
-      currentValue,
-      refList,
-      refField,
-      input: cleanInput,
-      context,
-      localField,
-      queueData,
-      target,
-    };
-    const result = await (many ? toManyNestedMutation(args) : toSingleNestedMutation(args));
-    await transaction.commit();
-    return result;
-  } catch (error) {
-    await transaction.rollback();
-    throw error;
-  }
+  const args = {
+    currentValue,
+    refList,
+    input: cleanAndValidateInput({ input, many, localField, target }),
+    context,
+    localField,
+    target,
+  };
+  return await (many ? resolveNestedMany(args) : resolveNestedSingle(args));
 }
 
 module.exports = {
-  nestedMutation,
-  resolveBacklinks,
-  enqueueBacklinkOperations,
+  resolveNested,
 };


### PR DESCRIPTION
This PR decouples the process of performing nested mutation operations from the process of updating the backlink queue. `resolveNested` in `nested-mutations` is now responsible for performing any required mutations and returning `{ connect: [ids], disconnect: [ids] }`. It's then up to the calling function to a) combine these with the existing object to compute the final resolved value and b) calling `enqueueBacklinkOperations` with the appropriate value.

This decoupling will make it easier to reason about what happens during the `resolveNested` step. This is important because this is about to become more complex as we will be passing through database transaction objects, and handling `afterChange` operations, as well as error handling.

The backlink queue functions have been moved into `backlinks.js`, but have otherwise been changed.