### PR TITLE
[trivial] Do backlink registration before validate and beforeDelete hooks

### DIFF
--- a/packages/core/List/index.js
+++ b/packages/core/List/index.js
@@ -1071,11 +1071,11 @@ module.exports = class List {
       mutationState = { afterChangeStack: [], queues: {} };
     }
 
+    await this._registerBacklinks(existingItem, mutationState);
+
     await this._validateDelete(existingItem, context, operation);
 
     await this._beforeDelete(existingItem, context);
-
-    await this._registerBacklinks(existingItem, mutationState);
 
     const result = await this.adapter.delete(existingItem.id);
 


### PR DESCRIPTION
This reordering brings gives us consistency with the `update` and `create` mutations, which do their relationship resolution before running `validateInput` and `beforeChange`.