### PR TITLE
Added option to hide Today button in Date field

### DIFF
--- a/fields/types/date/DateField.js
+++ b/fields/types/date/DateField.js
@@ -28,6 +28,7 @@ module.exports = Field.create({
 		note: React.PropTypes.string,
 		onChange: React.PropTypes.func,
 		path: React.PropTypes.string,
+		todayButton: React.PropTypes.bool,
 		value: React.PropTypes.string,
 	},
 
@@ -85,9 +86,12 @@ module.exports = Field.create({
 						value={value}
 					/>
 				</Section>
-				<Section>
-					<Button onClick={this.setToday}>Today</Button>
-				</Section>
+				{
+					this.props.todayButton
+					&& <Section>
+						<Button onClick={this.setToday}>Today</Button>
+					</Section>
+				}
 			</Group>
 		);
 	},

--- a/fields/types/date/DateType.js
+++ b/fields/types/date/DateType.js
@@ -13,12 +13,13 @@ function date (list, path, options) {
 	this._nativeType = Date;
 	this._underscoreMethods = ['format', 'moment', 'parse'];
 	this._fixedSize = 'medium';
-	this._properties = ['formatString', 'yearRange', 'isUTC', 'inputFormat'];
+	this._properties = ['formatString', 'yearRange', 'isUTC', 'inputFormat', 'todayButton'];
 	this.parseFormatString = options.inputFormat || 'YYYY-MM-DD';
 	this.formatString = (options.format === false) ? false : (options.format || 'Do MMM YYYY');
 
 	this.yearRange = options.yearRange;
 	this.isUTC = options.utc || false;
+	this.todayButton = typeof options.todayButton !== 'undefined' ? options.todayButton : true;
 
 	/*
 	 * This offset is used to determine whether or not a stored date is probably corrupted or not.

--- a/fields/types/date/Readme.md
+++ b/fields/types/date/Readme.md
@@ -30,6 +30,12 @@ Defaults to 'Do MMM YYYY'
 
 See the [momentjs format docs](http://momentjs.com/docs/#/displaying/format/) for information on the supported formats and options.
 
+* `todayButton` `Boolean`
+
+Determines if the Today button will be displayed.
+
+Defaults to 'true'
+
 ## Methods
 
 ### `format(formatString)`


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

Makes the Today button optional. 

## Description of changes

Adds a new property to Date field:
todayButton: true or false

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

