### PR TITLE
preSave/postRead item hooks run consistently

### DIFF
--- a/.changeset/08533c40/changes.json
+++ b/.changeset/08533c40/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@voussoir/core", "type": "patch" },
+    { "name": "@voussoir/fields", "type": "patch" },
+    { "name": "@voussoir/adapter-mongoose", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/08533c40/changes.md
+++ b/.changeset/08533c40/changes.md
@@ -1,0 +1,1 @@
+- preSave/postRead item hooks run consistently

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "p-finally": "^1.0.0",
     "p-lazy": "^1.0.0",
     "p-settle": "^2.1.0",
+    "p-waterfall": "^1.0.0",
     "passport": "^0.4.0",
     "passport-twitter": "^1.0.4",
     "pino": "5.0.0-rc.4",

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -1,3 +1,5 @@
+const pWaterfall = require('p-waterfall');
+
 class BaseKeystoneAdapter {
   constructor(config) {
     this.config = {
@@ -34,6 +36,9 @@ class BaseListAdapter {
     this.parentAdapter = parentAdapter;
     this.fieldAdapters = [];
     this.config = config;
+
+    this.preSaveHooks = [];
+    this.postReadHooks = [];
   }
 
   newFieldAdapter(fieldAdapterClass, name, path, getListByKey, config) {
@@ -44,6 +49,26 @@ class BaseListAdapter {
   }
 
   prepareFieldAdapter() {}
+
+  addPreSaveHook(hook) {
+    this.preSaveHooks.push(hook);
+  }
+
+  addPostReadHook(hook) {
+    this.postReadHooks.push(hook);
+  }
+
+  onPreSave(item) {
+    // We waterfall so the final item is a composed version of the input passing
+    // through each consecutive hook
+    return pWaterfall(this.preSaveHooks, item);
+  }
+
+  onPostRead(item) {
+    // We waterfall so the final item is a composed version of the input passing
+    // through each consecutive hook
+    return pWaterfall(this.postReadHooks, item);
+  }
 }
 
 class BaseFieldAdapter {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,7 @@
     "graphql-tools": "^3.0.0",
     "graphql-type-json": "^0.2.1",
     "oauth-libre": "^0.9.17",
+    "p-waterfall": "^1.0.0",
     "passport": "^0.4.0",
     "passport-twitter": "^1.0.4",
     "pluralize": "^7.0.0"

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -16,14 +16,11 @@ export const initItems = () => {
 
 const getIDs = async keystone => {
   const IDs = {};
-  await keystone.lists['test'].adapter
-    .findAll()
-    .exec()
-    .then(data => {
-      data.forEach(entry => {
-        IDs[entry.name] = entry._id.toString();
-      });
+  await keystone.lists['test'].adapter.findAll().then(data => {
+    data.forEach(entry => {
+      IDs[entry.name] = entry._id.toString();
     });
+  });
   return IDs;
 };
 

--- a/packages/fields/types/Decimal/Implementation.js
+++ b/packages/fields/types/Decimal/Implementation.js
@@ -36,7 +36,7 @@ class Decimal extends Implementation {
 }
 
 class MongoDecimalInterface extends MongooseFieldAdapter {
-  addToMongooseSchema(schema) {
+  addToMongooseSchema(schema, _, { addPreSaveHook, addPostReadHook }) {
     const { mongooseOptions = {} } = this.config;
     const { isRequired } = mongooseOptions;
 
@@ -51,18 +51,20 @@ class MongoDecimalInterface extends MongooseFieldAdapter {
     schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
 
     // Updates the relevant value in the item provided (by referrence)
-    this.addToServerHook(schema, item => {
+    addPreSaveHook(item => {
       if (item[this.path] && typeof item[this.path] === 'string') {
         item[this.path] = mongoose.Types.Decimal128.fromString(item[this.path]);
       } else if (!item[this.path]) {
         item[this.path] = null;
       }
       // else: Must either be undefined or a Decimal128 object, so leave it alone.
+      return item;
     });
-    this.addToClientHook(schema, item => {
+    addPostReadHook(item => {
       if (item[this.path]) {
         item[this.path] = item[this.path].toString();
       }
+      return item;
     });
   }
 

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -87,17 +87,17 @@ class Password extends Implementation {
 class MongoPasswordInterface extends MongooseFieldAdapter {
   // constructor(fieldName, path, listAdapter, getListByKey, config) {
 
-  addToMongooseSchema(schema) {
+  addToMongooseSchema(schema, _, { addPreSaveHook }) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: String }, this.config) });
 
     // Updates the relevant value in the item provided (by referrence)
-    this.addToServerHook(schema, async item => {
+    addPreSaveHook(async item => {
       const list = this.getListByKey(this.listAdapter.key);
       const field = list.fieldsByPath[this.path];
       const plaintext = item[field.path];
 
       if (typeof plaintext === 'undefined') {
-        return;
+        return item;
       }
 
       if (String(plaintext) === plaintext && plaintext !== '') {
@@ -105,6 +105,7 @@ class MongoPasswordInterface extends MongooseFieldAdapter {
       } else {
         item[field.path] = null;
       }
+      return item;
     });
   }
 


### PR DESCRIPTION
Fixes #552

The changes here are mostly to put the same functionality on the `ListAdapter` layer. It is general enough (just an array`.push()` and a `Promise.all()`) that it can now be used for any adapter we have.

Previously, fields would be able to add hooks via their `FieldAdapter`, which relied on passing through the Mongoose query object, etc. That logic has been replaced by passing in two functions `addPreSaveHook` and `addPostReadHook` that the fields can execute to setup the correct callbacks.

A design decision I made was to have all the hooks act as a waterfall, so the modified value of previous hooks is passed to subsequent hooks. This isn't strictly necessary (we could run them all in parallel then merge the objects together), but I feel it provides safer code. OTOH; I'm happy if we decide to do a `Object.assign({}, ...(await Promise.all()))` instead of a `pWaterfall()`.