### PR TITLE
Fix mongoose warning in jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
     ]
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "./jest/setup.js"
+    "setupTestFrameworkScriptFile": "./jest/setup.js",
+    "testEnvironment": "node"
   },
   "devDependencies": {
     "apollo-fetch": "^0.7.0",

--- a/packages/admin-ui/tests/server/AdminUI.test.js
+++ b/packages/admin-ui/tests/server/AdminUI.test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment node
- */
 // We don't want to actually run webpack, so we mock all the bits out
 jest.doMock('webpack', () => {
   const mock = jest.fn(() => {});

--- a/packages/fields/tests/fields.test.js
+++ b/packages/fields/tests/fields.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 const fs = require('fs');
 const path = require('path');
 const cuid = require('cuid');


### PR DESCRIPTION
Closes #567 

As far as I can tell, the jest tests are intended for node rather than jsdom so I think it makes sense to have node be the default test environment rather than jsdom.