### PR TITLE
Move gatsby site out of bolt repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
     "lint:flow": "flow check",
     "lint": "yarn lint:prettier && yarn lint:eslint && yarn lint:flow",
     "start": "/bin/sh -c 'cd projects/${1:-$0} && yarn start' basic",
-    "website:start": "bolt w @voussoir/website run start",
-    "website:build": "bolt w @voussoir/website run build",
+    "website:start": "cd website && yarn start",
+    "website:build": "cd website && yarn build",
     "arch": "cd packages/arch/www && yarn && cd .. && yarn start",
     "test": "yarn lint && yarn test:unit && yarn cypress:run",
     "test:unit": "DISABLE_LOGGING=true NODE_ENV=test jest",
     "test:unit:debug": "NODE_ENV=test node --inspect-brk `which jest` --runInBand",
     "changeset": "build-releases changeset",
     "version-packages": "build-releases version",
-    "publish-changed": "build-releases publish --public"
+    "publish-changed": "build-releases publish --public",
+    "postinstall": "cd website && yarn"
   },
   "dependencies": {
     "@atlaskit/build-releases": "^3.0.3",
@@ -152,8 +153,7 @@
   "bolt": {
     "workspaces": [
       "packages/*",
-      "projects/*",
-      "website"
+      "projects/*"
     ]
   },
   "jest": {


### PR DESCRIPTION
Avoids a conflict with `graphql` packages, but still allows doing a
`bolt install` & running `bolt website:start`

## Why

The graphql v14 update broke the gatsby website :disappointed:

Gatsby depends on `v0.13.x`
So there ends up being multiple versions of `graphql` in `node_modules` (due to Bolt), which then gives this error:

```
error Cannot use GraphQLScalarType "JSON" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
```

Use yarn's `resolutions` field doesn't work ([bolt doesn't support it](https://github.com/boltpkg/bolt/issues/212))