### PR TITLE
Access to a limited List API from within Hooks

### DIFF
--- a/.changeset/46d1f192/changes.json
+++ b/.changeset/46d1f192/changes.json
@@ -1,0 +1,84 @@
+{
+  "releases": [
+    { "name": "@voussoir/core", "type": "minor" },
+    { "name": "@voussoir/utils", "type": "minor" }
+  ],
+  "dependents": [
+    { "name": "@voussoir/access-control", "type": "patch", "dependencies": ["@voussoir/utils"] },
+    {
+      "name": "@voussoir/adapter-mongoose",
+      "type": "patch",
+      "dependencies": ["@voussoir/mongo-join-builder", "@voussoir/core", "@voussoir/utils"]
+    },
+    {
+      "name": "@voussoir/admin-ui",
+      "type": "patch",
+      "dependencies": ["@voussoir/fields", "@voussoir/utils"]
+    },
+    {
+      "name": "@voussoir/fields",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/access-control",
+        "@voussoir/adapter-mongoose",
+        "@voussoir/test-utils",
+        "@voussoir/utils"
+      ]
+    },
+    {
+      "name": "@voussoir/mongo-join-builder",
+      "type": "patch",
+      "dependencies": ["@voussoir/utils"]
+    },
+    { "name": "@voussoir/server", "type": "patch", "dependencies": ["@voussoir/utils"] },
+    {
+      "name": "@voussoir/test-utils",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/adapter-mongoose",
+        "@voussoir/server",
+        "@voussoir/core",
+        "@voussoir/utils"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/adapter-mongoose",
+        "@voussoir/admin-ui",
+        "@voussoir/fields",
+        "@voussoir/server",
+        "@voussoir/test-utils",
+        "@voussoir/core",
+        "@voussoir/utils"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/adapter-mongoose",
+        "@voussoir/admin-ui",
+        "@voussoir/fields",
+        "@voussoir/server",
+        "@voussoir/test-utils",
+        "@voussoir/core",
+        "@voussoir/utils"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/adapter-mongoose",
+        "@voussoir/admin-ui",
+        "@voussoir/fields",
+        "@voussoir/server",
+        "@voussoir/test-utils",
+        "@voussoir/core",
+        "@voussoir/utils"
+      ]
+    }
+  ]
+}

--- a/.changeset/46d1f192/changes.md
+++ b/.changeset/46d1f192/changes.md
@@ -1,0 +1,1 @@
+- Expose programatic querying of Lists within hooks via a new 'list' API

--- a/docs/hooks-api.md
+++ b/docs/hooks-api.md
@@ -40,8 +40,15 @@ keystone.createList('User', {
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const resolveInput = ({ resolvedData, existingItem, originalInput, context, adapter }) => resolvedData;
+const resolveInput = ({
+  resolvedData,
+  existingItem,
+  originalInput,
+  context,
+  list,
+}) => resolvedData;
 ```
 
 ### `ResolveInputArg: Object`
@@ -52,7 +59,7 @@ const resolveInput = ({ resolvedData, existingItem, originalInput, context, adap
   existingItem: Object,
   originalInput: Object,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -89,10 +96,55 @@ The [Apollo `context`
 object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context)
 for this request.
 
-#### `ResolveInputArg#adapter`
+#### `ResolveInputArg#list`
 
-The current Lists's internal Keystone Adapter, providing access to the
-underlying Keystone API and model.
+An API providing programatic access to List functions:
+
+```javascript
+{
+  /**
+   * @param args Object The same arguments as the *WhereUniqueInput graphql
+   * type
+   * @param context Object The Apollo context object for this request
+   * @param options.skipAccessControl Boolean By default access control _of
+   * the user making the initial request_ is still tested. Disable all
+   * Access Control checks with this flag
+   *
+   * @return Promise<Object> The found item
+   */
+  query: (args, context, options) => Promise<Object>,
+
+  /**
+   * @param args Object The same arguments as the *WhereInput graphql type
+   * @param context Object The Apollo context object for this request
+   * @param options.skipAccessControl Boolean By default access control _of
+   * the user making the initial request_ is still tested. Disable all
+   * Access Control checks with this flag
+   *
+   * @return Promise<[Object]|[]> The found item. May reject with Access
+   * Control errors.
+   */
+  queryMany: (args, context, options) => Promise<Object|null>,
+
+  /**
+   * @param args Object The same arguments as the *WhereInput graphql type
+   * @param context Object The Apollo context object for this request
+   * @param options.skipAccessControl Boolean By default access control _of
+   * the user making the initial request_ is still tested. Disable all
+   * Access Control checks with this flag
+   *
+   * @return Promise<Object> Meta data about the found items. Currently
+   * contains only a single key: `count`.
+   */
+  queryManyMeta: (args, context, options) => Promise<Object>,
+
+  /**
+   * @param key String The string name of a Keystone list
+   * @return Object The programatic API of the requested list.
+   */
+  getList: (key) => Object,
+}
+```
 
 ### `ResolveInputResult: Object|Promise<Object>`
 
@@ -106,8 +158,18 @@ order]('./hooks.md#hook-excecution-order) as the input data.
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const validateInput = ({ resolvedData, existingItem, originalInput, addFieldValidationError, context, adapter }) => { /* throw any errors here */ }
+const validateInput = ({
+  resolvedData,
+  existingItem,
+  originalInput,
+  addFieldValidationError,
+  context,
+  list,
+}) => {
+  /* throw any errors here */
+};
 ```
 
 ### `ValidateInputArg: Object`
@@ -119,7 +181,7 @@ const validateInput = ({ resolvedData, existingItem, originalInput, addFieldVali
   originalInput: Object,
   addFieldValidationError: Func,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -131,8 +193,16 @@ const validateInput = ({ resolvedData, existingItem, originalInput, addFieldVali
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const validateDelete = ({ existingItem, addFieldValidationError, context, adapter }) => { /* throw any errors here */ }
+const validateDelete = ({
+  existingItem,
+  addFieldValidationError,
+  context,
+  list,
+}) => {
+  /* throw any errors here */
+};
 ```
 
 ### `ValidateDeleteArg: Object`
@@ -142,7 +212,7 @@ const validateDelete = ({ existingItem, addFieldValidationError, context, adapte
   existingItem: Object,
   addFieldValidationError: Func,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -154,8 +224,17 @@ const validateDelete = ({ existingItem, addFieldValidationError, context, adapte
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const beforeChange = ({ resolvedData, existingItem, originalInput, context, adapter }) => { /* side effects here */ }
+const beforeChange = ({
+  resolvedData,
+  existingItem,
+  originalInput,
+  context,
+  list,
+}) => {
+  /* side effects here */
+};
 ```
 
 ### `BeforeChangeArg: Object`
@@ -166,7 +245,7 @@ const beforeChange = ({ resolvedData, existingItem, originalInput, context, adap
   existingItem: Object,
   originalInput: Object,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -178,8 +257,17 @@ const beforeChange = ({ resolvedData, existingItem, originalInput, context, adap
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const afterChange = ({ updatedItem, existingItem, originalInput, context, adapter }) => { /* side effects here */ }
+const afterChange = ({
+  updatedItem,
+  existingItem,
+  originalInput,
+  context,
+  list,
+}) => {
+  /* side effects here */
+};
 ```
 
 ### `ValidateDeleteArg: Object`
@@ -190,7 +278,7 @@ const afterChange = ({ updatedItem, existingItem, originalInput, context, adapte
   existingItem: Object,
   originalInput: Func,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -202,8 +290,15 @@ const afterChange = ({ updatedItem, existingItem, originalInput, context, adapte
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const beforeDelete = ({ existingItem, context, adapter }) => { /* throw any errors here */ }
+const beforeDelete = ({
+  existingItem,
+  context,
+  list,
+}) => {
+  /* throw any errors here */
+};
 ```
 
 ### `BeforeDeleteArg: Object`
@@ -212,7 +307,7 @@ const beforeDelete = ({ existingItem, context, adapter }) => { /* throw any erro
 {
   existingItem: Object,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 
@@ -224,8 +319,15 @@ const beforeDelete = ({ existingItem, context, adapter }) => { /* throw any erro
 
 Example:
 
+<!-- prettier-ignore -->
 ```javascript
-const afterDelete = ({ existingItem, context, adapter }) => { /* side effects here */ }
+const afterDelete = ({
+  existingItem,
+  context,
+  list,
+}) => {
+  /* side effects here */
+};
 ```
 
 ### `AfterDeleteArg: Object`
@@ -234,7 +336,7 @@ const afterDelete = ({ existingItem, context, adapter }) => { /* side effects he
 {
   existingItem: Object,
   context: Object,
-  adapter: Object,
+  list: Object,
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -159,7 +159,11 @@
   },
   "jest": {
     "setupTestFrameworkScriptFile": "./jest/setup.js",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/website/.cache"
+    ]
   },
   "devDependencies": {
     "apollo-fetch": "^0.7.0",

--- a/packages/core/Keystone/index.js
+++ b/packages/core/Keystone/index.js
@@ -58,6 +58,7 @@ module.exports = class Keystone {
     const adapterName = config.adapterName || this.defaultAdapter;
     const list = new List(key, config, {
       getListByKey,
+      getAdminSchema: this.getAdminSchema,
       adapter: adapters[adapterName],
       defaultAccess: this.defaultAccess,
       getAuth: () => this.auth[key],
@@ -197,6 +198,10 @@ module.exports = class Keystone {
   }
 
   getAdminSchema() {
+    if (this._adminSchema) {
+      return this._adminSchema;
+    }
+
     const typeDefs = this.getTypeDefs();
     if (debugGraphQLSchemas()) {
       typeDefs.forEach(i => console.log(i));
@@ -282,7 +287,8 @@ module.exports = class Keystone {
       console.log(resolvers);
     }
 
-    return { typeDefs, resolvers };
+    this._adminSchema = { typeDefs, resolvers };
+    return this._adminSchema;
   }
 
   getAuxQueryResolvers() {

--- a/packages/fields/types/Relationship/nested-mutations.js
+++ b/packages/fields/types/Relationship/nested-mutations.js
@@ -113,7 +113,7 @@ async function resolveNestedMany({
     // In the future, when WhereUniqueInput accepts more than just an id,
     // this will also resolve those queries for us too.
     const [connectedItems, connectErrors] = await _runActions(
-      where => refList.itemQuery(where.id, context, refList.gqlNames.itemQueryName),
+      where => refList.itemQuery({ where }, context, refList.gqlNames.itemQueryName),
       input.connect,
       [localField.path, 'connect']
     );
@@ -164,7 +164,7 @@ async function resolveNestedSingle({
       try {
         // Support other unique fields for disconnection
         idToDisconnect = (await refList.itemQuery(
-          input.disconnect,
+          { where: input.disconnect },
           context,
           refList.gqlNames.itemQueryName
         )).id.toString();
@@ -187,7 +187,7 @@ async function resolveNestedSingle({
     let item;
     try {
       item = await (input.connect
-        ? refList.itemQuery(input.connect.id, context, refList.gqlNames.itemQueryName)
+        ? refList.itemQuery({ where: input.connect }, context, refList.gqlNames.itemQueryName)
         : refList.createMutation(input.create, context, mutationState));
     } catch (error) {
       const operation = input.connect ? 'connect' : 'create';

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -66,8 +66,9 @@ exports.intersection = (array1, array2) =>
 exports.pick = (obj, keys) =>
   keys.reduce((acc, key) => (key in obj ? { ...acc, [key]: obj[key] } : acc), {});
 
-exports.omit = (obj, keys) =>
-  exports.pick(obj, Object.keys(obj).filter(value => !keys.includes(value)));
+exports.omitBy = (obj, func) => exports.pick(obj, Object.keys(obj).filter(value => !func(value)));
+
+exports.omit = (obj, keys) => exports.omitBy(obj, value => keys.includes(value));
 
 // [{ k1: v1, k2: v2, ...}, { k3: v3, k4: v4, ...}, ...] => { k1: v1, k2: v2, k3: v3, k4, v4, ... }
 // Gives priority to the objects which appear later in the list


### PR DESCRIPTION
## Use case

I need to run a query within a hook:

```javascript
keystone.createList('User', {
  fields: {
    email:     { type: Text },
  },
});

keystone.createList('Event', {
  fields: {
    owner:     { type: Relationship, ref: 'User' },
  },
});

keystone.createList('CFP', {
  fields: {
    event:     { type: Relationship, ref: 'Event' },
  },
  hooks: {
    afterChange: async ({ updatedItem, existingItem, adapter }) => {
      const isCreate = !existingItem;

      if (isCreate) {
        // I need to notify the event owner now...
        // How do I get `updatedItem.event.owner.email`?
      }
    },
  }
});
```

## FYI

The tests here are very limited, but so too are all the hooks tests!