### PR TITLE
Expose access to GraphQL query method within hooks

### DIFF
--- a/.changeset/46d1f192/changes.md
+++ b/.changeset/46d1f192/changes.md
@@ -1,1 +1,1 @@
-- Expose programatic querying of Lists within hooks via a new 'list' API
+- Expose access to GraphQL query method within hooks

--- a/packages/server/WebServer/graphql.js
+++ b/packages/server/WebServer/graphql.js
@@ -5,6 +5,7 @@ const { renderPlaygroundPage } = require('graphql-playground-html');
 const cuid = require('cuid');
 const logger = require('@voussoir/logger');
 const { omit } = require('@voussoir/utils');
+const { graphql } = require('graphql');
 
 const { NestedError } = require('./graphqlErrors');
 
@@ -94,6 +95,7 @@ module.exports = function createGraphQLMiddleware(keystone, { apiPath, graphiqlP
       }
     },
   });
+
   server.applyMiddleware({
     app,
     path: apiPath,
@@ -101,6 +103,7 @@ module.exports = function createGraphQLMiddleware(keystone, { apiPath, graphiqlP
     // https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#ApolloServer-applyMiddleware
     cors: false,
   });
+
   if (graphiqlPath) {
     app.use(graphiqlPath, (req, res) => {
       if (req.user && req.sessionID) {
@@ -113,6 +116,10 @@ module.exports = function createGraphQLMiddleware(keystone, { apiPath, graphiqlP
       res.end();
     });
   }
+
+  keystone.registerGraphQLQueryMethod((query, context, variables) =>
+    graphql(server.schema, query, null, context, variables)
+  );
 
   return app;
 };


### PR DESCRIPTION
Enables functionality such as:

```javascript
keystone.createList('CFPScheduleRequest', {
  fields: { /* ... */ },
  hooks: {
    afterChange: async ({ updatedItem, existingItem, actions: { query } }) => {
      const isCreate = !existingItem;

      if (!isCreate) {
        return;
      }

      const { data: { CFPScheduleRequest: data } } = query(
        `
          query extractInfo($id: ID!) {
            CFPScheduleRequest(where: { id: $id }) {
              cfp {
                presentation {
                  id
                  title
                  user {
                    email
                    displayName
                  }
                }
              }
              event {
                id
                name
                startTime
                group {
                  id
                  name
                }
                location {
                  name
                }
              }
            }
          }
        `,
        { variables: { id: updatedItem.id } },
      );

      sendEmail(`
        Hi ${data.cfp.presentation.user.name},

        Good news!
        The ${data.event.group.name} team wants you to give your talk "_${data.cfp.presentation.title}_"
        at an upcoming event:

        * **Event**: ${data.event.name}
        * **When**: ${formatDate(data.event.startTime)}
        * **Where**: ${data.event.location.name}

        <CTAButton href="...">Yes, I'll give my talk then</CTAButton>
        <CancelButton href="...">Sorry, I can't do that event</CancelButton>

        Or; [Get in touch with ${data.event.group.name}](mailto:...) to suggest an alternative.

        ❤️ The Cete team.
      `);
    }
  }
});
```