### PR TITLE
Adding a route which retrieves all the Lists registered on a Keystone instance

### DIFF
--- a/admin/server/api/list/all.js
+++ b/admin/server/api/list/all.js
@@ -1,0 +1,18 @@
+
+module.exports = function (req, res) {
+	var result = {};
+
+    var lists = req.list;
+
+    for (var l in lists) {
+        var item = lists[l];
+
+        result[item.key] = {
+            name: item.key,
+            path: item.path,
+            fields: item.fieldTypes
+        };
+    }
+
+    res.json(result);
+};

--- a/admin/server/api/list/all.js
+++ b/admin/server/api/list/all.js
@@ -2,17 +2,19 @@
 module.exports = function (req, res) {
 	var result = {};
 
-    var lists = req.list;
+	var lists = req.list;
 
-    for (var l in lists) {
-        var item = lists[l];
+	for (var l in lists) {
+		if (lists.hasOwnProperty(l)) {
+			var item = lists[l];
 
-        result[item.key] = {
-            name: item.key,
-            path: item.path,
-            fields: item.fieldTypes
-        };
-    }
+			result[item.key] = {
+				name: item.key,
+				path: item.path,
+				fields: item.fieldTypes,
+			};
+		}
+	}
 
-    res.json(result);
+	res.json(result);
 };

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -85,6 +85,7 @@ module.exports = function createDynamicRouter (keystone) {
 	router.post('/api/:list/create', initList, require('../api/list/create'));
 	router.post('/api/:list/update', initList, require('../api/list/update'));
 	router.post('/api/:list/delete', initList, require('../api/list/delete'));
+    router.all('/api', initList, require('../api/list/all'));
 	// items
 	router.get('/api/:list/:id', initList, require('../api/item/get'));
 	router.post('/api/:list/:id', initList, require('../api/item/update'));

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -85,7 +85,7 @@ module.exports = function createDynamicRouter (keystone) {
 	router.post('/api/:list/create', initList, require('../api/list/create'));
 	router.post('/api/:list/update', initList, require('../api/list/update'));
 	router.post('/api/:list/delete', initList, require('../api/list/delete'));
-    router.all('/api', initList, require('../api/list/all'));
+	router.all('/api', initList, require('../api/list/all'));
 	// items
 	router.get('/api/:list/:id', initList, require('../api/item/get'));
 	router.post('/api/:list/:id', initList, require('../api/item/update'));

--- a/lib/core/list.js
+++ b/lib/core/list.js
@@ -3,16 +3,14 @@
  */
 
 module.exports = function list (key) {
-    var result;
+	var result;
 
-    if (key)
-    {
-        result = this.lists[key] || this.lists[this.paths[key]];
-    }
-    else
-    {
-        result = this.lists;
-    }
+	if (key) {
+		result = this.lists[key] || this.lists[this.paths[key]];
+	}
+	else {
+		result = this.lists;
+	}
 
 	if (!result) throw new ReferenceError('Unknown keystone list ' + JSON.stringify(key));
 

--- a/lib/core/list.js
+++ b/lib/core/list.js
@@ -3,7 +3,18 @@
  */
 
 module.exports = function list (key) {
-	var result = this.lists[key] || this.lists[this.paths[key]];
+    var result;
+
+    if (key)
+    {
+        result = this.lists[key] || this.lists[this.paths[key]];
+    }
+    else
+    {
+        result = this.lists;
+    }
+
 	if (!result) throw new ReferenceError('Unknown keystone list ' + JSON.stringify(key));
+
 	return result;
 };


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
My changes aim at exposing a new route which returns all the lists currently registered on the models folder of a Keystone installation:  
```
GET http://localhost:3000/keystone/api

=>

{
    "MyCustomType": {
        "name": "MyCustomType",
        "path": "/mycustomtype",
        "fields": [...]
    }
}
```

## Related issues (if any)
_No related issues_

## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

My results/observations/issues:
- No admin UI change
- **Where can I add a test for this feature?**
- One test of `npm run test-all` failed, but it was failing before adding my code:
```
952 passing (16s)
  1 pending
  1 failing

  1) FieldType: Markdown: Filter "before all" hook:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

npm ERR! Test failed.  See above for more details.
```

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

