### PR TITLE
Don't try to resolve nested mutations which will be later backfilled

### DIFF
--- a/.changeset/adc549c5/changes.json
+++ b/.changeset/adc549c5/changes.json
@@ -1,0 +1,7 @@
+{
+  "releases": [
+    { "name": "@voussoir/fields", "type": "patch" },
+    { "name": "@voussoir/core", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/adc549c5/changes.md
+++ b/.changeset/adc549c5/changes.md
@@ -1,0 +1,1 @@
+- Don't try to resolve nested mutations which will be later backfilled

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -165,16 +165,29 @@ class Relationship extends Implementation {
   async resolveRelationship(input, item, context, getItem, mutationState) {
     const { many, isRequired } = this.config;
 
-    // Early out for null'd field
-    if (!isRequired && !input) {
-      return input;
-    }
-
     const { refList, refField } = this.tryResolveRefList();
     const listInfo = {
       local: { list: this.getListByKey(this.listKey), field: this },
       foreign: { list: refList, field: refField },
     };
+
+    // Possible early out for null'd field
+    // prettier-ignore
+    if (
+      !input
+      && (
+        // If the field is not required, and the value is `null`, we can ignore
+        // it and move on.
+        !isRequired
+        // This field will be backlinked to this field's containing item, so we
+        // can safely ignore it now expecing the backlinking process in the
+        // calling code to take care of it.
+        || (refField && this.getListByKey(refField.refListKey) === listInfo.local.list)
+      )
+    ) {
+      return input;
+    }
+
     let currentValue = item && item[this.path];
     if (many) {
       currentValue = (currentValue || []).map(id => id.toString());

--- a/projects/basic/tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
+++ b/projects/basic/tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
@@ -1,0 +1,65 @@
+const { gen, sampleOne } = require('testcheck');
+const { Text, Relationship } = require('@voussoir/fields');
+const cuid = require('cuid');
+const { keystoneMongoTest, setupServer, graphqlRequest } = require('@voussoir/test-utils');
+
+const alphanumGenerator = gen.alphaNumString.notEmpty();
+
+jest.setTimeout(6000000);
+
+function setupKeystone() {
+  return setupServer({
+    name: `ks5-testdb-${cuid()}`,
+    createLists: keystone => {
+      keystone.createList('Company', {
+        fields: {
+          name: { type: Text },
+          location: { type: Relationship, ref: 'Location.company' },
+        },
+      });
+
+      keystone.createList('Location', {
+        fields: {
+          name: { type: Text },
+          company: { type: Relationship, ref: 'Company.location', isRequired: true },
+        },
+      });
+    },
+  });
+}
+
+describe('update one to one relationship back reference', () => {
+  test(
+    'nested create',
+    keystoneMongoTest(setupKeystone, async ({ server: { server }, findById }) => {
+      const locationName = sampleOne(alphanumGenerator);
+      const queryResult = await graphqlRequest({
+        server,
+        query: `
+        mutation {
+          createCompany(data: {
+            location: { create: { name: "${locationName}" } }
+          }) {
+            id
+            location {
+              id
+            }
+          }
+        }
+    `,
+      });
+
+      expect(queryResult.body).not.toHaveProperty('errors');
+
+      const companyId = queryResult.body.data.createCompany.id;
+      const locationId = queryResult.body.data.createCompany.location.id;
+
+      const location = await findById('Location', locationId);
+      const company = await findById('Company', companyId);
+
+      // Everything should now be connected
+      expect(company.location.toString()).toBe(locationId.toString());
+      expect(location.company.toString()).toBe(companyId.toString());
+    })
+  );
+});


### PR DESCRIPTION
Would previously error with `Cannot convert undefined or null to object` because a `Relationship` field's `getDefaultValue()` returns `null`, which is later fed into the relationship resolution logic which assumes an object similar to `{ create: { foo: 'bar' } }`, not `null`.

There was already an early-exit for the non-required case, but the required case would still execute and fail.

This additional logic (and test) checks for the required case, and ensures the value will actually be backfilled, then early exits appropriately.