### PR TITLE
Remove kerberos from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "glamor": "^2.20.25",
     "grappling-hook": "^3.0.0",
     "i": "^0.3.5",
-    "kerberos": "^1.0.0",
     "keystone-storage-namefunctions": "^1.1.1",
     "keystone-utils": "^0.4.0",
     "knox-s3": "^0.9.5",


### PR DESCRIPTION
## Description of changes
Removal of kerberos since it's [not used anywhere in the project](https://github.com/keystonejs/keystone/search?q=kerberos) anyway and only creates problems when installing packages since kerberos requires compiling.

The only thing that happened is that the package version was bumped over time. It also makes it more difficult to deploy keystone in a docker container (based of alpine, because of the compile requirement).

## Related issues (if any)
#4851, #1564, 

## Testing
I didn't test since for some reason even the unit tests gave me issues without having modified anything.

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.


