### PR TITLE
Explicitly check whether field types are supported by the adapter

### DIFF
--- a/.changeset/d9537ae1/changes.json
+++ b/.changeset/d9537ae1/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@voussoir/core", "type": "patch" }], "dependents": [] }

--- a/.changeset/d9537ae1/changes.md
+++ b/.changeset/d9537ae1/changes.md
@@ -1,0 +1,1 @@
+- Explicitly check whether field types are supported by the adapter

--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -59,6 +59,11 @@ class MockAdapter {
   newListAdapter = () => new MockListAdapter();
 }
 
+Text.adapters['mock'] = {};
+Checkbox.adapters['mock'] = {};
+Float.adapters['mock'] = {};
+Relationship.adapters['mock'] = {};
+
 const context = {
   getListAccessControlForUser: () => true,
   getFieldAccessControlForUser: (listKey, fieldPath, existingItem) =>


### PR DESCRIPTION
Useful when developing a new adapter ;-)

Also fixes a typo in `mapNativeTypeToKeystoneType` and uses `mapKeys` to compute `this.fieldsByPath` for local consistency.