### PR TITLE
Move findFieldAdapterForQuerySegment onto the BaseListAdapter

### DIFF
--- a/.changeset/c164eef3/changes.json
+++ b/.changeset/c164eef3/changes.json
@@ -1,0 +1,58 @@
+{
+  "releases": [
+    { "name": "@voussoir/adapter-mongoose", "type": "major" },
+    { "name": "@voussoir/core", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@voussoir/fields",
+      "type": "patch",
+      "dependencies": ["@voussoir/test-utils", "@voussoir/adapter-mongoose"]
+    },
+    {
+      "name": "@voussoir/test-utils",
+      "type": "patch",
+      "dependencies": ["@voussoir/adapter-mongoose", "@voussoir/core"]
+    },
+    {
+      "name": "@voussoir/demo-project-todo",
+      "type": "patch",
+      "dependencies": ["@voussoir/fields", "@voussoir/adapter-mongoose", "@voussoir/core"]
+    },
+    {
+      "name": "@voussoir/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/fields",
+        "@voussoir/test-utils",
+        "@voussoir/adapter-mongoose",
+        "@voussoir/core"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/fields",
+        "@voussoir/test-utils",
+        "@voussoir/adapter-mongoose",
+        "@voussoir/core"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@voussoir/fields",
+        "@voussoir/test-utils",
+        "@voussoir/adapter-mongoose",
+        "@voussoir/core"
+      ]
+    },
+    {
+      "name": "@voussoir/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": ["@voussoir/fields", "@voussoir/adapter-mongoose", "@voussoir/core"]
+    }
+  ]
+}

--- a/.changeset/c164eef3/changes.md
+++ b/.changeset/c164eef3/changes.md
@@ -1,0 +1,1 @@
+- Move findFieldAdapterForQuerySegment onto the BaseListAdapter

--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -159,12 +159,6 @@ class MongooseListAdapter extends BaseListAdapter {
     });
   }
 
-  findFieldAdapterForQuerySegment(segment) {
-    return this.fieldAdapters
-      .filter(adapter => adapter.isRelationship)
-      .find(adapter => adapter.supportsRelationshipQuery(segment));
-  }
-
   prepareFieldAdapter(fieldAdapter) {
     fieldAdapter.addToMongooseSchema(this.schema, this.mongoose, {
       addPreSaveHook: this.addPreSaveHook.bind(this),

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -99,6 +99,12 @@ class BaseListAdapter {
     // through each consecutive hook
     return pWaterfall(this.postReadHooks, item);
   }
+
+  findFieldAdapterForQuerySegment(segment) {
+    return this.fieldAdapters
+      .filter(adapter => adapter.isRelationship)
+      .find(adapter => adapter.supportsRelationshipQuery(segment));
+  }
 }
 
 class BaseFieldAdapter {


### PR DESCRIPTION
Turns out this is a useful method for the knex adapter to have access to. Doing this as a separate PR to  keep the knex branch as clean as possible.