### PR TITLE
Remove named functions in favour of inline code

### DIFF
--- a/packages/core/Keystone/index.js
+++ b/packages/core/Keystone/index.js
@@ -360,24 +360,15 @@ module.exports = class Keystone {
   }
 
   async createItems(itemsToCreate) {
-    const createItems = data => {
-      return resolveAllKeys(
-        mapKeys(data, (value, list) => Promise.all(value.map(item => this.createItem(list, item))))
-      );
-    };
-
-    const cleanupItems = createdItems =>
-      Promise.all(
-        Object.keys(createdItems).map(listKey =>
-          Promise.all(createdItems[listKey].map(({ id }) => this.lists[listKey].adapter.delete(id)))
-        )
-      );
-
     // 1. Split it apart
     const { relationships, data } = unmergeRelationships(this.lists, itemsToCreate);
     // 2. Create the items
     // NOTE: Only works if all relationships fields are non-"required"
-    const createdItems = await createItems(data);
+    const createdItems = await resolveAllKeys(
+      mapKeys(data, (items, listKey) =>
+        Promise.all(items.map(itemData => this.createItem(listKey, itemData)))
+      )
+    );
 
     let createdRelationships;
     try {
@@ -385,7 +376,11 @@ module.exports = class Keystone {
       createdRelationships = await createRelationships(this.lists, relationships, createdItems);
     } catch (error) {
       // 3.5. If creation of relationships didn't work, unwind the createItems
-      cleanupItems(createdItems);
+      Promise.all(
+        Object.entries(createdItems).map(([listKey, items]) =>
+          Promise.all(items.map(({ id }) => this.lists[listKey].adapter.delete(id)))
+        )
+      );
       // Re-throw the error now that we've cleaned up
       throw error;
     }


### PR DESCRIPTION
No functional changes, just makes the code easier to read not having to jump back up to definitions further up the code.