### PR TITLE
Handle more graphQL errors

### DIFF
--- a/packages/server/WebServer/graphql.js
+++ b/packages/server/WebServer/graphql.js
@@ -79,7 +79,7 @@ module.exports = function createGraphQLMiddleware(
     context: ({ req }) => keystone.getAccessContext(req),
     formatError: error => {
       const { originalError } = error;
-      if (!originalError.path) {
+      if (originalError && !originalError.path) {
         originalError.path = error.path;
       }
 
@@ -105,7 +105,7 @@ module.exports = function createGraphQLMiddleware(
             };
 
             if (pinoError.errors) {
-              pinoError.errors = flattenNestedErrors(originalError).map(safeFormatError);
+              pinoError.errors = flattenNestedErrors(exception).map(safeFormatError);
             }
 
             graphqlLogger.error(pinoError);


### PR DESCRIPTION
Some GraphQL errors don't have an #originalError property, such as a
missing required parameter:

> Variable "$groupId" of required type "ID!" was not provided.

This change handles those cases better.