### PR TITLE
Remove mongo-specific ID-handling code

### DIFF
--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -208,7 +208,7 @@ class MongooseListAdapter extends BaseListAdapter {
   async create(data) {
     const dataToSave = await this.onPreSave(data);
     const createdData = await this.model.create(dataToSave);
-    return this.onPostRead(createdData);
+    return this.onPostRead(pick(createdData, ['id', ...Object.keys(data)]));
   }
 
   async delete(id) {

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -18,7 +18,7 @@ const getIDs = async keystone => {
   const IDs = {};
   await keystone.lists['test'].adapter.findAll().then(data => {
     data.forEach(entry => {
-      IDs[entry.name] = entry._id.toString();
+      IDs[entry.name] = entry.id;
     });
   });
   return IDs;

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -115,14 +115,10 @@ class Relationship extends Implementation {
         [this.path]: (item, _, context) => {
           // The field may have already been filled in during an early DB lookup
           // (ie; joining when doing a filter)
-          const id = item[this.path] && item[this.path]._id ? item[this.path]._id : item[this.path];
-
-          if (!id) {
+          if (item[this.path] === null) {
             return null;
           }
-
-          const filteredQueryArgs = { where: { id: id.toString() } };
-
+          const filteredQueryArgs = { where: { id: item[this.path].toString() } };
           // We do a full query to ensure things like access control are applied
           return refList
             .listQuery(filteredQueryArgs, context, refList.gqlNames.listQueryName)
@@ -138,8 +134,8 @@ class Relationship extends Implementation {
           .map(value => {
             // The field may have already been filled in during an early DB lookup
             // (ie; joining when doing a filter)
-            if (value && value._id) {
-              return value._id;
+            if (value && value.id) {
+              return value.id;
             }
 
             return value;

--- a/test-projects/basic/tests/queries/relationships.test.js
+++ b/test-projects/basic/tests/queries/relationships.test.js
@@ -122,9 +122,9 @@ describe('Querying with relationship filters', () => {
       ]);
 
       const users = await Promise.all([
-        create('User', { feed: [posts[0], posts[1]], name: sampleOne(alphanumGenerator) }),
-        create('User', { feed: [posts[2]], name: sampleOne(alphanumGenerator) }),
-        create('User', { feed: [posts[3]], name: sampleOne(alphanumGenerator) }),
+        create('User', { feed: [posts[0].id, posts[1].id], name: sampleOne(alphanumGenerator) }),
+        create('User', { feed: [posts[2].id], name: sampleOne(alphanumGenerator) }),
+        create('User', { feed: [posts[3].id], name: sampleOne(alphanumGenerator) }),
       ]);
 
       return { posts, users };
@@ -238,8 +238,8 @@ describe('Querying with relationship filters', () => {
       ]);
 
       const users = await Promise.all([
-        create('User', { feed: [posts[0], posts[1]], name: sampleOne(alphanumGenerator) }),
-        create('User', { feed: [posts[0]], name: sampleOne(alphanumGenerator) }),
+        create('User', { feed: [posts[0].id, posts[1].id], name: sampleOne(alphanumGenerator) }),
+        create('User', { feed: [posts[0].id], name: sampleOne(alphanumGenerator) }),
         create('User', { feed: [], name: sampleOne(alphanumGenerator) }),
       ]);
 


### PR DESCRIPTION
Mongo objects have a special `._id` property which is not present in other database adapters. This PR removes specific references to this property, replacing it with explicit references to the `.id` property.