### PR TITLE
Make each adapter entirely responsible for its postConnect process

### DIFF
--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const inflection = require('inflection');
+const pSettle = require('p-settle');
 const { escapeRegExp, pick, getType, mapKeys, mapKeyNames } = require('@voussoir/utils');
 
 const {
@@ -98,6 +99,11 @@ class MongooseAdapter extends BaseKeystoneAdapter {
       // For the case where both are set, the expected behaviour is for it to be
       // overwritten.
       { useNewUrlParser: true, ...adapterConnectOptions, dbName }
+    );
+  }
+  async postConnect() {
+    return await pSettle(
+      Object.values(this.listAdapters).map(listAdapter => listAdapter.postConnect())
     );
   }
 

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -1,5 +1,4 @@
 const pWaterfall = require('p-waterfall');
-const pSettle = require('p-settle');
 
 class BaseKeystoneAdapter {
   constructor(config) {
@@ -23,17 +22,15 @@ class BaseKeystoneAdapter {
 
   async connect(to, config = {}) {
     // Connect to the database
-    this._connect(to, config);
+    await this._connect(to, config);
 
     // Set up all list adapters
     try {
-      const taskResults = await pSettle(
-        Object.values(this.listAdapters).map(listAdapter => listAdapter.postConnect())
-      );
+      const taskResults = await this.postConnect();
       const errors = taskResults.filter(({ isRejected }) => isRejected);
 
       if (errors.length) {
-        const error = new Error('Connection error');
+        const error = new Error('Post connection error');
         error.errors = errors.map(({ reason }) => reason);
         throw error;
       }
@@ -51,6 +48,8 @@ class BaseKeystoneAdapter {
       throw error;
     }
   }
+
+  async postConnect() {}
 }
 
 class BaseListAdapter {


### PR DESCRIPTION
The Knex adapter requires a more flexible postConnect step than simple running `listAdapter.postConnect` in parallel. For example, it needs to create all tables before creating foreign key constraints. This change adds a `.postConnect` method to the top level adapter.