### PR TITLE
Functionality for creating auxiliary lists from another list

### DIFF
--- a/packages/core/tests/List.test.js
+++ b/packages/core/tests/List.test.js
@@ -113,8 +113,11 @@ const listExtras = (getAuth = () => true, queryMethod = undefined) => ({
   getGraphQLQuery: () => queryMethod,
 });
 
-const setup = (extraConfig, getAuth, queryMethod) =>
-  new List('Test', { ...config, ...extraConfig }, listExtras(getAuth, queryMethod));
+const setup = (extraConfig, getAuth, queryMethod) => {
+  const list = new List('Test', { ...config, ...extraConfig }, listExtras(getAuth, queryMethod));
+  list.initFields();
+  return list;
+};
 
 describe('new List()', () => {
   test('new List() - Smoke test', () => {
@@ -204,6 +207,7 @@ describe('new List()', () => {
     expect(list.fieldsByPath['writeOnce']).toBeInstanceOf(Text.implementation);
 
     const noFieldsList = new List('NoField', { fields: {} }, listExtras());
+    noFieldsList.initFields();
     expect(noFieldsList.fields).toHaveLength(0);
   });
 
@@ -1282,6 +1286,7 @@ describe('Maps from Native JS types to Keystone types', () => {
           defaultAccess: { list: true, field: true },
         }
       );
+      list.initFields();
       expect(list.fieldsByPath.foo).toBeInstanceOf(keystoneType.implementation);
     });
   });


### PR DESCRIPTION
This is the implementation of `internal.DONOTUSERORYOULLBEFIRED.createList` from [#616](https://github.com/keystonejs/keystone-5/issues/616#issuecomment-455007833)

I'll be using it to create "hidden" join tables of data for the Content type.