### PR TITLE
Add setupHooks to BaseFieldAdapter

### DIFF
--- a/.changeset/37b09b50/changes.json
+++ b/.changeset/37b09b50/changes.json
@@ -1,0 +1,8 @@
+{
+  "releases": [
+    { "name": "@voussoir/adapter-mongoose", "type": "minor" },
+    { "name": "@voussoir/core", "type": "minor" },
+    { "name": "@voussoir/fields", "type": "minor" }
+  ],
+  "dependents": []
+}

--- a/.changeset/37b09b50/changes.md
+++ b/.changeset/37b09b50/changes.md
@@ -1,0 +1,1 @@
+- Add a setupHooks method to BaseFieldAdapter

--- a/packages/adapter-mongoose/index.js
+++ b/packages/adapter-mongoose/index.js
@@ -166,10 +166,7 @@ class MongooseListAdapter extends BaseListAdapter {
   }
 
   prepareFieldAdapter(fieldAdapter) {
-    fieldAdapter.addToMongooseSchema(this.schema, this.mongoose, {
-      addPreSaveHook: this.addPreSaveHook.bind(this),
-      addPostReadHook: this.addPostReadHook.bind(this),
-    });
+    fieldAdapter.addToMongooseSchema(this.schema, this.mongoose);
   }
 
   /**

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -73,6 +73,10 @@ class BaseListAdapter {
   newFieldAdapter(fieldAdapterClass, name, path, getListByKey, config) {
     const adapter = new fieldAdapterClass(name, path, this, getListByKey, config);
     this.prepareFieldAdapter(adapter);
+    adapter.setupHooks({
+      addPreSaveHook: this.addPreSaveHook.bind(this),
+      addPostReadHook: this.addPostReadHook.bind(this),
+    });
     this.fieldAdapters.push(adapter);
     return adapter;
   }
@@ -118,6 +122,8 @@ class BaseFieldAdapter {
     this.config = config;
     this.getListByKey = getListByKey;
   }
+
+  setupHooks() {}
 }
 
 module.exports = {

--- a/packages/fields/types/DateTime/Implementation.js
+++ b/packages/fields/types/DateTime/Implementation.js
@@ -63,7 +63,7 @@ class _DateTime extends Implementation {
 const toDate = s => s && DateTime.fromISO(s, { zone: 'utc' }).toJSDate();
 
 class MongoDateTimeInterface extends MongooseFieldAdapter {
-  addToMongooseSchema(schema, _, { addPreSaveHook, addPostReadHook }) {
+  addToMongooseSchema(schema) {
     const { mongooseOptions } = this.config;
     const field_path = this.path;
     const utc_field = `${field_path}_utc`;
@@ -76,6 +76,12 @@ class MongoDateTimeInterface extends MongooseFieldAdapter {
       [utc_field]: { type: Date, ...mongooseOptions },
       [offset_field]: { type: String, ...mongooseOptions },
     });
+  }
+
+  setupHooks({ addPreSaveHook, addPostReadHook }) {
+    const field_path = this.path;
+    const utc_field = `${field_path}_utc`;
+    const offset_field = `${field_path}_offset`;
 
     // Updates the relevant value in the item provided (by referrence)
     addPreSaveHook(item => {

--- a/packages/fields/types/Decimal/Implementation.js
+++ b/packages/fields/types/Decimal/Implementation.js
@@ -37,7 +37,7 @@ class Decimal extends Implementation {
 }
 
 class MongoDecimalInterface extends MongooseFieldAdapter {
-  addToMongooseSchema(schema, _, { addPreSaveHook, addPostReadHook }) {
+  addToMongooseSchema(schema) {
     const { mongooseOptions = {} } = this.config;
     const { isRequired } = mongooseOptions;
 
@@ -50,7 +50,9 @@ class MongoDecimalInterface extends MongooseFieldAdapter {
       },
     };
     schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
+  }
 
+  setupHooks({ addPreSaveHook, addPostReadHook }) {
     // Updates the relevant value in the item provided (by referrence)
     addPreSaveHook(item => {
       if (item[this.path] && typeof item[this.path] === 'string') {

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -90,9 +90,11 @@ class Password extends Implementation {
 class MongoPasswordInterface extends MongooseFieldAdapter {
   // constructor(fieldName, path, listAdapter, getListByKey, config) {
 
-  addToMongooseSchema(schema, _, { addPreSaveHook }) {
+  addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: String }, this.config) });
+  }
 
+  setupHooks({ addPreSaveHook }) {
     // Updates the relevant value in the item provided (by referrence)
     addPreSaveHook(async item => {
       const list = this.getListByKey(this.listAdapter.key);
@@ -125,6 +127,7 @@ class KnexPasswordInterface extends KnexFieldAdapter {
   createColumn(table) {
     table.text(this.path);
   }
+
   getQueryConditions(f, g) {
     return {
       [`${this.path}_is_set`]: value => b =>


### PR DESCRIPTION
Provides a specific methods for adding pre- and post- hooks for fields. Decouples this process from the more mongoose specific `addToMongooseSchema`, which will allow for better code sharing across adapters in the extremely near future.