### PR TITLE
Refactor the path and value transform functions in getQueryConditions

### DIFF
--- a/packages/adapter-mongoose/tokenizers/simple.js
+++ b/packages/adapter-mongoose/tokenizers/simple.js
@@ -20,7 +20,9 @@ module.exports = ({ getRelatedListAdapterFromQueryPath, modifierConditions = {} 
     id_in: value => ({ _id: { $in: value.map(id => mongoose.Types.ObjectId(id)) } }),
     id_not_in: value => ({ _id: { $not: { $in: value.map(id => mongoose.Types.ObjectId(id)) } } }),
     ...objMerge(
-      refListAdapter.fieldAdapters.map(fieldAdapter => fieldAdapter.getQueryConditions())
+      refListAdapter.fieldAdapters.map(fieldAdapter =>
+        fieldAdapter.getQueryConditions(fieldAdapter.dbPath)
+      )
     ),
   };
   if (queryKey in simpleQueryConditions) {

--- a/packages/core/adapters/index.js
+++ b/packages/core/adapters/index.js
@@ -156,6 +156,7 @@ class BaseFieldAdapter {
     this.listAdapter = listAdapter;
     this.config = config;
     this.getListByKey = getListByKey;
+    this.dbPath = path;
   }
 
   setupHooks() {}

--- a/packages/fields/types/CalendarDay/Implementation.js
+++ b/packages/fields/types/CalendarDay/Implementation.js
@@ -36,7 +36,18 @@ class CalendarDay extends Implementation {
   }
 }
 
-class MongoCalendarDayInterface extends MongooseFieldAdapter {
+const CommonCalendarInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.orderingConditions(dbPath),
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoCalendarDayInterface extends CommonCalendarInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     const { mongooseOptions = {} } = this.config;
     const { isRequired } = mongooseOptions;
@@ -51,26 +62,11 @@ class MongoCalendarDayInterface extends MongooseFieldAdapter {
     };
     schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.orderingConditions(),
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexCalendarDayInterface extends KnexFieldAdapter {
+class KnexCalendarDayInterface extends CommonCalendarInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.text(this.path);
-  }
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(f, g),
-      ...this.orderingConditions(f, g),
-      ...this.inConditions(f, g),
-    };
   }
 }
 

--- a/packages/fields/types/Checkbox/Implementation.js
+++ b/packages/fields/types/Checkbox/Implementation.js
@@ -25,23 +25,22 @@ class Checkbox extends Implementation {
   }
 }
 
-class MongoCheckboxInterface extends MongooseFieldAdapter {
+const CommonCheckboxInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return this.equalityConditions(dbPath);
+    }
+  };
+
+class MongoCheckboxInterface extends CommonCheckboxInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: Boolean }, this.config) });
   }
-
-  getQueryConditions() {
-    return this.equalityConditions();
-  }
 }
 
-class KnexCheckboxInterface extends KnexFieldAdapter {
+class KnexCheckboxInterface extends CommonCheckboxInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.boolean(this.path);
-  }
-
-  getQueryConditions(f, g) {
-    return this.equalityConditions(f, g);
   }
 }
 

--- a/packages/fields/types/DateTime/Implementation.js
+++ b/packages/fields/types/DateTime/Implementation.js
@@ -133,9 +133,22 @@ const CommonDateTimeInterface = superclass =>
         return item;
       });
     }
+
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath, toDate),
+        ...this.orderingConditions(dbPath, toDate),
+        ...this.inConditions(dbPath, toDate),
+      };
+    }
   };
 
 class MongoDateTimeInterface extends CommonDateTimeInterface(MongooseFieldAdapter) {
+  constructor() {
+    super(...arguments);
+    this.dbPath = `${this.path}_utc`;
+  }
+
   addToMongooseSchema(schema) {
     const { mongooseOptions } = this.config;
     const field_path = this.path;
@@ -151,14 +164,6 @@ class MongoDateTimeInterface extends CommonDateTimeInterface(MongooseFieldAdapte
     });
   }
 
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(toDate, p => `${p}_utc`),
-      ...this.orderingConditions(toDate, p => `${p}_utc`),
-      ...this.inConditions(toDate, p => `${p}_utc`),
-    };
-  }
-
   getMongoFieldName() {
     return `${this.path}_utc`;
   }
@@ -172,6 +177,7 @@ class KnexDateTimeInterface extends CommonDateTimeInterface(KnexFieldAdapter) {
     const offset_field = `${field_path}_offset`;
     this.realKeys = [utc_field, offset_field];
     this.sortKey = utc_field;
+    this.dbPath = utc_field;
   }
 
   createColumn(table) {
@@ -181,14 +187,6 @@ class KnexDateTimeInterface extends CommonDateTimeInterface(KnexFieldAdapter) {
 
     table.timestamp(utc_field, { useTz: false });
     table.text(offset_field);
-  }
-
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(v => f(toDate(v)), p => g(`${p}_utc`)),
-      ...this.orderingConditions(v => f(toDate(v)), p => g(`${p}_utc`)),
-      ...this.inConditions(v => f(toDate(v)), p => g(`${p}_utc`)),
-    };
   }
 }
 

--- a/packages/fields/types/Decimal/Implementation.js
+++ b/packages/fields/types/Decimal/Implementation.js
@@ -71,11 +71,11 @@ class MongoDecimalInterface extends MongooseFieldAdapter {
     });
   }
 
-  getQueryConditions() {
+  getQueryConditions(dbPath) {
     return {
-      ...this.equalityConditions(mongoose.Types.Decimal128.fromString),
-      ...this.orderingConditions(mongoose.Types.Decimal128.fromString),
-      ...this.inConditions(mongoose.Types.Decimal128.fromString),
+      ...this.equalityConditions(dbPath, mongoose.Types.Decimal128.fromString),
+      ...this.orderingConditions(dbPath, mongoose.Types.Decimal128.fromString),
+      ...this.inConditions(dbPath, mongoose.Types.Decimal128.fromString),
     };
   }
 }
@@ -84,11 +84,11 @@ class KnexDecimalInterface extends KnexFieldAdapter {
   createColumn(table) {
     table.decimal(this.path);
   }
-  getQueryConditions(f, g) {
+  getQueryConditions(dbPath) {
     return {
-      ...this.equalityConditions(f, g),
-      ...this.orderingConditions(f, g),
-      ...this.inConditions(f, g),
+      ...this.equalityConditions(dbPath),
+      ...this.orderingConditions(dbPath),
+      ...this.inConditions(dbPath),
     };
   }
 }

--- a/packages/fields/types/File/Implementation.js
+++ b/packages/fields/types/File/Implementation.js
@@ -111,7 +111,18 @@ class File extends Implementation {
   }
 }
 
-class MongoFileInterface extends MongooseFieldAdapter {
+const CommonFileInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.stringConditions(dbPath),
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoFileInterface extends CommonFileInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     const schemaOptions = {
       type: {
@@ -124,26 +135,11 @@ class MongoFileInterface extends MongooseFieldAdapter {
     };
     schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.stringConditions(),
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexFileInterface extends KnexFieldAdapter {
+class KnexFileInterface extends CommonFileInterface(KnexFieldAdapter) {
   createColumn() {
     throw new Error('Knex Adapter does not currently support the `File` type.');
-  }
-  getQueryConditions(f) {
-    return {
-      ...this.equalityConditions(f),
-      ...this.stringConditions(f),
-      ...this.inConditions(f),
-    };
   }
 }
 

--- a/packages/fields/types/Float/Implementation.js
+++ b/packages/fields/types/Float/Implementation.js
@@ -29,30 +29,26 @@ class Float extends Implementation {
   }
 }
 
-class MongoFloatInterface extends MongooseFieldAdapter {
+const CommonFloatInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.orderingConditions(dbPath),
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoFloatInterface extends CommonFloatInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: Number }, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.orderingConditions(),
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexFloatInterface extends KnexFieldAdapter {
+class KnexFloatInterface extends CommonFloatInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.float(this.path);
-  }
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(f, g),
-      ...this.orderingConditions(f, g),
-      ...this.inConditions(f, g),
-    };
   }
 }
 

--- a/packages/fields/types/Integer/Implementation.js
+++ b/packages/fields/types/Integer/Implementation.js
@@ -29,7 +29,18 @@ class Integer extends Implementation {
   }
 }
 
-class MongoIntegerInterface extends MongooseFieldAdapter {
+const CommonIntegerInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.orderingConditions(dbPath),
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoIntegerInterface extends CommonIntegerInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     const { mongooseOptions = {} } = this.config;
     const { isRequired } = mongooseOptions;
@@ -46,27 +57,11 @@ class MongoIntegerInterface extends MongooseFieldAdapter {
     };
     schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.orderingConditions(),
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexIntegerInterface extends KnexFieldAdapter {
+class KnexIntegerInterface extends CommonIntegerInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.integer(this.path);
-  }
-
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(f, g),
-      ...this.orderingConditions(f, g),
-      ...this.inConditions(f, g),
-    };
   }
 }
 

--- a/packages/fields/types/Password/Implementation.js
+++ b/packages/fields/types/Password/Implementation.js
@@ -115,10 +115,10 @@ class MongoPasswordInterface extends CommonPasswordInterface(MongooseFieldAdapte
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: String }, this.config) });
   }
 
-  getQueryConditions() {
+  getQueryConditions(dbPath) {
     return {
       [`${this.path}_is_set`]: value => ({
-        [this.path]: value ? { $regex: bcryptHashRegex } : { $not: bcryptHashRegex },
+        [dbPath]: value ? { $regex: bcryptHashRegex } : { $not: bcryptHashRegex },
       }),
     };
   }
@@ -129,12 +129,12 @@ class KnexPasswordInterface extends CommonPasswordInterface(KnexFieldAdapter) {
     table.text(this.path);
   }
 
-  getQueryConditions(f, g) {
+  getQueryConditions(dbPath) {
     return {
       [`${this.path}_is_set`]: value => b =>
         value
-          ? b.where(g(this.path), '~', bcryptHashRegex.source)
-          : b.where(g(this.path), '!~', bcryptHashRegex.source).orWhereNull(g(this.path)),
+          ? b.where(dbPath, '~', bcryptHashRegex.source)
+          : b.where(dbPath, '!~', bcryptHashRegex.source).orWhereNull(dbPath),
     };
   }
 }

--- a/packages/fields/types/Relationship/Implementation.js
+++ b/packages/fields/types/Relationship/Implementation.js
@@ -343,10 +343,10 @@ class MongoRelationshipInterface extends MongooseFieldAdapter {
     return this.getListByKey(this.refListKey).adapter;
   }
 
-  getQueryConditions() {
+  getQueryConditions(dbPath) {
     return {
       [`${this.path}_is_null`]: value => ({
-        [this.path]: value ? { $not: { $exists: true, $ne: null } } : { $exists: true, $ne: null },
+        [dbPath]: value ? { $not: { $exists: true, $ne: null } } : { $exists: true, $ne: null },
       }),
     };
   }
@@ -428,10 +428,10 @@ class KnexRelationshipInterface extends KnexFieldAdapter {
       .inTable(`${schemaName}.${this.refListKey}`);
   }
 
-  getQueryConditions(f, g) {
+  getQueryConditions(dbPath) {
     return {
       [`${this.path}_is_null`]: value => b =>
-        value ? b.whereNull(g(this.path)) : b.whereNotNull(g(this.path)),
+        value ? b.whereNull(dbPath) : b.whereNotNull(dbPath),
     };
   }
   supportsRelationshipQuery(query) {

--- a/packages/fields/types/Select/Implementation.js
+++ b/packages/fields/types/Select/Implementation.js
@@ -57,28 +57,25 @@ class Select extends Implementation {
   }
 }
 
-class MongoSelectInterface extends MongooseFieldAdapter {
+const CommonSelectInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoSelectInterface extends CommonSelectInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: String }, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexSelectInterface extends KnexFieldAdapter {
+class KnexSelectInterface extends CommonSelectInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.enu(this.path, this.config.options.map(({ value }) => value));
-  }
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(f, g),
-      ...this.inConditions(f, g),
-    };
   }
 }
 

--- a/packages/fields/types/Text/Implementation.js
+++ b/packages/fields/types/Text/Implementation.js
@@ -31,35 +31,29 @@ class Text extends Implementation {
   }
 }
 
-class MongoTextInterface extends MongooseFieldAdapter {
+const CommonTextInterface = superclass =>
+  class extends superclass {
+    getQueryConditions(dbPath) {
+      return {
+        ...this.equalityConditions(dbPath),
+        ...this.stringConditions(dbPath),
+        ...this.equalityConditionsInsensitive(dbPath),
+        ...this.stringConditionsInsensitive(dbPath),
+        // These have no case-insensitive counter parts
+        ...this.inConditions(dbPath),
+      };
+    }
+  };
+
+class MongoTextInterface extends CommonTextInterface(MongooseFieldAdapter) {
   addToMongooseSchema(schema) {
     schema.add({ [this.path]: this.mergeSchemaOptions({ type: String }, this.config) });
   }
-
-  getQueryConditions() {
-    return {
-      ...this.equalityConditions(),
-      ...this.stringConditions(),
-      ...this.equalityConditionsInsensitive(),
-      ...this.stringConditionsInsensitive(),
-      // These have no case-insensitive counter parts
-      ...this.inConditions(),
-    };
-  }
 }
 
-class KnexTextInterface extends KnexFieldAdapter {
+class KnexTextInterface extends CommonTextInterface(KnexFieldAdapter) {
   createColumn(table) {
     table.text(this.path);
-  }
-  getQueryConditions(f, g) {
-    return {
-      ...this.equalityConditions(f, g),
-      ...this.stringConditions(f, g),
-      ...this.equalityConditionsInsensitive(f, g),
-      ...this.stringConditionsInsensitive(f, g),
-      ...this.inConditions(f, g),
-    };
   }
 }
 


### PR DESCRIPTION
The path transformation function `g` has been refactored into a field attribute `.dbPath` on each field adapter (which in most cases is equal to the field path, `.path`). This is transformed (if necessary) when `fieldAdapter.getQueryConditions()` is called to give the actual path required by the query (for example, in the knex adapter, a table alias needs to be added).

The value transformation function `f` is now only available as a parameter for non-string methods. The string methods always transform the value using `escapeRegExp`.
