### PR TITLE
Removing unused devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "xhr": "^2.4.0"
   },
   "devDependencies": {
-    "@ljharb/eslint-config": "^11.0.0",
     "browserify-middleware": "^7.1.0",
     "codeclimate-test-reporter": "^0.5.0",
     "connect-mongo": "^1.3.2",


### PR DESCRIPTION
ljharb/eslint-config isn't referenced in the codebase or config, seems to be an old thing that slipped through in a PR.