### PR TITLE
Fix heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start:test

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -181,7 +181,7 @@ server.app.get('/reset-db', (req, res) => {
 server.app.use(staticRoute, server.express.static(staticPath));
 
 async function start() {
-  await keystone.connect();
+  await keystone.connect(process.env.MONGODB_URI);
   server.start();
   const users = await keystone.lists.User.adapter.findAll();
   if (!users.length) {


### PR DESCRIPTION
I looked in the logs and the reason the app wasn't working is because keystone wasn't using the mongo database uri provided as an env variable.