### PR TITLE
Wrap adapter CRUD methods on list instance

### DIFF
--- a/packages/keystone/List/index.js
+++ b/packages/keystone/List/index.js
@@ -1311,4 +1311,12 @@ module.exports = class List {
   async findOne(condition) {
     return this.adapter.findOne(condition);
   }
+
+  addPreSaveHook(hook) {
+    this.adapter.addPreSaveHook(hook);
+  }
+
+  addPostReadHook(hook) {
+    this.adapter.addPostReadHook(hook);
+  }
 };


### PR DESCRIPTION
closes #798

IMHO it would be helpful to have this called directly on list instance instead of on the adapter. 

you can now call `list.findOne` (in addition to `list.adapter.findOne`).

not sure if pre-save and post-save hook will have any impact. it may contain adapter specific code, but when someone decide to change the adapter for List, there would be other breaking changes. I feel like having ease of using these methods outweigh rare decision someone may or may not make. 

this will not have any breaking impact on existing adapter methods. 

<TODO: change example/test project's code this way if any >