### PR TITLE
Fix typo in readme

### DIFF
--- a/demo-projects/blog/README.md
+++ b/demo-projects/blog/README.md
@@ -6,7 +6,7 @@ The Blog is a great example and boilerplate for more complex, real-world impleme
 
 ## Running the Project.
 
-Before you can run this demo project, create a .env file within the project folder `touch demo-projects/todo/.env`, and write the following...
+Before you can run this demo project, create a .env file within the project folder `touch demo-projects/blog/.env`, and write the following...
 
 ```
 PORT=3000


### PR DESCRIPTION
The readme for the blog starter project incorrectly asks the developer to point to `demo-projects/todo/.env` when it should instruct the user to point to `demo-projects/blog/.env`.