### PR TITLE
Factor out devQuery and _formatError from createGraphqlMiddleware

### DIFF
--- a/.changeset/143327d0/changes.json
+++ b/.changeset/143327d0/changes.json
@@ -1,0 +1,1 @@
+{ "releases": [{ "name": "@keystone-alpha/server", "type": "patch" }], "dependents": [] }

--- a/.changeset/143327d0/changes.md
+++ b/.changeset/143327d0/changes.md
@@ -1,0 +1,1 @@
+- Internal refactoring

--- a/packages/server/WebServer/devQuery.js
+++ b/packages/server/WebServer/devQuery.js
@@ -1,0 +1,85 @@
+// This module provides a mechanism for catching every query to a graphQL endpoint
+// and creating a unique link which can be used to repeat the query within the graphiql playground.
+
+const gql = require('graphql-tag');
+const hash = require('object-hash');
+const chalk = require('chalk');
+const terminalLink = require('terminal-link');
+const querystring = require('querystring');
+const bodyParser = require('body-parser');
+
+const chalkColour = new chalk.constructor({ enabled: true, level: 3 });
+
+const buildGraphiqlQueryParams = ({ query, variables }) =>
+  querystring.stringify({
+    query,
+    variables: JSON.stringify(variables),
+  });
+
+const graphiqlDevQueryMiddleware = (graphiqlPath, devQueryPath, devQueryLog) => (
+  req,
+  res,
+  next
+) => {
+  // Skip requests from graphiql itself
+  if (req.headers.referer && req.headers.referer.includes(graphiqlPath)) {
+    return next();
+  }
+
+  // hash query into id so that identical queries occupy
+  // the same space in the devQueryLog map.
+  const id = hash({ query: req.body.query, variables: req.body.variables });
+
+  // Store the loadable GraphiQL URL against that id
+  const queryParams = buildGraphiqlQueryParams(req.body);
+  devQueryLog[id] = `${graphiqlPath}?${queryParams}`;
+
+  const ast = gql(req.body.query);
+
+  const operations = ast.definitions.map(
+    def => `${def.operation} ${def.name ? `${def.name.value} ` : ''}{ .. }`
+  );
+
+  // Make the queries clickable in the terminal where supported
+  console.log(
+    terminalLink(
+      `${chalk.blue(operations.map(op => chalkColour.bold(op)).join(', '))}${
+        terminalLink.isSupported ? ` (👈 click to view)` : ''
+      }`,
+      `${req.protocol}://${req.get('host')}${devQueryPath}?id=${id}`,
+      {
+        // Otherwise, show the link on a new line
+        fallback: (text, url) => `${text}\n${chalkColour.gray(` ⤷ inspect @ ${url}`)}`,
+      }
+    )
+  );
+
+  // finally pass requests to the actual graphql endpoint
+  next();
+};
+
+const graphiqlDevQueryRedirector = (graphiqlPath, devQueryLog) => (req, res) => {
+  const { id } = req.query;
+  if (!devQueryLog[id]) {
+    const queryParams = buildGraphiqlQueryParams({
+      query: `# Unable to locate query '${id}'.\n# NOTE: You may have restarted your dev server. Doing so will clear query short URLs.`,
+    });
+    return res.redirect(`${graphiqlPath}?${queryParams}`);
+  }
+  return res.redirect(devQueryLog[id]);
+};
+
+const addDevQueryMiddlewares = (app, apiPath, graphiqlPath, devQueryPath) => {
+  // Needed to read the body contents out below
+  app.use(bodyParser.json());
+
+  const devQueryLog = {};
+  // peeks at incoming graphql requests and builds shortlinks
+  // NOTE: Must come before we setup the API below
+  app.use(apiPath, graphiqlDevQueryMiddleware(graphiqlPath, devQueryPath, devQueryLog));
+  // parses shortlinks and redirects to the GraphiQL editor
+
+  app.use(devQueryPath, graphiqlDevQueryRedirector(graphiqlPath, devQueryLog));
+};
+
+module.exports = { addDevQueryMiddlewares };

--- a/packages/server/WebServer/graphql.js
+++ b/packages/server/WebServer/graphql.js
@@ -3,22 +3,19 @@ const { ApolloServer } = require('apollo-server-express');
 const { formatError, isInstance: isApolloErrorInstance } = require('apollo-errors');
 const { renderPlaygroundPage } = require('graphql-playground-html');
 const playgroundPkg = require('graphql-playground-react/package.json');
-const gql = require('graphql-tag');
 const cuid = require('cuid');
-const hash = require('object-hash');
 const chalk = require('chalk');
 const logger = require('@keystone-alpha/logger');
 const falsey = require('falsey');
 const { omit } = require('@keystone-alpha/utils');
 const { graphql } = require('graphql');
 const StackUtils = require('stack-utils');
-const bodyParser = require('body-parser');
-const querystring = require('querystring');
 const ensureError = require('ensure-error');
 const terminalLink = require('terminal-link');
 const serializeError = require('serialize-error');
 
 const { NestedError } = require('./graphqlErrors');
+const { addDevQueryMiddlewares } = require('./devQuery');
 
 const graphqlLogger = logger('graphql');
 
@@ -72,16 +69,104 @@ const flattenNestedErrors = error =>
     []
   );
 
-const buildGraphiqlQueryParams = ({ query, variables }) =>
-  querystring.stringify({
-    query,
-    variables: JSON.stringify(variables),
-  });
+const _formatError = error => {
+  const { originalError } = error;
+  if (originalError && !originalError.path) {
+    originalError.path = error.path;
+  }
 
-const ttyClickableUrl = ({ path, port }) => {
-  const url = `http://localhost:${port}${path}`;
-  const prettyUrl = chalk.blue(url);
-  return terminalLink(prettyUrl, url, { fallback: () => prettyUrl });
+  try {
+    // For correlating user error reports with logs
+    error.uid = cuid();
+
+    if (isApolloErrorInstance(originalError)) {
+      // log internalData to stdout but not include it in the formattedError
+      // TODO: User pino for logging
+      graphqlLogger.info({
+        type: 'error',
+        data: originalError.data,
+        internalData: originalError.internalData,
+      });
+    } else {
+      const exception = originalError || (error.extensions && error.extensions.exception);
+      if (exception) {
+        const pinoError = {
+          ...omit(serializeError(error), ['extensions']),
+          ...omit(exception, ['name', 'model', 'stacktrace']),
+          stack: stackUtil.clean(exception.stacktrace || exception.stack),
+        };
+
+        if (pinoError.errors) {
+          pinoError.errors = flattenNestedErrors(exception).map(safeFormatError);
+        }
+
+        graphqlLogger.error(pinoError);
+      } else {
+        const errorOutput = serializeError(ensureError(error));
+        errorOutput.stack = stackUtil.clean(errorOutput.stack);
+        graphqlLogger.error(errorOutput);
+      }
+    }
+  } catch (formatErrorError) {
+    // Something went wrong with formatting above, so we log the errors
+    graphqlLogger.error(serializeError(ensureError(error)));
+    graphqlLogger.error(serializeError(ensureError(formatErrorError)));
+
+    return safeFormatError(error);
+  }
+
+  try {
+    let formattedError;
+
+    // Support throwing multiple errors
+    if (originalError && originalError.errors) {
+      const multipleErrorContainer = new NestedError({
+        data: {
+          // Format (aka; serialize) the error
+          errors: flattenNestedErrors(originalError).map(safeFormatError),
+        },
+      });
+
+      formattedError = safeFormatError(multipleErrorContainer);
+    } else {
+      formattedError = safeFormatError(error);
+    }
+
+    if (error.uid) {
+      formattedError.uid = error.uid;
+    }
+
+    return formattedError;
+  } catch (formatErrorError) {
+    // NOTE: We don't log again here as we assume the earlier try/catch
+    // correctly logged
+
+    // Return the original error as a fallback so the client gets at
+    // least some useful info
+    return safeFormatError(error);
+  }
+};
+
+const graphiqlMiddleware = endpoint => (req, res) => {
+  const tab = { endpoint };
+  if (req.query && req.query.query) {
+    tab.query = req.query.query;
+    tab.variables = req.query.variables;
+  }
+
+  res.setHeader('Content-Type', 'text/html');
+  res.write(renderPlaygroundPage({ endpoint, version: playgroundPkg.version, tabs: [tab] }));
+  res.end();
+};
+
+const ttyLink = (text, path, port, version) => {
+  if (falsey(process.env.DISABLE_LOGGING)) {
+    const url = `http://localhost:${port}${path}`;
+    const prettyUrl = chalk.blue(url);
+    const link = terminalLink(prettyUrl, url, { fallback: () => prettyUrl });
+    const versionString = version ? ` (v${version})` : '';
+    console.log(`🔗 ${chalk.green(text)} ${link}${versionString}`);
+  }
 };
 
 module.exports = function createGraphQLMiddleware(
@@ -90,55 +175,16 @@ module.exports = function createGraphQLMiddleware(
 ) {
   const app = express();
 
-  const devQueryLog = {};
-  const devLoggingEnabled =
-    process.env.NODE_ENV !== 'production' && falsey(process.env.DISABLE_LOGGING);
+  if (graphiqlPath) {
+    ttyLink('GraphQL Playground:', graphiqlPath, port, playgroundPkg.version);
+    app.use(graphiqlPath, graphiqlMiddleware(apiPath));
+    if (process.env.NODE_ENV !== 'production' && falsey(process.env.DISABLE_LOGGING)) {
+      const devQueryPath = `${graphiqlPath}/go`;
+      ttyLink('GraphQL Debug Links:', devQueryPath, port);
 
-  if (graphiqlPath && devLoggingEnabled) {
-    // Needed to read the body contents out below
-    app.use(bodyParser.json());
-
-    const chalkColour = new chalk.constructor({ enabled: true, level: 3 });
-
-    // peeks at incoming graphql requests and builds shortlinks
-    // NOTE: Must come before we setup the API below
-    app.use(apiPath, (req, res, next) => {
-      // Skip requests from graphiql itself
-      if (req.headers.referer && req.headers.referer.includes(graphiqlPath)) {
-        return next();
-      }
-
-      // hash query into id so that identical queries occupy
-      // the same space in the devQueryLog map.
-      const id = hash({ query: req.body.query, variables: req.body.variables });
-
-      // Store the loadable GraphiQL URL against that id
-      const queryParams = buildGraphiqlQueryParams(req.body);
-      devQueryLog[id] = `${graphiqlPath}?${queryParams}`;
-
-      const ast = gql(req.body.query);
-
-      const operations = ast.definitions.map(
-        def => `${def.operation} ${def.name ? `${def.name.value} ` : ''}{ .. }`
-      );
-
-      // Make the queries clickable in the terminal where supported
-      console.log(
-        terminalLink(
-          `${chalk.blue(operations.map(op => chalkColour.bold(op)).join(', '))}${
-            terminalLink.isSupported ? ` (👈 click to view)` : ''
-          }`,
-          `${req.protocol}://${req.get('host')}${graphiqlPath}/go?id=${id}`,
-          {
-            // Otherwise, show the link on a new line
-            fallback: (text, url) => `${text}\n${chalkColour.gray(` ⤷ inspect @ ${url}`)}`,
-          }
-        )
-      );
-
-      // finally pass requests to the actual graphql endpoint
-      next();
-    });
+      // NOTE: Must come before we setup the API below
+      addDevQueryMiddlewares(app, apiPath, graphiqlPath, devQueryPath);
+    }
   }
 
   // add the Admin GraphQL API
@@ -150,155 +196,23 @@ module.exports = function createGraphQLMiddleware(
     context: ({ req }) => keystone.getAccessContext(req),
     ...(process.env.ENGINE_API_KEY
       ? {
-          engine: {
-            apiKey: process.env.ENGINE_API_KEY,
-          },
+          engine: { apiKey: process.env.ENGINE_API_KEY },
           tracing: true,
         }
       : {
           engine: false,
           tracing: process.env.NODE_ENV !== 'production',
         }),
-    formatError: error => {
-      const { originalError } = error;
-      if (originalError && !originalError.path) {
-        originalError.path = error.path;
-      }
-
-      try {
-        // For correlating user error reports with logs
-        error.uid = cuid();
-
-        if (isApolloErrorInstance(originalError)) {
-          // log internalData to stdout but not include it in the formattedError
-          // TODO: User pino for logging
-          graphqlLogger.info({
-            type: 'error',
-            data: originalError.data,
-            internalData: originalError.internalData,
-          });
-        } else {
-          const exception = originalError || (error.extensions && error.extensions.exception);
-          if (exception) {
-            const pinoError = {
-              ...omit(serializeError(error), ['extensions']),
-              ...omit(exception, ['name', 'model', 'stacktrace']),
-              stack: stackUtil.clean(exception.stacktrace || exception.stack),
-            };
-
-            if (pinoError.errors) {
-              pinoError.errors = flattenNestedErrors(exception).map(safeFormatError);
-            }
-
-            graphqlLogger.error(pinoError);
-          } else {
-            const errorOutput = serializeError(ensureError(error));
-            errorOutput.stack = stackUtil.clean(errorOutput.stack);
-            graphqlLogger.error(errorOutput);
-          }
-        }
-      } catch (formatErrorError) {
-        // Something went wrong with formatting above, so we log the errors
-        graphqlLogger.error(serializeError(ensureError(error)));
-        graphqlLogger.error(serializeError(ensureError(formatErrorError)));
-
-        return safeFormatError(error);
-      }
-
-      try {
-        let formattedError;
-
-        // Support throwing multiple errors
-        if (originalError && originalError.errors) {
-          const multipleErrorContainer = new NestedError({
-            data: {
-              // Format (aka; serialize) the error
-              errors: flattenNestedErrors(originalError).map(safeFormatError),
-            },
-          });
-
-          formattedError = safeFormatError(multipleErrorContainer);
-        } else {
-          formattedError = safeFormatError(error);
-        }
-
-        if (error.uid) {
-          formattedError.uid = error.uid;
-        }
-
-        return formattedError;
-      } catch (formatErrorError) {
-        // NOTE: We don't log again here as we assume the earlier try/catch
-        // correctly logged
-
-        // Return the original error as a fallback so the client gets at
-        // least some useful info
-        return safeFormatError(error);
-      }
-    },
+    formatError: _formatError,
   });
-
-  if (falsey(process.env.DISABLE_LOGGING)) {
-    console.log(`🔗 ${chalk.green('GraphQL API:')} ${ttyClickableUrl({ path: apiPath, port })}`);
-  }
-  server.applyMiddleware({
-    app,
-    path: apiPath,
-    // Prevent ApolloServer from overriding Keystone's CORS configuration.
-    // https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#ApolloServer-applyMiddleware
-    cors: false,
-  });
-
-  if (graphiqlPath) {
-    if (devLoggingEnabled) {
-      // parses shortlinks and redirects to the GraphiQL editor
-      console.log(
-        `🔗 ${chalk.green('GraphQL Debug Links:')} ${ttyClickableUrl({
-          path: `${graphiqlPath}/go`,
-          port,
-        })}`
-      );
-      app.use(`${graphiqlPath}/go`, (req, res) => {
-        const { id } = req.query;
-        if (!devQueryLog[id]) {
-          const queryParams = buildGraphiqlQueryParams({
-            query: `# Unable to locate query '${id}'.\n# NOTE: You may have restarted your dev server. Doing so will clear query short URLs.`,
-          });
-          return res.redirect(`${graphiqlPath}?${queryParams}`);
-        }
-        return res.redirect(devQueryLog[id]);
-      });
-    }
-
-    if (falsey(process.env.DISABLE_LOGGING)) {
-      console.log(
-        `🔗 ${chalk.green('GraphQL Playground:')} ${ttyClickableUrl({
-          path: graphiqlPath,
-          port,
-        })} (v${playgroundPkg.version})`
-      );
-    }
-    app.use(graphiqlPath, (req, res) => {
-      const tab = {
-        endpoint: apiPath,
-      };
-
-      if (req.query && req.query.query) {
-        tab.query = req.query.query;
-        tab.variables = req.query.variables;
-      }
-
-      res.setHeader('Content-Type', 'text/html');
-      res.write(
-        renderPlaygroundPage({ endpoint: apiPath, version: playgroundPkg.version, tabs: [tab] })
-      );
-      res.end();
-    });
-  }
-
   keystone.registerGraphQLQueryMethod((query, context, variables) =>
     graphql(server.schema, query, null, context, variables)
   );
+
+  ttyLink('GraphQL API:', apiPath, port);
+  // { cors: false } - prevent ApolloServer from overriding Keystone's CORS configuration.
+  // https://www.apollographql.com/docs/apollo-server/api/apollo-server.html#ApolloServer-applyMiddleware
+  server.applyMiddleware({ app, path: apiPath, cors: false });
 
   return app;
 };


### PR DESCRIPTION
The aim of this change was to simplify the reading of `createGraphQLMiddleware` and make it easier to see where all the various middlewares are being introduced. 

This was achieved by:

 * Factoring out `_formatError` into a named function, rather than living inline in the `ApolloServer` constructor.
 * Factoring out the code related to creating dev query links into a separate `devQuery` module. That module could in theory be broken out into its own package somewhere if someone was so inclined, as it no longer has any keystone-specific code. That is a problem for another day though :-)

This is almost entirely a code shuffling exercise, there shouldn't be any functional changes to any system behaviour.