### PR TITLE
Admin UI authStrategy is set at constructor time

### DIFF
--- a/.changeset/5acae24c/changes.json
+++ b/.changeset/5acae24c/changes.json
@@ -1,0 +1,10 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/api-tests", "type": "patch" },
+    { "name": "@keystone-alpha/demo-project-blog", "type": "patch" },
+    { "name": "@keystone-alpha/cypress-project-access-control", "type": "patch" },
+    { "name": "@keystone-alpha/cypress-project-login", "type": "patch" },
+    { "name": "@keystone-alpha/cypress-project-twitter-login", "type": "patch" }
+  ],
+  "dependents": []
+}

--- a/.changeset/5acae24c/changes.md
+++ b/.changeset/5acae24c/changes.md
@@ -1,0 +1,1 @@
+- Use new authStrategy APIs

--- a/.changeset/88adea8a/changes.json
+++ b/.changeset/88adea8a/changes.json
@@ -1,0 +1,88 @@
+{
+  "releases": [
+    { "name": "@keystone-alpha/admin-ui", "type": "major" },
+    { "name": "@keystone-alpha/core", "type": "major" },
+    { "name": "@keystone-alpha/server", "type": "major" }
+  ],
+  "dependents": [
+    {
+      "name": "@keystone-alpha/demo-project-blog",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/demo-project-todo",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-access-control",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-basic",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/cypress-project-twitter-login",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/admin-ui",
+        "@keystone-alpha/core",
+        "@keystone-alpha/server"
+      ]
+    },
+    {
+      "name": "@keystone-alpha/keystone",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/core"]
+    },
+    {
+      "name": "@keystone-alpha/test-utils",
+      "type": "patch",
+      "dependencies": ["@keystone-alpha/keystone", "@keystone-alpha/server"]
+    },
+    {
+      "name": "@keystone-alpha/api-tests",
+      "type": "patch",
+      "dependencies": [
+        "@keystone-alpha/keystone",
+        "@keystone-alpha/test-utils",
+        "@keystone-alpha/server"
+      ]
+    }
+  ]
+}

--- a/.changeset/88adea8a/changes.md
+++ b/.changeset/88adea8a/changes.md
@@ -1,0 +1,6 @@
+- Update authStrategy APIs
+  * Removes `authStrategy` from the `config` API of `Webserver`.
+  * Removes `authStrategy` from the `serverConfig` of the core `keystone` system builder.
+  * Removes the `setAuthStrategy` method from `AdminUI`.
+  * Adds `authStrategy` to the `config` API of `AdminUI`.
+  * `Webserver` checks `keystone.auth` to determine whether to set up auth session middlewares.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ module.exports = {
   admin,
   serverConfig: {
     'cookie secret': 'qwerty',
-    authStrategy: authStrategy, // See 'Adding Authentication' below
     apiPath: '/admin/api',
     graphiqlPath: '/admin/graphiql',
   },
@@ -231,6 +230,7 @@ list used for authentication in `index.js`:
 <!-- prettier-ignore -->
 ```javascript
 const { Keystone }        = require('@keystone-alpha/keystone');
+const { AdminUI } = require('@keystone-alpha/admin-ui');
 const { MongooseAdapter } = require('@keystone-alpha/adapter-mongoose');
 const { Text, Password }  = require('@keystone-alpha/fields');
 const PasswordAuth        = require('@keystone-alpha/keystone/auth/Password');
@@ -256,11 +256,14 @@ const authStrategy = keystone.createAuthStrategy({
   }
 });
 
+const admin = new AdminUI(keystone, {
+  adminPath: '/admin',
+  authStrategy,
+});
+
 module.exports = {
   keystone,
-  serverConfig: {
-    authStrategy,
-  }
+  admin,
 };
 ```
 

--- a/api-tests/auth-header.test.js
+++ b/api-tests/auth-header.test.js
@@ -43,14 +43,13 @@ function setupKeystone() {
     },
   });
 
-  const authStrategy = keystone.createAuthStrategy({
+  keystone.createAuthStrategy({
     type: PasswordAuthStrategy,
     list: 'User',
   });
 
   const server = new WebServer(keystone, {
     'cookie secret': COOKIE_SECRET,
-    authStrategy: authStrategy,
     apiPath: '/admin/api',
     graphiqlPath: '/admin/graphiql',
   });

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -114,6 +114,7 @@ keystone.createList('Comment', {
 const admin = new AdminUI(keystone, {
   adminPath: '/admin',
   sortListsAlphabetically: true,
+  authStrategy,
 });
 
 module.exports = {
@@ -121,7 +122,4 @@ module.exports = {
   staticPath,
   keystone,
   admin,
-  serverConfig: {
-    authStrategy,
-  },
 };

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -24,10 +24,10 @@ Username / Password authentication can be enabled on the Admin UI.
 
 First, setup [a `PasswordAuthStrategy` instance](#passwordauthstrategy).
 
-Then, pass that instance into the Web Server setup:
+Then, pass that instance into the Admin UI setup:
 
 ```javascript
-const { WebServer } = require('@keystone-alpha/server');
+const { AdminUI } = require('@keystone-alpha/admin-ui');
 const PasswordAuthStrategy = require('@keystone-alpha/keystone/auth/Password');
 
 const keystone = // ...
@@ -37,9 +37,9 @@ const authStrategy = keystone.createAuthStrategy({
   list: 'User',
 });
 
-const server = new WebServer(keystone, {
-  authStrategy: authStrategy,
-  // ... other config
+const admin = new AdminUI(keystone, {
+  adminPath: '/admin',
+  authStrategy,
 });
 ```
 

--- a/packages/admin-ui/server/AdminUI.js
+++ b/packages/admin-ui/server/AdminUI.js
@@ -20,6 +20,11 @@ module.exports = class AdminUI {
     }
 
     this.adminPath = config.adminPath || '/admin';
+    const { authStrategy } = config;
+    if (authStrategy && authStrategy.authType !== 'password') {
+      throw new Error('Keystone 5 Admin currently only supports the `PasswordAuthStrategy`');
+    }
+    this.authStrategy = authStrategy;
 
     this.config = {
       ...config,
@@ -39,14 +44,6 @@ module.exports = class AdminUI {
       sessionPath: this.config.sessionPath,
       sortListsAlphabetically: this.config.sortListsAlphabetically,
     };
-  }
-
-  setAuthStrategy(authStrategy) {
-    if (authStrategy.authType !== 'password') {
-      throw new Error('Keystone 5 Admin currently only supports the `PasswordAuthStrategy`');
-    }
-
-    this.authStrategy = authStrategy;
   }
 
   createSessionMiddleware() {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -13,7 +13,6 @@ function cleanServerConfig(config) {
     'sessionStore',
     'pinoOptions',
     'cors',
-    'authStrategy',
     'apiPath',
     'graphiqlPath',
     'apollo',
@@ -69,12 +68,6 @@ module.exports = {
       const cleanedServerConfig = cleanServerConfig(resolvedConfig || {});
 
       const server = new WebServer(appEntry.keystone, {
-        // When an auth strategy is defined, we need a cookie secret
-        ...(cleanedServerConfig.authStrategy
-          ? {
-              'cookie secret': 'qwerty',
-            }
-          : {}),
         // Set all the other options
         ...cleanedServerConfig,
         // Force the admin & port

--- a/packages/core/tests/index.test.js
+++ b/packages/core/tests/index.test.js
@@ -122,7 +122,7 @@ describe('@keystone-alpha/core/index.js', () => {
         }));
 
         const entryFileObj = tmp.fileSync({ postfix: '.js' });
-        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: {} }`);
+        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: { auth: {} } }`);
 
         const localCore = require('../');
         await localCore.prepare({ entryFile: entryFileObj.name });
@@ -141,7 +141,7 @@ describe('@keystone-alpha/core/index.js', () => {
         }));
 
         const entryFileObj = tmp.fileSync({ postfix: '.js' });
-        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: {} }`);
+        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: { auth: {} } }`);
 
         const localCore = require('../');
         await localCore.prepare({ entryFile: entryFileObj.name });
@@ -171,7 +171,7 @@ describe('@keystone-alpha/core/index.js', () => {
           entryFileObj.fd,
           endent`
         module.exports = {
-          keystone: {},
+          keystone: { auth: {} },
           admin: {},
         };
       `
@@ -182,7 +182,6 @@ describe('@keystone-alpha/core/index.js', () => {
           sessionStore: {},
           pinoOptions: {},
           cors: {},
-          authStrategy: {},
           apiPath: 'def',
           graphiqlPath: 'xyz',
           apollo: {},
@@ -207,40 +206,6 @@ describe('@keystone-alpha/core/index.js', () => {
         );
       });
 
-      test('constructs server with default cookie secret if authStrategy set', async () => {
-        // Called internally within the .prepare() function, so we mock it out
-        // here, and replace the implementation on a per-test basis
-        const mockServerClass = jest.fn(() => {});
-        jest.resetModules();
-        jest.doMock('@keystone-alpha/server', () => ({
-          // Mock the class to do nothing
-          WebServer: mockServerClass,
-        }));
-
-        const entryFileObj = tmp.fileSync({ postfix: '.js' });
-        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: {} }`);
-
-        const serverConfig = {
-          authStrategy: {},
-        };
-
-        const localCore = require('../');
-        await localCore.prepare({
-          entryFile: entryFileObj.name,
-          serverConfig,
-        });
-
-        expect(mockServerClass).toHaveBeenCalledWith(
-          // The keystone object
-          expect.anything(),
-          // The config object
-          expect.objectContaining({
-            ...serverConfig,
-            'cookie secret': 'qwerty',
-          })
-        );
-      });
-
       test('returns the server instance', async () => {
         // Called internally within the .prepare() function, so we mock it out
         // here, and replace the implementation on a per-test basis
@@ -253,7 +218,7 @@ describe('@keystone-alpha/core/index.js', () => {
         }));
 
         const entryFileObj = tmp.fileSync({ postfix: '.js' });
-        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: {} }`);
+        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: { auth: {} } }`);
 
         const localCore = require('../');
         const { server } = await localCore.prepare({ entryFile: entryFileObj.name });
@@ -273,7 +238,7 @@ describe('@keystone-alpha/core/index.js', () => {
         }));
 
         const entryFileObj = tmp.fileSync({ postfix: '.js' });
-        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: { hi: 'bye' } }`);
+        fs.writeFileSync(entryFileObj.fd, `module.exports = { keystone: { auth: {}, hi: 'bye' } }`);
 
         const localCore = require('../');
         const { keystone } = await localCore.prepare({ entryFile: entryFileObj.name });

--- a/packages/server/WebServer/index.js
+++ b/packages/server/WebServer/index.js
@@ -27,7 +27,8 @@ module.exports = class WebServer {
       this.app.use(cors(this.config.cors));
     }
 
-    if (this.config.authStrategy) {
+    if (Object.keys(keystone.auth).length > 0) {
+      // We have at least one auth strategy
       // Setup the session as the very first thing.
       // The way express works, the `req.session` (and, really, anything added
       // to `req`) will be available to all sub `express()` instances.
@@ -81,8 +82,7 @@ module.exports = class WebServer {
       this.app.use(this.keystone.sessionManager.populateAuthedItemMiddleware);
     }
 
-    if (adminUI && this.config.authStrategy) {
-      adminUI.setAuthStrategy(this.config.authStrategy);
+    if (adminUI && adminUI.authStrategy) {
       // Inject the Admin specific session routes.
       // ie; this includes the signin/signout UI
       this.app.use(adminUI.createSessionMiddleware());

--- a/packages/server/WebServer/initConfig.js
+++ b/packages/server/WebServer/initConfig.js
@@ -8,6 +8,7 @@ const defaultConfig = {
   graphiqlPath: '/admin/graphiql',
   apollo: undefined,
   cors: { origin: true, credentials: true },
+  cookieSecret: 'qwerty',
 };
 
 const remapKeys = {

--- a/test-projects/access-control/index.js
+++ b/test-projects/access-control/index.js
@@ -141,12 +141,10 @@ listAccessVariations.forEach(createListWithDeclarativeAccess);
 
 const admin = new AdminUI(keystone, {
   adminPath: '/admin',
+  authStrategy,
 });
 
 module.exports = {
   keystone,
   admin,
-  serverConfig: {
-    authStrategy,
-  },
 };

--- a/test-projects/login/index.js
+++ b/test-projects/login/index.js
@@ -39,12 +39,10 @@ keystone.createList('Post', {
 
 const admin = new AdminUI(keystone, {
   adminPath: '/admin',
+  authStrategy,
 });
 
 module.exports = {
   keystone,
   admin,
-  serverConfig: {
-    authStrategy,
-  },
 };

--- a/test-projects/twitter-login/index.js
+++ b/test-projects/twitter-login/index.js
@@ -159,12 +159,9 @@ keystone.createList('Note', {
     authentication.listKey === authStrategy.listKey && item.user.id === authentication.item.id,
 });
 
-const admin = new AdminUI(keystone);
+const admin = new AdminUI(keystone, { authStrategy: DISABLE_AUTH ? undefined : authStrategy });
 
 module.exports = {
   keystone,
   admin,
-  serverConfig: {
-    authStrategy: DISABLE_AUTH ? undefined : authStrategy,
-  },
 };


### PR DESCRIPTION
This PR will introduce **major** version bumps for the `core`, `WebServer` and `admin-ui` packages. I believe this is worth the breakage, as I will outline below.

### TLDR
 * Removes `authStrategy` from the `config` API of `Webserver`.
 * Removes `authStrategy` from the `serverConfig` of the core `keystone` system builder.
 * Removes the `setAuthStrategy` method from `AdminUI`.
 * Adds `authStrategy` to the `config` API of `AdminUI`.
 * `Webserver` checks `keystone.auth` to determine whether to set up auth session middlewares.

### The gory details

Keystone currently supports adding multiple auth strategies to a system. The blog demo project currently has

```js
const keystone = new Keystone({
  name: 'Keystone Demo Blog',
  adapter: new MongooseAdapter(),
});

const authStrategy = keystone.createAuthStrategy({
  type: PasswordAuthStrategy,
  list: 'User',
  sortListsAlphabetically: true,
});
```

but we could add a second strategy by calling `createAuthStrategy` again,

```js
const authStrategy2 = keystone.createAuthStrategy({
  type: TwitterAuthStrategy,
  list: 'User',
});
```

These strategies have now been registered with `keystone`, but they don't do anything yet, they are simply available. They live in the `.auth` property of the keystone object,

```js
{ keystone: { auth: { User: { PasswordAuthStrategy: ..., TwitterAuthStrategy: ... } }, ... } 
```

What the user does with these strategies is up to them. One common use case is to use one for access to the admin UI. The current mechanism for this is to either return a `serverConfig` from `index.js` 

```js
module.exports = {
  keystone,
  admin,
  serverConfig: {
    authStrategy,
  },
};
```
or to pass it directly into the `Webserver` constructor, 

```
const server = new WebServer(keystone, { authStrategy, ... } );
```

Both these mechanisms end up calling the following code inside the `Webserver` constructor.

```
if (adminUI && this.config.authStrategy) {
  adminUI.setAuthStrategy(this.config.authStrategy);
  ...
}
```

While this technically works, it's a bit of a strange path to follow, and it's not in any way obvious that the `authStrategy` being passed around is really "the auth strategy to be used by the admin UI`. It would make much more sense if this was explicitly passed into the `AdminUI` constructor.

Furthermore, there is a bug in the `Webserver` constructor. If you want to set up an auth strategy to use, but don't want to use an admin UI (or if you have an admin UI but don't specify an `authStrategy` for it), then the session handling middleware will not be correctly set up. That's because we have the following check

```js
if (this.config.authStrategy) {
  // Setup the session as the very first thing.
  ...
}
```

We should really be checking the `keystone.auth` object to see if any strategies have been registered.

This PR addresses all of the issues outlined above. To summarise, the key changes are:
 * Removes `authStrategy` from the `config` API of `Webserver`.
 * Removes `authStrategy` from the `serverConfig` of the core `keystone` system builder.
 * Removes the `setAuthStrategy` method from `AdminUI`.
 * Adds `authStrategy` to the `config` API of `AdminUI`.
 * `Webserver` checks `keystone.auth` to determine whether to set up auth session middlewares.