### PR TITLE
Fix NumberColumn for money formatting be independent from path name

### DIFF
--- a/fields/types/number/NumberColumn.js
+++ b/fields/types/number/NumberColumn.js
@@ -13,7 +13,7 @@ var NumberColumn = React.createClass({
 		const value = this.props.data.fields[this.props.col.path];
 		if (value === undefined || isNaN(value)) return null;
 
-		const formattedValue = (this.props.col.path === 'money') ? numeral(value).format('$0,0.00') : value;
+		const formattedValue = (this.props.col.type === 'money') ? numeral(value).format('$0,0.00') : value;
 
 		return formattedValue;
 	},


### PR DESCRIPTION
## Description of changes
Money formatting NumberColumn requires the path (field name) to be exactly `money` to be rendered correctly. 

This change is to make the formatting/ rendering process name-independent and renders correctly when only money field type is met.

## Related issues (if any)

## Testing
 - [x] List browser version(s) any admin UI changes were tested in: Google Chrome Version 73.0.3683.86 (Official Build) (64-bit).
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.