### PR TITLE
add support for language cookie options

### DIFF
--- a/lib/middleware/language.js
+++ b/lib/middleware/language.js
@@ -14,6 +14,7 @@ module.exports = function (keystone) {
 		cookie: {
 			name: languageOptions['language cookie'],
 			url: languageOptions['language select url'],
+			options: languageOptions['language cookie options'],
 		},
 		queryName: languageOptions['language query name'],
 	});

--- a/test/unit/lib/middleware/language.js
+++ b/test/unit/lib/middleware/language.js
@@ -116,6 +116,28 @@ describe('language', function () {
 			});
 
 		});
+
+		describe('with custom cookie options', function () {
+			it('must create a custom language cookie', function (done) {
+				var keystone = keystoneOptions({
+					'language options': {
+						'language cookie options': {
+							maxAge: 24*3600*1000,
+							secure: true
+						}
+					}
+				});
+				var res = mockResponse();
+				var expected = true;
+
+				language(keystone)(mockRequest(), res, function (err) {
+					demand(err).be(undefined);
+					demand(res.cookie.secure).eql(expected);
+					done();
+				});
+			});
+
+		});
 	});
 
 	describe('must create language route', function () {


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
https://github.com/keystonejs/keystone/blob/master/lib/middleware/language.js#L8
The language middleware accepts a `language cookie options` configuration, but that value is not being used when creating the cookie:
https://github.com/keystonejs/keystone/blob/master/lib/middleware/language.js#L14-L17

This PR fixes this by consuming the given option.

## Related issues (if any)


## Testing

 - [x] List browser version(s) any admin UI changes were tested in: Chrome 74
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

