### PR TITLE
Update testing to target Node 8 and fix eslint errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '8'
 env:
   global:
     - SAUCE_USERNAME=jstockwin1
@@ -9,41 +9,41 @@ env:
     - JOB=lint-and-test-cov
 matrix:
   include:
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group006Fields
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group005Item
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group004List
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group003Home
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group002App
-    - node_js: '6'
+    - node_js: '8'
       script:
         - travis_retry npm run test-e2e-saucelabs-group
       env:
         - JOB=e2e GROUP=group001Login
-    - node_js: '6'
+    - node_js: '8'
       script:
         - npm run test-admin
       env:
-        - JOB=unit_tests_node_6
+        - JOB=unit_tests_node_8
 
 
 before_script:

--- a/admin/client/App/elemental/SegmentedControl/index.js
+++ b/admin/client/App/elemental/SegmentedControl/index.js
@@ -39,7 +39,7 @@ function SegmentedControl ({
 						type="button"
 						title={cropText ? opt.label : null}
 						tabIndex={opt.disabled ? '-1' : ''}
-						>
+					>
 						{opt.label}
 					</button>
 				);

--- a/admin/client/App/screens/Item/components/DrilldownItem.js
+++ b/admin/client/App/screens/Item/components/DrilldownItem.js
@@ -22,7 +22,7 @@ function DrilldownItem ({ className, href, label, separate, separator, style, ..
 				style={styles}
 				to={href}
 				variant="link"
-				>
+			>
 				{label}
 			</Button>
 			{separate && (

--- a/admin/client/App/screens/Item/components/EditFormHeader.js
+++ b/admin/client/App/screens/Item/components/EditFormHeader.js
@@ -67,7 +67,7 @@ export const EditFormHeader = React.createClass({
 					style={backStyles}
 					to={backPath}
 					variant="link"
-					>
+				>
 					{list.plural}
 				</GlyphButton>
 			);

--- a/admin/client/App/screens/Item/components/EditFormHeaderSearch.js
+++ b/admin/client/App/screens/Item/components/EditFormHeaderSearch.js
@@ -59,7 +59,7 @@ class EditFormHeaderSearch extends Component {
 				variant="link"
 				style={{ paddingLeft: '0.7em' }}
 				data-e2e-search-icon
-				>
+			>
 				Search
 			</GlyphButton>
 		);

--- a/admin/client/App/screens/Item/components/RelatedItemsList/RelatedItemsListRow.js
+++ b/admin/client/App/screens/Item/components/RelatedItemsList/RelatedItemsListRow.js
@@ -44,9 +44,9 @@ RelatedItemsListRow.propTypes = {
 	relatedItemId: PropTypes.string.isRequired,
 	relationship: PropTypes.object.isRequired,
 	// Injected by React DnD:
-	isDragging: PropTypes.bool,         // eslint-disable-line react/sort-prop-types
-	connectDragSource: PropTypes.func,  // eslint-disable-line react/sort-prop-types
-	connectDropTarget: PropTypes.func,  // eslint-disable-line react/sort-prop-types
+	isDragging: PropTypes.bool, // eslint-disable-line react/sort-prop-types
+	connectDragSource: PropTypes.func, // eslint-disable-line react/sort-prop-types
+	connectDropTarget: PropTypes.func, // eslint-disable-line react/sort-prop-types
 	connectDragPreview: PropTypes.func, // eslint-disable-line react/sort-prop-types
 };
 
@@ -96,9 +96,9 @@ const dropItem = {
 	hover (props, monitor, component) {
 		// reset row alerts
 		// if (props.rowAlert.success || props.rowAlert.fail) {
-			// props.dispatch(setRowAlert({
-			// 	reset: true,
-			// }));
+		// 	props.dispatch(setRowAlert({
+		// 		reset: true,
+		// 	}));
 		// }
 
 		const dragged = monitor.getItem().index;

--- a/admin/client/App/screens/List/components/Filtering/ListFiltersAdd.js
+++ b/admin/client/App/screens/List/components/Filtering/ListFiltersAdd.js
@@ -75,7 +75,7 @@ var ListFiltersAdd = React.createClass({
 			filteredFilters = filteredFilters
 				.filter(filter => filter.type !== 'heading')
 				.filter(filter => new RegExp(searchString)
-				.test(filter.field.label.toLowerCase()));
+					.test(filter.field.label.toLowerCase()));
 		}
 
 		const popoutList = filteredFilters.map((el, i) => {
@@ -169,7 +169,7 @@ var ListFiltersAdd = React.createClass({
 						transitionName={selectedField ? 'Popout__pane-next' : 'Popout__pane-prev'}
 						transitionEnterTimeout={360}
 						transitionLeaveTimeout={360}
-						>
+					>
 						{selectedField ? this.renderForm() : this.renderList()}
 					</Transition>
 				</Popout>

--- a/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
+++ b/admin/client/App/screens/List/components/ItemsTable/ItemsTableRow.js
@@ -22,9 +22,9 @@ const ItemsRow = React.createClass({
 		items: React.PropTypes.object,
 		list: React.PropTypes.object,
 		// Injected by React DnD:
-		isDragging: React.PropTypes.bool,         // eslint-disable-line react/sort-prop-types
-		connectDragSource: React.PropTypes.func,  // eslint-disable-line react/sort-prop-types
-		connectDropTarget: React.PropTypes.func,  // eslint-disable-line react/sort-prop-types
+		isDragging: React.PropTypes.bool, // eslint-disable-line react/sort-prop-types
+		connectDragSource: React.PropTypes.func, // eslint-disable-line react/sort-prop-types
+		connectDropTarget: React.PropTypes.func, // eslint-disable-line react/sort-prop-types
 		connectDragPreview: React.PropTypes.func, // eslint-disable-line react/sort-prop-types
 	},
 	renderRow (item) {

--- a/admin/client/constants.js
+++ b/admin/client/constants.js
@@ -39,5 +39,5 @@ exports.spacing = {
 
 // table constants
 
-exports.TABLE_CONTROL_COLUMN_WIDTH = 26;  // icon + padding
+exports.TABLE_CONTROL_COLUMN_WIDTH = 26; // icon + padding
 exports.NETWORK_ERROR_RETRY_DELAY = 500; // in ms

--- a/fields/components/DateInput.js
+++ b/fields/components/DateInput.js
@@ -131,7 +131,7 @@ module.exports = React.createClass({
 					ref="popout"
 					relativeToID={this.state.id}
 					width={260}
-					>
+				>
 					<DayPicker
 						modifiers={modifiers}
 						onDayClick={this.handleDaySelect}

--- a/fields/types/boolean/BooleanType.js
+++ b/fields/types/boolean/BooleanType.js
@@ -37,8 +37,8 @@ boolean.prototype.validateInput = function (data, callback) {
 boolean.prototype.validateRequiredInput = function (item, data, callback) {
 	var value = this.getValueFromData(data);
 	var result = value && value !== 'false'
-			? true
-			: false;
+		? true
+		: false;
 	utils.defer(callback, result);
 };
 

--- a/fields/types/embedly/EmbedlyType.js
+++ b/fields/types/embedly/EmbedlyType.js
@@ -222,8 +222,8 @@ embedly.prototype.updateItem = function (item, data, callback) {
 	// TODO: This could be more granular and check for actual changes to values,
 	// see the Location field for an example
 
- // This field type is never editable, so to ensure that we don't inadvertently reset the fields on this item with a null value
- // A conditional has been added to negate updating this item should the fromPath on the passed in data object be the same as that on the item.
+	// This field type is never editable, so to ensure that we don't inadvertently reset the fields on this item with a null value
+	// A conditional has been added to negate updating this item should the fromPath on the passed in data object be the same as that on the item.
 	if (data[this.fromPath] !== item[this.fromPath]) {
 		item.set(item.set(this.path, {
 			exists: data[this.paths.exists],

--- a/fields/types/html/HtmlField.js
+++ b/fields/types/html/HtmlField.js
@@ -114,10 +114,10 @@ module.exports = Field.create({
 	getOptions () {
 		var plugins = ['code', 'link'];
 		var options = Object.assign(
-				{},
-				Keystone.wysiwyg.options,
-				this.props.wysiwyg
-			);
+			{},
+			Keystone.wysiwyg.options,
+			this.props.wysiwyg
+		);
 		var toolbar = options.overrideToolbar ? '' : 'bold italic | alignleft aligncenter alignright | bullist numlist | outdent indent | removeformat | link ';
 		var i;
 

--- a/fields/types/location/LocationType.js
+++ b/fields/types/location/LocationType.js
@@ -363,28 +363,30 @@ function doGoogleGeocodeRequest (address, region, callback) {
 
 	https.get(endpoint, function (res) {
 		var data = [];
-		res.on('data', function (chunk) {
-			data.push(chunk);
-		})
-		.on('end', function () {
-			var dataBuff = data.join('').trim();
-			var result;
-			try {
-				result = JSON.parse(dataBuff);
-			}
-			catch (exp) {
-				result = {
-					status_code: 500,
-					status_text: 'JSON Parse Failed',
-					status: 'UNKNOWN_ERROR',
-				};
-			}
-			callback(null, result);
-		});
+
+		res
+			.on('data', function (chunk) {
+				data.push(chunk);
+			})
+			.on('end', function () {
+				var dataBuff = data.join('').trim();
+				var result;
+				try {
+					result = JSON.parse(dataBuff);
+				}
+				catch (exp) {
+					result = {
+						status_code: 500,
+						status_text: 'JSON Parse Failed',
+						status: 'UNKNOWN_ERROR',
+					};
+				}
+				callback(null, result);
+			});
 	})
-	.on('error', function (err) {
-		callback(err);
-	});
+		.on('error', function (err) {
+			callback(err);
+		});
 }
 
 /**

--- a/fields/types/markdown/MarkdownField.js
+++ b/fields/types/markdown/MarkdownField.js
@@ -153,8 +153,8 @@ module.exports = Field.create({
 			this.props.value !== undefined
 			&& this.props.value.md !== undefined
 		)
-		? this.props.value.md
-		: '';
+			? this.props.value.md
+			: '';
 
 		return (
 			<textarea

--- a/fields/types/name/NameType.js
+++ b/fields/types/name/NameType.js
@@ -156,11 +156,11 @@ name.prototype.validateRequiredInput = function (item, data, callback) {
 				|| typeof value.last === 'string' && value.last.length)
 			|| (item.get(this.paths.full)
 				|| item.get(this.paths.first)
-				|| item.get(this.paths.last)) && (
-					value === undefined
+				|| item.get(this.paths.last))
+					&& (value === undefined
 					|| (value.first === undefined
 						&& value.last === undefined))
-			) ? true : false;
+		) ? true : false;
 	}
 	utils.defer(callback, result);
 };

--- a/lib/schemaPlugins/methods/getRelated.js
+++ b/lib/schemaPlugins/methods/getRelated.js
@@ -86,10 +86,9 @@ module.exports = function getRelated (paths, callback, nocollapse) {
 							item.populateRelated(options.related, done);
 						};
 					}),
-						function (err) {
-							done(err, results);
-						}
-					);
+					function (err) {
+						done(err, results);
+					});
 				});
 			} else {
 				query.exec(done);

--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -23,12 +23,12 @@ var ADAPTER_COMPATIBILITY_LEVEL = 1;
 	Storage Adapters can specify additional schema properties.
 */
 var SCHEMA_TYPES = {
-//	filename: String,       // the filename, without the full path
-	size: Number,           // the size of the file
-	mimetype: String,       // the mime type of the file
-	path: String,           // the path (e.g directory) the file is stored in; not the full path to the file
-	originalname: String,   // the original (uploaded) name of the file; useful when filename generated
-	url: String,            // publicly accessible URL of the stored file
+//	filename: String, // the filename, without the full path
+	size: Number, // the size of the file
+	mimetype: String, // the mime type of the file
+	path: String, // the path (e.g directory) the file is stored in; not the full path to the file
+	originalname: String, // the original (uploaded) name of the file; useful when filename generated
+	url: String, // publicly accessible URL of the stored file
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keystone",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4341,7 +4341,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4359,11 +4360,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4376,15 +4379,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4487,7 +4493,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4497,6 +4504,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4509,17 +4517,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4536,6 +4547,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4608,7 +4620,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4618,6 +4631,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4693,7 +4707,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4723,6 +4738,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4740,6 +4756,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4778,11 +4795,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/server/startHTTPServer.js
+++ b/server/startHTTPServer.js
@@ -18,14 +18,14 @@ module.exports = function (keystone, app, callback) {
 	var forceSsl = (keystone.get('ssl') === 'force');
 
 	keystone.httpServer = http
-	.createServer(app)
-	.listen(port, host, function ready (err) {
-		if (err) { return callback(err); }
+		.createServer(app)
+		.listen(port, host, function ready (err) {
+			if (err) { return callback(err); }
 
-		var message = keystone.get('name') + ' is ready on '
-		+ 'http://' + host + ':' + port
-		+ (forceSsl ? ' (SSL redirect)' : '');
-		callback(null, message);
-	});
+			var message = keystone.get('name') + ' is ready on '
+				+ 'http://' + host + ':' + port
+				+ (forceSsl ? ' (SSL redirect)' : '');
+			callback(null, message);
+		});
 
 };


### PR DESCRIPTION
## Description of changes

.travis.yml has been updated to use Node 8 as a target.  Node 8 will be supported through the end of 2019, at which point Keystone will support only the versions of Node that are current or in LTS.

## Testing

 `npm run test-all` did not run successfully, but from the looks of it was broken before I got here.  A separate fix should address the failing tests.

