### PR TITLE
Add ability to import a single file to Keystone

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var grappling = require('grappling-hook');
 var path = require('path');
 var utils = require('keystone-utils');
 var importer = require('./lib/core/importer');
+var fileImporter = require('./lib/core/fileImporter');
 
 /**
  * Don't use process.cwd() as it breaks module encapsulation
@@ -114,6 +115,7 @@ Keystone.prototype.createItems = require('./lib/core/createItems');
 Keystone.prototype.createRouter = require('./lib/core/createRouter');
 Keystone.prototype.getOrphanedLists = require('./lib/core/getOrphanedLists');
 Keystone.prototype.importer = importer;
+Keystone.prototype.fileImporter = fileImporter;
 Keystone.prototype.init = require('./lib/core/init');
 Keystone.prototype.initDatabaseConfig = require('./lib/core/initDatabaseConfig');
 Keystone.prototype.initExpressApp = require('./lib/core/initExpressApp');
@@ -166,6 +168,17 @@ keystone.security = {
 keystone.utils = utils;
 
 /**
+ * returns a single .js module at the path specified, relative
+ * to the module root (where the keystone project is being consumed from).
+ *
+ * ####Example:
+ *     var myModel = keystone.import('myModel');
+ */
+Keystone.prototype.importFile = function (fileName) {
+	return fileImporter(this.get('module root'))(fileName);
+};
+
+/**
  * returns all .js modules (recursively) in the path specified, relative
  * to the module root (where the keystone project is being consumed from).
  *
@@ -176,7 +189,6 @@ keystone.utils = utils;
 Keystone.prototype.import = function (dirname) {
 	return importer(this.get('module root'))(dirname);
 };
-
 
 /**
  * Applies Application updates

--- a/lib/core/fileImporter.js
+++ b/lib/core/fileImporter.js
@@ -1,0 +1,42 @@
+var fs = require('fs');
+var debug = require('debug')('keystone:core:importer');
+var path = require('path');
+
+/**
+ * Returns a function that looks in a specified path relative to the current
+ * directory, and returns all .js modules in it (recursively).
+ *
+ * ####Example:
+ *
+ *     var file = keystone.fileImporter(fileName);
+ *
+ * @param {String} rel__dirname
+ * @api public
+ */
+
+function dispatchFileImporter (rel__dirname) {
+
+	function importer (fileName) {
+		debug('importing ', fileName);
+		var imported = {};
+		var joinPath = function () {
+			return '.' + path.sep + path.join.apply(path, arguments);
+		};
+
+		var filePath = joinPath(path.relative(process.cwd(), rel__dirname), fileName);
+		// only import files that we can `require`
+		var ext = path.extname(filePath);
+		var base = path.basename(filePath, ext);
+		if (require.extensions[ext]) {
+			imported[base] = require(path.join(rel__dirname, filePath));
+		} else {
+			debug('cannot require ', ext);
+		}
+
+		return imported;
+	}
+
+	return importer;
+}
+
+module.exports = dispatchFileImporter;


### PR DESCRIPTION
## Description of changes

This is something I created for my own repo that allows loading of Keystone models from different component directories instead of requiring them to exist in the same models directory.

See lines 79-83 of https://github.com/mareinc/mare/blob/update-application-structure/keystone.js for an example.

## Related issues (if any)

No related issues

## Testing

Tests are currently failing, however, this exposes new functionality without changing how existing Keystone functionality operates.

