### PR TITLE
fix value for noEdit InputForm in UrlField

### DIFF
--- a/fields/types/url/UrlField.js
+++ b/fields/types/url/UrlField.js
@@ -35,11 +35,9 @@ module.exports = Field.create({
 		const { value } = this.props;
 		return (
 			<div>
-				<FormInput
-					noedit
-					onClick={value && this.openValue}
-					value={value}
-				/>
+				<FormInput noedit onClick={value && this.openValue}>
+					{value}
+				</FormInput>
 				{ this.renderThumb() }
 			</div>
 		);


### PR DESCRIPTION
PR https://github.com/keystonejs/keystone/pull/4856/ resulted in a bug when UrlField was set to `noedit`

this fixes it again.