### PR TITLE
Change lodash flatten to flattenDeep (recursive)

### DIFF
--- a/fields/types/cloudinaryimages/CloudinaryImagesType.js
+++ b/fields/types/cloudinaryimages/CloudinaryImagesType.js
@@ -345,7 +345,7 @@ cloudinaryimages.prototype.updateItem = function (item, data, files, callback) {
 		}
 		return value;
 	});
-	values = _.flatten(values);
+	values = _.flattenDeep(values);
 
 	async.map(values, function (value, next) {
 		if (typeof value === 'object' && 'public_id' in value) {


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes

Change lodash flatten to flattenDeep. The lodash flatten function ``Flattens `array` a single level deep.`` which is inadequate for more than 2 image uploads as outlined in [this comment](https://github.com/keystonejs/keystone/issues/4857#issuecomment-513577935_). The lodash function flattenDeep ``Recursively flattens a nested array.``

## Related issues (if any)

[Cloudinary: multiple images upload not working #4857](https://github.com/keystonejs/keystone/issues/4857)

This may or may not be fixed in PR https://github.com/keystonejs/keystone/pull/4774 which is unlikely to be merged due to its size.

## Testing

`npm run test-all` ran the same before and after changes we're made on Windows 10 and Ubuntu 18.04 (running in WSL). 
This fix works in Windows Chrome Version 76.0.3809.100 (Official Build) (64-bit) and I wouldn't foresee it not working elsewhere

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

