### PR TITLE
[POC] [Discussion] Custom actions (extension/plugins)

### DIFF
--- a/demo-projects/blog/admin/plugins/ListActions.js
+++ b/demo-projects/blog/admin/plugins/ListActions.js
@@ -1,0 +1,74 @@
+
+import React, { useState } from 'react';
+import { DesktopDownloadIcon } from '@arch-ui/icons';
+import { IconButton } from '@arch-ui/button';
+import { useQuery } from 'react-apollo-hooks';
+import gql from 'graphql-tag';
+import { Button } from '@arch-ui/button';
+import Confirm from '@arch-ui/confirm';
+import PageLoading from '@keystone-alpha/app-admin-ui/client/components/PageLoading';
+
+
+export default () => {
+  const [showExportModal, toggleExportModal] = useState(false);
+
+  const closeExportModal = () => {
+    toggleExportModal(false);
+  };
+  const openExportModal = () => {
+    toggleExportModal(true);
+  };
+
+  return (
+    <>
+      {showExportModal ? <DownloadModal isOpen onClose={closeExportModal} />  : null}
+      <IconButton
+        appearance="default"
+        icon={DesktopDownloadIcon}
+        onClick={openExportModal}
+      >Export
+      </IconButton>
+    </>
+  );
+};
+
+export const DownloadModal = ({ isOpen, onClose }) => {
+  const { data, error, loading } = useQuery(gql`
+    query {
+      allPosts {
+        id title slug posted body
+      }
+    }
+  `);
+  if(!loading && data && data.allPosts) {
+    console.log(data.allPosts);
+  }
+  return (
+    <Confirm
+      isOpen={isOpen}
+      onKeyDown={e => {
+        if (e.key === 'Escape' && !loading) {
+          onClose();
+        }
+      }}
+    >
+      {loading ? (<PageLoading />) :
+        (<p style={{ marginTop: 0 }}>
+          This is demo of plugin feature, see output in browser console, actual csv export may also be done
+            </p>)
+      }
+      <footer>
+        <Button
+          // isDisabled={loading}
+          variant="subtle"
+          onClick={() => {
+            if (loading) return;
+            onClose();
+          }}
+        >
+          Close
+              </Button>
+      </footer>
+    </Confirm>
+  );
+};

--- a/demo-projects/blog/admin/plugins/ListActions.js
+++ b/demo-projects/blog/admin/plugins/ListActions.js
@@ -33,7 +33,7 @@ export default () => {
 };
 
 export const DownloadModal = ({ isOpen, onClose }) => {
-  const { data, error, loading } = useQuery(gql`
+  const { data, loading } = useQuery(gql`
     query {
       allPosts {
         id title slug posted body

--- a/demo-projects/blog/admin/plugins/ListActions.js
+++ b/demo-projects/blog/admin/plugins/ListActions.js
@@ -1,4 +1,3 @@
-
 import React, { useState } from 'react';
 import { DesktopDownloadIcon } from '@arch-ui/icons';
 import { IconButton } from '@arch-ui/button';
@@ -7,7 +6,6 @@ import gql from 'graphql-tag';
 import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
 import PageLoading from '@keystone-alpha/app-admin-ui/client/components/PageLoading';
-
 
 export default () => {
   const [showExportModal, toggleExportModal] = useState(false);
@@ -21,12 +19,9 @@ export default () => {
 
   return (
     <>
-      {showExportModal ? <DownloadModal isOpen onClose={closeExportModal} />  : null}
-      <IconButton
-        appearance="default"
-        icon={DesktopDownloadIcon}
-        onClick={openExportModal}
-      >Export
+      {showExportModal ? <DownloadModal isOpen onClose={closeExportModal} /> : null}
+      <IconButton appearance="default" icon={DesktopDownloadIcon} onClick={openExportModal}>
+        Export
       </IconButton>
     </>
   );
@@ -36,11 +31,15 @@ export const DownloadModal = ({ isOpen, onClose }) => {
   const { data, loading } = useQuery(gql`
     query {
       allPosts {
-        id title slug posted body
+        id
+        title
+        slug
+        posted
+        body
       }
     }
   `);
-  if(!loading && data && data.allPosts) {
+  if (!loading && data && data.allPosts) {
     console.log(data.allPosts);
   }
   return (
@@ -52,11 +51,14 @@ export const DownloadModal = ({ isOpen, onClose }) => {
         }
       }}
     >
-      {loading ? (<PageLoading />) :
-        (<p style={{ marginTop: 0 }}>
-          This is demo of plugin feature, see output in browser console, actual csv export may also be done
-            </p>)
-      }
+      {loading ? (
+        <PageLoading />
+      ) : (
+        <p style={{ marginTop: 0 }}>
+          This is demo of plugin feature, see output in browser console, actual csv export may also
+          be done
+        </p>
+      )}
       <footer>
         <Button
           // isDisabled={loading}
@@ -67,7 +69,7 @@ export const DownloadModal = ({ isOpen, onClose }) => {
           }}
         >
           Close
-              </Button>
+        </Button>
       </footer>
     </Confirm>
   );

--- a/demo-projects/blog/admin/plugins/ListManagementActions.js
+++ b/demo-projects/blog/admin/plugins/ListManagementActions.js
@@ -1,16 +1,16 @@
-
 import React from 'react';
 import { EyeIcon } from '@arch-ui/icons';
 import { IconButton } from '@arch-ui/button';
 import { useMutation } from 'react-apollo-hooks';
 
-
 export default ({ list, selectedItems, onUpdateMany }) => {
   const publishVariable = selectedItems.map(id => ({ id, data: { status: 'published' } }));
   const unPublishVariable = selectedItems.map(id => ({ id, data: { status: 'draft' } }));
-  const updatePosts = useMutation(list.updateManyMutation, { update: () => {
-    onUpdateMany();
-  } });
+  const updatePosts = useMutation(list.updateManyMutation, {
+    update: () => {
+      onUpdateMany();
+    },
+  });
 
   return (
     <>

--- a/demo-projects/blog/admin/plugins/ListManagementActions.js
+++ b/demo-projects/blog/admin/plugins/ListManagementActions.js
@@ -1,0 +1,35 @@
+
+import React from 'react';
+import { EyeIcon } from '@arch-ui/icons';
+import { IconButton } from '@arch-ui/button';
+import { useMutation } from 'react-apollo-hooks';
+
+
+export default ({ list, selectedItems, onUpdateMany }) => {
+  const publishVariable = selectedItems.map(id => ({ id, data: { status: 'published' } }));
+  const unPublishVariable = selectedItems.map(id => ({ id, data: { status: 'draft' } }));
+  const updatePosts = useMutation(list.updateManyMutation, { update: () => {
+    onUpdateMany();
+  } });
+
+  return (
+    <>
+      <IconButton
+        appearance="default"
+        variant="nuance"
+        icon={EyeIcon}
+        onClick={() => updatePosts({ variables: { data: publishVariable } })}
+      >
+        Publish Posts
+      </IconButton>
+      <IconButton
+        appearance="danger"
+        variant="nuance"
+        icon={EyeIcon}
+        onClick={() => updatePosts({ variables: { data: unPublishVariable } })}
+      >
+        Un-Publish
+      </IconButton>
+    </>
+  );
+};

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -24,6 +24,20 @@ const keystone = new Keystone({
   },
 });
 
+function exportFile(list, fields) {
+  keystone.executeQuery(keystone.getListByKey(list));
+}
+
+keystone.extendGraphQLSchema({
+  types: [{ type: 'type FileDownloadType { ready: Boolean, file: String }' }],
+  mutations: [
+    {
+      schema: 'ExportList(list: String!, fields: [String!]!): FileDownloadType',
+      resolver: (_, { list }) => ({ ready: true, file: `2 - ${list}` }),
+    },
+  ],
+});
+
 const authStrategy = keystone.createAuthStrategy({
   type: PasswordAuthStrategy,
   list: 'User',

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -24,10 +24,6 @@ const keystone = new Keystone({
   },
 });
 
-function exportFile(list, fields) {
-  keystone.executeQuery(keystone.getListByKey(list));
-}
-
 keystone.extendGraphQLSchema({
   types: [{ type: 'type FileDownloadType { ready: Boolean, file: String }' }],
   mutations: [

--- a/demo-projects/blog/package.json
+++ b/demo-projects/blog/package.json
@@ -14,6 +14,9 @@
     "start": "cross-env NODE_ENV=production node -r dotenv-safe/config `yarn bin`/keystone start"
   },
   "dependencies": {
+    "@arch-ui/button": "^0.0.9",
+    "@arch-ui/confirm": "^0.0.8",
+    "@arch-ui/icons": "^0.0.5",
     "@arch-ui/layout": "^0.2.4",
     "@arch-ui/typography": "^0.0.8",
     "@emotion/core": "^10.0.14",
@@ -42,6 +45,7 @@
     "node-fetch": "^2.3.0",
     "react": "^16.8.6",
     "react-apollo": "2.4.0",
+    "react-apollo-hooks": "^0.4.4",
     "react-dom": "^16.8.6"
   }
 }

--- a/demo-projects/blog/schema.js
+++ b/demo-projects/blog/schema.js
@@ -84,7 +84,10 @@ exports.Post = {
     defaultPageSize: 20,
     defaultColumns: 'title, status',
     defaultSort: 'title',
-    listActions: require.resolve('./admin/plugins/ListActions')
+    customActions: {
+      listActions: require.resolve('./admin/plugins/ListActions'),
+      listManagementActions: require.resolve('./admin/plugins/ListManagementActions'),
+    }
   },
   labelResolver: item => item.title,
 };

--- a/demo-projects/blog/schema.js
+++ b/demo-projects/blog/schema.js
@@ -84,6 +84,7 @@ exports.Post = {
     defaultPageSize: 20,
     defaultColumns: 'title, status',
     defaultSort: 'title',
+    listActions: require.resolve('./admin/plugins/ListActions')
   },
   labelResolver: item => item.title,
 };

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -12,9 +12,9 @@ import UpdateManyItemsModal from '../../components/UpdateManyItemsModal';
 import DeleteManyItemsModal from '../../components/DeleteManyItemsModal';
 
 const renderManagementActions = ({ list, adminMeta, ...props }) => {
-  if(list.adminConfig.customActions && list.adminConfig.customActions.listManagementActions) {
+  if (list.adminConfig.customActions && list.adminConfig.customActions.listManagementActions) {
     const [View] = adminMeta.readViews([list.adminConfig.customActions.listManagementActions]);
-    return (<View {...{ list, adminMeta, ...props }} />);
+    return <View {...{ list, adminMeta, ...props }} />;
   }
   return null;
 };

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -11,6 +11,14 @@ import { colors, gridSize } from '@arch-ui/theme';
 import UpdateManyItemsModal from '../../components/UpdateManyItemsModal';
 import DeleteManyItemsModal from '../../components/DeleteManyItemsModal';
 
+const renderManagementActions = ({ list, adminMeta, ...props }) => {
+  if(list.adminConfig.customActions && list.adminConfig.customActions.listManagementActions) {
+    const [View] = adminMeta.readViews([list.adminConfig.customActions.listManagementActions]);
+    return (<View {...{ list, adminMeta, ...props }} />);
+  }
+  return null;
+};
+
 export const ManageToolbar = styled.div(({ isVisible }) => ({
   height: 35,
   marginBottom: gridSize * 2,
@@ -24,6 +32,7 @@ const SelectedCount = styled.div({
 
 type Props = {
   list: Object,
+  adminMeta: Object,
   onDeleteMany: (*) => void,
   onUpdateMany: (*) => void,
   selectedItems: Array<string>,
@@ -76,6 +85,7 @@ export default function ListManage(props: Props) {
             Delete
           </IconButton>
         ) : null}
+        {renderManagementActions(props)}
       </FlexGroup>
 
       <UpdateManyItemsModal

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -47,9 +47,9 @@ type LayoutProps = Props & {
 const renderListActions = (list, { readViews, ...adminMeta }) => {
   // console.log(list);
   // console.log(adminMeta);
-  if(list.adminConfig.listActions) {
+  if(list.adminConfig.customActions && list.adminConfig.customActions.listActions) {
     // const [View] = readViews([list.listActions]);
-    const [View] = readViews([list.adminConfig.listActions]);
+    const [View] = readViews([list.adminConfig.customActions.listActions]);
     return (<View {...{ list, adminMeta }} />);
   }
   return null;
@@ -154,6 +154,7 @@ function ListLayout(props: LayoutProps) {
           <ManageToolbar isVisible css={{ marginLeft: 2 }}>
             {selectedItems.length ? (
               <Management
+                adminMeta={adminMeta}
                 list={list}
                 onDeleteMany={onDeleteSelectedItems}
                 onUpdateMany={onUpdateSelectedItems}

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef, useState, Suspense } from 'react';
 import { Query } from 'react-apollo';
 
 import { IconButton } from '@arch-ui/button';
@@ -27,6 +27,7 @@ import Pagination, { getPaginationLabel } from './Pagination';
 import Search from './Search';
 import Management, { ManageToolbar } from './Management';
 import { useListFilter, useListSelect, useListSort, useListUrlState } from './dataHooks';
+import PageLoading from '../../components/PageLoading';
 
 const HeaderInset = props => (
   <div css={{ paddingLeft: gridSize * 2, paddingRight: gridSize * 2 }} {...props} />
@@ -41,6 +42,17 @@ type LayoutProps = Props & {
   items: Array<Object>,
   itemCount: number,
   queryErrors: Array<Object>,
+};
+
+const renderListActions = (list, { readViews, ...adminMeta }) => {
+  // console.log(list);
+  // console.log(adminMeta);
+  if(list.adminConfig.listActions) {
+    // const [View] = readViews([list.listActions]);
+    const [View] = readViews([list.adminConfig.listActions]);
+    return (<View {...{ list, adminMeta }} />);
+  }
+  return null;
 };
 
 function ListLayout(props: LayoutProps) {
@@ -115,16 +127,21 @@ function ListLayout(props: LayoutProps) {
         <HeaderInset>
           <FlexGroup align="center" justify="space-between">
             <PageTitle>{list.plural}</PageTitle>
-            {list.access.create ? (
-              <IconButton
-                appearance="primary"
-                icon={PlusIcon}
-                onClick={openCreateModal}
-                id={cypressCreateId}
-              >
-                Create
+            <FlexGroup align="center" justify="flex-end">
+              {list.access.create ? (
+                <IconButton
+                  appearance="primary"
+                  icon={PlusIcon}
+                  onClick={openCreateModal}
+                  id={cypressCreateId}
+                >
+                  Create
               </IconButton>
-            ) : null}
+              ) : null}
+              <Suspense fallback={<PageLoading />}>
+                {renderListActions(list, adminMeta)}
+              </Suspense>
+            </FlexGroup>
           </FlexGroup>
           <div
             css={{ alignItems: 'center', display: 'flex', flexWrap: 'wrap' }}

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -45,12 +45,9 @@ type LayoutProps = Props & {
 };
 
 const renderListActions = (list, { readViews, ...adminMeta }) => {
-  // console.log(list);
-  // console.log(adminMeta);
-  if(list.adminConfig.customActions && list.adminConfig.customActions.listActions) {
-    // const [View] = readViews([list.listActions]);
+  if (list.adminConfig.customActions && list.adminConfig.customActions.listActions) {
     const [View] = readViews([list.adminConfig.customActions.listActions]);
-    return (<View {...{ list, adminMeta }} />);
+    return <View {...{ list, adminMeta }} />;
   }
   return null;
 };
@@ -136,11 +133,9 @@ function ListLayout(props: LayoutProps) {
                   id={cypressCreateId}
                 >
                   Create
-              </IconButton>
+                </IconButton>
               ) : null}
-              <Suspense fallback={<PageLoading />}>
-                {renderListActions(list, adminMeta)}
-              </Suspense>
+              {renderListActions(list, adminMeta)}
             </FlexGroup>
           </FlexGroup>
           <div

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { Fragment, useEffect, useRef, useState, Suspense } from 'react';
+import { Fragment, useEffect, useRef, useState } from 'react';
 import { Query } from 'react-apollo';
 
 import { IconButton } from '@arch-ui/button';
@@ -27,7 +27,6 @@ import Pagination, { getPaginationLabel } from './Pagination';
 import Search from './Search';
 import Management, { ManageToolbar } from './Management';
 import { useListFilter, useListSelect, useListSort, useListUrlState } from './dataHooks';
-import PageLoading from '../../components/PageLoading';
 
 const HeaderInset = props => (
   <div css={{ paddingLeft: gridSize * 2, paddingRight: gridSize * 2 }} {...props} />

--- a/packages/field-views-loader/index.js
+++ b/packages/field-views-loader/index.js
@@ -34,7 +34,7 @@ function findPageComponents(pages, pageComponents = {}) {
   return pageComponents;
 }
 
-module.exports = function() {
+module.exports = function () {
   const options = loaderUtils.getOptions(this);
   const adminMeta = options.adminMeta;
 
@@ -90,17 +90,23 @@ module.exports = function() {
   let allViews = Object.entries(adminMeta.lists).reduce(
     (obj, [listPath, { views, adminConfig }]) => {
       obj[listPath] = views;
-      if(adminConfig.listActions) {
-        obj[`${listPath}-listActions`] = adminConfig.listActions;
-      }
-      if(adminConfig.toolbarActions) {
-        obj[`${listPath}-toolbarActions`] = adminConfig.toolbarActions;
+      if (adminConfig.customActions) {
+        Object.entries(adminConfig.customActions).forEach(([name, options]) => {
+          if (typeof options === 'string') {
+            obj[`${listPath}-${name}`] = options;
+          } else {
+            if (options.path) {
+              obj[`${listPath}-${name}`] = options.path;
+            }
+          }
+        });
       }
       return obj;
     },
     { __pages__: pageComponents }
   );
 
+  // const stringifiedObject = serialize([allViews, customViews], allPaths);
   const stringifiedObject = serialize(allViews, allPaths);
 
   let loaders = `{\n${[...allPaths]

--- a/packages/field-views-loader/index.js
+++ b/packages/field-views-loader/index.js
@@ -88,8 +88,14 @@ module.exports = function() {
   let pageComponents = findPageComponents(adminMeta.pages);
 
   let allViews = Object.entries(adminMeta.lists).reduce(
-    (obj, [listPath, { views }]) => {
+    (obj, [listPath, { views, adminConfig }]) => {
       obj[listPath] = views;
+      if(adminConfig.listActions) {
+        obj[`${listPath}-listActions`] = adminConfig.listActions;
+      }
+      if(adminConfig.toolbarActions) {
+        obj[`${listPath}-toolbarActions`] = adminConfig.toolbarActions;
+      }
       return obj;
     },
     { __pages__: pageComponents }

--- a/packages/field-views-loader/index.js
+++ b/packages/field-views-loader/index.js
@@ -34,7 +34,7 @@ function findPageComponents(pages, pageComponents = {}) {
   return pageComponents;
 }
 
-module.exports = function () {
+module.exports = function() {
   const options = loaderUtils.getOptions(this);
   const adminMeta = options.adminMeta;
 

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -333,6 +333,7 @@ module.exports = class List {
         .map(field => field.getAdminMeta({ schemaName })),
       views: this.views,
       adminConfig: {
+        ...this.adminConfig,
         defaultPageSize: this.adminConfig.defaultPageSize,
         defaultColumns: this.adminConfig.defaultColumns.replace(/\s/g, ''), // remove all whitespace
         defaultSort: this.adminConfig.defaultSort,


### PR DESCRIPTION
ref: #1452 #310 
Tried to work my way to add some extensibility, see this gif and explanation
![keystone plugin demo](https://user-images.githubusercontent.com/5769869/66274863-7d883280-e8a0-11e9-8552-10d43f7c0a4b.gif)
> click gif to open in new window for better viewing

## Intention

intention is to enable devs write custom actions which can extend Admin UI with custom Buttons for List and List multi item select management. 

### working:
1. You can add List Action to add UI elements after the "Create" button on List page, this can be any Ui element, I just used the way field view loaders are loaded. 
> the example I used is very crude, actual export features can also be written using this way and the Ui may give download link rather than the item in the console log.

2. You can add ui elements on the toolbar when you select items in the list. ( again very simple example but this can achieve complex scenarios as well)

### possibility
immediate possibility is to 

1. add list item actions similar to #1724 Duplicate items from drop down ( this can also be refactored as list item action rather than in build feature)

2. add Item Action which is on the Item detail/Edit page.

I will work on these two after seeing positive feedback for first two actions working.

## Beyond

later this can also extend to import plugins installed dynamically, I was not able to figure out (yet) the webpack stuff with field-view-loader to load from disk without bundling with webpack.

additionally we can also enable composing with other ui elements like 
* custom filtering options which may enable quick filtering with pre-made filters.
* add ui elements in the create/update item modal which may fetch some information based on input and pre-fill some fields
* allow devs replace CreateItem modal (and other models) with custom one.
 

> this PR may not make it to the repo "as is" due to changes in the Blog Demo project, I will modify this to run with test projects and create new PR once it is acceptable to core team otherwise it will become part of [`keystonejs-contrib`](https://github.com/keystonejs-contrib/keystonejs-contrib) project for sure