### PR TITLE
[WIP] Run tests without lockfile

### DIFF
--- a/scripts/test-unlocked.sh
+++ b/scripts/test-unlocked.sh
@@ -1,0 +1,2 @@
+mv yarn.lock cached-yarn.lock
+(yarn fresh && yarn test && mv cached-yarn.lock yarn.lock) || mv yarn.lock failed-yarn.lock && mv cached-yarn.lock yarn.lock


### PR DESCRIPTION
Hey!

Lockfiles are great. They make our lives a lot easier. Working without one would be insane. Unfortunately, they can also mask problems to us as open source maintainers, where code within our repository runs, but a user getting a fresh install from npm will encounter an error in the exact same scenario.

To try and mitigate this 'works-on-my-machine-ness' of this, I'm suggesting we run a 'clean install' at least once in our release loop. This script should do that.

Still to-do:

- [ ] Set this up to run on specific branches, namely this branch (for testing this) and the `version` branch that gets kept open
- [ ] Make it so running this doesn't immediately cause failures 🚎 . This may involve pinning versions of some devDeps so I don't fight through upgrading them.