### PR TITLE
Doc updates and minor functionality improvements for file field/adapters

### DIFF
--- a/.changeset/moody-hairs-type.md
+++ b/.changeset/moody-hairs-type.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': patch
+'@keystonejs/file-adapters': patch
+---
+
+Doc updates and minor functionality improvements for file field/adapters

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -98,7 +98,8 @@ export class File extends Implementation {
       return null;
     }
 
-    const { stream, filename: originalFilename, mimetype, encoding } = await uploadData;
+    const { createReadStream, filename: originalFilename, mimetype, encoding } = await uploadData;
+    const stream = createReadStream();
 
     if (!stream && previousData) {
       // TODO: FIXME: Handle when stream is null. Can happen when:

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -18,6 +18,10 @@ export class File extends Implementation {
     this.directory = directory;
     this.route = route;
     this.fileAdapter = adapter;
+
+    if (!this.fileAdapter) {
+      throw new Error(`No file adapter provided for File field.`);
+    }
   }
 
   gqlOutputFields() {

--- a/packages/fields/src/types/File/README.md
+++ b/packages/fields/src/types/File/README.md
@@ -6,21 +6,35 @@ title: File
 
 # File
 
+Support files hosted in a range of different contexts, e.g. in the local filesystem, or on a cloud based file server.
+
 ## Usage
 
 ```js
+const { File } = require('@keystonejs/fields');
+const { LocalFileAdapter } = require('@keystonejs/file-adapters');
+
+const fileAdapter = new LocalFileAdapter({
+  /*...config */
+});
+
 keystone.createList('Applicant', {
   fields: {
-    name: { type: Text },
-    resume: { type: File, isRequired: true },
+    file: {
+      type: File,
+      adapter: fileAdapter,
+      isRequired: true,
+    },
   },
 });
 ```
 
 ### Config
 
-| Option       | Type      | Default | Description                      |
-| ------------ | --------- | ------- | -------------------------------- |
-| `isRequired` | `Boolean` | `false` | Does this field require a value? |
+| Option       | Type      | Default  | Description                                                                                            |
+| ------------ | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| `adapter`    | `Object`  | Required | See the [File Adapters](https://www.keystonejs.com/keystone/file-adapters/) page for more information. |
+| `route`      | `String`  | `null`   |                                                                                                        |
+| `isRequired` | `Boolean` | `false`  | Does this field require a value?                                                                       |
 
----
+_Note:_ `adapter` currently may be one of `LocalFileAdapter` or `CloudinaryFileAdapter`.

--- a/packages/file-adapters/README.md
+++ b/packages/file-adapters/README.md
@@ -15,10 +15,35 @@ Different contexts are supported by different file adapters. This package contai
 ### Usage
 
 ```javascript
+const { LocalFileAdapter } = require('@keystonejs/file-adapters');
+
 const fileAdapter = new LocalFileAdapter({
-  src: './files',
-  path: '/public',
+  /*...config */
 });
 ```
 
+### Config
+
+| Option | Type     | Default | Description                                                            |
+| ------ | -------- | ------- | ---------------------------------------------------------------------- |
+| `src`  | `String` | `null`  | The path where uploaded files will be stored on the server.            |
+| `path` | `String` | `null`  | The path from which requests for files will be served from the server. |
+
+_Note:_ `src` and `path` may be the same.
+
 ## `CloudinaryFileAdapter`
+
+```javascript
+const { CloudinaryAdapter } = require('@keystonejs/file-adapters');
+
+const fileAdapter = new CloudinaryAdapter({
+  /*...config */
+});
+```
+
+| Option      | Type     | Default     | Description |
+| ----------- | -------- | ----------- | ----------- |
+| `cloudName` | `String` | Required    |             |
+| `apiKey`    | `String` | Required    |             |
+| `apiSecret` | `String` | Required    |             |
+| `folder`    | `String` | `undefined` |             |

--- a/packages/file-adapters/README.md
+++ b/packages/file-adapters/README.md
@@ -24,10 +24,10 @@ const fileAdapter = new LocalFileAdapter({
 
 ### Config
 
-| Option | Type     | Default | Description                                                            |
-| ------ | -------- | ------- | ---------------------------------------------------------------------- |
-| `src`  | `String` | `null`  | The path where uploaded files will be stored on the server.            |
-| `path` | `String` | `null`  | The path from which requests for files will be served from the server. |
+| Option | Type     | Default        | Description                                                            |
+| ------ | -------- | -------------- | ---------------------------------------------------------------------- |
+| `src`  | `String` | Required       | The path where uploaded files will be stored on the server.            |
+| `path` | `String` | Value of `src` | The path from which requests for files will be served from the server. |
 
 _Note:_ `src` and `path` may be the same.
 

--- a/packages/file-adapters/lib/cloudinary.js
+++ b/packages/file-adapters/lib/cloudinary.js
@@ -14,14 +14,14 @@ function uploadStream(stream, options) {
 }
 
 module.exports = class CloudinaryAdapter {
-  constructor(options) {
-    if (!options.cloudName || !options.apiKey || !options.apiSecret) {
+  constructor({ cloudName, apiKey, apiSecret, folder }) {
+    if (!cloudName || !apiKey || !apiSecret) {
       throw new Error('CloudinaryAdapter requires cloudName, apiKey, and apiSecret');
     }
-    this.cloudName = options.cloudName;
-    this.apiKey = options.apiKey;
-    this.apiSecret = options.apiSecret;
-    this.folder = options.folder || undefined;
+    this.cloudName = cloudName;
+    this.apiKey = apiKey;
+    this.apiSecret = apiSecret;
+    this.folder = folder || undefined;
   }
 
   /**

--- a/packages/file-adapters/lib/local-file.js
+++ b/packages/file-adapters/lib/local-file.js
@@ -7,6 +7,14 @@ module.exports = class LocalFileAdapter {
     this.src = path.resolve(src);
     this.path = inputPath;
 
+    if (!this.src) {
+      throw new Error('LocalFileAdapter requires a src attribute.');
+    }
+
+    if (!this.path) {
+      this.path = src;
+    }
+
     mkdirp.sync(this.src);
   }
 


### PR DESCRIPTION
EDIT: Summary of current changes:
* `fileAdapter` is now properly treated as mandatory in File fields.
* `src` is now mandatory for `LocalFileAdapter`.
*  `path` now defaults to `src` if not provided for `LocalFileAdapter`.
* Improved documentation for both file adapters and the File field.
* Fixed this warning:
```
DeprecationWarning: File upload property ‘stream’ is deprecated. Use ‘createReadStream()’ instead.
```
