### PR TITLE
Remove pluralization of Todo in list creation

### DIFF
--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -92,7 +92,7 @@ In order to be able to start an app we need to add at least one List. A List is 
 In `index.js` add following before `module.exports`:
 
 ```
-keystone.createList('Todos', {
+keystone.createList('Todo', {
   fields: {
     name: { type: Text },
   }


### PR DESCRIPTION
Bumped into the following error when running through the guide: `Error: Unable to use Todos as a List name - it has an ambiguous plural (Todos).` Changing from Todos to Todo fixes the error (the later sections of the guides seem to use singular `Todo` also for list creation)