### PR TITLE
Allow dev projects as part of monorepo when contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ tags
 [._]*.un~
 
 # End of https://www.gitignore.io/api/vim
+
+projects/
+temp/

--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
       "api-tests",
       "benchmarks",
       "website",
-      "packages/create-keystone-app/example-projects/*"
+      "packages/create-keystone-app/example-projects/*",
+      "projects/*"
     ],
     "nohoist": [
       "**/mocha-multi-reporters"


### PR DESCRIPTION
I have struggled in past on how to work on my own keystone based projects and contribute to keystone at the same time. 

now that we have yarn workspaces which does not need to add dependency to root (unlike BoltPkg) I have this PR:
1. add `projects/*` to workspaces
2. .gitignore `projects/`  and `temp/` (just for sanity)

this helps me work on my projects (separate git repo) inside the cloned kystone repo, enables easy contribution otherwise I had to maintain multiple copy of repo locally.