### PR TITLE
Set correct users link

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -84,7 +84,7 @@ Second, disable access control by removing `access` from the
 -  },
 ```
 
-Restart your KeystoneJS App, and visit <http://localhost:3000/users> - you should now be able to access the Admin UI without logging in.
+Restart your KeystoneJS App, and visit <http://localhost:3000/admin/users> - you should now be able to access the Admin UI without logging in.
 
 Next, create a User (be sure to set both a username and password).
 
@@ -95,7 +95,7 @@ Add the `authStrategy` config back to the `new AdminUIApp()` call
 + const admin = new AdminUIApp({ authStrategy });
 ```
 
-Restart your KeystoneJS App once more, and try to visit <http://localhost:3000/users>; you will be presented with the login screen.
+Restart your KeystoneJS App once more, and try to visit <http://localhost:3000/admin/users>; you will be presented with the login screen.
 
 Finally; login with the newly created `User`'s credentials.
 


### PR DESCRIPTION
The authentication guide documentation (https://www.keystonejs.com/guides/authentication) suggests to navigate to http://localhost:3000/users which is a broken link. I believe the correct URL should be http://localhost:3000/admin/users