### PR TITLE
Corrected doc mistake I made

### DIFF
--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -38,8 +38,8 @@ If not specified, KeystoneJS will first look for one of the following environmen
 
 If none of these are found a connection string is derived with a `DATABASE_NAME` from the KeystoneJS project name.
 
-### `mongooseConfig` (optional)
+### Mongoose Options (optional)
 
-These options are passed directly through to `mongoose.connect()`.
+Additional Mongoose config options are passed directly through to `mongoose.connect()`.
 
-See: <https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect> for a detailed list of options.
+See the [Mongoose docs](https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect) for a detailed list of options.


### PR DESCRIPTION
I misread the code and though MongoAdapter took a `mongooseConfig` key (a2d0b3b5c71d7ac1ed55593a5b7889d319d3e3e1). Turns out there's no key, you just pass options directly. Fixed my mistake and clarified this.