### PR TITLE
Better error messages when unique validation fails (mongodb)

### DIFF
--- a/.changeset/three-wolves-prove.md
+++ b/.changeset/three-wolves-prove.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-mongoose': patch
+---
+
+Deployed mongoose-unique-validator for a more readable error message when unique checks fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
       - run: yarn lint:markdown
       - run:
           name: Unit tests
-          command: yarn jest --ci --testResultsProcessor="jest-junit" --maxWorkers=1
+          command: yarn jest --ci --reporters=default --reporters=jest-junit --maxWorkers=1
           environment:
             JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
       - store_test_results:

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -41,7 +41,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           expect(errors).toHaveProperty('0.message');
-          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
+          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
         })
       );
 
@@ -59,7 +59,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           expect(errors).toHaveProperty('0.message');
-          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key/));
+          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
         })
       );
 

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+const uniqueValidator = require('mongoose-unique-validator');
+
 const pSettle = require('p-settle');
 const {
   escapeRegExp,
@@ -28,6 +30,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
     if (debugMongoose()) {
       this.mongoose.set('debug', true);
     }
+    this.mongoose.plugin(uniqueValidator);
     this.listAdapterClass = this.listAdapterClass || this.defaultListAdapterClass;
   }
 
@@ -184,7 +187,11 @@ class MongooseListAdapter extends BaseListAdapter {
   _update(id, data) {
     // Avoid any kind of injection attack by explicitly doing a `$set` operation
     // Return the modified item, not the original
-    return this.model.findByIdAndUpdate(id, { $set: data }, { new: true });
+    return this.model.findByIdAndUpdate(
+      id,
+      { $set: data },
+      { new: true, runValidators: true, context: 'query' }
+    );
   }
 
   _findAll() {

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -16,6 +16,7 @@
     "@sindresorhus/slugify": "^0.6.0",
     "lodash.omitby": "^4.6.0",
     "mongoose": "^5.7.7",
+    "mongoose-unique-validator": "^2.0.3",
     "p-settle": "^3.1.0",
     "pluralize": "^7.0.0"
   }


### PR DESCRIPTION
Should close #433 since the error appears.

This utilizes [mongoose-unique-validator](https://www.npmjs.com/package/mongoose-unique-validator) as a global schema plugin. Test done with a unique URL field.

**Before**
![image](https://user-images.githubusercontent.com/3558659/67709174-8688a180-fa11-11e9-9c4a-f569642ecdca.png)

**After**
![image](https://user-images.githubusercontent.com/3558659/67709209-9902db00-fa11-11e9-83eb-a30729549e74.png)

