### PR TITLE
docs: update next app documentation

### DIFF
--- a/packages/app-next/README.md
+++ b/packages/app-next/README.md
@@ -10,8 +10,6 @@ A KeystoneJS App for serving a [Next.js](https://nextjs.org/) application.
 
 ## Usage
 
-/!\ Pay attention, don't forget to disable `enableDefaultRoute` option on `AdminUIApp`.
-
 ```javascript
 const { NextApp } = require('@keystonejs/app-next');
 
@@ -21,7 +19,7 @@ module.exports = {
   keystone,
   apps: [
     new GraphQLApp(),
-    new AdminUIApp(authStrategy),
+    new AdminUIApp({ enableDefaultRoute: false }),
     new NextApp({ dir: 'app' }),
   ],
   distDir,

--- a/packages/app-next/README.md
+++ b/packages/app-next/README.md
@@ -10,6 +10,8 @@ A KeystoneJS App for serving a [Next.js](https://nextjs.org/) application.
 
 ## Usage
 
+/!\ Pay attention, don't forget to disable `enableDefaultRoute` option on `AdminUIApp`.
+
 ```javascript
 const { NextApp } = require('@keystonejs/app-next');
 
@@ -19,7 +21,7 @@ module.exports = {
   keystone,
   apps: [
     new GraphQLApp(),
-    new AdminUIApp(),
+    new AdminUIApp(authStrategy),
     new NextApp({ dir: 'app' }),
   ],
   distDir,


### PR DESCRIPTION
I just setup my project with `keystone-app` and after some investigation, I notice these two points;
1. By default `AdminUIApp` should have `authStrategy`
2. When you just initialize a project, you have this configuration `new AdminUIApp({ enableDefaultRoute: true, authStrategy })`

So I think it may be useful to prevent it.
