### PR TITLE
Admin UI: made NavIcons section easier to click

### DIFF
--- a/.changeset/warm-camels-tie.md
+++ b/.changeset/warm-camels-tie.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/navbar': patch
+---
+
+Made NavIcons section easier to click

--- a/packages/arch/packages/navbar/src/PrimaryNav.js
+++ b/packages/arch/packages/navbar/src/PrimaryNav.js
@@ -13,7 +13,14 @@ export const NavGroupIcons = styled.div({
   display: 'flex',
   flexFlow: 'row nowrap',
   justifyContent: 'space-between',
-  padding: PRIMARY_NAV_GUTTER,
+  padding: 0,
+
+  '> *': {
+    marginBottom: 0,
+    padding: '1em 0',
+    textAlign: 'center',
+    width: '100%',
+  },
 });
 
 export const PrimaryNav = styled.nav({


### PR DESCRIPTION
Small UX change. Gets rid of the massive padding around and between the bottom nav buttons so they're easier to click. Also brings them in line with the list items above that extend to the screen edge.

**Before**
![buttonlayoutorig](https://user-images.githubusercontent.com/3558659/67789163-9ebaf800-fac7-11e9-99cd-751177046470.jpg)

**After**
![image](https://user-images.githubusercontent.com/3558659/67789193-aa0e2380-fac7-11e9-8a7c-c11218aaaa46.png)
