### PR TITLE
Mention symlink caveats when installing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ yarn dev
 See [`demo-projects/README.md`](./demo-projects/README.md) for more details on
 the available demo projects.
 
+#### Note For Windows Users
+
+While running `yarn` on Windows, the process may fail with an error such as this:
+
+```sh
+error { [Error: EPERM: operation not permitted, symlink 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\src\index.js' -> 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\dist\alert.cjs.js.flow']
+```
+
+This is due to permission restrictions regarding the creation of [symbolic links](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/). To solve this, you should enable Windows' [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development?redirectedfrom=MSDN) and run `yarn` again.
+
 ### Testing
 
 Keystone uses [Jest](https://facebook.github.io/jest) for unit tests and [Cypress](https://www.cypress.io) for end-to-end tests.


### PR DESCRIPTION
See #1487. This directs people to enable Developer Mode since the general consensus is we shouldn't encourage elevated console usage.