### PR TITLE
Fix singular/plural

### DIFF
--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -170,9 +170,9 @@ module.exports = class List {
     const _singular = pluralize.singular(_label);
     const _plural = pluralize.plural(_label);
 
-    if (_plural === _label) {
+    if (_plural === _singular) {
       throw new Error(
-        `Unable to use ${_label} as a List name - it has an ambiguous plural (${_plural}). Please choose another name for your list.`
+        `Unable to use ${_label} as a List name - it has an ambiguous singular form (${_singular}) and plural form (${_plural}). Please choose another name for your list.`
       );
     }
 


### PR DESCRIPTION
Right now, when you use a plural word (like 'users') as the list key, an exception will be generated. However, the word 'user' clearly has a different singular and plural form.

Why do we need to use a plural word as the table name? Allowing the user to set a table name directly allows keystone to work with legacy system with a different naming schema. Right now the table name is directly associated with the list key and there's no way to change that. This means if the legacy system uses a table named 'users', there's no way for the user to connect keystone with that system. To work around this, we can simply relax the constraint of the list name, or give a warning instead of throwing an exception.
