### PR TITLE
Added getter for connect-mongo middleware that shares the db connection

### DIFF
--- a/.changeset/breezy-apples-change.md
+++ b/.changeset/breezy-apples-change.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-mongoose': minor
+---
+
+Added getSessionMiddleware() to get a connect-mongo object that share's the adapter's connection

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -43,3 +43,9 @@ If none of these are found a connection string is derived with a `DATABASE_NAME`
 Additional Mongoose config options are passed directly through to `mongoose.connect()`.
 
 See the [Mongoose docs](https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect) for a detailed list of options.
+
+## Methods
+
+### getSessionMiddleware()
+
+Returns a new [`connect-mongo`](https://github.com/jdesboeufs/connect-mongo) session middleware that shares this adapter's connection to the database. This should be passed to the `sessionStore` option in the [keystone constructor](keystonejs/keystone/).

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -21,6 +21,9 @@ const slugify = require('@sindresorhus/slugify');
 
 const debugMongoose = () => !!process.env.DEBUG_MONGOOSE;
 
+const expressSession = require('express-session');
+const MongoStore = require('connect-mongo')(expressSession);
+
 class MongooseAdapter extends BaseKeystoneAdapter {
   constructor() {
     super(...arguments);
@@ -96,6 +99,10 @@ class MongooseAdapter extends BaseKeystoneAdapter {
         `MongoDB version ${info.version} is incompatible. Version ${this.minVer} or later is required.`
       );
     }
+  }
+
+  getSessionMiddleware() {
+    return new MongoStore({ mongooseConnection: this.mongoose.connection });
   }
 }
 

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -14,6 +14,8 @@
     "@keystonejs/mongo-join-builder": "^5.0.1",
     "@keystonejs/utils": "^5.1.0",
     "@sindresorhus/slugify": "^0.6.0",
+    "connect-mongo": "^3.1.0",
+    "express-session": "^1.17.0",
     "lodash.omitby": "^4.6.0",
     "mongoose": "^5.7.7",
     "mongoose-unique-validator": "^2.0.3",

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -59,6 +59,20 @@ const keystone = new Keystone({
 });
 ```
 
+The [Mongoose adapter](https://www.keystonejs.com/keystonejs/adapter-mongoose/) also provides a convenience getter for `connect-mongo` if you want to share the same database connection:
+
+```javascript
+const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
+
+const adapter = new MongooseAdapter();
+
+const keystone = new Keystone({
+  /* ...config */
+  adapter: adapter,
+  sessionStore: adapter.getSessionMiddleware(),
+});
+```
+
 ### `queryLimits`
 
 Configures global query limits.

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -12,6 +12,6 @@
     "cookie": "^0.3.1",
     "cookie-signature": "^1.1.0",
     "express": "^4.17.1",
-    "express-session": "^1.16.2"
+    "express-session": "^1.17.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5936,6 +5936,13 @@ connect-history-api-fallback@^1.3.0:
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
   integrity sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=
 
+connect-mongo@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/connect-mongo/-/connect-mongo-3.1.2.tgz#c89080ac2eb4432b03ec3250127a5a11472e0e7d"
+  integrity sha512-UBHOk+T3pj1nTDIb75y/m45sWDt2j9B9nG7C4RkvxGUmK7nA8kAH9lD9FgK06MrKiBTwV25rzXPbGk9yTURzfw==
+  dependencies:
+    mongodb "^3.1.0"
+
 connect@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/connect/-/connect-3.7.0.tgz#5d49348910caa5e07a01800b030d0c35f20484f8"
@@ -8258,18 +8265,18 @@ express-react-views@^0.11.0:
     lodash.escaperegexp "^4.1.2"
     object-assign "^4.1.1"
 
-express-session@^1.16.2:
-  version "1.16.2"
-  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.16.2.tgz#59f36d7770e94872d19b163b6708a2d16aa6848c"
-  integrity sha512-oy0sRsdw6n93E9wpCNWKRnSsxYnSDX9Dnr9mhZgqUEEorzcq5nshGYSZ4ZReHFhKQ80WI5iVUUSPW7u3GaKauw==
+express-session@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.0.tgz#9b50dbb5e8a03c3537368138f072736150b7f9b3"
+  integrity sha512-t4oX2z7uoSqATbMfsxWMbNjAL0T5zpvcJCk3Z9wnPPN7ibddhnmDZXHfEcoBMG2ojKXZoCyPMc5FbtK+G7SoDg==
   dependencies:
-    cookie "0.3.1"
+    cookie "0.4.0"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "~2.0.0"
     on-headers "~1.0.2"
     parseurl "~1.3.3"
-    safe-buffer "5.1.2"
+    safe-buffer "5.2.0"
     uid-safe "~2.1.5"
 
 express@^4.16.2, express@^4.16.3, express@^4.17.1:
@@ -13048,12 +13055,12 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
+lodash.foreach@^4.1.0, lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.get@4.4.2, lodash.get@^4.4.2, lodash.get@~4.4.2:
+lodash.get@4.4.2, lodash.get@^4.0.2, lodash.get@^4.4.2, lodash.get@~4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -14360,7 +14367,7 @@ mongodb-memory-server@^6.0.1:
   dependencies:
     mongodb-memory-server-core "6.0.1"
 
-mongodb@3.3.3, mongodb@^3.2.7, mongodb@^3.3.3:
+mongodb@3.3.3, mongodb@^3.1.0, mongodb@^3.2.7, mongodb@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.3.3.tgz#509cad2225a1c56c65a331ed73a0d5d4ed5cbe67"
   integrity sha512-MdRnoOjstmnrKJsK8PY0PjP6fyF/SBS4R8coxmhsfEU7tQ46/J6j+aSHF2n4c2/H8B+Hc/Klbfp8vggZfI0mmA==
@@ -14375,6 +14382,14 @@ mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
+
+mongoose-unique-validator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/mongoose-unique-validator/-/mongoose-unique-validator-2.0.3.tgz#247adbcda391bf5bc63fc3dcd43286a9ec833fa4"
+  integrity sha512-3/8pmvAC1acBZS6eWKAWQUiZBlARE1wyWtjga4iQ2wDJeOfRlIKmAvTNHSZXKaAf7RCRUd7wh7as6yWAOrjpQg==
+  dependencies:
+    lodash.foreach "^4.1.0"
+    lodash.get "^4.0.2"
 
 mongoose@^5.7.7:
   version "5.7.7"
@@ -18975,6 +18990,11 @@ safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Bit on the fence about this one, but figured I'd toss it out there for consideration anyway.

Basically, this add a `getSessionMiddleware()` method to the Mongoose adapter that returns a new `connect-mongo` instance sharing the same db connection as the adapter. Example usage:

```js
const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
const adapter = new MongooseAdapter();

const keystone = new Keystone({
  /* ...config */
  adapter: adapter,
  sessionStore: adapter.getSessionMiddleware(),
});
```

Few reasons this is useful:

1. It's more efficient since you don't open two different connections to the database.
2. It's more convenient, since you only need to keep track of your connection URI in one place.
3. Using ```new MongoStore({ url: `mongodb://localhost/${PROJECT_NAME}` })``` doesn't actually work if your `PROJECT_NAME` contains spaces ("My New Project", for example). The Mongoose adapter runs it through `slugify` first, but that's really an implementation detail and not something one should expect devs to duplicate. Obviously a production build would probably use an env var with a set db name, but this keeps things simpler when doing dev work.