### PR TITLE
Knex adapter does not recognise config

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -23,7 +23,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
   }
 
   async _connect({ name }) {
-    const { knexOptions = {} } = this.config;
+    const knexOptions = this.config;
     const { connection } = knexOptions;
     let knexConnection =
       connection || process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI;


### PR DESCRIPTION
Something goes wrong when adapter-knex tries to get config object from BaseKeystoneAdapter.
Either the syntax is wrong or Node.js v.12.13.0 does not understand the notation for default value of an empty object.