### PR TITLE
add chunkSortMode option to HtmlWebpackPlugin

### DIFF
--- a/.changeset/wild-zoos-shout.md
+++ b/.changeset/wild-zoos-shout.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fix bug with loading mulitple complex custom pages with chunkSortMode option in HtmlWebpackPlugin

--- a/.changeset/wild-zoos-shout.md
+++ b/.changeset/wild-zoos-shout.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Fix bug with loading mulitple complex custom pages with chunkSortMode option in HtmlWebpackPlugin
+Fix bug with loading multiple complex custom pages with chunkSortMode option in HtmlWebpackPlugin

--- a/packages/app-admin-ui/server/getWebpackConfig.js
+++ b/packages/app-admin-ui/server/getWebpackConfig.js
@@ -8,6 +8,7 @@ module.exports = function({ adminMeta, entry, outputPath }) {
   const templatePlugin = new HtmlWebpackPlugin({
     title: 'KeystoneJS',
     template: 'index.html',
+    chunksSortMode: 'none',
   });
   const environmentPlugin = new webpack.DefinePlugin({
     ENABLE_DEV_FEATURES: enableDevFeatures,


### PR DESCRIPTION
I hit a bug similar to https://github.com/marcelklehr/toposort/issues/20 when loading custom pages little more complex than blog-demo example. My scenario contained reusing components from same directory in pages.

it throws cyclic dependency error 

```
/Volumes/dev/dr/ks/ks5-projects/node_modules/toposort/index.js:35
      throw new Error('Cyclic dependency' + nodeRep)
```

fixed it by setting `chunksSortMode` to `none` in HtmlWebpackPlugin.