### PR TITLE
upgrade react-router-dom

### DIFF
--- a/.changeset/wicked-ears-promise.md
+++ b/.changeset/wicked-ears-promise.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@arch-ui/button': patch
+'@arch-ui/dropdown': patch
+'@arch-ui/navbar': patch
+'@arch-ui/pagination': patch
+---
+
+Upgrade `react-router-dom` to v5.1.2 to make use of `useParams` and other hooks provided by `react-router-dom` v5.1.0.

--- a/packages/app-admin-ui/package.json
+++ b/packages/app-admin-ui/package.json
@@ -75,7 +75,7 @@
     "react-node-resolver": "^2.0.1",
     "react-prop-toggle": "^1.0.2",
     "react-pseudo-state": "^2.2.2",
-    "react-router-dom": "5.0.0",
+    "react-router-dom": "5.1.2",
     "react-select": "^3.0.4",
     "react-toast-notifications": "^2.2.4",
     "react-transition-group": "^2.6.1",

--- a/packages/arch/packages/button/package.json
+++ b/packages/arch/packages/button/package.json
@@ -20,7 +20,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.22",
     "react-pseudo-state": "^2.2.2",
-    "react-router-dom": "5.0.0"
+    "react-router-dom": "5.1.2"
   },
   "module": "dist/button.esm.js"
 }

--- a/packages/arch/packages/dropdown/package.json
+++ b/packages/arch/packages/dropdown/package.json
@@ -20,7 +20,7 @@
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.22",
     "react-focus-marshal": "^1.0.1",
-    "react-router-dom": "5.0.0"
+    "react-router-dom": "5.1.2"
   },
   "module": "dist/dropdown.esm.js"
 }

--- a/packages/arch/packages/navbar/package.json
+++ b/packages/arch/packages/navbar/package.json
@@ -17,7 +17,7 @@
     "@babel/runtime": "^7.4.3",
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.22",
-    "react-router-dom": "5.0.0"
+    "react-router-dom": "5.1.2"
   },
   "module": "dist/navbar.esm.js"
 }

--- a/packages/arch/packages/pagination/package.json
+++ b/packages/arch/packages/pagination/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime": "^7.4.3",
     "@emotion/core": "^10.0.22",
     "@emotion/styled": "^10.0.22",
-    "react-router-dom": "5.0.0"
+    "react-router-dom": "5.1.2"
   },
   "module": "dist/pagination.esm.js"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,7 +1237,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.6.3":
+"@babel/runtime@^7.4.0", "@babel/runtime@^7.6.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
   integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
@@ -6266,7 +6266,7 @@ create-react-context@^0.1.5:
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.1.6.tgz#0f425931d907741127acc6e31acb4f9015dd9fdc"
   integrity sha512-eCnYYEUEc5i32LHwpE/W7NlddOB9oHwsPaWtWzYtflNkkwa3IfindIcoXdVWs12zCbwaMCavKNu84EXogVIWHw==
 
-create-react-context@^0.2.1, create-react-context@^0.2.2:
+create-react-context@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -13915,6 +13915,15 @@ min-document@^2.19.0:
   dependencies:
     dom-walk "^0.1.0"
 
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
+
 mini-css-extract-plugin@^0.4.0:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz#c99e9e78d54f3fa775633aee5933aeaa4e80719a"
@@ -17919,16 +17928,16 @@ react-redux@^5.0.6:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
-react-router-dom@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
-  integrity sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==
+react-router-dom@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
+  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
   dependencies:
     "@babel/runtime" "^7.1.2"
     history "^4.9.0"
     loose-envify "^1.3.1"
     prop-types "^15.6.2"
-    react-router "5.0.0"
+    react-router "5.1.2"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
@@ -17944,16 +17953,16 @@ react-router-dom@^4.2.2:
     react-router "^4.3.1"
     warning "^4.0.1"
 
-react-router@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.0.tgz#349863f769ffc2fa10ee7331a4296e86bc12879d"
-  integrity sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==
+react-router@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"
+  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    create-react-context "^0.2.2"
     history "^4.9.0"
     hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
     path-to-regexp "^1.7.0"
     prop-types "^15.6.2"
     react-is "^16.6.0"
@@ -20879,6 +20888,11 @@ tiny-warning@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
   integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinycolor2@^1.1.2, tinycolor2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
When trying to make use or params for path in custom pages like this:

```js
const adminApp = new AdminUIApp({
  adminPath: '/admin',
  authStrategy,
  isAccessAllowed: ({ authentication: { item: user } }) => !!user && !!user.isAdmin,
  pages: [
    {
      label: 'DashBoard for List',
      path: 'dashboard/:list', // route params "list"
      component: require.resolve('./admin/pages/dashboard'),
    },
    // ........
  ],
});
```

I can not capture the `lis` param for dashboard route. With this I was able to use `useParams` and other hooks provided by `react-router-dom@5.1.0`.