### PR TITLE
Clear yarn warnings

### DIFF
--- a/.changeset/warm-humans-press.md
+++ b/.changeset/warm-humans-press.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/apollo-helpers': patch
+'@keystonejs/build-field-types': patch
+---
+
+Upgraded dependencies to include correct peer dependencies.

--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
     "unist-util-visit": "^1.4.0",
     "unsplash-js": "^5.0.0",
     "uuid": "^3.3.2",
-    "vue-loader": "^15.7.1",
     "webpack": "4.28.4"
   },
   "prettier": {

--- a/packages/apollo-helpers/package.json
+++ b/packages/apollo-helpers/package.json
@@ -13,6 +13,10 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "@jesstelford/apollo-cache-invalidation": "^0.0.3-gh3-gh5",
+    "@types/react": "^16.8.12",
+    "apollo-cache": "^1.3.2",
+    "apollo-link": "^1.2.13",
+    "apollo-utilities": "^1.3.2",
     "graphql-tag": "^2.10.1",
     "hoist-non-react-statics": "^3.0.1",
     "lodash.mapvalues": "^4.6.0",

--- a/packages/build-field-types/package.json
+++ b/packages/build-field-types/package.json
@@ -43,7 +43,7 @@
     "pirates": "^4.0.1",
     "resolve": "^1.10.0",
     "resolve-from": "^4.0.0",
-    "rollup": "^1.0.0",
+    "rollup": "^1.20.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "rollup-pluginutils": "^2.6.0",
     "sarcastic": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,7 +2676,7 @@
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.3.29.tgz#7f2ad7ec55f914482fc9b1ec4bb1ae6028d46066"
   integrity sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY=
 
-"@types/node@*", "@types/node@^12.6.9", "@types/node@^12.7.1":
+"@types/node@*", "@types/node@^12.7.1":
   version "12.7.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.9.tgz#da0210f91096aa67138cf5afd04c4d629f8a406a"
   integrity sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ==
@@ -3521,7 +3521,7 @@ apollo-cache@1.2.1, apollo-cache@^1.2.1:
     apollo-utilities "^1.2.1"
     tslib "^1.9.3"
 
-apollo-cache@1.3.2:
+apollo-cache@1.3.2, apollo-cache@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.2.tgz#df4dce56240d6c95c613510d7e409f7214e6d26a"
   integrity sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==
@@ -19010,14 +19010,14 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.0.0:
-  version "1.19.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.19.2.tgz#64f74ef9b743cbc31e5aa226c7bce0a767cd9a33"
-  integrity sha512-nH8Sr5MMhdq+Se4w9RsJiwIFJ7eHNt+UyqR8a1WKlP36+ruJnzRoXMeSXicdRScAyDhrdQQR7GUX6W41qHlp+A==
+rollup@^1.20.0:
+  version "1.26.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.26.5.tgz#c492c8bb88b661e7952a864e40bdec209aa1aa03"
+  integrity sha512-c6Pv0yWzjYNpy2DIhLFUnyP6e1UTGownr4IfpJcPY/k186RJjpaGGPRwKQ62KCauctG6dgtHt88pw1EGrPRkuA==
   dependencies:
-    "@types/estree" "0.0.39"
-    "@types/node" "^12.6.9"
-    acorn "^6.2.1"
+    "@types/estree" "*"
+    "@types/node" "*"
+    acorn "^7.1.0"
 
 rollup@^1.26.2:
   version "1.26.2"


### PR DESCRIPTION
Yarn was complaining about missing peer dependencies, and now it is less so.