### PR TITLE
Updated Keystone GitHub link

### DIFF
--- a/website/src/components/SocialIconsNav.js
+++ b/website/src/components/SocialIconsNav.js
@@ -12,7 +12,7 @@ const SocialIconsNav = props => (
       </li>
       <li css={{ marginRight: [`1rem`] }}>
         <IconGithub
-          href="https://github.com/keystonejs/keystone-5"
+          href="https://github.com/keystonejs/keystone"
           target="_blank"
           title="Github"
         />

--- a/website/src/components/SocialIconsNav.js
+++ b/website/src/components/SocialIconsNav.js
@@ -11,11 +11,7 @@ const SocialIconsNav = props => (
         <IconTwitter href="https://twitter.com/keystonejs" target="_blank" title="Twitter" />
       </li>
       <li css={{ marginRight: [`1rem`] }}>
-        <IconGithub
-          href="https://github.com/keystonejs/keystone"
-          target="_blank"
-          title="Github"
-        />
+        <IconGithub href="https://github.com/keystonejs/keystone" target="_blank" title="Github" />
       </li>
       <li css={{ marginRight: [`0`] }}>
         <IconSlack href="https://launchpass.com/keystonejs" target="_blank" title="Slack" />


### PR DESCRIPTION
Now that Keystone 5 is at /keystone, the link goes to the right place.