### PR TITLE
Allow lists to work without fields (or fields with no access)

### DIFF
--- a/.changeset/cyan-walls-attend.md
+++ b/.changeset/cyan-walls-attend.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/keystone': minor
+---
+
+Fixes a bug with schema generation and display in the AdminUI when a list contains only fields where access control is false.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -101,8 +101,12 @@ export default class List {
     }`;
   }
 
-  getQuery({ fields, filters, search, orderBy, skip, first }) {
-    const queryArgs = List.getQueryArgs({ first, filters, search, skip, orderBy });
+  getQuery(args) {
+    const { fields, filters, search, orderBy, skip, first } = args;
+    const sanatisedQueryArgs = Object.keys({ first, filters, search, skip, orderBy })
+      .filter(key => args[key])
+      .reduce((acc, key) => ({ ...acc, [key]: args[key] }), {});
+    const queryArgs = List.getQueryArgs(sanatisedQueryArgs);
     const metaQueryArgs = List.getQueryArgs({ filters, search });
     const safeFields = fields.filter(field => field.path !== '_label_');
     return gql`{

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 
 import { captureSuspensePromises, noop } from '@keystonejs/utils';
-import { DiffIcon, KebabHorizontalIcon, LinkIcon, ShieldIcon, TrashcanIcon } from '@arch-ui/icons';
+import { KebabHorizontalIcon, LinkIcon, ShieldIcon, TrashcanIcon } from '@arch-ui/icons';
 import { colors, gridSize } from '@arch-ui/theme';
 import { alpha } from '@arch-ui/color-utils';
 import { Button } from '@arch-ui/button';

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -187,12 +187,6 @@ class ListRow extends Component {
     const copyText = window.location.origin + link({ path: list.path, item });
     const items = [
       {
-        content: 'Duplicate',
-        icon: <DiffIcon />,
-        isDisabled: true, // TODO: implement duplicate
-        onClick: () => console.log('TODO'),
-      },
-      {
         content: 'Copy Link',
         icon: <LinkIcon />,
         onClick: () => copyToClipboard(copyText),
@@ -350,17 +344,20 @@ export default function ListTable(props) {
               />
             </div>
           </HeaderCell>
-          {fields.map(field => (
-            <SortLink
-              data-field={field.path}
-              key={field.path}
-              sortable={field.path !== '_label_'}
-              field={field}
-              handleSortChange={onSortChange}
-              active={sortBy.field.path === field.path}
-              sortAscending={sortBy.direction === 'ASC'}
-            />
-          ))}
+          {fields.map(field => {
+            if (!sortBy) return;
+            return (
+              <SortLink
+                data-field={field.path}
+                key={field.path}
+                sortable={field.path !== '_label_'}
+                field={field}
+                handleSortChange={onSortChange}
+                active={sortBy ? sortBy.field.path === field.path : false}
+                sortAscending={sortBy ? sortBy.direction === 'ASC' : 'ASC'}
+              />
+            );
+          })}
           <HeaderCell css={{ padding: 0 }}>{columnControl}</HeaderCell>
         </tr>
       </thead>

--- a/packages/app-admin-ui/client/pages/List/dataHooks.js
+++ b/packages/app-admin-ui/client/pages/List/dataHooks.js
@@ -91,7 +91,7 @@ export function useListQuery(listKey) {
 
   // Query prep
   const { currentPage, fields, filters, pageSize, search, sortBy } = urlState;
-  const orderBy = `${sortBy.field.path}_${sortBy.direction}`;
+  const orderBy = sortBy ? `${sortBy.field.path}_${sortBy.direction}` : null;
   const first = pageSize;
   const skip = (currentPage - 1) * pageSize;
 

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -165,8 +165,14 @@ export function ListLayout(props: LayoutProps) {
                     })}
                     ,
                   </span>
-                  <span css={{ paddingLeft: '0.5ex' }}>sorted by</span>
-                  <SortPopout listKey={list.key} />
+                  {sortBy ? (
+                    <Fragment>
+                      <span css={{ paddingLeft: '0.5ex' }}>sorted by</span>
+                      <SortPopout listKey={list.key} />
+                    </Fragment>
+                  ) : (
+                    ''
+                  )}
                   <span css={{ paddingLeft: '0.5ex' }}>with</span>
                   <ColumnPopout
                     listKey={list.key}
@@ -333,7 +339,7 @@ export default function ListData(props: Props) {
   const { urlState } = useListUrlState(list.key);
 
   const { currentPage, fields, filters, pageSize, search, sortBy } = urlState;
-  const orderBy = `${sortBy.field.path}_${sortBy.direction}`;
+  const orderBy = sortBy ? `${sortBy.field.path}_${sortBy.direction}` : null;
   const first = pageSize;
   const skip = (currentPage - 1) * pageSize;
 

--- a/packages/app-admin-ui/client/pages/List/url-state.js
+++ b/packages/app-admin-ui/client/pages/List/url-state.js
@@ -67,6 +67,8 @@ const encodeFields = fields => {
 };
 
 const parseSortBy = (sortBy: string, list: List): SortByType | null => {
+  if (!sortBy) return null;
+
   let key = sortBy;
   let direction = 'ASC';
 
@@ -86,6 +88,7 @@ const parseSortBy = (sortBy: string, list: List): SortByType | null => {
 };
 
 const encodeSortBy = (sortBy: SortByType): string => {
+  if (!sortBy) return '';
   const {
     direction,
     field: { path },

--- a/packages/app-admin-ui/client/pages/List/url-state.js
+++ b/packages/app-admin-ui/client/pages/List/url-state.js
@@ -40,7 +40,10 @@ const getSearchDefaults = (props: Props): SearchType => {
 
   // Dynamic defaults
   const fields = parseFields(defaultColumns, props.list);
-  const sortBy = parseSortBy(defaultSort, props.list) || { field: fields[0], direction: 'ASC' };
+  const sortBy =
+    parseSortBy(defaultSort, props.list) || fields[0]
+      ? { field: fields[0], direction: 'ASC' }
+      : null;
   fields.unshift(pseudoLabelField);
   return {
     currentPage: 1,

--- a/packages/app-admin-ui/client/pages/List/url-state.js
+++ b/packages/app-admin-ui/client/pages/List/url-state.js
@@ -11,7 +11,7 @@ import type { AdminMeta } from '../../providers/AdminMeta';
 export type SortByType = {
   field: { label: string, path: string },
   direction: 'ASC' | 'DESC',
-};
+} | null;
 
 export type FilterType = {
   field: FieldControllerType,

--- a/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
+++ b/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
@@ -148,7 +148,7 @@ export function serialize({ node }) {
 }
 
 export function deserialize({ node, joins }) {
-  if (!joins || !joins.length) {
+  if (!joins || !Array.isArray(joins) || joins.length === 0 || !joins[0].embed) {
     console.error('No embed data received when rehydrating oEmbed block');
     return;
   }

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -643,7 +643,7 @@ describe('getAdminMeta()', () => {
       const authenticateOutput = `type authenticateTestOutput {
         """ Used to make subsequent authenticated requests by setting this token in a header: 'Authorization: Bearer <token>'. """
         token: String
-        """ Retreive information on the newly authenticated Test here. """
+        """ Retrieve information on the newly authenticated Test here. """
         item: Test
       }`;
 


### PR DESCRIPTION
This PR allows you to create lists without any fields (which is PROBABLY a bad idea) but it's nice that you can do it.

The above is really a side-effect of being able to handle lists that have all access control set to 'false' which is plausible for some edge-case situations.

But that is also kinda a side-effect. The true reason for this PR is that it removes items from the schema when lists have no fields with the required access. E.g. no create for lists where all fields have no create access and no update for lists where all fields had no update access. -- This fixes a bug where an invalid schema would be generated.

This edge case becomes particularly important for computed fields that have no create and update access.

 