### PR TITLE
update package apollo-boost version

### DIFF
--- a/demo-projects/blog/package.json
+++ b/demo-projects/blog/package.json
@@ -30,7 +30,7 @@
     "@keystonejs/file-adapters": "^5.0.0",
     "@keystonejs/keystone": "^5.2.0",
     "@keystonejs/oembed-adapters": "^5.0.1",
-    "apollo-boost": "^0.3.1",
+    "apollo-boost": "^0.4.1",
     "apollo-client": "^2.6.4",
     "apollo-upload-client": "^10.0.0",
     "cross-env": "^5.2.0",


### PR DESCRIPTION
TypeError: Cannot assign to read only property '__esModule' of object '#<Object>'