### PR TITLE
Removed deprecated use of <container> in blog demo

### DIFF
--- a/.changeset/brown-moose-sleep.md
+++ b/.changeset/brown-moose-sleep.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/demo-project-blog': patch
+---
+
+Removed deprecated use of <container> in custom Next app

--- a/demo-projects/blog/app/pages/_app.js
+++ b/demo-projects/blog/app/pages/_app.js
@@ -1,4 +1,4 @@
-import App, { Container } from 'next/app';
+import App from 'next/app';
 import React from 'react';
 import withApolloClient from '../lib/with-apollo-client';
 import { ApolloProvider } from 'react-apollo';
@@ -7,11 +7,9 @@ class MyApp extends App {
   render() {
     const { Component, pageProps, apolloClient } = this.props;
     return (
-      <Container>
-        <ApolloProvider client={apolloClient}>
-          <Component {...pageProps} />
-        </ApolloProvider>
-      </Container>
+      <ApolloProvider client={apolloClient}>
+        <Component {...pageProps} />
+      </ApolloProvider>
     );
   }
 }


### PR DESCRIPTION
Address this: https://err.sh/zeit/next.js/app-container-deprecated

This is also possibly an issue in the meetup demo (the `static` folder should also be renamed `public`) but I can't easily run the meetup demo so I'll leave someone else to deal with that.