### PR TITLE
Required changeset for field views

### DIFF
--- a/.changeset/lazy-guests-retire.md
+++ b/.changeset/lazy-guests-retire.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/field-views-loader': minor
+---
+
+Adds loading of hooks to `allViews`.

--- a/packages/field-views-loader/package.json
+++ b/packages/field-views-loader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystonejs/field-views-loader",
   "version": "5.0.0",
-  "description": "A webpack loader used to load all thew field views used in an app",
+  "description": "A webpack loader used to load all the field views used in an app",
   "main": "index.js",
   "author": "The Keystone Development Team",
   "license": "MIT",


### PR DESCRIPTION
This was missing from a changeset that updated the adminUI to accept pages as a hook. We need to bump the version and release.