### PR TITLE
Removed stray indicatorVariant prop

### DIFF
--- a/.changeset/pretty-balloons-sell.md
+++ b/.changeset/pretty-balloons-sell.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/button': patch
+---
+
+Removed stray indicatorVariant prop

--- a/packages/arch/packages/button/src/loading.js
+++ b/packages/arch/packages/button/src/loading.js
@@ -34,7 +34,7 @@ function LoadingButtonComponent({ children, indicatorVariant, isLoading, ...prop
   const isSpinner = indicatorVariant === 'spinner';
 
   return (
-    <Button ref={ref} variant="bold" indicatorVariant="dots" {...props}>
+    <Button ref={ref} variant="bold" {...props}>
       <LoadingButtonInner>
         {isLoading ? (
           <LoadingIndicatorWrapper>


### PR DESCRIPTION
Fixes this long-standing console error:
![image](https://user-images.githubusercontent.com/3558659/69729506-8a2b5780-117a-11ea-8471-515488a2d9e0.png)
