### PR TITLE
Corrected assignment to keystone const

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -34,7 +34,9 @@ const { Text, Password } = require('@keystonejs/fields');
 const { PasswordAuthStrategy } = require('@keystonejs/auth-password');
 const { AdminUIApp } = require('@keystonejs/app-admin-ui');
 
-const keystone = keystone.createList('User', {
+const keystone = // ...
+
+keystone.createList('User', {
   // ...
   fields: {
     username: { type: Text },


### PR DESCRIPTION
Documentation shows the `keystone` variable being accessed before it is defined, with the result of `keystone.createList(..)` then assiged to `const keystone`. This is cause for confusion. The proposed adjustment continues the convention of the `keystone` instance being defined `const keystone = // ...`, as is the case elsewhere in the docs