### PR TITLE
Quick start link in Schema page is broken

### DIFF
--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -98,7 +98,7 @@ type User {
 ```
 
 _(NOTE: Only a subset of all the generated types/mutations/queries are shown
-here. To see a more complete example [follow the Quick Start](../quick-start).)_
+here. To see a more complete example [follow the Quick Start](../../quick-start).)_
 
 ### Customizing Lists & Fields
 


### PR DESCRIPTION
https://www.keystonejs.com/guides/schema page

`Follow the Quick Start` link leads to: https://www.keystonejs.com/guides/quick-start
Should link to: https://www.keystonejs.com/quick-start