### PR TITLE
Refactoring hook documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,7 +275,9 @@ We also build commonjs builds to run in node (for testing with jest or etc.) and
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 <!-- prettier-ignore -->
+
 <table>
   <tr>
     <td align="center"><a href="http://www.thinkmill.com.au"><img src="https://avatars3.githubusercontent.com/u/872310?v=4" width="100px;" alt="Jed Watson"/><br /><sub><b>Jed Watson</b></sub></a><br /><a href="https://github.com/keystonejs/keystone/commits?author=JedWatson" title="Code">💻</a></td>

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -20,7 +20,7 @@ keystone.createList('Post', {
 | --------------- | ----------------------------------- | ----------------------------- | -------------------------------------------------------------- |
 | `fields`        | `Object`                            |                               | Defines the fields in a list.                                  |
 | `schemaDoc`     | `String`                            |                               | A description for the list. Used in the Admin UI.              |
-| `hooks`         | `Object`                            | `{}`                          | Specify hooks to execute functions after list actions.         |
+| `hooks`         | `Object`                            | `{}`                          | Functions to be called during list operations.                 |
 | `label`         | `String`                            | `listName`                    | Overrides label for the list in the AdminUI.                   |
 | `labelField`    | `String`                            | `name`                        | Specify a field to use as a label for individual list items.   |
 | `labelResolver` | `Function`                          | Resolves `labelField` or `id` | Function to resolve labels for individual list items.          |
@@ -58,15 +58,20 @@ A description for the list used in the GraphQL schema.
 
 ### `hooks`
 
-Specify hooks to execute functions after list actions. List actions include:
+Specify functions to be executed during list operations.
+Supported hooks include:
 
-- `resolveInput`
-- `validateInput`
-- `beforeChange`
-- `afterChange`
-- `beforeDelete`
-- `validateDelete`
-- `afterDelete`
+- Create and update operations
+  - `resolveInput`
+  - `validateInput`
+  - `beforeChange`
+  - `afterChange`
+- Delete operations
+  - `validateDelete`
+  - `beforeDelete`
+  - `afterDelete`
+
+See [List Hooks in the API docs](/docs/api/hooks.md#list-hooks) and the [Hooks Guide](/docs/guides/hooks.md) for details.
 
 #### Usage
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -4,225 +4,431 @@ title: Hooks
 order: 7
 [meta]-->
 
-# Hooks
+# Hooks APIs
 
-The APIs for each hook are mostly the same across the 3 hook types
-([list hooks](/guides/hooks#list-hooks), [field hooks](/guides/hooks#field-hooks), [field type
-hooks](/guides/hooks#field-type-hooks)).
+Hooks give solution developers a way to add custom logic to the framework of lists, fields and operations Keystone provides.
 
+This document describes:
+
+- How and where to configure hooks of different types
+- The specific arguments and usage information of different hook sets
+
+For a more general overview of the concepts, patterns and function of the Keystone hook system, see the
+[Hook Guide](/docs/guides/hooks.md).
+
+---
+
+## Hook Types
+
+Hooks can be categories into three [types](/docs/guides/hooks.md#hook-type)
+depending on where in the list schema they're attached:
+
+- [List hooks](#list-hooks)
+- [Field hooks](#field-hooks)
+- [Field Type hooks](#field-type-hooks)
+
+The [hook sets](/docs/guides/hooks.md#hook-set) that span these types have very similar signatures.
 Any differences are called out in the documentation below.
 
-## Usage
+### List Hooks
+
+List hooks can be defined by the system developer by specifying the `hooks` attribute of a list configuration when calling `createList()`.
+Hooks for the `create`, `update` and `delete` operations are available.
+
+#### Usage
+
+```js
+keystone.createList('User', {
+  fields: {
+    name: { type: Text },
+    ...
+  },
+  hooks: {
+    // Hooks for create and update operations
+    resolveInput: async (...) => { ... },
+    validateInput: async (...) => { ... },
+    beforeChange: async (...) => { ... },
+    afterChange: async (...) => { ... },
+
+    // Hooks for delete operations
+    validateDelete: async (...) => { ... },
+    beforeDelete: async (...) => { ... },
+    afterDelete: async (...) => { ... },
+  },
+  ...
+});
+```
+
+### Field Hooks
+
+Field hooks can be defined by the system developer by specifying the `hooks` attribute of a field configuration when calling `createList()`.
+Hooks for the `create`, `update` and `delete` operations are available.
+
+#### Usage
 
 ```js
 keystone.createList('User', {
   fields: {
     name: {
-      type: Text
-      hooks: { /* hooks config */ },
+      type: Text,
+      hooks: {
+        // Hooks for create and update operations
+        resolveInput: async (...) => { ... },
+        validateInput: async (...) => { ... },
+        beforeChange: async (...) => { ... },
+        afterChange: async (...) => { ... },
+
+        // Hooks for delete operations
+        validateDelete: async (...) => { ... },
+        beforeDelete: async (...) => { ... },
+        afterDelete: async (...) => { ... },
+      },
+      ...
     },
+    ...
   },
-  hooks: { /* hooks config */ },
   ...
 });
 ```
 
-## Config
+### Field Type Hooks
 
-| option           | Type       | Description                                                                          |
-| ---------------- | ---------- | ------------------------------------------------------------------------------------ |
-| `resolveInput`   | `Function` | Executed after access control checks and default values are assigned.                |
-| `validateInput`  | `Function` | Executed after `resolveInput`. Should throw if `resolvedData` is invalid.            |
-| `beforeChange`   | `Function` | Executed after `validateInput`.                                                      |
-| `afterChange`    | `Function` | Executed once the mutation has been completed and all transactions finalised.        |
-| `validateDelete` | `Function` | Executed after access control checks. Should throw if `resolvedData` is invalid.     |
-| `beforeDelete`   | `Function` | Executed after `validateDelete`.                                                     |
-| `afterDelete`    | `Function` | Executed once the delete mutation has been completed and all transactions finalised. |
+Field Type hooks are associated with a particular _field type_ and are applied to all fields of that type.
+Custom field types can implement hooks by implementing the following hook methods on the `Field` base class.
+See the [Custom Field Types guide](../guides/custom-field-types.md) for more info.
+
+Hooks for the `create`, `update` and `delete` operations are available.
+
+#### Usage
+
+```js
+class CustomFieldType extends Field {
+  // Hooks for create and update operations
+  async resolveInput(...) { ... }
+  async validateInput(...) { ... }
+  async beforeChange(...) { ... }
+  async afterChange(...) { ... }
+
+  // Hooks for delete operations
+  async beforeDelete(...) { ... }
+  async validateDelete(...) { ... }
+  async afterDelete(...) { ... }
+}
+```
+
+---
+
+## Hook Sets
 
 ### `resolveInput`
 
-Executed after access control checks and default values are assigned. Used to modify the `resolvedData`.
+**Used to modify the `resolvedData`.**
 
-The result of `resolveInput` can be a `Promise` or an `Object`. It should have the same structure as the `resolvedData`.
+- Invoked after access control and field defaults are applied
+- Available for `create` and `update` operations
 
-The result is passed to [the next function in the execution order](/guides/hooks/#hook-execution-order).
+The return of `resolveInput` can be a `Promise` or an `Object`.
+It should resolve to the same structure as the `resolvedData`.
+The result is passed to [the next function in the execution order](/docs/guides/hooks.md#hook-execution-order).
 
-_Note_: `resolveInput` is not executed for deleted items.
+#### Arguments
 
-#### Usage:
+| Argument        | Type                    | Description                                                                                                                   |
+| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
+| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
+| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+
+#### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const resolveInput = ({
-  resolvedData,
+  operation,
   existingItem,
   originalInput,
+  resolvedData,
   context,
   actions,
-  operation,
-}) => resolvedData;
+}) => {
+  // Input resolution logic
+  // Object returned is used in place of resolvedData
+  return resolvedData;
+};
 ```
 
 ### `validateInput`
 
-Executed after `resolveInput`. Should throw if `resolvedData` is invalid.
+**Used to verify the `resolvedData` is valid.**
+
+- Invoked after all `resolveInput` hooks have resolved
+- Available for `create` and `update` operations
+
+If errors are found in `resolvedData` the function should either throw or call the supplied `addFieldValidationError` argument.
+Return values are ignored.
+
+#### Arguments
+
+| Argument                  | Type                    | Description                                                                                                                   |
+| :------------------------ | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`               | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
+| `existingItem`            | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
+| `originalInput`           | `Object`                | The data received by the GraphQL mutation                                                                                     |
+| `resolvedData`            | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
+| `context`                 | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`                 | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| `addFieldValidationError` | `Function`              | Used to set a field validation error; accepts a `String`                                                                      |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const validateInput = ({
-  resolvedData,
+  operation,
   existingItem,
   originalInput,
-  addFieldValidationError,
+  resolvedData,
   context,
   actions,
-  operation,
+  addFieldValidationError,
 }) => {
-  /* throw any errors here */
+  // Throw error objects or register validation errors with addFieldValidationError(<String>)
+  // Return values ignored
 };
 ```
-
-_Note_: `validateInput` is not executed for deleted items. See: [`validateDelete`](#validate-delete)
 
 ### `beforeChange`
 
-Executed after `validateInput`. `beforeChange` is not used to manipulate data but can be used to preform actions before data is saved.
+**Used to cause side effects before the primary operation is executed.**
+
+- Invoked after all `validateInput` hooks have resolved
+- Available for `create` and `update` operations
+
+`beforeChange` hooks can't manipulate the data passed to the primary operation but perform operations before data is saved.
+Return values are ignored.
+
+#### Arguments
+
+| Argument        | Type                    | Description                                                                                                                   |
+| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
+| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
+| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const beforeChange = ({
-  resolvedData,
-  existingItem,
-  context,
-  originalInput,
-  actions,
   operation,
+  existingItem,
+  originalInput,
+  resolvedData,
+  context,
+  actions,
 }) => {
-  /* side effects here */
+  // Perform side effects
+  // Return values ignored
 };
 ```
-
-_Note_: `beforeChange` is not executed for deleted items. See: [`beforeDelete`](#before-delete)
 
 ### `afterChange`
 
-Executed once the mutation has been completed and all transactions finalised.
+**Used to cause side effects after the primary operation is executed.**
+
+- Invoked after the primary operation has completed
+- Available for `create` and `update` operations
+
+`afterChange` hooks perform actions after data is saved.
+It receives both the "pre-update" item that was stored (`existingItem`) and the resultant, "post-update" item data (`updatedItem`).
+This includes any DB-level defaults.
+Notably, for `create` operations, this includes the item's `id`.
+
+Return values are ignored.
+
+#### Arguments
+
+| Argument        | Type                    | Description                                                                                                                   |
+| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
+| `existingItem`  | `Object` or `undefined` | The previously stored item (or `undefined` for `create` operations)                                                           |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
+| `updatedItem`   | `Object`                | The new/currently stored item                                                                                                 |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const afterChange = ({
-  updatedItem,
+  operation,
   existingItem,
   originalInput,
+  updatedItem,
   context,
   actions,
-  operation,
 }) => {
-  /* side effects here */
+  // Perform side effects
+  // Return values ignored
 };
 ```
 
-_Note_: `afterChange` is not executed for deleted items. See: [`afterDelete`](#after-delete)
-
 ### `validateDelete`
 
-Executed after access control checks. Should throw if delete operation is invalid.
+**Used to verify a delete operation is valid**, ie. will maintain data consitency.
+
+- Invoked after access control has been tested
+- Available for `delete` operations
+
+Should throw or register errors with `addFieldValidationError(<String>)` if the delete operation is invalid.
+
+#### Arguments
+
+| Argument                  | Type             | Description                                                                                                                   |
+| :------------------------ | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`               | `String`         | The operation being performed (`delete` in this case)                                                                         |
+| `existingItem`            | `Object`         | The current stored item                                                                                                       |
+| `context`                 | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`                 | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| `addFieldValidationError` | `Function`       | Used to set a field validation error; accepts a `String`                                                                      |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const validateDelete = ({
+  operation,
   existingItem,
-  addFieldValidationError,
   context,
   actions,
-  operation,
+  addFieldValidationError,
 }) => {
-  /* throw any errors here */
+  // Throw error objects or register validation errors with addFieldValidationError(<String>)
+  // Return values ignored
 };
 ```
 
 ### `beforeDelete`
 
-Executed after `validateDelete`.
+**Used to cause side effects before the delete operation is executed.**
+
+- Invoked after all `validateDelete` hooks have resolved
+- Available for `delete` operations
+
+Perform actions before the delete operation is executed.
+Return values are ignored.
+
+#### Arguments
+
+| Argument       | Type             | Description                                                                                                                   |
+| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                         |
+| `existingItem` | `Object`         | The current stored item                                                                                                       |
+| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const beforeDelete = ({
+  operation,
   existingItem,
   context,
   actions,
-  operation,
 }) => {
-  /* throw any errors here */
+  // Perform side effects
+  // Return values ignored
 };
 ```
 
 ### `afterDelete`
 
-Executed once the delete mutation has been completed and all transactions finalised.
+**Used to cause side effects before the delete operation is executed.**
+
+- Invoked after the delete operation has been executed
+- Available for `delete` operations
+
+Perform actions after the delete operation has been executed.
+This is the last chance to operate on the previously stored item, supplied as `existingItem`.
+
+Return values are ignored.
+
+#### Arguments
+
+| Argument       | Type             | Description                                                                                                                   |
+| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                         |
+| `existingItem` | `Object`         | The previously stored item, now deleted                                                                                       |
+| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
+| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
 
 #### Usage
 
 <!-- prettier-ignore -->
-
 ```js
 const afterDelete = ({
+  operation,
   existingItem,
   context,
   actions,
-  operation,
 }) => {
-  /* side effects here */
+  // Perform side effects
+  // Return values ignored
 };
 ```
 
 ---
 
-## Hook Function Arguments
+## `actions` Argument
 
-| Argument                  | Type             | Description                                                                                                                    |
-| ------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `resolvedData`            | `Object`         | An object containing data received by the graphQL mutation and defaults values.                                                |
-| `existingItem`            | `any`            | The current stored value. (`undefined` for create)                                                                             |
-| `originalInput`           | `Object`         | An object containing arguments passed to the field in the graphQL query.                                                       |
-| `context`                 | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request. |
-| `addFieldValidationError` | `Function`       | Used to set a field validation error. Accepts a `String`.                                                                      |
-| `actions`                 | `Object`         | An Object providing access to List functions, see [`actions` Argument](#actions-argument).                                     |
-| `operation`               | `String`         | A key indicating the current operation being performed, ie. `'create'`, `'update'` or `'delete'`.                              |
+All hooks receive an `actions` object as an argument.
+It contains helper functionality for accessing the GraphQL schema, optionally _within_ the context of the current request.
+When used, this context reuse causes access control to be applied as though the caller themselves initiated an operation.
+It can therefore be useful for performing additional operations on behalf of the caller.
 
+The `actions` object currently contains a single function: `query`.
 
-### `actions` Argument
+### Query Helper
 
-The `actions` argument is an object containing a query helper:
+Perform a GraphQL query, optionally _within_ the context of the current request.
+It returns a `Promise<Object>` containing the standard GraphQL `errors` and `data` properties.
+
+#### Argument
+
+| Argument                    | Type      | Description                                                                                                                          |
+| :-------------------------- | :-------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `queryString`               | `String`  | A graphQL query string                                                                                                               |
+| `options`                   | `Object`  | Config for the query                                                                                                                 |
+| `options.skipAccessControl` | `Boolean` | By default access control _of the user making the initial request_ is still tested. Pass as `true` to disable access control checks. |
+| `options.variables`         | `Object`  | The variables passed to the graphql query for the given queryString                                                                  |
+
+#### Usage
 
 ```js
-{
-  /**
-   * @param queryString String A graphQL query string
-   * @param options.skipAccessControl Boolean By default access control _of
-   * the user making the initial request_ is still tested. Disable all
-   * Access Control checks with this flag
-   * @param options.variables Object The variables passed to the graphql
-   * query for the given queryString.
-   *
-   * @return Promise<Object> The graphql query response
-   */
-  query: (queryString, options, options) => Promise({ errors, data }),
-}
+const myHook = ({
+  // ...
+  actions: { query },
+}) => {
+  const queryString = `
+    query {
+      # GraphQL query here...
+    }
+  `;
+  const options = {
+    skipAccessControl: false,
+    variables: { /* GraphQL variables here.. */ },
+  };
+  const { errors, data } = await query(queryString, options);
+
+  // Check for errors
+  // Do something with data
+};
 ```

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -145,6 +145,7 @@ The result is passed to [the next function in the execution order](/docs/guides/
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const resolveInput = ({
   operation,
@@ -185,6 +186,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const validateInput = ({
   operation,
@@ -224,6 +226,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeChange = ({
   operation,
@@ -266,6 +269,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterChange = ({
   operation,
@@ -302,6 +306,7 @@ Should throw or register errors with `addFieldValidationError(<String>)` if the 
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const validateDelete = ({
   operation,
@@ -337,6 +342,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeDelete = ({
   operation,
@@ -373,6 +379,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterDelete = ({
   operation,

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -3,133 +3,132 @@ section: guides
 title: Hooks
 [meta]-->
 
-# Hooks
+# Hooks Guide
 
-> _NOTE: Below is an overview of hooks. For API docs see
-> [Hooks API](/api/hooks)._
+Hooks give solution developers a way to add custom logic to the framework of lists, fields and operations Keystone provides.
 
-KeystoneJS provide a system of hooks on the `create`, `update`, and `delete` mutations which allow developers to customise the behaviour of their system.
+This document provides an overview of the concepts, patterns and function of the Keystone hook system.
+The [Hooks API docs](/docs/api/hooks.md) describe the specific arguments and usage information.
 
-There are 7 hooks available to use, which can be grouped into pre- and post-hooks depending on whether they get invoked before or after the database update operation.
+## Conceptual Organisation
 
-- Pre-hooks
-  - `resolveInput`
-  - `validateInput`/`validateDelete`
-  - `beforeChange`/`beforeDelete`
-- Post-hooks
-  - `afterChange`/`afterDelete`
+There are several categorisations that can be applied to hooks and are useful for understanding what is run and when.
 
-## Hook Types
+> Note: the concepts listed here have some exceptions.
+> See the [Gotchas section](#gotchas).
 
-For each of these hooks, there are three _types_ of hook which can be defined.
+### Stage
 
-- [List hooks](#list-hooks)
-- [Field hooks](#field-hooks)
-- [Field Type hooks](#field-type-hooks)
+Keystone defines several _stages_ within the [hook execution order](#execution-order).
+These stages are intended to be used for different purposes; they help organise your hook functionality.
 
-### List hooks
+- Input resolution - modify the values supplied
+- Data validation - check the values are valid
+- Before operation - perform side effects _before_ the primary operation
+- After operation - perform side effects _after_ the primary operation
 
-List hooks can be defined by the system developer by specifying the `hooks` attribute of a list configuration when calling `createList()`.
+### Operation
 
-```js
-keystone.createList('User', {
-  fields: {
-    name: { type: Text },
-    ...
-  },
-  hooks: {
-    resolveInput: async (...) => { ... },
-    validateInput: async (...) => { ... },
-    beforeChange: async (...) => { ... },
-    afterChange: async (...) => { ... },
-    beforeDelete: async (...) => { ... },
-    validateDelete: async (...) => { ... },
-    afterDelete: async (...) => { ... },
-  },
-  ...
-});
-```
+Hooks are available for four of the core operations:
 
-### Field hooks
+- `create`
+- `update`
+- `delete`
 
-Field hooks can be defined by the system developer by specifying the `hooks` attribute of a field configuration when calling `createList()`.
+These operations are reused used for both "single" and "many" modes.
+Eg. the `deleteUser` (singluar) and `deleteUsers` (plural) mutations are both considered to be `delete` operations.
 
-```js
-keystone.createList('User', {
-  fields: {
-    name: {
-      type: Text,
-      hooks: {
-        resolveInput: async (...) => { ... },
-        validateInput: async (...) => { ... },
-        beforeChange: async (...) => { ... },
-        afterChange: async (...) => { ... },
-        beforeDelete: async (...) => { ... },
-        validateDelete: async (...) => { ... },
-        afterDelete: async (...) => { ... },
-      },
-      ...
-    },
-    ...
-  },
-  ...
-});
-```
+Hooks for these operations have different signatures due to the nature of the operations being performed.
+See the [Hook API docs](/docs/api/hooks.md) for specifics.
 
-### Field Type hooks
+> Note: Keystone does not currently implement `read` hooks.
 
-Field Type hooks are associated with a particular _Field Type_ and are applied to all fields of that type.
-Custom field types can implement hooks by implementing the following hook methods on the `Field` base class.
+### Hook Type
 
-```js
-class CustomFieldType extends Field {
-  async resolveInput(...) { ... }
-  async validateInput(...) { ... }
-  async beforeChange(...) { ... }
-  async afterChange(...) { ... }
-  async beforeDelete(...) { ... }
-  async validateDelete(...) { ... }
-  async afterDelete(...) { ... }
-}
-```
+A hooks _type_ is defined by where it is attached.
+Keystone recognises three _types_ of hook:
 
-## Hook Execution Order
+- [Field Type hooks](/docs/api/hooks.md#field-type-hooks) -
+  Field Type hooks are associated with a particular _field type_ and are applied to all fields of that type across all lists.
+- [Field hooks](/docs/api/hooks.md/docs/api/hooks.md#field-hooks) -
+  Field hooks can be defined by the app developer by specifying the `hooks` attribute of a field configuration when calling `createList()`.
+- [List hooks](/docs/api/hooks.md#list-hooks) -
+  List hooks can be defined by the app developer by specifying the `hooks` attribute of a list configuration when calling `createList()`.
 
-The hooks are invoked in a specific order during a mutation operation.
+### Hook Set
+
+For most _stage_ and _operation_ combinations, different functions (hooks) can be supplied for each _hook type_.
+This group of distinct but related hooks are referred to as a _hook set_.
+
+Eg. a `beforeDelete` function could be supplied for a list, several specific fields on the list and a field type used by the list.
+All hooks in a hook set share the same functional signature but are invoked at different times.
+See the [Hooks API docs](/docs/api/hooks.md) and [Intra-Hook Execution Order section](#intra-hook-execution-order) for more information.
+
+### Putting It Together
+
+In total there 7 _hook sets_ available.
+This table shows the _hook set_ relevant to each combination of _stage_ and _operation_:
+
+| Stage            | `create`        | `update`        | `delete`         |
+| ---------------- | --------------- | --------------- | ---------------- |
+| Input resolution | `resolveInput`  | `resolveInput`  | n/a              |
+| Data validation  | `validateInput` | `validateInput` | `validateDelete` |
+| Before operation | `beforeChange`  | `beforeChange`  | `beforeDelete`   |
+| After operation  | `afterChange`   | `afterChange`   | `afterDelete`    |
+
+The `create`, `update` and `delete` _hook sets_ can be attached as _list_, _field_ or _field type_ hooks.
+
+Due to their similarity, the `create` and `update` operations share a single set of hooks.
+To implement different logic for these operations make it conditional on either the `operation` or `existingItem` arguments;
+for create operations `existingItem` will be `undefined`.
+
+See the [Hooks API docs](/docs/api/hooks.md) for argument details and usage.
+
+## Execution Order
+
+The hooks are invoked in a specific order during an operation.
+For full details of the mutation lifecycle, and where hooks fit within this, see the [Mutation Lifecycle Guide](/docs/guides/mutation-lifecycle.md).
 
 ### Create/Update
 
-1. `resolveInput`
-2. `validateInput`
-3. `beforeChange`
-4. Database operation
-5. `afterChange`
+1. Access control checks
+2. Field defaults applied
+3. `resolveInput` called on all fields, even if they are not defined in the supplied data
+4. `validateInput` called on all fields which have a resolved value (after all `resolveInput` calls have returned)
+5. `beforeChange` called on all fields which have a resolved value (after all `beforeChange` calls have returned)
+6. Database operation
+7. `afterChange` called on all fields, even if their value was not changed
 
 ### Delete
 
-1. `validateDelete`
-2. `beforeDelete`
-3. Database operation
-4. `afterDelete`
+1. Access control checks
+2. `validateDelete` called on all fields
+3. `beforeDelete` called on all fields (after all `validateDelete` calls have returned)
+4. Database operation (after all `beforeDelete` calls have returned)
+5. `afterDelete` called on all fields (after the DB operation has completed)
 
-For full details of the mutation lifecycle, and where hooks fit within this, please see [here](/guides/mutation-lifecycle).
+### Intra-Hook Execution Order
 
-### Intra-hook Execution Order
+Within each hook set, the different [hook types](#hook-type) are invoked in a specific order.
 
-Within each hook, the different hook types are invoked in a specific order.
+1. All relevant and defined [field type hooks](/docs/api/hooks.md#field-type-hooks) are invoked in **parallel**
+2. All relevant and defined [field hooks](/docs/api/hooks.md#field-hooks) are invoked in **parallel**
+3. If defined the [list hook](/docs/api/hooks.md#list-hooks) is invoked
 
-1. All relevant [`Field Type hooks`](#field-type-hooks) are invoked in parallel.
-2. then, All relevant [`Field hooks`](#field-hooks) are invoked in parallel.
-3. then, The [`List hook`](#list-hooks) is invoked.
+## Gotchas
 
-Which [Field](#field-hooks) & [Field Type](#field-type-hooks) hooks are executed depend on the following flow:
+The hook system is a powerful but it's breadth and flexibility introduce some complexity.
+A few of the main stumbling blocks are:
 
-- `resolveInput`: Called on all fields, even if they are not defined in the supplied data.
-- `validateInput`: Called on all fields which have a resolved value after the `resolveInput` hook has run.
-- `beforeChange`: Called on all fields which have a resolved value after the `resolveInput` hook has run.
-- `afterChange`: Called on all fields, even if their value was not changed.
-- `validateDelete`: Called on all fields.
-- `beforeDelete`: Call on all fields.
-- `afterDelete`: Called on all fields.
+- The `create` and `update` operations share a single set of hooks.
+  To implement different logic for these operations make it conditional on either the `operation` or `existingItem` arguments;
+  for create operations `existingItem` will be `undefined`.
+- As per the table above, the `delete` operations have no hook set for the _input resolution_ stage.
+  This operation doesn't accept any input (other than the target IDs).
+- Keystone does not currently implement `read` hooks
+- field type hooks and field hooks are run in parallel
+
+These nuances aren't bugs per se -- they generally exist for good reason --
+but they can make understanding the hook system difficult.
 
 <!-- TODO: ## Error Handling -->

--- a/docs/guides/mutation-lifecycle.md
+++ b/docs/guides/mutation-lifecycle.md
@@ -14,21 +14,21 @@ subSection: graphql
 
   - [Access Control Phase](#access-control-phase)
 
-    - [1. Check list access (create/update/delete)](#1-check-list-access-createupdatedelete)
-    - [2. Get item(s) (update/delete)](#2-get-items-updatedelete)
-    - [3. Check field access (create/update)](#3-check-field-access-createupdate)
+    - [1. Check List Access (create/update/delete)](#1-check-list-access-createupdatedelete)
+    - [2. Get Item(s) (update/delete)](#2-get-items-updatedelete)
+    - [3. Check Field Access (create/update)](#3-check-field-access-createupdate)
 
   - [Operational Phase](#operational-phase)
 
-    - [1. Resolve defaults (create)](#1-resolve-defaults-create)
-    - [2a. Resolve relationship (create/update)](#2a-resolve-relationship-createupdate)
-    - [2b. Register backlinks (delete)](#2b-register-backlinks-delete)
-    - [3. Resolve input (create/update)](#3-resolve-input-createupdate)
-    - [3. Validate input/delete (create/update/delete)](#3-validate-inputdelete-createupdatedelete)
-    - [4. Before change/delete (create/update/delete)](#4-before-changedelete-createupdatedelete)
-    - [5. Database operation (create/update/delete)](#5-database-operation-createupdatedelete)
-    - [6. Resolve backlinks (create/update/delete)](#6-resolve-backlinks-createupdatedelete)
-    - [7. After change (create/update/delete)](#7-after-change-createupdatedelete)
+    - [1. Resolve Defaults (create)](#1-resolve-defaults-create)
+    - [2a. Resolve Relationship (create/update)](#2a-resolve-relationship-createupdate)
+    - [2b. Register Backlinks (delete)](#2b-register-backlinks-delete)
+    - [3. Resolve Input (create/update)](#3-resolve-input-createupdate)
+    - [4. Validate Data (create/update/delete)](#4-validate-data-createupdatedelete)
+    - [5. Before Operation (create/update/delete)](#5-before-operation-createupdatedelete)
+    - [6. Database Operation (create/update/delete)](#6-database-operation-createupdatedelete)
+    - [7. Resolve Backlinks (create/update/delete)](#7-resolve-backlinks-createupdatedelete)
+    - [8. After Operation (create/update/delete)](#8-after-operation-createupdatedelete)
 
 - [Summary](#summary)
 
@@ -62,7 +62,7 @@ Each of these mutations is implemented within KeystoneJS by a corresponding reso
 Please refer to the [API documentation](LINK_TODO)) for full details on how to call these mutations either from [GraphQL](LINK_TODO)) or directly from [Keystone](LINK_TODO)).
 -->
 
-KeystoneJS provides [access control](/guides/access-control)) mechanisms and a [hook system](/guides/hooks)) which allows the developer to customise the behaviour of each of these mutations.
+KeystoneJS provides [access control](/docs/guides/access-control.md) mechanisms and a [hook system](/docs/guides/hooks.md) which allows the developer to customise the behaviour of each of these mutations.
 
 This document details the lifecycle of each mutation, and how the different access control mechanisms and hooks interact.
 
@@ -79,7 +79,7 @@ This transaction encapsulates a database transaction, as well as any state requi
 
 This transaction is used by all the nested mutations of the operation.
 
-It is committed after the [resolve backlinks](#6-resolve-backlinks-createupdatedelete) step of the root operation.
+It is committed after the [resolve backlinks](#7-resolve-backlinks-createupdatedelete) step of the root operation.
 
 The Operational Phase for a `many` mutation consists of the the Operational Phase for the corresponding `single` mutation performed in parallel over each of the target items.
 
@@ -87,25 +87,21 @@ Each of these `single` mutations is executed within its own transaction.
 
 As such, a `many` mutation maybe have partial success during this phase, as some of the the single mutations may succeed while others fail.
 
-<!-- Dead link
-See [Error Handling](LINK_TODO)) for more details on this.
--->
-
 ### Access Control Phase
 
 During the Access Control Phase the target items are retrieved from the database, and access control is checked to ensure that the user has permission to perform the operation.
 
 This phase will throw an `AccessDeniedError` if any of the access control checks fail. This error is returned in the `.errors` field of the GraphQL response. The Access Control Phase consists of three distinct steps.
 
-#### 1. Check list access (`create/update/delete`)
+#### 1. Check List Access (`create/update/delete`)
 
 The first step in all mutations is to check that the user has access to perform the required operation on the `List`.
 
 If access control has been defined statically or imperatively this check can be performed here. An `AccessDeniedError` is returned if the access control failed. If the access control mechanism for this list is defined declaratively (i.e using a GraphQL `where` statement), this check is deferred until the next step.
 
-For more information on how to define access control, please consult the [access control documentation](/guides/access-control)).
+For more information on how to define access control, please consult the [access control documentation](/docs/guides/access-control.md)).
 
-#### 2. Get item(s) (`update/delete`)
+#### 2. Get Item(s) (`update/delete`)
 
 In this step the targeted items are retrieved from the database.
 
@@ -117,7 +113,7 @@ If the mutation is a multi item mutation then only those items which exist and p
 
 No error is thrown if some items do not exist or do not pass access control.
 
-#### 3. Check field access (`create/update`)
+#### 3. Check Field Access (`create/update`)
 
 The field access permissions can now be checked.
 
@@ -133,7 +129,7 @@ The Operational Phase for a `many` mutation will perform the Operational Phase f
 
 The Operational Phase consists of seven distinct steps.
 
-#### 1. Resolve defaults (`create`)
+#### 1. Resolve Defaults (`create`)
 
 The first step when creating a new item is to resolve any default values.
 
@@ -147,7 +143,7 @@ Custom field types can override this behaviour by defining the method `getDefaul
 
 Relationship fields do not currently support default values.
 
-#### 2a. Resolve relationship (`create/update`)
+#### 2a. Resolve Relationship (`create/update`)
 
 The create and update mutations specify the value of relationship fields using the [nested mutation] pattern.
 
@@ -161,7 +157,7 @@ Any errors thrown by this nested `createMutation` will be cause the current muta
 
 As well as resolving the IDs and performing any nested create mutations, this step must also track.
 
-#### 2b. Register backlinks (`delete`)
+#### 2b. Register Backlinks (`delete`)
 
 When deleting an item with relationship fields, it is important that any backlinks to the deleted item are also removed.
 
@@ -171,31 +167,31 @@ During this step, any backlinks which need to be updated are identified and regi
 
 The actual update step for these backlinks will be performed during the [Resolve backlinks] step, once all other pre-hooks and database operations have been completed on the primary target list.
 
-#### 3. Resolve input (`create/update`)
+#### 3. Resolve Input (`create/update`)
 
 The `resolveInput` hook allows the developer to modify the incoming item before it is inserted/updated within the database.
 
-For full details of how and when to use this hook, please consult the hooks documentation.
+For full details of how and when to use this hook, please consult the [API docs](/docs/api/hooks.md).
 
-#### 3. Validate input/delete (`create/update/delete`)
+#### 4. Validate Data (`create/update/delete`)
 
 The `validateInput` and `validateDelete` hooks allow the developer to specify validation rules which must be met before the data is inserted into the database.
 
 These hooks can throw a `ValidationFailureError` when they encounter invalid data, which will terminate the operational phase.
 
-For full details of how and when to use these hooks, please consult the hooks documentation.
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
-#### 4. Before change/delete (`create/update/delete`)
+#### 5. Before Operation (`create/update/delete`)
 
 The `beforeChange` and `beforeDelete` hooks allows the developer to perform any operations which interact with external systems, such as external data stores, which depend on resolved and validated data.
 
-For full details of how and when to use these hooks, please consult the hooks documentation.
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
-#### 5. Database operation (`create/update/delete`)
+#### 6. Database Operation (`create/update/delete`)
 
 The database operation is where the keystone database adapter is used to make the requested changes in the database.
 
-#### 6. Resolve backlinks (`create/update/delete`)
+#### 7. Resolve Backlinks (`create/update/delete`)
 
 During this stage, all pending backlinks which need to be updated on referenced lists are resolved.
 This involves performing an `updateMutation` on the referenced list, performing either a `connect` or `disconnect` operation on the referenced relationship field.
@@ -206,11 +202,13 @@ It can still result in either an `AccessDeniedError` or `ValidationFailureError`
 
 As with [Resolve relationship], the nested `AfterChange` hooks will be returned an added to the stack of deferred hooks for this mutation.
 
-#### 7. After change (`create/update/delete`)
+#### 8. After Operation (`create/update/delete`)
 
-The after change hook is only executed once all database operations for the mutation have been completed and the transaction has been finalised.
+The `afterChange` and `afterDelete` hooks are only executed once all database operations for the mutation have been completed and the transaction has been finalised.
 This means that the database is in a consistent state when this hook is executed.
 It also means that if there is a failure of any kind during this hook, the operation will still be considered complete, and no roll back will be performed.
+
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
 ## Summary
 

--- a/packages/fields/src/types/CalendarDay/README.md
+++ b/packages/fields/src/types/CalendarDay/README.md
@@ -76,8 +76,8 @@ They produce values according to their configured `format` but always expect val
 
 ### Output Fields
 
-| Field name | Type      | Description                                 |
-| :--------- | :-------- | :------------------------------------------ |
+| Field name | Type     | Description                                 |
+| :--------- | :------- | :------------------------------------------ |
 | `${path}`  | `String` | The stored value in the configured `format` |
 
 ### Filters

--- a/packages/fields/src/types/Text/README.md
+++ b/packages/fields/src/types/Text/README.md
@@ -19,8 +19,8 @@ keystone.createList('Product', {
 
 ### Config
 
-| Option       | Type      | Default | Description                                                     |
-| ------------ | --------- | ------- | --------------------------------------------------------------- |
-| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
-| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
+| Option        | Type      | Default | Description                                                     |
+| ------------- | --------- | ------- | --------------------------------------------------------------- |
+| `isRequired`  | `Boolean` | `false` | Does this field require a value?                                |
+| `isUnique`    | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |
 | `isMultiline` | `Boolean` | `false` | Makes the field render as a textarea                            |

--- a/packages/fields/src/types/Virtual/README.md
+++ b/packages/fields/src/types/Virtual/README.md
@@ -68,4 +68,4 @@ keystone.createList('Example', {
 | `resolver`              | `Function` | (required) |                                                             |
 | `graphQLReturnType`     | `String`   | 'String'   | A GraphQL Type String                                       |
 | `graphQLReturnFragment` | `String`   | ''         | A GraphQL Fragment String -required for nested return types |
-| `extendGraphQLTypes`    | `Array`    | []         | An array of custom GraphQL type definitions                 |
+| `extendGraphQLTypes`    | `Array`    | \[]        | An array of custom GraphQL type definitions                 |


### PR DESCRIPTION
I've cleaned up and restructured the two main hook docs (the guide and the API docs) with some related changes in the `mutation-lifecycle` and `create-list` docs too.

Changes are such that the diff isn't terribly helpful; the best way to review might be to just view the new files:

* [Guide](https://github.com/keystonejs/keystone/blob/be229ab64c1e6cf02546a73e15f7523986df530f/docs/guides/hooks.md)
* [API docs](https://github.com/keystonejs/keystone/blob/be229ab64c1e6cf02546a73e15f7523986df530f/docs/api/hooks.md)

In terms of content:

* Several small corrections/clarifications have been made
* I've tries to better separate the conceptual discussion and the technical usage content into the guide and API docs respectively
* There's a new concept of "hook set" -- as in the _set_ of functions with the same name that are attached variously to lists, fields and field types, eg. the `beforeChange` hook set; as distinct from a specific function called `beforeChange` attached in just one place.
* A lot of the API docs have been "unpacked". This makes it much easier to look in one place and see all the relevant info for a hook (or hook set) at the cost of some duplication of argument docs. This makes more sense once we introduce auth hooks (which have quite different arguments).
* Doubling down on the concept of `operations` in a hook context (following on from #2008)

Much of this is a setup for introducing docs for the authentication hooks. TBA.