### PR TITLE
Clarify how to use markdown field

### DIFF
--- a/packages/fields-markdown/README.md
+++ b/packages/fields-markdown/README.md
@@ -8,6 +8,26 @@ title: Markdown
 
 This field inserts a string path into your schema based on the `Text` field type implementation, and renders a Markdown editor using CodeMirror.
 
+## Usage
+
+This package isn't included with the keystone fields package and needs to be installed with `yarn add @keystonejs/fields-markdown` or `npm install @keystonejs/fields-markdown`
+
+Then import it, and use it like any other field:
+
+```js
+const { Markdown } = require('@keystonejs/fields-markdown');
+
+
+keystone.createList('Post', {
+  fields: {
+    content: {
+      type: Markdown,
+    },
+  },
+});
+
+```
+
 ## Credit
 
 The `Editor` implementation is based on [SquidDev/MirrorMark](https://github.com/SquidDev/MirrorMark).


### PR DESCRIPTION
It's not clear that this is an external package and not shipped with @keystonejs/fields