### PR TITLE
Refactor out react-document-title dependency

### DIFF
--- a/.changeset/clean-singers-reply.md
+++ b/.changeset/clean-singers-reply.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Remove react-document-title dependency

--- a/packages/app-admin-ui/client/components/DocTitle.js
+++ b/packages/app-admin-ui/client/components/DocTitle.js
@@ -1,13 +1,15 @@
-import React, { Children } from 'react';
-import DocumentTitle from 'react-document-title';
-
+import { Children, useEffect } from 'react';
 import { withAdminMeta } from '../providers/AdminMeta';
 
-const DocTitle = ({ adminMeta, children }) => {
+const DocTitle = ({ adminMeta: { name }, children }) => {
   const text = Children.toArray(children).join('');
-  const title = `${text} - ${adminMeta.name}`;
+  const title = `${text} - ${name}`;
 
-  return <DocumentTitle title={title} />;
+  useEffect(() => {
+    document.title = title;
+  });
+
+  return null;
 };
 
 export default withAdminMeta(DocTitle);

--- a/packages/app-admin-ui/package.json
+++ b/packages/app-admin-ui/package.json
@@ -71,7 +71,6 @@
     "raf-schd": "^4.0.0",
     "react": "^16.12.0",
     "react-apollo": "^3.1.3",
-    "react-document-title": "^2.0.3",
     "react-dom": "^16.12.0",
     "react-node-resolver": "^2.0.1",
     "react-prop-toggle": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17612,7 +17612,7 @@ prop-types-exact@1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -18112,14 +18112,6 @@ react-display-name@^0.2.3, react-display-name@^0.2.4:
   resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.4.tgz#e2a670b81d79a2204335510c01246f4c92ff12cf"
   integrity sha512-zvU6iouW+SWwHTyThwxGICjJYCMZFk/6r/+jmOdC7ntQoPlS/Pqb81MkxaMf2bHTSq9TN3K3zX2/ayMW/jCtyA==
 
-react-document-title@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-document-title/-/react-document-title-2.0.3.tgz#bbf922a0d71412fc948245e4283b2412df70f2b9"
-  integrity sha1-u/kioNcUEvyUgkXkKDskEt9w8rk=
-  dependencies:
-    prop-types "^15.5.6"
-    react-side-effect "^1.0.2"
-
 react-dom@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -18370,7 +18362,7 @@ react-select@^3.0.8:
     react-input-autosize "^2.2.2"
     react-transition-group "^2.2.1"
 
-react-side-effect@^1.0.2, react-side-effect@^1.1.0:
+react-side-effect@^1.1.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
   integrity sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
@@ -22787,7 +22779,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@^1.2.9, which@^1.3.0:
+which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
That package hasn't been updated since April 2017 (a January 2018 commit to the repo was just to update the readme). It depends on an outdated version of `react-side-effect` that causes warnings on React >= 16.9 due to use of componentWillMount. Since the same effect is easy to achieve with a hook, there's no reason to keep this package around.

Fixes this warning:
![image](https://user-images.githubusercontent.com/3558659/70375105-278e4480-194e-11ea-9898-3360da85886e.png)
