### PR TITLE
Admin UI: convert remaining uses of Apollo components to hooks

### DIFF
--- a/.changeset/bright-pumas-thank.md
+++ b/.changeset/bright-pumas-thank.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Convert remaining uses of Apollo components to hooks

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { Component, Fragment, useCallback, useMemo, Suspense } from 'react';
-import { Mutation } from '@apollo/react-components';
+import { useMutation } from '@apollo/react-hooks';
 import { useToasts } from 'react-toast-notifications';
 
 import { Button, LoadingButton } from '@arch-ui/button';
@@ -197,16 +197,8 @@ class CreateItemModal extends Component {
 export default function CreateItemModalWithMutation(props) {
   const { list } = props;
   const { addToast } = useToasts();
+  const [createItem, { loading }] = useMutation(list.createMutation);
   return (
-    <Mutation mutation={list.createMutation}>
-      {(createItem, { loading }) => (
-        <CreateItemModal
-          createItem={createItem}
-          isLoading={loading}
-          addToast={addToast}
-          {...props}
-        />
-      )}
-    </Mutation>
+    <CreateItemModal createItem={createItem} isLoading={loading} addToast={addToast} {...props} />
   );
 }

--- a/packages/app-admin-ui/client/components/DeleteItemModal.js
+++ b/packages/app-admin-ui/client/components/DeleteItemModal.js
@@ -1,48 +1,43 @@
 import React from 'react';
-import { Mutation } from '@apollo/react-components';
+import { useMutation } from '@apollo/react-hooks';
 import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
 
 export default function DeleteItemModal({ isOpen, item, list, onClose, onDelete }) {
+  const [deleteItem, { loading }] = useMutation(list.deleteMutation);
   return (
-    <Mutation mutation={list.deleteMutation}>
-      {(deleteItem, { loading }) => {
-        return (
-          <Confirm
-            isOpen={isOpen}
-            onKeyDown={e => {
-              if (e.key === 'Escape' && !loading) {
-                onClose();
-              }
-            }}
-          >
-            <p style={{ marginTop: 0 }}>
-              Are you sure you want to delete <strong>{item._label_}</strong>?
-            </p>
-            <footer>
-              <Button
-                appearance="danger"
-                variant="ghost"
-                onClick={() => {
-                  if (loading) return;
-                  onDelete(deleteItem({ variables: { id: item.id } }));
-                }}
-              >
-                Delete
-              </Button>
-              <Button
-                variant="subtle"
-                onClick={() => {
-                  if (loading) return;
-                  onClose();
-                }}
-              >
-                Cancel
-              </Button>
-            </footer>
-          </Confirm>
-        );
+    <Confirm
+      isOpen={isOpen}
+      onKeyDown={e => {
+        if (e.key === 'Escape' && !loading) {
+          onClose();
+        }
       }}
-    </Mutation>
+    >
+      <p style={{ marginTop: 0 }}>
+        Are you sure you want to delete <strong>{item._label_}</strong>?
+      </p>
+      <footer>
+        <Button
+          appearance="danger"
+          variant="ghost"
+          onClick={() => {
+            if (loading) return;
+            onDelete(deleteItem({ variables: { id: item.id } }));
+          }}
+        >
+          Delete
+        </Button>
+        <Button
+          variant="subtle"
+          onClick={() => {
+            if (loading) return;
+            onClose();
+          }}
+        >
+          Cancel
+        </Button>
+      </footer>
+    </Confirm>
   );
 }

--- a/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
@@ -1,50 +1,45 @@
 import React from 'react';
-import { Mutation } from '@apollo/react-components';
+import { useMutation } from '@apollo/react-hooks';
 import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
 
 export default function DeleteManyModal({ isOpen, itemIds, list, onClose, onDelete }) {
+  const [deleteItems, { loading }] = useMutation(list.deleteManyMutation);
   return (
-    <Mutation mutation={list.deleteManyMutation}>
-      {(deleteItems, { loading }) => {
-        return (
-          <Confirm
-            isOpen={isOpen}
-            onKeyDown={event => {
-              if (event.key === 'Escape' && !loading) {
-                onClose();
-              }
-            }}
-          >
-            <p style={{ marginTop: 0 }}>
-              Are you sure you want to delete <strong>{list.formatCount(itemIds)}</strong>?
-            </p>
-            <footer>
-              <Button
-                appearance="danger"
-                variant="ghost"
-                onClick={() => {
-                  if (loading) return;
-                  deleteItems({
-                    variables: { ids: itemIds },
-                  }).then(onDelete);
-                }}
-              >
-                Delete
-              </Button>
-              <Button
-                variant="subtle"
-                onClick={() => {
-                  if (loading) return;
-                  onClose();
-                }}
-              >
-                Cancel
-              </Button>
-            </footer>
-          </Confirm>
-        );
+    <Confirm
+      isOpen={isOpen}
+      onKeyDown={event => {
+        if (event.key === 'Escape' && !loading) {
+          onClose();
+        }
       }}
-    </Mutation>
+    >
+      <p style={{ marginTop: 0 }}>
+        Are you sure you want to delete <strong>{list.formatCount(itemIds)}</strong>?
+      </p>
+      <footer>
+        <Button
+          appearance="danger"
+          variant="ghost"
+          onClick={() => {
+            if (loading) return;
+            deleteItems({
+              variables: { ids: itemIds },
+            }).then(onDelete);
+          }}
+        >
+          Delete
+        </Button>
+        <Button
+          variant="subtle"
+          onClick={() => {
+            if (loading) return;
+            onClose();
+          }}
+        >
+          Cancel
+        </Button>
+      </footer>
+    </Confirm>
   );
 }

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { Component, Fragment, useMemo, useCallback, Suspense } from 'react';
-import { Mutation } from '@apollo/react-components';
+import { useMutation } from '@apollo/react-hooks';
 import { Button, LoadingButton } from '@arch-ui/button';
 import Drawer from '@arch-ui/drawer';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
@@ -201,15 +201,9 @@ class UpdateManyModal extends Component {
   }
 }
 
-export default class UpdateManyModalWithMutation extends Component {
-  render() {
-    const { list } = this.props;
-    return (
-      <Mutation mutation={list.updateManyMutation}>
-        {(updateItem, { loading }) => (
-          <UpdateManyModal updateItem={updateItem} isLoading={loading} {...this.props} />
-        )}
-      </Mutation>
-    );
-  }
+export default function UpdateManyModalWithMutation(props) {
+  const { list } = props;
+  const [updateItem, { loading }] = useMutation(list.updateManyMutation);
+
+  return <UpdateManyModal updateItem={updateItem} isLoading={loading} {...props} />;
 }

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { withRouter, Link } from 'react-router-dom';
-import { Query } from '@apollo/react-components';
+import { useQuery } from '@apollo/react-hooks';
 
 import { Container, Grid, Cell } from '@arch-ui/layout';
 import { PageTitle } from '@arch-ui/typography';
@@ -83,6 +83,9 @@ const ListProvider = ({ getListByKey, listKeys, ...props }) => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
+  const query = gqlCountQueries(lists);
+  const { data, error } = useQuery(query, { fetchPolicy: 'cache-and-network', errorPolicy: 'all' });
+
   if (lists.length === 0) {
     return (
       <Fragment>
@@ -99,50 +102,46 @@ const ListProvider = ({ getListByKey, listKeys, ...props }) => {
     );
   }
 
-  const query = gqlCountQueries(lists);
+  let allowedLists = lists;
+
+  if (error) {
+    if (!error.graphQLErrors || !error.graphQLErrors.length) {
+      return (
+        <PageError>
+          <p>{error.message}</p>
+        </PageError>
+      );
+    }
+
+    const deniedQueries = error.graphQLErrors
+      .filter(({ name }) => name === 'AccessDeniedError')
+      .map(({ path }) => path && path[0]);
+
+    if (deniedQueries.length !== error.graphQLErrors.length) {
+      // There were more than Access Denied Errors, so throw a normal
+      // error message
+      return (
+        <PageError>
+          <p>{error.message}</p>
+        </PageError>
+      );
+    }
+
+    allowedLists = allowedLists.filter(
+      list => deniedQueries.indexOf(list.gqlNames.listQueryMetaName) === -1
+    );
+  }
+
   return (
     <Fragment>
       <DocTitle>Home</DocTitle>
-      <Query query={query} fetchPolicy="cache-and-network" errorPolicy="all">
-        {({ data, error }) => {
-          let allowedLists = lists;
-
-          if (error) {
-            if (!error.graphQLErrors || !error.graphQLErrors.length) {
-              return (
-                <PageError>
-                  <p>{error.message}</p>
-                </PageError>
-              );
-            }
-
-            const deniedQueries = error.graphQLErrors
-              .filter(({ name }) => name === 'AccessDeniedError')
-              .map(({ path }) => path && path[0]);
-
-            if (deniedQueries.length !== error.graphQLErrors.length) {
-              // There were more than Access Denied Errors, so throw a normal
-              // error message
-              return (
-                <PageError>
-                  <p>{error.message}</p>
-                </PageError>
-              );
-            }
-
-            allowedLists = allowedLists.filter(
-              list => deniedQueries.indexOf(list.gqlNames.listQueryMetaName) === -1
-            );
-          }
-
-          // NOTE: `loading` is intentionally omitted here
-          // the display of a loading indicator for counts is defered to the
-          // list component so we don't block rendering the lists immediately
-          // to the user.
-
-          return <HomePage lists={allowedLists} data={data} {...props} />;
-        }}
-      </Query>
+      {
+        // NOTE: `loading` is intentionally omitted here
+        // the display of a loading indicator for counts is deferred to the
+        // list component so we don't block rendering the lists immediately
+        // to the user.
+      }
+      <HomePage lists={allowedLists} data={data} {...props} />;
     </Fragment>
   );
 };

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -2,7 +2,7 @@
 import { jsx } from '@emotion/core';
 import { Component, Fragment, Suspense, useMemo, useCallback } from 'react';
 import styled from '@emotion/styled';
-import { Mutation, Query } from '@apollo/react-components';
+import { useMutation, useQuery } from '@apollo/react-hooks';
 import { withRouter } from 'react-router-dom';
 import { useToasts } from 'react-toast-notifications';
 import memoizeOne from 'memoize-one';
@@ -392,96 +392,96 @@ const ItemNotFound = ({ adminPath, errorMessage, list }) => (
 const ItemPage = ({ list, itemId, adminPath, getListByKey }) => {
   const itemQuery = list.getItemQuery(itemId);
   const { addToast } = useToasts();
+
+  // network-only because the data we mutate with is important for display
+  // in the UI, and may be different than what's in the cache
+  const { loading, error, data, refetch } = useQuery(itemQuery, {
+    fetchPolicy: 'network-only',
+    errorPolicy: 'all',
+  });
+
+  const [updateItem, { loading: updateInProgress, error: updateError }] = useMutation(
+    list.updateMutation,
+    {
+      onError: updateError => {
+        const [title, ...rest] = updateError.message.split(/\:/);
+        const toastContent = rest.length ? (
+          <div>
+            <strong>{title.trim()}</strong>
+            <div>{rest.join('').trim()}</div>
+          </div>
+        ) : (
+          updateError.message
+        );
+
+        addToast(toastContent, {
+          appearance: 'error',
+        });
+      },
+    }
+  );
+
+  // Now that the network request for data has been triggered, we
+  // try to initialise the fields. They are Suspense capable, so may
+  // throw Promises which will be caught by the above <Suspense>
+  captureSuspensePromises(
+    list.fields
+      .filter(({ isPrimaryKey }) => !isPrimaryKey)
+      .filter(({ maybeAccess }) => !!maybeAccess.update)
+      .map(field => () => field.initFieldView())
+  );
+
+  // If the views load before the API request comes back, keep showing
+  // the loading component
+  if (loading) return <PageLoading />;
+
+  // Only show error page if there is no data
+  // (ie; there could be partial data + partial errors)
+  if (
+    error &&
+    (!data ||
+      !data[list.gqlNames.itemQueryName] ||
+      !Object.keys(data[list.gqlNames.itemQueryName]).length)
+  ) {
+    return (
+      <Fragment>
+        <DocTitle>{list.singular} not found</DocTitle>
+        <ItemNotFound adminPath={adminPath} errorMessage={error.message} list={list} />
+      </Fragment>
+    );
+  }
+
+  const item = deserializeItem(list, data);
+  const itemErrors = deconstructErrorsToDataShape(error)[list.gqlNames.itemQueryName] || {};
+
   return (
     <Suspense fallback={<PageLoading />}>
-      {/* network-only because the data we mutate with is important for display
-          in the UI, and may be different than what's in the cache */}
-      <Query query={itemQuery} fetchPolicy="network-only" errorPolicy="all">
-        {({ loading, error, data, refetch }) => {
-          // Now that the network request for data has been triggered, we
-          // try to initialise the fields. They are Suspense capable, so may
-          // throw Promises which will be caught by the above <Suspense>
-          captureSuspensePromises(
-            list.fields
-              .filter(({ isPrimaryKey }) => !isPrimaryKey)
-              .filter(({ maybeAccess }) => !!maybeAccess.update)
-              .map(field => () => field.initFieldView())
-          );
-
-          // If the views load before the API request comes back, keep showing
-          // the loading component
-          if (loading) return <PageLoading />;
-
-          // Only show error page if there is no data
-          // (ie; there could be partial data + partial errors)
-          if (
-            error &&
-            (!data ||
-              !data[list.gqlNames.itemQueryName] ||
-              !Object.keys(data[list.gqlNames.itemQueryName]).length)
-          ) {
-            return (
-              <Fragment>
-                <DocTitle>{list.singular} not found</DocTitle>
-                <ItemNotFound adminPath={adminPath} errorMessage={error.message} list={list} />
-              </Fragment>
-            );
-          }
-
-          const item = deserializeItem(list, data);
-          const itemErrors = deconstructErrorsToDataShape(error)[list.gqlNames.itemQueryName] || {};
-
-          return item ? (
-            <main>
-              <DocTitle>
-                {item._label_} - {list.singular}
-              </DocTitle>
-              <Container id="toast-boundary">
-                <Mutation
-                  mutation={list.updateMutation}
-                  onError={updateError => {
-                    const [title, ...rest] = updateError.message.split(/\:/);
-                    const toastContent = rest.length ? (
-                      <div>
-                        <strong>{title.trim()}</strong>
-                        <div>{rest.join('').trim()}</div>
-                      </div>
-                    ) : (
-                      updateError.message
-                    );
-
-                    addToast(toastContent, {
-                      appearance: 'error',
-                    });
-                  }}
-                >
-                  {(updateItem, { loading: updateInProgress, error: updateError }) => {
-                    return (
-                      <ItemDetails
-                        adminPath={adminPath}
-                        item={item}
-                        itemErrors={itemErrors}
-                        key={itemId}
-                        list={list}
-                        getListByKey={getListByKey}
-                        onUpdate={() =>
-                          refetch().then(refetchedData => deserializeItem(list, refetchedData.data))
-                        }
-                        toastManager={{ addToast }}
-                        updateInProgress={updateInProgress}
-                        updateErrorMessage={updateError && updateError.message}
-                        updateItem={updateItem}
-                      />
-                    );
-                  }}
-                </Mutation>
-              </Container>
-            </main>
-          ) : (
-            <ItemNotFound adminPath={adminPath} list={list} />
-          );
-        }}
-      </Query>
+      {item ? (
+        <main>
+          <DocTitle>
+            {item._label_} - {list.singular}
+          </DocTitle>
+          <Container id="toast-boundary">
+            <ItemDetails
+              adminPath={adminPath}
+              item={item}
+              itemErrors={itemErrors}
+              key={itemId}
+              list={list}
+              getListByKey={getListByKey}
+              onUpdate={() =>
+                refetch().then(refetchedData => deserializeItem(list, refetchedData.data))
+              }
+              toastManager={{ addToast }}
+              updateInProgress={updateInProgress}
+              updateErrorMessage={updateError && updateError.message}
+              updateItem={updateItem}
+            />
+          </Container>
+        </main>
+      ) : (
+        <ItemNotFound adminPath={adminPath} list={list} />
+      )}
     </Suspense>
   );
 };

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -2,7 +2,7 @@
 
 import { jsx } from '@emotion/core';
 import { Fragment, useEffect, useRef, useState, Suspense } from 'react';
-import { Query } from '@apollo/react-components';
+import { useQuery } from '@apollo/react-hooks';
 
 import { IconButton } from '@arch-ui/button';
 import { PlusIcon } from '@arch-ui/icons';
@@ -370,10 +370,7 @@ export default function ListData(props: Props) {
   const skip = (currentPage - 1) * pageSize;
 
   const query = list.getQuery({ fields, filters, search, orderBy, skip, first });
+  const res = useQuery(query, { fetchPolicy: 'cache-and-network', errorPolicy: 'all' });
 
-  return (
-    <Query query={query} fetchPolicy="cache-and-network" errorPolicy="all">
-      {res => <List query={res} {...props} />}
-    </Query>
-  );
+  return <List query={res} {...props} />;
 }

--- a/packages/app-admin-ui/package.json
+++ b/packages/app-admin-ui/package.json
@@ -8,7 +8,6 @@
     "node": ">=8.4.0"
   },
   "dependencies": {
-    "@apollo/react-components": "^3.1.3",
     "@apollo/react-hooks": "^3.1.3",
     "@arch-ui/alert": "^0.0.9",
     "@arch-ui/badge": "^0.0.9",
@@ -72,7 +71,6 @@
     "prop-types": "^15.7.2",
     "raf-schd": "^4.0.0",
     "react": "^16.12.0",
-    "react-apollo": "^3.1.3",
     "react-dom": "^16.12.0",
     "react-prop-toggle": "^1.0.2",
     "react-pseudo-state": "^2.2.2",


### PR DESCRIPTION
Companion to #2056.

Converts the remaining uses of Apollo components in the Admin UI (save those touched by #2056) to hooks. Kept these separate since getting rid of the session provider is in different scope.