### PR TITLE
Add missing colon in example code

### DIFF
--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -727,7 +727,7 @@ keystone.createList('User', {
   fields: {
     name: { type: Text },
     email: { type: Text },
-    todolist { type: Relationship, ref: 'Todo', many: true },
+    todolist: { type: Relationship, ref: 'Todo', many: true },
   }
 });
 ```


### PR DESCRIPTION
This PR corrects a typo in the relationships section of the docs. 