### PR TITLE
Fix handling of cache headers with mutations

### DIFF
--- a/.changeset/famous-moose-hang.md
+++ b/.changeset/famous-moose-hang.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/keystone': patch
+---
+
+Fix handling of cache headers with mutations

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -288,6 +288,31 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(res.headers['cache-control']).toBe('max-age=5, public');
         })
       );
+
+      test(
+        'mutations',
+        runner(setupKeystone, async ({ app, create }) => {
+          await addFixtures(create);
+
+          // Mutation responses shouldn't be cached.
+          // Here's a smoke test to make sure they still work.
+
+          // Basic query
+          const { data, errors } = await networkedGraphqlRequest({
+            app,
+            query: `
+              mutation {
+                deletePost(id: 1) {
+                  id
+                }
+              }
+            `,
+          });
+
+          expect(errors).toBe(undefined);
+          expect(data).toHaveProperty('deletePost');
+        })
+      );
     });
   })
 );

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -73,7 +73,7 @@ const addFixtures = async create => {
     create('User', { name: 'Sam', favNumber: 5 }),
   ]);
 
-  await Promise.all([
+  const posts = await Promise.all([
     create('Post', { author: [users[0].id], title: 'One author' }),
     create('Post', { author: [users[0].id, users[1].id], title: 'Two authors' }),
     create('Post', {
@@ -81,6 +81,8 @@ const addFixtures = async create => {
       title: 'Three authors',
     }),
   ]);
+
+  return { users, posts };
 };
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
@@ -292,7 +294,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'mutations',
         runner(setupKeystone, async ({ app, create }) => {
-          await addFixtures(create);
+          const { posts } = await addFixtures(create);
 
           // Mutation responses shouldn't be cached.
           // Here's a smoke test to make sure they still work.
@@ -302,7 +304,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             app,
             query: `
               mutation {
-                deletePost(id: 1) {
+                deletePost(id: "${posts[0].id}") {
                   id
                 }
               }

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -1026,7 +1026,7 @@ module.exports = class List {
       }
     }
 
-    if (extra && extra.info) {
+    if (extra && extra.info && extra.info.cacheControl) {
       switch (typeof this.cacheHint) {
         case 'object':
           extra.info.cacheControl.setCacheHint(this.cacheHint);


### PR DESCRIPTION
This used to work on older versions of Apollo, but we really shouldn't
assume mutation resolvers support cache hints.