### PR TITLE
Improve validation errors in Admin UI

### DIFF
--- a/.changeset/six-pans-compete.md
+++ b/.changeset/six-pans-compete.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': minor
 ---
 
-Improved toast messaging when updating items
+Improved toast messaging when creating and updating items

--- a/.changeset/six-pans-compete.md
+++ b/.changeset/six-pans-compete.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Improved toast messaging when updating items

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -77,7 +77,34 @@ class CreateItemModal extends Component {
         this.setState({ item: this.props.list.getInitialItemData({}) });
       })
       .catch(error => {
-        toastError({ addToast, options: { autoDismiss: true } }, error);
+        if (error.graphQLErrors) {
+          error.graphQLErrors.forEach(error => {
+            let toastContent;
+            if (error.data && error.data.messages && error.data.messages.length) {
+              toastContent = (
+                <div>
+                  <strong>{error.name}</strong>
+                  <ul css={{ paddingLeft: 0, listStylePosition: 'inside' }}>
+                    {error.data.messages.map((message, i) => (
+                      <li key={i}>{message}</li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            } else {
+              toastContent = (
+                <div>
+                  <strong>{error.name}</strong>
+                  <div>{error.message}</div>
+                </div>
+              );
+            }
+            addToast(toastContent, {
+              appearance: 'error',
+              autoDismiss: true,
+            });
+          });
+        }
       });
   };
   onClose = () => {

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -11,7 +11,7 @@ import { gridSize } from '@arch-ui/theme';
 import { AutocompleteCaptor } from '@arch-ui/input';
 
 import PageLoading from './PageLoading';
-import { validateFields, toastError } from '../util';
+import { validateFields, handleCreateUpdateMutationError } from '../util';
 
 let Render = ({ children }) => children();
 
@@ -41,7 +41,6 @@ class CreateItemModal extends Component {
       list: { fields },
       createItem,
       isLoading,
-      addToast,
     } = this.props;
     if (isLoading) return;
     const { item, validationErrors, validationWarnings } = this.state;
@@ -71,41 +70,10 @@ class CreateItemModal extends Component {
 
     createItem({
       variables: { data },
-    })
-      .then(data => {
-        this.props.onCreate(data);
-        this.setState({ item: this.props.list.getInitialItemData({}) });
-      })
-      .catch(error => {
-        if (error.graphQLErrors) {
-          error.graphQLErrors.forEach(error => {
-            let toastContent;
-            if (error.data && error.data.messages && error.data.messages.length) {
-              toastContent = (
-                <div>
-                  <strong>{error.name}</strong>
-                  <ul css={{ paddingLeft: 0, listStylePosition: 'inside' }}>
-                    {error.data.messages.map((message, i) => (
-                      <li key={i}>{message}</li>
-                    ))}
-                  </ul>
-                </div>
-              );
-            } else {
-              toastContent = (
-                <div>
-                  <strong>{error.name}</strong>
-                  <div>{error.message}</div>
-                </div>
-              );
-            }
-            addToast(toastContent, {
-              appearance: 'error',
-              autoDismiss: true,
-            });
-          });
-        }
-      });
+    }).then(data => {
+      this.props.onCreate(data);
+      this.setState({ item: this.props.list.getInitialItemData({}) });
+    });
   };
   onClose = () => {
     const { isLoading } = this.props;
@@ -224,7 +192,10 @@ class CreateItemModal extends Component {
 export default function CreateItemModalWithMutation(props) {
   const { list } = props;
   const { addToast } = useToasts();
-  const [createItem, { loading }] = useMutation(list.createMutation);
+  const [createItem, { loading }] = useMutation(list.createMutation, {
+    errorPolicy: 'all',
+    onError: error => handleCreateUpdateMutationError({ error, addToast }),
+  });
   return (
     <CreateItemModal createItem={createItem} isLoading={loading} addToast={addToast} {...props} />
   );

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -32,6 +32,7 @@ import {
   toastItemSuccess,
   toastError,
   validateFields,
+  handleCreateUpdateMutationError,
 } from '../../util';
 import { ItemTitle } from './ItemTitle';
 
@@ -404,36 +405,7 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey }) => {
     list.updateMutation,
     {
       errorPolicy: 'all',
-      onError: error => {
-        if (error.graphQLErrors) {
-          error.graphQLErrors.forEach(error => {
-            let toastContent;
-            if (error.data && error.data.messages && error.data.messages.length) {
-              toastContent = (
-                <div>
-                  <strong>{error.name}</strong>
-                  <ul css={{ paddingLeft: 0, listStylePosition: 'inside' }}>
-                    {error.data.messages.map((message, i) => (
-                      <li key={i}>{message}</li>
-                    ))}
-                  </ul>
-                </div>
-              );
-            } else {
-              toastContent = (
-                <div>
-                  <strong>{error.name}</strong>
-                  <div>{error.message}</div>
-                </div>
-              );
-            }
-            addToast(toastContent, {
-              appearance: 'error',
-              autoDismiss: true,
-            });
-          });
-        }
-      },
+      onError: error => handleCreateUpdateMutationError({ error, addToast }),
     }
   );
 

--- a/packages/app-admin-ui/client/util.js
+++ b/packages/app-admin-ui/client/util.js
@@ -1,4 +1,5 @@
-import React from 'react';
+/** @jsx jsx **/
+import { jsx } from '@emotion/core';
 import set from 'lodash.set';
 
 // When there are errors, we want to see if they're Access Denied.
@@ -58,6 +59,37 @@ export function toastError({ addToast, options = {} }, error) {
     ...options,
   });
 }
+
+export const handleCreateUpdateMutationError = ({ error, addToast }) => {
+  if (error.graphQLErrors) {
+    error.graphQLErrors.forEach(error => {
+      let toastContent;
+      if (error.data && error.data.messages && error.data.messages.length) {
+        toastContent = (
+          <div>
+            <strong>{error.name}</strong>
+            <ul css={{ paddingLeft: 0, listStylePosition: 'inside' }}>
+              {error.data.messages.map((message, i) => (
+                <li key={i}>{message}</li>
+              ))}
+            </ul>
+          </div>
+        );
+      } else {
+        toastContent = (
+          <div>
+            <strong>{error.name}</strong>
+            <div>{error.message}</div>
+          </div>
+        );
+      }
+      addToast(toastContent, {
+        appearance: 'error',
+        autoDismiss: true,
+      });
+    });
+  }
+};
 
 // ==============================
 // Validate Fields


### PR DESCRIPTION
Closes #2088 

Fixes:
- Currently when updating an item, a success toast will be always shown - even if the update didn't update. In this PR I have stopped this from happening.
- I have improved the error toasts when creating or updating an item. Now, instead of just showing `GraphQL Mutation Error` which isn't helpful at all to the user - it will show the actual error message.

### Screenshots

Some screenshots when using the Keystone config below

<img width="648" alt="Screen Shot 2019-12-13 at 2 13 19 pm" src="https://user-images.githubusercontent.com/6265154/70768853-cd104080-1db2-11ea-8319-1282373e0617.png">
<img width="639" alt="Screen Shot 2019-12-13 at 2 13 25 pm" src="https://user-images.githubusercontent.com/6265154/70768854-cda8d700-1db2-11ea-9bb4-fe63be8a558a.png">

```javascript
const { Keystone } = require('@keystonejs/keystone');
const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
const { Text } = require('@keystonejs/fields');
const { GraphQLApp } = require('@keystonejs/app-graphql');
const { AdminUIApp } = require('@keystonejs/app-admin-ui');
const keystone = new Keystone({
  name: 'Keystone To-Do List',
  adapter: new MongooseAdapter(),
});

keystone.createList('Todo', {
  fields: {
    name: { type: Text, isRequired: true },
  },
  hooks: {
    validateInput: async ({ resolvedData, addValidationError }) => {
      if (resolvedData.name === 'test') {
        addValidationError('The name can not be test');
        addValidationError('Another validation error');
      }
    },
  },
});

module.exports = {
  keystone,
  apps: [
    new GraphQLApp(),
    new AdminUIApp({ enableDefaultRoute: true }),
  ],
};

```
