### PR TITLE
Corrected PasswordAuthStrategy config options

### DIFF
--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -63,8 +63,8 @@ app.post('/admin/signin', async (req, res) => {
 
 | Option              | Type      | Default    | Description                                                               |
 | ------------------- | --------- | ---------- | ------------------------------------------------------------------------- |
-| `identity`          | `String`  | `email`    | The field `path` for values that uniquely identifies items                |
-| `secret`            | `String`  | `password` | The field `path` for secret values known only to the authenticating party |
+| `identityField`     | `String`  | `email`    | The field `path` for values that uniquely identifies items                |
+| `secretField`       | `String`  | `password` | The field `path` for secret values known only to the authenticating party |
 | `protectIdentities` | `Boolean` | `false`    | Protect identities at the expense of usability                            |
 
 #### `identity`


### PR DESCRIPTION
Documentation shows incorrect options for `PasswordAuthStrategy` config object as `identity` and `secret`. The documentation should instead read; `identityField` and `secretField`, for the `PasswordAuthStrategy` option keys.