### PR TITLE
Remove isSetup logic

### DIFF
--- a/.changeset/lazy-ladybugs-call.md
+++ b/.changeset/lazy-ladybugs-call.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-knex': minor
+---
+
+Removed logic that (incorrectly) auto-detects when the DB needs to be setup (and nukes existing data).

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -68,8 +68,9 @@ class KnexAdapter extends BaseKeystoneAdapter {
     Object.values(this.listAdapters).forEach(listAdapter => {
       listAdapter._postConnect();
     });
-    const isSetup = await this.schema().hasTable(Object.keys(this.listAdapters)[0]);
-    if (this.config.dropDatabase || !isSetup) {
+
+    // Run this only if explicity configured and still never in production
+    if (this.config.dropDatabase && process.env.NODE_ENV !== 'production') {
       console.log('Knex adapter: Dropping database');
       await this.dropDatabase();
     } else {


### PR DESCRIPTION
Same as #2100 in removing the `isSetup` logic but without breaking the `dropDatabase` option. With an extra guard to ensure it never runs in a "production" env.

I still want to change how this works but don't want to break anything for people making use of it.