### PR TITLE
Remove pagination from Admin List page

### DIFF
--- a/.changeset/afraid-seas-develop.md
+++ b/.changeset/afraid-seas-develop.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@arch-ui/pagination': minor
+---
+
+Removed pagination per page from Admin List UI

--- a/packages/app-admin-ui/client/pages/List/Pagination.js
+++ b/packages/app-admin-ui/client/pages/List/Pagination.js
@@ -17,6 +17,7 @@ export default function ListPagination({ isLoading, listKey }) {
       isLoading={isLoading}
       pageSize={data.pageSize}
       total={data.itemCount}
+      showAllPages={false}
     />
   );
 }

--- a/packages/arch/packages/pagination/src/Pagination.js
+++ b/packages/arch/packages/pagination/src/Pagination.js
@@ -41,6 +41,7 @@ class Pagination extends Component {
     ariaPageLabel: ariaPageLabelFn,
     currentPage: 1,
     limit: 5,
+    showAllPages: true,
   };
   state = { allPagesVisible: false };
 
@@ -51,7 +52,7 @@ class Pagination extends Component {
   };
 
   renderPages() {
-    let { ariaPageLabel, currentPage, limit, pageSize, total } = this.props;
+    let { ariaPageLabel, currentPage, limit, pageSize, total, showAllPages } = this.props;
 
     if (total <= pageSize) return [];
 
@@ -129,6 +130,20 @@ class Pagination extends Component {
       );
     }
 
+    const allPages = this.state.allPagesVisible ? (
+      pages
+    ) : (
+      <Page
+        aria-label="Click to show all pages"
+        key="page_dot"
+        onClick={this.toggleAllPages}
+        id="ks-pagination-show-pages"
+        value={1} // needs value for flow...
+      >
+        <ListOrderedIcon />
+      </Page>
+    );
+
     // return pages;
     return [
       <Page
@@ -140,19 +155,10 @@ class Pagination extends Component {
       >
         <ChevronLeftIcon />
       </Page>,
-      this.state.allPagesVisible ? (
-        pages
-      ) : (
-        <Page
-          aria-label="Click to show all pages"
-          key="page_dot"
-          onClick={this.toggleAllPages}
-          id="ks-pagination-show-pages"
-          value={1} // needs value for flow...
-        >
-          <ListOrderedIcon />
-        </Page>
-      ),
+      // Nothing should be included if the all pages aren't displayed
+      // because FlexGroup border radius formatting depends on the count of
+      // elements
+      ...(showAllPages ? allPages : []),
       <Page
         aria-label="Go to next page"
         key="page_next"


### PR DESCRIPTION
* Add prop `showAllPages` to arch-ui Pagination element. When this prop is false, the element that shows/hides all the pages by number won't be displayed.
* Used the new prop to hide the pagination by number from the Admin Table List
