### PR TITLE
Fixing links in Markdown docs to use file paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you develop custom fields, adapters, apps or any other Keystone feature, (or 
 
 ## Code of Conduct
 
-KeystoneJS adheres to the [Contributor Covenant Code of Conduct](code-of-conduct.md).
+KeystoneJS adheres to the [Contributor Covenant Code of Conduct](/code-of-conduct.md).
 
 ## Repository Setup
 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ documentation](https://www.keystonejs.com/guides/).
 
 ## Contributing
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. 
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
 
 **Contributions of any kind are welcome!**
 
-You will find the set-up steps in this readme and full release processes and project guidelines in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+You will find the set-up steps in this readme and full release processes and project guidelines in [`CONTRIBUTING.md`](/CONTRIBUTING.md).
 
 ### Contributors
 
-We'd like to start by thanking all our wonderful contributors: 
+We'd like to start by thanking all our wonderful contributors:
 ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
@@ -128,7 +128,7 @@ We'd like to start by thanking all our wonderful contributors:
 These projects are designed to show off different aspects of KeystoneJS features
 at a range of complexities (from a simple Todo App to a complex Meetup Site).
 
-See the [`demo-projects/README.md`](./demo-projects/README.md) docs to get
+See the [`demo-projects/README.md`](/demo-projects/README.md) docs to get
 started.
 
 ### Development Practices
@@ -159,7 +159,7 @@ yarn
 yarn dev
 ```
 
-See [`demo-projects/README.md`](./demo-projects/README.md) for more details on
+See [`demo-projects/README.md`](/demo-projects/README.md) for more details on
 the available demo projects.
 
 #### Note For Windows Users
@@ -167,7 +167,7 @@ the available demo projects.
 While running `yarn` on Windows, the process may fail with an error such as this:
 
 ```sh
-error { [Error: EPERM: operation not permitted, symlink 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\src\index.js' -> 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\dist\alert.cjs.js.flow']
+Error: EPERM: operation not permitted, symlink 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\src\index.js' -> 'C:\Users\user\Documents\keystone-5\packages\arch\packages\alert\dist\alert.cjs.js.flow'
 ```
 
 This is due to permission restrictions regarding the creation of [symbolic links](https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/). To solve this, you should enable Windows' [Developer Mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development?redirectedfrom=MSDN) and run `yarn` again.
@@ -267,7 +267,7 @@ Where `simple_tests` can be replaced with any job listed in
 
 ## Code of Conduct
 
-KeystoneJS adheres to the [Contributor Covenant Code of Conduct](code-of-conduct.md).
+KeystoneJS adheres to the [Contributor Covenant Code of Conduct](/code-of-conduct.md).
 
 ## License
 

--- a/docs/api/access-control.md
+++ b/docs/api/access-control.md
@@ -9,8 +9,8 @@ order: 5
 Control who can do what with your GraphQL API.
 
 _Note_: This is the API documentation for Access Control. For getting started,
-see the [Access Control Guide](/guides/access-control) or the
-[Authentication Guide](/guides/authentication).
+see the [Access Control Guide](/docs/guides/access-control.md) or the
+[Authentication Guide](/docs/guides/authentication.md).
 
 ## Table of Contents
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -6,10 +6,11 @@ order: 4
 
 # Authentication
 
-Authentication strategies allow users to identify themselves to KeystoneJS. This can be used to restrict access to the AdminUI, and to configure [access controls](/guides/access-control/).
+Authentication strategies allow users to identify themselves to KeystoneJS.
+This can be used to restrict access to the AdminUI, and to configure [access controls](/docs/guides/access-control.md).
 
-- For password logins see: [`auth-password`](/keystonejs/auth-password/)
-- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](/keystonejs/auth-passport/)
+- For password logins see: [`auth-password`](/packages/auth-password/)
+- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](/packages/auth-passport/)
 
 ## Usage
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -9,8 +9,8 @@ order: 4
 Authentication strategies allow users to identify themselves to KeystoneJS.
 This can be used to restrict access to the AdminUI, and to configure [access controls](/docs/guides/access-control.md).
 
-- For password logins see: [`auth-password`](/packages/auth-password/)
-- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](/packages/auth-passport/)
+- For password logins see: [`auth-password`](/packages/auth-password/README.md)
+- For social logins using [Passport.js](http://www.passportjs.org/) see: [`auth-passport`](/packages/auth-passport/README.md)
 
 ## Usage
 

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -16,25 +16,25 @@ keystone.createList('Post', {
 
 ### Config
 
-| Option          | Type                                | Default                       | Description                                                    |
-| --------------- | ----------------------------------- | ----------------------------- | -------------------------------------------------------------- |
-| `fields`        | `Object`                            |                               | Defines the fields in a list.                                  |
-| `schemaDoc`     | `String`                            |                               | A description for the list. Used in the Admin UI.              |
-| `hooks`         | `Object`                            | `{}`                          | Functions to be called during list operations.                 |
-| `label`         | `String`                            | `listName`                    | Overrides label for the list in the AdminUI.                   |
-| `labelField`    | `String`                            | `name`                        | Specify a field to use as a label for individual list items.   |
-| `labelResolver` | `Function`                          | Resolves `labelField` or `id` | Function to resolve labels for individual list items.          |
-| `access`        | `Function` \| `Object` \| `Boolean` | `true`                        | [Access control](/guides/access-control) options for the list. |
-| `adapterConfig` | `Object`                            |                               | Override the adapter config options for a specific list.       |
-| `itemQueryName` | `String`                            |                               | Changes the _item_ name in GraphQL queries and mutations.      |
-| `listQueryName` | `String`                            |                               | Changes the _list_ name in GraphQL queries and mutations.      |
-| `singular`      | `String`                            |                               | Specify a singular noun for `Keystone` to use for the list.    |
-| `plural`        | `String`                            |                               | Specify a plural for `Keystone` to use for the list.           |
-| `path`          | `String`                            |                               | Changes the path in the Admin UI.                              |
-| `plugins`       | `Array`                             | `[]`                          | An array of `plugins` that can modify the list config.         |
-| `queryLimits`   | `Object`                            | `{}`                          | Configures list-level query limits.                            |
-| `cacheHint`     | `Object`                            | `{}`                          | Configures a default caching hint for list.                    |
-| `adminConfig`   | `Object`                            | `{}`                          | Options for the AdminUI.                                       |
+| Option          | Type                                | Default                       | Description                                                            |
+| --------------- | ----------------------------------- | ----------------------------- | ---------------------------------------------------------------------- |
+| `fields`        | `Object`                            |                               | Defines the fields in a list.                                          |
+| `schemaDoc`     | `String`                            |                               | A description for the list. Used in the Admin UI.                      |
+| `hooks`         | `Object`                            | `{}`                          | Functions to be called during list operations.                         |
+| `label`         | `String`                            | `listName`                    | Overrides label for the list in the AdminUI.                           |
+| `labelField`    | `String`                            | `name`                        | Specify a field to use as a label for individual list items.           |
+| `labelResolver` | `Function`                          | Resolves `labelField` or `id` | Function to resolve labels for individual list items.                  |
+| `access`        | `Function` \| `Object` \| `Boolean` | `true`                        | [Access control](/docs/guides/access-control.md) options for the list. |
+| `adapterConfig` | `Object`                            |                               | Override the adapter config options for a specific list.               |
+| `itemQueryName` | `String`                            |                               | Changes the _item_ name in GraphQL queries and mutations.              |
+| `listQueryName` | `String`                            |                               | Changes the _list_ name in GraphQL queries and mutations.              |
+| `singular`      | `String`                            |                               | Specify a singular noun for `Keystone` to use for the list.            |
+| `plural`        | `String`                            |                               | Specify a plural for `Keystone` to use for the list.                   |
+| `path`          | `String`                            |                               | Changes the path in the Admin UI.                                      |
+| `plugins`       | `Array`                             | `[]`                          | An array of `plugins` that can modify the list config.                 |
+| `queryLimits`   | `Object`                            | `{}`                          | Configures list-level query limits.                                    |
+| `cacheHint`     | `Object`                            | `{}`                          | Configures a default caching hint for list.                            |
+| `adminConfig`   | `Object`                            | `{}`                          | Options for the AdminUI.                                               |
 
 ### `fields`
 
@@ -50,7 +50,7 @@ keystone.createList('Post', {
 });
 ```
 
-See: [Fields](/keystonejs/fields/) for more information on configuring field options.
+See: [Fields](/packages/fields/) for more information on configuring field options.
 
 ### `schemaDoc`
 
@@ -128,9 +128,9 @@ keystone.createList('User', {
 
 ### `access`
 
-[Access control](/guides/access-control) options for the list.
+[Access control](/docs/guides/access-control.md) options for the list.
 
-Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the [access control API documentation](/api/access-control) for more details.
+Options for `create`, `read`, `update` and `delete` - can be a function, GraphQL where clause or Boolean. See the [access control API documentation](/docs/api/access-control.md) for more details.
 
 #### Usage
 
@@ -304,7 +304,7 @@ This provides a method for packaging features that can be applied to multiple li
 
 Configuration for limiting the kinds of queries that can be made against the list, to avoid queries that might overload the server.
 
-See also [global query limits on the Keystone object](/api/keystone#query-limits).
+See also [global query limits on the Keystone object](/packages/keystone/README.md#querylimits).
 
 - `maxResults`: maximum number of results that can be returned in a query (or subquery)
 

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -4,7 +4,7 @@ title: Create List
 order: 2
 [meta]-->
 
-# createList(name, options)
+# `keystone.createList(name, options)`
 
 ## Usage
 
@@ -50,7 +50,7 @@ keystone.createList('Post', {
 });
 ```
 
-See: [Fields](/packages/fields/) for more information on configuring field options.
+See: [Fields](/packages/fields/README.md) for more information on configuring field options.
 
 ### `schemaDoc`
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -133,14 +133,14 @@ The result is passed to [the next function in the execution order](/docs/guides/
 
 #### Arguments
 
-| Argument        | Type                    | Description                                                                                                                   |
-| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
-| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
-| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
-| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
-| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| Argument        | Type                    | Description                                                                                                                  |
+| :-------------- | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                     |
+| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                             |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                    |
+| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                               |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
 
 #### Usage
 
@@ -173,15 +173,15 @@ Return values are ignored.
 
 #### Arguments
 
-| Argument                  | Type                    | Description                                                                                                                   |
-| :------------------------ | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`               | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
-| `existingItem`            | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
-| `originalInput`           | `Object`                | The data received by the GraphQL mutation                                                                                     |
-| `resolvedData`            | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
-| `context`                 | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`                 | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
-| `addFieldValidationError` | `Function`              | Used to set a field validation error; accepts a `String`                                                                      |
+| Argument                  | Type                    | Description                                                                                                                  |
+| :------------------------ | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`               | `String`                | The operation being performed (ie. `create` or `update`)                                                                     |
+| `existingItem`            | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                             |
+| `originalInput`           | `Object`                | The data received by the GraphQL mutation                                                                                    |
+| `resolvedData`            | `Object`                | The data received by the GraphQL mutation plus defaults values                                                               |
+| `context`                 | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`                 | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
+| `addFieldValidationError` | `Function`              | Used to set a field validation error; accepts a `String`                                                                     |
 
 #### Usage
 
@@ -214,14 +214,14 @@ Return values are ignored.
 
 #### Arguments
 
-| Argument        | Type                    | Description                                                                                                                   |
-| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
-| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                              |
-| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
-| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                                |
-| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| Argument        | Type                    | Description                                                                                                                  |
+| :-------------- | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                     |
+| `existingItem`  | `Object` or `undefined` | The current stored item (or `undefined` for `create` operations)                                                             |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                    |
+| `resolvedData`  | `Object`                | The data received by the GraphQL mutation plus defaults values                                                               |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
 
 #### Usage
 
@@ -257,14 +257,14 @@ Return values are ignored.
 
 #### Arguments
 
-| Argument        | Type                    | Description                                                                                                                   |
-| :-------------- | :---------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                      |
-| `existingItem`  | `Object` or `undefined` | The previously stored item (or `undefined` for `create` operations)                                                           |
-| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                     |
-| `updatedItem`   | `Object`                | The new/currently stored item                                                                                                 |
-| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| Argument        | Type                    | Description                                                                                                                  |
+| :-------------- | :---------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`     | `String`                | The operation being performed (ie. `create` or `update`)                                                                     |
+| `existingItem`  | `Object` or `undefined` | The previously stored item (or `undefined` for `create` operations)                                                          |
+| `originalInput` | `Object`                | The data received by the GraphQL mutation                                                                                    |
+| `updatedItem`   | `Object`                | The new/currently stored item                                                                                                |
+| `context`       | `Apollo Context`        | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`       | `Object`                | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
 
 #### Usage
 
@@ -295,13 +295,13 @@ Should throw or register errors with `addFieldValidationError(<String>)` if the 
 
 #### Arguments
 
-| Argument                  | Type             | Description                                                                                                                   |
-| :------------------------ | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`               | `String`         | The operation being performed (`delete` in this case)                                                                         |
-| `existingItem`            | `Object`         | The current stored item                                                                                                       |
-| `context`                 | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`                 | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
-| `addFieldValidationError` | `Function`       | Used to set a field validation error; accepts a `String`                                                                      |
+| Argument                  | Type             | Description                                                                                                                  |
+| :------------------------ | :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`               | `String`         | The operation being performed (`delete` in this case)                                                                        |
+| `existingItem`            | `Object`         | The current stored item                                                                                                      |
+| `context`                 | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`                 | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
+| `addFieldValidationError` | `Function`       | Used to set a field validation error; accepts a `String`                                                                     |
 
 #### Usage
 
@@ -332,12 +332,12 @@ Return values are ignored.
 
 #### Arguments
 
-| Argument       | Type             | Description                                                                                                                   |
-| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                         |
-| `existingItem` | `Object`         | The current stored item                                                                                                       |
-| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| Argument       | Type             | Description                                                                                                                  |
+| :------------- | :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                        |
+| `existingItem` | `Object`         | The current stored item                                                                                                      |
+| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
 
 #### Usage
 
@@ -369,12 +369,12 @@ Return values are ignored.
 
 #### Arguments
 
-| Argument       | Type             | Description                                                                                                                   |
-| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------------------------- |
-| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                         |
-| `existingItem` | `Object`         | The previously stored item, now deleted                                                                                       |
-| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/essentials/data.html#context) for this request |
-| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)   |
+| Argument       | Type             | Description                                                                                                                  |
+| :------------- | :--------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `operation`    | `String`         | The operation being performed (`delete` in this case)                                                                        |
+| `existingItem` | `Object`         | The previously stored item, now deleted                                                                                      |
+| `context`      | `Apollo Context` | The [Apollo `context` object](https://www.apollographql.com/docs/apollo-server/data/data/#context-argument) for this request |
+| `actions`      | `Object`         | Contains a `query` functions that queries the list within the current operations context, see [Query Helper](#query-helper)  |
 
 #### Usage
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -95,7 +95,7 @@ keystone.createList('User', {
 
 Field Type hooks are associated with a particular _field type_ and are applied to all fields of that type.
 Custom field types can implement hooks by implementing the following hook methods on the `Field` base class.
-See the [Custom Field Types guide](../guides/custom-field-types.md) for more info.
+See the [Custom Field Types guide](/docs/guides/custom-field-types.md) for more info.
 
 Hooks for the `create`, `update` and `delete` operations are available.
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -3,4 +3,17 @@ title: API
 section: api
 [meta]-->
 
-# API
+# API Reference
+
+Reference documentation for Keystone APIs.
+
+- [Access Control](/docs/api/access-control.md) --
+  Control who can do what with your GraphQL API
+- [Authentication](/docs/api/authentication.md) --
+  Authentication strategies allow users to identify themselves to KeystoneJS
+- [`keystone.createList(name, options)`](/docs/api/create-list.md) --
+  Where and how list schemas are defined
+- [Hooks API](/docs/api/hooks.md) --
+  Hooks give solution developers a way to add custom logic to the framework of lists, fields and operations Keystone provides
+- [Query Validation](/docs/api/validation.md) --
+  Stop maliciously complex or invalid queries against your `Keystone` instance

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -14,13 +14,15 @@ What a user _can_ and _cannot_ do in KeystoneJS depends on two things: _authenti
 
 This guide focuses on the GraphQL API _access control_, which refers to the specific actions an authenticated or anonymous user can take.
 
-_Authentication_, on the other hand, refers to a user identifying themselves in the Admin UI. You can learn about it in the [Authentication guide](/guides/authentication).
+_Authentication_, on the other hand, refers to a user identifying themselves in the Admin UI.
+You can learn about it in the [Authentication guide](/docs/guides/authentication.md).
 
 ## GraphQL Access Control
 
 Access control is about limiting CRUD (Create, Read, Update, Delete) actions that can be performed based on the current user (authenticated or anonymous).
 
-In KeystoneJS, both [Lists](/api/create-list) and [Fields](keystone-alpha/fields) take an `access` option, which lets you define rules of access control with fine precision - see [Access Control API](/api/access-control) docs for more details.
+In KeystoneJS, both [Lists](/docs/api/create-list.md) and [Fields](/packages/fields) take an `access` option,
+which lets you define rules of access control with fine precision - see [Access Control API](/docs/api/access-control.md) docs for more details.
 
 ### Example
 
@@ -37,7 +39,7 @@ Let's assume we want set the following access controls for a `User` list:
 
 Here's how we would set that up:
 
-_NOTE: The code below depends on having a correct [authentication setup](/guides/authentication)._
+_NOTE: The code below depends on having a correct [authentication setup](/docs/guides/authentication.md)._
 
 ```javascript
 const { Text, Select, Checkbox, Password } = require('@keystonejs/fields');
@@ -106,4 +108,4 @@ Note that Jess can only read _his own_ email, and cannot read any passwords.
 
 ---
 
-Read more in the [Access Control API docs](/api/access-control).
+Read more in the [Access Control API docs](/docs/api/access-control.md).

--- a/docs/guides/access-control.md
+++ b/docs/guides/access-control.md
@@ -21,7 +21,7 @@ You can learn about it in the [Authentication guide](/docs/guides/authentication
 
 Access control is about limiting CRUD (Create, Read, Update, Delete) actions that can be performed based on the current user (authenticated or anonymous).
 
-In KeystoneJS, both [Lists](/docs/api/create-list.md) and [Fields](/packages/fields) take an `access` option,
+In KeystoneJS, both [Lists](/docs/api/create-list.md) and [Fields](/packages/fields/README.md) take an `access` option,
 which lets you define rules of access control with fine precision - see [Access Control API](/docs/api/access-control.md) docs for more details.
 
 ### Example

--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -7,7 +7,7 @@ order: 2
 
 # Adding Lists To Your Keystone Project
 
-We've already created one list during [previous tutorial](/guides/new-project).
+We've already created one list during [previous tutorial](/docs/guides/new-project.md).
 Now it's the time to dive deeper. Let's make ToDos object a bit more complex.
 
 ## Creating basic list in separate file
@@ -71,7 +71,8 @@ module.exports = {
 }
 ```
 
-If you're curious about the usage options you can read more about `CalendarDay` [here](/keystonejs/fields/src/types/calendar-day/). Now it's time to explore docs on other field types and get a bit familiar with them. It will help you make your schema cleaner.
+If you're curious about the usage options you can read more about `CalendarDay` [here](/packages/fields/src/types/CalendarDay).
+Now it's time to explore docs on other field types and get a bit familiar with them. It will help you make your schema cleaner.
 
 ## Defining User list
 
@@ -103,8 +104,9 @@ const UsersSchema = require('./lists/Users.js');
 keystone.createList('User', UsersSchema);
 ```
 
-Relaunch your app and check if new list appeared in admin panel. Note, now `type: Password` looks when you're creating new user. But how can we assign a task to specific user? Let's proceed with [Defining Relationships](/guides/relationships)
+Relaunch your app and check if new list appeared in admin panel. Note, now `type: Password` looks when you're creating new user.
+But how can we assign a task to specific user? Let's proceed with [Defining Relationships](/docs/guides/relationships.md)
 
 See also:
-[Schema - Lists & Fields](/guides/schema)
-[API - createList](/api/create-list)
+[Schema - Lists & Fields](/docs/guides/schema.md)
+[API - createList](/docs/api/create-list.md)

--- a/docs/guides/add-lists.md
+++ b/docs/guides/add-lists.md
@@ -71,7 +71,7 @@ module.exports = {
 }
 ```
 
-If you're curious about the usage options you can read more about `CalendarDay` [here](/packages/fields/src/types/CalendarDay).
+If you're curious about the usage options you can read [more about `CalendarDay`](/packages/fields/src/types/CalendarDay/README.md).
 Now it's time to explore docs on other field types and get a bit familiar with them. It will help you make your schema cleaner.
 
 ## Defining User list

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -19,8 +19,7 @@ A KeystoneJS **App** has two primary purposes
 1. Prepare an `express`-compatible middleware for handling incoming http requests
 2. Provide a `build()` method to create a static production build for this app
 
-The mimimum KeystoneJS application requires at least one app, the [GraphQL
-API](../../keystonejs/app-graphql):
+The mimimum KeystoneJS application requires at least one app, the [GraphQL API](/packages/app-graphql):
 
 `index.js`
 
@@ -65,11 +64,11 @@ In both cases, the `keystone dev` and `keystone start` commands will consume the
 exported `.apps` array, making their middleware available in the order the apps
 are specified.
 
-If you're using a [Custom Server](/guides/custom-server), it will be your
+If you're using a [Custom Server](/docs/guides/custom-server.md), it will be your
 responsibility to ensure each app's middleware is correctly injected into any
 http server you setup.
 
 Other interesting KeystoneJS compatible Apps are:
 
-- [Static App](/keystonejs/app-static) for serving static files.
-- [Next.js App](/keystonejs/app-next) for serving a Next.js App on the same server as the API
+- [Static App](/packages/app-static) for serving static files.
+- [Next.js App](/packages/app-next) for serving a Next.js App on the same server as the API

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -19,7 +19,7 @@ A KeystoneJS **App** has two primary purposes
 1. Prepare an `express`-compatible middleware for handling incoming http requests
 2. Provide a `build()` method to create a static production build for this app
 
-The mimimum KeystoneJS application requires at least one app, the [GraphQL API](/packages/app-graphql):
+The mimimum KeystoneJS application requires at least one app, the [GraphQL API](/packages/app-graphql/README.md):
 
 `index.js`
 
@@ -70,5 +70,5 @@ http server you setup.
 
 Other interesting KeystoneJS compatible Apps are:
 
-- [Static App](/packages/app-static) for serving static files.
-- [Next.js App](/packages/app-next) for serving a Next.js App on the same server as the API
+- [Static App](/packages/app-static/README.md) for serving static files.
+- [Next.js App](/packages/app-next/README.md) for serving a Next.js App on the same server as the API

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -13,7 +13,7 @@ _Note on terminology_:
 - _Access Control_ refers to the specific actions an authenticated or anonymous
   user can take. Often referred to as _authorization_ elsewhere.
   The specifics of how this is done is outside the scope of this document.
-  See [Access Control](/guides/access-control) for more.
+  See [Access Control](/docs/guides/access-control.md) for more.
 
 ## Admin UI
 
@@ -22,7 +22,7 @@ Username / Password authentication can be enabled on the Admin UI.
 > NOTE: Admin Authentication will only restrict access to the Admin _UI_.
 >
 > To also restrict access to the _API_,
-> you must setup [Access Control](/guides/access-control) config.
+> you must setup [Access control](/docs/guides/access-control.md) config.
 
 To setup authentication, you must instantiate an _Auth Strategy_, and create a
 list used for authentication in `index.js`:
@@ -107,4 +107,4 @@ Finally; login with the newly created `User`'s credentials.
 Adding Authentication as above will only enable login to the Admin UI, it _will
 not_ restrict API access.
 
-**To restrict API access, you must setup [Access Control](/guides/access-control).**
+**To restrict API access, you must setup [Access control](/docs/guides/access-control.md).**

--- a/docs/guides/custom-mutations.md
+++ b/docs/guides/custom-mutations.md
@@ -10,7 +10,7 @@ Out of the box Keystone provides predictable CRUD operations (Create, Read, Upda
 
 Custom Queries and Mutations may be required if you wish to preform non-CRUD operations or actions that don't relate to a specific List.
 
-See the [GraphQL Philosophy](/guides/graphql-philosophy) for more information on how Keystone implements CRUD operations in GraphQL and when Custom Queries and Mutations may be required.
+See the [GraphQL Philosophy](/docs/guides/graphql-philosophy.md) for more information on how Keystone implements CRUD operations in GraphQL and when Custom Queries and Mutations may be required.
 
 You can add to Keystone's generated schema with custom types, queries, and mutations using the `keystone.extendGraphQLSchema()` method.
 
@@ -18,7 +18,8 @@ You can add to Keystone's generated schema with custom types, queries, and mutat
 
 A common example where a custom mutation might be beneficial is if you want to increment a value.
 
-Like any problem there are multiple solutions. You can implement an incrementing value with [Hooks](/guides/hooks) but in this example we're going to look at how to do this with a custom mutation.
+Like any problem there are multiple solutions.
+You can implement an incrementing value with [Hooks](/docs/guides/hooks.md) but in this example we're going to look at how to do this with a custom mutation.
 
 First let's define a `Page` list. For the sake of simplicity, we'll give it only two fields: `title` and `views`.
 

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -18,15 +18,15 @@ handles the GraphQL API and Admin UI. Things such as:
 - ... etc
 
 A **Custom Server** can replace the default and act as the entry point to your
-application which consumes your [schema definition](/guides/schema). A Custom
+application which consumes your [schema definition](/docs/guides/schema.md). A Custom
 Server must handle initialising a http server which correctly executes any given KeystoneJS Apps.
 
 _Note_: Before reaching for a custom server, consider using a KeystoneJS
 App which can enhance the functionality of the default server. Apps
 available in KeystoneJS include:
 
-- [Static App](../../keystonejs/app-static) for serving static files.
-- [Next.js App](../../keystonejs/app-next) for serving a Next.js App on the same server as the API
+- [Static App](/packages/app-static) for serving static files.
+- [Next.js App](/packages/app-next) for serving a Next.js App on the same server as the API
   The following are some possible ways of setting up a custom server, roughly in
   order of complexity.
 

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -25,8 +25,8 @@ _Note_: Before reaching for a custom server, consider using a KeystoneJS
 App which can enhance the functionality of the default server. Apps
 available in KeystoneJS include:
 
-- [Static App](/packages/app-static) for serving static files.
-- [Next.js App](/packages/app-next) for serving a Next.js App on the same server as the API
+- [Static App](/packages/app-static/README.md) for serving static files.
+- [Next.js App](/packages/app-next/README.md) for serving a Next.js App on the same server as the API
   The following are some possible ways of setting up a custom server, roughly in
   order of complexity.
 

--- a/docs/guides/graphql-philosophy.md
+++ b/docs/guides/graphql-philosophy.md
@@ -7,7 +7,7 @@ order: 3
 
 # GraphQL Philosophy
 
-> 💡 _This is a conceptual introduction to how the Keystone team think about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](/guides/intro-to-graphql)._
+> 💡 _This is a conceptual introduction to how the Keystone team think about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](/docs/guides/intro-to-graphql.md)._
 
 ## Goals
 

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -50,7 +50,7 @@ Keystone recognises three _types_ of hook:
 
 - [Field Type hooks](/api/hooks.md#field-type-hooks) -
   Field Type hooks are associated with a particular _field type_ and are applied to all fields of that type across all lists.
-- [Field hooks](/api/hooks.md#field-hooks) -
+- [Field hooks](/docs/api/hooks.md#field-hooks) -
   Field hooks can be defined by the app developer by specifying the `hooks` attribute of a field configuration when calling `createList()`.
 - [List hooks](/api/hooks.md#list-hooks) -
   List hooks can be defined by the app developer by specifying the `hooks` attribute of a list configuration when calling `createList()`.

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -8,7 +8,7 @@ title: Hooks
 Hooks give solution developers a way to add custom logic to the framework of lists, fields and operations Keystone provides.
 
 This document provides an overview of the concepts, patterns and function of the Keystone hook system.
-The [Hooks API docs](/api/hooks.md) describe the specific arguments and usage information.
+The [Hooks API docs](/docs/api/hooks.md) describe the specific arguments and usage information.
 
 ## Conceptual Organisation
 
@@ -39,7 +39,7 @@ These operations are reused used for both "single" and "many" modes.
 Eg. the `deleteUser` (singluar) and `deleteUsers` (plural) mutations are both considered to be `delete` operations.
 
 Hooks for these operations have different signatures due to the nature of the operations being performed.
-See the [Hook API docs](/api/hooks.md) for specifics.
+See the [Hook API docs](/docs/api/hooks.md) for specifics.
 
 > Note: Keystone does not currently implement `read` hooks.
 
@@ -48,11 +48,11 @@ See the [Hook API docs](/api/hooks.md) for specifics.
 A hooks _type_ is defined by where it is attached.
 Keystone recognises three _types_ of hook:
 
-- [Field Type hooks](/api/hooks.md#field-type-hooks) -
+- [Field Type hooks](/docs/api/hooks.md#field-type-hooks) -
   Field Type hooks are associated with a particular _field type_ and are applied to all fields of that type across all lists.
 - [Field hooks](/docs/api/hooks.md#field-hooks) -
   Field hooks can be defined by the app developer by specifying the `hooks` attribute of a field configuration when calling `createList()`.
-- [List hooks](/api/hooks.md#list-hooks) -
+- [List hooks](/docs/api/hooks.md#list-hooks) -
   List hooks can be defined by the app developer by specifying the `hooks` attribute of a list configuration when calling `createList()`.
 
 ### Hook Set
@@ -62,7 +62,7 @@ This group of distinct but related hooks are referred to as a _hook set_.
 
 Eg. a `beforeDelete` function could be supplied for a list, several specific fields on the list and a field type used by the list.
 All hooks in a hook set share the same functional signature but are invoked at different times.
-See the [Hooks API docs](/api/hooks.md) and [Intra-Hook Execution Order section](#intra-hook-execution-order) for more information.
+See the [Hooks API docs](/docs/api/hooks.md) and [Intra-Hook Execution Order section](#intra-hook-execution-order) for more information.
 
 ### Putting It Together
 
@@ -82,12 +82,12 @@ Due to their similarity, the `create` and `update` operations share a single set
 To implement different logic for these operations make it conditional on either the `operation` or `existingItem` arguments;
 for create operations `existingItem` will be `undefined`.
 
-See the [Hooks API docs](/api/hooks.md) for argument details and usage.
+See the [Hooks API docs](/docs/api/hooks.md) for argument details and usage.
 
 ## Execution Order
 
 The hooks are invoked in a specific order during an operation.
-For full details of the mutation lifecycle, and where hooks fit within this, see the [Mutation Lifecycle Guide](/guides/mutation-lifecycle.md).
+For full details of the mutation lifecycle, and where hooks fit within this, see the [Mutation Lifecycle Guide](/docs/guides/mutation-lifecycle.md).
 
 ### Create/Update
 
@@ -111,9 +111,9 @@ For full details of the mutation lifecycle, and where hooks fit within this, see
 
 Within each hook set, the different [hook types](#hook-type) are invoked in a specific order.
 
-1. All relevant and defined [field type hooks](/api/hooks.md#field-type-hooks) are invoked in **parallel**
-2. All relevant and defined [field hooks](/api/hooks.md#field-hooks) are invoked in **parallel**
-3. If defined the [list hook](/api/hooks.md#list-hooks) is invoked
+1. All relevant and defined [field type hooks](/docs/api/hooks.md#field-type-hooks) are invoked in **parallel**
+2. All relevant and defined [field hooks](/docs/api/hooks.md#field-hooks) are invoked in **parallel**
+3. If defined the [list hook](/docs/api/hooks.md#list-hooks) is invoked
 
 ## Gotchas
 

--- a/docs/guides/intro-to-graphql.md
+++ b/docs/guides/intro-to-graphql.md
@@ -163,7 +163,9 @@ mutation {
 
 ## Executing Queries and Mutations
 
-Before you begin writing application code, a great place test queries and mutations is the [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/). The default path for KeystoneJS' GraphQl Playground is `http://localhost:3000/admin/graphql`. Here you can execute queries and mutations against the KeystoneJS API without writing any JavaScript.
+Before you begin writing application code, a great place test queries and mutations is the [GraphQL Playground](https://www.apollographql.com/docs/apollo-server/features/graphql-playground/).
+The default path for KeystoneJS' GraphQl Playground is `http://localhost:3000/admin/graphql`.
+Here you can execute queries and mutations against the KeystoneJS API without writing any JavaScript.
 
 Once you have determined the correct query or mutation, you can add this to your application. To do this you will need to submit a `POST` request to KeystoneJS' API. The default API endpoint is: `http://localhost:3000/admin/api`.
 
@@ -218,13 +220,15 @@ fetch('/admin/api', {
 
 A good next step is to write an `executeQuery` function that accepts a query and variables and returns the results from the API. Take a look at the `todo` sample application in the `cli` for examples of this.
 
-**Note:** If you have configured [Access Control](/api/access-control) it can effect the result of some queries.
+**Note:** If you have configured [Access Control](/docs/api/access-control.md) it can effect the result of some queries.
 
 ## Executing Queries and Mutations on the Server
 
-In addition to executing queries via the API, you can execute queries and mutations on the server using [the `keystone.executeQuery()` method](/keystonejs/keystone/#executequeryquerystring-config).
+In addition to executing queries via the API, you can execute queries and mutations on the server using [the `keystone.executeQuery()` method](/packages/keystone/README.md#executequeryquerystring-config).
 
-**Note: ** No access control checks are run when executing queries on the server. Any queries or mutations that checked for `context.req` in the resolver may also return different results as the `req` object is set to `{}`. See: [Keystone executeQuery()](/keystonejs/keystone/#executequeryquerystring-config)
+**Note:** No access control checks are run when executing queries on the server.
+Any queries or mutations that checked for `context.req` in the resolver may also return different results as the `req` object is set to `{}`.
+See: [Keystone executeQuery()](/packages/keystone/README.md#executequeryquerystring-config)
 
 ## Filter, Limit and Sorting
 

--- a/docs/guides/mutation-lifecycle.md
+++ b/docs/guides/mutation-lifecycle.md
@@ -62,7 +62,7 @@ Each of these mutations is implemented within KeystoneJS by a corresponding reso
 Please refer to the [API documentation](LINK_TODO)) for full details on how to call these mutations either from [GraphQL](LINK_TODO)) or directly from [Keystone](LINK_TODO)).
 -->
 
-KeystoneJS provides [access control](/guides/access-control.md) mechanisms and a [hook system](/guides/hooks.md) which allows the developer to customise the behaviour of each of these mutations.
+KeystoneJS provides [access control](/docs/guides/access-control.md) mechanisms and a [hook system](/docs/guides/hooks.md) which allows the developer to customise the behaviour of each of these mutations.
 
 This document details the lifecycle of each mutation, and how the different access control mechanisms and hooks interact.
 
@@ -99,7 +99,7 @@ The first step in all mutations is to check that the user has access to perform 
 
 If access control has been defined statically or imperatively this check can be performed here. An `AccessDeniedError` is returned if the access control failed. If the access control mechanism for this list is defined declaratively (i.e using a GraphQL `where` statement), this check is deferred until the next step.
 
-For more information on how to define access control, please consult the [access control documentation](/guides/access-control.md)).
+For more information on how to define access control, please consult the [access control documentation](/docs/guides/access-control.md)).
 
 #### 2. Get Item(s) (`update/delete`)
 
@@ -171,7 +171,7 @@ The actual update step for these backlinks will be performed during the [Resolve
 
 The `resolveInput` hook allows the developer to modify the incoming item before it is inserted/updated within the database.
 
-For full details of how and when to use this hook, please consult the [API docs](/api/hooks.md).
+For full details of how and when to use this hook, please consult the [API docs](/docs/api/hooks.md).
 
 #### 4. Validate Data (`create/update/delete`)
 
@@ -179,13 +179,13 @@ The `validateInput` and `validateDelete` hooks allow the developer to specify va
 
 These hooks can throw a `ValidationFailureError` when they encounter invalid data, which will terminate the operational phase.
 
-For full details of how and when to use these hooks, please consult the [API docs](/api/hooks.md).
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
 #### 5. Before Operation (`create/update/delete`)
 
 The `beforeChange` and `beforeDelete` hooks allows the developer to perform any operations which interact with external systems, such as external data stores, which depend on resolved and validated data.
 
-For full details of how and when to use these hooks, please consult the [API docs](/api/hooks.md).
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
 #### 6. Database Operation (`create/update/delete`)
 
@@ -208,7 +208,7 @@ The `afterChange` and `afterDelete` hooks are only executed once all database op
 This means that the database is in a consistent state when this hook is executed.
 It also means that if there is a failure of any kind during this hook, the operation will still be considered complete, and no roll back will be performed.
 
-For full details of how and when to use these hooks, please consult the [API docs](/api/hooks.md).
+For full details of how and when to use these hooks, please consult the [API docs](/docs/api/hooks.md).
 
 ## Summary
 

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -44,7 +44,7 @@ const keystone = new Keystone({
 });
 ```
 
-You can specify any suitable name for your application. Note that we created an instance of the [Mongoose Adapter](/keystonejs/adapter-mongoose/) and passed it to KeystoneJS' constructor.
+You can specify any suitable name for your application. Note that we created an instance of the [Mongoose Adapter](/packages/adapter-mongoose/) and passed it to KeystoneJS' constructor.
 
 Now we can export our instance and make it available for running. Add following to the end of `index.js`:
 
@@ -139,4 +139,4 @@ You should see something like this
 🔗 GraphQL API:          http://localhost:3000/admin/api
 ```
 
-Now it's the time to check those routes in browser to ensure that everything works as expected. Then proceed to second step - [Adding Lists](/guides/add-lists)
+Now it's the time to check those routes in browser to ensure that everything works as expected. Then proceed to second step - [Adding Lists](/docs/guides/add-lists.md)

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -44,7 +44,7 @@ const keystone = new Keystone({
 });
 ```
 
-You can specify any suitable name for your application. Note that we created an instance of the [Mongoose Adapter](/packages/adapter-mongoose/) and passed it to KeystoneJS' constructor.
+You can specify any suitable name for your application. Note that we created an instance of the [Mongoose Adapter](/packages/adapter-mongoose/README.md) and passed it to KeystoneJS' constructor.
 
 Now we can export our instance and make it available for running. Add following to the end of `index.js`:
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -36,7 +36,7 @@ On the second step, you will see a screen such as:
 
 Ignore the `npx apollo service:push` command for now,
 we'll need to upload the schema a slightly different way to account for any
-[Access Control](/guides/access-control.) you may have setup.
+[Access Control](/docs/guides/access-control.md) you may have setup.
 
 #### Config
 

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -10,13 +10,13 @@ Yes, KeystoneJS can be (and is!) used for production websites. Here's a handy li
 
 ## Secure Cookies
 
-In production builds, [KeystoneJS' `secureCookies`](/keystonejs/keystone/#config) defaults to true. Make sure your server is HTTPS-enabled when `secureCookies` is enabled or you will be unable to log in.
+In production builds, [KeystoneJS' `secureCookies`](/packages/keystone/README.md#config) defaults to true. Make sure your server is HTTPS-enabled when `secureCookies` is enabled or you will be unable to log in.
 
 ## Session Handling
 
 ### Cookie Secret
 
-Make sure the production deployment sets a long, unguessable value for [KeystoneJS' `cookieSecret`](/keystonejs/keystone/#config).
+Make sure the production deployment sets a long, unguessable value for [KeystoneJS' `cookieSecret`](/packages/keystone/README.md#config).
 
 A randomly generated value is suitable (but keep it secret):
 
@@ -31,23 +31,23 @@ Sessions are stored inside the KeystoneJS app by default, but in production it's
 - You can restart your app for upgrades without breaking sessions
 - You can replicate your KeystoneJS app for availability, while keeping sessions consistent
 
-This option [can be set](/keystonejs/keystone/) in the `Keystone` constructor.
+This option [can be set](/packages/keystone/) in the `Keystone` constructor.
 
 ## Caching
 
-Improve performance and responsiveness by adding cache hints to your [lists](/api/create-list/#cachehint) and [fields](/keystonejs/fields/#cachehint).
+Improve performance and responsiveness by adding cache hints to your [lists](/docs/api/create-list.md#cachehint) and [fields](/packages/fields/README.md#cachehint).
 
 ## Access Control
 
-Configure [access control](/guides/access-control/) to limit who can do what with your data.
+Configure [access control](/docs/guides/access-control.md) to limit who can do what with your data.
 
 ## DoS Hardening
 
-Add [query limits](/api/create-list/#querylimits) and [validation](/api/validation/) to protect your server against maliciously complex queries.
+Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/api/validation.md) to protect your server against maliciously complex queries.
 
 ## Using Reverse Proxies
 
-NB: If you're using a third-party hosted environment, you might already be using a reverse proxy, but Keystone will need to be [configured for it](/keystonejs/keystone/#trustproxies).
+NB: If you're using a third-party hosted environment, you might already be using a reverse proxy, but Keystone will need to be [configured for it](/packages/keystone/README.md#trustproxies).
 
 It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)).
 

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -31,7 +31,7 @@ Sessions are stored inside the KeystoneJS app by default, but in production it's
 - You can restart your app for upgrades without breaking sessions
 - You can replicate your KeystoneJS app for availability, while keeping sessions consistent
 
-This option [can be set](/packages/keystone/) in the `Keystone` constructor.
+This option [can be set](/packages/keystone/README.md) in the `Keystone` constructor.
 
 ## Caching
 

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -80,5 +80,5 @@ The `many: true` option indicates that `User` can store multiple references to t
 
 See also:
 
-- [Schema - Lists & Fields](/guides/schema)
-- [Field Types - Relationship](/keystonejs/fields/src/types/relationship/)
+- [Schema - Lists & Fields](/docs/guides/schema.md)
+- [Field Types - Relationship](/packages/fields/src/types/Relationship/)

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -81,4 +81,4 @@ The `many: true` option indicates that `User` can store multiple references to t
 See also:
 
 - [Schema - Lists & Fields](/docs/guides/schema.md)
-- [Field Types - Relationship](/packages/fields/src/types/Relationship/)
+- [Field Types - Relationship](/packages/fields/src/types/Relationship/README.md)

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -98,7 +98,7 @@ type User {
 ```
 
 _(NOTE: Only a subset of all the generated types/mutations/queries are shown
-here. To see a more complete example [follow the Quick Start](../../quick-start).)_
+here. To see a more complete example [follow the Quick Start](/docs/quick-start).)_
 
 ### Customizing Lists & Fields
 
@@ -117,15 +117,14 @@ keystone.createList('Todo', {
 
 In this example, the `adminConfig` options will apply only to the `Todo` list
 (setting how many items are shown per page in the [Admin
-UI](/keystonejs/app-admin-ui)). The `isRequired` option will ensure an API error
+UI](/packages/app-admin-ui)). The `isRequired` option will ensure an API error
 is thrown if a `task` value is not provided when creating/updating items.
 
 <!-- TODO: Screenshot -->
 
-_For more List options, see the [`createList()` API
-docs](/api/create-list)._
+_For more List options, see the [`createList()` API docs](/docs/api/create-list.md)._
 
-_[There are many different field types available](/keystonejs/fields/),
+_[There are many different field types available](/packages/fields),
 each specifying their own options._
 
 ### Related Lists
@@ -653,8 +652,7 @@ mutation {
 }
 ```
 
-_See [the Relationship API docs for more on
-`connect`](../../keystonejs/fields/src/types/relationship)._
+_See [the Relationship API docs for more on `connect`](/packages/fields/src/types/Relationship)._
 
 If this was the first `Todo` item created, the database would now look like:
 
@@ -818,8 +816,8 @@ keystone.createList('User', {
 ```
 
 In this case, we'll create the first task along with creating the user. _For
-more info on the `create` syntax, see [the Relationship API
-docs](../../keystonejs/fields/src/types/relationship/)._
+more info on the `create` syntax, see
+[the Relationship API docs](/packages/fields/src/types/Relationship)._
 
 ```graphql
 mutation {

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -817,7 +817,7 @@ keystone.createList('User', {
 
 In this case, we'll create the first task along with creating the user. _For
 more info on the `create` syntax, see
-[the Relationship API docs](/packages/fields/src/types/Relationship)._
+[the Relationship API docs](/packages/fields/src/types/Relationship/README.md)._
 
 ```graphql
 mutation {

--- a/docs/guides/schema.md
+++ b/docs/guides/schema.md
@@ -98,7 +98,7 @@ type User {
 ```
 
 _(NOTE: Only a subset of all the generated types/mutations/queries are shown
-here. To see a more complete example [follow the Quick Start](/docs/quick-start).)_
+here. To see a more complete example [follow the Quick Start](/docs/quick-start/README.md).)_
 
 ### Customizing Lists & Fields
 
@@ -116,15 +116,15 @@ keystone.createList('Todo', {
 ```
 
 In this example, the `adminConfig` options will apply only to the `Todo` list
-(setting how many items are shown per page in the [Admin
-UI](/packages/app-admin-ui)). The `isRequired` option will ensure an API error
+(setting how many items are shown per page in the [Admin UI](/packages/app-admin-ui/README.md)).
+The `isRequired` option will ensure an API error
 is thrown if a `task` value is not provided when creating/updating items.
 
 <!-- TODO: Screenshot -->
 
 _For more List options, see the [`createList()` API docs](/docs/api/create-list.md)._
 
-_[There are many different field types available](/packages/fields),
+_[There are many different field types available](/packages/fields/README.md),
 each specifying their own options._
 
 ### Related Lists
@@ -652,7 +652,7 @@ mutation {
 }
 ```
 
-_See [the Relationship API docs for more on `connect`](/packages/fields/src/types/Relationship)._
+_See [the Relationship API docs for more on `connect`](/packages/fields/src/types/Relationship/README.md)._
 
 If this was the first `Todo` item created, the database would now look like:
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -26,7 +26,7 @@ And ONE of the following databases:
 - [MongoDB](https://www.mongodb.com/) >= 4.x: MongoDB is a powerful NoSQL document storage database.
 - [Postgres](https://www.postgresql.org) >= 9.x: PostgreSQL is an open source relational database that uses the SQL language.
 
-Finally, make sure [your database is configured and running](/quick-start/adapters).
+Finally, make sure [your database is configured and running](/docs/quick-start/adapters.md).
 
 All set? Great, let's get started!
 
@@ -96,4 +96,7 @@ KeystoneJS provides a web interface for this API at this URL:
 
 This todo app is a good introduction to KeystoneJS, but chances are you'll want to build something a bit more complex and secure than that!
 
-The [guides section](/guides) is a great next step. It will walk you through concepts like [creating lists](/guides/add-lists), setting up [content relationships](/guides/relationships), managing [access control](/guides/access-control) and much more.
+The [guides section](/docs/guides) is a great next step. It will walk you through concepts like
+[creating lists](/docs/guides/add-lists.md),
+setting up [content relationships](/docs/guides/relationships.md),
+managing [Access control](/docs/guides/access-control.md) and much more.

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -96,7 +96,7 @@ KeystoneJS provides a web interface for this API at this URL:
 
 This todo app is a good introduction to KeystoneJS, but chances are you'll want to build something a bit more complex and secure than that!
 
-The [guides section](/docs/guides) is a great next step. It will walk you through concepts like
-[creating lists](/docs/guides/add-lists.md),
+The [guides section](/docs/guides/index.md) is a great next step.
+It will walk you through concepts like [creating lists](/docs/guides/add-lists.md),
 setting up [content relationships](/docs/guides/relationships.md),
 managing [Access control](/docs/guides/access-control.md) and much more.

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -7,9 +7,11 @@ title: Database Setup and Adapters
 
 ## Choosing an Adapter
 
-KeystoneJS currently provides two adapters for connecting to either a MongoDB or PostgreSQL database. Choose the [Mongoose Adapter](/keystonejs/adapter-mongoose/) for MongoDB or the [Knex Adapter](/keystonejs/adapter-knex/) for PostgreSQL.
+KeystoneJS currently provides two adapters for connecting to either a MongoDB or PostgreSQL database.
+Choose the [Mongoose Adapter](/packages/adapter-mongoose/) for MongoDB or the [Knex Adapter](/packages/adapter-knex/) for PostgreSQL.
 
-If you're following the [quick start guide](/quick-start/adapters), simply select the appropriate adapter for your database of choice when prompted. More information on adapter configuration can be found under the _Setup_ sections.
+If you're following the [quick start guide](/docs/quick-start), simply select the appropriate adapter for your database of choice when prompted.
+More information on adapter configuration can be found under the _Setup_ sections.
 
 _Note_: PostgreSQL requires an additional step to create a database.
 
@@ -17,7 +19,8 @@ _Note_: PostgreSQL requires an additional step to create a database.
 
 ### MacOS
 
-The simplest way to install MongoDB is using [Homebrew](https://brew.sh/). Refer the [official guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/) for more information.
+The simplest way to install MongoDB is using [Homebrew](https://brew.sh/).
+Refer the [official guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/) for more information.
 
 ### Windows
 
@@ -29,7 +32,8 @@ Follow the [official guide](https://docs.mongodb.com/manual/tutorial/install-mon
 
 ### Setup
 
-By default the Mongoose Adapter will attempt to connect to MongoDB as the current user and create a new database using the project name. You can override these options when [configuring the Mongoose Adapter](/keystonejs/adapter-mongoose/).
+By default the Mongoose Adapter will attempt to connect to MongoDB as the current user and create a new database using the project name.
+You can override these options when [configuring the Mongoose Adapter](/packages/adapter-mongoose/).
 
 ## Installing [Postgres](https://www.postgresql.org/)
 
@@ -47,7 +51,9 @@ For Windows and other platforms see the [download instructions](https://www.post
 
 ### Setup
 
-By default the Knex Adapter will attempt to connect to a PostgreSQL database as the current user. It will look for a a database matching the project name. You can override these options when [configuring the Knex Adapter](/keystonejs/adapter-knex/).
+By default the Knex Adapter will attempt to connect to a PostgreSQL database as the current user.
+It will look for a a database matching the project name.
+You can override these options when [configuring the Knex Adapter](/packages/adapter-knex/).
 
 To create database run the following command:
 

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -8,9 +8,9 @@ title: Database Setup and Adapters
 ## Choosing an Adapter
 
 KeystoneJS currently provides two adapters for connecting to either a MongoDB or PostgreSQL database.
-Choose the [Mongoose Adapter](/packages/adapter-mongoose/) for MongoDB or the [Knex Adapter](/packages/adapter-knex/) for PostgreSQL.
+Choose the [Mongoose Adapter](/packages/adapter-mongoose/README.md) for MongoDB or the [Knex Adapter](/packages/adapter-knex/README.md) for PostgreSQL.
 
-If you're following the [quick start guide](/docs/quick-start), simply select the appropriate adapter for your database of choice when prompted.
+If you're following the [quick start guide](/docs/quick-start/README.md), simply select the appropriate adapter for your database of choice when prompted.
 More information on adapter configuration can be found under the _Setup_ sections.
 
 _Note_: PostgreSQL requires an additional step to create a database.
@@ -33,7 +33,7 @@ Follow the [official guide](https://docs.mongodb.com/manual/tutorial/install-mon
 ### Setup
 
 By default the Mongoose Adapter will attempt to connect to MongoDB as the current user and create a new database using the project name.
-You can override these options when [configuring the Mongoose Adapter](/packages/adapter-mongoose/).
+You can override these options when [configuring the Mongoose Adapter](/packages/adapter-mongoose/README.md).
 
 ## Installing [Postgres](https://www.postgresql.org/)
 
@@ -53,7 +53,7 @@ For Windows and other platforms see the [download instructions](https://www.post
 
 By default the Knex Adapter will attempt to connect to a PostgreSQL database as the current user.
 It will look for a a database matching the project name.
-You can override these options when [configuring the Knex Adapter](/packages/adapter-knex/).
+You can override these options when [configuring the Knex Adapter](/packages/adapter-knex/README.md).
 
 To create database run the following command:
 

--- a/packages/arch/packages/alert/README.md
+++ b/packages/arch/packages/alert/README.md
@@ -36,7 +36,7 @@ Import the component into your application.
 import { Alert } from '@arch-ui/alert';
 ```
 
-To override the styles use the `@arch-ui/theme` package
+To override the styles use the [`@arch-ui/theme` package][theme].
 
 ## Documentation
 
@@ -144,11 +144,9 @@ An alert that is full width; removes border and border radius.
 
 MIT © [Thinkmill](https://www.thinkmill.com.au/)
 
-[source]: https://github.com/keystonejs/arch
+[source]: https://github.com/keystonejs/keystone/tree/master/packages/arch
 
-[docs]: http://arch.keystonejs.com/
-
-[npm]: https://www.npmjs.com/
+[npm]: https://www.npmjs.com/package/@arch-ui/alert
 
 [install-npm]: https://docs.npmjs.com/getting-started/installing-node
 

--- a/packages/auth-passport/README.md
+++ b/packages/auth-passport/README.md
@@ -7,7 +7,7 @@ title: Passport Auth Strategy
 # Passport Auth Strategy
 
 Enable KeystoneJS authentication via services such as Google, Twitter, Facebook,
-GitHub, and any [others supported by `passport.js`](http://www.passportjs.org/packages/).
+GitHub, and any [others supported by `passport.js`](http://www.passportjs.org).
 
 ## Authentication Flows
 
@@ -154,10 +154,9 @@ module.exports = {
 _NOTE: The below can be done with any of the supported strategies (Twitter,
 Facebook, etc)._
 
-Due to the extra route used for gathering the user's name, this example
-implements [an All-in-one Custom
-Server](/guides/custom-server#all-in-one-custom-server) and should be run
-with `node server.js`, then visit `http://localhost:3000/auth/google` to start
+Due to the extra route used for gathering the user's name, this example implements
+[an All-in-one Custom Server](/docs/guides/custom-server.md#all-in-one-custom-server)
+and should be run with `node server.js`, then visit `http://localhost:3000/auth/google` to start
 the Google authentication process.
 
 `server.js`

--- a/packages/fields-datetime-utc/README.md
+++ b/packages/fields-datetime-utc/README.md
@@ -16,6 +16,7 @@ Unlike the core `DateTime` field type only the UTC value is stored.
 This package is not part of the core fields, and needs to be installed separately with `npm i @keystonejs/fields-datetime-utc`
 
 ## Usage
+
 ```js
 keystone.createList('User', {
   fields: {

--- a/packages/fields/src/types/CloudinaryImage/README.md
+++ b/packages/fields/src/types/CloudinaryImage/README.md
@@ -27,11 +27,10 @@ Then when creating your list, use the field as so:
 
 ```js
 keystone.createList('Item', {
- // ...
- fields: {
-   // ...
-   image: { type: CloudinaryImage, adapter: cloudinaryAdapter },
- }
+  // ...
+  fields: {
+    // ...
+    image: { type: CloudinaryImage, adapter: cloudinaryAdapter },
+  },
 });
 ```
-

--- a/packages/fields/src/types/Password/README.md
+++ b/packages/fields/src/types/Password/README.md
@@ -81,7 +81,7 @@ A work factor of 12 will cause passwords to take _four times_ as long as 10. Etc
 
 The `Password` field exposes a `compare()` function.
 This allows `Password` fields to be specified as a `secretField` when configuring a `PasswordAuthStrategy`.
-See the [Authentication docs](https://github.com/keystonejs/keystone-5/blob/master/docs/authentication) for details.
+See the [Authentication docs](/docs/guides/authentication.md) for details.
 
 ## GraphQL
 

--- a/test-projects/basic/custom-fields/Stars/README.md
+++ b/test-projects/basic/custom-fields/Stars/README.md
@@ -41,7 +41,7 @@ for the Admin UI in the browser.
 of the field type work such as: GraphQL filter options, the formatting of various labels for
 Keystone Admin UI, how data is formatted for sending via GraphQl and how it is interpreted when
 retrieved from the server. In this example our requirements are the same as for Integer so we can
-re-export the default [Integer field type's Controller](https://github.com/keystonejs/keystone-5/blob/master/packages/fields/types/Integer/Controller.js).
+re-export the default [Integer field type's Controller](/packages/fields/src/types/Integer/views/Controller.js).
 
 `Implementation.js` is used server side by Keystone. It exports an `Implementation` class and one or
 more `Database Field Adapters`.
@@ -63,7 +63,7 @@ This is where we will spend most of our time in this tutorial.
 
 ## Defining The Field Type
 
-Field Types should have an `index.js` file which exports the Field Type definition. Explanations on what each thing does can be found [here](../../../../packages/fields/README.md).
+Field Types should have an `index.js` file which exports the Field Type definition. Explanations on what each thing does can be found [here](/packages/fields/README.md).
 
 ```jsx
 const { Stars, MongoIntegerInterface } = require('./Implementation');


### PR DESCRIPTION
Links in Markdown documents should follow [the guidelines documented in #2041](https://github.com/keystonejs/keystone/issues/2041#issuecomment-566802733). This brings a swathe of existing docs inline with these decisions. These fixes are not exhaustive. 

See also #2114, which should possibly be resolved either before this PR is merged or before the docs site is next updated.