### PR TITLE
Cors & pinoOptions for default server

### DIFF
--- a/.changeset/chilly-berries-yell.md
+++ b/.changeset/chilly-berries-yell.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': minor
+---
+
+Allow configuring cors & pinoOptions for default server by adding them to the export in index.js

--- a/.changeset/old-geese-vanish.md
+++ b/.changeset/old-geese-vanish.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Document cors & pinoOptions params for keystone.prepare()

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -262,11 +262,13 @@ const { middlewares } = await keystone.prepare({
 
 ### Config
 
-| Option    | Type      | default | Description                                          |
-| --------- | --------- | ------- | ---------------------------------------------------- |
-| `dev`     | `Boolean` | `false` | Sets the dev flag in KeystoneJS' express middleware. |
-| `apps`    | `Array`   | `[]`    | An array of 'Apps' which are express middleware.     |
-| `distDir` | `String`  | `dist`  | The build directory for keystone.                    |
+| Option        | Type      | default                               | Description                                          |
+| ------------- | --------- | ------------------------------------- | ---------------------------------------------------- |
+| `dev`         | `Boolean` | `false`                               | Sets the dev flag in KeystoneJS' express middleware. |
+| `apps`        | `Array`   | `[]`                                  | An array of 'Apps' which are express middleware.     |
+| `distDir`     | `String`  | `dist`                                | The build directory for keystone.                    |
+| `cors`        | `Object`  | `{ origin: true, credentials: true }` | CORS options passed to the [`cors` npm module](https://www.npmjs.com/package/cors) |
+| `pinoOptions` | `Object`  | `undefined`                           | Logging options passed to the [`express-pino-logger` npm module](https://www.npmjs.com/package/express-pino-logger) |
 
 ## connect()
 

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -93,7 +93,13 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   // Allow the spinner time to flush its output to the console.
   await new Promise(resolve => setTimeout(resolve, 100));
 
-  const { keystone, apps = [], configureExpress = () => {} } = require(path.resolve(entryFile));
+  const {
+    keystone,
+    apps = [],
+    configureExpress = () => {},
+    cors,
+    pinoOptions,
+  } = require(path.resolve(entryFile));
 
   configureExpress(app);
 
@@ -104,7 +110,7 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
 
   const dev = process.env.NODE_ENV !== 'production';
 
-  const { middlewares } = await keystone.prepare({ apps, distDir, dev });
+  const { middlewares } = await keystone.prepare({ apps, distDir, dev, cors, pinoOptions });
 
   await keystone.connect();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20200,7 +20200,7 @@ semver-truncate@^1.1.2:
   dependencies:
     semver "^5.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -20209,11 +20209,6 @@ semver@4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
   integrity sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c=
-
-semver@^5.7.1:
-  version "5.7.1"
-  resolved "https://registry.able.co/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
Previously it was possible to configure cors when instantiating a GraphQL App, but since [the `cors` option was moved to `keystone.prepare()](https://github.com/keystonejs/keystone/pull/1618), it was no longer possible to set it from a default server:

```javascript
module.exports = {
  keystone: /* ... */,
  apps: /* ... */,
  cors: { /* NEW set cors here */ },
  pinoOptions: { /* NEW set pinoOptions here */ },
};
```

This PR brings that functionality back and includes some docs.