### PR TITLE
Fix releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js 10.x
         uses: actions/setup-node@master


### PR DESCRIPTION
It looks like default fetch depth that GH actions uses changed recently. Note that the 0 means an infinite depth