### PR TITLE
fixed toJSON is not a function error on cloudinary block

### DIFF
--- a/.changeset/fresh-files-smash.md
+++ b/.changeset/fresh-files-smash.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fix for cloudinary images block error when serialized

--- a/packages/fields/src/types/CloudinaryImage/views/blocks/single-image.js
+++ b/packages/fields/src/types/CloudinaryImage/views/blocks/single-image.js
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import insertImages from 'slate-drop-or-paste-images';
 import imageExtensions from 'image-extensions';
 import { findNode } from 'slate-react';
-import { Block } from 'slate';
+import { Data, Block } from 'slate';
 import pluralize from 'pluralize';
 
 export const type = 'cloudinaryImage';
@@ -194,7 +194,7 @@ export function serialize({ node, blocks }) {
 
   // zero out the data field to ensure we don't accidentally store the `file` as
   // a JSON blob
-  const newNode = node.setNode(node.getPath(imageNode.key), { data: {} });
+  const newNode = node.setNode(node.getPath(imageNode.key), { data: Data.create() });
 
   const mutations =
     joinIds && joinIds.length


### PR DESCRIPTION
Fix for `this.data.toJSON is not a function` error when trying to save slate content that contains cloudinary images in the Admin UI