### PR TITLE
implemented error boundary on field-content editor

### DIFF
--- a/.changeset/six-scissors-visit.md
+++ b/.changeset/six-scissors-visit.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/field-content': patch
+---
+
+Error handling for field-content

--- a/packages/field-content/src/views/Field.js
+++ b/packages/field-content/src/views/Field.js
@@ -1,8 +1,28 @@
 /** @jsx jsx */
+import { Component } from 'react';
 import { jsx } from '@emotion/core';
+import { colors } from '@arch-ui/theme';
 import Editor from './editor';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
 import { inputStyles } from '@arch-ui/input';
+
+class ErrorBoundary extends Component {
+  state = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <span css={{ color: colors.danger }}>Unable to render content</span>;
+    }
+
+    return this.props.children;
+  }
+}
 
 let ContentField = ({ field, value, onChange, autoFocus, errors }) => {
   const htmlID = `ks-content-editor-${field.path}`;
@@ -19,26 +39,28 @@ let ContentField = ({ field, value, onChange, autoFocus, errors }) => {
           }
         }}
       >
-        {Object.values(field.getBlocks())
-          .filter(({ Provider, options }) => Provider && options)
-          .reduce(
-            (children, { Provider, options }, index) => (
-              // Using index within key is ok here as the blocks never change
-              // across renders
-              <Provider value={options} key={`${htmlID}-provider-${index}`}>
-                {children}
-              </Provider>
-            ),
-            <Editor
-              key={htmlID}
-              blocks={field.getBlocks()}
-              value={value}
-              onChange={onChange}
-              autoFocus={autoFocus}
-              id={htmlID}
-              css={inputStyles({ isMultiline: true })}
-            />
-          )}
+        <ErrorBoundary>
+          {Object.values(field.getBlocks())
+            .filter(({ Provider, options }) => Provider && options)
+            .reduce(
+              (children, { Provider, options }, index) => (
+                // Using index within key is ok here as the blocks never change
+                // across renders
+                <Provider value={options} key={`${htmlID}-provider-${index}`}>
+                  {children}
+                </Provider>
+              ),
+              <Editor
+                key={htmlID}
+                blocks={field.getBlocks()}
+                value={value}
+                onChange={onChange}
+                autoFocus={autoFocus}
+                id={htmlID}
+                css={inputStyles({ isMultiline: true })}
+              />
+            )}
+        </ErrorBoundary>
       </FieldInput>
     </FieldContainer>
   );


### PR DESCRIPTION
Prevent errors from field-content from stopping the entire List Item page from rendering