### PR TITLE
Consume field hooks

### DIFF
--- a/.changeset/thick-oranges-change.md
+++ b/.changeset/thick-oranges-change.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/fields': minor
+---
+
+Enabled use of cuatom field views. Custom Field, Cell and Filter views can now be configured per field in list.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -6,8 +6,13 @@ export const gqlCountQueries = lists => gql`{
   ${lists.map(list => list.countQuery()).join('\n')}
 }`;
 
+const getFieldViews = (hookViews, fieldPath) => {
+  const fieldViews = hookViews.views || {};
+  return fieldViews[fieldPath] || {};
+};
+
 export default class List {
-  constructor(config, adminMeta, views) {
+  constructor(config, adminMeta, views, listHooks = {}) {
     this.config = config;
     this.adminMeta = adminMeta;
 
@@ -16,7 +21,13 @@ export default class List {
 
     this.fields = config.fields.map(fieldConfig => {
       const [Controller] = adminMeta.readViews([views[fieldConfig.path].Controller]);
-      return new Controller(fieldConfig, this, adminMeta, views[fieldConfig.path]);
+      return new Controller(
+        fieldConfig,
+        this,
+        adminMeta,
+        views[fieldConfig.path],
+        getFieldViews(listHooks, fieldConfig.path)
+      );
     });
 
     this._fieldsByPath = arrayToObject(this.fields, 'path');

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -184,7 +184,9 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
               return creatable.map((field, i) => (
                 <Render key={field.path}>
                   {() => {
-                    let [Field] = field.adminMeta.readViews([field.views.Field]);
+                    let [Field] = field.hooks.Field
+                      ? [field.hooks.Field]
+                      : field.adminMeta.readViews([field.views.Field]);
                     // eslint-disable-next-line react-hooks/rules-of-hooks
                     let onChange = useCallback(value => {
                       setItem(item => ({

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -232,8 +232,10 @@ class ListRow extends Component {
 
           let content;
 
-          if (field.views.Cell) {
-            const [Cell] = field.adminMeta.readViews([field.views.Cell]);
+          if (field.hooks.Cell || field.views.Cell) {
+            const [Cell] = field.hooks.Cell
+              ? [field.hooks.Cell]
+              : field.adminMeta.readViews([field.views.Cell]);
 
             // TODO
             // fix this later, creating a react component on every render is really bad

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -152,7 +152,9 @@ class UpdateManyModal extends Component {
             >
               <Render>
                 {() => {
-                  let [Field] = field.adminMeta.readViews([field.views.Field]);
+                  let [Field] = field.hooks.Field
+                    ? [field.hooks.Field]
+                    : field.adminMeta.readViews([field.views.Field]);
                   let onChange = useCallback(
                     value => {
                       this.setState(({ item }) => ({

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -261,7 +261,9 @@ const ItemDetails = ({
           {getRenderableFields(list).map((field, i) => (
             <Render key={field.path}>
               {() => {
-                const [Field] = field.adminMeta.readViews([field.views.Field]);
+                const [Field] = field.hooks.Field
+                  ? [field.hooks.Field]
+                  : field.adminMeta.readViews([field.views.Field]);
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 const onChange = useCallback(
                   value => {

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -292,7 +292,7 @@ export default class AddFilterPopout extends Component<Props, State> {
             />
           );
 
-          if (!field.views.Filter) {
+          if (!field.hooks.Filter && !field.views.Filter) {
             return (
               <div ref={ref} style={style}>
                 <Alert appearance="warning" variant="bold">
@@ -337,7 +337,9 @@ export default class AddFilterPopout extends Component<Props, State> {
               >
                 <Render>
                   {() => {
-                    let [Filter] = field.adminMeta.readViews([field.views.Filter]);
+                    let [Filter] = field.hooks.Filter
+                      ? [field.hooks.Filter]
+                      : field.adminMeta.readViews([field.views.Filter]);
 
                     return (
                       <Filter

--- a/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -32,7 +32,9 @@ export default class EditFilterPopout extends Component {
   render() {
     const { filter, target } = this.props;
     const { value } = this.state;
-    let [Filter] = filter.field.adminMeta.readViews([filter.field.views.Filter]);
+    let [Filter] = filter.field.hooks.Filter
+      ? [filter.field.hooks.Filter]
+      : filter.field.adminMeta.readViews([filter.field.views.Filter]);
     const headerTitle = filter.field.getFilterLabel(filter);
 
     return (

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -1,7 +1,7 @@
 import isEqual from 'lodash.isequal';
 
 export default class FieldController {
-  constructor(config, list, adminMeta, views) {
+  constructor(config, list, adminMeta, views, hooks) {
     this.config = config;
     this.label = config.label;
     this.path = config.path;
@@ -11,6 +11,7 @@ export default class FieldController {
     this.list = list;
     this.adminMeta = adminMeta;
     this.views = views;
+    this.hooks = hooks;
 
     if ('defaultValue' in config) {
       if (typeof config.defaultValue !== 'function') {
@@ -106,6 +107,9 @@ export default class FieldController {
 
   initFieldView = () => {
     const { Field } = this.views;
+    if (this.hooks.Field) {
+      return;
+    }
     if (!Field) {
       return;
     }

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -99,7 +99,7 @@ export default class FieldController {
 
   initCellView = () => {
     const { Cell } = this.views;
-    if (!Cell) {
+    if (!Cell || this.hooks.Cell) {
       return;
     }
     this.adminMeta.readViews([Cell]);
@@ -107,10 +107,7 @@ export default class FieldController {
 
   initFieldView = () => {
     const { Field } = this.views;
-    if (this.hooks.Field) {
-      return;
-    }
-    if (!Field) {
+    if (!Field || this.hooks.Field) {
       return;
     }
     this.adminMeta.readViews([Field]);
@@ -118,7 +115,7 @@ export default class FieldController {
 
   initFilterView = () => {
     const { Filter } = this.views;
-    if (!Filter) {
+    if (!Filter || this.hooks.Filter) {
       return;
     }
     this.adminMeta.readViews([Filter]);


### PR DESCRIPTION
continuing  from #1927 
* enable use of Field UI hooks from hooks config

```js
// hooks config for list based per field views
lists: {
    User: {
      views: {
        email: {
          Field: TextFieldEx,
        },
      },
    },
  },
```

Example of copying the Text Field view and using it with background Changed in Email field in blog demo 
(ideally we should have a way to add theming hook per field)

![image](https://user-images.githubusercontent.com/5769869/71412317-3e81a600-2673-11ea-880a-bb166c8ac8cf.png)


> Still need to figure out how to provide correct example with blog demo or add it to test projects for reference. Not sure of the testing scenario either. @MadeByMike 