### PR TITLE
Force cfont version to be 2.4.5

### DIFF
--- a/packages/create-keystone-app/package.json
+++ b/packages/create-keystone-app/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@sindresorhus/slugify": "^0.6.0",
     "arg": "^4.1.1",
-    "cfonts": "^2.4.4",
+    "cfonts": "2.4.5",
     "chalk": "^2.4.2",
     "execa": "^2.0.4",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
cfont minor version 2.4.6 breaks cli.js usage.

#2170 