### PR TITLE
Update hooks.md

### DIFF
--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -29,14 +29,14 @@ These stages are intended to be used for different purposes; they help organise 
 
 ### Operation
 
-Hooks are available for four of the core operations:
+Hooks are available for these core operations:
 
 - `create`
 - `update`
 - `delete`
 
 These operations are reused used for both "single" and "many" modes.
-Eg. the `deleteUser` (singluar) and `deleteUsers` (plural) mutations are both considered to be `delete` operations.
+E.g. the `deleteUser` (singluar) and `deleteUsers` (plural) mutations are both considered to be `delete` operations.
 
 Hooks for these operations have different signatures due to the nature of the operations being performed.
 See the [Hook API docs](/api/hooks.md) for specifics.
@@ -60,7 +60,7 @@ Keystone recognises three _types_ of hook:
 For most _stage_ and _operation_ combinations, different functions (hooks) can be supplied for each _hook type_.
 This group of distinct but related hooks are referred to as a _hook set_.
 
-Eg. a `beforeDelete` function could be supplied for a list, several specific fields on the list and a field type used by the list.
+E.g. a `beforeDelete` function could be supplied for a list, several specific fields on the list and a field type used by the list.
 All hooks in a hook set share the same functional signature but are invoked at different times.
 See the [Hooks API docs](/api/hooks.md) and [Intra-Hook Execution Order section](#intra-hook-execution-order) for more information.
 


### PR DESCRIPTION
Changed Eg into E.g. (correct abbreviation).
Changed 'four core operations' into 'these core operations', since it only lists three core operations in the list. 'these' will always be correct.