### PR TITLE
Fix for custom express apps

### DIFF
--- a/.changeset/warm-suns-smoke.md
+++ b/.changeset/warm-suns-smoke.md
@@ -1,0 +1,18 @@
+---
+'@keystonejs/keystone': major
+---
+
+Fixed `configureExpress(app)` to work properly when customizing the `express` instance. Earlier the configuration passed to express instance inside `configureExpress` were lost.
+
+**breaking changes**: You must return the express instance from `configureExpress` function.
+
+example:
+```js
+const configureExpress = (app) => {
+  app.use(bodyParser.urlencoded({ extended: true }));
+  app.set('views', './templates');
+  app.set('view engine', 'pug');
+// ... other custom work with app
+  return app; // required to return the instance.
+}
+```

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -39,6 +39,7 @@ custom server. The KeystoneJS CLI accepts an additional `configureExpress` expor
 module.exports = {
   configureExpress: app => {
     /* ... */
+    return app;
   },
 };
 ```
@@ -50,6 +51,7 @@ before any middlewares are set up, so you can perform any Express configuration 
 module.exports = {
   configureExpress: app => {
     app.set('view engine', 'pug');
+    return app;
   },
 };
 ```

--- a/docs/guides/custom-server.md
+++ b/docs/guides/custom-server.md
@@ -90,7 +90,12 @@ keystone
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    app.use(middlewares).listen(3000);
+    app.set(/* ... */);
+    app.use(/* ... */);
+    // must use the app instance as middleware to preserve express configuration.
+    express()
+      .use([...middlewares, app])
+      .listen(3000);
   });
 ```
 
@@ -125,7 +130,12 @@ keystone
   .then(async ({ middlewares }) => {
     await keystone.connect();
     const app = express();
-    app.use(middlewares).listen(3000);
+    app.set(/* ... */);
+    app.use(/* ... */);
+    // must use the app instance as middleware to preserve express configurations.
+    express()
+      .use([...middlewares, app])
+      .listen(3000);
   });
 ```
 
@@ -163,7 +173,12 @@ const preparations = [new GraphQLApp(), new AdminUIApp()].map(app =>
 Promise.all(preparations).then(async middlewares => {
   await keystone.connect();
   const app = express();
-  app.use(middlewares).listen(3000);
+  app.set(/* ... */);
+  app.use(/* ... */);
+  // must use the app instance as middleware to preserve express configurations.
+  express()
+    .use([...middlewares, app])
+    .listen(3000);
 });
 ```
 
@@ -195,7 +210,10 @@ const setup = keystone
     await keystone.connect();
     const app = express();
     app.use(middlewares);
-    return serverless(app);
+    app.set(/* ... */);
+    app.use(/* ... */);
+    // must use the app instance as middleware to preserve express configurations.
+    return serverless(express().use([...middlewares, app]));
   });
 
 module.exports.handler = async (event, context) => {

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -95,12 +95,12 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   const {
     keystone,
     apps = [],
-    configureExpress = () => {},
+    configureExpress = () => null,
     cors,
     pinoOptions,
   } = require(path.resolve(entryFile));
 
-  configureExpress(app);
+  const customApp = configureExpress(express());
 
   spinner.succeed('Initialised Keystone instance');
   spinner.start('Connecting to database');
@@ -116,7 +116,7 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   spinner.succeed('Connected to database');
   spinner.start('Preparing to accept requests');
 
-  app.use(middlewares);
+  app.use([...middlewares, ...(customApp ? [customApp] : [])]);
   status = 'started';
   spinner.succeed(chalk.green.bold(`Keystone instance is ready at http://localhost:${port} 🚀`));
 

--- a/packages/keystone/tests/bin/dev-command.test.js
+++ b/packages/keystone/tests/bin/dev-command.test.js
@@ -61,7 +61,7 @@ describe('dev command', () => {
         // A mock keystone instance
         keystone: {
           auth: {},
-          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
+          prepare: () => Promise.resolve({ middlewares: [(req, res, next) => res.send(200)] }),
           connect: () => Promise.resolve(),
         }
       }`
@@ -87,7 +87,7 @@ describe('dev command', () => {
         // A mock keystone instance
         keystone: {
           auth: {},
-          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
+          prepare: () => Promise.resolve({ middlewares: [(req, res, next) => res.send(200)] }),
           connect: () => Promise.resolve(),
         }
       }`


### PR DESCRIPTION
fixes #1887 
fixes #1818 

continuing from https://github.com/keystonejs/keystone/pull/2152#issuecomment-568563553

This PR fixes the `configureExpress` scenario where express configuration (value of `app.set(/*...*/)`) were lost after recent upgrade.

it should fix #1887 and definitely fixes #1818.

Also updated documentation of how to use custom sever properly to preserve the express configuration.

#### Breaking Changes

`configureExpress` must return an express instance, either provided in parameter or a new instance.
> this documentation is separate commit, in case we do not want to include this yet. 

```js
const configureExpress = (app) => {
  app.use(bodyParser.urlencoded({ extended: true }));
  app.set('views', './templates');
  app.set('view engine', 'pug');
// ... other custom work with app
  return app; // this is must
}

module.exports = {
  keystone,
  apps: [
    new GraphQLApp(),
    new StaticApp({ path: staticPath, src: staticSrc }),
    adminApp,
  ],
  configureExpress,
  distDir,
};
```

##### Update to Custom Server example in guides
This is finding from configureExpress and other issue. 
with `keystone` it is required to use the custom express instance use as middleware otherwise the routes and configs does not work properly.

```javascript
const express = require('express');
const { keystone, apps } = require('./index.js');
keystone
  .prepare({ apps, dev: process.env.NODE_ENV !== 'production' })
  .then(async ({ middlewares }) => {
    await keystone.connect();
    const app = express();
    app.set(/* ... */);
    app.use(/* ... */);
    // must use the app instance as middleware to preserve express configuration.
    express()
      .use([...middlewares, app])
      .listen(3000);
  });
```