### PR TITLE
Fix apps which don't define build()

### DIFF
--- a/.changeset/dull-taxis-relax.md
+++ b/.changeset/dull-taxis-relax.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Apps which don't define `build()` no longer cause keystone to fail.

--- a/docs/guides/apps.md
+++ b/docs/guides/apps.md
@@ -72,3 +72,28 @@ Other interesting KeystoneJS compatible Apps are:
 
 - [Static App](/packages/app-static/README.md) for serving static files.
 - [Next.js App](/packages/app-next/README.md) for serving a Next.js App on the same server as the API
+
+## Custom Apps
+
+If you need to provide your own custom middleware for your system you can create a custom **App** and include it in your exported `apps`.
+
+```
+class CustomApp {
+  prepareMiddleware({ keystone, dev, distDir }) {
+    const middleware = express();
+    // ...
+    return middleware;
+  }
+}
+
+// ...
+
+module.exports = {
+  keystone,
+  apps: [
+    new GraphQLApp(),
+    new AdminUIApp(),
+    new CustomApp(),
+  ]
+}
+```

--- a/docs/guides/new-project.md
+++ b/docs/guides/new-project.md
@@ -84,15 +84,16 @@ In order to be able to start an app we need to add at least one List. A List is 
 ## Adding first List
 
 To type the fields of the list, a package has to be installed:
+
 ```
 yarn add @keystonejs/fields
 ```
 
 In this example the type `Text` is used, require this in index.js:
+
 ```javascript
 const { Text } = require('@keystonejs/fields');
 ```
-
 
 In `index.js` add the following above `module.exports` and below `const keystone = new Keystone({...`:
 

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -47,7 +47,7 @@ Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/
 
 ## Using Reverse Proxies
 
-It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](<https://en.wikipedia.org/wiki/Slowloris_(computer_security)>).
+It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)).
 
 ## Environment Variables
 

--- a/packages/keystone/bin/commands/build.js
+++ b/packages/keystone/bin/commands/build.js
@@ -40,12 +40,7 @@ module.exports = {
 
     if (apps) {
       await Promise.all(
-        apps.map(app => {
-          return app.build({
-            distDir: resolvedDistDir,
-            keystone,
-          });
-        })
+        apps.filter(app => app.build).map(app => app.build({ distDir: resolvedDistDir, keystone }))
       );
 
       spinner.succeed(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,7 +5477,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-change-case@^3.0.2:
+change-case@^3.0.2, change-case@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
   integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==
@@ -10186,6 +10186,12 @@ global-prefix@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
   integrity sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
 
 global@^4.3.0, global@~4.3.0:
   version "4.3.2"


### PR DESCRIPTION
Previously, if you defined a custom app with a `prepareMiddleware` method but no `build` method then you'd have a bad time when you ran the `build` script. This filters out apps with no build to avoid this mode of failure.