### PR TITLE
Fix deprecation message

### DIFF
--- a/packages/keystone/tests/bin/dev-command.test.js
+++ b/packages/keystone/tests/bin/dev-command.test.js
@@ -61,7 +61,7 @@ describe('dev command', () => {
         // A mock keystone instance
         keystone: {
           auth: {},
-          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
+          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.sendStatus(200) }),
           connect: () => Promise.resolve(),
         }
       }`
@@ -87,7 +87,7 @@ describe('dev command', () => {
         // A mock keystone instance
         keystone: {
           auth: {},
-          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.send(200) }),
+          prepare: () => Promise.resolve({ middlewares: (req, res, next) => res.sendStatus(200) }),
           connect: () => Promise.resolve(),
         }
       }`

--- a/yarn.lock
+++ b/yarn.lock
@@ -23005,7 +23005,7 @@ which-pm-runs@^1.0.0:
   resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
   integrity sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
 
-which@^1.2.9, which@^1.3.0:
+which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
Before:
```
➜  keystone-5 git:(master) yarn test:unit packages/keystone/tests/bin 
yarn run v1.17.3
$ cross-env DISABLE_LOGGING=true NODE_ENV=test jest --maxWorkers=1 packages/keystone/tests/bin
express deprecated res.send(status): Use res.sendStatus(status) instead ../../../../private/var/folders/dg/5hp4wbxj1svfwqy2w3mmpb940000gn/T/tmp-273091ZAUpoSSfzOd.js:8:44
express deprecated res.send(status): Use res.sendStatus(status) instead ../../../../private/var/folders/dg/5hp4wbxj1svfwqy2w3mmpb940000gn/T/tmp-27309AyUTe5IG9vzV.js:8:44
 PASS  packages/keystone/tests/bin/dev-command.test.js
 PASS  packages/keystone/tests/bin/command-runner.test.js

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        1.615s
Ran all test suites matching /packages\/keystone\/tests\/bin/i.
✨  Done in 2.77s.
```

After:
```
➜  keystone-5 git:(master) yarn test:unit packages/keystone/tests/bin
yarn run v1.17.3
$ cross-env DISABLE_LOGGING=true NODE_ENV=test jest --maxWorkers=1 packages/keystone/tests/bin
 PASS  packages/keystone/tests/bin/dev-command.test.js
 PASS  packages/keystone/tests/bin/command-runner.test.js

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        1.935s, estimated 2s
Ran all test suites matching /packages\/keystone\/tests\/bin/i.
✨  Done in 3.10s.
```