### PR TITLE
Fix deprecation warnings

### DIFF
--- a/packages/mongo-join-builder/tests/mongo-results.test.js
+++ b/packages/mongo-join-builder/tests/mongo-results.test.js
@@ -38,7 +38,10 @@ jest.setTimeout(60000);
 beforeAll(async () => {
   mongoServer = new MongoDBMemoryServer();
   const mongoUri = await mongoServer.getConnectionString();
-  mongoConnection = await MongoClient.connect(mongoUri, { useNewUrlParser: true });
+  mongoConnection = await MongoClient.connect(mongoUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
   mongoDb = mongoConnection.db(await mongoServer.getDbName());
 });
 
@@ -49,7 +52,7 @@ afterAll(() => {
 
 beforeEach(async () => {
   const collections = await mongoDb.collections();
-  await Promise.all(collections.map(collection => collection.remove({})));
+  await Promise.all(collections.map(collection => collection.deleteMany({})));
 });
 
 describe('mongo memory servier is alive', () => {


### PR DESCRIPTION
https://mongoosejs.com/docs/deprecations.html

Before:
```
yarn run v1.17.3
$ cross-env DISABLE_LOGGING=true NODE_ENV=test jest --maxWorkers=1 packages/mongo-join-builder
(node:30468) DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor.
(node:30468) DeprecationWarning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.
 PASS  packages/mongo-join-builder/tests/mongo-results.test.js
 PASS  packages/mongo-join-builder/tests/join-builder.test.js
 PASS  packages/mongo-join-builder/tests/query-parser.test.js
 PASS  packages/mongo-join-builder/tests/index.test.js
 PASS  packages/mongo-join-builder/tests/relationship-path.test.js
 PASS  packages/mongo-join-builder/tests/relationship.test.js
 PASS  packages/mongo-join-builder/tests/simple.test.js

Test Suites: 7 passed, 7 total
Tests:       50 passed, 50 total
Snapshots:   0 total
Time:        1.858s, estimated 3s
Ran all test suites matching /packages\/mongo-join-builder/i.
✨  Done in 3.54s.
```

After:
```
➜  keystone-5 git:(fix-mongo-deprecations) yarn test:unit packages/mongo-join-builder               
yarn run v1.17.3
$ cross-env DISABLE_LOGGING=true NODE_ENV=test jest --maxWorkers=1 packages/mongo-join-builder
 PASS  packages/mongo-join-builder/tests/mongo-results.test.js
 PASS  packages/mongo-join-builder/tests/query-parser.test.js
 PASS  packages/mongo-join-builder/tests/join-builder.test.js
 PASS  packages/mongo-join-builder/tests/index.test.js
 PASS  packages/mongo-join-builder/tests/relationship-path.test.js
 PASS  packages/mongo-join-builder/tests/simple.test.js
 PASS  packages/mongo-join-builder/tests/relationship.test.js

Test Suites: 7 passed, 7 total
Tests:       50 passed, 50 total
Snapshots:   0 total
Time:        3.046s
Ran all test suites matching /packages\/mongo-join-builder/i.
✨  Done in 5.17s.
```