### PR TITLE
Corrected a spelling mistake + question

### DIFF
--- a/docs/guides/graphql-philosophy.md
+++ b/docs/guides/graphql-philosophy.md
@@ -7,7 +7,7 @@ order: 3
 
 # GraphQL Philosophy
 
-> 💡 _This is a conceptual introduction to how the Keystone team think about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](/docs/guides/intro-to-graphql.md)._
+> 💡 _This is a conceptual introduction to how the Keystone team thinks about GraphQL APIs (and hence how Keystone's GraphQL API is generated). For more specific API docs, see [**Introduction to the GraphQL API**](/docs/guides/intro-to-graphql.md)._
 
 ## Goals
 


### PR DESCRIPTION
In the GraphQL Schema represented on this page, there is a reference to 'UserToOneRelationshipInput', which is not defined in the schema. Is this left out on purpose?