### PR TITLE
Refactor relationshipTokenizer return shape

### DIFF
--- a/.changeset/odd-ladybugs-look.md
+++ b/.changeset/odd-ladybugs-look.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/mongo-join-builder': patch
+---
+
+Refactor the internal `relationshipTokenizer`, no functional changes.

--- a/packages/adapter-mongoose/tests/list-adapter.test.js
+++ b/packages/adapter-mongoose/tests/list-adapter.test.js
@@ -82,6 +82,7 @@ describe('MongooseListAdapter', () => {
       { $addFields: expect.any(Object) },
       { $match: { $and: [expect.any(Object), { title: { $eq: 'bar' } }] } },
       { $addFields: { id: '$_id' } },
+      { $project: { posts: 0 } },
     ]);
 
     await userListAdapter.itemsQuery({
@@ -105,6 +106,7 @@ describe('MongooseListAdapter', () => {
       { $addFields: expect.any(Object) },
       { $match: { $or: [expect.any(Object), { title: { $eq: 'bar' } }] } },
       { $addFields: { id: '$_id' } },
+      { $project: { posts: 0 } },
     ]);
   });
 
@@ -168,6 +170,7 @@ describe('MongooseListAdapter', () => {
       { $addFields: expect.any(Object) },
       { $match: expect.any(Object) },
       { $addFields: { id: '$_id' } },
+      { $project: { posts: 0 } },
     ]);
 
     await userListAdapter.itemsQuery({
@@ -191,6 +194,7 @@ describe('MongooseListAdapter', () => {
       { $addFields: expect.any(Object) },
       { $match: expect.any(Object) },
       { $addFields: { id: '$_id' } },
+      { $project: { posts: 0 } },
     ]);
   });
 });

--- a/packages/mongo-join-builder/lib/join-builder.js
+++ b/packages/mongo-join-builder/lib/join-builder.js
@@ -76,8 +76,8 @@ function mutation(uid, lookupPath) {
 
 function mutationBuilder(relationships, path = []) {
   return compose(
-    Object.entries(relationships).map(([uid, { field, relationships }]) => {
-      const uniqueField = `${uid}_${field}`;
+    Object.entries(relationships).map(([uid, { relationshipInfo, relationships }]) => {
+      const uniqueField = `${uid}_${relationshipInfo.field}`;
       const postQueryMutations = mutationBuilder(relationships, [...path, uniqueField]);
       // NOTE: Order is important. We want depth first, so we perform the related mutators first.
       return compose([postQueryMutations, mutation(uid, [...path, uniqueField])]);
@@ -86,7 +86,7 @@ function mutationBuilder(relationships, path = []) {
 }
 
 function relationshipPipeline([uid, relationship]) {
-  const { field, many, from } = relationship;
+  const { field, many, from } = relationship.relationshipInfo;
   const uniqueField = `${uid}_${field}`;
   const idsName = `${uniqueField}_id${many ? 's' : ''}`;
   const fieldSize = { $size: `$${uniqueField}` };

--- a/packages/mongo-join-builder/lib/query-parser.js
+++ b/packages/mongo-join-builder/lib/query-parser.js
@@ -39,19 +39,20 @@ function parser({ listAdapter, getUID = cuid }, query, pathSoFar = [], include) 
       } else {
         // A relationship query component
         const uid = getUID(key);
-        const queryAst = relationshipTokenizer(listAdapter, query, key, path, uid);
-        if (getType(queryAst) !== 'Object') {
-          throw new Error(
-            `Must return an Object from 'relationshipTokenizer' function, given ${path.join('.')}`
-          );
-        }
+        const { matchTerm, relationshipInfo } = relationshipTokenizer(
+          listAdapter,
+          query,
+          key,
+          path,
+          uid
+        );
         return {
-          // queryAst.matchTerm is our filtering expression. This determines if the
+          // matchTerm is our filtering expression. This determines if the
           // parent item is included in the final list
-          matchTerm: queryAst.matchTerm,
+          matchTerm,
           postJoinPipeline: [],
           relationships: {
-            [uid]: { ...queryAst, ...parser({ listAdapter, getUID }, value, path) },
+            [uid]: { relationshipInfo, ...parser({ listAdapter, getUID }, value, path) },
           },
         };
       }

--- a/packages/mongo-join-builder/lib/tokenizers.js
+++ b/packages/mongo-join-builder/lib/tokenizers.js
@@ -67,8 +67,6 @@ const relationshipTokenizer = (listAdapter, query, queryKey, path, uid) => {
   }[queryKey];
 
   return {
-    from: fieldAdapter.getRefListAdapter().model.collection.name, // the collection name to join with
-    field: fieldAdapter.path, // The field on this collection
     // The conditions under which an item from the 'orders' collection is
     // considered a match and included in the end result
     // All the keys on an 'order' are available, plus 3 special keys:
@@ -79,8 +77,11 @@ const relationshipTokenizer = (listAdapter, query, queryKey, path, uid) => {
     // 3) <uid>_<field>_none - is `true` when none of the joined items match
     //    the query
     matchTerm: { [`${uid}_${fieldAdapter.path}_${filterType}`]: true },
-    // Flag this is a to-many relationship
-    many: fieldAdapter.field.many,
+    relationshipInfo: {
+      from: fieldAdapter.getRefListAdapter().model.collection.name, // the collection name to join with
+      field: fieldAdapter.path, // The field on this collection
+      many: fieldAdapter.field.many, // Flag this is a to-many relationship
+    },
   };
 };
 

--- a/packages/mongo-join-builder/tests/join-builder.test.js
+++ b/packages/mongo-join-builder/tests/join-builder.test.js
@@ -39,11 +39,13 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         abc123: {
-          from: 'user-collection',
-          field: 'author',
           matchTerm: { name: { $eq: 'Alice' } },
+          relationshipInfo: {
+            from: 'user-collection',
+            field: 'author',
+            many: false,
+          },
           postJoinPipeline: [],
-          many: false,
           relationships: {},
         },
       },
@@ -104,10 +106,12 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         abc123: {
-          from: 'posts-collection',
-          field: 'posts',
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {},
         },
       },
@@ -169,10 +173,12 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         abc123: {
-          from: 'posts-collection',
-          field: 'posts',
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [{ $orderBy: 'title' }],
-          many: true,
           relationships: {},
         },
       },
@@ -244,27 +250,33 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         abc123: {
-          from: 'posts-collection',
-          field: 'posts',
           matchTerm: { $and: [{ title: { $eq: 'hello' } }, { def456_tags_some: { $eq: true } }] },
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {
             def456: {
-              from: 'tags-collection',
-              field: 'tags',
               matchTerm: {
                 $and: [{ name: { $eq: 'React' } }, { xyz890_posts_every: { $eq: true } }],
               },
+              relationshipInfo: {
+                from: 'tags-collection',
+                field: 'tags',
+                many: true,
+              },
               postJoinPipeline: [],
-              many: true,
               relationships: {
                 xyz890: {
-                  from: 'posts-collection',
-                  field: 'posts',
                   matchTerm: { published: { $eq: true } },
+                  relationshipInfo: {
+                    from: 'posts-collection',
+                    field: 'posts',
+                    many: true,
+                  },
                   postJoinPipeline: [],
-                  many: true,
                   relationships: {},
                 },
               },
@@ -385,20 +397,24 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         zip567: {
-          from: 'posts-collection',
-          field: 'posts',
           matchTerm: {
             $and: [{ title: { $eq: 'hello' } }, { quux987_labels_some: { $eq: true } }],
           },
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {
             quux987: {
-              from: 'labels-collection',
-              field: 'labels',
               matchTerm: { name: { $eq: 'foo' } },
+              relationshipInfo: {
+                from: 'labels-collection',
+                field: 'labels',
+                many: true,
+              },
               postJoinPipeline: [],
-              many: true,
               relationships: {},
             },
           },
@@ -494,18 +510,22 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         zip567: {
-          from: 'posts-collection',
-          field: 'posts',
           matchTerm: { $or: [{ title: { $eq: 'hello' } }, { quux987_labels_some: { $eq: true } }] },
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {
             quux987: {
-              from: 'labels-collection',
-              field: 'labels',
               matchTerm: { name: { $eq: 'foo' } },
+              relationshipInfo: {
+                from: 'labels-collection',
+                field: 'labels',
+                many: true,
+              },
               postJoinPipeline: [],
-              many: true,
               relationships: {},
             },
           },
@@ -603,18 +623,23 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         zip567: {
-          from: 'posts-collection',
-          field: 'posts',
           matchTerm: { $or: [{ title: { $eq: 'hello' } }, { quux987_labels_some: { $eq: true } }] },
+
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {
             quux987: {
-              from: 'labels-collection',
-              field: 'labels',
               matchTerm: { name: { $eq: 'foo' } },
+              relationshipInfo: {
+                from: 'labels-collection',
+                field: 'labels',
+                many: true,
+              },
               postJoinPipeline: [],
-              many: true,
               relationships: {},
             },
           },
@@ -712,20 +737,24 @@ describe('join builder', () => {
     const pipeline = pipelineBuilder({
       relationships: {
         zip567: {
-          from: 'posts-collection',
-          field: 'posts',
           matchTerm: {
             $and: [{ title: { $eq: 'hello' } }, { quux987_labels_some: { $eq: true } }],
           },
+          relationshipInfo: {
+            from: 'posts-collection',
+            field: 'posts',
+            many: true,
+          },
           postJoinPipeline: [],
-          many: true,
           relationships: {
             quux987: {
-              from: 'labels-collection',
-              field: 'labels',
               matchTerm: { name: { $eq: 'foo' } },
+              relationshipInfo: {
+                from: 'labels-collection',
+                field: 'labels',
+                many: true,
+              },
               postJoinPipeline: [],
-              many: true,
               relationships: {},
             },
           },
@@ -816,11 +845,14 @@ describe('join builder', () => {
 
     const postQueryMutations = mutationBuilder({
       zip567: {
-        from: 'posts-collection',
-        field: 'posts',
         matchTerm: { title: { $eq: 'hello' } },
+
+        relationshipInfo: {
+          from: 'posts-collection',
+          field: 'posts',
+          many: true,
+        },
         postJoinPipeline: [],
-        many: true,
         relationships: {},
       },
     });

--- a/packages/mongo-join-builder/tests/query-parser.test.js
+++ b/packages/mongo-join-builder/tests/query-parser.test.js
@@ -88,11 +88,13 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts: {
-            from: 'posts',
-            field: 'posts',
             matchTerm: { title: { $eq: 'hello' } },
+            relationshipInfo: {
+              from: 'posts',
+              field: 'posts',
+              many: true,
+            },
             postJoinPipeline: [{ $sort: { title: 1 } }],
-            many: true,
             relationships: {},
           },
         },
@@ -116,11 +118,13 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts: {
-            from: 'posts',
-            field: 'posts',
             matchTerm: { title: { $eq: 'hello' } },
+            relationshipInfo: {
+              from: 'posts',
+              field: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {},
           },
         },
@@ -143,11 +147,13 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts: {
-            from: 'posts',
-            field: 'posts',
             matchTerm: undefined,
+            relationshipInfo: {
+              from: 'posts',
+              field: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {},
           },
         },
@@ -170,11 +176,13 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           company: {
-            from: 'company-collection',
-            field: 'company',
             matchTerm: { name: { $eq: 'hello' } },
+            relationshipInfo: {
+              from: 'company-collection',
+              field: 'company',
+              many: false,
+            },
             postJoinPipeline: [],
-            many: false,
             relationships: {},
           },
         },
@@ -207,27 +215,33 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts_every: {
-            from: 'posts',
-            field: 'posts',
             matchTerm: { $and: [{ title: { $eq: 'hello' } }, { tags_some_tags_some: true }] },
+            relationshipInfo: {
+              from: 'posts',
+              field: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {
               tags_some: {
-                from: 'tags',
-                field: 'tags',
                 matchTerm: {
                   $and: [{ name: { $eq: 'React' } }, { posts_every_posts_every: true }],
                 },
+                relationshipInfo: {
+                  from: 'tags',
+                  field: 'tags',
+                  many: true,
+                },
                 postJoinPipeline: [],
-                many: true,
                 relationships: {
                   posts_every: {
-                    from: 'posts',
-                    field: 'posts',
                     matchTerm: { title: { $eq: 'foo' } },
+                    relationshipInfo: {
+                      from: 'posts',
+                      field: 'posts',
+                      many: true,
+                    },
                     postJoinPipeline: [],
-                    many: true,
                     relationships: {},
                   },
                 },
@@ -260,18 +274,22 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts_every: {
-            field: 'posts',
-            from: 'posts',
             matchTerm: { $and: [{ title: { $eq: 'hello' } }, { tags_some_tags_some: true }] },
+            relationshipInfo: {
+              field: 'posts',
+              from: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {
               tags_some: {
-                field: 'tags',
-                from: 'tags',
                 matchTerm: { name: { $eq: 'foo' } },
+                relationshipInfo: {
+                  field: 'tags',
+                  from: 'tags',
+                  many: true,
+                },
                 postJoinPipeline: [],
-                many: true,
                 relationships: {},
               },
             },
@@ -302,18 +320,22 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts_every: {
-            field: 'posts',
-            from: 'posts',
             matchTerm: { $or: [{ title: { $eq: 'hello' } }, { tags_some_tags_some: true }] },
+            relationshipInfo: {
+              field: 'posts',
+              from: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {
               tags_some: {
-                field: 'tags',
-                from: 'tags',
                 matchTerm: { name: { $eq: 'foo' } },
+                relationshipInfo: {
+                  field: 'tags',
+                  from: 'tags',
+                  many: true,
+                },
                 postJoinPipeline: [],
-                many: true,
                 relationships: {},
               },
             },
@@ -344,18 +366,22 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts_every: {
-            field: 'posts',
-            from: 'posts',
             matchTerm: { $or: [{ title: { $eq: 'hello' } }, { tags_some_tags_some: true }] },
+            relationshipInfo: {
+              field: 'posts',
+              from: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {
               tags_some: {
-                field: 'tags',
-                from: 'tags',
                 matchTerm: { name: { $eq: 'foo' } },
+                relationshipInfo: {
+                  field: 'tags',
+                  from: 'tags',
+                  many: true,
+                },
                 postJoinPipeline: [],
-                many: true,
                 relationships: {},
               },
             },
@@ -386,18 +412,22 @@ describe('query parser', () => {
       expect(queryTree).toMatchObject({
         relationships: {
           posts_every: {
-            field: 'posts',
-            from: 'posts',
             matchTerm: { $and: [{ title: { $eq: 'hello' } }, { tags_some_tags_some: true }] },
+            relationshipInfo: {
+              field: 'posts',
+              from: 'posts',
+              many: true,
+            },
             postJoinPipeline: [],
-            many: true,
             relationships: {
               tags_some: {
-                field: 'tags',
-                from: 'tags',
                 matchTerm: { name: { $eq: 'foo' } },
+                relationshipInfo: {
+                  field: 'tags',
+                  from: 'tags',
+                  many: true,
+                },
                 postJoinPipeline: [],
-                many: true,
                 relationships: {},
               },
             },

--- a/packages/mongo-join-builder/tests/relationship.test.js
+++ b/packages/mongo-join-builder/tests/relationship.test.js
@@ -13,10 +13,12 @@ describe('Relationship tokenizer', () => {
     expect(
       relationshipTokenizer(listAdapter, { name: 'hi' }, 'name', ['name'], 'abc123')
     ).toMatchObject({
-      field: 'name',
-      from: 'name',
       matchTerm: { abc123_name_every: true },
-      many: false,
+      relationshipInfo: {
+        field: 'name',
+        from: 'name',
+        many: false,
+      },
     });
     expect(findFieldAdapterForQuerySegment).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
This refactor groups the `relationshipInfo` fields into an object separate from the `matchTerm` to make it easier to trace through where this group of fields actually gets used. No functional changes.