### PR TITLE
Update Content Field README

### DIFF
--- a/packages/field-content/README.md
+++ b/packages/field-content/README.md
@@ -16,7 +16,11 @@ editing flows.
 
 ## Usage
 
+This package isn't included with the keystone fields package and needs to be installed with yarn add @keystonejs/field-content or npm install @keystonejs/field-content.
+
 ```javascript
+const { Content } = require('@keystonejs/field-content');
+
 keystone.createList('Post', {
   fields: {
     body: {

--- a/packages/field-content/README.md
+++ b/packages/field-content/README.md
@@ -16,7 +16,7 @@ editing flows.
 
 ## Usage
 
-This package isn't included with the keystone fields package and needs to be installed with yarn add @keystonejs/field-content or npm install @keystonejs/field-content.
+This package isn't included with the keystone fields package and needs to be installed with `yarn add @keystonejs/field-content` or `npm install @keystonejs/field-content`.
 
 ```javascript
 const { Content } = require('@keystonejs/field-content');


### PR DESCRIPTION
The README for Content Field should point out that you have to install the `field-content` package separately, the same way the Wysiwig Field docs do.