### PR TITLE
Use tmpVar in generated queries

### DIFF
--- a/.changeset/strong-feet-hug.md
+++ b/.changeset/strong-feet-hug.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/mongo-join-builder': patch
+---
+
+Query generator now uses `tmpVar` rather than a generated variable name in lookup queries.

--- a/packages/mongo-join-builder/README.md
+++ b/packages/mongo-join-builder/README.md
@@ -109,13 +109,11 @@ db.orders.aggregate([
     $lookup: {
       from: 'items',
       as: 'abc123_items',
-      let: {
-        abc123_items_items: '$items',
-      },
+      let: { tmpVar: '$items' },
       pipeline: [
         {
           $match: {
-            $and: [{ name: { $regex: /a/ } }, { $expr: { $in: ['$_id', '$$abc123_items_items'] } }],
+            $and: [{ name: { $regex: /a/ } }, { $expr: { $in: ['$_id', '$$tmpVar'] } }],
           },
         },
         {

--- a/packages/mongo-join-builder/tests/index.test.js
+++ b/packages/mongo-join-builder/tests/index.test.js
@@ -64,16 +64,16 @@ describe('Test main export', () => {
         $lookup: {
           from: 'posts',
           as: 'posts_every_posts',
-          let: { posts_every_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$posts_every_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'tags',
                 as: 'tags_some_tags',
-                let: { tags_some_tags_ids: { $ifNull: ['$tags', []] } },
+                let: { tmpVar: { $ifNull: ['$tags', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$tags_some_tags_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   { $match: { name: { $eq: 'foo' } } },
                   { $addFields: { id: '$_id' } },
                 ],

--- a/packages/mongo-join-builder/tests/join-builder.test.js
+++ b/packages/mongo-join-builder/tests/join-builder.test.js
@@ -68,9 +68,9 @@ describe('join builder', () => {
         $lookup: {
           from: 'user-collection',
           as: 'abc123_author',
-          let: { abc123_author_id: '$author' },
+          let: { tmpVar: '$author' },
           pipeline: [
-            { $match: { $expr: { $eq: ['$_id', '$$abc123_author_id'] } } },
+            { $match: { $expr: { $eq: ['$_id', '$$tmpVar'] } } },
             { $match: { name: { $eq: 'Alice' } } },
             { $addFields: { id: '$_id' } },
           ],
@@ -131,9 +131,9 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'abc123_posts',
-          let: { abc123_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$abc123_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             { $addFields: { id: '$_id' } },
           ],
         },
@@ -193,9 +193,9 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'abc123_posts',
-          let: { abc123_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$abc123_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             { $addFields: { id: '$_id' } },
             { $orderBy: 'title' },
           ],
@@ -305,23 +305,23 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'abc123_posts',
-          let: { abc123_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$abc123_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'tags-collection',
                 as: 'def456_tags',
-                let: { def456_tags_ids: { $ifNull: ['$tags', []] } },
+                let: { tmpVar: { $ifNull: ['$tags', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$def456_tags_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   {
                     $lookup: {
                       from: 'posts-collection',
                       as: 'xyz890_posts',
-                      let: { xyz890_posts_ids: { $ifNull: ['$posts', []] } },
+                      let: { tmpVar: { $ifNull: ['$posts', []] } },
                       pipeline: [
-                        { $match: { $expr: { $in: ['$_id', '$$xyz890_posts_ids'] } } },
+                        { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                         { $match: { published: { $eq: true } } },
                         { $addFields: { id: '$_id' } },
                       ],
@@ -445,16 +445,16 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'zip567_posts',
-          let: { zip567_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$zip567_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'labels-collection',
                 as: 'quux987_labels',
-                let: { quux987_labels_ids: { $ifNull: ['$labels', []] } },
+                let: { tmpVar: { $ifNull: ['$labels', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$quux987_labels_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   { $match: { name: { $eq: 'foo' } } },
                   { $addFields: { id: '$_id' } },
                 ],
@@ -561,16 +561,16 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'zip567_posts',
-          let: { zip567_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$zip567_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'labels-collection',
                 as: 'quux987_labels',
-                let: { quux987_labels_ids: { $ifNull: ['$labels', []] } },
+                let: { tmpVar: { $ifNull: ['$labels', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$quux987_labels_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   {
                     $match: { name: { $eq: 'foo' } },
                   },
@@ -680,16 +680,16 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'zip567_posts',
-          let: { zip567_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$zip567_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'labels-collection',
                 as: 'quux987_labels',
-                let: { quux987_labels_ids: { $ifNull: ['$labels', []] } },
+                let: { tmpVar: { $ifNull: ['$labels', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$quux987_labels_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   {
                     $match: { name: { $eq: 'foo' } },
                   },
@@ -798,16 +798,16 @@ describe('join builder', () => {
         $lookup: {
           from: 'posts-collection',
           as: 'zip567_posts',
-          let: { zip567_posts_ids: { $ifNull: ['$posts', []] } },
+          let: { tmpVar: { $ifNull: ['$posts', []] } },
           pipeline: [
-            { $match: { $expr: { $in: ['$_id', '$$zip567_posts_ids'] } } },
+            { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
             {
               $lookup: {
                 from: 'labels-collection',
                 as: 'quux987_labels',
-                let: { quux987_labels_ids: { $ifNull: ['$labels', []] } },
+                let: { tmpVar: { $ifNull: ['$labels', []] } },
                 pipeline: [
-                  { $match: { $expr: { $in: ['$_id', '$$quux987_labels_ids'] } } },
+                  { $match: { $expr: { $in: ['$_id', '$$tmpVar'] } } },
                   { $match: { name: { $eq: 'foo' } } },
                   { $addFields: { id: '$_id' } },
                 ],


### PR DESCRIPTION
It makes more sense for this field to be generic/anonymous (e.g. `tmpVar`) once we move to generic "foreign key" style joins, so this moves us in that direction.