### PR TITLE
Add ._createTables() method to KnexAdapter

### DIFF
--- a/.changeset/big-moons-train.md
+++ b/.changeset/big-moons-train.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-knex': patch
+---
+
+Added an internal method `_createTables()` to factor out table creation.

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -79,7 +79,10 @@ class KnexAdapter extends BaseKeystoneAdapter {
     } else {
       return [];
     }
+    return this._createTables();
+  }
 
+  async _createTables() {
     const createResult = await pSettle(
       Object.values(this.listAdapters).map(listAdapter => listAdapter.createTable())
     );


### PR DESCRIPTION
This provides an escape hatch until the issue of database init/migration is fully solved.