### PR TITLE
Added support for --name, --adapter and --template CLI arguments for unattended Keystone app creation

### DIFF
--- a/.changeset/chilled-fishes-smoke.md
+++ b/.changeset/chilled-fishes-smoke.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-app': minor
+---
+
+Added CLI arguments to support unattended Keystone app initializations

--- a/packages/create-keystone-app/lib/get-adapter-choice.js
+++ b/packages/create-keystone-app/lib/get-adapter-choice.js
@@ -1,4 +1,5 @@
 const prompts = require('prompts');
+const { getArgs } = require('./get-args');
 const { getExampleProject } = require('./get-example-project');
 
 let ADAPTER_CHOICE;
@@ -8,7 +9,21 @@ const getAdapterChoice = async () => {
   if (ADAPTER_CHOICE) {
     return ADAPTER_CHOICE;
   }
+
   const project = await getExampleProject();
+
+  // If the adapter option was provided via the CLI arguments
+  const args = getArgs();
+  const argValue = args['--adapter'];
+  if (argValue) {
+    if (project.adapters[argValue]) {
+      ADAPTER_CHOICE = project.adapters[argValue];
+      return ADAPTER_CHOICE;
+    }
+    console.error('Invalid --adapter value:', argValue);
+  }
+
+  // Prompt for an adapter
   const choices = Object.keys(project.adapters).map(key => ({
     value: project.adapters[key],
     title: key,

--- a/packages/create-keystone-app/lib/get-args.js
+++ b/packages/create-keystone-app/lib/get-args.js
@@ -8,7 +8,9 @@ const getArgs = () => {
   }
 
   const argsSpec = {
+    '--name': String,
     '--template': String,
+    '--adapter': String,
     '--help': Boolean,
     '--dry-run': Boolean,
     '-h': '--help',

--- a/packages/create-keystone-app/lib/get-example-project.js
+++ b/packages/create-keystone-app/lib/get-example-project.js
@@ -15,7 +15,7 @@ const getExampleProject = async () => {
   const argValue = args['--template'];
   if (argValue) {
     projects.map(project => {
-      if (project.folder == argValue) {
+      if (project.folder === argValue) {
         EXAMPLE_PROJECT_CHOICE = project;
       }
     });

--- a/packages/create-keystone-app/lib/get-example-project.js
+++ b/packages/create-keystone-app/lib/get-example-project.js
@@ -1,13 +1,31 @@
 const prompts = require('prompts');
+const { getArgs } = require('./get-args');
 const { projects } = require('../example-projects/config');
 
 let EXAMPLE_PROJECT_CHOICE;
 
 const getExampleProject = async () => {
+  // If we already have the project template return it
   if (EXAMPLE_PROJECT_CHOICE) {
     return EXAMPLE_PROJECT_CHOICE;
   }
 
+  // If the project template was provided via the CLI arguments
+  const args = getArgs();
+  const argValue = args['--template'];
+  if (argValue) {
+    projects.map(project => {
+      if (project.folder == argValue) {
+        EXAMPLE_PROJECT_CHOICE = project;
+      }
+    });
+    if (EXAMPLE_PROJECT_CHOICE) {
+      return EXAMPLE_PROJECT_CHOICE;
+    }
+    console.error('Invalid --template value:', argValue);
+  }
+
+  // Prompt for an project template
   const choices = projects.map(project => {
     return {
       value: project,

--- a/packages/create-keystone-app/lib/get-project-name.js
+++ b/packages/create-keystone-app/lib/get-project-name.js
@@ -1,4 +1,5 @@
 const prompts = require('prompts');
+const { getArgs } = require('./get-args');
 
 let PROJECT_NAME = null;
 
@@ -8,6 +9,14 @@ const getProjectName = async () => {
     return PROJECT_NAME;
   }
 
+  // If the project name was provided via the CLI arguments
+  const args = getArgs();
+  if (args['--name']) {
+    PROJECT_NAME = args['--name'];
+    return PROJECT_NAME;
+  }
+
+  // Prompt for a project name
   const response = await prompts(
     {
       type: 'text',


### PR DESCRIPTION
Enhanced the create-keastone-app CLI functionality:

* added support for `--name` and `--adapter` CLI arguments
* fixed the unused `--template` CLI argument

The user can now use the following command to create a Keystone application without any prompts (unattended installation).

```bash
create-keystone-app --name "My App" --template "starter" --adapter "Mongoose" my-app
```

or using npm:

```bash
npm init keystone-app --name "My App" --template "starter" --adapter "Mongoose" my-app
```

There are issues with `yarn create` because it does not pass the arguments to create-keystone-app:

```bash
# NOT WORKING
yarn create keystone-app --name "My App" --template "starter" --adapter "Mongoose" my-app
```