### PR TITLE
Refactor PasswordAuthStrategy internals

### DIFF
--- a/.changeset/wild-students-shake.md
+++ b/.changeset/wild-students-shake.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/auth-password': patch
+---
+
+Refactor code internals to make code paths clearer.


### PR DESCRIPTION
I've prefixed the helper methods with an underscore to indicate that they're not part of any kind of public API, but for power users they can dig in and use these until such time as we choose to change them up. 