### PR TITLE
Updated README.md

### DIFF
--- a/packages/auth-password/README.md
+++ b/packages/auth-password/README.md
@@ -45,8 +45,8 @@ app.post('/admin/signin', async (req, res) => {
   const password = req.body.password;
 
   const result = await this.authStrategy.validate({
-    identity: username,
-    secret: password,
+    username,
+    password,
   });
 
   if (result.success) {


### PR DESCRIPTION
The keys in the object passed to authStrategy.validate() should match the actual field names, instead of hard-coded as `identity` and `secret`.