### PR TITLE
Don't call postRead hooks on the result of the internal delete function

### DIFF
--- a/.changeset/lucky-apples-warn.md
+++ b/.changeset/lucky-apples-warn.md
@@ -2,4 +2,4 @@
 '@keystonejs/keystone': patch
 ---
 
-Removing unnecessary calls to field type postRead hooks on delete operations
+Removing unnecessary calls to field type postRead hooks on delete operations. The internal _delete() functions provide by the DB adapter now return a count of the records removed.

--- a/.changeset/lucky-apples-warn.md
+++ b/.changeset/lucky-apples-warn.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Removing unnecessary calls to field type postRead hooks on delete operations

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -181,7 +181,7 @@ class MongooseListAdapter extends BaseListAdapter {
   }
 
   _delete(id) {
-    return this.model.findByIdAndRemove(id);
+    return this.model.deleteOne({ _id: id }).then(result => result.deletedCount);
   }
 
   _update(id, data) {

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -113,7 +113,7 @@ class BaseListAdapter {
   }
 
   async delete(id) {
-    return this.onPostRead(this._delete(id));
+    return this._delete(id);
   }
 
   async update(id, data) {


### PR DESCRIPTION
Ok, this is a fun one.

When the abstract `BaseListAdapter` class invokes the `_delete()` operation on its child class (the concrete database adapter), it doesn't need to then run the `postRead` hooks (contributed by the field types used).

Delete's aren't reads. The delete operation(s) _do_ read the item(s) they're about to delete but if you look at the implementation in the `List` class, you'll see this happens before the delete itself kicks off -- the item read is needed for things like the `beforeDelete` hooks, etc. so it's done first thing. The `postRead` hooks on the field types are correctly applied at this time.

When we come to actually remove the item from the DB, there's no reason to re-read the item, so no reason to call the `postRead` hooks.

---

Right now, the Mongoose adapters internal `_delete()` function _does_ return the item...

```js
return this.model.findByIdAndRemove(id);
```

While the Knex adapter function for the same _does not_...

```js
return this._query().table(this.tableName).where({ id }).del();
```

Because the `BaseListAdapter` invokes the `postRead` hooks on the result (which in Knex's case will be the number of records affected), **items from lists containing field types that use `postRead` hooks can't be deleted on Knex**. 

The practical example of this is the core `DateTime` field type, which uses a `postRead` hook to re-pack its UTC value and offset into a single value. This surfaces as an error like:

```
Cannot use 'in' operator to search for 'updatedAt_utc' in 1
```