### PR TITLE
Add type="date" on TextDayPicker (html5 date picker)

### DIFF
--- a/packages/arch/packages/day-picker/src/TextDayPicker.js
+++ b/packages/arch/packages/day-picker/src/TextDayPicker.js
@@ -19,6 +19,7 @@ export const TextDayPicker = ({
 
   return (
     <Input
+      type="date"
       value={value}
       placeholder="Enter a date..."
       onBlur={() => {


### PR DESCRIPTION
This is very basic, but for those who can't wait for a better date picker, the browser native do the job.