### PR TITLE
Fixed invalid argument dereference in Virtual Field

### DIFF
--- a/.changeset/modern-cats-trade.md
+++ b/.changeset/modern-cats-trade.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed invalid argument dereference in Virtual Field

--- a/packages/fields/src/types/Virtual/views/Field.js
+++ b/packages/fields/src/types/Virtual/views/Field.js
@@ -34,7 +34,7 @@ export const FieldLabel = props => {
 };
 
 const VirtualField = ({ field, errors, value: serverValue }) => {
-  const value = typeof serverValue !== 'undefined' ? value : '';
+  const value = typeof serverValue !== 'undefined' ? serverValue : '';
   const canRead = errors.every(
     error => !(error instanceof Error && error.name === 'AccessDeniedError')
   );


### PR DESCRIPTION
`value` was being used before it was defined resulting in a broken admin-ui.