### PR TITLE
Admin UI: fixed some minor issues when deleting items

### DIFF
--- a/.changeset/light-planets-breathe.md
+++ b/.changeset/light-planets-breathe.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Resolved two history issues when deleting items:
+- Fixed being able to go back to a now-invalid item entry
+- Fixed being able to remain on an item page even after it was deleted if it had unsaved data at the time.

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -121,7 +121,7 @@ const ItemDetails = ({
           setShowDeleteModal(false);
         }
 
-        history.push(`${adminPath}/${list.path}`);
+        history.replace(`${adminPath}/${list.path}`);
         toastItemSuccess({ addToast }, initialData, 'Deleted successfully');
       })
       .catch(error => {

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -76,6 +76,7 @@ const ItemDetails = ({
 
   const itemHasChanged = useRef(false);
   const itemSaveCheckCache = useRef({});
+  const deleteConfirmed = useRef(false);
 
   const history = useHistory();
   const { addToast } = useToasts();
@@ -115,6 +116,7 @@ const ItemDetails = ({
   };
 
   const onDelete = deletePromise => {
+    deleteConfirmed.current = true;
     deletePromise
       .then(() => {
         if (mounted) {
@@ -251,7 +253,7 @@ const ItemDetails = ({
 
   return (
     <Fragment>
-      {itemHasChanged.current && <PreventNavigation />}
+      {itemHasChanged.current && !deleteConfirmed.current && <PreventNavigation />}
       <ItemTitle id={item.id} list={list} adminPath={adminPath} titleText={initialData._label_} />
       <Card css={{ marginBottom: '3em', paddingBottom: 0 }}>
         <Form>


### PR DESCRIPTION
Resolved two history issues when deleting items:
- Fixed being able to go back to a now-invalid item entry
- Fixed being able to remain on an item page even after it was deleted if it had unsaved data at the time.