### PR TITLE
Admin UI: fixed everything breaking en-route to Item Not Found

### DIFF
--- a/.changeset/late-mayflies-dream.md
+++ b/.changeset/late-mayflies-dream.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed fatal errors when attempting to view a nonexistant item.

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -409,7 +409,15 @@ const ItemPage = ({ list, itemId, adminPath, getListByKey }) => {
     // Deserialising requires the field be loaded and also any of its
     // deserialisation dependencies (eg; the Content field relies on the Blocks
     // being loaded), so it too could suspend here.
-    () => deserializeItem(list, loading || !data ? {} : data[list.gqlNames.itemQueryName]),
+    () =>
+      deserializeItem(
+        list,
+        loading || !data
+          ? {}
+          : data[list.gqlNames.itemQueryName]
+          ? data[list.gqlNames.itemQueryName]
+          : {}
+      ),
   ]);
 
   // If the views load before the API request comes back, keep showing


### PR DESCRIPTION
Without this, you get fatal console errors when attempting to view a nonexistent *item*. Nonexistent lists properly showed an error.