### PR TITLE
Admin UI: fixed an error when creating an item with a valueless required field

### DIFF
--- a/.changeset/silver-peaches-care.md
+++ b/.changeset/silver-peaches-care.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed an error when creating an item with a valueless required field.

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -73,6 +73,7 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
     }
 
     createItem({ variables: { data } }).then(data => {
+      if (!data) return;
       closeCreateItemModal();
       setItem(list.getInitialItemData({}));
       if (onCreate) {


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/3558659/75035038-a97c1b80-5502-11ea-9495-1c649767dde5.png)

Also fixes the Create drawer closing despite the validation failure.