### PR TITLE
Update Documentation: Temporarily add schemaNames param to allow user success

### DIFF
--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -74,7 +74,7 @@ keystone.createList('Foo', {
 
 // ---- Schema dumping ----
 if (typeof process.env.DUMP_SCHEMA === 'string') {
-  keystone.dumpSchema(process.env.DUMP_SCHEMA);
+  keystone.dumpSchema(process.env.DUMP_SCHEMA, keystone._schemaNames);
   console.log(`Schema dumped to: ${path.resolve(process.env.DUMP_SCHEMA)}`);
   process.exit(0);
 }

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -74,7 +74,8 @@ keystone.createList('Foo', {
 
 // ---- Schema dumping ----
 if (typeof process.env.DUMP_SCHEMA === 'string') {
-  keystone.dumpSchema(process.env.DUMP_SCHEMA, keystone._schemaNames);
+  const schemaName = 'public'; //this is the default keystonejs schema name
+  keystone.dumpSchema(process.env.DUMP_SCHEMA, schemaName);
   console.log(`Schema dumped to: ${path.resolve(process.env.DUMP_SCHEMA)}`);
   process.exit(0);
 }


### PR DESCRIPTION
This function no longer works without schemaName/s passed in. This change will allow users to successfully run the `dumpSchema` command per the documentation.

This should be superseded by a change to `keystone.dumpSchema` to read this value by default.