### PR TITLE
Fixed filter for Select Field multiple value filter

### DIFF
--- a/.changeset/curvy-rabbits-brake.md
+++ b/.changeset/curvy-rabbits-brake.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Fixed Select field filter when there are multiple values, generated GraphQL query did not include the `[]` in case of multi value filter.
+Enabled selection of multiple options in Filter for Select type fields. This also disables use of filter with empty values, you can not apply new filter if none of the options are selected. Can not deselect last filter item when adding or editing.

--- a/.changeset/curvy-rabbits-brake.md
+++ b/.changeset/curvy-rabbits-brake.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed Select field filter when there are multiple values, generated GraphQL query did not include the `[]` in case of multi value filter.

--- a/.changeset/loud-dryers-compare.md
+++ b/.changeset/loud-dryers-compare.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Enabled selection of multiple options in Filter for Select type fields.
+
+This also disables use of filter with empty values, you can not apply new filter if none of the options are selected. Can not deselect last filter item when adding or editing.

--- a/.changeset/loud-dryers-compare.md
+++ b/.changeset/loud-dryers-compare.md
@@ -1,7 +1,0 @@
----
-'@keystonejs/app-admin-ui': patch
----
-
-Enabled selection of multiple options in Filter for Select type fields.
-
-This also disables use of filter with empty values, you can not apply new filter if none of the options are selected. Can not deselect last filter item when adding or editing.

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -181,7 +181,7 @@ export default class AddFilterPopout extends Component<Props, State> {
     const { field, filter, value } = this.state;
 
     event.preventDefault();
-    if (!filter || value === null) return;
+    if (!filter || value === null || field.getFilterValue(value) === null) return;
 
     onChange({ field, label: filter.label, type: filter.type, value });
   };

--- a/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -12,7 +12,7 @@ export default class EditFilterPopout extends Component {
   onSubmit = () => {
     const { filter, onChange } = this.props;
     const { value } = this.state;
-    if (value === null) return;
+    if (value === null || filter.field.getFilterValue(value) === null) return;
     onChange({
       field: filter.field,
       label: filter.label,

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -121,4 +121,5 @@ export default class FieldController {
   };
 
   getFilterTypes = () => [];
+  getFilterValue = value => value;
 }

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -19,7 +19,7 @@ export default class SelectController extends FieldController {
       key = `${this.path}_not`;
     }
 
-    const value = isMulti ? options.map(x => x.value).join(',') : options[0].value;
+    const value = isMulti ? `[${options.map(x => x.value).join(',')}]` : options[0].value;
 
     return this.dataType === 'string' ? `${key}: "${value}"` : `${key}: ${value}`;
   };

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -8,6 +8,10 @@ export default class SelectController extends FieldController {
     this.dataType = config.dataType;
   }
   getFilterGraphQL = ({ value: { inverted, options } }) => {
+    if (!options.length) {
+      return '';
+    }
+
     const isMulti = options.length > 1;
 
     let key = this.path;
@@ -40,6 +44,9 @@ export default class SelectController extends FieldController {
     return value.inverted
       ? `${this.label} is not ${optionLabel}`
       : `${this.label} is ${optionLabel}`;
+  };
+  getFilterValue = value => {
+    return value && value.options && value.options.length ? value : null;
   };
   getFilterTypes = () => [
     {

--- a/packages/fields/src/types/Select/views/Filter.js
+++ b/packages/fields/src/types/Select/views/Filter.js
@@ -25,9 +25,10 @@ const SelectFilterView = ({ innerRef, field, value, onChange }) => {
   };
 
   const handleSelectChange = newValue => {
-    if (newValue.length == 0) return;
-    const options = [].concat(newValue); // ensure consistent data shape
-    onChange({ ...value, options });
+    if (newValue.length) {
+      const options = [...newValue]; // ensure consistent data shape
+      onChange({ ...value, options });
+    }
   };
 
   const radioValue = value.inverted ? 'does_not_match' : 'does_match';

--- a/packages/fields/src/types/Select/views/Filter.js
+++ b/packages/fields/src/types/Select/views/Filter.js
@@ -37,6 +37,7 @@ const SelectFilterView = ({ innerRef, field, value, onChange }) => {
     options: field.options,
     placeholder: 'Select...',
     value: value.options,
+    isMulti: true,
   };
 
   return (

--- a/packages/fields/src/types/Select/views/Filter.js
+++ b/packages/fields/src/types/Select/views/Filter.js
@@ -25,6 +25,7 @@ const SelectFilterView = ({ innerRef, field, value, onChange }) => {
   };
 
   const handleSelectChange = newValue => {
+    if (newValue.length == 0) return;
     const options = [].concat(newValue); // ensure consistent data shape
     onChange({ ...value, options });
   };


### PR DESCRIPTION
UI can only allow selection of single value in Matches or not matches, it should actually be multi select 

this PR only fixes generation of graphql query when setSearch is used with multiple values manually, another PR may fix the UI part,

example on how it works

![image](https://user-images.githubusercontent.com/5769869/75374501-6e0e9200-58f2-11ea-8e20-4185bd5d04c1.png)

Update: Also fixed multi select for the Filter popout

![image](https://user-images.githubusercontent.com/5769869/75384133-9ce13400-5903-11ea-904a-360c0ccf61c4.png)

* Can now select multiple value for the filter for Select field. 
* Can hit apply with no value selected which does nothing (equivalent to cancel)
* Can not deselect all options to prevent incorrect behavior, idle situation would be to have filter error state and disable "Apply" button, but that is large change. 
  - you can still cancel out or clear filter using pill clear button.
