### PR TITLE
Added listView option for persisted url state

### DIFF
--- a/.changeset/fuzzy-apples-perform.md
+++ b/.changeset/fuzzy-apples-perform.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Made internal changes to allow separate key for persisted list ui state (search/filter/column etc.) when composing custom pages using admin-ui components.
+
+when you compose using `List` component, you can now add `listView='some string'` to separate config from one rendering to another.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -143,10 +143,10 @@ export default class List {
     const count = Array.isArray(items) ? items.length : items;
     return count === 1 ? `1 ${this.singular}` : `${count} ${this.plural}`;
   }
-  getPersistedSearch() {
-    return localStorage.getItem(`search:${this.config.path}`);
+  getPersistedSearch(listView = '') {
+    return localStorage.getItem(`search:${this.config.path}${listView ? `:${listView}` : ''}`);
   }
-  setPersistedSearch(value) {
-    localStorage.setItem(`search:${this.config.path}`, value);
+  setPersistedSearch(value, listView = '') {
+    localStorage.setItem(`search:${this.config.path}${listView ? `:${listView}` : ''}`, value);
   }
 }

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -300,6 +300,7 @@ export default function ListTable(props) {
     items,
     queryErrors = [],
     list,
+    listView,
     onChange,
     onSelectChange,
     selectedItems,
@@ -310,7 +311,7 @@ export default function ListTable(props) {
     linkField = '_label_',
   } = props;
 
-  const [sortBy, onSortChange] = useListSort(list.key);
+  const [sortBy, onSortChange] = useListSort(list.key, listView);
 
   const handleSelectAll = () => {
     const allSelected = items && items.length === selectedItems.length;

--- a/packages/app-admin-ui/client/components/NoResults.js
+++ b/packages/app-admin-ui/client/components/NoResults.js
@@ -27,8 +27,8 @@ const NoResultsWrapper = ({ children, ...props }) => (
   </div>
 );
 
-export const NoResults = ({ currentPage, filters, list, search }) => {
-  const { onChange } = useListPagination(list.key);
+export const NoResults = ({ currentPage, filters, list, search, listView }) => {
+  const { onChange } = useListPagination(list.key, listView);
   const onResetPage = () => onChange(1);
 
   const pageDepthMessage = (

--- a/packages/app-admin-ui/client/pages/List/ColumnSelect.js
+++ b/packages/app-admin-ui/client/pages/List/ColumnSelect.js
@@ -11,9 +11,9 @@ type Props = {
   listKey: string,
 };
 
-export default function ColumnPopout({ listKey, target }: Props) {
+export default function ColumnPopout({ listKey, target, listView }: Props) {
   const list = useList(listKey);
-  const [columns, handleColumnChange] = useListColumns(listKey);
+  const [columns, handleColumnChange] = useListColumns(listKey, listView);
   const cypresSelectId = 'ks-column-select';
 
   return (

--- a/packages/app-admin-ui/client/pages/List/Filters/ActiveFilters.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/ActiveFilters.js
@@ -16,8 +16,8 @@ export const elementOffsetStyles = {
   marginRight: gridSize / 2,
 };
 
-export default function ActiveFilters({ list }) {
-  const { filters, onAdd, onRemove, onRemoveAll, onUpdate } = useListFilter(list.key);
+export default function ActiveFilters({ list, listView }) {
+  const { filters, onAdd, onRemove, onRemoveAll, onUpdate } = useListFilter(list.key, listView);
 
   return (
     <Fragment>

--- a/packages/app-admin-ui/client/pages/List/Pagination.js
+++ b/packages/app-admin-ui/client/pages/List/Pagination.js
@@ -6,8 +6,8 @@ import { useListPagination } from './dataHooks';
 
 const CYPRESS_TEST_ID = 'ks-pagination';
 
-export default function ListPagination({ isLoading, listKey }) {
-  const { data, onChange } = useListPagination(listKey);
+export default function ListPagination({ isLoading, listKey, listView }) {
+  const { data, onChange } = useListPagination(listKey, listView);
 
   return (
     <Pagination

--- a/packages/app-admin-ui/client/pages/List/SortSelect.js
+++ b/packages/app-admin-ui/client/pages/List/SortSelect.js
@@ -15,9 +15,9 @@ type Props = {
   listKey: string,
 };
 
-export default function SortPopout({ listKey }: Props) {
+export default function SortPopout({ listKey, listView }: Props) {
   const list = useList(listKey);
-  const [sortValue, handleSortChange] = useListSort(listKey);
+  const [sortValue, handleSortChange] = useListSort(listKey, listView);
   const altIsDown = useKeyDown('Alt');
   const popoutRef = useRef();
 

--- a/packages/app-admin-ui/client/pages/List/dataHooks.js
+++ b/packages/app-admin-ui/client/pages/List/dataHooks.js
@@ -95,7 +95,7 @@ export function useListQuery(listKey) {
  * @returns {function} setSearch - Used for internal hooks to modify the URL
  */
 
-export function useListModifier(listKey) {
+export function useListModifier(listKey, listView) {
   const history = useHistory();
   const location = useLocation();
   const list = useList(listKey);
@@ -108,7 +108,7 @@ export function useListModifier(listKey) {
    * @param {boolean} addHistoryRecord - whether to add an item to history, or not
    * @returns {undefined}
    */
-  return function setSearch(changes, addHistoryRecord = true, listView = '') {
+  return function setSearch(changes, addHistoryRecord = true, overrideListView) {
     let overrides = {};
 
     // NOTE: some changes should reset the currentPage number to 1.
@@ -122,7 +122,7 @@ export function useListModifier(listKey) {
     const encodedSearch = encodeSearch({ ...urlState, ...changes, ...overrides }, decodeConfig);
     const newLocation = { ...location, search: encodedSearch };
 
-    list.setPersistedSearch(encodedSearch, listView);
+    list.setPersistedSearch(encodedSearch, overrideListView || listView);
 
     if (addHistoryRecord) {
       history.push(newLocation);
@@ -170,9 +170,9 @@ export function useListItems(listKey) {
  * @returns {Function} - The function to reset url state
  */
 
-export function useReset(listKey) {
+export function useReset(listKey, listView) {
   const { decodeConfig } = useListUrlState(listKey);
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
 
   return () => setSearch(decodeSearch('', decodeConfig));
 }
@@ -188,10 +188,10 @@ export function useReset(listKey) {
  * - onSubmit - commit the current search to history and update the URL
  */
 
-export function useListSearch(listKey) {
+export function useListSearch(listKey, listView) {
   const { urlState } = useListUrlState(listKey);
   const { search: searchValue } = urlState;
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
   const { items } = useListItems(listKey);
   const history = useHistory();
   const match = useRouteMatch();
@@ -248,10 +248,10 @@ export function useListSearch(listKey) {
 //   value: any,
 // }>
 
-export function useListFilter(listKey) {
+export function useListFilter(listKey, listView) {
   const { urlState } = useListUrlState(listKey);
   const { filters } = urlState;
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
 
   const onRemove = value => () => {
     const newFilters = filters.filter(f => {
@@ -296,10 +296,10 @@ export function useListFilter(listKey) {
 //   pageSize: numnber,
 // }
 
-export function useListPagination(listKey) {
+export function useListPagination(listKey, listView) {
   const { urlState } = useListUrlState(listKey);
   const { currentPage, pageSize } = urlState;
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
   const { itemCount } = useListItems(listKey);
 
   const onChange = cp => {
@@ -334,10 +334,10 @@ export function useListPagination(listKey) {
 //   field: { label: string, path: string },
 // };
 
-export function useListSort(listKey) {
+export function useListSort(listKey, listView) {
   const { urlState } = useListUrlState(listKey);
   const { sortBy } = urlState;
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
 
   const onChange = sb => {
     setSearch({ sortBy: sb });
@@ -357,11 +357,11 @@ export function useListSort(listKey) {
 
 // type Fields = Array<FieldController>;
 
-export function useListColumns(listKey) {
+export function useListColumns(listKey, listView) {
   const list = useList(listKey);
   const { urlState } = useListUrlState(listKey);
   const { fields } = urlState;
-  const setSearch = useListModifier(listKey);
+  const setSearch = useListModifier(listKey, listView);
 
   const onChange = selectedFields => {
     // Ensure that the displayed fields maintain their original sortDirection

--- a/packages/app-admin-ui/client/pages/List/dataHooks.js
+++ b/packages/app-admin-ui/client/pages/List/dataHooks.js
@@ -108,7 +108,7 @@ export function useListModifier(listKey) {
    * @param {boolean} addHistoryRecord - whether to add an item to history, or not
    * @returns {undefined}
    */
-  return function setSearch(changes, addHistoryRecord = true) {
+  return function setSearch(changes, addHistoryRecord = true, listView = '') {
     let overrides = {};
 
     // NOTE: some changes should reset the currentPage number to 1.
@@ -122,7 +122,7 @@ export function useListModifier(listKey) {
     const encodedSearch = encodeSearch({ ...urlState, ...changes, ...overrides }, decodeConfig);
     const newLocation = { ...location, search: encodedSearch };
 
-    list.setPersistedSearch(encodedSearch);
+    list.setPersistedSearch(encodedSearch, listView);
 
     if (addHistoryRecord) {
       history.push(newLocation);

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -38,12 +38,12 @@ const HeaderInset = props => (
 );
 
 export function ListLayout(props) {
-  const { items, itemCount, queryErrors, routeProps, query, listView = '' } = props;
+  const { items, itemCount, queryErrors, routeProps, query, listView } = props;
   const measureElementRef = useRef();
   const { list, openCreateItemModal } = useList();
   const { urlState } = useListUrlState(list.key);
-  const { filters } = useListFilter(list.key);
-  const [sortBy, handleSortChange] = useListSort(list.key);
+  const { filters } = useListFilter(list.key, listView);
+  const [sortBy, handleSortChange] = useListSort(list.key, listView);
 
   const { adminPath } = useAdminMeta();
   const { history, location } = routeProps;
@@ -130,7 +130,7 @@ export function ListLayout(props) {
                 }}
               </Render>
             </Suspense>
-            <ActiveFilters list={list} />
+            <ActiveFilters list={list} listView={listView} />
           </div>
 
           <ManageToolbar isVisible css={{ marginLeft: 2 }}>
@@ -167,7 +167,7 @@ export function ListLayout(props) {
                   {sortBy ? (
                     <Fragment>
                       <span css={{ paddingLeft: '0.5ex' }}>sorted by</span>
-                      <SortPopout listKey={list.key} />
+                      <SortPopout listKey={list.key} listView={listView} />
                     </Fragment>
                   ) : (
                     ''
@@ -175,6 +175,7 @@ export function ListLayout(props) {
                   <span css={{ paddingLeft: '0.5ex' }}>with</span>
                   <ColumnPopout
                     listKey={list.key}
+                    listView={listView}
                     target={handlers => (
                       <Button
                         variant="subtle"
@@ -198,7 +199,13 @@ export function ListLayout(props) {
                             .filter(field => field.path !== '_label_')
                             .map(field => () => field.initCellView())
                         );
-                        return <Pagination listKey={list.key} isLoading={query.loading} />;
+                        return (
+                          <Pagination
+                            listKey={list.key}
+                            listView={listView}
+                            isLoading={query.loading}
+                          />
+                        );
                       }}
                     </Render>
                   </Suspense>
@@ -218,6 +225,7 @@ export function ListLayout(props) {
           columnControl={
             <ColumnPopout
               listKey={list.key}
+              listView={listView}
               target={handlers => (
                 <Tooltip placement="top" content="Columns">
                   {ref => (
@@ -258,7 +266,7 @@ export function ListLayout(props) {
 }
 
 export function List(props) {
-  const { list, query, routeProps, listView = '' } = props;
+  const { list, query, routeProps, listView } = props;
 
   // get item data
   const items = query.data && query.data[list.gqlNames.listQueryName];

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -38,7 +38,7 @@ const HeaderInset = props => (
 );
 
 export function ListLayout(props) {
-  const { items, itemCount, queryErrors, routeProps, query } = props;
+  const { items, itemCount, queryErrors, routeProps, query, listView = '' } = props;
   const measureElementRef = useRef();
   const { list, openCreateItemModal } = useList();
   const { urlState } = useListUrlState(list.key);
@@ -54,11 +54,11 @@ export function ListLayout(props) {
   // Mount with Persisted Search
   // ------------------------------
   useEffect(() => {
-    const maybePersistedSearch = list.getPersistedSearch();
+    const maybePersistedSearch = list.getPersistedSearch(listView);
 
     if (location.search) {
       if (location.search !== maybePersistedSearch) {
-        list.setPersistedSearch(location.search);
+        list.setPersistedSearch(location.search, listView);
       }
     } else if (maybePersistedSearch) {
       history.replace({
@@ -258,7 +258,7 @@ export function ListLayout(props) {
 }
 
 export function List(props) {
-  const { list, query, routeProps } = props;
+  const { list, query, routeProps, listView = '' } = props;
 
   // get item data
   const items = query.data && query.data[list.gqlNames.listQueryName];
@@ -273,11 +273,11 @@ export function List(props) {
   // Mount with Persisted Search
   // ------------------------------
   useEffect(() => {
-    const maybePersistedSearch = list.getPersistedSearch();
+    const maybePersistedSearch = list.getPersistedSearch(listView);
 
     if (location.search) {
       if (location.search !== maybePersistedSearch) {
-        list.setPersistedSearch(location.search);
+        list.setPersistedSearch(location.search, listView);
       }
     } else if (maybePersistedSearch) {
       history.replace({


### PR DESCRIPTION
Internal changes on key name for persisted config names. 

in general no one should be affected unless composing custom pages based on admin-ui components

### **Why do I need it**
I have followed a strategy where I compose custom pages by using existing admin-ui components. I have multiple custom pages which is kind of filtered view for same list. having same persisted search/filter/url-state/config is frustrating, as soon as you change a filter on one page it changes everywhere. 

with this change , default behavior does not changes unless you add `listView='name'` for different component affected and/or the list data-hooks. when you add a value for `listView` then it appends this string in local storage and no more same list state on all pages.

I named it `listView`, please suggest better name if needed. 