### PR TITLE
Providers 6/n: Auth list provider

### DIFF
--- a/.changeset/plenty-pandas-smoke.md
+++ b/.changeset/plenty-pandas-smoke.md
@@ -1,0 +1,17 @@
+---
+'@keystonejs/keystone': major
+---
+
+Introduced `ListAuthProvider` to generate authentication mutations and queries. This introduces the following breaking changes:
+ * `Keystone.createAuthStrategy()` must be called *after* the associated `List` has been created.
+ * `List.hasAuth()` has been removed.
+ * `List.getAuth()` has been removed.
+ * `List.gqlNames.authenticatedQueryName` has been removed.
+ * `List.gqlNames.authenticateMutationPrefix` has been removed.
+ * `List.gqlNames.unauthenticateMutationName` has been removed.
+ * `List.gqlNames.authenticateOutputName` has been removed.
+ * `List.gqlNames.unauthenticateOutputName` has been removed.
+ * `List.checkAuthAccess()` has been removed.
+ * `List.authenticatedQuery()` has been removed.
+ * `List.authenticateMutation()` has been removed.
+ * `List.unauthenticateMutation()` has been removed.

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -24,15 +24,15 @@ const keystone = new Keystone({
   },
 });
 
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
-});
-
 keystone.createList('User', User);
 keystone.createList('Post', Post);
 keystone.createList('PostCategory', PostCategory);
 keystone.createList('Comment', Comment);
+
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
+});
 
 const adminApp = new AdminUIApp({
   adminPath: '/admin',

--- a/demo-projects/meetup/index.js
+++ b/demo-projects/meetup/index.js
@@ -18,11 +18,6 @@ const keystone = new Keystone({
   onConnect: initialiseData,
 });
 
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
-});
-
 keystone.createList('Event', Event);
 keystone.createList('Rsvp', Rsvp);
 keystone.createList('Talk', Talk);
@@ -30,6 +25,11 @@ keystone.createList('User', User);
 keystone.createList('Organiser', Organiser);
 keystone.createList('Sponsor', Sponsor);
 keystone.createList('ForgottenPasswordToken', ForgottenPasswordToken);
+
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
+});
 
 const adminApp = new AdminUIApp({
   adminPath: '/admin',

--- a/packages/keystone/lib/providers/index.js
+++ b/packages/keystone/lib/providers/index.js
@@ -1,4 +1,5 @@
 const { CustomProvider } = require('./custom');
+const { ListAuthProvider } = require('./listAuth');
 const { VersionProvider } = require('./version');
 
 // The GraphQL Provider Framework expects to see classes with the following API:
@@ -27,4 +28,4 @@ const { VersionProvider } = require('./version');
 //   }
 // }
 
-module.exports = { CustomProvider, VersionProvider };
+module.exports = { CustomProvider, ListAuthProvider, VersionProvider };

--- a/packages/keystone/lib/providers/listAuth.js
+++ b/packages/keystone/lib/providers/listAuth.js
@@ -1,0 +1,152 @@
+const { mergeWhereClause } = require('@keystonejs/utils');
+const { logger } = require('@keystonejs/logger');
+
+const { throwAccessDenied } = require('../List/graphqlErrors');
+
+const graphqlLogger = logger('graphql');
+
+const upcase = str => str.substr(0, 1).toUpperCase() + str.substr(1);
+
+class ListAuthProvider {
+  constructor({ authStrategy, list }) {
+    this.authStrategy = authStrategy;
+    this.list = list;
+    this.access = list.access;
+    const { outputTypeName, itemQueryName } = list.gqlNames;
+    this.gqlNames = {
+      outputTypeName,
+      authenticatedQueryName: `authenticated${itemQueryName}`,
+      authenticateMutationName: `authenticate${itemQueryName}With${upcase(authStrategy.authType)}`,
+      unauthenticateMutationName: `unauthenticate${itemQueryName}`,
+      authenticateOutputName: `authenticate${itemQueryName}Output`,
+      unauthenticateOutputName: `unauthenticate${itemQueryName}Output`,
+    };
+  }
+
+  getTypes({ schemaName }) {
+    if (!this.access[schemaName].auth) return [];
+    const { unauthenticateOutputName, authenticateOutputName, outputTypeName } = this.gqlNames;
+    return [
+      `
+        type ${unauthenticateOutputName} {
+          """
+          \`true\` when unauthentication succeeds.
+          NOTE: unauthentication always succeeds when the request has an invalid or missing authentication token.
+          """
+          success: Boolean
+        }
+      `,
+      `
+        type ${authenticateOutputName} {
+          """ Used to make subsequent authenticated requests by setting this token in a header: 'Authorization: Bearer <token>'. """
+          token: String
+          """ Retrieve information on the newly authenticated ${outputTypeName} here. """
+          item: ${outputTypeName}
+        }
+      `,
+    ];
+  }
+  getQueries({ schemaName }) {
+    if (!this.access[schemaName].auth) return [];
+    const { authenticatedQueryName, outputTypeName } = this.gqlNames;
+    return [`${authenticatedQueryName}: ${outputTypeName}`];
+  }
+  getMutations({ schemaName }) {
+    if (!this.access[schemaName].auth) return [];
+    const {
+      authenticateMutationName,
+      authenticateOutputName,
+      unauthenticateMutationName,
+      unauthenticateOutputName,
+      outputTypeName,
+    } = this.gqlNames;
+    const { authStrategy } = this;
+    const authTypeTitleCase = upcase(authStrategy.authType);
+    return [
+      `""" Authenticate and generate a token for a ${outputTypeName} with the ${authTypeTitleCase} Authentication Strategy. """
+        ${authenticateMutationName}(${authStrategy.getInputFragment()}): ${authenticateOutputName}
+      `,
+      `${unauthenticateMutationName}: ${unauthenticateOutputName}`,
+    ];
+  }
+
+  getTypeResolvers({}) {
+    return {};
+  }
+  getQueryResolvers({ schemaName }) {
+    if (!this.access[schemaName].auth) return {};
+    const { authenticatedQueryName } = this.gqlNames;
+    return {
+      [authenticatedQueryName]: (_, __, context, info) => this._authenticatedQuery(context, info),
+    };
+  }
+  getMutationResolvers({ schemaName }) {
+    if (!this.access[schemaName].auth) return {};
+    const { authenticateMutationName, unauthenticateMutationName } = this.gqlNames;
+    return {
+      [authenticateMutationName]: (_, args, context) => this._authenticateMutation(args, context),
+      [unauthenticateMutationName]: (_, __, context) => this._unauthenticateMutation(context),
+    };
+  }
+
+  _authenticatedQuery(context, info) {
+    if (info && info.cacheControl) {
+      info.cacheControl.setCacheHint({ scope: 'PRIVATE' });
+    }
+
+    if (!context.authedItem || context.authedListKey !== this.list.key) {
+      return null;
+    }
+
+    const gqlName = this.gqlNames.authenticatedQueryName;
+    const access = this.checkAccess(context, 'query', { gqlName });
+    return this.list.itemQuery(
+      mergeWhereClause({ where: { id: context.authedItem.id } }, access),
+      context,
+      this.gqlNames.authenticatedQueryName
+    );
+  }
+
+  async _authenticateMutation(args, context) {
+    const gqlName = this.gqlNames.authenticateMutationName;
+    this.checkAccess(context, 'mutation', { gqlName });
+
+    // This is currently hard coded to enable authenticating with the admin UI.
+    // In the near future we will set up the admin-ui application and api to be
+    // non-public.
+    const audiences = ['admin'];
+
+    // Verify incoming details
+    const { item, success, message } = await this.authStrategy.validate(args);
+    if (!success) {
+      throw new Error(message);
+    }
+
+    const token = await context.startAuthedSession({ item, list: this.list }, audiences);
+    return { token, item };
+  }
+
+  async _unauthenticateMutation(context) {
+    const gqlName = this.gqlNames.unauthenticateMutationName;
+    this.checkAccess(context, 'mutation', { gqlName });
+
+    await context.endAuthedSession();
+    return { success: true };
+  }
+
+  checkAccess(context, type, { gqlName }) {
+    const operation = 'auth';
+    const access = context.getAuthAccessControlForUser(this.list.key, { gqlName });
+    if (!access) {
+      graphqlLogger.debug({ operation, access, gqlName }, 'Access statically or implicitly denied');
+      graphqlLogger.info({ operation, gqlName }, 'Access Denied');
+      // If the client handles errors correctly, it should be able to
+      // receive partial data (for the fields the user has access to),
+      // and then an `errors` array of AccessDeniedError's
+      throwAccessDenied(type, context, gqlName);
+    }
+    return access;
+  }
+}
+
+module.exports = { ListAuthProvider };

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -141,11 +141,6 @@ class MockAdapter {
   getDefaultPrimaryKeyConfig = () => ({ type: MockIdType });
 }
 
-class MockPasswordAuthStrategy {
-  getInputFragment = () => 'password: String';
-  validate = () => {};
-}
-
 Text.adapters['mock'] = {};
 Checkbox.adapters['mock'] = {};
 Float.adapters['mock'] = {};
@@ -195,10 +190,9 @@ const getListByKey = listKey => {
   }
 };
 
-const listExtras = (getAuth = () => {}, queryMethod = undefined) => ({
+const listExtras = (queryMethod = undefined) => ({
   getListByKey,
   adapter: new MockAdapter(),
-  getAuth,
   defaultAccess: { list: true, field: true },
   queryHelper: context => (queryString, { variables } = {}) => {
     return queryMethod(queryString, context, variables);
@@ -207,8 +201,8 @@ const listExtras = (getAuth = () => {}, queryMethod = undefined) => ({
   schemaNames: ['public'],
 });
 
-const setup = (extraConfig, getAuth, queryMethod) => {
-  const list = new List('Test', { ...config, ...extraConfig }, listExtras(getAuth, queryMethod));
+const setup = (extraConfig, queryMethod) => {
+  const list = new List('Test', { ...config, ...extraConfig }, listExtras(queryMethod));
   list.initFields();
   return list;
 };
@@ -220,7 +214,6 @@ describe('new List()', () => {
     expect(list.key).toEqual('Test');
     expect(list.getListByKey).toBe(getListByKey);
     expect(list.defaultAccess).toEqual({ list: true, field: true });
-    expect(list.getAuth).toBeInstanceOf(Function);
   });
 
   test('new List() - Plural throws error', () => {
@@ -257,11 +250,6 @@ describe('new List()', () => {
       listQueryName: 'allTests',
       listQueryMetaName: '_allTestsMeta',
       listMetaName: '_TestsMeta',
-      authenticatedQueryName: 'authenticatedTest',
-      authenticateMutationPrefix: 'authenticateTest',
-      authenticateOutputName: 'authenticateTestOutput',
-      unauthenticateMutationName: 'unauthenticateTest',
-      unauthenticateOutputName: 'unauthenticateTestOutput',
       deleteMutationName: 'deleteTest',
       deleteManyMutationName: 'deleteTests',
       updateMutationName: 'updateTest',
@@ -451,11 +439,6 @@ describe('getAdminMeta()', () => {
       listQueryName: 'allTests',
       listQueryMetaName: '_allTestsMeta',
       listMetaName: '_TestsMeta',
-      authenticatedQueryName: 'authenticatedTest',
-      authenticateMutationPrefix: 'authenticateTest',
-      authenticateOutputName: 'authenticateTestOutput',
-      unauthenticateMutationName: 'unauthenticateTest',
-      unauthenticateOutputName: 'unauthenticateTestOutput',
       deleteMutationName: 'deleteTest',
       deleteManyMutationName: 'deleteTests',
       updateMutationName: 'updateTest',
@@ -529,12 +512,8 @@ describe('getAdminMeta()', () => {
   });
 });
 
-[false, true].forEach(withAuth => {
-  [false, true].forEach(auth => {
-    describe(`getGqlTypes() ${
-      withAuth ? 'with' : 'without'
-    } auth (access: { auth: ${auth} })`, () => {
-      const type = `""" A keystone list """
+describe(`getGqlTypes() `, () => {
+  const type = `""" A keystone list """
       type Test {
         """
         This virtual field will be resolved in one of the following ways (in this order):
@@ -550,7 +529,7 @@ describe('getAdminMeta()', () => {
         other: Other
         writeOnce: String
       }`;
-      const whereInput = `input TestWhereInput {
+  const whereInput = `input TestWhereInput {
         AND: [TestWhereInput]
         OR: [TestWhereInput]
         id: ID
@@ -611,143 +590,86 @@ describe('getAdminMeta()', () => {
         writeOnce_in: [String]
         writeOnce_not_in: [String]
       }`;
-      const whereUniqueInput = `input TestWhereUniqueInput {
+  const whereUniqueInput = `input TestWhereUniqueInput {
         id: ID!
       }`;
-      const updateInput = `input TestUpdateInput {
+  const updateInput = `input TestUpdateInput {
         name: String
         email: String
         other: OtherRelateToOneInput
         hidden: String
       }`;
-      const updateManyInput = `input TestsUpdateInput {
+  const updateManyInput = `input TestsUpdateInput {
         id: ID!
         data: TestUpdateInput
       }`;
-      const createInput = `input TestCreateInput {
+  const createInput = `input TestCreateInput {
         name: String
         email: String
         other: OtherRelateToOneInput
         hidden: String
         writeOnce: String
       }`;
-      const createManyInput = `input TestsCreateInput {
+  const createManyInput = `input TestsCreateInput {
         data: TestCreateInput
       }`;
-      const unauthenticateOutput = `type unauthenticateTestOutput {
-      """
-        \`true\` when unauthentication succeeds.
-        NOTE: unauthentication always succeeds when the request has an invalid or missing authentication token.
-        """
-        success: Boolean
-      }`;
-      const authenticateOutput = `type authenticateTestOutput {
-        """ Used to make subsequent authenticated requests by setting this token in a header: 'Authorization: Bearer <token>'. """
-        token: String
-        """ Retrieve information on the newly authenticated Test here. """
-        item: Test
-      }`;
 
-      const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-      const schemaName = 'public';
-      test('access: true', () => {
-        expect(
-          setup({ access: true }, getAuth)
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual(
-          [
-            type,
-            whereInput,
-            whereUniqueInput,
-            updateInput,
-            updateManyInput,
-            createInput,
-            createManyInput,
-            ...(withAuth ? [unauthenticateOutput, authenticateOutput] : []),
-          ].map(s => print(gql(s)))
-        );
-      });
-      test('access: false', () => {
-        expect(
-          setup({ access: false }, getAuth)
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual([]);
-      });
-      test('read: true', () => {
-        expect(
-          setup(
-            { access: { read: true, create: false, update: false, delete: false, auth } },
-            getAuth
-          )
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual(
-          [
-            type,
-            whereInput,
-            whereUniqueInput,
-            ...(withAuth && auth ? [unauthenticateOutput, authenticateOutput] : []),
-          ].map(s => print(gql(s)))
-        );
-      });
-      test('create: true', () => {
-        expect(
-          setup(
-            { access: { read: false, create: true, update: false, delete: false, auth } },
-            getAuth
-          )
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual(
-          [
-            type,
-            whereInput,
-            whereUniqueInput,
-            createInput,
-            createManyInput,
-            ...(withAuth && auth ? [unauthenticateOutput, authenticateOutput] : []),
-          ].map(s => print(gql(s)))
-        );
-      });
-      test('update: true', () => {
-        expect(
-          setup(
-            { access: { read: false, create: false, update: true, delete: false, auth } },
-            getAuth
-          )
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual(
-          [
-            type,
-            whereInput,
-            whereUniqueInput,
-            updateInput,
-            updateManyInput,
-            ...(withAuth && auth ? [unauthenticateOutput, authenticateOutput] : []),
-          ].map(s => print(gql(s)))
-        );
-      });
-      test('delete: true', () => {
-        expect(
-          setup(
-            { access: { read: false, create: false, update: false, delete: true, auth } },
-            getAuth
-          )
-            .getGqlTypes({ schemaName })
-            .map(s => print(gql(s)))
-        ).toEqual(
-          [
-            type,
-            whereInput,
-            whereUniqueInput,
-            ...(withAuth && auth ? [unauthenticateOutput, authenticateOutput] : []),
-          ].map(s => print(gql(s)))
-        );
-      });
-    });
+  const schemaName = 'public';
+  test('access: true', () => {
+    expect(
+      setup({ access: true })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [
+        type,
+        whereInput,
+        whereUniqueInput,
+        updateInput,
+        updateManyInput,
+        createInput,
+        createManyInput,
+      ].map(s => print(gql(s)))
+    );
+  });
+  test('access: false', () => {
+    expect(
+      setup({ access: false })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual([]);
+  });
+  test('read: true', () => {
+    expect(
+      setup({ access: { read: true, create: false, update: false, delete: false } })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual([type, whereInput, whereUniqueInput].map(s => print(gql(s))));
+  });
+  test('create: true', () => {
+    expect(
+      setup({ access: { read: false, create: true, update: false, delete: false } })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [type, whereInput, whereUniqueInput, createInput, createManyInput].map(s => print(gql(s)))
+    );
+  });
+  test('update: true', () => {
+    expect(
+      setup({ access: { read: false, create: false, update: true, delete: false } })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual(
+      [type, whereInput, whereUniqueInput, updateInput, updateManyInput].map(s => print(gql(s)))
+    );
+  });
+  test('delete: true', () => {
+    expect(
+      setup({ access: { read: false, create: false, update: false, delete: true } })
+        .getGqlTypes({ schemaName })
+        .map(s => print(gql(s)))
+    ).toEqual([type, whereInput, whereUniqueInput].map(s => print(gql(s))));
   });
 });
 
@@ -762,18 +684,16 @@ test('getGraphqlFilterFragment', () => {
   ]);
 });
 
-[false, true].forEach(withAuth => {
-  describe(`getGqlQueries() ${withAuth ? 'with' : 'without'} auth`, () => {
-    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-    const schemaName = 'public';
-    test('access: true', () => {
-      expect(
-        setup({ access: true }, getAuth)
-          .getGqlQueries({ schemaName })
-          .map(normalise)
-      ).toEqual(
-        [
-          `""" Search for all Test items which match the where clause. """
+describe(`getGqlQueries()`, () => {
+  const schemaName = 'public';
+  test('access: true', () => {
+    expect(
+      setup({ access: true })
+        .getGqlQueries({ schemaName })
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Search for all Test items which match the where clause. """
           allTests(
           where: TestWhereInput
           search: String
@@ -781,11 +701,11 @@ test('getGraphqlFilterFragment', () => {
           first: Int
           skip: Int
         ): [Test]`,
-          `""" Search for the Test item with the matching ID. """
+        `""" Search for the Test item with the matching ID. """
           Test(
           where: TestWhereUniqueInput!
         ): Test`,
-          `""" Perform a meta-query on all Test items which match the where clause. """
+        `""" Perform a meta-query on all Test items which match the where clause. """
           _allTestsMeta(
           where: TestWhereInput
           search: String
@@ -793,19 +713,17 @@ test('getGraphqlFilterFragment', () => {
           first: Int
           skip: Int
         ): _QueryMeta`,
-          `""" Retrieve the meta-data for the Test list. """
+        `""" Retrieve the meta-data for the Test list. """
         _TestsMeta: _ListMeta`,
-          ...(withAuth ? [`authenticatedTest: Test`] : []),
-        ].map(normalise)
-      );
-    });
-    test('access: false', () => {
-      expect(
-        setup({ access: false }, getAuth)
-          .getGqlQueries({ schemaName })
-          .map(normalise)
-      ).toEqual([]);
-    });
+      ].map(normalise)
+    );
+  });
+  test('access: false', () => {
+    expect(
+      setup({ access: false })
+        .getGqlQueries({ schemaName })
+        .map(normalise)
+    ).toEqual([]);
   });
 });
 
@@ -852,138 +770,86 @@ test('gqlAuxMutationResolvers', () => {
   expect(list.gqlAuxMutationResolvers()).toEqual({});
 });
 
-[false, true].forEach(withAuth => {
-  [false, true].forEach(auth => {
-    describe(`getGqlMutations() ${
-      withAuth ? 'with' : 'without'
-    } auth (access: { auth: ${auth} })`, () => {
-      const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-      const extraConfig = {};
-      const schemaName = 'public';
-      test('access: true', () => {
-        expect(
-          setup({ access: true, ...extraConfig }, getAuth)
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual(
-          [
-            `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
-            `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
-            `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
-            `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
-            `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
-            `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
-            ...(withAuth
-              ? [
-                  `unauthenticateTest: unauthenticateTestOutput`,
-                  `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
-                ]
-              : []),
-          ].map(normalise)
-        );
-      });
-      test('access: false', () => {
-        expect(
-          setup({ access: false, ...extraConfig }, getAuth)
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual([]);
-      });
-      test('read: true', () => {
-        expect(
-          setup(
-            {
-              access: { read: true, create: false, update: false, delete: false, auth },
-              ...extraConfig,
-            },
-            getAuth
-          )
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual(
-          [
-            ...(withAuth && auth
-              ? [
-                  `unauthenticateTest: unauthenticateTestOutput`,
-                  `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
-                ]
-              : []),
-          ].map(normalise)
-        );
-      });
-      test('create: true', () => {
-        expect(
-          setup(
-            {
-              access: { read: false, create: true, update: false, delete: false, auth },
-              ...extraConfig,
-            },
-            getAuth
-          )
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual(
-          [
-            `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
-            `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
-            ...(withAuth && auth
-              ? [
-                  `unauthenticateTest: unauthenticateTestOutput`,
-                  `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
-                ]
-              : []),
-          ].map(normalise)
-        );
-      });
-      test('update: true', () => {
-        expect(
-          setup(
-            {
-              access: { read: false, create: false, update: true, delete: false, auth },
-              ...extraConfig,
-            },
-            getAuth
-          )
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual(
-          [
-            `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
-            `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
-            ...(withAuth && auth
-              ? [
-                  `unauthenticateTest: unauthenticateTestOutput`,
-                  `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
-                ]
-              : []),
-          ].map(normalise)
-        );
-      });
-      test('delete: true', () => {
-        expect(
-          setup(
-            {
-              access: { read: false, create: false, update: false, delete: true, auth },
-              ...extraConfig,
-            },
-            getAuth
-          )
-            .getGqlMutations({ schemaName })
-            .map(normalise)
-        ).toEqual(
-          [
-            `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
-            `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
-            ...(withAuth && auth
-              ? [
-                  `unauthenticateTest: unauthenticateTestOutput`,
-                  `""" Authenticate and generate a token for a Test with the Password Authentication Strategy. """ authenticateTestWithPassword(password: String): authenticateTestOutput`,
-                ]
-              : []),
-          ].map(normalise)
-        );
-      });
-    });
+describe(`getGqlMutations()`, () => {
+  const extraConfig = {};
+  const schemaName = 'public';
+  test('access: true', () => {
+    expect(
+      setup({ access: true, ...extraConfig })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
+        `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
+        `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
+        `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
+        `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
+        `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
+      ].map(normalise)
+    );
+  });
+  test('access: false', () => {
+    expect(
+      setup({ access: false, ...extraConfig })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual([]);
+  });
+  test('read: true', () => {
+    expect(
+      setup({
+        access: { read: true, create: false, update: false, delete: false },
+        ...extraConfig,
+      })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual([].map(normalise));
+  });
+  test('create: true', () => {
+    expect(
+      setup({
+        access: { read: false, create: true, update: false, delete: false },
+        ...extraConfig,
+      })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Create a single Test item. """ createTest(data: TestCreateInput): Test`,
+        `""" Create multiple Test items. """ createTests(data: [TestsCreateInput]): [Test]`,
+      ].map(normalise)
+    );
+  });
+  test('update: true', () => {
+    expect(
+      setup({
+        access: { read: false, create: false, update: true, delete: false },
+        ...extraConfig,
+      })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Update a single Test item by ID. """ updateTest(id: ID! data: TestUpdateInput): Test`,
+        `""" Update multiple Test items by ID. """ updateTests(data: [TestsUpdateInput]): [Test]`,
+      ].map(normalise)
+    );
+  });
+  test('delete: true', () => {
+    expect(
+      setup({
+        access: { read: false, create: false, update: false, delete: true },
+        ...extraConfig,
+      })
+        .getGqlMutations({ schemaName })
+        .map(normalise)
+    ).toEqual(
+      [
+        `""" Delete a single Test item by ID. """ deleteTest(id: ID!): Test`,
+        `""" Delete multiple Test items by ID. """ deleteTests(ids: [ID!]): [Test]`,
+      ].map(normalise)
+    );
   });
 });
 
@@ -1177,32 +1043,19 @@ test('getAccessControlledItems', async () => {
   ]);
 });
 
-[false, true].forEach(withAuth => {
-  test(`gqlQueryResolvers ${withAuth ? 'with' : 'without'} auth`, () => {
-    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-    const schemaName = 'public';
-    const resolvers = setup({ access: true }, getAuth).gqlQueryResolvers({ schemaName });
-    expect(resolvers['allTests']).toBeInstanceOf(Function); // listQueryName
-    expect(resolvers['_allTestsMeta']).toBeInstanceOf(Function); // listQueryMetaName
-    expect(resolvers['_TestsMeta']).toBeInstanceOf(Function); // listMetaName
-    expect(resolvers['Test']).toBeInstanceOf(Function); // itemQueryName
-    if (withAuth) {
-      expect(resolvers['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
-    } else {
-      expect(resolvers['authenticatedTest']).toBe(undefined); // authenticatedQueryName
-    }
+test(`gqlQueryResolvers`, () => {
+  const schemaName = 'public';
+  const resolvers = setup({ access: true }).gqlQueryResolvers({ schemaName });
+  expect(resolvers['allTests']).toBeInstanceOf(Function); // listQueryName
+  expect(resolvers['_allTestsMeta']).toBeInstanceOf(Function); // listQueryMetaName
+  expect(resolvers['_TestsMeta']).toBeInstanceOf(Function); // listMetaName
+  expect(resolvers['Test']).toBeInstanceOf(Function); // itemQueryName
 
-    const resolvers2 = setup({ access: false }, getAuth).gqlQueryResolvers({ schemaName });
-    expect(resolvers2['allTests']).toBe(undefined); // listQueryName
-    expect(resolvers2['_allTestsMeta']).toBe(undefined); // listQueryMetaName
-    expect(resolvers2['_TestsMeta']).toBe(undefined); // listMetaName
-    expect(resolvers2['Test']).toBe(undefined); // itemQueryName
-    if (withAuth) {
-      expect(resolvers['authenticatedTest']).toBeInstanceOf(Function); // authenticatedQueryName
-    } else {
-      expect(resolvers['authenticatedTest']).toBe(undefined); // authenticatedQueryName
-    }
-  });
+  const resolvers2 = setup({ access: false }).gqlQueryResolvers({ schemaName });
+  expect(resolvers2['allTests']).toBe(undefined); // listQueryName
+  expect(resolvers2['_allTestsMeta']).toBe(undefined); // listQueryMetaName
+  expect(resolvers2['_TestsMeta']).toBe(undefined); // listMetaName
+  expect(resolvers2['Test']).toBe(undefined); // itemQueryName
 });
 
 test('listQuery', async () => {
@@ -1222,43 +1075,38 @@ test('listQueryMeta', async () => {
   ).toEqual(2);
 });
 
-[false, true].forEach(withAuth => {
-  test(`listMeta ${withAuth ? 'with' : 'without'} auth`, () => {
-    const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-    const meta = setup({}, getAuth).listMeta(context);
-    expect(meta.getAccess).toBeInstanceOf(Function);
-    expect(meta.getSchema).toBeInstanceOf(Function);
-    expect(meta.name).toEqual('Test');
+test(`listMeta`, () => {
+  const meta = setup({}).listMeta(context);
+  expect(meta.getAccess).toBeInstanceOf(Function);
+  expect(meta.getSchema).toBeInstanceOf(Function);
+  expect(meta.name).toEqual('Test');
 
-    const access = meta.getAccess();
-    expect(access.getCreate).toBeInstanceOf(Function);
-    expect(access.getDelete).toBeInstanceOf(Function);
-    expect(access.getRead).toBeInstanceOf(Function);
-    expect(access.getUpdate).toBeInstanceOf(Function);
-    expect(access.getAuth).toBeInstanceOf(Function);
+  const access = meta.getAccess();
+  expect(access.getCreate).toBeInstanceOf(Function);
+  expect(access.getDelete).toBeInstanceOf(Function);
+  expect(access.getRead).toBeInstanceOf(Function);
+  expect(access.getUpdate).toBeInstanceOf(Function);
 
-    expect(access.getCreate()).toEqual(true);
-    expect(access.getDelete()).toEqual(true);
-    expect(access.getRead()).toEqual(true);
-    expect(access.getUpdate()).toEqual(true);
-    expect(access.getAuth()).toEqual(true);
+  expect(access.getCreate()).toEqual(true);
+  expect(access.getDelete()).toEqual(true);
+  expect(access.getRead()).toEqual(true);
+  expect(access.getUpdate()).toEqual(true);
 
-    const schema = meta.getSchema();
-    expect(schema).toEqual({
-      key: 'Test',
-      queries: ['Test', 'allTests', '_allTestsMeta', ...(withAuth ? ['authenticatedTest'] : [])],
-      type: 'Test',
-    });
+  const schema = meta.getSchema();
+  expect(schema).toEqual({
+    key: 'Test',
+    queries: ['Test', 'allTests', '_allTestsMeta'],
+    type: 'Test',
+  });
 
-    expect(
-      setup({ access: true }, () => false)
-        .listMeta(context)
-        .getSchema()
-    ).toEqual({
-      key: 'Test',
-      queries: ['Test', 'allTests', '_allTestsMeta'],
-      type: 'Test',
-    });
+  expect(
+    setup({ access: true }, () => false)
+      .listMeta(context)
+      .getSchema()
+  ).toEqual({
+    key: 'Test',
+    queries: ['Test', 'allTests', '_allTestsMeta'],
+    type: 'Test',
   });
 });
 
@@ -1272,109 +1120,52 @@ test('itemQuery', async () => {
   await expect(list.itemQuery({ where: { id: 4 } }, context)).rejects.toThrow(AccessDeniedError);
 });
 
-test('authenticatedQuery', async () => {
-  const list = setup();
-  expect(await list.authenticatedQuery(context)).toEqual({
-    name: 'b',
-    email: 'b@example.com',
-    index: 1,
+describe(`gqlMutationResolvers`, () => {
+  const schemaName = 'public';
+  let resolvers;
+  test('access: true', () => {
+    resolvers = setup({ access: true }).gqlMutationResolvers({ schemaName });
+    expect(resolvers['createTest']).toBeInstanceOf(Function);
+    expect(resolvers['updateTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTests']).toBeInstanceOf(Function);
   });
-  expect(await list.authenticatedQuery({ ...context, authedItem: undefined })).toBe(null);
-  expect(await list.authenticatedQuery({ ...context, authedListKey: 'Other' })).toBe(null);
-});
-
-[false, true].forEach(withAuth => {
-  [false, true].forEach(auth => {
-    describe(`gqlMutationResolvers ${
-      withAuth ? 'with' : 'without'
-    } auth (access: { auth: ${auth} })`, () => {
-      const getAuth = withAuth ? () => ({ password: new MockPasswordAuthStrategy() }) : undefined;
-      const schemaName = 'public';
-      let resolvers;
-      test('access: true', () => {
-        resolvers = setup({ access: true }, getAuth).gqlMutationResolvers({ schemaName });
-        expect(resolvers['createTest']).toBeInstanceOf(Function);
-        expect(resolvers['updateTest']).toBeInstanceOf(Function);
-        expect(resolvers['deleteTest']).toBeInstanceOf(Function);
-        expect(resolvers['deleteTests']).toBeInstanceOf(Function);
-        if (withAuth) {
-          expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
-          expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
-        } else {
-          expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-          expect(resolvers['unauthenticateTest']).toBe(undefined);
-        }
-      });
-      test('access: false', () => {
-        resolvers = setup({ access: false }, getAuth).gqlMutationResolvers({ schemaName });
-        expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-        expect(resolvers['unauthenticateTest']).toBe(undefined);
-      });
-      test('read: true', () => {
-        resolvers = setup(
-          { access: { read: true, create: false, update: false, delete: false, auth } },
-          getAuth
-        ).gqlMutationResolvers({ schemaName });
-        if (withAuth && auth) {
-          expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
-          expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
-        } else {
-          expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-          expect(resolvers['unauthenticateTest']).toBe(undefined);
-        }
-      });
-      test('create: true', () => {
-        resolvers = setup(
-          { access: { read: false, create: true, update: false, delete: false, auth } },
-          getAuth
-        ).gqlMutationResolvers({ schemaName });
-        expect(resolvers['createTest']).toBeInstanceOf(Function);
-        expect(resolvers['updateTest']).toBe(undefined);
-        expect(resolvers['deleteTest']).toBe(undefined);
-        expect(resolvers['deleteTests']).toBe(undefined);
-        if (withAuth && auth) {
-          expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
-          expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
-        } else {
-          expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-          expect(resolvers['unauthenticateTest']).toBe(undefined);
-        }
-      });
-      test('update: true', () => {
-        resolvers = setup(
-          { access: { read: false, create: false, update: true, delete: false, auth } },
-          getAuth
-        ).gqlMutationResolvers({ schemaName });
-        expect(resolvers['createTest']).toBe(undefined);
-        expect(resolvers['updateTest']).toBeInstanceOf(Function);
-        expect(resolvers['deleteTest']).toBe(undefined);
-        expect(resolvers['deleteTests']).toBe(undefined);
-        if (withAuth && auth) {
-          expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
-          expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
-        } else {
-          expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-          expect(resolvers['unauthenticateTest']).toBe(undefined);
-        }
-      });
-      test('delete: true', () => {
-        resolvers = setup(
-          { access: { read: false, create: false, update: false, delete: true, auth } },
-          getAuth
-        ).gqlMutationResolvers({ schemaName });
-        expect(resolvers['createTest']).toBe(undefined);
-        expect(resolvers['updateTest']).toBe(undefined);
-        expect(resolvers['deleteTest']).toBeInstanceOf(Function);
-        expect(resolvers['deleteTests']).toBeInstanceOf(Function);
-        if (withAuth && auth) {
-          expect(resolvers['authenticateTestWithPassword']).toBeInstanceOf(Function);
-          expect(resolvers['unauthenticateTest']).toBeInstanceOf(Function);
-        } else {
-          expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
-          expect(resolvers['unauthenticateTest']).toBe(undefined);
-        }
-      });
-    });
+  test('access: false', () => {
+    resolvers = setup({ access: false }).gqlMutationResolvers({ schemaName });
+    expect(resolvers['authenticateTestWithPassword']).toBe(undefined);
+    expect(resolvers['unauthenticateTest']).toBe(undefined);
+  });
+  test('read: true', () => {
+    resolvers = setup({
+      access: { read: true, create: false, update: false, delete: false },
+    }).gqlMutationResolvers({ schemaName });
+  });
+  test('create: true', () => {
+    resolvers = setup({
+      access: { read: false, create: true, update: false, delete: false },
+    }).gqlMutationResolvers({ schemaName });
+    expect(resolvers['createTest']).toBeInstanceOf(Function);
+    expect(resolvers['updateTest']).toBe(undefined);
+    expect(resolvers['deleteTest']).toBe(undefined);
+    expect(resolvers['deleteTests']).toBe(undefined);
+  });
+  test('update: true', () => {
+    resolvers = setup({
+      access: { read: false, create: false, update: true, delete: false },
+    }).gqlMutationResolvers({ schemaName });
+    expect(resolvers['createTest']).toBe(undefined);
+    expect(resolvers['updateTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTest']).toBe(undefined);
+    expect(resolvers['deleteTests']).toBe(undefined);
+  });
+  test('delete: true', () => {
+    resolvers = setup({
+      access: { read: false, create: false, update: false, delete: true },
+    }).gqlMutationResolvers({ schemaName });
+    expect(resolvers['createTest']).toBe(undefined);
+    expect(resolvers['updateTest']).toBe(undefined);
+    expect(resolvers['deleteTest']).toBeInstanceOf(Function);
+    expect(resolvers['deleteTests']).toBeInstanceOf(Function);
   });
 });
 
@@ -1493,7 +1284,7 @@ describe('List Hooks', () => {
             }),
           };
 
-          const list = setup({ hooks }, undefined, queryMethod);
+          const list = setup({ hooks }, queryMethod);
           await action(list);
 
           expect(queryMethod).toHaveBeenCalledWith(
@@ -1523,7 +1314,7 @@ describe('List Hooks', () => {
             }),
           };
 
-          const list = setup({ hooks }, undefined, queryMethod);
+          const list = setup({ hooks }, queryMethod);
           await action(list);
 
           expect(queryMethod).toHaveBeenCalledWith(
@@ -1583,7 +1374,6 @@ describe('Maps from Native JS types to Keystone types', () => {
         { fields: { foo: { type: nativeType } } },
         {
           adapter,
-          getAuth: () => {},
           defaultAccess: { list: true, field: true },
           registerType: () => {},
           schemaNames: ['public'],

--- a/test-projects/access-control/index.js
+++ b/test-projects/access-control/index.js
@@ -22,12 +22,6 @@ const keystone = new Keystone({
   adapter: new MongooseAdapter(),
 });
 
-// eslint-disable-next-line no-unused-vars
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
-});
-
 keystone.createList('User', {
   fields: {
     email: {
@@ -50,6 +44,11 @@ keystone.createList('User', {
     noRead: { type: Text, access: { read: () => false } },
     yesRead: { type: Text, access: { read: () => true } },
   },
+});
+
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
 });
 
 function createListWithStaticAccess(access) {

--- a/test-projects/login/index.js
+++ b/test-projects/login/index.js
@@ -24,13 +24,6 @@ const keystone = new Keystone({
   },
 });
 
-// eslint-disable-next-line no-unused-vars
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
-  // config: { protectIdentities: true },
-});
-
 keystone.createList('User', {
   fields: {
     name: { type: Text },
@@ -71,6 +64,12 @@ keystone.createList('ListWithPlugin', {
     createdBy(),
     updatedBy(),
   ],
+});
+
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
+  // config: { protectIdentities: true },
 });
 
 module.exports = {

--- a/test-projects/social-login/index.js
+++ b/test-projects/social-login/index.js
@@ -28,12 +28,6 @@ const keystone = new Keystone({
   cookieSecret,
 });
 
-// eslint-disable-next-line no-unused-vars
-const authStrategy = keystone.createAuthStrategy({
-  type: PasswordAuthStrategy,
-  list: 'User',
-});
-
 const fileAdapter = new LocalFileAdapter({
   src: LOCAL_FILE_SRC,
   path: LOCAL_FILE_ROUTE,
@@ -166,6 +160,11 @@ keystone.createList('PostCategory', {
     delete: false,
     auth: true,
   },
+});
+
+const authStrategy = keystone.createAuthStrategy({
+  type: PasswordAuthStrategy,
+  list: 'User',
 });
 
 module.exports = {


### PR DESCRIPTION
c.f. #2418 

This PR moves the responsibility for generating and resolver authentication queries/mutations out of the `List` class and into a `ListAuthProvider` class.

This will hopefully make it much easier to understand the behaviour of these mutations and to decouple the CRUD API from the Auth API.

This will be a *major* breaking change, as you can no longer call `createAuthStrategy` before defining the associated. This is probably for the best, as it explicitly prevents people setting up an auth strategy against a non-existent list.