### PR TITLE
Partially revert #2279 CreateItemModal props

### DIFF
--- a/.changeset/olive-cooks-work.md
+++ b/.changeset/olive-cooks-work.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@keystonejs/fields': patch
+---
+
+Detached `CreateItemModal` state from `useList`, this prevents multiple CreateItemModal being shown in case of extending the UI.

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -44,8 +44,8 @@ function useEventCallback(callback) {
   return cb;
 }
 
-function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onCreate }) {
-  const { list, closeCreateItemModal, isCreateItemModalOpen } = useList();
+function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onCreate, isOpen }) {
+  const { list } = useList();
   const [item, setItem] = useState(list.getInitialItemData({ prefill: prefillData }));
   const [validationErrors, setValidationErrors] = useState({});
   const [validationWarnings, setValidationWarnings] = useState({});
@@ -103,7 +103,6 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
 
     createItem({ variables: { data } }).then(data => {
       if (!data) return;
-      closeCreateItemModal();
       setItem(list.getInitialItemData({}));
       if (onCreate) {
         onCreate(data);
@@ -113,7 +112,6 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
 
   const _onClose = () => {
     if (isLoading) return;
-    closeCreateItemModal();
     setItem(list.getInitialItemData({}));
     const data = arrayToObject(creatable, 'path', field => field.serialize(item));
     if (onClose) {
@@ -143,7 +141,7 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
     <Drawer
       closeOnBlanketClick
       component={formComponent}
-      isOpen={isCreateItemModalOpen}
+      isOpen={isOpen}
       onClose={_onClose}
       heading={`Create ${list.singular}`}
       onKeyDown={_onKeyDown}

--- a/packages/app-admin-ui/client/pages/Home/components.js
+++ b/packages/app-admin-ui/client/pages/Home/components.js
@@ -35,12 +35,13 @@ const BoxElement = styled(Card)`
 `;
 
 const BoxComponent = ({ focusOrigin, isActive, isHover, isFocus, meta, ...props }) => {
-  const { list, openCreateItemModal } = useList();
+  const { list, openCreateItemModal, closeCreateItemModal, isCreateItemModalOpen } = useList();
   const history = useHistory();
   const { adminPath } = useAdminMeta();
 
   const onCreate = ({ data }) => {
     const id = data[list.gqlNames.createMutationName].id;
+    closeCreateItemModal();
     history.push(`${adminPath}/${list.path}/${id}`);
   };
 
@@ -71,7 +72,11 @@ const BoxComponent = ({ focusOrigin, isActive, isHover, isFocus, meta, ...props 
           <A11yText>Create {singular}</A11yText>
         </CreateButton>
       </BoxElement>
-      <CreateItemModal onCreate={onCreate} />
+      <CreateItemModal
+        onCreate={onCreate}
+        onClose={closeCreateItemModal}
+        isOpen={isCreateItemModalOpen}
+      />
     </Fragment>
   );
 };

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -36,6 +36,7 @@ import {
 } from '../../util';
 import { ItemTitle } from './ItemTitle';
 import { ItemProvider } from '../../providers/Item';
+import { useList } from '../../providers/List';
 
 let Render = ({ children }) => children();
 
@@ -62,7 +63,6 @@ const getRenderableFields = memoizeOne(list =>
 
 const ItemDetails = ({
   adminPath,
-  list,
   item: initialData,
   itemErrors,
   onUpdate,
@@ -73,6 +73,8 @@ const ItemDetails = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [validationErrors, setValidationErrors] = useState({});
   const [validationWarnings, setValidationWarnings] = useState({});
+
+  const { list, closeCreateItemModal, isCreateItemModalOpen } = useList();
 
   const itemHasChanged = useRef(false);
   const itemSaveCheckCache = useRef({});
@@ -248,6 +250,7 @@ const ItemDetails = ({
 
   const onCreate = ({ data }) => {
     const { id } = data[list.gqlNames.createMutationName];
+    closeCreateItemModal();
     history.push(`${adminPath}/${list.path}/${id}`);
   };
 
@@ -332,7 +335,11 @@ const ItemDetails = ({
         />
       </Card>
 
-      <CreateItemModal onCreate={onCreate} />
+      <CreateItemModal
+        onCreate={onCreate}
+        onClose={closeCreateItemModal}
+        isOpen={isCreateItemModalOpen}
+      />
       <DeleteItemModal
         isOpen={showDeleteModal}
         item={initialData}

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -38,7 +38,7 @@ const HeaderInset = props => (
 export function ListLayout(props) {
   const { adminMeta, items, itemCount, queryErrors, routeProps, query } = props;
   const measureElementRef = useRef();
-  const { list, openCreateItemModal } = useList();
+  const { list, openCreateItemModal, isCreateItemModalOpen, closeCreateItemModal } = useList();
   const { urlState } = useListUrlState(list.key);
   const { filters } = useListFilter(list.key);
   const [sortBy, handleSortChange] = useListSort(list.key);
@@ -84,6 +84,7 @@ export function ListLayout(props) {
     query.refetch().then(() => {
       history.push(`${adminPath}/${list.path}/${id}`);
     });
+    closeCreateItemModal();
   };
 
   // Success
@@ -207,7 +208,11 @@ export function ListLayout(props) {
         </HeaderInset>
       </Container>
 
-      <CreateItemModal onCreate={onCreate} />
+      <CreateItemModal
+        onCreate={onCreate}
+        onClose={closeCreateItemModal}
+        isOpen={isCreateItemModalOpen}
+      />
 
       <Container isFullWidth>
         <ListTable

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -104,7 +104,7 @@ function LinkToRelatedItems({ field, value }) {
 }
 
 function CreateAndAddItem({ field, item, onCreate, CreateItemModal }) {
-  const { list, openCreateItemModal } = useList();
+  const { list, openCreateItemModal, closeCreateItemModal, isCreateItemModalOpen } = useList();
 
   let relatedList = field.adminMeta.getListByKey(field.config.ref);
   let label = `Create and add ${relatedList.singular}`;
@@ -152,7 +152,10 @@ function CreateAndAddItem({ field, item, onCreate, CreateItemModal }) {
         prefillData={prefillData}
         onCreate={({ data }) => {
           onCreate(data[relatedList.gqlNames.createMutationName]);
+          closeCreateItemModal();
         }}
+        onClose={closeCreateItemModal}
+        isOpen={isCreateItemModalOpen}
       />
     </Fragment>
   );


### PR DESCRIPTION
I really feel that the modals should be independent from `useList` variables.

in https://github.com/keystonejs/keystone/pull/2279 CreateItemModal was made dependent directly on `useList()` variables which prevents me from extending the admin pages and make use of multiple `CreateItemModal` component (custom actions for duplicate).

I reverted that specific dependency and made is dependent to `useList()` state via props, this way I can use multiple CreateItemModal without making big change to the admin ui.