### PR TITLE
Enable list specific hooks

### DIFF
--- a/.changeset/clever-kiwis-impress.md
+++ b/.changeset/clever-kiwis-impress.md
@@ -1,0 +1,16 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Enable use of ui hooks for specific List page.
+
+```js
+module.exports = {
+    // other hooks
+    itemHeaderActions: ActionsForAllPage,
+    itemHeaderPostActions: ActionsForPostPageOnly,
+    listHeaderUserActions: ActionsForUserPageOnly,
+    listManageUserActions: ActionsForUserPageOnly,
+    listItemUserActions: ActionsForUserPageOnly,
+}
+```

--- a/.changeset/empty-laws-smell.md
+++ b/.changeset/empty-laws-smell.md
@@ -1,0 +1,30 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Enabled the use of `listItemActions` hook in the Admin UI.
+
+Usage: 
+
+```js
+// index.js
+new AdminUIApp({
+  hooks: require.resolve('./admin-ui/'),
+});
+```
+
+The index file in the `admin-ui` directory should export a hooks which will be packaged for use in the Admin UI during the Keystone build:
+
+```js
+// ./admin-ui/index.js
+import { ItemDropDown } '@keystonejs/admin-ui/components/'
+const dropDownItem = {
+  content: 'Hello world',
+  icon: <PencilIcon />,
+  onClick: () => console.log('Hello World'),
+};
+export default {
+  // re-implement the default dropdown with additional items
+  listItemActions: () => (<ItemDropDown items={[dropDownItem]} />), 
+};
+```

--- a/packages/app-admin-ui/README.md
+++ b/packages/app-admin-ui/README.md
@@ -81,9 +81,9 @@ export default {
 };
 ```
 
-#### `itemHeaderActions`
+#### `itemHeaderActions`, `itemHeader${listKey}Actions`
 
-Header components on the Item Details page can be replaced using this hook. This replaces the components for item Details page for all Lists.
+Header components on the Item Details page can be replaced using this hook. `itemHeaderActions` replaces the components for item Details page for all lists whereas `itemHeader${listKey}Actions` replaces components on specific list. List specific UI hooks supersedes global UI hooks
 
 > This must return a React component.
 
@@ -92,12 +92,13 @@ import { ItemId, AddNewItem } '@keystonejs/admin-ui/components/'
 export default {
   // re-implement the default AddNewItem and ItemId button + custom text
   itemHeaderActions: () => (<div><ItemId /><AddNewItem /><p>Hello world</p></div>),
+  itemHeaderUserActions: () => <UserSpecificItemHeaderAction />,
 };
 ```
 
-#### `listHeaderActions`
+#### `listHeaderActions`, `listHeader${listKey}Actions`
 
-Header components on the List page can be replaced using this hook. This replaces components on list page for all Lists.
+Header components on the List page can be replaced using this hook. `listHeaderActions` replaces components on list page for all lists whereas `listHeader${listKey}Actions` replaces components on specific list. List specific UI hooks supersedes global UI hooks.This.
 
 > This must return a React component.
 
@@ -106,12 +107,13 @@ import { CreateItem } '@keystonejs/admin-ui/components/'
 export default {
   // re-implement the default create item button + custom text
   listHeaderActions: () => (<div><CreateItem /><p>Hello world</p></div>),
+  listHeaderUserActions: () => <UserSpecificListHeaderAction />,
 };
 ```
 
-#### `listManageActions`
+#### `listManageActions`, `listManage${listKey}Actions`
 
-Custom Actions component for multiple items in the list can be replaced with this hook. This replaces the list management toolbar Items for all lists.
+Custom Actions component for multiple items in the list can be replaced with this hook. `listManageActions` replaces the list management toolbar Items for all lists whereas `listManage${listKey}Actions` replaces components on specific list. List specific UI hooks supersedes global UI hooks.This.
 
 > This must return a React component.
 
@@ -120,12 +122,13 @@ import { UpdateItems, DeleteItems } '@keystonejs/admin-ui/components/'
 export default {
   // re-implement the default delete many and update many items buttons + custom text
   listManageActions: () => (<div><UpdateItems /><DeleteItems /><p>Hello world</p></div>),
+  listManageUserActions: () => <UserSpecificListManageAction />,
 };
 ```
 
-#### `listItemActions`
+#### `listItemActions`, `listItem${listKey}Actions`
 
-Dropdown component for individual item in list view can be replaced with this hook. This replaces the item dropdown for all lists.
+Dropdown component for individual item in list view can be replaced with this hook. `listItemActions` replaces the item dropdown for all lists whereas `listItem${listKey}Actions` replaces components on specific list. List specific UI hooks supersedes global UI hooks.This.
 
 > This must return a React component.
 
@@ -139,6 +142,7 @@ const dropDownItem = {
 export default {
   // re-implement the default dropdown with additional items
   listItemActions: () => (<ItemDropDown items={[dropDownItem]} />),
+  listItemUserActions: () => <UserSpecificListItemAction />,
 };
 ```
 

--- a/packages/app-admin-ui/README.md
+++ b/packages/app-admin-ui/README.md
@@ -83,7 +83,7 @@ export default {
 
 #### `itemHeaderActions`
 
-Header components on the Item Details page can be replaced using this hook. Ths replaces the components for item Details page for all Lists.
+Header components on the Item Details page can be replaced using this hook. This replaces the components for item Details page for all Lists.
 
 > This must return a React component.
 
@@ -91,7 +91,7 @@ Header components on the Item Details page can be replaced using this hook. Ths 
 import { ItemId, AddNewItem } '@keystonejs/admin-ui/components/'
 export default {
   // re-implement the default AddNewItem and ItemId button + custom text
-  listHeaderActions: () => (<div><ItemId /><AddNewItem /><p>Hello world</p></div>),
+  itemHeaderActions: () => (<div><ItemId /><AddNewItem /><p>Hello world</p></div>),
 };
 ```
 
@@ -120,6 +120,25 @@ import { UpdateItems, DeleteItems } '@keystonejs/admin-ui/components/'
 export default {
   // re-implement the default delete many and update many items buttons + custom text
   listManageActions: () => (<div><UpdateItems /><DeleteItems /><p>Hello world</p></div>),
+};
+```
+
+#### `listItemActions`
+
+Dropdown component for individual item in list view can be replaced with this hook. This replaces the item dropdown for all lists.
+
+> This must return a React component.
+
+```javascript title=/admin-ui/index.js
+import { ItemDropDown } '@keystonejs/admin-ui/components/'
+const dropDownItem = {
+  content: 'Hello world',
+  icon: <PencilIcon />,
+  onClick: () => console.log('Hello World'),
+};
+export default {
+  // re-implement the default dropdown with additional items
+  listItemActions: () => (<ItemDropDown items={[dropDownItem]} />),
 };
 ```
 

--- a/packages/app-admin-ui/client/components/ItemDropDown.js
+++ b/packages/app-admin-ui/client/components/ItemDropDown.js
@@ -1,0 +1,87 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { Fragment, useState, useEffect, useRef } from 'react';
+import copyToClipboard from 'clipboard-copy';
+
+import { KebabHorizontalIcon, LinkIcon, TrashcanIcon } from '@arch-ui/icons';
+import Dropdown from '@arch-ui/dropdown';
+import { Button } from '@arch-ui/button';
+
+import DeleteItemModal from './DeleteItemModal';
+import { useList } from '../providers/List';
+import { useItem } from '../providers/Item';
+
+const ItemDropDown = ({ useCopy = true, useDelete = true, items: additionalItems = [] }) => {
+  const [deleteModalIsVisible, setDeleteModal] = useState(false);
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const item = useItem();
+  const { list, query } = useList();
+
+  const copyText = `${window.location.origin}${list.fullPath}/${item.id}`;
+
+  const handleDelete = () => {
+    query.refetch();
+    if (mounted.current) {
+      setDeleteModal(false);
+    }
+  };
+
+  const items = [
+    ...(useCopy
+      ? [
+          {
+            content: 'Copy Link',
+            icon: <LinkIcon />,
+            onClick: () => copyToClipboard(copyText),
+          },
+        ]
+      : []),
+    ...(useDelete
+      ? [
+          {
+            content: 'Delete',
+            icon: <TrashcanIcon />,
+            onClick: () => setDeleteModal(true),
+          },
+        ]
+      : []),
+    ...additionalItems,
+  ];
+  return (
+    <Fragment>
+      <DeleteItemModal
+        isOpen={deleteModalIsVisible}
+        item={item}
+        list={list}
+        onClose={() => setDeleteModal(false)}
+        onDelete={handleDelete}
+      />
+      <Dropdown
+        align="right"
+        target={handlers => (
+          <Button
+            variant="subtle"
+            css={{
+              opacity: 0,
+              transition: 'opacity 150ms',
+              'tr:hover > td > &': { opacity: 1 },
+            }}
+            {...handlers}
+          >
+            <KebabHorizontalIcon />
+          </Button>
+        )}
+        items={items}
+      />
+    </Fragment>
+  );
+};
+
+export default ItemDropDown;

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -173,8 +173,11 @@ const ListRow = ({
   linkField = '_label_',
   isSelected,
   onSelectChange,
-  hooks: { listItemActions },
+  hooks,
 }) => {
+  const { listItemActions, [`listItem${list.key}Actions`]: listItemListActions } = hooks;
+  const listItemHook = listItemListActions || listItemActions;
+
   const onCheckboxChange = () => {
     onSelectChange(item.id);
   };
@@ -242,9 +245,7 @@ const ListRow = ({
         );
       })}
       <BodyCell css={{ padding: 0 }}>
-        <ItemProvider item={item}>
-          {listItemActions ? listItemActions() : <ItemDropDown />}
-        </ItemProvider>
+        <ItemProvider item={item}>{listItemHook ? listItemHook() : <ItemDropDown />}</ItemProvider>
       </BodyCell>
     </TableRow>
   );

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.js
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.js
@@ -23,7 +23,11 @@ const Container = ({ children }) => {
 
 export const ItemTitle = memo(function ItemTitle({ titleText }) {
   const { list } = useList();
-  const { itemHeaderActions } = useUIHooks();
+  const {
+    itemHeaderActions,
+    [`itemHeader${list.key}Actions`]: itemHeaderListActions,
+  } = useUIHooks();
+  const itemHeaderHook = itemHeaderListActions || itemHeaderActions;
   return (
     <Container>
       <PageTitle>{titleText}</PageTitle>
@@ -40,8 +44,8 @@ export const ItemTitle = memo(function ItemTitle({ titleText }) {
           </IconButton>
           <Search list={list} />
         </div>
-        {itemHeaderActions ? (
-          itemHeaderActions()
+        {itemHeaderHook ? (
+          itemHeaderHook()
         ) : (
           <div>
             <ItemId />

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -6,6 +6,7 @@ import { FlexGroup } from '@arch-ui/layout';
 import { colors, gridSize } from '@arch-ui/theme';
 
 import { useUIHooks } from '../../providers/Hooks';
+import { useList } from '../../providers/List';
 import DeleteItems from '../../components/DeleteItems';
 import UpdateItems from '../../components/UpdateItems';
 
@@ -26,16 +27,20 @@ const SelectedCount = props => (
 );
 
 const ListManage = ({ pageSize, totalItems, selectedItems }) => {
-  const { listManageActions } = useUIHooks();
-
+  const { list } = useList();
+  const {
+    listManageActions,
+    [`listManage${list.key}Actions`]: listManageListActions,
+  } = useUIHooks();
+  const listManageHook = listManageListActions || listManageActions;
   return (
     <Fragment>
       <FlexGroup align="center">
         <SelectedCount>
           {`${selectedItems.length} of ${Math.min(pageSize, totalItems)} Selected`}
         </SelectedCount>
-        {listManageActions ? (
-          listManageActions()
+        {listManageHook ? (
+          listManageHook()
         ) : (
           <Fragment>
             <UpdateItems />

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -44,8 +44,11 @@ export function ListLayout(props) {
   const { filters } = useListFilter();
   const [sortBy, handleSortChange] = useListSort();
 
-  const { listHeaderActions } = useUIHooks();
-
+  const {
+    listHeaderActions,
+    [`listHeader${list.key}Actions`]: listHeaderListActions,
+  } = useUIHooks();
+  const listHeaderHook = listHeaderListActions || listHeaderActions;
   // Success
   // ------------------------------
 
@@ -58,7 +61,7 @@ export function ListLayout(props) {
         <HeaderInset>
           <FlexGroup align="center" justify="space-between">
             <PageTitle>{list.plural}</PageTitle>
-            {listHeaderActions ? listHeaderActions() : <CreateItem />}
+            {listHeaderHook ? listHeaderHook() : <CreateItem />}
           </FlexGroup>
           <ListDescription text={list.adminDoc} />
           <div

--- a/packages/app-admin-ui/components/index.js
+++ b/packages/app-admin-ui/components/index.js
@@ -1,5 +1,6 @@
 export { ListProvider, useList } from '../client/providers/List';
 export { default as ListPage, ListLayout } from '../client/pages/List/index';
+export { ItemProvider, useItem } from '../client/providers/Item';
 export { default as ListManage } from '../client/pages/List/Management';
 export { default as FieldSelect } from '../client/pages/List/FieldSelect';
 export { default as Search } from '../client/pages/List/Search';
@@ -20,3 +21,4 @@ export { default as ItemId } from '../client/pages/Item/ItemId';
 export { default as CreateItem } from '../client/pages/List/CreateItem';
 export { default as UpdateItems } from '../client/components/UpdateItems';
 export { default as DeleteItems } from '../client/components/DeleteItems';
+export { default as ItemDropDown } from '../client/components/ItemDropDown';


### PR DESCRIPTION
this PR code is on top of #2483 

[see changes for just this PR](https://github.com/gautamsi/keystone/compare/enable-listItemActions-hook...gautamsi:enable-list-specific-hooks?expand=1)

I felt that not all UI hooks components are intended for each and every list page. there are two ways to do it. 

1. you can detect if the list key matches your intended list (existing logic) 
2. add hooks under list key (new logic)

this PR enables 2nd options and you can add hook for specific List as `*${listKey}Actions`

```js
module.exports = {
    // .... other hooks
    itemHeaderActions: ActionsForAllPage,
    itemHeaderPostActions: ActionsForPostItemOnly,
    itemHeaderUserActions: ActionsForUserItemOnly,
}
```

using list specific ui hook will override the global hooks but that can easily be composed inside list specific hook compared to checking if this should render or not.