### PR TITLE
fix chrome mac print bug

### DIFF
--- a/.changeset/sour-timers-teach.md
+++ b/.changeset/sour-timers-teach.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/theme': patch
+---
+
+Fixed issue with Chrome for Mac producing strange characters when printing

--- a/packages/arch/packages/theme/src/index.js
+++ b/packages/arch/packages/theme/src/index.js
@@ -10,6 +10,10 @@ export const fontFamily = `
   "Segoe UI Emoji",
   "Segoe UI Symbol"
 `;
+
+// BlinkMacSystemFont produces very strange characters when printing from Chrome on Mac.
+const printFontFamily = fontFamily.replace('BlinkMacSystemFont,', '');
+
 export const borderRadius = 6;
 export const gridSize = 8;
 export const fontSize = 16;
@@ -33,6 +37,10 @@ export const globalStyles = {
     MozFontFeatureSettings: "'liga' on",
     MozOsxFontSmoothing: 'grayscale',
     WebkitFontSmoothing: 'antialiased',
+    '@media print': {
+      backgroundColor: 'white',
+      fontFamily: printFontFamily,
+    },
   },
   a: {
     color: colors.primary,


### PR DESCRIPTION
## Fixes an issue with printing docs in Chrome on Mac
Also removes the background colour when printing.

### Old print:

![image](https://user-images.githubusercontent.com/814227/76173617-fd6e4c00-61f4-11ea-9523-c8ae89b1b6a1.png)

### New print:

![image](https://user-images.githubusercontent.com/814227/76173631-0bbc6800-61f5-11ea-9361-9396a12cc0ce.png)
