### PR TITLE
More content field updates

### DIFF
--- a/.changeset/stale-rabbits-approve.md
+++ b/.changeset/stale-rabbits-approve.md
@@ -1,0 +1,11 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/field-content': minor
+'@keystonejs/fields': patch
+---
+
+Passed details of the current item to blocks in the content field.
+
+Correctly count block length in the content field.
+
+Fixed some incorrect aria attributes.

--- a/.changeset/stale-rabbits-approve.md
+++ b/.changeset/stale-rabbits-approve.md
@@ -6,6 +6,6 @@
 
 Passed details of the current item to blocks in the content field.
 
-Correctly count block length in the content field.
+Fixed an issue with counting the block length in the content field.
 
 Fixed some incorrect aria attributes.

--- a/demo-projects/meetup/site/components/Modal.js
+++ b/demo-projects/meetup/site/components/Modal.js
@@ -29,7 +29,7 @@ const ModalElement = props => {
   return (
     <>
       <Blanket onClick={onClose} />
-      <Dialog ariaLabel={title}>
+      <Dialog aria-label={title}>
         <Close onClick={onClose} />
         <Title>{title}</Title>
         {children}

--- a/packages/app-admin-ui/client/pages/Item/Footer.js
+++ b/packages/app-admin-ui/client/pages/Item/Footer.js
@@ -15,6 +15,7 @@ const Toolbar = styled.div({
   paddingBottom: gridSize * 2,
   paddingTop: gridSize * 2,
   position: 'sticky',
+  zIndex: 99,
 });
 
 function useKeyListener(listener, deps) {

--- a/packages/field-content/src/views/Field.js
+++ b/packages/field-content/src/views/Field.js
@@ -24,9 +24,8 @@ class ErrorBoundary extends Component {
   }
 }
 
-let ContentField = ({ field, value, onChange, autoFocus, errors }) => {
+let ContentField = ({ field, value, onChange, autoFocus, errors, item }) => {
   const htmlID = `ks-content-editor-${field.path}`;
-
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
@@ -57,6 +56,7 @@ let ContentField = ({ field, value, onChange, autoFocus, errors }) => {
                 onChange={onChange}
                 autoFocus={autoFocus}
                 id={htmlID}
+                item={item}
                 css={{
                   ...inputStyles({ isMultiline: true }),
                   padding: '16px 32px',

--- a/packages/field-content/src/views/editor/add-block.js
+++ b/packages/field-content/src/views/editor/add-block.js
@@ -34,7 +34,7 @@ let AddBlock = ({ editorState, editor, blocks }) => {
       return;
     }
 
-    if (!blocks || !blocks.length) return;
+    if (!blocks || !Object.keys(blocks).length) return;
 
     if (elm && editor && editor.el.contains(elm)) {
       iconEle.style.top = `${elm.offsetTop + elm.offsetHeight / 2}px`;

--- a/packages/field-content/src/views/editor/index.js
+++ b/packages/field-content/src/views/editor/index.js
@@ -32,7 +32,7 @@ function getSchema(blocks) {
   return schema;
 }
 
-function Stories({ value: editorState, onChange, blocks, className, id }) {
+function Stories({ value: editorState, onChange, blocks, className, id, item }) {
   let schema = useMemo(() => {
     return getSchema(blocks);
   }, [blocks]);
@@ -41,7 +41,7 @@ function Stories({ value: editorState, onChange, blocks, className, id }) {
     const renderNode = props => {
       let block = blocks[props.node.type];
       if (block) {
-        return <block.Node {...props} blocks={blocks} />;
+        return <block.Node {...props} blocks={blocks} item={item} />;
       }
       return null;
     };

--- a/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
+++ b/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
@@ -95,7 +95,7 @@ export function Sidebar({ editor }) {
     <svg
       width={16}
       height={16}
-      ariaHidden="true"
+      aria-hidden="true"
       focusable="false"
       role="img"
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Makes the footer float above content field. Fixes some aria attributes. Ensures item data is passed to blocks in the content field. Fix some logic  around counting block length.