### PR TITLE
Website: don't show scrollbars on code cards

### DIFF
--- a/website/src/components/homepage/SectionCode.js
+++ b/website/src/components/homepage/SectionCode.js
@@ -110,7 +110,7 @@ const Card = props => (
       backgroundColor: colors.N100,
       borderRadius: 8,
       padding: '1rem',
-      overflow: 'scroll',
+      overflow: 'auto',
     }}
     {...props}
   />


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/3558659/76282694-82885c80-62ec-11ea-8f4e-f7088271522b.png)
