### PR TITLE
Website: fix some links

### DIFF
--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -26,7 +26,7 @@ export const Footer = () => (
     and
     <br />
     amazing{' '}
-    <Anchor href="https://github.com/keystonejs/keystone-5/graphs/contributors" target="_blank">
+    <Anchor href="https://github.com/keystonejs/keystone/graphs/contributors" target="_blank">
       contributors
     </Anchor>
   </footer>

--- a/website/src/components/homepage/HomepageFooter.js
+++ b/website/src/components/homepage/HomepageFooter.js
@@ -37,7 +37,7 @@ const HomepageFooter = () => (
           and{' '}
           <a
             css={{ color: colors.N80 }}
-            href="https://github.com/keystonejs/keystone-5/blob/master/CONTRIBUTING.md#contributors"
+            href="https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md#contributors"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -49,7 +49,7 @@ const HomepageFooter = () => (
           Keystone v4 has moved to{' '}
           <a
             css={{ color: colors.N80 }}
-            href="https://github.com/keystonejs/keystone-5"
+            href="https://v4.keystonejs.com/"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/website/src/components/homepage/SectionHero.js
+++ b/website/src/components/homepage/SectionHero.js
@@ -32,7 +32,7 @@ const SectionHero = () => (
           </Button>
           <Button
             variant="link"
-            href="https://github.com/keystonejs/keystone-5"
+            href="https://github.com/keystonejs/keystone"
             rel="noopener noreferrer"
             target="_blank"
             css={{


### PR DESCRIPTION
A few GH links were still using the `keystone-5` format and the v4 link pointed to the wrong thing.