### PR TITLE
Mention that dropDatabase is ignored in production

### DIFF
--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -32,7 +32,7 @@ All postgres tables are grouped within a schema and `public` is the default sche
 
 _**Default:**_ `false`
 
-Allow the adapter to drop the entire database and recreate the tables / foreign keys based on the list schema in your application.
+Allow the adapter to drop the entire database and recreate the tables / foreign keys based on the list schema in your application. This option is ignored in production, i.e. when the environment variable NODE_ENV === 'production'.
 
 ### `options.knexOptions`
 


### PR DESCRIPTION
As can be seen here:
https://github.com/keystonejs/keystone/blob/2582d22d8fb3ff38920412ccab0624a07d385ace/packages/adapter-knex/lib/adapter-knex.js#L76