### PR TITLE
Fixed letters sometimes being cut off in input fields

### DIFF
--- a/.changeset/clean-zebras-flash.md
+++ b/.changeset/clean-zebras-flash.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/common': patch
+---
+
+Fixed some letters being cut off in input fields.

--- a/packages/arch/packages/common/src/index.js
+++ b/packages/arch/packages/common/src/index.js
@@ -8,7 +8,6 @@ export const uniformHeight = {
   boxSizing: 'border-box',
   fontFamily: 'inherit',
   fontSize: '1.0rem',
-  lineHeight: '1.2rem',
   margin: 0,
   minWidth: 1,
   padding: `${gridSize}px ${gridSize * 1.5}px`,


### PR DESCRIPTION
Fixes this (note the bottom of the G is cut off):
![image](https://user-images.githubusercontent.com/3558659/76687216-f83a5280-6675-11ea-8715-c609cbef7617.png)

Similar to #2023