### PR TITLE
Refactored `matchFilter` to use named args (via an object)

### DIFF
--- a/.changeset/little-geese-hunt.md
+++ b/.changeset/little-geese-hunt.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/test-utils': major
+'@keystonejs/fields': patch
+---
+
+Refactored `matchFilter` to use named args (via an object) which makes understanding test code easier.

--- a/packages/fields/src/types/CalendarDay/filterTests.js
+++ b/packages/fields/src/types/CalendarDay/filterTests.js
@@ -24,8 +24,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(keystone, filter, '{ name, birthday }', targets, 'name');
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name birthday',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Checkbox/filterTests.js
+++ b/packages/fields/src/types/Checkbox/filterTests.js
@@ -23,8 +23,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(keystone, filter, '{ name enabled }', targets, 'name');
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name enabled',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/DateTime/filterTests.js
+++ b/packages/fields/src/types/DateTime/filterTests.js
@@ -24,8 +24,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets, forceSortBy = 'name') =>
-    matchFilter(keystone, filter, '{ name, lastOnline }', targets, forceSortBy);
+  const match = (keystone, queryArgs, expected, forceSortBy = 'name') =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name lastOnline',
+      expected,
+      sortKey: forceSortBy,
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Decimal/filterTests.js
+++ b/packages/fields/src/types/Decimal/filterTests.js
@@ -24,8 +24,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(keystone, filter, '{ name, price }', targets, 'name');
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name price',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Float/filterTests.js
+++ b/packages/fields/src/types/Float/filterTests.js
@@ -28,8 +28,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(keystone, filter, '{ name, stars }', targets, 'name');
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name stars',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Integer/filterTests.js
+++ b/packages/fields/src/types/Integer/filterTests.js
@@ -24,8 +24,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(keystone, filter, '{ name, count }', targets, 'name');
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'name count',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Password/filterTests.js
+++ b/packages/fields/src/types/Password/filterTests.js
@@ -22,14 +22,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
       keystone,
-      filter,
-      '{ name password_is_set }',
-      targets,
-      'name' // Sort by name
-    );
+      queryArgs,
+      fieldSelection: 'name password_is_set',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Select/filterTests.js
+++ b/packages/fields/src/types/Select/filterTests.js
@@ -32,14 +32,14 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) =>
-    matchFilter(
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
       keystone,
-      filter,
-      '{ company name }',
-      targets,
-      'name' // Sort by name
-    );
+      queryArgs,
+      fieldSelection: 'name company',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/fields/src/types/Text/filterTests.js
+++ b/packages/fields/src/types/Text/filterTests.js
@@ -30,9 +30,14 @@ export const initItems = () => {
 // See https://github.com/keystonejs/keystone-5/issues/391
 
 export const filterTests = withKeystone => {
-  const match = (keystone, gqlArgs, targets) => {
-    return matchFilter(keystone, gqlArgs, '{ name order }', targets, 'order');
-  };
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'order name',
+      expected,
+      sortKey: 'order',
+    });
 
   test(
     `No 'where' argument`,

--- a/packages/fields/src/types/Uuid/filterTests.js
+++ b/packages/fields/src/types/Uuid/filterTests.js
@@ -28,9 +28,14 @@ export const initItems = () => {
 // See https://github.com/keystonejs/keystone-5/issues/391
 
 export const filterTests = withKeystone => {
-  const match = (keystone, gqlArgs, targets) => {
-    return matchFilter(keystone, gqlArgs, '{ order otherId }', targets, 'order');
-  };
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'order otherId',
+      expected,
+      sortKey: 'order',
+    });
 
   test(
     `No 'where' argument`,

--- a/packages/fields/tests/idFilterTests.js
+++ b/packages/fields/tests/idFilterTests.js
@@ -24,9 +24,14 @@ const getIDs = async keystone => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, filter, targets) => {
-    return matchFilter(keystone, filter, '{ id name }', targets, 'name');
-  };
+  const match = (keystone, queryArgs, expected) =>
+    matchFilter({
+      keystone,
+      queryArgs,
+      fieldSelection: 'id name',
+      expected,
+      sortKey: 'name',
+    });
 
   test(
     'No filter',

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -207,12 +207,15 @@ const sorted = (arr, keyFn) => {
   return arr;
 };
 
-const matchFilter = (keystone, gqlArgs, fields, target, sortkey) => {
-  gqlArgs = gqlArgs ? `(${gqlArgs})` : '';
-  const snippet = `allTests ${gqlArgs} ${fields}`;
-  return graphqlRequest({ keystone, query: `query { ${snippet} }` }).then(({ data }) => {
-    const value = sortkey ? sorted(data.allTests || [], i => i[sortkey]) : data.allTests;
-    expect(value).toEqual(target);
+const matchFilter = ({ keystone, queryArgs, fieldSelection, expected, sortKey }) => {
+  return graphqlRequest({
+    keystone,
+    query: `query {
+      allTests${queryArgs ? `(${queryArgs})` : ''} { ${fieldSelection} }
+    }`,
+  }).then(({ data }) => {
+    const value = sortKey ? sorted(data.allTests || [], i => i[sortKey]) : data.allTests;
+    expect(value).toEqual(expected);
   });
 };
 


### PR DESCRIPTION
I found myself switching back and forward from implementation to usage to figure out exactly what this method does. Now with the named args, it makes more sense to my brain.