### PR TITLE
Fixed access control oversight in starter (fixes #2518)

### DIFF
--- a/.changeset/twelve-singers-do.md
+++ b/.changeset/twelve-singers-do.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-app': minor
+---
+
+Improved starter access control example so users can't make themselves admins using it.

--- a/packages/create-keystone-app/example-projects/starter/index.js
+++ b/packages/create-keystone-app/example-projects/starter/index.js
@@ -24,11 +24,13 @@ const userOwnsItem = ({ authentication: { item: user } }) => {
   }
   return { id: user.id };
 };
+
 const userIsAdminOrOwner = auth => {
   const isAdmin = access.userIsAdmin(auth);
   const isOwner = access.userOwnsItem(auth);
   return isAdmin ? isAdmin : isOwner;
 };
+
 const access = { userIsAdmin, userOwnsItem, userIsAdminOrOwner };
 
 keystone.createList('User', {
@@ -38,11 +40,19 @@ keystone.createList('User', {
       type: Text,
       isUnique: true,
     },
-    isAdmin: { type: Checkbox },
+    isAdmin: {
+      type: Checkbox,
+      // Field-level access controls
+      // Here, we set more restrictive field access so a non-admin cannot make themselves admin.
+      access: {
+        update: access.userIsAdmin,
+      },
+    },
     password: {
       type: Password,
     },
   },
+  // List-level access controls
   access: {
     read: access.userIsAdminOrOwner,
     update: access.userIsAdminOrOwner,


### PR DESCRIPTION
Fixes #2518. Now starter users can't make themselves admins. 😬 