### PR TITLE
Remove useless existingItem field from defaultValue field function

### DIFF
--- a/.changeset/plenty-donkeys-draw.md
+++ b/.changeset/plenty-donkeys-draw.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': patch
+'@keystonejs/keystone': patch
+---
+
+Remove unused 'existingItem' parameter from calls to .defaultValue() methods

--- a/.changeset/plenty-donkeys-draw.md
+++ b/.changeset/plenty-donkeys-draw.md
@@ -3,4 +3,4 @@
 '@keystonejs/keystone': patch
 ---
 
-Remove unused 'existingItem' parameter from calls to .defaultValue() methods
+Removed unused 'existingItem' parameter from calls to .defaultValue() methods.

--- a/api-tests/default-value/defaults.test.js
+++ b/api-tests/default-value/defaults.test.js
@@ -144,7 +144,6 @@ describe('defaultValue field config', () => {
               expect(defaultValue).toHaveBeenCalledTimes(1);
               expect(defaultValue).toHaveBeenCalledWith(
                 expect.objectContaining({
-                  existingItem: undefined,
                   context: expect.any(Object),
                   originalInput: expect.any(Object),
                   actions: expect.any(Object),
@@ -171,7 +170,6 @@ describe('defaultValue field config', () => {
               expect(defaultValue).toHaveBeenCalledTimes(1);
               expect(defaultValue).toHaveBeenCalledWith(
                 expect.objectContaining({
-                  existingItem: undefined,
                   context: expect.any(Object),
                   originalInput: {
                     salutation: 'Doctor',

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -84,7 +84,7 @@ keystone.createList('Post', {
   fields: {
     title: {
       type: Text,
-      defaultValue: ({ existingItem, context, originalInput, actions }) => {
+      defaultValue: ({ context, originalInput, actions }) => {
         /**/
       },
     },

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -189,10 +189,10 @@ class Field {
   extendAdminViews(views) {
     return views;
   }
-  getDefaultValue({ existingItem, context, originalInput, actions }) {
+  getDefaultValue({ context, originalInput, actions }) {
     if (typeof this.defaultValue !== 'undefined') {
       if (typeof this.defaultValue === 'function') {
-        return this.defaultValue({ existingItem, context, originalInput, actions });
+        return this.defaultValue({ context, originalInput, actions });
       } else {
         return this.defaultValue;
       }

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -184,16 +184,15 @@ describe('getDefaultValue()', () => {
 
   test('executes a function', () => {
     const defaultValue = jest.fn(() => 'foobar');
-    const existingItem = {};
     const context = {};
     const originalInput = {};
     const actions = {};
 
     const impl = new Field('path', { defaultValue }, args);
 
-    const value = impl.getDefaultValue({ existingItem, context, originalInput, actions });
+    const value = impl.getDefaultValue({ context, originalInput, actions });
     expect(value).toEqual('foobar');
     expect(defaultValue).toHaveBeenCalledTimes(1);
-    expect(defaultValue).toHaveBeenCalledWith({ existingItem, context, originalInput, actions });
+    expect(defaultValue).toHaveBeenCalledWith({ context, originalInput, actions });
   });
 });

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -1066,9 +1066,8 @@ module.exports = class List {
     );
   }
 
-  async _resolveDefaults({ existingItem, context, originalInput }) {
+  async _resolveDefaults({ context, originalInput }) {
     const args = {
-      existingItem,
       context,
       originalInput,
       actions: mapKeys(this.hooksActions, hook => hook(context)),
@@ -1332,7 +1331,7 @@ module.exports = class List {
   async _createSingle(originalInput, existingItem, context, mutationState) {
     const operation = 'create';
     return await this._nestedMutation(mutationState, context, async mutationState => {
-      const defaultedItem = await this._resolveDefaults({ existingItem, context, originalInput });
+      const defaultedItem = await this._resolveDefaults({ context, originalInput });
 
       // Enable resolveRelationship to perform some action after the item is created by
       // giving them a promise which will eventually resolve with the value of the


### PR DESCRIPTION
Because `getDefaultValue` (and hence the field's `defaultValue`) function is only ever called during create, there can never be an `existingItem`.