### PR TITLE
Add new @keystonejs/fields-authed-relationship for auto-filling currently logged in user

### DIFF
--- a/.changeset/lucky-bears-stare.md
+++ b/.changeset/lucky-bears-stare.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields-authed-relationship': major
+---
+
+Initial release.

--- a/demo-projects/blog/package.json
+++ b/demo-projects/blog/package.json
@@ -27,6 +27,7 @@
     "@keystonejs/app-static": "^5.1.1",
     "@keystonejs/auth-password": "^5.1.2",
     "@keystonejs/fields": "^7.0.0",
+    "@keystonejs/fields-authed-relationship": "^0.0.0",
     "@keystonejs/fields-markdown": "^5.1.3",
     "@keystonejs/fields-wysiwyg-tinymce": "^5.2.1",
     "@keystonejs/file-adapters": "^6.0.0",

--- a/demo-projects/blog/schema.js
+++ b/demo-projects/blog/schema.js
@@ -12,6 +12,7 @@ const {
   OEmbed,
 } = require('@keystonejs/fields');
 const { Wysiwyg } = require('@keystonejs/fields-wysiwyg-tinymce');
+const { AuthedRelationship } = require('@keystonejs/fields-authed-relationship');
 const { LocalFileAdapter } = require('@keystonejs/file-adapters');
 const getYear = require('date-fns/get_year');
 
@@ -59,13 +60,19 @@ exports.User = {
   labelResolver: item => `${item.name} <${item.email}>`,
 };
 
+const isAccessAllowed = ({ authentication: { item: user } }) => !!user && !!user.isAdmin;
+
 exports.Post = {
   fields: {
     title: { type: Text },
     slug: { type: Slug, from: 'title' },
     author: {
-      type: Relationship,
+      type: AuthedRelationship,
       ref: 'User',
+      access: {
+        create: isAccessAllowed,
+        update: isAccessAllowed,
+      },
     },
     categories: {
       type: Relationship,

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "packages": [
       "packages/field-content",
       "packages/fields",
+      "packages/fields-authed-relationship",
       "packages/fields-auto-increment",
       "packages/fields-datetime-utc",
       "packages/fields-markdown",

--- a/packages/fields-authed-relationship/CHANGELOG.md
+++ b/packages/fields-authed-relationship/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @keystonejs/fields-authed-relationship

--- a/packages/fields-authed-relationship/README.md
+++ b/packages/fields-authed-relationship/README.md
@@ -1,0 +1,80 @@
+<!--[meta]
+section: api
+subSection: field-types
+title: AuthedRelationship
+[meta]-->
+
+# AuthedRelationship
+
+An extension on the `Relationship` field which is automatically set to the
+currently authenticated item during a create mutation.
+
+Great for setting fields like `Post.author` or `Product.owner`, etc.
+
+## Usage
+
+### Basic
+
+```js
+keystone.createList('User', {
+  fields: {
+    name: { type: String },
+  }
+});
+
+keystone.createList('Post', {
+  fields: {
+    // Automatically set to the currently logged in user on create
+    author: {
+      type: AuthedRelationship,
+      ref: 'User',
+    }
+  }
+});
+```
+
+### Complete example
+
+This example allows "admins" to overwrite the value
+
+```js
+keystone.createList('User', {
+  fields: {
+    name: { type: String },
+    isAdmin: { type: Checkbox, default: false },
+  }
+});
+
+const isAdmin = ({ authentication: { item } }) => !!item && item.isAdmin;
+
+keystone.createList('Post', {
+  fields: {
+    author: {
+      type: AuthedRelationship,
+      ref: 'User',
+      access: {
+        create: isAdmin,
+        update: isAdmin,
+      },
+    }
+  }
+});
+```
+
+### Config
+
+| Option       | Type      | Default | Description                                                     |
+| ------------ | --------- | ------- | --------------------------------------------------------------- |
+| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
+
+## Differences from `Relationship`
+
+- No `many: true`. This field is purely for a to-single relationship and cannot
+  be used to refer to more than one item.
+- Cannot specify a `defaultValue`. The entire purpose of this field is to
+  provide that method for you.
+- When setting `isRequired`, it will be checked during the "default value" phase
+  of the mutation lifecycle. This means it may throw an error earlier than other
+  fields
+- Default access control set to `{ create: false, read: true, update: false }`
+- Access control _does not_ respect any Keystone-level `defaultAccess`

--- a/packages/fields-authed-relationship/package.json
+++ b/packages/fields-authed-relationship/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@keystonejs/fields-authed-relationship",
+  "description": "KeystoneJS AuthedRelationship Field Type",
+  "version": "0.0.0",
+  "author": "The KeystoneJS Development Team",
+  "license": "MIT",
+  "main": "dist/fields-authed-relationship.cjs.js",
+  "repository": "https://github.com/keystonejs/keystone/tree/master/packages/fields-authed-relationship",
+  "homepage": "https://github.com/keystonejs/keystone",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.8.4",
+    "@keystonejs/fields": "^7.0.0"
+  },
+  "module": "dist/fields-authed-relationship.esm.js"
+}

--- a/packages/fields-authed-relationship/src/Implementation.js
+++ b/packages/fields-authed-relationship/src/Implementation.js
@@ -1,0 +1,74 @@
+import { Relationship } from '@keystonejs/fields';
+
+export class AuthedRelationship extends Relationship.implementation {
+  constructor(path, config, meta) {
+    let access;
+    if (typeof config.access === 'object') {
+      access = config.access;
+    } else {
+      access = {
+        create: config.access,
+        read: config.access,
+        update: config.access,
+      };
+    }
+
+    access = {
+      // Set default access control values
+      // These are stricter than Keystone's defaults
+      ...{ create: false, read: true, update: false },
+      ...access,
+    };
+
+    super(
+      path,
+      {
+        ...config,
+        access,
+      },
+      meta
+    );
+
+    if (typeof this.defaultValue !== 'undefined') {
+      throw new Error(
+        `An AuthedRelationship field's default is derived from the currently authenticated item. Try removing 'defaultValue: ...' from ${this.listKey}.${this.path}`
+      );
+    }
+
+    if (this.many) {
+      throw new Error(
+        `An AuthedRelationship field can only be to-single, not to-many. Try removing 'many: true' from ${this.listKey}.${this.path}`
+      );
+    }
+
+    // Reset this so there are no core-level isRequired checks run. We'll handle
+    // them ourselves with this.isRequiredOnCreate
+    this.isRequiredOnCreate = this.isRequired;
+    this.isRequired = false;
+
+    this.defaultValue = ({ context }) => {
+      if (this.isRequiredOnCreate) {
+        if (!context.authedListKey) {
+          throw new Error(
+            `An unauthenticated request attempted to create a new ${this.listKey} without specifying a value for ${this.listKey}.${this.path}<AuthenticatedRelationship>, however it is marked 'isRequired'.`
+          );
+        }
+
+        if (context.authedListKey !== this.refListKey) {
+          throw new Error(
+            `${this.listKey}.${this.path}<AuthedRelationship> is marked as 'isRequired'`
+          );
+          throw new Error(
+            `A request attempted to create a new ${this.listKey} without specifying a value for ${this.listKey}.${this.path}<AuthenticatedRelationship>. This request was authenticated with the list ${this.listKey}, however ${this.listKey}.${this.path} is configured to reference the list ${this.refListKey}.`
+          );
+        }
+      }
+
+      if (context.authedListKey === this.refListKey && context.authedItem) {
+        return { connect: { id: context.authedItem.id } };
+      }
+
+      return undefined;
+    };
+  }
+}

--- a/packages/fields-authed-relationship/src/index.js
+++ b/packages/fields-authed-relationship/src/index.js
@@ -1,0 +1,8 @@
+import { Relationship } from '@keystonejs/fields';
+import { AuthedRelationship as implementation } from './Implementation';
+
+export const AuthedRelationship = {
+  ...Relationship,
+  type: 'AuthedRelationship',
+  implementation,
+};


### PR DESCRIPTION
[Read the docs](https://github.com/keystonejs/keystone/compare/authed-item-field-2517?expand=1#diff-d8d55cbfe2a4ee1b6a075a69e54720b0)

Depends on: https://github.com/keystonejs/keystone/pull/2570

See #2517 for motivations

See #2564 for a usage demo.

Closes #2517