### PR TITLE
Use the AuthedRelationship field in Blog demo

### DIFF
--- a/.changeset/ninety-beers-taste.md
+++ b/.changeset/ninety-beers-taste.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/demo-project-blog': minor
+---
+
+- Add a Sign In screen to the Blog demo for submitting posts & comments.
+- Show usage of `AuthedRelationship` field in the Blog demo. With this field, the client no longer needs to send along the user id of the author; instead, it is set automatically based on the currently authenticated user.

--- a/demo-projects/blog/app/components/banner.js
+++ b/demo-projects/blog/app/components/banner.js
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+export const Banner = ({ style = 'success', children }) => {
+  return (
+    <div
+      css={{
+        background: style === 'success' ? '#90ee9061' : '#ee909061',
+        border: `1px solid ${style === 'success' ? 'green' : 'red'}`,
+        color: style === 'success' ? 'green' : 'red',
+        padding: 12,
+        marginBottom: 32,
+        borderRadius: 6,
+      }}
+    >
+      <span>{children}</span>
+    </div>
+  );
+};

--- a/demo-projects/blog/app/pages/post/[slug].js
+++ b/demo-projects/blog/app/pages/post/[slug].js
@@ -10,19 +10,15 @@ import { format } from 'date-fns';
 
 import Layout from '../../templates/layout';
 import Header from '../../components/header';
+import { Banner } from '../../components/banner';
 import { withApollo } from '../../lib/apollo';
 
 /** @jsx jsx */
 
 const ADD_COMMENT = gql`
-  mutation AddComment($body: String!, $author: ID!, $postId: ID!, $posted: DateTime!) {
+  mutation AddComment($body: String!, $postId: ID!, $posted: DateTime!) {
     createComment(
-      data: {
-        body: $body
-        author: { connect: { id: $author } }
-        originalPost: { connect: { id: $postId } }
-        posted: $posted
-      }
+      data: { body: $body, originalPost: { connect: { id: $postId } }, posted: $posted }
     ) {
       id
       body
@@ -63,12 +59,6 @@ const ALL_QUERIES = gql`
         }
       }
       posted
-    }
-
-    allUsers {
-      name
-      email
-      id
     }
   }
 `;
@@ -118,81 +108,100 @@ const Comments = ({ data }) => (
   </div>
 );
 
-const AddComments = ({ users, post }) => {
-  let user = users.filter(u => u.email == 'user@keystonejs.com')[0];
+const AddComments = ({ post }) => {
   let [comment, setComment] = useState('');
 
-  const [createComment] = useMutation(ADD_COMMENT, {
-    update: (cache, { data: data }) => {
-      const { allComments, allUsers, allPosts } = cache.readQuery({
-        query: ALL_QUERIES,
-        variables: { slug: post.slug },
-      });
+  const { data, loading: userLoading, error: userError } = useQuery(gql`
+    query {
+      authenticatedUser {
+        id
+      }
+    }
+  `);
 
-      cache.writeQuery({
-        query: ALL_QUERIES,
-        variables: { slug: post.slug },
-        data: {
-          allPosts,
-          allUsers,
-          allComments: allComments.concat([data.createComment]),
-        },
-      });
-    },
+  const [createComment, { loading: savingComment, error: saveError }] = useMutation(ADD_COMMENT, {
+    refetchQueries: ['AllQueries'],
   });
+
+  const loggedIn = !userLoading && !!data.authenticatedUser;
+  const formDisabled = !loggedIn || savingComment;
+  const error = userError || saveError;
 
   return (
     <div>
       <h2>Add new Comment</h2>
-      <form
-        onSubmit={e => {
-          e.preventDefault();
 
-          createComment({
-            variables: {
-              body: comment,
-              author: user.id,
-              postId: post.id,
-              posted: new Date(),
-            },
-          });
+      {userLoading ? (
+        <p>loading...</p>
+      ) : (
+        <>
+          {error && (
+            <Banner style={'error'}>
+              <strong>Whoops!</strong> Something has gone wrong
+              <br />
+              {error.message || userError.toString()}
+            </Banner>
+          )}
+          {!loggedIn && (
+            <Banner style={'error'}>
+              <a href="/signin" as="/signin">
+                Sign In
+              </a>{' '}
+              to leave a comment.
+            </Banner>
+          )}
+          <form
+            onSubmit={e => {
+              e.preventDefault();
 
-          setComment('');
-        }}
-      >
-        <textarea
-          type="text"
-          placeholder="Write a comment"
-          name="comment"
-          css={{
-            padding: 12,
-            fontSize: 16,
-            width: '100%',
-            height: 60,
-            border: 0,
-            borderRadius: 6,
-            resize: 'none',
-          }}
-          value={comment}
-          onChange={event => {
-            setComment(event.target.value);
-          }}
-        />
+              createComment({
+                variables: {
+                  body: comment,
+                  postId: post.id,
+                  posted: new Date(),
+                },
+              });
 
-        <input
-          type="submit"
-          value="Submit"
-          css={{
-            padding: '6px 12px',
-            borderRadius: 6,
-            background: 'hsl(200, 20%, 50%)',
-            fontSize: '1em',
-            color: 'white',
-            border: 0,
-            marginTop: 6,
-          }}
-        />
-      </form>
+              setComment('');
+            }}
+          >
+            <textarea
+              type="text"
+              placeholder="Write a comment"
+              name="comment"
+              disabled={formDisabled}
+              css={{
+                padding: 12,
+                fontSize: 16,
+                width: '100%',
+                height: 60,
+                border: 0,
+                borderRadius: 6,
+                resize: 'none',
+              }}
+              value={comment}
+              onChange={event => {
+                setComment(event.target.value);
+              }}
+            />
+
+            <input
+              type="submit"
+              value="Submit"
+              disabled={formDisabled}
+              css={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                background: 'hsl(200, 20%, 50%)',
+                fontSize: '1em',
+                color: 'white',
+                border: 0,
+                marginTop: 6,
+              }}
+            />
+          </form>
+        </>
+      )}
     </div>
   );
 };
@@ -249,7 +258,7 @@ const PostPage = withApollo(({ slug }) => {
 
                 <Comments data={data} />
 
-                <AddComments post={post} users={data.allUsers} />
+                <AddComments post={post} />
               </>
             );
           }}

--- a/demo-projects/blog/app/pages/post/new.js
+++ b/demo-projects/blog/app/pages/post/new.js
@@ -9,6 +9,8 @@ import { useState } from 'react';
 import styled from '@emotion/styled';
 
 import Layout from '../../templates/layout';
+import { Banner } from '../../components/banner';
+
 import { withApollo } from '../../lib/apollo';
 
 const FormGroup = styled.div({
@@ -31,22 +33,8 @@ const Input = styled.input({
 });
 
 const ADD_POST = gql`
-  mutation AddPost(
-    $title: String!
-    $body: String!
-    $authorId: ID!
-    $posted: DateTime!
-    $image: Upload!
-  ) {
-    createPost(
-      data: {
-        title: $title
-        body: $body
-        author: { connect: { id: $authorId } }
-        posted: $posted
-        image: $image
-      }
-    ) {
+  mutation AddPost($title: String!, $body: String!, $posted: DateTime!, $image: Upload!) {
+    createPost(data: { title: $title, body: $body, posted: $posted, image: $image }) {
       id
       slug
     }
@@ -57,26 +45,25 @@ export default withApollo(() => {
   const [title, setTitle] = useState('');
   const [body, setBody] = useState('');
   const [image, setImage] = useState('');
-  const [authorId, setAuthorId] = useState('');
-  const [showBanner, setShowBanner] = useState(false);
   const [slug, setSlug] = useState('');
 
-  const { data, loading, error } = useQuery(gql`
+  const { data, loading: userLoading, error: userError } = useQuery(gql`
     query {
-      allUsers(where: { isAdmin: true }) {
-        name
-        email
+      authenticatedUser {
         id
       }
     }
   `);
 
-  const [createPost] = useMutation(ADD_POST, {
+  const [createPost, { error: saveError, loading: savingPost }] = useMutation(ADD_POST, {
     update: (cache, { data: { createPost } }) => {
       setSlug(createPost.slug);
-      setShowBanner(true);
     },
   });
+
+  const loggedIn = !userLoading && !!data.authenticatedUser;
+  const formDisabled = !loggedIn || savingPost;
+  const error = userError || saveError;
 
   return (
     <Layout>
@@ -86,118 +73,98 @@ export default withApollo(() => {
         </Link>
         <h1>New Post</h1>
 
-        {showBanner && (
-          <div
-            css={{
-              background: slug ? '#90ee9061' : '#ee909061',
-              border: `1px solid ${slug ? 'green' : 'red'}`,
-              color: slug ? 'green' : 'red',
-              padding: 12,
-              marginBottom: 32,
-              borderRadius: 6,
-            }}
-          >
-            {slug ? (
-              <span>
-                <strong>Success!</strong> Post has been created.{' '}
-                <Link href={`/post/[slug]?slug=${slug}`} as={`/post/${slug}`} passHref>
-                  <a css={{ color: 'green' }}>Check it out</a>
-                </Link>
-              </span>
-            ) : (
-              <span>
-                <strong>Whoops!</strong> Something has gone wrong
-              </span>
-            )}
-          </div>
+        {slug && (
+          <Banner style="success">
+            <strong>Success!</strong> Post has been created.{' '}
+            <Link href={`/post/[slug]?slug=${slug}`} as={`/post/${slug}`} passHref>
+              <a css={{ color: 'green' }}>Check it out</a>
+            </Link>
+          </Banner>
         )}
 
-        {loading ? (
+        {userLoading ? (
           <p>loading...</p>
-        ) : error ? (
-          <p>Error!</p>
         ) : (
-          <form
-            onSubmit={e => {
-              e.preventDefault();
-              createPost({
-                variables: {
-                  title,
-                  body,
-                  image,
-                  authorId: authorId || data.allUsers[0].id,
-                  posted: new Date(),
-                },
-              });
+          <>
+            {error && (
+              <Banner style={'error'}>
+                <strong>Whoops!</strong> Something has gone wrong
+                <br />
+                {error.message || userError.toString()}
+              </Banner>
+            )}
+            {!loggedIn && (
+              <Banner style={'error'}>
+                <a href="/signin" as="/signin">
+                  Sign In
+                </a>{' '}
+                to create a post.
+              </Banner>
+            )}
+            <form
+              disabled={formDisabled}
+              onSubmit={e => {
+                e.preventDefault();
+                createPost({
+                  variables: {
+                    title,
+                    body,
+                    image,
+                    posted: new Date(),
+                  },
+                });
 
-              setTitle('');
-              setBody('');
-            }}
-          >
-            <FormGroup>
-              <Label htmlFor="title">Title:</Label>
-              <Input
-                type="text"
-                name="title"
-                value={title}
-                onChange={event => {
-                  setTitle(event.target.value);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <Label htmlFor="body">Body:</Label>
-              <textarea
-                css={{
-                  width: '100%',
-                  padding: 8,
-                  fontSize: '1em',
-                  borderRadius: 4,
-                  border: '1px solid hsl(200,20%,70%)',
-                  height: 200,
-                  resize: 'none',
-                }}
-                name="body"
-                value={body}
-                onChange={event => {
-                  setBody(event.target.value);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <Label htmlFor="image">Image URL:</Label>
-              <Input
-                type="file"
-                name="image"
-                // value={image}
-                onChange={event => {
-                  setImage(event.target.files[0]);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <Label htmlFor="admin">Post as:</Label>
-              <select
-                name="admin"
-                css={{
-                  width: '100%',
-                  height: 32,
-                  fontSize: '1em',
-                  borderRadius: 4,
-                  border: '1px solid hsl(200,20%,70%)',
-                }}
-                value={authorId}
-                onChange={event => {
-                  setAuthorId(event.target.value);
-                }}
-              >
-                {data.allUsers.map(user => (
-                  <option value={user.id} key={user.id}>{`${user.name} <${user.email}>`}</option>
-                ))}
-              </select>
-            </FormGroup>
-            <input type="submit" value="submit" />
-          </form>
+                setTitle('');
+                setBody('');
+              }}
+            >
+              <FormGroup>
+                <Label htmlFor="title">Title:</Label>
+                <Input
+                  disabled={formDisabled}
+                  type="text"
+                  name="title"
+                  value={title}
+                  onChange={event => {
+                    setTitle(event.target.value);
+                  }}
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="body">Body:</Label>
+                <textarea
+                  disabled={formDisabled}
+                  css={{
+                    width: '100%',
+                    padding: 8,
+                    fontSize: '1em',
+                    borderRadius: 4,
+                    border: '1px solid hsl(200,20%,70%)',
+                    height: 200,
+                    resize: 'none',
+                  }}
+                  name="body"
+                  value={body}
+                  onChange={event => {
+                    setBody(event.target.value);
+                  }}
+                />
+              </FormGroup>
+              <FormGroup>
+                <Label htmlFor="image">Image URL:</Label>
+                <Input
+                  disabled={formDisabled}
+                  type="file"
+                  name="image"
+                  // value={image}
+                  onChange={event => {
+                    setImage(event.target.files[0]);
+                  }}
+                />
+              </FormGroup>
+              <input type="submit" value="submit" disabled={formDisabled} />
+            </form>
+          </>
         )}
       </div>
     </Layout>

--- a/demo-projects/blog/app/pages/signin.js
+++ b/demo-projects/blog/app/pages/signin.js
@@ -1,0 +1,125 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import Link from 'next/link';
+
+import gql from 'graphql-tag';
+import { useMutation, useQuery } from '@apollo/react-hooks';
+import { useState } from 'react';
+
+import styled from '@emotion/styled';
+
+import Layout from '../templates/layout';
+import { Banner } from '../components/banner';
+import { withApollo } from '../lib/apollo';
+
+const FormGroup = styled.div({
+  display: 'flex',
+  marginBottom: 8,
+  width: '100%',
+  maxWidth: 500,
+});
+
+const Label = styled.label({
+  width: 200,
+});
+
+const Input = styled.input({
+  width: '100%',
+  padding: 8,
+  fontSize: '1em',
+  borderRadius: 4,
+  border: '1px solid hsl(200,20%,70%)',
+});
+
+const AUTHENTICATE = gql`
+  mutation authenticate($email: String!, $password: String!) {
+    authenticateUserWithPassword(email: $email, password: $password) {
+      item {
+        id
+      }
+    }
+  }
+`;
+
+const AUTHENTICATED_USER = gql`
+  query authenticatedUser {
+    authenticatedUser {
+      id
+    }
+  }
+`;
+
+export default withApollo(() => {
+  const [email, setEmail] = useState('user@keystonejs.com');
+  const [password, setPassword] = useState('password');
+
+  const { data: { authenticatedUser } = {}, loading, error } = useQuery(AUTHENTICATED_USER);
+  const [authenticate, { loading: signingIn, error: signinError }] = useMutation(AUTHENTICATE, {
+    refetchQueries: ['authenticatedUser'],
+  });
+
+  return (
+    <Layout>
+      <div css={{ margin: '48px 0' }}>
+        <Link href="/" passHref>
+          <a css={{ color: 'hsl(200,20%,50%)', cursor: 'pointer' }}>{'< Home'}</a>
+        </Link>
+        <h1>Sign In</h1>
+
+        {loading || signingIn ? (
+          <p>loading...</p>
+        ) : error || signinError ? (
+          <p>Error!</p>
+        ) : authenticatedUser ? (
+          <Banner style={'success'}>
+            ✅ Signed In
+            <br />
+            <a href="/" as="/">
+              Go home
+            </a>{' '}
+            |{' '}
+            <a href="/post/new" as="/post/new">
+              Create new post
+            </a>
+          </Banner>
+        ) : (
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              authenticate({
+                variables: {
+                  email,
+                  password,
+                },
+              });
+            }}
+          >
+            <FormGroup>
+              <Label htmlFor="email">Email:</Label>
+              <Input
+                type="text"
+                name="email"
+                value={email}
+                onChange={event => {
+                  setEmail(event.target.value);
+                }}
+              />
+            </FormGroup>
+            <FormGroup>
+              <Label htmlFor="password">Password:</Label>
+              <Input
+                type="password"
+                name="password"
+                value={password}
+                onChange={event => {
+                  setPassword(event.target.value);
+                }}
+              />
+            </FormGroup>
+            <input type="submit" value="submit" />
+          </form>
+        )}
+      </div>
+    </Layout>
+  );
+});

--- a/demo-projects/blog/app/templates/layout.js
+++ b/demo-projects/blog/app/templates/layout.js
@@ -19,6 +19,10 @@ const Layout = ({ children }) => (
           textTransform: 'uppercase',
           color: 'hsl(200, 20%, 50%)',
         },
+        '[disabled]': {
+          cursor: 'not-allowed',
+          opacity: 0.6,
+        },
       }}
     />
     <Head>

--- a/demo-projects/blog/schema.js
+++ b/demo-projects/blog/schema.js
@@ -60,7 +60,7 @@ exports.User = {
   labelResolver: item => `${item.name} <${item.email}>`,
 };
 
-const isAccessAllowed = ({ authentication: { item: user } }) => !!user && !!user.isAdmin;
+const isAdmin = ({ authentication: { item: user } }) => !!user && !!user.isAdmin;
 
 exports.Post = {
   fields: {
@@ -69,9 +69,10 @@ exports.Post = {
     author: {
       type: AuthedRelationship,
       ref: 'User',
+      isRequired: true,
       access: {
-        create: isAccessAllowed,
-        update: isAccessAllowed,
+        create: isAdmin,
+        update: isAdmin,
       },
     },
     categories: {
@@ -131,8 +132,13 @@ exports.Comment = {
       ref: 'Post',
     },
     author: {
-      type: Relationship,
+      type: AuthedRelationship,
       ref: 'User',
+      isRequired: true,
+      access: {
+        create: isAdmin,
+        update: isAdmin,
+      },
     },
     posted: { type: DateTime },
   },

--- a/packages/fields-authed-relationship/README.md
+++ b/packages/fields-authed-relationship/README.md
@@ -19,7 +19,7 @@ Great for setting fields like `Post.author` or `Product.owner`, etc.
 keystone.createList('User', {
   fields: {
     name: { type: String },
-  }
+  },
 });
 
 keystone.createList('Post', {
@@ -28,8 +28,8 @@ keystone.createList('Post', {
     author: {
       type: AuthedRelationship,
       ref: 'User',
-    }
-  }
+    },
+  },
 });
 ```
 
@@ -42,7 +42,7 @@ keystone.createList('User', {
   fields: {
     name: { type: String },
     isAdmin: { type: Checkbox, default: false },
-  }
+  },
 });
 
 const isAdmin = ({ authentication: { item } }) => !!item && item.isAdmin;
@@ -56,16 +56,16 @@ keystone.createList('Post', {
         create: isAdmin,
         update: isAdmin,
       },
-    }
-  }
+    },
+  },
 });
 ```
 
 ### Config
 
-| Option       | Type      | Default | Description                                                     |
-| ------------ | --------- | ------- | --------------------------------------------------------------- |
-| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
+| Option       | Type      | Default | Description                      |
+| ------------ | --------- | ------- | -------------------------------- |
+| `isRequired` | `Boolean` | `false` | Does this field require a value? |
 
 ## Differences from `Relationship`
 


### PR DESCRIPTION
~Depends on #2563, #2562 & https://github.com/keystonejs/keystone/pull/2570~ (all merged)

This shows off the usage of [`AuthedRelationship`](https://github.com/keystonejs/keystone/pull/2562) field  meaning the client no longer needs to send along the user id of the author; instead, it is set automatically based on the currently authenticated user:

![new-post](https://user-images.githubusercontent.com/612020/77220336-2a2a4800-6b93-11ea-8ea2-6b1a7daf00e5.gif)

If you were to force submit the form (via the devtools) while you're _not_ logged in, you'd see this:

<img width="686" alt="Screen Shot 2020-03-21 at 4 08 34 pm" src="https://user-images.githubusercontent.com/612020/77220332-167ee180-6b93-11ea-97be-88c80f5ec38e.png">
