### PR TITLE
Uncaught GraphQLError when no list is defined

### DIFF
--- a/.changeset/forty-suns-hunt.md
+++ b/.changeset/forty-suns-hunt.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Uncaught GraphQLError when no list is defined

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { useQuery } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
+import { useLazyQuery } from '@apollo/react-hooks';
+
 import { Container, Grid, Cell } from '@arch-ui/layout';
 import { PageTitle } from '@arch-ui/typography';
 
@@ -53,21 +53,11 @@ const HomepageListProvider = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
-  const query =
-    lists.length !== 0
-      ? gqlCountQueries(lists)
-      : gql`
-          {
-            _ksListsMeta {
-              name
-            }
-          }
-        `;
+  const query = lists.length !== 0 && gqlCountQueries(lists);
 
-  const { data, error } = useQuery(query, {
+  const [getLists, { data, error, called }] = useLazyQuery(query, {
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
-    skip: lists.length === 0,
   });
 
   if (lists.length === 0) {
@@ -84,6 +74,10 @@ const HomepageListProvider = () => {
         </PageError>
       </Fragment>
     );
+  }
+
+  if (!called) {
+    getLists();
   }
 
   let allowedLists = lists;

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
-
+import gql from 'graphql-tag';
 import { Container, Grid, Cell } from '@arch-ui/layout';
 import { PageTitle } from '@arch-ui/typography';
 
@@ -53,6 +53,23 @@ const HomepageListProvider = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
+  const query =
+    lists.length !== 0
+      ? gqlCountQueries(lists)
+      : gql`
+          {
+            _ksListsMeta {
+              name
+            }
+          }
+        `;
+
+  const { data, error } = useQuery(query, {
+    fetchPolicy: 'cache-and-network',
+    errorPolicy: 'all',
+    skip: lists.length === 0,
+  });
+
   if (lists.length === 0) {
     return (
       <Fragment>
@@ -68,10 +85,6 @@ const HomepageListProvider = () => {
       </Fragment>
     );
   }
-
-  const query = gqlCountQueries(lists);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { data, error } = useQuery(query, { fetchPolicy: 'cache-and-network', errorPolicy: 'all' });
 
   let allowedLists = lists;
 

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -53,8 +53,7 @@ const HomepageListProvider = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
-  const query = lists.length !== 0 && gqlCountQueries(lists);
-
+  const query = lists.length !== 0 ? gqlCountQueries(lists) : null;
   const [getLists, { data, error, called }] = useLazyQuery(query, {
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -53,9 +53,6 @@ const HomepageListProvider = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
-  const query = gqlCountQueries(lists);
-  const { data, error } = useQuery(query, { fetchPolicy: 'cache-and-network', errorPolicy: 'all' });
-
   if (lists.length === 0) {
     return (
       <Fragment>
@@ -71,6 +68,10 @@ const HomepageListProvider = () => {
       </Fragment>
     );
   }
+
+  const query = gqlCountQueries(lists);
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { data, error } = useQuery(query, { fetchPolicy: 'cache-and-network', errorPolicy: 'all' });
 
   let allowedLists = lists;
 


### PR DESCRIPTION
Accessing /admin when no list is defined causes Uncaught GraphQLError, if gqlCountQueries is called on an empty array.

Moving this statement below the error page should work, but that causes eslint to complain about conditional hooks. So I also had to add an eslint-ignore-next-line. Not sure if that is ok or not.