### PR TITLE
WIP: Update @sindresorhus/slugify

### DIFF
--- a/packages/adapter-knex/package.json
+++ b/packages/adapter-knex/package.json
@@ -12,7 +12,7 @@
     "@keystonejs/keystone": "^7.0.0",
     "@keystonejs/logger": "^5.1.1",
     "@keystonejs/utils": "^5.4.0",
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "knex": "^0.20.6",
     "p-settle": "^3.1.0",
     "pg": "^7.17.0"


### PR DESCRIPTION
Seeing some weird behaviour in this dependency @sindresorhus/slugify of the @keystone/adapter-knex package. At the current specified version 0.6.0 the slugify function processes “HELLO3 Website” to “hell_o3_website”. That’s the minimum version in the package.json for that package https://github.com/keystonejs/keystone/blob/master/packages/adapter-knex/package.json. As of v0.10.0 it processes “HELLO3 Website” as “hello_3_website”. That is…better, but not “hello3_website” as we are expecting. Take a look here and switch the version of the dependency https://codesandbox.io/s/youthful-blackburn-wvk5n