### PR TITLE
Website: allow ToC items to wrap

### DIFF
--- a/.changeset/selfish-pens-lay.md
+++ b/.changeset/selfish-pens-lay.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/website': patch
+---
+
+Allow ToC entries to wrap.

--- a/website/src/templates/docs.js
+++ b/website/src/templates/docs.js
@@ -137,15 +137,7 @@ export default function Template({
                   {headings
                     .filter(h => h.depth > 1 && h.depth < 4)
                     .map((h, i) => (
-                      <li
-                        key={h.value + i}
-                        css={{
-                          maxWidth: '100%',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
+                      <li key={h.value + i}>
                         <a
                           css={{
                             color: h.depth === 3 ? colors.N60 : colors.N80,


### PR DESCRIPTION
Noticed this one long ToC entry was getting cut off:
![image](https://user-images.githubusercontent.com/3558659/78053719-ba0a9600-73cc-11ea-96a4-3c0d07194f55.png)

Probably best to have these wrap so the full title is readable:
![image](https://user-images.githubusercontent.com/3558659/78053775-ce4e9300-73cc-11ea-819c-a2c473e9a466.png)
