### PR TITLE
Docs: Cleanup table of contents

### DIFF
--- a/.changeset/fresh-news-enjoy.md
+++ b/.changeset/fresh-news-enjoy.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/website': patch
+---
+
+Fix table-of-contents in docs pages:
+- resolve out-of-sync ID issue (`github-slugger` VS `@sindresorhus/slugify`)
+- allow items to wrap, without looking like separate items

--- a/website/src/templates/docs.js
+++ b/website/src/templates/docs.js
@@ -19,6 +19,7 @@ import { media, mq } from '../utils/media';
 import { useNavData } from '../utils/hooks';
 import { titleCase } from '../utils/case';
 
+// TODO: headings, with ids, should come from graphQL
 const slugger = new Slugger();
 
 export default function Template({


### PR DESCRIPTION
- resolve out-of-sync IDs issue (`github-slugger`)
- let ToC items wrap, without looking like separate headings

Replaces #2619 