### PR TITLE
Update @sindresorhus/slugify

### DIFF
--- a/.changeset/slow-bikes-wonder.md
+++ b/.changeset/slow-bikes-wonder.md
@@ -6,3 +6,5 @@
 ---
 
 Updated @sindresorhus/slugify to fix a problem where it was producing unexpected output, eg. adding unexpected underscores: 'NAME1 Website' => 'nam_e1_website'. The slugify output for db name may be different with this change. For the above example, the output will now be 'name_1_website' for the same string.
+
+If your database name changes unexpectedly, add an environmental variable called `DATABASE_URL` with a full path to the database.

--- a/.changeset/slow-bikes-wonder.md
+++ b/.changeset/slow-bikes-wonder.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/adapter-knex': major
+'@keystonejs/adapter-mongoose': major
+'create-keystone-app': major
+'@keystonejs/fields': major
+'@keystonejs/website': major
+---
+
+Updated @sindresorhus/slugify to fix a problem where it was producing unexpected output, eg. adding unexpected underscores: 'NAME1 Website' => 'nam_e1_website'. The slugify output for db name may be different with this change. For the above example, the output will now be 'name_1_website' for the same string.

--- a/.changeset/slow-bikes-wonder.md
+++ b/.changeset/slow-bikes-wonder.md
@@ -7,4 +7,4 @@
 
 Updated @sindresorhus/slugify to fix a problem where it was producing unexpected output, eg. adding unexpected underscores: 'NAME1 Website' => 'nam_e1_website'. The slugify output for db name may be different with this change. For the above example, the output will now be 'name_1_website' for the same string.
 
-If your database name changes unexpectedly, add an environmental variable called `DATABASE_URL` with a full path to the database.
+If your database name changes unexpectedly, add an environment variable called `DATABASE_URL` with a full path to the database.

--- a/.changeset/slow-bikes-wonder.md
+++ b/.changeset/slow-bikes-wonder.md
@@ -3,7 +3,6 @@
 '@keystonejs/adapter-mongoose': major
 'create-keystone-app': major
 '@keystonejs/fields': major
-'@keystonejs/website': major
 ---
 
 Updated @sindresorhus/slugify to fix a problem where it was producing unexpected output, eg. adding unexpected underscores: 'NAME1 Website' => 'nam_e1_website'. The slugify output for db name may be different with this change. For the above example, the output will now be 'name_1_website' for the same string.

--- a/packages/adapter-knex/package.json
+++ b/packages/adapter-knex/package.json
@@ -12,7 +12,7 @@
     "@keystonejs/keystone": "^7.0.0",
     "@keystonejs/logger": "^5.1.1",
     "@keystonejs/utils": "^5.4.0",
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "knex": "^0.20.6",
     "p-settle": "^3.1.0",
     "pg": "^7.17.0"

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -13,7 +13,7 @@
     "@keystonejs/logger": "^5.1.1",
     "@keystonejs/mongo-join-builder": "^6.1.3",
     "@keystonejs/utils": "^5.4.0",
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "mongoose": "^5.9.5",
     "p-settle": "^3.1.0",
     "pluralize": "^7.0.0"

--- a/packages/create-keystone-app/package.json
+++ b/packages/create-keystone-app/package.json
@@ -11,7 +11,7 @@
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "dependencies": {
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "arg": "^4.1.1",
     "cfonts": "^2.7.0",
     "chalk": "^2.4.2",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -41,7 +41,7 @@
     "@keystonejs/field-content": "^5.4.3",
     "@keystonejs/test-utils": "^6.0.1",
     "@keystonejs/utils": "^5.4.0",
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "apollo-errors": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "cuid": "^2.1.6",

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,7 @@
     "@mdx-js/react": "^1.0.20",
     "@reach/router": "^1.3.3",
     "@reach/skip-nav": "^0.1.2",
-    "@sindresorhus/slugify": "^0.6.0",
+    "@sindresorhus/slugify": "^0.11.0",
     "facepaint": "^1.2.1",
     "gatsby": "^2.13.25",
     "gatsby-plugin-google-analytics": "^2.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,12 +3126,20 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sindresorhus/slugify@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-0.6.0.tgz#21ea00f4abf43d13a4c39c8174f241ff9b5d12bc"
-  integrity sha512-m6smRWGuY0kr0oRdfuTNHWvtBlgtr/ixSa9xiGzFtRjXHghQIlf8s8ZKPWSXj/KraaYuvI//bVBEcncIMzjxVg==
+"@sindresorhus/slugify@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/slugify/-/slugify-0.11.0.tgz#642acb99adefa4187285fd17de88745afc161de8"
+  integrity sha512-ECTZT6z1hYDsopRh8GECaQ5L6hoJHVd4uq5hPi8se9GB31tgtZfnlM8G64hZVhJNmtJ9eIK0SuNhtsaPQStXEQ==
   dependencies:
-    escape-string-regexp "^1.0.5"
+    "@sindresorhus/transliterate" "^0.1.0"
+    escape-string-regexp "^2.0.0"
+
+"@sindresorhus/transliterate@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/transliterate/-/transliterate-0.1.0.tgz#c063bfc4102783fb19c91c2f8c1efb3adfb754be"
+  integrity sha512-bO6v0M0EuJPjm5Ntfow4nk+r3EZQ41n0ahvAmh766FzPqlm6V/2uDc01vZI3gLeI/1lgV2BTMb6QvxOk9z73ng==
+  dependencies:
+    escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
 
 "@sinonjs/commons@^1.7.0":
@@ -9005,7 +9013,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@2.0.0:
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==


### PR DESCRIPTION
Seeing some weird behaviour in this dependency @sindresorhus/slugify of the @keystone/adapter-knex package. At the current specified version 0.6.0 the slugify function processes “HELLO3 Website” to “hell_o3_website”. That’s the minimum version in the package.json for that package https://github.com/keystonejs/keystone/blob/master/packages/adapter-knex/package.json. As of v0.10.0 it processes “HELLO3 Website” as “hello_3_website”. Take a look here and switch the version of the dependency https://codesandbox.io/s/youthful-blackburn-wvk5n