### PR TITLE
Document missing argument in custom resolver functions

### DIFF
--- a/.changeset/lazy-elephants-repeat.md
+++ b/.changeset/lazy-elephants-repeat.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Updated documenation for the last argument in custom resolver functions

--- a/.changeset/lazy-elephants-repeat.md
+++ b/.changeset/lazy-elephants-repeat.md
@@ -2,4 +2,4 @@
 '@keystonejs/keystone': patch
 ---
 
-Updated documenation for the last argument in custom resolver functions
+Updated documentation for the last argument in custom resolver functions.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -328,7 +328,9 @@ The `schema` for both queries and mutations should be a string defining the grap
 }
 ```
 
-The `resolver` for both queries and mutations should be a resolver function with the signature `(obj, args, context, info)`. See the [Apollo docs](https://www.apollographql.com/docs/graphql-tools/resolvers/#resolver-function-signature) for more details.
+The `resolver` for both queries and mutations should be a resolver function with the signature `(obj, args, context, info, extra)`.
+
+For more information about the first 4 arguments, please see the [Apollo docs](https://www.apollographql.com/docs/graphql-tools/resolvers/#resolver-function-signature). The last argument `extra` is an object that contains 2 properties: `query` and `access`. `query` is an executable function for running a query, while `access` provides access control information about the current user.
 
 The `access` argument for `types`, `queries`, and `mutations` are all boolean values which are used at schema generation time to include or exclude the item from the schema.
 


### PR DESCRIPTION
There is a 5th argument passed into custom resolver functions that isn't documented. [See here](https://github.com/keystonejs/keystone/blob/master/packages/keystone/lib/providers/custom.js#L93)