### PR TITLE
Docs: Code Snippet Meta

### DIFF
--- a/.changeset/poor-readers-care.md
+++ b/.changeset/poor-readers-care.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/website': minor
+---
+
+Introduce meta data to code blocks

--- a/.changeset/poor-readers-care.md
+++ b/.changeset/poor-readers-care.md
@@ -2,4 +2,4 @@
 '@keystonejs/website': minor
 ---
 
-Introduce meta data to code blocks
+Introduced meta data to code blocks.

--- a/website/package.json
+++ b/website/package.json
@@ -58,6 +58,7 @@
     "react-helmet": "^5.2.0",
     "rehype-slug": "^2.0.3",
     "underscore.string": "^3.3.5",
-    "unist-util-visit": "^1.4.0"
+    "unist-util-visit": "^1.4.0",
+    "use-clipboard-copy": "^0.1.2"
   }
 }

--- a/website/src/components/markdown/Code.js
+++ b/website/src/components/markdown/Code.js
@@ -213,8 +213,8 @@ function languageLabel(lang) {
 }
 
 function resolveBool(str) {
-  if (['true', 'yes', '1'].includes(str)) return true;
-  if (['false', 'no', '0'].includes(str)) return false;
+  if (str === 'true') return true;
+  if (str === 'false') return false;
 
   return undefined;
 }

--- a/website/src/components/markdown/Code.js
+++ b/website/src/components/markdown/Code.js
@@ -1,8 +1,33 @@
 /** @jsx jsx */
 
+import { useCallback, useRef } from 'react';
+import { useClipboard } from 'use-clipboard-copy';
 import { jsx } from '@emotion/core';
+import { colors, borderRadius, gridSize } from '@arch-ui/theme';
+
+import { CONTAINER_GUTTERS } from '../Container';
+import { mediaMax } from '../../utils/media';
 
 import theme from '../../prism-themes/custom';
+
+const commonCodeStyles = {
+  fontFamily: 'Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace',
+  fontSize: '0.85em',
+  fontWeight: 'normal',
+};
+export const InlineCode = props => (
+  <code
+    css={{
+      ...commonCodeStyles,
+      backgroundColor: 'rgba(255, 227, 128,0.2)',
+      borderRadius: 2,
+      color: colors.N100,
+      margin: 0,
+      padding: '0.2em 0.4em',
+    }}
+    {...props}
+  />
+);
 
 function themeToDict(theme, language) {
   const { plain } = theme;
@@ -24,8 +49,8 @@ function themeToDict(theme, language) {
 
   const themeDict = Object.assign(
     {
-      ['.root']: plain,
-      ['.plain']: { ...plain, backgroundColor: null },
+      '.root': plain,
+      '.plain': { ...plain, backgroundColor: null },
     },
     ...styles
   );
@@ -33,9 +58,163 @@ function themeToDict(theme, language) {
   return themeDict;
 }
 
-export const Code = props => {
-  const lang = props.className ? props.className.replace('language-', '') : null;
-  const styles = themeToDict(theme, lang);
+// NOTE: `metastring` is everything after the language declaration e.g. ```javascript title=package.json allowCopy=false
+// We ignore it because the space separated values come in as props
+export const CodeBlock = ({
+  allowCopy: allowCopyStr = 'true',
+  metastring,
+  showLanguage: showLanguageStr = 'true',
+  title,
+  ...props
+}) => {
+  let language = props.className ? props.className.replace('language-', '') : null;
+  let themeStyles = themeToDict(theme, language);
+  let codeRef = useRef();
+  let clipboard = useClipboard({ copiedTimeout: 750 });
+  let handleCopy = useCallback(() => {
+    clipboard.copy(codeRef.current.innerText.trim());
+  }, [clipboard.copy]);
 
-  return <code css={styles} {...props} />;
+  let allowCopy = resolveBool(allowCopyStr);
+  let showLanguage = resolveBool(showLanguageStr);
+  let hasHeader = title || allowCopy || showLanguage;
+
+  return (
+    <div css={{ marginBottom: '1em', marginTop: '1em' }}>
+      {hasHeader && (
+        <Header>
+          {title ? <Title>{title}</Title> : <span />}
+          <div css={{ alignItems: 'center', display: 'flex' }}>
+            {language && showLanguage && <Language>{languageLabel(language)}</Language>}
+            {allowCopy && (
+              <CopyButton onClick={handleCopy}>{clipboard.copied ? 'Copied!' : 'Copy'}</CopyButton>
+            )}
+          </div>
+        </Header>
+      )}
+      <Pre hasHeader={hasHeader} className={props.className}>
+        <code ref={codeRef} css={{ ...commonCodeStyles, ...themeStyles }} {...props} />
+      </Pre>
+    </div>
+  );
 };
+
+// Styled Components
+// ------------------------------
+
+const Header = props => (
+  <div
+    css={{
+      alignItems: 'center',
+      backgroundColor: colors.page,
+      border: `1px solid ${colors.N10}`,
+      borderBottom: 0,
+      borderTopLeftRadius: borderRadius,
+      borderTopRightRadius: borderRadius,
+      display: 'flex',
+      justifyContent: 'space-between',
+      padding: gridSize,
+    }}
+    {...props}
+  />
+);
+const Title = props => (
+  <div
+    css={{
+      ...commonCodeStyles,
+      color: colors.N60,
+      paddingLeft: gridSize,
+    }}
+    {...props}
+  />
+);
+const Language = props => (
+  <div
+    css={{
+      color: colors.N80,
+      fontSize: '0.85rem',
+    }}
+    {...props}
+  />
+);
+const CopyButton = props => (
+  <button
+    css={{
+      background: 0,
+      border: 0,
+      borderRadius: 3,
+      color: colors.N80,
+      cursor: 'pointer',
+      fontSize: '0.85rem',
+      lineHeight: 'inherit',
+      marginLeft: gridSize,
+      padding: `2px 0`,
+      width: 60,
+
+      ':hover, :focus': {
+        background: colors.N10,
+      },
+      ':active': {
+        background: colors.N15,
+      },
+    }}
+    {...props}
+  />
+);
+
+const Pre = ({ hasHeader, ...props }) => (
+  <pre
+    css={{
+      backgroundColor: colors.N05,
+      border: `1px solid ${colors.N10}`,
+      borderBottomLeftRadius: borderRadius,
+      borderBottomRightRadius: borderRadius,
+      borderTopLeftRadius: hasHeader ? null : borderRadius,
+      borderTopRightRadius: hasHeader ? null : borderRadius,
+      boxSizing: 'border-box',
+      fontFamily: 'Consolas,Menlo,Monaco,"Andale Mono","Ubuntu Mono",monospace',
+      lineHeight: '1.4',
+      margin: 0,
+      padding: gridSize * 2,
+      overflowX: 'auto',
+      tabSize: 2,
+      WebkitOverflowScrolling: 'touch',
+
+      [mediaMax.sm]: {
+        borderRadius: 0,
+        borderLeft: 0,
+        borderRight: 0,
+        marginLeft: -CONTAINER_GUTTERS[0],
+        marginRight: -CONTAINER_GUTTERS[0],
+      },
+    }}
+    {...props}
+  />
+);
+
+// Utils
+// ------------------------------
+
+function languageLabel(lang) {
+  let map = {
+    bash: 'shell', // this is a bit dodgy, we should probably replace `bash` references with `shell`...
+    graphql: 'GraphQL',
+    javascript: 'JS',
+    js: 'JS',
+    json: 'JSON',
+    jsx: 'JSX',
+    sh: 'shell',
+    sql: 'SQL',
+    ts: 'TS',
+    typescript: 'TS',
+  };
+
+  return map[lang] || lang;
+}
+
+function resolveBool(str) {
+  if (['true', 'yes', '1'].includes(str)) return true;
+  if (['false', 'no', '0'].includes(str)) return false;
+
+  return undefined;
+}

--- a/website/src/components/markdown/Heading.js
+++ b/website/src/components/markdown/Heading.js
@@ -55,7 +55,7 @@ const Heading = ({ as: Tag, children, id, ...props }) => {
           display: 'block',
           position: 'relative',
 
-          '&:hover a': {
+          '&:hover a, &:focus-within a': {
             opacity: 1,
           },
         }}

--- a/website/src/components/markdown/index.js
+++ b/website/src/components/markdown/index.js
@@ -1,11 +1,12 @@
 /** @jsx jsx */
 
+import { Fragment } from 'react';
 import { jsx } from '@emotion/core';
 import { colors } from '@arch-ui/theme';
 
 import { Link } from 'gatsby';
 import { H1, H2, H3, H4, H5, H6 } from './Heading';
-import { Code } from './Code';
+import { InlineCode, CodeBlock } from './Code';
 import { Table } from './Table';
 
 const Hr = props => (
@@ -58,7 +59,9 @@ export default {
   h5: H5,
   h6: H6,
   hr: Hr,
-  code: Code,
+  pre: ({ children }) => <Fragment>{children}</Fragment>, // The `CodeBlock` component handles pre-wrapping
+  code: CodeBlock,
+  inlineCode: InlineCode,
   table: Table,
   a: Anchor,
 };

--- a/website/src/components/markdown/index.js
+++ b/website/src/components/markdown/index.js
@@ -59,9 +59,27 @@ export default {
   h5: H5,
   h6: H6,
   hr: Hr,
+  p: Paragraph,
   pre: ({ children }) => <Fragment>{children}</Fragment>, // The `CodeBlock` component handles pre-wrapping
   code: CodeBlock,
   inlineCode: InlineCode,
   table: Table,
   a: Anchor,
 };
+
+// NOTE: filter out paragraphs that contain badges
+// ------------------------------
+// we're following a golden path here that assumes A LOT
+// the pattern we're expecting is `p > a > img` -- React's single child quirk lets us chain
+// i know it's super brittle, but will tidy things up for the moment
+function hasBadge(props) {
+  return props?.children?.props?.children?.props?.src.includes('shields.io');
+}
+
+function Paragraph(props) {
+  if (hasBadge(props)) {
+    return null;
+  }
+
+  return <p {...props} />;
+}

--- a/website/src/components/markdown/index.js
+++ b/website/src/components/markdown/index.js
@@ -73,7 +73,7 @@ export default {
 // the pattern we're expecting is `p > a > img` -- React's single child quirk lets us chain
 // i know it's super brittle, but will tidy things up for the moment
 function hasBadge(props) {
-  return props?.children?.props?.children?.props?.src.includes('shields.io');
+  return props?.children?.props?.children?.props?.src?.includes('shields.io');
 }
 
 function Paragraph(props) {

--- a/website/src/templates/layout.js
+++ b/website/src/templates/layout.js
@@ -6,7 +6,6 @@ import { colors, borderRadius, gridSize } from '@arch-ui/theme';
 import { SkipNavLink } from '@reach/skip-nav';
 
 import { Header, SiteMeta } from '../components';
-import { CONTAINER_GUTTERS } from '../components/Container';
 import { media, mediaMax } from '../utils/media';
 
 export const Layout = ({ children }) => {
@@ -154,52 +153,6 @@ export const Content = props => (
       },
       'blockquote > p:last-of-type': {
         marginBottom: 0,
-      },
-
-      // Code
-      // ------------------------------
-
-      code: {
-        fontFamily: 'Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace',
-        fontSize: '0.85em',
-        fontWeight: 'normal',
-      },
-      pre: {
-        backgroundColor: colors.N05,
-        border: `1px solid ${colors.N10}`,
-        borderRadius: 4,
-        boxSizing: 'border-box',
-        fontFamily: 'Consolas,Menlo,Monaco,"Andale Mono","Ubuntu Mono",monospace',
-        lineHeight: '1.4',
-        padding: gridSize * 2,
-        overflowX: 'auto',
-        tabSize: 2,
-        WebkitOverflowScrolling: 'touch',
-
-        // our snippets seem to have an extra line...
-        '.token-line:last-of-type': {
-          display: 'none',
-        },
-
-        [mediaMax.sm]: {
-          borderRadius: 0,
-          borderLeft: 0,
-          borderRight: 0,
-          marginLeft: -CONTAINER_GUTTERS[0],
-          marginRight: -CONTAINER_GUTTERS[0],
-        },
-      },
-
-      '& :not(pre) > code': {
-        backgroundColor: 'rgba(255, 227, 128,0.2)',
-        borderRadius: 2,
-        color: colors.N100,
-        margin: 0,
-        padding: '0.2em 0.4em',
-      },
-
-      '& h1 > code, & h2 > code, & h3 > code, & h4 > code, & h5 > code, & h6 > code': {
-        backgroundColor: 'rgba(255, 235, 229, 0.6)',
       },
     }}
     {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -24120,6 +24120,13 @@ url@0.11.0, url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-clipboard-copy@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/use-clipboard-copy/-/use-clipboard-copy-0.1.2.tgz#83b16292dfa8ea262be714252022a8b4ad1c28c5"
+  integrity sha512-EkauxqyX+us4+Mfif/f61ew89EAOWIArqFpHR0jSG4SwwuDZzDAOeqO7gkK0vi+DQVADeB1RB3xqU3U0oOO3NQ==
+  dependencies:
+    clipboard-copy "^3.0.0"
+
 use-subscription@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.1.1.tgz#5509363e9bb152c4fb334151d4dceb943beaa7bb"


### PR DESCRIPTION
Introduce code snippet meta. This moves the code and pre styles from the `<Content />` wrapper to the MDX renderer.

We take advantage of the `metastring` provided by `MDXProvider` from "@mdx-js/react", which takes arguments after the language declaration on a code block and passes them to the component as props e.g. (pretend they're back ticks)

```
'''json title=package.json allowCopy=false
{
  "scripts": {
    "start": "node server.js"
  }
}
'''
```

> **Note:** Meta properties are ignored in environments like GitHub and NPM so will not effect rendering.

Supported meta properties. Willing to change these to something less verbose, like `copy`/`lang`, but prefer explicit:

| Key          | Type      | Description                                                                    |
| :----------- | :-------- | :----------------------------------------------------------------------------- |
| title        | `string`  | Default `undefined`. Presents a title above the code snippet                   |
| allowCopy    | `boolean` | Default `true`. Display a button that allows the user to copy the code snippet |
| showLanguage | `boolean` | Default `true`. Display a prettified label of the snippet language             |

An example of the updated UI:

![image](https://user-images.githubusercontent.com/2730833/78113196-18765980-744b-11ea-905c-d0ae209e1005.png)

I'll need to come through in another PR and cleanup any weirdness that arises from this change. There's some snippets where displaying the language or copy button doesn't really make sense.

* * *

Some unrelated changes were made in this PR, and can be found under the commit messages:
- [fix bug with focus on heading anchors](https://github.com/keystonejs/keystone/pull/2631/commits/f781f70548d987cd7d53cf98aa9adb7e2abe3fb7)
- [filter out paragraphs that contain badges](https://github.com/keystonejs/keystone/pull/2631/commits/c80540e9cecf60bec7f2a2993bbfd30016c9ac03)