### PR TITLE
Fixed state updates on Tooltip when unmounted (fixes #2419)

### DIFF
--- a/.changeset/tough-ears-juggle.md
+++ b/.changeset/tough-ears-juggle.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/tooltip': patch
+---
+
+Fixed state updates on Tooltip when unmounted.

--- a/packages/arch/packages/tooltip/src/index.js
+++ b/packages/arch/packages/tooltip/src/index.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { Component, createRef, Fragment } from 'react';
+import { Fragment, useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import flushable from 'flushable';
 import styled from '@emotion/styled';
@@ -24,7 +24,7 @@ const TooltipElement = styled.div({
   zIndex: 2,
 });
 
-let TooltipPositioner = props => {
+const TooltipPositioner = props => {
   return createPortal(
     <Popper
       referenceElement={props.targetNode}
@@ -48,7 +48,6 @@ let TooltipPositioner = props => {
 // ==============================
 
 const LISTENER_OPTIONS = { passive: true };
-const NOOP = () => {};
 
 let pendingHide;
 
@@ -57,118 +56,122 @@ const showTooltip = (fn, defaultDelay) => {
   if (isHidePending) {
     pendingHide.flush();
   }
-  const pendingShow = flushable(() => fn(isHidePending), isHidePending ? 0 : defaultDelay);
+
+  const pendingShow = flushable(fn, isHidePending ? 0 : defaultDelay);
   return pendingShow.cancel;
 };
 
 const hideTooltip = (fn, defaultDelay) => {
-  pendingHide = flushable(flushed => fn(flushed), defaultDelay);
+  pendingHide = flushable(fn, defaultDelay);
   return pendingHide.cancel;
 };
 
-export default class Tooltip extends Component {
-  state = {
-    immediatelyHide: false,
-    immediatelyShow: false,
-    isVisible: false,
-  };
-  ref = createRef();
-  cancelPendingSetState = NOOP;
-  static defaultProps = {
-    delay: 300,
-    placement: 'bottom',
-  };
-  componentDidMount() {
-    const target = this.ref.current;
+const Tooltip = ({
+  children,
+  content,
+  onHide,
+  onShow,
+  placement,
+  className,
+  hideOnMouseDown,
+  hideOnKeyDown,
+  delay,
+}) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const ref = useRef();
+
+  useEffect(() => {
+    const target = ref.current;
 
     if (!target) {
       throw new Error('You must pass the ref onto your target node.');
     }
+
     if (!target.nodeName) {
       throw new Error(
         "It looks like you've passed the ref onto a component. You must pass the ref onto your target node."
       );
     }
 
-    target.addEventListener('mouseenter', this.handleMouseEnter, LISTENER_OPTIONS);
-    target.addEventListener('mouseleave', this.handleMouseLeave, LISTENER_OPTIONS);
-  }
-  componentWillUnmount() {
-    this.cancelPendingSetState();
+    let cancelPendingSetState = () => {};
 
-    const target = this.ref.current;
+    const cancel = () => {
+      cancelPendingSetState();
+      setIsVisible(false);
+    };
 
-    if (target) {
-      target.removeEventListener('mouseenter', this.handleMouseEnter, LISTENER_OPTIONS);
-      target.removeEventListener('mouseleave', this.handleMouseLeave, LISTENER_OPTIONS);
-    }
-  }
+    const handleMouseEnter = () => {
+      cancelPendingSetState();
 
-  cancel = () => {
-    this.cancelPendingSetState();
-    this.setState({ isVisible: false, immediatelyHide: true });
-  };
+      if (isVisible) {
+        return;
+      }
 
-  handleMouseEnter = () => {
-    this.cancelPendingSetState();
+      if (hideOnMouseDown && target) {
+        target.addEventListener('mousedown', cancel, LISTENER_OPTIONS);
+      }
 
-    if (this.state.isVisible) {
-      return;
-    }
-    if (this.props.hideOnMouseDown && this.ref.current) {
-      this.ref.current.addEventListener('mousedown', this.cancel, LISTENER_OPTIONS);
-    }
-    if (this.props.hideOnKeyDown) {
-      document.addEventListener('keydown', this.cancel, LISTENER_OPTIONS);
-    }
+      if (hideOnKeyDown) {
+        document.addEventListener('keydown', cancel, LISTENER_OPTIONS);
+      }
 
-    this.cancelPendingSetState = showTooltip(immediatelyShow => {
-      this.setState({
-        isVisible: true,
-        immediatelyShow,
-      });
-    }, this.props.delay);
-  };
-  handleMouseLeave = () => {
-    this.cancelPendingSetState();
+      cancelPendingSetState = showTooltip(() => setIsVisible(true), delay);
+    };
 
-    if (!this.state.isVisible) {
-      return;
-    }
-    if (this.props.hideOnMouseDown && this.ref.current) {
-      this.ref.current.removeEventListener('mousedown', this.cancel, LISTENER_OPTIONS);
-    }
-    if (this.props.hideOnKeyDown) {
-      document.removeEventListener('keydown', this.cancel, LISTENER_OPTIONS);
-    }
+    const handleMouseLeave = () => {
+      cancelPendingSetState();
 
-    this.cancelPendingSetState = hideTooltip(immediatelyHide => {
-      this.setState({ isVisible: false, immediatelyHide });
-    }, this.props.delay);
-  };
+      if (!isVisible) {
+        return;
+      }
 
-  render() {
-    const { children, content, onHide, onShow, placement, className } = this.props;
-    const { isVisible } = this.state;
-    const ref = this.ref;
+      if (hideOnMouseDown && target) {
+        target.removeEventListener('mousedown', cancel, LISTENER_OPTIONS);
+      }
 
-    return (
-      <Fragment>
-        {children(ref)}
+      if (hideOnKeyDown) {
+        document.removeEventListener('keydown', cancel, LISTENER_OPTIONS);
+      }
 
-        <TransitionProvider isOpen={isVisible} onEntered={onShow} onExited={onHide}>
-          {transitionState => (
-            <TooltipPositioner
-              targetNode={this.ref.current}
-              placement={placement}
-              className={className}
-              style={fade(transitionState)}
-            >
-              {content}
-            </TooltipPositioner>
-          )}
-        </TransitionProvider>
-      </Fragment>
-    );
-  }
-}
+      cancelPendingSetState = hideTooltip(() => setIsVisible(false), delay);
+    };
+
+    target.addEventListener('mouseenter', handleMouseEnter, LISTENER_OPTIONS);
+    target.addEventListener('mouseleave', handleMouseLeave, LISTENER_OPTIONS);
+
+    return () => {
+      cancelPendingSetState();
+
+      if (target) {
+        target.removeEventListener('mouseenter', handleMouseEnter, LISTENER_OPTIONS);
+        target.removeEventListener('mouseleave', handleMouseLeave, LISTENER_OPTIONS);
+      }
+    };
+  }, [isVisible]);
+
+  return (
+    <Fragment>
+      {children(ref)}
+
+      <TransitionProvider isOpen={isVisible} onEntered={onShow} onExited={onHide}>
+        {transitionState => (
+          <TooltipPositioner
+            targetNode={ref.current}
+            placement={placement}
+            className={className}
+            style={fade(transitionState)}
+          >
+            {content}
+          </TooltipPositioner>
+        )}
+      </TransitionProvider>
+    </Fragment>
+  );
+};
+
+Tooltip.defaultProps = {
+  delay: 300,
+  placement: 'bottom',
+};
+
+export default Tooltip;


### PR DESCRIPTION
Converted `Tooltip` to a functional component and the problem went away. Also removed the `immediatelyHide` and `immediatelyShow` states in the process since they weren't being used (they weren't the cause of the problem, though).