### PR TITLE
Admin UI: Handle non-admin users better

### DIFF
--- a/.changeset/metal-ties-camp.md
+++ b/.changeset/metal-ties-camp.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Handle post-signin redirects also for unauthorized users

--- a/.changeset/six-queens-shop.md
+++ b/.changeset/six-queens-shop.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+- Show AccessDeniedPage when access is denied & user is already signed in

--- a/packages/app-admin-ui/client/index.js
+++ b/packages/app-admin-ui/client/index.js
@@ -109,9 +109,6 @@ export const KeystoneAdminUI = () => {
             <Global styles={globalStyles} />
             <BrowserRouter>
               <Switch>
-                <Route exact path={signinPath}>
-                  <Redirect to={adminPath} />
-                </Route>
                 <Route exact path={signoutPath} render={() => <SignoutPage />} />
                 <Route>
                   <ScrollToTop>

--- a/packages/app-admin-ui/client/pages/AccessDeniedPage.js
+++ b/packages/app-admin-ui/client/pages/AccessDeniedPage.js
@@ -1,0 +1,71 @@
+import React, { Fragment } from 'react';
+import styled from '@emotion/styled';
+
+import KeystoneLogo from '../components/KeystoneLogo';
+
+import { useAdminMeta } from '../providers/AdminMeta';
+
+const Container = styled.div({
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  minHeight: '100vh',
+});
+
+const Alerts = styled.div({
+  margin: '20px auto',
+  width: 650,
+  height: 48,
+});
+
+const Box = styled.div({
+  boxShadow: '0 2px 1px #f1f1f1',
+  backgroundColor: 'white',
+  border: '1px solid #e9e9e9',
+  borderRadius: '0.3em',
+  margin: '0 auto',
+  minWidth: 650,
+  padding: 40,
+  display: 'flex',
+  flexWrap: 'nowrap',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const Divider = styled.div({
+  borderRight: '1px solid #eee',
+  minHeight: 185,
+  lineHeight: 185,
+  margin: '0 40px',
+});
+
+const Content = styled.div({
+  marginTop: 16,
+  minWidth: 280,
+});
+
+const Spacer = styled.div({
+  height: 120,
+});
+
+const AccessDeniedPage = () => {
+  const {} = useAdminMeta();
+  return (
+    <Container>
+      <Alerts />
+      <Box>
+        <KeystoneLogo />
+        <Divider />
+        <Content>
+          <h3>Access Denied</h3>
+          <p>You do not have admin access.</p>
+          <a href={'/'}>Go Home</a>
+        </Content>
+      </Box>
+      <Spacer />
+    </Container>
+  );
+};
+
+export default AccessDeniedPage;

--- a/packages/app-admin-ui/client/public.js
+++ b/packages/app-admin-ui/client/public.js
@@ -12,7 +12,7 @@ import ApolloClient from './apolloClient';
 import ConnectivityListener from './components/ConnectivityListener';
 import { AdminMetaProvider, useAdminMeta } from './providers/AdminMeta';
 
-import InvalidRoutePage from './pages/InvalidRoute';
+import AccessDeniedPage from './pages/AccessDeniedPage';
 import SignoutPage from './pages/Signout';
 import SigninPage from './pages/Signin';
 
@@ -24,7 +24,7 @@ import SigninPage from './pages/Signin';
 */
 
 const Keystone = () => {
-  const { authStrategy, apiPath, signoutPath } = useAdminMeta();
+  const { authStrategy, apiPath, signinPath, signoutPath } = useAdminMeta();
 
   const apolloClient = useMemo(() => new ApolloClient({ uri: apiPath }), [apiPath]);
 
@@ -37,8 +37,9 @@ const Keystone = () => {
         {authStrategy ? (
           <BrowserRouter>
             <Switch>
+              <Route exact path={signinPath} render={() => <SigninPage />} />
               <Route exact path={signoutPath} render={() => <SignoutPage />} />
-              <Route render={() => <SigninPage />} />
+              <Route render={() => <AccessDeniedPage />} />,
             </Switch>
           </BrowserRouter>
         ) : (

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -70,21 +70,6 @@ class AdminUIApp {
     );
   }
 
-  createSessionMiddleware() {
-    const { signinPath } = this.routes;
-
-    const app = express();
-
-    // Short-circuit GET requests when the user already signed in (avoids
-    // downloading UI bundle, doing a client side redirect, etc)
-    app.get(signinPath, (req, res, next) =>
-      this.isAccessAllowed(req) ? res.redirect(this.adminPath) : next()
-    );
-
-    // TODO: Attach a server-side signout to signoutPath
-
-    return app;
-  }
 
   build({ keystone, distDir }) {
     const builtAdminRoot = path.join(distDir, 'admin');
@@ -201,7 +186,6 @@ class AdminUIApp {
     }
 
     if (this.authStrategy) {
-      app.use(this.createSessionMiddleware());
       for (const pair of middlewarePairs) {
         app.use(mountPath, (req, res, next) => {
           return this.isAccessAllowed(req)

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -162,7 +162,7 @@ class AdminUIApp {
         // For private pages, we want to redirect back to signin page
         'text/html': () => {
           const isPublicUrl = this.publicPaths.includes(req.originalUrl);
-          if (!isPublicUrl && !this.isAccessAllowed(req)) {
+          if (!isPublicUrl && !this.isAccessAllowed(req) && !req.user) {
             return res.redirect(this.routes.signinPath);
           }
           next();

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -43,6 +43,10 @@ class AdminUIApp {
       signinPath: `${this.adminPath}/signin`,
       signoutPath: `${this.adminPath}/signout`,
     };
+    this.publicPaths = [
+      this.routes.signinPath,
+      this.routes.signoutPath,
+    ];
   }
 
   getAdminMeta() {
@@ -155,9 +159,10 @@ class AdminUIApp {
         '*/*': () => {
           next();
         },
-        // For page loads, we want to redirect back to signin page
+        // For private pages, we want to redirect back to signin page
         'text/html': () => {
-          if (req.originalUrl !== this.routes.signinPath && !this.isAccessAllowed(req)) {
+          const isPublicUrl = this.publicPaths.includes(req.originalUrl);
+          if (!isPublicUrl && !this.isAccessAllowed(req)) {
             return res.redirect(this.routes.signinPath);
           }
           next();

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -146,6 +146,16 @@ class AdminUIApp {
     const { adminPath } = this;
     const app = express.Router();
 
+    app.use(this.routes.signinPath, (req, res, next) => {
+      if (this.isAccessAllowed(req)) {
+        return res.redirect(this.adminPath)
+      }
+      if (req.user) {
+        return res.redirect('/')
+      }
+      next()
+    });
+
     app.use(adminPath, (req, res, next) => {
       // Depending on what was requested, we might redirect the user based on
       // their access


### PR DESCRIPTION
This PR fixes two minor issues handling unauthorized/non-admin users:
- After signing in, unauthorized users are left in signin page.
  - Now after signing in, unauthorized users are redirected to the `/` path (the assumed public home)
- When trying to access a private page, unauthorized users are redirected to signin page, even if they're signed in already
  - Now when trying to access a private page, unauthorized users are redirected to signin page only if they're signed out, otherwise they see the following "Access Denied" page. The styles and layout are the same as SignoutPage & SigninPage.
![image](https://user-images.githubusercontent.com/3198597/78322667-653a5d00-753d-11ea-88d7-3f704690de84.png)
