### PR TITLE
Fix count queries on one-to-one relationships

### DIFF
--- a/.changeset/curvy-ants-wave.md
+++ b/.changeset/curvy-ants-wave.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/adapter-knex': patch
+---
+
+Fixed a bug with `_allItemsMeta { count }` queries on one-to-one relationships.

--- a/.changeset/large-cheetahs-begin.md
+++ b/.changeset/large-cheetahs-begin.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-mongoose': patch
+---
+
+Removed a stray `console.log()`.

--- a/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
@@ -183,6 +183,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         );
       });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allUsersMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(3);
+            })
+          );
+        });
+
       describe('Create', () => {
         test(
           'With connect',

--- a/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
@@ -183,24 +183,24 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         );
       });
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allUsersMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(3);
+          })
+        );
+      });
 
       describe('Create', () => {
         test(

--- a/api-tests/relationships/crud-self-ref/many-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many.test.js
@@ -197,6 +197,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
         });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allUsersMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
@@ -81,6 +81,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         });
       }
 
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
+                {
+                  _allUsersMeta { count }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(3);
+          })
+        );
+      });
+
       describe('Create', () => {
         test(
           'With connect',

--- a/api-tests/relationships/crud-self-ref/one-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many.test.js
@@ -214,6 +214,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
         });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allUsersMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -96,6 +96,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
         }
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allUsersMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/many-to-many-one-sided.test.js
@@ -206,6 +206,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
         });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allCompaniesMeta { count }
+                  _allLocationsMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud/many-to-many.test.js
+++ b/api-tests/relationships/crud/many-to-many.test.js
@@ -208,6 +208,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
         });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allCompaniesMeta { count }
+                  _allLocationsMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -108,6 +108,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
         }
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allCompaniesMeta { count }
+                  _allLocationsMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud/one-to-many.test.js
+++ b/api-tests/relationships/crud/one-to-many.test.js
@@ -224,6 +224,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
         });
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allCompaniesMeta { count }
+                  _allLocationsMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -110,6 +110,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
         }
 
+        describe('Count', () => {
+          test(
+            'Count',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                {
+                  _allCompaniesMeta { count }
+                  _allLocationsMeta { count }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(3);
+            })
+          );
+        });
+
         describe('Create', () => {
           test(
             'With connect',

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -55,7 +55,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
       uri = `mongodb://localhost/${defaultDbName}`;
       logger.warn(`No MongoDB connection URI specified. Defaulting to '${uri}'`);
     }
-    console.log(uri);
+
     await this.mongoose.connect(uri, {
       useNewUrlParser: true,
       useFindAndModify: false,


### PR DESCRIPTION
We shouldn't be doing the `1:1` select operation when we're performing a `count(*)` operation, so we guard against the `meta` flag.