### PR TITLE
Added `fields` list to ListSchema

### DIFF
--- a/.changeset/thin-mirrors-refuse.md
+++ b/.changeset/thin-mirrors-refuse.md
@@ -3,4 +3,4 @@
 '@keystonejs/keystone': minor
 ---
 
-Added `fields` list to ListSchema. This optionally takes a `where: { type }` argument and returns all matching field names on a list along with their types.
+Added `fields` list to ListSchema. This optionally takes a `where: { type }` argument and returns metadata for all matching fields on list, including name, type, and user-provided config.

--- a/.changeset/thin-mirrors-refuse.md
+++ b/.changeset/thin-mirrors-refuse.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': minor
+---
+
+Added `fields` list to ListSchema. This optionally takes a `where: { type }` argument and returns all matching field names on a list along with their types.

--- a/.changeset/thin-mirrors-refuse.md
+++ b/.changeset/thin-mirrors-refuse.md
@@ -3,4 +3,4 @@
 '@keystonejs/keystone': minor
 ---
 
-Added `fields` list to ListSchema. This optionally takes a `where: { type }` argument and returns metadata for all matching fields on list, including name, type, and user-provided config.
+Added `fields` list to ListSchema. This optionally takes a `where: { type }` argument and returns all matching field names on a list along with their types.

--- a/.changeset/thin-mirrors-refuse.md
+++ b/.changeset/thin-mirrors-refuse.md
@@ -1,4 +1,5 @@
 ---
+'@keystonejs/api-tests': minor
 '@keystonejs/keystone': minor
 ---
 

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -117,7 +117,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields {
                   name
                   type
-                  config
                 }
                 relatedFields {
                   type
@@ -140,17 +139,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'company',
                     type: 'Relationship',
-                    config: {
-                      ref: 'Company',
-                    },
                   },
                   {
                     name: 'workHistory',
                     type: 'Relationship',
-                    config: {
-                      ref: 'Company',
-                      many: true,
-                    },
                   },
                 ],
                 relatedFields: [
@@ -175,15 +167,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'name',
                     type: 'Text',
-                    config: {},
                   },
                   {
                     name: 'employees',
                     type: 'Relationship',
-                    config: {
-                      ref: 'User',
-                      many: true,
-                    },
                   },
                 ],
                 relatedFields: [
@@ -202,14 +189,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'content',
                     type: 'Text',
-                    config: {},
                   },
                   {
                     name: 'author',
                     type: 'Relationship',
-                    config: {
-                      ref: 'User',
-                    },
                   },
                 ],
                 relatedFields: [],
@@ -235,7 +218,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields {
                   name
                   type
-                  config
                 }
                 relatedFields {
                   type
@@ -258,17 +240,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'company',
                     type: 'Relationship',
-                    config: {
-                      ref: 'Company',
-                    },
                   },
                   {
                     name: 'workHistory',
                     type: 'Relationship',
-                    config: {
-                      ref: 'Company',
-                      many: true,
-                    },
                   },
                 ],
                 relatedFields: [
@@ -303,7 +278,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields(where: { type: "Text" }) {
                   name
                   type
-                  config
                 }
                 relatedFields {
                   type
@@ -327,7 +301,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'name',
                     type: 'Text',
-                    config: {},
                   },
                 ],
                 relatedFields: [

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -117,6 +117,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields {
                   name
                   type
+                  config
                 }
                 relatedFields {
                   type
@@ -139,10 +140,17 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'company',
                     type: 'Relationship',
+                    config: {
+                      ref: 'Company',
+                    },
                   },
                   {
                     name: 'workHistory',
                     type: 'Relationship',
+                    config: {
+                      ref: 'Company',
+                      many: true,
+                    },
                   },
                 ],
                 relatedFields: [
@@ -167,10 +175,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'name',
                     type: 'Text',
+                    config: {},
                   },
                   {
                     name: 'employees',
                     type: 'Relationship',
+                    config: {
+                      ref: 'User',
+                      many: true,
+                    },
                   },
                 ],
                 relatedFields: [
@@ -189,10 +202,14 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'content',
                     type: 'Text',
+                    config: {},
                   },
                   {
                     name: 'author',
                     type: 'Relationship',
+                    config: {
+                      ref: 'User',
+                    },
                   },
                 ],
                 relatedFields: [],
@@ -218,6 +235,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields {
                   name
                   type
+                  config
                 }
                 relatedFields {
                   type
@@ -240,10 +258,17 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'company',
                     type: 'Relationship',
+                    config: {
+                      ref: 'Company',
+                    },
                   },
                   {
                     name: 'workHistory',
                     type: 'Relationship',
+                    config: {
+                      ref: 'Company',
+                      many: true,
+                    },
                   },
                 ],
                 relatedFields: [
@@ -278,6 +303,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 fields(where: { type: "Text" }) {
                   name
                   type
+                  config
                 }
                 relatedFields {
                   type
@@ -301,6 +327,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   {
                     name: 'name',
                     type: 'Text',
+                    config: {},
                   },
                 ],
                 relatedFields: [

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -114,6 +114,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               schema {
                 type
                 queries
+                fields {
+                  name
+                  type
+                }
                 relatedFields {
                   type
                   fields
@@ -131,6 +135,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'User',
               schema: {
                 queries: ['User', 'allUsers', '_allUsersMeta'],
+                fields: [
+                  {
+                    name: 'company',
+                    type: 'Relationship',
+                  },
+                  {
+                    name: 'workHistory',
+                    type: 'Relationship',
+                  },
+                ],
                 relatedFields: [
                   {
                     fields: ['employees', '_employeesMeta'],
@@ -149,6 +163,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               schema: {
                 type: 'Company',
                 queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+                fields: [
+                  {
+                    name: 'name',
+                    type: 'Text',
+                  },
+                  {
+                    name: 'employees',
+                    type: 'Relationship',
+                  },
+                ],
                 relatedFields: [
                   {
                     type: 'User',
@@ -161,6 +185,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'Post',
               schema: {
                 queries: ['Post', 'allPosts', '_allPostsMeta'],
+                fields: [
+                  {
+                    name: 'content',
+                    type: 'Text',
+                  },
+                  {
+                    name: 'author',
+                    type: 'Relationship',
+                  },
+                ],
                 relatedFields: [],
                 type: 'Post',
               },
@@ -170,7 +204,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       );
 
       test(
-        'returns results for one list lists',
+        'returns results for one list',
         runner(setupKeystone, async ({ keystone }) => {
           const { data, errors } = await graphqlRequest({
             keystone,
@@ -181,6 +215,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               schema {
                 type
                 queries
+                fields {
+                  name
+                  type
+                }
                 relatedFields {
                   type
                   fields
@@ -198,6 +236,16 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'User',
               schema: {
                 queries: ['User', 'allUsers', '_allUsersMeta'],
+                fields: [
+                  {
+                    name: 'company',
+                    type: 'Relationship',
+                  },
+                  {
+                    name: 'workHistory',
+                    type: 'Relationship',
+                  },
+                ],
                 relatedFields: [
                   {
                     fields: ['employees', '_employeesMeta'],
@@ -209,6 +257,58 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   },
                 ],
                 type: 'User',
+              },
+            },
+          ]);
+        })
+      );
+
+      test(
+        'returns results for one list and one type of fields',
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data, errors } = await graphqlRequest({
+            keystone,
+            query: `
+          query {
+            _ksListsMeta(where: { key: "Company" }) {
+              name
+              schema {
+                type
+                queries
+                fields(where: { type: "Text" }) {
+                  name
+                  type
+                }
+                relatedFields {
+                  type
+                  fields
+                }
+              }
+            }
+          }
+      `,
+          });
+
+          expect(errors).toBe(undefined);
+          expect(data).toHaveProperty('_ksListsMeta');
+          expect(data._ksListsMeta).toMatchObject([
+            {
+              name: 'Company',
+              schema: {
+                type: 'Company',
+                queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+                fields: [
+                  {
+                    name: 'name',
+                    type: 'Text',
+                  },
+                ],
+                relatedFields: [
+                  {
+                    type: 'User',
+                    fields: ['company', 'workHistory', '_workHistoryMeta'],
+                  },
+                ],
               },
             },
           ]);

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -41,6 +41,13 @@ class ListCRUDProvider {
            user when performing 'auth' operations."""
         auth: JSON
       }`,
+      `type _ListSchemaFields {
+        """The name of the field in its list."""
+        name: String
+
+        """The field type (ie, Checkbox, Text, etc)"""
+        type: String
+      }`,
       `type _ListSchemaRelatedFields {
         """The typename as used in GraphQL queries"""
         type: String
@@ -55,6 +62,9 @@ class ListCRUDProvider {
         """Top level GraphQL query names which either return this type, or
            provide aggregate information about this type"""
         queries: [String]
+
+        """Information about fields defined on this list. """
+        fields(where: _ListSchemaFieldsInput): [_ListSchemaFields]
 
         """Information about fields on other types which return this type, or
            provide aggregate information about this type"""
@@ -76,6 +86,9 @@ class ListCRUDProvider {
       }`,
       `input ${this.gqlNames.listsMetaInput} {
         key: String
+      }`,
+      `input _ListSchemaFieldsInput {
+        type: String
       }`,
     ]);
   }
@@ -119,6 +132,19 @@ class ListCRUDProvider {
     // NOTE: some fields are passed through unchanged from the list, and so are
     // not specified here.
     const listSchemaResolver = {
+      // Aux lists aren't filtered out here since you can query them via _ksListsMeta.
+      // They need to be included so the `key` check can match them and fetch their fields.
+      fields: ({ key }, { where: { type } = {} }) => {
+        return this.lists
+          .find(list => list.key === key)
+          .getFieldsWithAccess({ schemaName, access: 'read' })
+          .filter(field => !type || field.constructor.name === type)
+          .map(field => ({
+            name: field.path,
+            type: field.constructor.name,
+          }));
+      },
+
       // A function so we can lazily evaluate this potentially expensive
       // operation
       // (Could we memoize this in the future?)

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -47,6 +47,9 @@ class ListCRUDProvider {
 
         """The field type (ie, Checkbox, Text, etc)"""
         type: String
+
+        """The user-provided field config options. """
+        config: JSON
       }`,
       `type _ListSchemaRelatedFields {
         """The typename as used in GraphQL queries"""
@@ -139,9 +142,10 @@ class ListCRUDProvider {
           .find(list => list.key === key)
           .getFieldsWithAccess({ schemaName, access: 'read' })
           .filter(field => !type || field.constructor.name === type)
-          .map(field => ({
-            name: field.path,
-            type: field.constructor.name,
+          .map(({ path, constructor, config }) => ({
+            name: path,
+            type: constructor.name,
+            config,
           }));
       },
 

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -47,9 +47,6 @@ class ListCRUDProvider {
 
         """The field type (ie, Checkbox, Text, etc)"""
         type: String
-
-        """The user-provided field config options. """
-        config: JSON
       }`,
       `type _ListSchemaRelatedFields {
         """The typename as used in GraphQL queries"""
@@ -142,10 +139,9 @@ class ListCRUDProvider {
           .find(list => list.key === key)
           .getFieldsWithAccess({ schemaName, access: 'read' })
           .filter(field => !type || field.constructor.name === type)
-          .map(({ path, constructor, config }) => ({
-            name: path,
-            type: constructor.name,
-            config,
+          .map(field => ({
+            name: field.path,
+            type: field.constructor.name,
           }));
       },
 


### PR DESCRIPTION
@jesstelford 

Resolves #1281
Partially implements #1280 (only includes `name` and `type` keys right now)

Example:
```graphql
query {
  _ksListsMeta(where: { key: "User" }) {
    name
    schema {
      fields(where: { type: "Text" }) {
        name
        type
      }
    }
  }
}
```

Produces:
```js
{
  "data": {
    "_ksListsMeta": [
      {
        "name": "User",
        "schema": {
          "fields": [
            {
              "name": "name",
              "type": "Text"
            },
            {
              "name": "email",
              "type": "Text"
            }
          ]
        }
      }
    ]
  }
```

