### PR TITLE
Second cleanup pass on the new docs

### DIFF
--- a/docs/discussions/database-schema.md
+++ b/docs/discussions/database-schema.md
@@ -3,7 +3,7 @@ section: discussions
 title: Database schema
 [meta]-->
 
-# Database Schema
+# Database schema
 
 Keystone models its data using `Lists`, which comprise of `Fields`.
 In order to store data we need to translate the Keystone data model into an appropriate form for the underlying data store.
@@ -17,7 +17,7 @@ Each field type is responsible for articulating the exact correspondence, which 
 The most complicated aspect of the database schema is the representation of relationships.
 To understand the storage of relationships you should first make sure you understand the basic ideas behind [Keystone relationships](/docs/discussions/relationships.md).
 
-## One to many
+## One-to-many
 
 ```javascript
 keystone.createList('User', {
@@ -35,7 +35,7 @@ keystone.createList('Post', {
 });
 ```
 
-If we consider the above `one to many` relationship we know that each `Post` has a single `author` of type `User`.
+If we consider the above `one-to-many` relationship we know that each `Post` has a single `author` of type `User`.
 This means that we `Post` needs to store a reference to a single `User`.
 
 In PostgreSQL this is stored as a [foreign key column](https://www.postgresql.org/docs/12/ddl-constraints.html#DDL-CONSTRAINTS-FK) called `author` on the `Posts` table,
@@ -43,7 +43,7 @@ In MongoDB it is stored as a field called `author` on the `posts` collection wit
 
 The two-sided cases is handled identically to the one-sided case.
 
-## Many to many
+## Many-to-many
 
 ```javascript
 keystone.createList('User', {
@@ -61,7 +61,7 @@ keystone.createList('Post', {
 });
 ```
 
-If we consider the above `many to many` relationship we know that each `Post` has a multiple `authors` of type `User`.
+If we consider the above `many-to-many` relationship we know that each `Post` has a multiple `authors` of type `User`.
 This means that we `Post` needs to store multiple reference to `Users`, and also each `User` can be referenced by multiple `Posts`.
 
 To store this information we use a join table with two columns.
@@ -71,7 +71,7 @@ In MongoDB this is implemented as a collection the the contents of each field is
 
 The two-sided cases is handled using the same pattern, however the generated table/collection and column/fields names will be different.
 
-## One to one
+## One-to-one
 
 ```javascript
 keystone.createList('User', {
@@ -90,9 +90,9 @@ keystone.createList('Post', {
 });
 ```
 
-If we consider the above `one to one` relationship we know that each `Post` has a single `author`, and each `User` is the author of a single `Post`.
-This is similar to the `one to many` case, however now because of the symmetry of the configuration it is possible to store the data on either the `Post` or `User` table.
+If we consider the above `one-to-one` relationship we know that each `Post` has a single `author`, and each `User` is the author of a single `Post`.
+This is similar to the `one-to-many` case, however now because of the symmetry of the configuration it is possible to store the data on either the `Post` or `User` table.
 
 To break this symmetry we pick the list with the name that comes first alphabetically, so in this case `Post`.
-Just as in the `one to many` case, in PostgreSQL the data is stored as a [foreign key column](https://www.postgresql.org/docs/12/ddl-constraints.html#DDL-CONSTRAINTS-FK) called `author` on the `Posts` table,
+Just as in the `one-to-many` case, in PostgreSQL the data is stored as a [foreign key column](https://www.postgresql.org/docs/12/ddl-constraints.html#DDL-CONSTRAINTS-FK) called `author` on the `Posts` table.
 In MongoDB it is stored as a field called `author` on the `posts` collection with type `ObjectID`.

--- a/docs/discussions/new-data-schema.md
+++ b/docs/discussions/new-data-schema.md
@@ -1,9 +1,9 @@
 <!--[meta]
 section: discussions
-title: A New Data Schema For Keystone
+title: A new data schema
 [meta]-->
 
-# Arcade - A New Data Schema For Keystone
+# Arcade - A new data schema for Keystone
 
 > **Note:** This document refers to a set of package releases which are all part of one Keystone release.
 > These package releases are collectively known as the `Arcade` release of Keystone. The packages included are:
@@ -34,7 +34,7 @@ Unfortunately we have now outgrown this original schema.
 More and more we are finding that certain bugs are hard to fix, and certain features difficult to implement, because of the limitations of our initial design.
 While it has served us well, it's time for an upgrade.
 
-## The Problem
+## The problem
 
 The key challenge in designing our schema is how we represent relationships between lists.
 Our initial design borrowed heavily from a `MongDB` inspired pattern, where each object was responsible for tracking its related items.
@@ -49,7 +49,7 @@ Maintaining the denormalised data is now more complex than generating queries ag
 We are finding that some reported bugs are difficult to resolve due to the complex nature of resolving denormalised data.
 There are also more sophisticated relationship patterns, such as ordered relationships, which are too difficult to implement in the current schema.
 
-## The Solution
+## The solution
 
 To address these problems at their core we have changed our data schema to be normalised and to eliminate the duplicated data.
 This means that our query generation code has become more complex, but this trade off gains us a number of benefits:
@@ -87,6 +87,6 @@ To assist with this process we have written a [Schema Upgrade Guide](/docs/guide
 
 ## Summary
 
-The new Keystone data schema will simplify and improve the storage of your crucial system data, and will unlock
+The new Keystone data schema will simplify and improve the storage of your crucial system data, and will unlock new functionality.
 We appreciate that making changes to your production database can be a daunting task, but we hope to make this process as smooth as possible.
 We are looking forward to building on these change to provide an even more powerful Keystone in the future 🚀

--- a/docs/discussions/relationships.md
+++ b/docs/discussions/relationships.md
@@ -9,7 +9,7 @@ Keystone allows you to model your data as a collection of related `Lists`.
 For example, a blogging application might have lists called `Post` and `User`, where each post has a single author.
 This would be represented in Keystone by a relationship between the `Post` and `User` lists.
 
-## Defining a Relationship
+## Defining a relationship
 
 Relationships are implemented using the `Relationship` field type and defined along with other fields in `createLists`.
 For our blog example, we could define:
@@ -38,12 +38,12 @@ If we wanted to allow a post to have multiple authors we could change our defini
 We have used `many: true` to indicate that the post relates to multiple `Users`, who are the `authors` of that post.
 The default configuration is `many: false`, which indicates that each post is related to exactly one user.
 
-### One sided vs Two sided
+### One-sided vs two-sided
 
 In our example we know the authors of each post.
 We can access this information from our GraphQL API by querying for the `authors` field of a post.
 
-```graphQL
+```graphql
 Query {
   allPosts {
     title
@@ -83,7 +83,7 @@ This type of configuration is called a _two-sided_ relationship, while the origi
 
 We can now write the following query to find all the posts written by each user:
 
-```graphQL
+```graphql
 Query {
   allUsers {
     name
@@ -101,7 +101,7 @@ There are some important things to remember when defining a two-sided relationsh
 - The `ref` config must be formatted as `<listName>.<fieldName>` and both sides must refer to each other.
 - Both fields are sharing the same data. If you change the author of a post, that post will no longer show up in the original author's `posts`.
 
-## Self referential lists
+## Self-referential lists
 
 In the above examples we defined relationships between two different lists, `Users` and `Posts`.
 It is also possible to define relationships which refer to the same list.
@@ -135,15 +135,15 @@ The only relationship configuration not currently supported is having a field re
 
 The _cardinality_ of a relationship is the number items which can exist on either side of the relationship.
 In general, each side can have either `one` or `many` related items.
-Since each relationship has two sides this means we can have `one to one`, `one to many` and `many to many` relationships.
+Since each relationship has two sides this means we can have `one-to-one`, `one-to-many` and `many-to-many` relationships.
 
 The cardinality of your relationship is controlled by the use of the `many` config option.
 In two-sided relationships the `many` option on both sides must be considered.
 The follow examples will demonstrate how to set up each type of cardinality in the context of our blog.
 
-### One Sided
+### One-sided
 
-#### One to many
+#### One-to-many
 
 Each post has a single author, and each user can have multiple posts, however we cannot directly access a users' posts.
 
@@ -163,7 +163,7 @@ keystone.createList('Post', {
 });
 ```
 
-#### Many to many
+#### Many-to-many
 
 Each post has multiple authors, and each user can have multiple posts, however we cannot directly access a users' posts.
 
@@ -183,9 +183,9 @@ keystone.createList('Post', {
 });
 ```
 
-### Two Sided
+### Twos-sided
 
-#### One to one
+#### One-to-one
 
 Each post has a single author, and each user is only allowed to write one post.
 
@@ -206,7 +206,7 @@ keystone.createList('Post', {
 });
 ```
 
-#### One to many
+#### One-to-many
 
 Each post has a single author, and each user can have multiple posts.
 
@@ -227,7 +227,7 @@ keystone.createList('Post', {
 });
 ```
 
-#### Many to many
+#### Many-to-many
 
 Each post can have multiple authors, and each user can have multiple posts.
 

--- a/docs/guides/new-schema-cheatsheet.md
+++ b/docs/guides/new-schema-cheatsheet.md
@@ -1,16 +1,14 @@
 <!--[meta]
 section: guides
-title: New Schema Cheatsheet
+title: New schema cheatsheet
 [meta]-->
 
-# New Schema Cheatsheet
+# New schema cheatsheet
 
-This cheatsheet summarises the changes needed to update your database to use the new Keystone database schema, introduced in the [`Aracde`](/docs/discussions/new-data-schema.md) release.
+This cheatsheet summarises the changes needed to update your database to use the new Keystone database schema, introduced in the [`Arcade`](/docs/discussions/new-data-schema.md) release.
 For full instructions please consult the [migration guide](/docs/guides/relationship-migration.md).
 
-## One to Many (one-sided)
-
-### Example list config
+## One-to-many (one-sided)
 
 ```javascript
 keystone.createList('User', { fields: { name: { type: Text } } });
@@ -24,13 +22,11 @@ keystone.createList('Post', {
 });
 ```
 
-### Migration Strategy
+### Migration strategy
 
 - No changes are required for these relationships.
 
-## Many to Many (one-sided)
-
-### Example list config
+## Many-to-many (one-sided)
 
 ```javascript
 keystone.createList('User', { fields: { name: { type: Text } } });
@@ -57,9 +53,7 @@ keystone.createList('Post', {
 - Move the data from `posts.authors` into `post_authors_manies`.
 - Delete `posts.authors`.
 
-## One to Many (two-sided)
-
-### Example list config
+## One-to-many (two-sided)
 
 ```javascript
 keystone.createList('User', {
@@ -78,7 +72,7 @@ keystone.createList('Post', {
 });
 ```
 
-### Migration Strategy
+### Migration strategy
 
 #### PostgreSQL
 
@@ -88,9 +82,7 @@ keystone.createList('Post', {
 
 - Remove `users.posts`.
 
-## Many to Many (two-sided)
-
-### Example list config
+## Many-to-many (two-sided)
 
 ```javascript
 keystone.createList('User', {
@@ -109,7 +101,7 @@ keystone.createList('Post', {
 });
 ```
 
-### Migration Strategy
+### Migration strategy
 
 #### PostgreSQL
 
@@ -124,9 +116,7 @@ keystone.createList('Post', {
 - Delete `users.posts`.
 - Delete `posts.authors`.
 
-## One to One (two-sided)
-
-### Example list config
+## One-to-one (two-sided)
 
 ```javascript
 keystone.createList('User', {
@@ -145,13 +135,13 @@ keystone.createList('Post', {
 });
 ```
 
-### Migration Strategy
+### Migration strategy
 
 #### PostgreSQL
 
 One to one relationships in the `before` state had a foreign key column on each table.
 In the `after` state, only one of these is stored.
-Because of the symmetry of the one to one relationship, Keystone makes an arbitrary decision about which column to use.
+Because of the symmetry of the one-to-one relationship, Keystone makes an arbitrary decision about which column to use.
 
 - Identify the foreign key column which is no longer required, and delete it.
 - In our example above we would delete the `Post.author` column.
@@ -160,7 +150,7 @@ Because of the symmetry of the one to one relationship, Keystone makes an arbitr
 
 One to one relationships in the `before` state had a field in each collection.
 In the `after` state, only one of these is stored.
-Because of the symmetry of the one to one relationship, Keystone makes an arbitrary decision about which field to use.
+Because of the symmetry of the one-to-one relationship, Keystone makes an arbitrary decision about which field to use.
 
 - Identify the field which is no longer required, and delete it.
 - In our example above we would delete the `post.author` field.

--- a/docs/guides/relationship-migration.md
+++ b/docs/guides/relationship-migration.md
@@ -1,9 +1,9 @@
 <!--[meta]
 section: guides
-title: Relationship Migration Guide
+title: Relationship migration
 [meta]-->
 
-# Relationship Migration Guide
+# Relationship migration guide
 
 In the [`Arcade`](/docs/discussions/new-data-schema.md) release of Keystone we [changed the database schema](/docs/discussions/new-data-schema.md) which Keystone uses to store its data.
 This means that if you are upgrading to these new packages you will need to perform a migration on your database in order for it to continue working.
@@ -14,7 +14,7 @@ We recommend familiarising yourself with the [relationships](/docs/discussions/r
 
 ## Overview
 
-There are four steps to updating your database
+There are four steps to updating your database:
 
 1. Take a backup of your production database.
 2. Identify the changes required for your system.
@@ -44,7 +44,7 @@ The [official PostgreSQL documentation](https://www.postgresql.org/docs/12/backu
 ## Identify required changes
 
 The next step is to identify the changes you need to make to your database.
-To assist with this you can use the command `keystone upgrade-relationships`
+To assist with this you can use the command `keystone upgrade-relationships`.
 This tool will analyse your relationships and generate a summary of the changes you need to make in your database.
 We recommend adding it as a script into your `package.json` file and running it with `yarn`.
 

--- a/docs/guides/relationships.md
+++ b/docs/guides/relationships.md
@@ -1,9 +1,9 @@
 <!--[meta]
 section: guides
-title: Configuring Relationships
+title: Configuring relationships
 [meta]-->
 
-# Configuring Relationships
+# Configuring relationships
 
 Keystone allows you to model your data by declaring [relationships](/docs/discussions/relationships.md) between lists.
 There are a number of different ways you can configure relationships, depending on how you want to model your data and how you need to access it from the graphQL API.
@@ -41,7 +41,7 @@ keystone.createList('Post', {
 In the `author` field we have specified `ref: 'User'` to indicate that this field relates to an item in the `User` list.
 We can now write the following query to find the author for each post:
 
-```graphQL
+```graphql
 Query {
   allPosts {
     title
@@ -77,7 +77,7 @@ keystone.createList('Post', {
 In this case we have a `Relationship` field on both lists, and they both have a `ref` config in the form `<listName>.<fieldName>`.
 These `Relationship` fields represent the two sides of the relationship, and we can now use the following graphQL query as well:
 
-```graphQL
+```graphql
 Query {
   allUsers {
     name
@@ -97,11 +97,11 @@ In our blog do we want each post to have exactly one author, or can it have mult
 Are users allowed to write more than one post or do we want to restrict them to exactly one post each for some reason?
 The answers to these questions will give us the cardinality of our relationship.
 
-There are three types of cardinality, `one to many`, `many to many`, and `one to one`, and they can be configured using the `many` config option.
+There are three types of cardinality, `one-to-many`, `many-to-many`, and `one-to-one`, and they can be configured using the `many` config option.
 
-### One to many
+### One-to-many
 
-If we want a blog where each post can have **one** author, and each user can be the author of **many** posts, then we have a `one to many` relationship.
+If we want a blog where each post can have **one** author, and each user can be the author of **many** posts, then we have a `one-to-many` relationship.
 We can configure a one-sided version of this:
 
 ```javascript
@@ -137,9 +137,9 @@ keystone.createList('Post', {
 
 Note that we have used `many: false` in the `author` field and `many: true` in the `posts` field.
 
-### Many to many
+### Many-to-many
 
-If we want a blog where each post can have **many** authors, and each user can be the author of **many** posts, then we have a `many to many` relationship.
+If we want a blog where each post can have **many** authors, and each user can be the author of **many** posts, then we have a `many-to-many` relationship.
 We can configure a one-sided version of this:
 
 ```javascript
@@ -175,9 +175,9 @@ keystone.createList('Post', {
 
 Note that we have used `many: true` in both the `authors` and `posts` fields.
 
-### One to one
+### One-to-one
 
-If we want a blog where each post has exactly **one** author, and each user is restricted to writing exactly **one** post, then we have a `one to one` relationship.
+If we want a blog where each post has exactly **one** author, and each user is restricted to writing exactly **one** post, then we have a `one-to-one` relationship.
 In this case we can only specify this with a two-sided relationship:
 
 ```javascript


### PR DESCRIPTION
- Made headings conform to the sentence case convention introduced in #2592
- Fixed a few GQL codeblocks having incorrect langcodes
- Shortened two sidebar titles (not in-document titles)
- Used "a-to-b" punctuation everywhere to be consistent with existing Relationship docs
- Removed a few superfluous headings on one page
- Fixed a few more typos and missing punctuation