### PR TITLE
Return meta data for Select field from GraphQL API

### DIFF
--- a/.changeset/thin-eels-train.md
+++ b/.changeset/thin-eels-train.md
@@ -1,0 +1,24 @@
+---
+'@keystonejs/api-tests': minor
+'@keystonejs/keystone': minor
+---
+
+Exposes `dataType` and `options` meta data for `Select` fields:
+    ```graphql
+    query {
+      _UserMeta {
+        schema {
+          fields {
+            name
+            type
+            ...on _SelectMeta {
+              dataType
+              options {
+                label
+              }
+            }
+          }
+        }
+      }
+    }
+    ```

--- a/api-tests/fields.test.js
+++ b/api-tests/fields.test.js
@@ -46,6 +46,14 @@ describe('Fields', () => {
             test.todo('CRUD operations - tests missing');
           }
 
+          if (mod.metaTests) {
+            describe(`Meta query`, () => {
+              mod.metaTests(keystoneTestWrapper);
+            });
+          } else {
+            test.todo('Meta query - tests missing');
+          }
+
           if (mod.filterTests) {
             describe(`Filtering`, () => {
               mod.filterTests(keystoneTestWrapper);

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -5,7 +5,7 @@ class Field {
   constructor(
     path,
     { hooks = {}, isRequired, defaultValue, access, label, schemaDoc, adminDoc, ...config },
-    { getListByKey, listKey, listAdapter, fieldAdapterClass, defaultAccess, schemaNames }
+    { getListByKey, listKey, listAdapter, fieldAdapterClass, defaultAccess, schemaNames, type }
   ) {
     this.path = path;
     this.isPrimaryKey = path === 'id';
@@ -27,6 +27,8 @@ class Field {
       getListByKey,
       { ...config }
     );
+    this.type = type;
+    this.gqlMetaType = `_${type.type}Meta`;
 
     // Should be overwritten by types that implement a Relationship interface
     this.isRelationship = false;
@@ -81,6 +83,24 @@ class Field {
   }
   gqlAuxMutationResolvers() {
     return {};
+  }
+
+  getGqlMetaTypes({ interfaceType }) {
+    return [
+      `
+        type ${this.gqlMetaType} implements ${interfaceType} {
+          name: String
+          type: String
+        }
+      `,
+    ];
+  }
+  gqlMetaQueryResolver() {
+    return {
+      __typename: this.gqlMetaType,
+      name: this.path,
+      type: this.type.type,
+    };
   }
 
   /*

--- a/packages/fields/src/types/OEmbed/Implementation.test.js
+++ b/packages/fields/src/types/OEmbed/Implementation.test.js
@@ -6,7 +6,11 @@ const newOEmbed = ({ config = {} } = {}) => {
   return new OEmbed(
     path,
     { access: true, ...config },
-    { listAdapter: { newFieldAdapter: () => {} }, schemaNames: ['public'] }
+    {
+      listAdapter: { newFieldAdapter: () => {} },
+      schemaNames: ['public'],
+      type: { type: 'OEmebed' },
+    }
   );
 };
 

--- a/packages/fields/src/types/Relationship/tests/implementation.test.js
+++ b/packages/fields/src/types/Relationship/tests/implementation.test.js
@@ -56,6 +56,7 @@ function createRelationship({ path, config = {}, getListByKey = () => new MockLi
     fieldAdapterClass: MockFieldAdapter,
     defaultAccess: true,
     schemaNames: ['public'],
+    type: { type: 'Relationship' },
   });
 }
 

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -97,6 +97,29 @@ export class Select extends Implementation {
         ]
       : [];
   }
+  getGqlMetaTypes({ interfaceType }) {
+    const dataTypeEnum = `${this.gqlMetaType}DataType`;
+    return [
+      `
+        enum ${dataTypeEnum} {
+          ${VALID_DATA_TYPES.map(type => type.toUpperCase()).join('\n')}
+        }
+      `,
+      `
+        type ${this.gqlMetaType} implements ${interfaceType} {
+          name: String
+          type: String
+          dataType: ${dataTypeEnum}
+        }
+      `
+    ];
+  }
+  gqlMetaQueryResolver() {
+    return {
+      ...super.gqlMetaQueryResolver(),
+      dataType: this.dataType.toUpperCase(),
+    };
+  }
 
   extendAdminMeta(meta) {
     const { options, dataType } = this;

--- a/packages/fields/src/types/Select/test-fixtures.js
+++ b/packages/fields/src/types/Select/test-fixtures.js
@@ -280,6 +280,18 @@ export const metaTests = withKeystone => {
                 type
                 ...on _SelectMeta {
                   dataType
+                  options {
+                    label
+                    ...on _SelectMetaTypeEnum {
+                      enumValue
+                    }
+                    ...on _SelectMetaTypeString {
+                      stringValue
+                    }
+                    ...on _SelectMetaTypeInteger {
+                      integerValue
+                    }
+                  }
                 }
               }
             }
@@ -307,18 +319,34 @@ export const metaTests = withKeystone => {
               name: 'company',
               type: 'Select',
               dataType: 'ENUM',
+              options: [
+                { label: 'Thinkmill', enumValue: 'thinkmill' },
+                { label: 'Atlassian', enumValue: 'atlassian' },
+                { label: 'Thomas Walker Gelato', enumValue: 'gelato' },
+                { label: 'Cete, or Seat, or Attend ¯\\_(ツ)_/¯', enumValue: 'cete' },
+              ],
             },
             {
               __typename: '_SelectMeta',
               name: 'selectString',
               type: 'Select',
               dataType: 'STRING',
+              options: [
+                { label: 'A string', stringValue: 'a string' },
+                { label: '1number', stringValue: '1number' },
+                { label: '@¯\\_(ツ)_/¯', stringValue: '@¯\\_(ツ)_/¯' },
+              ],
             },
             {
               __typename: '_SelectMeta',
               name: 'selectNumber',
               type: 'Select',
               dataType: 'INTEGER',
+              options: [
+                { label: 'One', integerValue: 1 },
+                { label: 'Two', integerValue: 2 },
+                { label: 'Three', integerValue: 3 },
+              ],
             },
           ],
         },

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -8,6 +8,7 @@ const args = {
   },
   defaultAccess: true,
   schemaNames: ['public'],
+  type: { type: 'AType' },
 };
 
 describe('new Implementation()', () => {
@@ -23,6 +24,7 @@ describe('new Implementation()', () => {
         },
         defaultAccess: true,
         schemaNames: ['public'],
+        type: { type: 'AType' },
       }
     );
     expect(impl).not.toBeNull();

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -314,6 +314,7 @@ module.exports = class List {
           defaultAccess: this.defaultAccess.field,
           createAuxList: this.createAuxList,
           schemaNames: this._schemaNames,
+          type,
         })
     );
     this.fields = Object.values(this.fieldsByPath);

--- a/packages/keystone/tests/Keystone.test.js
+++ b/packages/keystone/tests/Keystone.test.js
@@ -39,12 +39,30 @@ class MockFieldImplementation {
   getGqlAuxMutations() {
     return ['mutateFoo: Boolean'];
   }
+  getGqlMetaTypes({ interfaceType }) {
+    return [
+      `
+        type _MockFieldMeta implements ${interfaceType} {
+          name: String
+          type: String
+        }
+      `,
+    ];
+  }
+  gqlMetaQueryResolver() {
+    return {
+      __typename: '_MockFieldMeta',
+      name: this.path,
+      type: this.type.type,
+    };
+  }
   extendAdminViews(views) {
     return views;
   }
 }
 
 const MockFieldType = {
+  type: 'MockField',
   implementation: MockFieldImplementation,
   views: {},
   adapters: { mock: MockFieldAdapter },
@@ -572,6 +590,7 @@ describe('keystone.prepare()', () => {
     };
     const mockMiddlewareFn = jest.fn(() => {});
     const MockFieldWithMiddleware = {
+      type: 'MockFieldWithMiddleware',
       prepareMiddleware: jest.fn(() => mockMiddlewareFn),
       implementation: MockFieldImplementation,
       views: {},


### PR DESCRIPTION
Following on from @Vultraz' PR #2673, and referencing #1280 & #354.

> **NOTE**: See "how to read this PR" below 👇

## Examples

Given a list:

```javascript
keystone.createList('User', {
  fields: {
    company: {
      type: Select,
      dataType: 'enum',
      options: [
        { label: 'Thinkmill', value: 'thinkmill' },
        { label: 'Atlassian', value: 'atlassian' },
        { label: 'Thomas Walker Gelato', value: 'gelato' },
        { label: 'Cete, or Seat, or Attend ¯\\_(ツ)_/¯', value: 'cete' },
      ],
    },
});
```

### Query for `Select` "dataType"

```graphql
query {
  _UserMeta {
    schema {
      fields {
        name
        type
        ...on _SelectMeta {
          dataType
        }
      }
    }
  }
}
```

Returns

```javascript
{
  _UserMeta: {
    schema: {
      fields: [
        {
          name: 'company',
          type: 'Select',
          dataType: 'ENUM',
        },
      ]
    }
  }
}
```

### Query for `Select` "options"

> _NOTE: This query may appear a bit more complicated, but the result just returns an array of `{ label, value }`-ish objects. (The added complexity is due to the recently added enum vs string vs int `dataType` option of the `Select` field from #2678)_

```graphql
query {
  _UserMeta {
    schema {
      fields {
        name
        type
        ...on _SelectMeta {
          dataType
          options {
            label
            ...on _SelectMetaTypeEnum {
              enumValue
            }
            ...on _SelectMetaTypeString {
              stringValue
            }
            ...on _SelectMetaTypeInteger {
              integerValue
            }
          }
        }
      }
    }
  }
}
```

Returns:

```javascript
{
  _UserMeta: {
    schema: {
      fields: [
        {
          name: 'company',
          type: 'Select',
          dataType: 'ENUM',
          options: [
            { label: 'Thinkmill', enumValue: 'thinkmill' },
            { label: 'Atlassian', enumValue: 'atlassian' },
            { label: 'Thomas Walker Gelato', enumValue: 'gelato' },
            { label: 'Cete, or Seat, or Attend ¯\\_(ツ)_/¯', enumValue: 'cete' },
          ],
        },
      ]
    }
  }
}
```

## Going Forward

With this pattern in place, it should be possible for all other fields to implement any specific meta data they want to provide.

Then, we could setup the Admin UI to do a query such as:

```graphql
query {
  _UserMeta {
    schema {
      fields {
        name
        type
        ...on _DecimalMeta {
          symbol
        }
        ...on _PasswordMeta {
          minLength
        }
        ...on _SelectMeta {
          dataType
          options {
            label
            ...on _SelectMetaTypeEnum {
              enumValue
            }
            ...on _SelectMetaTypeString {
              stringValue
            }
            ...on _SelectMetaTypeInteger {
              integerValue
            }
          }
        }
      }
    }
  }
}
```

Which would actually be auto-generated based on all the known possible field types the Admin UI was built with:

```
const query = `
query {
  _UserMeta {
    schema {
      fields {
        __typename
        name
        type
        ${fieldTypes.map(fieldType => `
          ...on _${fieldType.type}Meta {
            ${fieldType.getMetaQueryFragment}
          }
        `)}
      }
    }
  }
}
`;
```

Notice the `__typename` field being queried. That will let us know for every field what type it is (`_DecimalMeta` / `_SelectMeta` / etc), which could perhaps then be passed into a function which does a dynamic import of the right component type, and passes the returned data to the render.

## How to read this PR

Go commit-by-commit:

- 0ed58bf75d5ef60b9906051e937a988edd3bafc9: Takes @Vultraz' work and makes the type an `interface` ready for individual fields to extend
- 1d4d7fc1e20309a0af65afa0d485b3cab032870c: Implements the first interface (`_SelectMeta`) by exposing the `dataType` field (`enum`, `string`, `integer`). See: #2678
- a597d0395c4aea3f9234b631bd0eca6166e55544: Implements the `options` meta field for `_SelectMeta`. This brings with it its own complexity and hence the separate PR.