### PR TITLE
Added a Keystone meta provider

### DIFF
--- a/.changeset/tasty-masks-count.md
+++ b/.changeset/tasty-masks-count.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': minor
+---
+
+Added a Keystone meta provider.

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -32,7 +32,12 @@ const {
 } = require('./relationship-utils');
 const List = require('../List');
 const { DEFAULT_DIST_DIR } = require('../../constants');
-const { CustomProvider, ListAuthProvider, ListCRUDProvider } = require('../providers');
+const {
+  CustomProvider,
+  ListAuthProvider,
+  ListCRUDProvider,
+  KeystoneMetaProvider,
+} = require('../providers');
 
 module.exports = class Keystone {
   constructor({
@@ -86,6 +91,7 @@ module.exports = class Keystone {
         access: appVersion.access,
         schemaNames,
       }),
+      new KeystoneMetaProvider({ name: this.name }),
     ];
 
     if (adapters) {

--- a/packages/keystone/lib/providers/index.js
+++ b/packages/keystone/lib/providers/index.js
@@ -1,6 +1,7 @@
 const { CustomProvider } = require('./custom');
 const { ListAuthProvider } = require('./listAuth');
 const { ListCRUDProvider } = require('./listCRUD');
+const { KeystoneMetaProvider } = require('./keystoneMeta');
 
 // The GraphQL Provider Framework expects to see classes with the following API:
 //
@@ -28,4 +29,4 @@ const { ListCRUDProvider } = require('./listCRUD');
 //   }
 // }
 
-module.exports = { CustomProvider, ListAuthProvider, ListCRUDProvider };
+module.exports = { CustomProvider, ListAuthProvider, ListCRUDProvider, KeystoneMetaProvider };

--- a/packages/keystone/lib/providers/keystoneMeta.js
+++ b/packages/keystone/lib/providers/keystoneMeta.js
@@ -1,0 +1,49 @@
+const { unique } = require('@keystonejs/utils');
+
+class KeystoneMetaProvider {
+  constructor({ metaPrefix = 'ks', name } = {}) {
+    this.name = name;
+    this.gqlNames = {
+      ksMetaQuery: `_${metaPrefix}Meta`,
+    };
+  }
+
+  getTypes() {
+    return unique([
+      `
+      type _Meta {
+        """ The name of your Keystone project. """
+        projectName: String
+      }`,
+    ]);
+  }
+
+  getQueries() {
+    return unique([
+      `
+      """ Retrieves metadata about the Keystone instance. """
+      ${this.gqlNames.ksMetaQuery}: _Meta
+      `,
+    ]);
+  }
+
+  getMutations() {
+    return [];
+  }
+
+  getTypeResolvers() {
+    return {};
+  }
+
+  getQueryResolvers() {
+    return {
+      [this.gqlNames.ksMetaQuery]: () => ({ projectName: this.name }),
+    };
+  }
+
+  getMutationResolvers() {
+    return {};
+  }
+}
+
+module.exports = { KeystoneMetaProvider };


### PR DESCRIPTION
Going off what @jesstelford said in #2673, I went looking at the various `getAdminMeta` getters to see what could be added to the meta APIs. Most of the stuff in list and field-level `getAdminMeta` could be added to `_ksListsMeta`/`_${List}Meta`, but there wasn't anything to handle the Keystone-level meta.

This adds a new provider that enables this query:
```gql
query {
  _ksMeta {
    projectName
  }
}
```
to get
```js
{
  "data": {
    "_ksMeta": {
      "projectName": "Keystone To-Do List"
    }
  }
}
```

Right now it only provides a `projectName` field since that's all `keystone.getAdminMeta` added (there called simply `name`, but `projectName` seems more descriptive). I gave it its own return type so we could easily add more stuff later.

Side note: I realize this overlaps somewhat with the App Version Provider... maybe it should be merged with this? 🤔 Then one could do, say:
```gql
query {
  _ksMeta {
    projectName
    appVersion
  }
}
```