### PR TITLE
docs: Fix simple typo, unnecesarily -> unnecessarily

### DIFF
--- a/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
+++ b/packages/fields/src/types/OEmbed/views/blocks/o-embed.js
@@ -154,7 +154,7 @@ export function serialize({ node }) {
     mutations,
     node: {
       ...node.toJSON(),
-      // Zero out the data so we don't unnecesarily duplicate the url
+      // Zero out the data so we don't unnecessarily duplicate the url
       data: {},
     },
   };

--- a/packages/fields/src/types/Unsplash/views/blocks/unsplash-image.js
+++ b/packages/fields/src/types/Unsplash/views/blocks/unsplash-image.js
@@ -381,7 +381,7 @@ export function serialize({ node }) {
     mutations,
     node: {
       ...node.toJSON(),
-      // Zero out the data so we don't unnecesarily duplicate the url
+      // Zero out the data so we don't unnecessarily duplicate the url
       data: {},
     },
   };


### PR DESCRIPTION
There is a small typo in packages/fields/src/types/OEmbed/views/blocks/o-embed.js, packages/fields/src/types/Unsplash/views/blocks/unsplash-image.js.

Should read `unnecessarily` rather than `unnecesarily`.

