### PR TITLE
Update create-keystone-app and associated quick-start guide.

### DIFF
--- a/.changeset/healthy-lemons-travel.md
+++ b/.changeset/healthy-lemons-travel.md
@@ -1,0 +1,11 @@
+---
+'create-keystone-app': major
+---
+
+This release adds support for specifying and testing the database connection string used when setting up a new project.
+The quick-start guide has also been updated to give better instructions on to setup both MongoDB and PostgreSQL databases.
+
+The command line API for `create keystone-app` has also changed:
+ - `--adapter` has been replaced with `--database`, which accepts options of either `MongoDB` or `PostgreSQL`.
+ - `--conection-string` has been added, which allows you to specify either a `mongodb://` or `postgres://` connection string.
+ - `--test-connection` has been added, which will tell the installer to test the connection string before setting up the project.

--- a/docs/guides/heroku.md
+++ b/docs/guides/heroku.md
@@ -98,10 +98,12 @@ A default administrator is created the first time the app is started, or if the 
 
 The Heroku app start log can be reached by pressing [More] and View logs.
 
-    2020-03-25T07:19:04.841481+00:00 app[web.1]: User created:
-    2020-03-25T07:19:04.841483+00:00 app[web.1]:   email: admin@example.com
-    2020-03-25T07:19:04.841483+00:00 app[web.1]:   password: a04ecbcb963d
-    2020-03-25T07:19:04.841483+00:00 app[web.1]: Please change these details after initial login.
+```
+2020-03-25T07:19:04.841481+00:00 app[web.1]: User created:
+2020-03-25T07:19:04.841483+00:00 app[web.1]:   email: admin@example.com
+2020-03-25T07:19:04.841483+00:00 app[web.1]:   password: a04ecbcb963d
+2020-03-25T07:19:04.841483+00:00 app[web.1]: Please change these details after initial login.
+```
 
 #### Use secure cookies
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -7,26 +7,41 @@ slug: /quick-start/
 
 # Getting started
 
-This quick start guide will get you up and running in just a few minutes. Let's build a simple todo app with a fresh install of Keystone!
+Welcome to KeystoneJS!
+This quick start guide will get you up and running in just a few minutes.
+Let's build a simple Todo app with a fresh install of Keystone!
 
 ## Requirements
 
-Before we start, check that your computer meets the following requirements:
+Before we start, make sure that you have a basic development environment set up, with the following tools installed on your system.
 
 - [Node.js](https://nodejs.org/) >= 10.x: Node.js is a server platform which runs JavaScript.
+- [yarn](https://yarnpkg.com/) or [npm](https://docs.npmjs.com/cli/npm): yarn and npm are different package managers which can be used to install Keystone.
 
-And ONE of the following databases:
+```shell allowCopy=false showLanguage=false
+$ node --version
+v12.11.0
+$ npm --version
+6.9.0
+$ yarn --version
+1.17.3
+```
+
+## Database Setup
+
+You will also need to have a database for Keystone to store your application data in.
+You can use either `MongoDB` or `PostgreSQL`.
 
 - [MongoDB](https://www.mongodb.com/) >= 4.x: MongoDB is a powerful NoSQL document storage database.
 - [PostgreSQL](https://www.postgresql.org) >= 9.x: PostgreSQL is an open source relational database that uses the SQL language.
 
-Finally, make sure [your database is configured and running](/docs/quick-start/adapters.md).
+Follow the [database setup](/docs/quick-start/adapters.md) instructions to install and configure your databasem, and to find out what your `connection string` is.
 
-All set? Great, let's get started!
+> **Important:** You will need to make sure you have a valid `connection string` for your database in order to set up Keystone.
 
-## Installation
+## Installing Keystone
 
-To create a new Keystone application, run the following commands in your terminal:
+To create a new Keystone application, run the following command in your terminal:
 
 ```shell allowCopy=false showLanguage=false
 npm init keystone-app my-app
@@ -37,15 +52,37 @@ yarn create keystone-app my-app
 You'll be prompted with a few questions:
 
 1. **What is your project name?** Pick any name for your project. You can change it later if you like.
-2. **Select a starter project.** Select the `Todo` application if you wish to follow this guide.
-3. **Select an adapter.** Choose `Mongoose` if you're running a MongoDB database and `Knex` if you're running a PostgreSQL one.
+2. **Select a starter project.** These are some preconfigured projects you can use as the base of your own application. Select the `Todo` application if you wish to follow the rest of the Keystone tutorials.
+3. **Select an database type.** Choose between `MongoDB` and `PostgreSQL`.
+4. **Where is your database located?** Provide the `connection string` for your database.
+5. **Test your database connection.** Test that Keystone can connect to your database.
 
-Wait until all the project dependencies are installed, then run:
+Once you have answered these questions, Keystone will be installed in a project directory.
+This will take a few minutes, as there are a number of dependencies which need to be downloaded and installed.
+
+Once your project has been set up you should move into its directory so that you can start using it
 
 ```shell allowCopy=false showLanguage=false
-cd my-app   # This changes directory
-npm run dev # This starts the development server
+cd my-app
 ```
+
+If you are using `PostgreSQL` then you will need to create the tables in your database for Keystone to use.
+
+```
+yarn create-tables
+# or
+npm run create-tables
+```
+
+You can now start your development server with the following command:
+
+```
+yarn dev
+# or
+npm run dev
+```
+
+### Troubleshooting
 
 If you run into database related errors at this stage, follow the [Database Setup and Adapters](/docs/quick-start/adapters.md) instructions.
 

--- a/docs/quick-start/README.md
+++ b/docs/quick-start/README.md
@@ -53,7 +53,7 @@ You'll be prompted with a few questions:
 
 1. **What is your project name?** Pick any name for your project. You can change it later if you like.
 2. **Select a starter project.** These are some preconfigured projects you can use as the base of your own application. Select the `Todo` application if you wish to follow the rest of the Keystone tutorials.
-3. **Select an database type.** Choose between `MongoDB` and `PostgreSQL`.
+3. **Select a database type.** Choose between `MongoDB` and `PostgreSQL`.
 4. **Where is your database located?** Provide the `connection string` for your database.
 5. **Test your database connection.** Test that Keystone can connect to your database.
 

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -3,46 +3,83 @@ section: quick-start
 title: Database setup
 [meta]-->
 
-# Database setup
+# Database Setup
 
-<!-- TODO: Needs some introductory text -->
+Before starting your Keystone project you need to have a database set up and ready for Keystone to use.
 
-## Choosing an adapter
+## Choosing A Database
 
-Keystone currently provides two adapters for connecting to either a MongoDB or PostgreSQL database.
-Choose the [Mongoose adapter](/packages/adapter-mongoose/README.md) for MongoDB or the [Knex adapter](/packages/adapter-knex/README.md) for PostgreSQL.
+Keystone currently provides support for [MongoDB](https://www.mongodb.com/) or [PostgreSQL](https://www.postgresql.org/) databases.
+You will need to pick one of these databases to use for your system.
+Both databases are fully supported, and you should consider the [pros and cons](https://www.google.com/search?q=mongodb+vs+postgresql) of each to determine which one is best suited to your situation.
 
-<!-- FIXME:TL This sentence implies that all the user has to do is select the adapter and nothing else.
-In reality they have to follow the steps in this guide! -->
+Once you have chosen a database to use you will need to make sure that it is correctly installed and set up, and that you are able to connect to it.
+The instructions below will take you through this process to ensure that you are ready to continue with your Keystone project.
 
-If you're following the [quick start guide](/docs/quick-start/README.md), simply select the appropriate adapter for your database of choice when prompted.
-More information on adapter configuration can be found under the _Setup_ sections.
+> **Tip** Take note of the `connection string` that you use to connect to your database, as you will need to know this to set up your Keystone project.
 
-> **Note:** PostgreSQL requires an additional step to create a database.
+## MongoDB
 
-## Installing [MongoDB](https://www.mongodb.com/)
+### Installation
 
-### MacOS
+#### MacOS
 
 The simplest way to install MongoDB is using [Homebrew](https://brew.sh/).
 Refer the [official guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/) for more information.
 
-### Windows
+#### Windows
 
 Follow the [official guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/) for installing MongoDB on Windows.
 
-### Other platforms
+#### Other platforms
 
 [Downloads](https://www.mongodb.com/download-center/community) and [instructions](https://docs.mongodb.com/manual/administration/install-on-linux/) for installation on various Linux systems are also available.
 
-### Setup
+### Connection
 
-By default the Mongoose adapter will attempt to connect to MongoDB as the current user and create a new database using the project name.
-You can override these options when [configuring the Mongoose adapter](/packages/adapter-mongoose/README.md).
+Once you have installed MongoDB you can connect to your database using the command:
 
-## Installing [PostgreSQL](https://www.postgresql.org/)
+```shell allowCopy=false showLanguage=false
+$ mongo mongodb://localhost/my-keystone-project
+```
 
-### MacOS
+In this case the connection string `mongodb://localhost/my-keystone-project` tells MongoDB to connect to a database called `my-keystone-project` on your computer (`localhost`). You should see output which looks like this:
+
+```none allowCopy=false showLanguage=false
+$ mongo mongodb://localhost/my-keystone-project
+MongoDB shell version v4.0.3
+connecting to: mongodb://localhost/my-keystone-project
+Implicit session: session { "id" : UUID("2f47e753-d347-4305-92e2-347c095c8072") }
+MongoDB server version: 4.0.3
+Server has startup warnings:
+2020-04-08T09:31:10.824+1000 I CONTROL  [initandlisten]
+2020-04-08T09:31:10.825+1000 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
+2020-04-08T09:31:10.825+1000 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
+2020-04-08T09:31:10.825+1000 I CONTROL  [initandlisten]
+---
+Enable MongoDB's free cloud-based monitoring service, which will then receive and display
+metrics about your deployment (disk utilization, CPU, operation statistics, etc).
+
+The monitoring data will be available on a MongoDB website with a unique URL accessible to you
+and anyone you share the URL with. MongoDB may use this information to make product
+improvements and to suggest MongoDB products and deployment options to you.
+
+To enable free monitoring, run the following command: db.enableFreeMonitoring()
+To permanently disable this reminder, run the following command: db.disableFreeMonitoring()
+---
+
+>
+```
+
+If this works then you are ready to start setting up your Keystone project, and can head back to the [getting started guide](/docs/quick-start/README.md).
+
+If you run into problems please consult the [MongoDB docs](https://docs.mongodb.com/manual/installation/) for troubleshooting tips.
+
+## PostgreSQL
+
+### Installation
+
+#### MacOS
 
 The simplest way to install PostgreSQL is using [Homebrew](https://brew.sh/).
 
@@ -50,20 +87,65 @@ The simplest way to install PostgreSQL is using [Homebrew](https://brew.sh/).
 brew install postgres
 ```
 
-### Other platforms
+#### Other platforms
 
 For Windows and other platforms see the [download instructions](https://www.postgresql.org/download/) on the [postgresql.org](https://postgresql.org) website.
 
 ### Setup
 
-By default the Knex adapter will attempt to connect to a PostgreSQL database as the current user.
+<!-- ### MongoDB -->
+
+<!-- By default the Mongoose adapter will attempt to connect to MongoDB as the current user and create a new database using the project name.
+You can override these options when [configuring the Mongoose adapter](/packages/adapter-mongoose/README.md). -->
+
+<!-- ### PostgreSQL -->
+
+<!-- By default the Knex adapter will attempt to connect to a PostgreSQL database as the current user.
 It will look for a database matching the project name.
-You can override these options when [configuring the Knex adapter](/packages/adapter-knex/README.md).
+You can override these options when [configuring the Knex adapter](/packages/adapter-knex/README.md). -->
 
 <!-- FIXME:TL These instructions are inadequate for a new user folowing the quicks start. -->
 
-To create database run the following command:
+Once you have installed PostgreSQL you will need to create a database for Keystone to use.
+To create the database run the following command:
 
-```shell
-createdb my-database-name
+```shell allowCopy=false showLanguage=false
+createdb my-keystone-project
 ```
+
+If the command runs with no output then you have successfully created your database.
+You may see an error which looks like this:
+
+```shell allowCopy=false showLanguage=false
+createdb: error: could not connect to database template1: FATAL:  password authentication failed for user ...
+```
+
+If this is the case then you will need to configure the user permissions for your database. Please consult the [PostgreSQL docs](https://www.postgresql.org/docs/) for instructions on how to do this.
+
+### Connection
+
+Once you have created your database you can connect to it using the command:
+
+```shell allowCopy=false showLanguage=false
+$ psql postgres://localhost/my-keystone-project
+```
+
+In this case the connection string `postgres://localhost/my-keystone-project` tells PostgreSQL to connect to a database called `my-keystone-project` on your computer (`localhost`). You should see output which looks like this:
+
+```
+$ psql postgres://localhost/my-keystone-project
+psql (12.2, server 9.6.8)
+Type "help" for help.
+
+my-keystone-project=#
+```
+
+If you need to connect to to your database as a particular user then you can include the username and password in the connection string:
+
+```shell allowCopy=false showLanguage=false
+$ psql postgres://<username>:<password>@localhost/my-keystone-project
+```
+
+If this works then you are ready to start setting up your Keystone project, and can head back to the [getting started guide](/docs/quick-start/README.md).
+
+If you run into problems please consult the [PostgreSQL docs](https://www.postgresql.org/docs/) for troubleshooting tips.

--- a/docs/quick-start/adapters.md
+++ b/docs/quick-start/adapters.md
@@ -31,7 +31,7 @@ Refer the [official guide](https://docs.mongodb.com/manual/tutorial/install-mong
 
 Follow the [official guide](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/) for installing MongoDB on Windows.
 
-#### Other platforms
+#### Other Platforms
 
 [Downloads](https://www.mongodb.com/download-center/community) and [instructions](https://docs.mongodb.com/manual/administration/install-on-linux/) for installation on various Linux systems are also available.
 
@@ -87,24 +87,11 @@ The simplest way to install PostgreSQL is using [Homebrew](https://brew.sh/).
 brew install postgres
 ```
 
-#### Other platforms
+#### Other Platforms
 
 For Windows and other platforms see the [download instructions](https://www.postgresql.org/download/) on the [postgresql.org](https://postgresql.org) website.
 
 ### Setup
-
-<!-- ### MongoDB -->
-
-<!-- By default the Mongoose adapter will attempt to connect to MongoDB as the current user and create a new database using the project name.
-You can override these options when [configuring the Mongoose adapter](/packages/adapter-mongoose/README.md). -->
-
-<!-- ### PostgreSQL -->
-
-<!-- By default the Knex adapter will attempt to connect to a PostgreSQL database as the current user.
-It will look for a database matching the project name.
-You can override these options when [configuring the Knex adapter](/packages/adapter-knex/README.md). -->
-
-<!-- FIXME:TL These instructions are inadequate for a new user folowing the quicks start. -->
 
 Once you have installed PostgreSQL you will need to create a database for Keystone to use.
 To create the database run the following command:

--- a/packages/create-keystone-app/README.md
+++ b/packages/create-keystone-app/README.md
@@ -25,7 +25,7 @@ One such example is creating a Docker image with a generated Keystone app built 
 See the list of possible arguments in the **Arguments** section below.
 
 ```shell
-npm init keystone-app --name "My App" --template "starter" --adapter "Mongoose" my-app
+npm init keystone-app --name "My App" --template "starter" --database "MongoDB" my-app
 ```
 
 The app generation will fall back to interactive prompts if any of the arguments are
@@ -36,12 +36,14 @@ missing or have incorrect values.
 
 ### Arguments
 
-| Argument     | Type      | Description                                                                                                                     |
-| :----------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| `--name`     | `String`  | The Keystone app name visible in the Admin UI and page titles.                                                                  |
-| `--template` | `String`  | One of the existing app templates (folder name). For example: `starter`, `todo`, etc.                                           |
-| `--adapter`  | `String`  | One of the adapters listed in the app template. Usually one of: `Mongoose`, `Knex`.                                             |
-| `--dry-run`  | `Boolean` | Will go through the app generation process validating the user inputs or CLI arguments but in the end no app will be generated. |
+| Argument              | Type      | Description                                                                                                                     |
+| :-------------------- | :-------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `--name`              | `String`  | The Keystone app name visible in the Admin UI and page titles.                                                                  |
+| `--template`          | `String`  | One of the existing app templates (folder name). For example: `starter`, `todo`, etc.                                           |
+| `--database`          | `String`  | One of the databases listed in the app template. One of: `MongoDB` or `PostgreSQL`.                                             |
+| `--connection-string` | `String`  | The connection string to connect to your database.                                                                              |
+| `--test-connection`   | `Boolean` | Test the database connection before setting up the project.                                                                     |
+| `--dry-run`           | `Boolean` | Will go through the app generation process validating the user inputs or CLI arguments but in the end no app will be generated. |
 
 ## Run the app
 

--- a/packages/create-keystone-app/bin/cli.js
+++ b/packages/create-keystone-app/bin/cli.js
@@ -7,6 +7,8 @@ const { copyExampleProject } = require('../lib/copy-example-project');
 const { installProjectDependencies } = require('../lib/install-project-dependencies');
 const { updateProjectDependencies } = require('../lib/update-project-dependencies');
 const { getAdapterChoice } = require('../lib/get-adapter-choice');
+const { getAdapterConfig } = require('../lib/get-adapter-config');
+const { testAdapterConnection } = require('../lib/test-adapter-connection');
 const { replaceKeystoneMagicComments } = require('../lib/replace-keystone-magic-comments');
 
 // Start
@@ -14,9 +16,11 @@ const { replaceKeystoneMagicComments } = require('../lib/replace-keystone-magic-
   showWelcomeMessage();
   await getProjectName();
   await getAdapterChoice();
+  await getAdapterConfig();
+  await testAdapterConnection();
   await copyExampleProject();
+  await replaceKeystoneMagicComments();
   await installProjectDependencies();
   await updateProjectDependencies();
-  await replaceKeystoneMagicComments();
   showSuccessMessage();
 })();

--- a/packages/create-keystone-app/example-projects/blank/index.js
+++ b/packages/create-keystone-app/example-projects/blank/index.js
@@ -4,6 +4,7 @@ const { AdminUIApp } = require('@keystonejs/app-admin-ui');
 /* keystone-cli: generated-code */
 const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');
 const PROJECT_NAME = 'My KeystoneJS Project';
+const adapterConfig = {};
 /* /keystone-cli: generated-code */
 
 /**
@@ -14,7 +15,7 @@ const PROJECT_NAME = 'My KeystoneJS Project';
 
 const keystone = new Keystone({
   name: PROJECT_NAME,
-  adapter: new Adapter(),
+  adapter: new Adapter(adapterConfig),
 });
 
 module.exports = {

--- a/packages/create-keystone-app/example-projects/config.js
+++ b/packages/create-keystone-app/example-projects/config.js
@@ -1,14 +1,20 @@
+const slugify = require('@sindresorhus/slugify');
+
 const adapters = {
-  Mongoose: {
+  MongoDB: {
+    name: 'MongoDB',
     file: 'adapter-mongoose.js',
     dependencies: ['@keystonejs/adapter-mongoose'],
-    description: 'Connect to a Mongo database.',
+    description: 'Connect to a MongoDB database.',
+    defaultConfig: name => `mongodb://localhost/${slugify(name)}`,
   },
-  Knex: {
+  PostgreSQL: {
+    name: 'PostgreSQL',
     file: 'adapter-knex.js',
     dependencies: ['@keystonejs/adapter-knex'],
-    description: 'Connect to a Postgres database.',
+    description: 'Connect to a PostgreSQL database.',
     removeDependencies: ['@keystonejs/adapter-mongoose'],
+    defaultConfig: name => `postgres://localhost/${slugify(name, { separator: '_' })}`,
   },
 };
 

--- a/packages/create-keystone-app/example-projects/nuxt/index.js
+++ b/packages/create-keystone-app/example-projects/nuxt/index.js
@@ -7,11 +7,12 @@ const { NuxtApp } = require('@keystonejs/app-nuxt');
 /* keystone-cli: generated-code */
 const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');
 const PROJECT_NAME = 'Nuxt';
+const adapterConfig = {};
 /* /keystone-cli: generated-code */
 
 const keystone = new Keystone({
   name: PROJECT_NAME,
-  adapter: new Adapter(),
+  adapter: new Adapter(adapterConfig),
 });
 
 keystone.createList('Todo', {

--- a/packages/create-keystone-app/example-projects/starter/index.js
+++ b/packages/create-keystone-app/example-projects/starter/index.js
@@ -8,11 +8,12 @@ const initialiseData = require('./initial-data');
 /* keystone-cli: generated-code */
 const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');
 const PROJECT_NAME = 'My KeystoneJS Project';
+const adapterConfig = {};
 /* /keystone-cli: generated-code */
 
 const keystone = new Keystone({
   name: PROJECT_NAME,
-  adapter: new Adapter(),
+  adapter: new Adapter(adapterConfig),
   onConnect: initialiseData,
 });
 

--- a/packages/create-keystone-app/example-projects/todo/index.js
+++ b/packages/create-keystone-app/example-projects/todo/index.js
@@ -7,11 +7,12 @@ const { StaticApp } = require('@keystonejs/app-static');
 /* keystone-cli: generated-code */
 const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');
 const PROJECT_NAME = 'My KeystoneJS Project';
+const adapterConfig = {};
 /* /keystone-cli: generated-code */
 
 const keystone = new Keystone({
   name: PROJECT_NAME,
-  adapter: new Adapter(),
+  adapter: new Adapter(adapterConfig),
 });
 
 keystone.createList('Todo', {

--- a/packages/create-keystone-app/lib/copy-example-project.js
+++ b/packages/create-keystone-app/lib/copy-example-project.js
@@ -8,7 +8,7 @@ const createNewProjectFolder = newProjectFolder => {
   fs.mkdirpSync(newProjectFolder);
   const readDir = fs.readdirSync(newProjectFolder);
   if (readDir && readDir.length > 0) {
-    error(`The project directory ${newProjectFolder} is not empty`);
+    error(`The project directory "./${newProjectFolder}" is not empty`);
     process.exit(0);
   }
 };
@@ -17,7 +17,7 @@ const copyExampleProject = async () => {
   const args = getArgs();
   if (args['--dry-run']) {
     tick('Skipping copy project files');
-    return true;
+    return;
   }
 
   const exampleProject = await getExampleProject();

--- a/packages/create-keystone-app/lib/generate-code.js
+++ b/packages/create-keystone-app/lib/generate-code.js
@@ -1,16 +1,23 @@
 const { getAdapterTemplateContent } = require('./get-adapter-template-content');
 const { getProjectName } = require('./get-project-name');
+const { getAdapterChoice } = require('./get-adapter-choice');
+const { getAdapterConfig } = require('./get-adapter-config');
 
 const generateCode = async () => {
   const adapterTemplateContent = await getAdapterTemplateContent();
 
   const projectName = await getProjectName();
-  const projectConfigString = `const PROJECT_NAME = ${JSON.stringify(projectName)};`;
 
-  const generatedCode = `${adapterTemplateContent}
-${projectConfigString}
+  const adapterChoice = await getAdapterChoice();
+  const adapterConfig =
+    adapterChoice.name === 'MongoDB'
+      ? `{ mongoUri: '${await getAdapterConfig()}' }`
+      : `{ knexOptions: { connection: '${await getAdapterConfig()}' } }`;
+
+  return `${adapterTemplateContent}
+const PROJECT_NAME = '${projectName}';
+const adapterConfig = ${adapterConfig};
 `;
-  return generatedCode;
 };
 
 module.exports = { generateCode };

--- a/packages/create-keystone-app/lib/get-adapter-choice.js
+++ b/packages/create-keystone-app/lib/get-adapter-choice.js
@@ -12,15 +12,15 @@ const getAdapterChoice = async () => {
 
   const project = await getExampleProject();
 
-  // If the adapter option was provided via the CLI arguments
+  // If the database option was provided via the CLI arguments
   const args = getArgs();
-  const argValue = args['--adapter'];
+  const argValue = args['--database'];
   if (argValue) {
     if (project.adapters[argValue]) {
       ADAPTER_CHOICE = project.adapters[argValue];
       return ADAPTER_CHOICE;
     }
-    console.error('Invalid --adapter value:', argValue);
+    console.error('Invalid --database value:', argValue);
   }
 
   // Prompt for an adapter
@@ -34,7 +34,7 @@ const getAdapterChoice = async () => {
     {
       type: 'select',
       name: 'value',
-      message: 'Select an adapter',
+      message: 'Select a database type',
       choices,
       initial: 0,
       onCancel: () => {

--- a/packages/create-keystone-app/lib/get-adapter-config.js
+++ b/packages/create-keystone-app/lib/get-adapter-config.js
@@ -1,0 +1,41 @@
+const prompts = require('prompts');
+const { getArgs } = require('./get-args');
+const { getAdapterChoice } = require('./get-adapter-choice');
+const { getProjectName } = require('./get-project-name');
+
+let CONNECTION_STRING;
+
+const getAdapterConfig = async () => {
+  // If we already have the project name return it
+  if (!CONNECTION_STRING) {
+    // If the adapter option was provided via the CLI arguments
+    const args = getArgs();
+    const argValue = args['--connection-string'];
+    if (argValue) {
+      CONNECTION_STRING = argValue;
+    }
+
+    const adapter = await getAdapterChoice();
+    const projectName = await getProjectName();
+    const response = await prompts(
+      {
+        type: 'text',
+        name: 'value',
+        message: 'Where is your database located?',
+        initial: adapter.defaultConfig(projectName),
+        onCancel: () => {
+          return true;
+        },
+      },
+      {
+        onCancel: () => {
+          process.exit(0);
+        },
+      }
+    );
+    CONNECTION_STRING = response.value;
+  }
+  return CONNECTION_STRING;
+};
+
+module.exports = { getAdapterConfig };

--- a/packages/create-keystone-app/lib/get-args.js
+++ b/packages/create-keystone-app/lib/get-args.js
@@ -10,7 +10,9 @@ const getArgs = () => {
   const argsSpec = {
     '--name': String,
     '--template': String,
-    '--adapter': String,
+    '--database': String,
+    '--connection-string': String,
+    '--test-connection': Boolean,
     '--help': Boolean,
     '--dry-run': Boolean,
     '-h': '--help',

--- a/packages/create-keystone-app/lib/install-project-dependencies.js
+++ b/packages/create-keystone-app/lib/install-project-dependencies.js
@@ -8,7 +8,7 @@ const installProjectDependencies = async () => {
     return true;
   }
 
-  console.log('Installing dependencies with yarn. This could take a few minutes.');
+  console.log('Installing dependencies with yarn. This will take a few minutes.');
   // FIXME: Can we put a spinner in here to make it look like something is happening?
   const result = await exec('yarn');
 

--- a/packages/create-keystone-app/lib/install-project-dependencies.js
+++ b/packages/create-keystone-app/lib/install-project-dependencies.js
@@ -9,6 +9,7 @@ const installProjectDependencies = async () => {
   }
 
   console.log('Installing dependencies with yarn. This could take a few minutes.');
+  // FIXME: Can we put a spinner in here to make it look like something is happening?
   const result = await exec('yarn');
 
   if (result.failed) {

--- a/packages/create-keystone-app/lib/show-success-message.js
+++ b/packages/create-keystone-app/lib/show-success-message.js
@@ -3,22 +3,19 @@ const path = require('path');
 const terminalLink = require('terminal-link');
 const { getProjectDirectory } = require('./util');
 const { getAdapterChoice } = require('./get-adapter-choice');
-const { getProjectName } = require('./get-project-name');
-const slugify = require('@sindresorhus/slugify');
 
 const showSuccessMessage = async () => {
   const projectDir = await getProjectDirectory();
-  const projectName = await getProjectName();
   const adapterConfig = await getAdapterChoice();
   let knexMessage = '';
-  if (adapterConfig.file === 'adapter-knex.js') {
+  if (adapterConfig.name === 'PostgreSQL') {
     knexMessage = `
-${c.bold('Before you run Keystone you will need to create a database and initialise tables:')}
+${c.bold('  Before you run Keystone you will need to initialise the tables in your database:')}
 
-  - createdb ${slugify(projectName, { separator: '_' })}
+  - cd ${projectDir}
   - yarn create-tables
 
-For troubleshooting and further information see:
+  For troubleshooting and further information see:
 
   - https://www.keystonejs.com/quick-start/adapters/
   - https://www.keystonejs.com/keystonejs/adapter-knex/

--- a/packages/create-keystone-app/lib/test-adapter-connection.js
+++ b/packages/create-keystone-app/lib/test-adapter-connection.js
@@ -1,0 +1,82 @@
+const prompts = require('prompts');
+const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
+const { KnexAdapter } = require('@keystonejs/adapter-knex');
+const terminalLink = require('terminal-link');
+const { error, tick } = require('./util');
+const { getArgs } = require('./get-args');
+const { getAdapterChoice } = require('./get-adapter-choice');
+const { getAdapterConfig } = require('./get-adapter-config');
+const { getProjectName } = require('../lib/get-project-name');
+
+let TEST_CONNECTION;
+
+const testAdapterConnection = async () => {
+  // If we already have the project name return it
+  if (TEST_CONNECTION) {
+    return TEST_CONNECTION;
+  }
+
+  // If the adapter option was provided via the CLI arguments
+  const args = getArgs();
+  const argValue = args['--test-connection'];
+  if (argValue) {
+    TEST_CONNECTION = argValue;
+  } else {
+    const response = await prompts(
+      {
+        type: 'toggle',
+        name: 'value',
+        message: 'Test database connection?',
+        initial: true,
+        active: 'Yes',
+        inactive: 'No',
+        onCancel: () => {
+          return true;
+        },
+      },
+      {
+        onCancel: () => {
+          process.exit(0);
+        },
+      }
+    );
+    TEST_CONNECTION = response.value;
+  }
+  if (TEST_CONNECTION) {
+    const adapterChoice = await getAdapterChoice();
+    const config = await getAdapterConfig();
+
+    const Adapter = adapterChoice.name === 'MongoDB' ? MongooseAdapter : KnexAdapter;
+    const adapterConfig =
+      adapterChoice.name === 'MongoDB'
+        ? { mongoUri: config }
+        : { knexOptions: { connection: config } };
+    const adapter = new Adapter(adapterConfig);
+    try {
+      await adapter._connect({ name: await getProjectName() });
+      adapter.disconnect();
+      tick(`Successfully connected to ${config}`);
+    } catch (err) {
+      error(`Failed to connect to ${adapterChoice.name} at: ${config}`);
+      console.log(
+        'Please check that you can connect directly to your database with the following command:'
+      );
+      console.log('');
+      console.log(`$ ${adapterChoice.name === 'MongoDB' ? 'mongo' : 'psql'} ${config}`);
+      console.log('');
+      console.log(
+        `Please see the database ${terminalLink(
+          'setup docs',
+          'https://www.keystonejs.com/quick-start/adapters'
+        )} for more help`
+      );
+      console.log('');
+      error('Details:');
+      console.log(err);
+      process.exit(0);
+    }
+  }
+  return TEST_CONNECTION;
+};
+
+module.exports = { testAdapterConnection };

--- a/packages/create-keystone-app/package.json
+++ b/packages/create-keystone-app/package.json
@@ -11,6 +11,8 @@
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "dependencies": {
+    "@keystonejs/adapter-knex": "^9.0.1",
+    "@keystonejs/adapter-mongoose": "^8.0.1",
     "@sindresorhus/slugify": "^0.11.0",
     "arg": "^4.1.1",
     "cfonts": "^2.7.0",


### PR DESCRIPTION
These changes will hopefully make it much easier for a user to get started, particularly if they are running postgres. In particular, the default connection string we previously used had a vanishingly small chance of ever working. We now give much more explicit instructions on how to find a connection string which will work and then allow the user to explicitly provide and test this connection string when setting up their project.