### PR TITLE
Give upgrade-relationships output some space for legibility

### DIFF
--- a/.changeset/seven-dryers-cheat.md
+++ b/.changeset/seven-dryers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Improve legibility of `keystone upgrade-relationships` CLI command

--- a/packages/keystone/bin/commands/upgrade-relationships.js
+++ b/packages/keystone/bin/commands/upgrade-relationships.js
@@ -52,32 +52,27 @@ const ttyLink = (url, text) => {
 const printArrow = ({ migration, left, right }) => {
   if (!migration) {
     if (right) {
-      console.log(`  ${left.listKey}.${left.path} -> ${right.listKey}.${right.path}`);
+      console.log(`\n  ${left.listKey}.${left.path} -> ${right.listKey}.${right.path}`);
     } else {
-      console.log(`  ${left.listKey}.${left.path} -> ${left.refListKey}`);
+      console.log(`\n  ${left.listKey}.${left.path} -> ${left.refListKey}`);
     }
   }
 };
 
 const strategySummary = (
-  { one_one_to_many, one_many_to_many, two_one_to_one, two_one_to_many, two_many_to_many },
+  { one_many_to_many, two_one_to_one, two_one_to_many, two_many_to_many },
   keystone,
   migration
 ) => {
   const mongo = !!keystone.adapters.MongooseAdapter;
 
   if (!migration) {
-    console.log(chalk.bold('One-sided: one to many'));
+    console.log('\n', chalk.bold('One-sided: one to many'));
+    console.log('    ✅ No action required');
   }
-  one_one_to_many.forEach(({ left }) => {
-    printArrow({ migration, left });
-    if (!migration) {
-      console.log('    * No action required');
-    }
-  });
 
   if (!migration) {
-    console.log(chalk.bold('One-sided: many to many'));
+    console.log('\n\n', chalk.bold('One-sided: many to many'));
   }
   one_many_to_many.forEach(({ left, columnNames, tableName }) => {
     const { near, far } = columnNames[`${left.listKey}.${left.path}`];
@@ -95,7 +90,7 @@ const strategySummary = (
   });
 
   if (!migration) {
-    console.log(chalk.bold('Two-sided: one to one'));
+    console.log('\n\n', chalk.bold('Two-sided: one to one'));
   }
   two_one_to_one.forEach(({ left, right }) => {
     printArrow({ migration, left, right });
@@ -109,7 +104,7 @@ const strategySummary = (
   });
 
   if (!migration) {
-    console.log(chalk.bold('Two-sided: one to many'));
+    console.log('\n\n', chalk.bold('Two-sided: one to many'));
   }
   two_one_to_many.forEach(({ left, right, tableName }) => {
     const dropper = left.listKey === tableName ? right : left;
@@ -124,7 +119,7 @@ const strategySummary = (
   });
 
   if (!migration) {
-    console.log(chalk.bold('Two-sided: many to many'));
+    console.log('\n\n', chalk.bold('Two-sided: many to many'));
   }
   two_many_to_many.forEach(({ left, right, tableName, columnNames }) => {
     const { near, far } = columnNames[`${left.listKey}.${left.path}`];
@@ -152,7 +147,6 @@ const upgradeRelationships = async (args, entryFile) => {
 
   const rels = keystone._consolidateRelationships();
 
-  const one_one_to_many = rels.filter(({ right, cardinality }) => !right && cardinality !== 'N:N');
   const one_many_to_many = rels.filter(({ right, cardinality }) => !right && cardinality === 'N:N');
 
   const two_one_to_one = rels.filter(({ right, cardinality }) => right && cardinality === '1:1');
@@ -163,7 +157,6 @@ const upgradeRelationships = async (args, entryFile) => {
 
   strategySummary(
     {
-      one_one_to_many,
       one_many_to_many,
       two_one_to_one,
       two_one_to_many,

--- a/packages/keystone/bin/commands/upgrade-relationships.js
+++ b/packages/keystone/bin/commands/upgrade-relationships.js
@@ -165,8 +165,23 @@ const upgradeRelationships = async (args, entryFile) => {
     keystone,
     migration
   );
+
   console.log('');
   ttyLink('https://www.keystonejs.com/discussions/relationships', 'More info on relationships');
+
+  if (!migration) {
+    const mongo = !!keystone.adapters.MongooseAdapter;
+    console.log('');
+    console.log(
+      chalk.green(
+        `💡 Re-run with --migration flag to generate executable ${
+          mongo ? 'MongoDB commands' : 'SQL statements'
+        }`
+      )
+    );
+    console.log('');
+  }
+
   process.exit(0);
 };
 


### PR DESCRIPTION
## Adding space

### From this:

<img width="638" alt="Screen Shot 2020-04-08 at 11 32 35 pm" src="https://user-images.githubusercontent.com/612020/78791637-7da1f000-79f3-11ea-9171-3e7ff42702a7.png">

### To this:

<img width="663" alt="Screen Shot 2020-04-08 at 11 44 04 pm" src="https://user-images.githubusercontent.com/612020/78791658-82ff3a80-79f3-11ea-8edb-c4d211efb8aa.png">

## Also adds a hint about the `--migration` flag

### From this:
<img width="979" alt="Screen Shot 2020-04-08 at 11 57 35 pm" src="https://user-images.githubusercontent.com/612020/78792739-dcb43480-79f4-11ea-9d42-d23edf2c6857.png">

### To this:
<img width="977" alt="Screen Shot 2020-04-08 at 11 57 14 pm" src="https://user-images.githubusercontent.com/612020/78792752-e178e880-79f4-11ea-8097-ead5ab9b87f3.png">

