### PR TITLE
Added a `format` argument to CalendarDay GraphQL queries

### DIFF
--- a/.changeset/rude-pumas-behave.md
+++ b/.changeset/rude-pumas-behave.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': minor
+---
+
+Added a `format` argument to CalendarDay GraphQL queries. If true, it will return the date in the config-provided format.

--- a/packages/fields/src/types/CalendarDay/Implementation.js
+++ b/packages/fields/src/types/CalendarDay/Implementation.js
@@ -21,7 +21,21 @@ export class CalendarDay extends Implementation {
   }
 
   gqlOutputFields() {
-    return [`${this.path}: String`];
+    return [
+      `${this.path}(
+        """Whether to return the date in the config-provided format or as a raw ISO8601 string."""
+        format: Boolean = false
+      ): String`,
+    ];
+  }
+
+  gqlOutputFieldResolvers() {
+    return {
+      // TODO: consider a schema directive
+      [this.path]: ({ [this.path]: value }, { format: shouldFormat }) => {
+        return shouldFormat ? format(value, this.format) : value;
+      },
+    };
   }
 
   gqlQueryInputFields() {


### PR DESCRIPTION
Just something I thought might be useful. This enables queries such as this:
```graphql
query {
  allDateFnsUpgradeTests {
    cday(format: true)
  }
}
```

`format` defaults to false. If true, the date will be returned in the field config-provided format.

Few things to consider:
- Should this also be available to other date-related fields?
- I noticed the `DateTime` field uses a custom `DateTime` scalar. Perhaps `CalendarDay` should use that too for consistency? If so, would the `DateTime` definition need to be elevated to the CRUD provider?
- Perhaps this should be done with a schema directive to avoid having to add an argument to every query in each field type where formatting is desired? Though, in that case, I'd have to add directive support to the providers.

@timleslie / @jesstelford thoughts?