### PR TITLE
Added more stuff to list meta queries

### DIFF
--- a/.changeset/angry-spiders-deliver.md
+++ b/.changeset/angry-spiders-deliver.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': minor
+---
+
+Expanded list metadata queries.

--- a/api-tests/queries-access-control/meta.test.js
+++ b/api-tests/queries-access-control/meta.test.js
@@ -84,7 +84,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             _CompaniesMeta {
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 relatedFields {
                   type
                   fields
@@ -99,7 +103,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
-            queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+            queries: {
+              item: 'Company',
+              list: 'allCompanies',
+              meta: '_allCompaniesMeta',
+            },
             relatedFields: [
               {
                 type: 'User',
@@ -172,7 +180,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 relatedFields {
                   type
                   fields
@@ -189,7 +201,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             {
               name: 'User',
               schema: {
-                queries: ['User', 'allUsers', '_allUsersMeta'],
+                queries: {
+                  item: 'User',
+                  list: 'allUsers',
+                  meta: '_allUsersMeta',
+                },
                 relatedFields: [
                   {
                     fields: ['employees'],
@@ -207,7 +223,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'Company',
               schema: {
                 type: 'Company',
-                queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+                queries: {
+                  item: 'Company',
+                  list: 'allCompanies',
+                  meta: '_allCompaniesMeta',
+                },
                 relatedFields: [
                   {
                     type: 'User',

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -43,7 +43,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             _CompaniesMeta {
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 relatedFields {
                   type
                   fields
@@ -58,7 +62,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
-            queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+            queries: {
+              item: 'Company',
+              list: 'allCompanies',
+              meta: '_allCompaniesMeta',
+            },
             relatedFields: [
               {
                 type: 'User',
@@ -79,7 +87,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             _PostsMeta {
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 relatedFields {
                   type
                   fields
@@ -94,7 +106,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(data).toHaveProperty('_PostsMeta.schema');
           expect(data._PostsMeta.schema).toMatchObject({
             type: 'Post',
-            queries: ['Post', 'allPosts', '_allPostsMeta'],
+            queries: {
+              item: 'Post',
+              list: 'allPosts',
+              meta: '_allPostsMeta',
+            },
             relatedFields: [],
           });
         })
@@ -113,7 +129,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 fields {
                   name
                   type
@@ -134,7 +154,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             {
               name: 'User',
               schema: {
-                queries: ['User', 'allUsers', '_allUsersMeta'],
+                queries: {
+                  item: 'User',
+                  list: 'allUsers',
+                  meta: '_allUsersMeta',
+                },
                 fields: [
                   {
                     name: 'id',
@@ -168,7 +192,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'Company',
               schema: {
                 type: 'Company',
-                queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+                queries: {
+                  item: 'Company',
+                  list: 'allCompanies',
+                  meta: '_allCompaniesMeta',
+                },
                 fields: [
                   {
                     name: 'id',
@@ -196,7 +224,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             {
               name: 'Post',
               schema: {
-                queries: ['Post', 'allPosts', '_allPostsMeta'],
+                queries: {
+                  item: 'Post',
+                  list: 'allPosts',
+                  meta: '_allPostsMeta',
+                },
                 fields: [
                   {
                     name: 'id',
@@ -232,7 +264,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 fields {
                   name
                   type
@@ -253,7 +289,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             {
               name: 'User',
               schema: {
-                queries: ['User', 'allUsers', '_allUsersMeta'],
+                queries: {
+                  item: 'User',
+                  list: 'allUsers',
+                  meta: '_allUsersMeta',
+                },
                 fields: [
                   {
                     name: 'id',
@@ -298,7 +338,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name
               schema {
                 type
-                queries
+                queries {
+                  item
+                  list
+                  meta
+                }
                 fields(where: { type: "Text" }) {
                   name
                   type
@@ -320,7 +364,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               name: 'Company',
               schema: {
                 type: 'Company',
-                queries: ['Company', 'allCompanies', '_allCompaniesMeta'],
+                queries: {
+                  item: 'Company',
+                  list: 'allCompanies',
+                  meta: '_allCompaniesMeta',
+                },
                 fields: [
                   {
                     name: 'name',

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -1476,7 +1476,6 @@ module.exports = class List {
       singular: this.adminUILabels.singular,
       plural: this.adminUILabels.plural,
       path: this.adminUILabels.path,
-      adminConfig: this.adminConfig,
 
       // Return these as functions so they're lazily evaluated depending
       // on what the user requested

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -1476,6 +1476,7 @@ module.exports = class List {
       singular: this.adminUILabels.singular,
       plural: this.adminUILabels.plural,
       path: this.adminUILabels.path,
+      adminConfig: this.adminConfig,
 
       // Return these as functions so they're lazily evaluated depending
       // on what the user requested

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -1471,9 +1471,14 @@ module.exports = class List {
     return {
       key: this.key,
       name: this.key,
+      label: this.adminUILabels.label,
+      singular: this.adminUILabels.singular,
+      plural: this.adminUILabels.plural,
+      path: this.adminUILabels.path,
+
       // Return these as functions so they're lazily evaluated depending
       // on what the user requested
-      // Evalutation takes place in ../Keystone/index.js
+      // Evaluation takes place in ../providers/listCRUD.js
       // NOTE: These could return a Boolean or a JSON object (if using the
       // declarative syntax)
       getAccess: () => ({
@@ -1483,18 +1488,33 @@ module.exports = class List {
         getDelete: () => context.getListAccessControlForUser(this.key, undefined, 'delete'),
         getAuth: () => context.getAuthAccessControlForUser(this.key),
       }),
+
       getSchema: () => {
-        const queries = [
-          this.gqlNames.itemQueryName,
-          this.gqlNames.listQueryName,
-          this.gqlNames.listQueryMetaName,
-        ];
+        const queries = {
+          item: this.gqlNames.itemQueryName,
+          list: this.gqlNames.listQueryName,
+          meta: this.gqlNames.listQueryMetaName,
+        };
+
+        const mutations = {
+          create: this.gqlNames.createMutationName,
+          createInput: this.gqlNames.createInputName,
+          createMany: this.gqlNames.createManyMutationName,
+          createManyInput: this.gqlNames.createManyInputName,
+          update: this.gqlNames.updateMutationName,
+          updateInput: this.gqlNames.updateInputName,
+          updateMany: this.gqlNames.updateManyMutationName,
+          updateManyInput: this.gqlNames.updateManyInputName,
+          delete: this.gqlNames.deleteMutationName,
+          deleteMany: this.gqlNames.deleteManyMutationName,
+        };
 
         // NOTE: Other fields on this type are resolved in the main resolver in
-        // ../Keystone/index.js
+        // ../providers/listCRUD.js
         return {
           type: this.gqlNames.outputTypeName,
           queries,
+          mutations,
           key: this.key,
         };
       },

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -1471,6 +1471,7 @@ module.exports = class List {
     return {
       key: this.key,
       name: this.key,
+      description: this.adminDoc,
       label: this.adminUILabels.label,
       singular: this.adminUILabels.singular,
       plural: this.adminUILabels.plural,

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -41,6 +41,47 @@ class ListCRUDProvider {
            user when performing 'auth' operations."""
         auth: JSON
       }`,
+      `type _ListQueries {
+        """Single-item query name."""
+        item: String
+
+        """All-items query name."""
+        list: String
+
+        """List metadata query name."""
+        meta: String
+      }`,
+      `type _ListMutations {
+        """Create mutation name."""
+        create: String
+
+        """Create mutation input type name."""
+        createInput: String
+
+        """Create many mutation name."""
+        createMany: String
+
+        """Create many mutation input type name."""
+        createManyInput: String
+
+        """Update mutation name."""
+        update: String
+
+        """Update mutation name input."""
+        updateInput: String
+
+        """Update many mutation name."""
+        updateMany: String
+
+        """Update many mutation name input."""
+        updateManyInput: String
+
+        """Delete mutation name."""
+        delete: String
+
+        """Delete many mutation name."""
+        deleteMany: String
+      }`,
       `type _ListSchemaFields {
         """ The path of the field in its list. """
         path: String
@@ -64,7 +105,10 @@ class ListCRUDProvider {
 
         """Top level GraphQL query names which either return this type, or
            provide aggregate information about this type"""
-        queries: [String]
+        queries: _ListQueries
+
+        """Top-level GraphQL mutation names"""
+        mutations: _ListMutations
 
         """Information about fields defined on this list. """
         fields(where: _ListSchemaFieldsInput): [_ListSchemaFields]
@@ -79,6 +123,18 @@ class ListCRUDProvider {
 
         """The Keystone List name"""
         name: String @deprecated(reason: "Use \`key\` instead")
+
+        """The list's display name in the Admin UI"""
+        label: String
+
+        """The list's singular display name"""
+        singular: String
+
+        """The list's plural display name"""
+        plural: String
+
+        """The list's data path"""
+        path: String
 
         """Access control configuration for the currently authenticated
            request"""

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -143,9 +143,6 @@ class ListCRUDProvider {
            request"""
         access: _ListAccess
 
-        """Admin UI-specific configuration options"""
-        adminConfig: JSON
-
         """Information on the generated GraphQL schema"""
         schema: _ListSchema
       }`,

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -143,6 +143,9 @@ class ListCRUDProvider {
            request"""
         access: _ListAccess
 
+        """Admin UI-specific configuration options"""
+        adminConfig: JSON
+
         """Information on the generated GraphQL schema"""
         schema: _ListSchema
       }`,

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -124,6 +124,9 @@ class ListCRUDProvider {
         """The Keystone List name"""
         name: String @deprecated(reason: "Use \`key\` instead")
 
+        """The list's user-facing description"""
+        description: String
+
         """The list's display name in the Admin UI"""
         label: String
 

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -1104,7 +1104,23 @@ test(`listMeta`, () => {
   const schema = meta.getSchema();
   expect(schema).toEqual({
     key: 'Test',
-    queries: ['Test', 'allTests', '_allTestsMeta'],
+    queries: {
+      item: 'Test',
+      list: 'allTests',
+      meta: '_allTestsMeta',
+    },
+    mutations: {
+      create: 'createTest',
+      createInput: 'TestCreateInput',
+      createMany: 'createTests',
+      createManyInput: 'TestsCreateInput',
+      update: 'updateTest',
+      updateInput: 'TestUpdateInput',
+      updateMany: 'updateTests',
+      updateManyInput: 'TestsUpdateInput',
+      delete: 'deleteTest',
+      deleteMany: 'deleteTests',
+    },
     type: 'Test',
   });
 
@@ -1114,7 +1130,23 @@ test(`listMeta`, () => {
       .getSchema()
   ).toEqual({
     key: 'Test',
-    queries: ['Test', 'allTests', '_allTestsMeta'],
+    queries: {
+      item: 'Test',
+      list: 'allTests',
+      meta: '_allTestsMeta',
+    },
+    mutations: {
+      create: 'createTest',
+      createInput: 'TestCreateInput',
+      createMany: 'createTests',
+      createManyInput: 'TestsCreateInput',
+      update: 'updateTest',
+      updateInput: 'TestUpdateInput',
+      updateMany: 'updateTests',
+      updateManyInput: 'TestsUpdateInput',
+      delete: 'deleteTest',
+      deleteMany: 'deleteTests',
+    },
     type: 'Test',
   });
 });


### PR DESCRIPTION
With the goal of eventually using queries to populate the Admin UI, this adds more data that's currently passed through via `getAdminMeta` to the list metadata queries.

Adds:
- `description`
- `label`
- `singular`
- `plural`
- `path`
- ~`adminConfig`~
- A `mutation` object with the various list mutation names
- Changes the `queries` object to match the new `mutations` format (not entirely happy with these property names, might change)

Enables:
```gql
query {
  _UsersMeta {
    name
    label
    singular
    plural
    path
    schema {
      queries {
        item
        list
        meta
      }
      mutations {
        create
        createInput
        createMany
        createManyInput
        update
        updateInput
        updateMany
        updateManyInput
        delete
        deleteMany
      }
    }
  }
}
```

which gives

```js
{
  "data": {
    "_UsersMeta": {
      "name": "User",
      "label": "Users",
      "singular": "User",
      "plural": "Users",
      "path": "users",
      "schema": {
        "queries": {
          "item": "User",
          "list": "allUsers",
          "meta": "_allUsersMeta"
        },
        "mutations": {
          "create": "createUser",
          "createInput": "UserCreateInput",
          "createMany": "createUsers",
          "createManyInput": "UsersCreateInput",
          "update": "updateUser",
          "updateInput": "UserUpdateInput",
          "updateMany": "updateUsers",
          "updateManyInput": "UsersUpdateInput",
          "delete": "deleteUser",
          "deleteMany": "deleteUsers"
        }
      }
    }
  }
}
```