### PR TITLE
Expanded `_ksListsMeta` query input to take a key list

### DIFF
--- a/.changeset/silver-monkeys-shop.md
+++ b/.changeset/silver-monkeys-shop.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Expanded `_ksListsMeta` query input to take a key list.

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -91,7 +91,7 @@ class ListCRUDProvider {
         count: Int
       }`,
       `input ${this.gqlNames.listsMetaInput} {
-        key: String
+        key: [String]
       }`,
       `input _ListSchemaFieldsInput {
         type: String
@@ -193,7 +193,7 @@ class ListCRUDProvider {
       // And the Keystone meta queries must always be available
       [this.gqlNames.listsMeta]: (_, { where: { key } = {} }, context) =>
         this.lists
-          .filter(list => list.access[schemaName].read && (!key || list.key === key))
+          .filter(list => list.access[schemaName].read && (!key || key.includes(list.key)))
           .map(list => list.listMeta(context)),
     };
   }


### PR DESCRIPTION
I was thinking more about the `where` input I added to `_ksListsMeta` in #2664, and it occurred to me that that change was perhaps not the most useful. If you already know the key you want - for example, `User` - you could just do a `_UsersMeta` query instead of `_ksListsMeta(where: { key: "User" })`.

This expands `key` to accept an array, so as to be more versitile:
```gql
query {
  _ksListsMeta(where: { key: ["User", "Todo"] }) {
    name
  }
}
```
gives
```js
{
  "data": {
    "_ksListsMeta": [
      {
        "name": "User"
      },
      {
        "name": "Todo"
      }
    ]
  }
}
```

Though, admittedly, one could still just do...
```gql
query {
  _UsersMeta {
    name
  }
  _TodosMeta {
    name
  }
}
```

So perhaps the `where` input still isn't that useful after all... 🤔 @jesstelford thoughts?