### PR TITLE
Upgrade cypress from 4.3.0 to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "chalk": "^2.4.2",
     "chalk-cli": "^4.1.0",
     "cross-env": "^7.0.0",
-    "cypress": "^4.3.0",
+    "cypress": "^4.4.0",
     "cypress-multi-reporters": "^1.2.3",
     "dotenv": "^8.2.0",
     "dotenv-safe": "^8.1.0",

--- a/test-projects/access-control/package.json
+++ b/test-projects/access-control/package.json
@@ -29,7 +29,7 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
-    "cypress": "^4.3.0",
+    "cypress": "^4.4.0",
     "cypress-file-upload": "^3.4.0",
     "cypress-multi-reporters": "^1.2.3",
     "dotenv-safe": "^8.1.0",

--- a/test-projects/basic/package.json
+++ b/test-projects/basic/package.json
@@ -37,7 +37,7 @@
     "react": "^16.13.0"
   },
   "devDependencies": {
-    "cypress": "^4.3.0",
+    "cypress": "^4.4.0",
     "cypress-file-upload": "^3.4.0",
     "cypress-multi-reporters": "^1.2.3",
     "dotenv-safe": "^8.1.0",

--- a/test-projects/client-validation/package.json
+++ b/test-projects/client-validation/package.json
@@ -32,7 +32,7 @@
     "react": "^16.13.0"
   },
   "devDependencies": {
-    "cypress": "^4.3.0",
+    "cypress": "^4.4.0",
     "cypress-multi-reporters": "^1.2.3",
     "dotenv-safe": "^8.1.0",
     "execa": "^2.0.4",

--- a/test-projects/login/package.json
+++ b/test-projects/login/package.json
@@ -32,7 +32,7 @@
     "express": "^4.17.1"
   },
   "devDependencies": {
-    "cypress": "^4.3.0",
+    "cypress": "^4.4.0",
     "cypress-file-upload": "^3.4.0",
     "cypress-multi-reporters": "^1.2.3",
     "dotenv-safe": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,10 +8026,10 @@ cypress-multi-reporters@^1.2.3:
     debug "^4.1.1"
     lodash "^4.17.11"
 
-cypress@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.3.0.tgz#74694c2407846119368a6aecc456b3ee1a8ee32b"
-  integrity sha512-xO1oef4ns4koDAkQROGJIhKKhGHDOKfOmlirwP1QAk9w/no+YJpN7HZ6IUPiXwWw3C7xVLjScoI8Dad0z5uTTg==
+cypress@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.4.0.tgz#566ac224e11601634c31e5648e5c15199dde7954"
+  integrity sha512-ZpsV3pVemANGi4Cxu0UIqFv23uHdDJZYlKY+8P/eixujCpI1TQ5RSPBp2grfV3ZvlGYrOXPJY44j9iEh1xoQug==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/request" "2.88.5"


### PR DESCRIPTION
Since upgrading to cypress 4.x I've noticed some instability in our tests. I want to spend some time making sure cypress is working well for us, so this is the first in what will perhaps be a few PRs in this area.