### PR TITLE
Allowed configuring default/maximumPageSize for all lists

### DIFF
--- a/.changeset/tasty-cooks-begin.md
+++ b/.changeset/tasty-cooks-begin.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/keystone': patch
+---
+
+Added defaultPageSize and maximumPageSize config options fto the Admin UI. These can be used to set defaults for all lists (previously, these defaults were 50 and 1000, respectively).

--- a/packages/app-admin-ui/README.md
+++ b/packages/app-admin-ui/README.md
@@ -47,6 +47,8 @@ module.exports = {
 | `schemaName`         | `String`   | `public`      | `false`  |                                                                            |
 | `isAccessAllowed`    | `Function` | `true`        | `false`  | Controls which users have access to the Admin UI.                          |
 | `adminMeta`          | `Object`   | `{}`          | `false`  | Provides additional `adminMeta`. Useful for Hooks and other customizations |
+| `defaultPageSize`    | `Integer`  | 50            | `false`  | The default number of list items to show at once.                          |
+| `maximumPageSize`    | `Integer`  | 1000          | `false`  | The maximum number of list items to show at once.                          |
 
 ### `hooks`
 

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -22,6 +22,8 @@ class AdminUIApp {
     hooks = path.resolve('./admin-ui/'),
     schemaName = 'public',
     adminMeta = {},
+    defaultPageSize = 50,
+    maximumPageSize = 1000,
   } = {}) {
     if (adminPath === '/') {
       throw new Error("Admin path cannot be the root path. Try; '/admin'");
@@ -39,6 +41,8 @@ class AdminUIApp {
     this.graphiqlPath = graphiqlPath;
     this.enableDefaultRoute = enableDefaultRoute;
     this.hooks = hooks;
+    this.defaultPageSize = defaultPageSize;
+    this.maximumPageSize = Math.max(defaultPageSize, maximumPageSize);
     this._isAccessAllowed = isAccessAllowed;
     this._schemaName = schemaName;
     this._adminMeta = adminMeta;
@@ -105,6 +109,29 @@ class AdminUIApp {
     const { signinPath, signoutPath } = this.routes;
     const { lists } = keystone.getAdminMeta({ schemaName: this._schemaName });
     const authStrategy = this.authStrategy ? this.authStrategy.getAdminMeta() : undefined;
+
+    // Normalize list adminConfig data, falling back to admin-level size defaults if necessary.
+    Object.values(lists || {}).forEach(
+      ({
+        key,
+        adminConfig: {
+          defaultPageSize = this.defaultPageSize,
+          defaultColumns,
+          defaultSort,
+          maximumPageSize = this.maximumPageSize,
+          ...rest
+        },
+      }) => {
+        lists[key].adminConfig = {
+          defaultPageSize,
+          defaultColumns: defaultColumns.replace(/\s/g, ''), // remove all whitespace
+          defaultSort,
+          maximumPageSize: Math.max(defaultPageSize, maximumPageSize),
+          ...rest,
+        };
+      }
+    );
+
     return {
       adminPath,
       apiPath,

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -20,7 +20,7 @@ const {
   labelToClass,
   opToType,
   mapNativeTypeToKeystoneType,
-  getDefautlLabelResolver,
+  getDefaultLabelResolver,
   mapToFields,
 } = require('./utils');
 const { HookManager } = require('./hooks');
@@ -61,14 +61,12 @@ module.exports = class List {
     // Assuming the id column shouldn't be included in default columns or sort
     const nonIdFieldNames = Object.keys(fields).filter(k => k !== 'id');
     this.adminConfig = {
-      defaultPageSize: 50,
       defaultColumns: nonIdFieldNames ? nonIdFieldNames.slice(0, 2).join(',') : 'id',
       defaultSort: nonIdFieldNames.length ? nonIdFieldNames[0] : '',
-      maximumPageSize: 1000,
       ...adminConfig,
     };
 
-    this.labelResolver = labelResolver || getDefautlLabelResolver(labelField);
+    this.labelResolver = labelResolver || getDefaultLabelResolver(labelField);
     this.isAuxList = isAuxList;
     this.getListByKey = getListByKey;
     this.defaultAccess = defaultAccess;
@@ -230,13 +228,6 @@ module.exports = class List {
 
   getAdminMeta({ schemaName }) {
     const schemaAccess = this.access[schemaName];
-    const {
-      defaultPageSize,
-      defaultColumns,
-      defaultSort,
-      maximumPageSize,
-      ...adminConfig
-    } = this.adminConfig;
     return {
       key: this.key,
       // Reduce to truthy values (functions can't be passed over the webpack
@@ -251,13 +242,7 @@ module.exports = class List {
         .filter(field => field.access[schemaName].read)
         .map(field => field.getAdminMeta({ schemaName })),
       adminDoc: this.adminDoc,
-      adminConfig: {
-        defaultPageSize,
-        defaultColumns: defaultColumns.replace(/\s/g, ''), // remove all whitespace
-        defaultSort: defaultSort,
-        maximumPageSize: Math.max(defaultPageSize, maximumPageSize),
-        ...adminConfig,
-      },
+      adminConfig: this.adminConfig,
     };
   }
 

--- a/packages/keystone/lib/ListTypes/utils.js
+++ b/packages/keystone/lib/ListTypes/utils.js
@@ -76,7 +76,7 @@ const mapNativeTypeToKeystoneType = (type, listKey, fieldPath) => {
   return keystoneType;
 };
 
-const getDefautlLabelResolver = labelField => item => {
+const getDefaultLabelResolver = labelField => item => {
   const value = item[labelField || 'name'];
   if (typeof value === 'number') {
     return value.toString();
@@ -101,6 +101,6 @@ module.exports = {
   labelToClass,
   opToType,
   mapNativeTypeToKeystoneType,
-  getDefautlLabelResolver,
+  getDefaultLabelResolver,
   mapToFields,
 };

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -100,9 +100,7 @@ describe('new List()', () => {
     expect(list.fields).toBeInstanceOf(Object);
     expect(list.adminConfig).toEqual({
       defaultColumns: 'name,email',
-      defaultPageSize: 50,
       defaultSort: 'name',
-      maximumPageSize: 1000,
     });
   });
 
@@ -332,9 +330,7 @@ describe('getAdminMeta()', () => {
     });
     expect(adminMeta.adminConfig).toEqual({
       defaultColumns: 'name,email',
-      defaultPageSize: 50,
       defaultSort: 'name',
-      maximumPageSize: 1000,
     });
   });
 


### PR DESCRIPTION
~It occurred to me that these options make a *lot* more sense when applied to the whole Admin UI, instead of per-list. I really doubt anyone is thinking, hey, we want list A to show 50 items at once while lists B and C have 10 items and this other one has 20. Max page size makes even less sense on a per-list basis (who would want to see a completely arbitrary maximum number of items depending on the given list?)~

~This leaves the sort options untouched (since those are indeed list-dependent) and moves the `defaultPageSize` and `maximumPageSize` config options to the Admin UI ctor.~

Update: this now just adds `defaultPageSize` and `maximumPageSize` config options that allows configuring the defaults for all lists. All handling of `adminConfig` options (such as stripping whitespace) is now handled by the Admin UI app.