### PR TITLE
Clarified reverse proxy instructions

### DIFF
--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -47,7 +47,14 @@ Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/
 
 ## Using reverse proxies
 
-It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)).
+It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
+```javascript title=index.js
+module.exports = {
+    configureExpress: app => {
+        app.set("trust proxy", true);
+    },
+};
+```
 
 ## Environment variables
 


### PR DESCRIPTION
It should be made clear that an express application variable needs to be set. The docs give no indication of how reverse proxy support must be implemented at the app level. Perhaps it would be advisable to add a trustProxy field directly to the Keystone constructor and pass it on to express.