### PR TITLE
Highlight active page in Pagination control

### DIFF
--- a/.changeset/fifty-wolves-press.md
+++ b/.changeset/fifty-wolves-press.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/pagination': patch
+---
+
+Highlight active page in Pagination control.

--- a/packages/arch/packages/pagination/src/Page.js
+++ b/packages/arch/packages/pagination/src/Page.js
@@ -1,14 +1,24 @@
-import * as React from 'react';
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
 import { Button } from '@arch-ui/button';
+import { colors } from '@arch-ui/theme';
 
 const Page = props => {
+  const { onClick, value, isSelected } = props;
+
   const handleClick = () => {
-    if (props.onClick) {
-      props.onClick(props.value);
+    if (onClick) {
+      onClick(value);
     }
   };
 
-  return <Button {...props} onClick={handleClick} />;
+  return (
+    <Button
+      {...props}
+      onClick={handleClick}
+      css={isSelected ? { backgroundColor: colors.primary, color: 'white' } : {}}
+    />
+  );
 };
 
 export default Page;


### PR DESCRIPTION
Just a quick change since I noticed there's really no indication of what page you're on:
![image](https://user-images.githubusercontent.com/3558659/79417347-8f8c2000-7ffd-11ea-8045-0553080b7020.png)

I know the pagination control will probably be removed (#578), but until then this makes it slightly more functional.