### PR TITLE
Fixed typo: ListAttribute -> ListAdapter

### DIFF
--- a/packages/keystone/lib/adapters/README.md
+++ b/packages/keystone/lib/adapters/README.md
@@ -64,7 +64,7 @@ All required information is passed in to the adapter as parameters to the constr
 
 Each `KeystoneAdapter` contains references to its associated `ListAdapter` instances, via the `.listAdapters` property.
 The `ListAdapter` instances contain a back reference to the `KeystoneAdapter` via the `.parentAdapter` property.
-Each `ListAttribute` keeps a list of associated `FieldAdapter` instances, via .`fieldAdapters`.
+Each `ListAdapter` keeps a list of associated `FieldAdapter` instances, via .`fieldAdapters`.
 These in turn have back reference to the `ListAdapter` in the property `.listAdapter`.
 
 This data model allows all fields under a `KeystoneAdapter` to access all other fields in the same adapter,


### PR DESCRIPTION
I assume "ListAttribute" was a typo based on the context and the fact it doesn't occur in the rest of the repo.