### PR TITLE
Fix #2765 missed packages/arch/docs requirements

### DIFF
--- a/packages/arch/README.md
+++ b/packages/arch/README.md
@@ -9,7 +9,7 @@ Resources, tooling, and design guidelines by KeystoneJS using [GastbyJS](https:/
 
 ## Getting Started
 
-To start, run
+To start, run:
 
 ```sh
 cd docs

--- a/packages/arch/docs/package.json
+++ b/packages/arch/docs/package.json
@@ -29,7 +29,8 @@
     "@reach/router": "^1.3.3",
     "clipboard-copy": "^3.0.0",
     "gatsby": "^2.13.25",
-    "react": "^16.13.0"
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
   },
   "scripts": {
     "start": "gatsby develop",


### PR DESCRIPTION
Info here: https://github.com/keystonejs/keystone/issues/2765