### PR TITLE
Added branding/custom logo to Signout page of app-admin-ui

### DIFF
--- a/.changeset/fuzzy-kings-join.md
+++ b/.changeset/fuzzy-kings-join.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': minor
+---
+
+Added a UI hook (logo) to display a custom logo on the signout screen.

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -9,6 +9,7 @@ import KeystoneLogo from '../components/KeystoneLogo';
 import { LoadingIndicator } from '@arch-ui/loading';
 
 import { useAdminMeta } from '../providers/AdminMeta';
+import { useUIHooks } from '../providers/Hooks';
 
 const Container = styled.div({
   alignItems: 'center',
@@ -60,6 +61,8 @@ const SignedOutPage = () => {
     signinPath,
   } = useAdminMeta();
 
+  const { logo: getCustomLogo } = useUIHooks();
+
   const UNAUTH_MUTATION = gql`
     mutation {
       unauthenticate: unauthenticate${listKey} {
@@ -88,7 +91,7 @@ const SignedOutPage = () => {
     <Container>
       <Alerts />
       <Box>
-        <KeystoneLogo />
+        {getCustomLogo ? getCustomLogo() : <KeystoneLogo />}
         <Divider />
         <Content>
           {loading ? (


### PR DESCRIPTION
Changes from @Vultraz PR #2474 has left to add custom branding logo to signout page. Made a minor change on signout page similar to signin page.