### PR TITLE
Fix updating one-to-one values

### DIFF
--- a/.changeset/pink-kids-try.md
+++ b/.changeset/pink-kids-try.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/adapter-knex': patch
+'@keystonejs/adapter-mongoose': patch
+---
+
+Fixed a bug with updating one-to-one relationship values.

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -54,6 +54,32 @@ mutation {
   return { company: createCompany, location: createCompany.location };
 };
 
+const createLocationAndCompany = async keystone => {
+  const {
+    data: { createLocation },
+  } = await graphqlRequest({
+    keystone,
+    query: `
+mutation {
+  createLocation(data: {
+    name: "${sampleOne(alphanumGenerator)}"
+    company: { create: { name: "${sampleOne(alphanumGenerator)}" } }
+  }) { id name company { id name } }
+}`,
+  });
+  const { Company, Location } = await getCompanyAndLocation(
+    keystone,
+    createLocation.id,
+    createLocation.company.id
+  );
+
+  // Sanity check the links are setup correctly
+  expect(Company.location.id.toString()).toBe(Location.id.toString());
+  expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+  return { location: createLocation, company: createLocation.company };
+};
+
 const getCompanyAndLocation = async (keystone, companyId, locationId) => {
   const { data } = await graphqlRequest({
     keystone,
@@ -114,10 +140,29 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         describe('Read', () => {
           if (adapterName !== 'mongoose') {
             test(
-              'Where',
+              'Where A',
               runner(setupKeystone, async ({ keystone }) => {
                 await createInitialData(keystone);
                 const { location, company } = await createCompanyAndLocation(keystone);
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{
+                  allLocations(where: { company: { name: "${company.name}"} }) { id }
+                  allCompanies(where: { location: { name: "${location.name}"} }) { id }
+                }`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allLocations.length).toEqual(1);
+                expect(data.allLocations[0].id).toEqual(location.id);
+                expect(data.allCompanies.length).toEqual(1);
+                expect(data.allCompanies[0].id).toEqual(company.id);
+              })
+            );
+            test(
+              'Where B',
+              runner(setupKeystone, async ({ keystone }) => {
+                await createInitialData(keystone);
+                const { location, company } = await createLocationAndCompany(keystone);
                 const { data, errors } = await graphqlRequest({
                   keystone,
                   query: `{
@@ -155,10 +200,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           if (adapterName !== 'mongoose') {
             test(
-              'Where with count',
+              'Where with count A',
               runner(setupKeystone, async ({ keystone }) => {
                 await createInitialData(keystone);
                 const { location, company } = await createCompanyAndLocation(keystone);
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{
+                  _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
+                  _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
+                }`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(1);
+                expect(data._allLocationsMeta.count).toEqual(1);
+              })
+            );
+            test(
+              'Where with count B',
+              runner(setupKeystone, async ({ keystone }) => {
+                await createInitialData(keystone);
+                const { location, company } = await createLocationAndCompany(keystone);
                 const { data, errors } = await graphqlRequest({
                   keystone,
                   query: `{
@@ -176,7 +238,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         describe('Create', () => {
           test(
-            'With connect',
+            'With connect A',
             runner(setupKeystone, async ({ keystone }) => {
               const { locations } = await createInitialData(keystone);
               const location = locations[0];
@@ -205,7 +267,36 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
 
           test(
-            'With create',
+            'With connect B',
+            runner(setupKeystone, async ({ keystone }) => {
+              const { companies } = await createInitialData(keystone);
+              const company = companies[0];
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                mutation {
+                  createLocation(data: {
+                    company: { connect: { id: "${company.id}" } }
+                  }) { id company { id } }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.createLocation.company.id.toString()).toEqual(company.id);
+
+              const { Company, Location } = await getCompanyAndLocation(
+                keystone,
+                company.id,
+                data.createLocation.id
+              );
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+            })
+          );
+
+          test(
+            'With create A',
             runner(setupKeystone, async ({ keystone }) => {
               const locationName = sampleOne(alphanumGenerator);
               const { data, errors } = await graphqlRequest({
@@ -233,7 +324,35 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
 
           test(
-            'With nested connect',
+            'With create B',
+            runner(setupKeystone, async ({ keystone }) => {
+              const companyName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                mutation {
+                  createLocation(data: {
+                    company: { create: { name: "${companyName}" } }
+                  }) { id company { id } }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+
+              const { Company, Location } = await getCompanyAndLocation(
+                keystone,
+                data.createLocation.company.id,
+                data.createLocation.id
+              );
+
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+            })
+          );
+
+          test(
+            'With nested connect A',
             runner(setupKeystone, async ({ keystone }) => {
               const { companies } = await createInitialData(keystone);
               const company = companies[0];
@@ -278,6 +397,55 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 });
             })
           );
+
+          if (adapterName !== 'mongoose') {
+            test(
+              'With nested connect B',
+              runner(setupKeystone, async ({ keystone }) => {
+                const { locations } = await createInitialData(keystone);
+                const location = locations[0];
+                const companyName = sampleOne(alphanumGenerator);
+
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                mutation {
+                  createLocation(data: {
+                    company: { create: { name: "${companyName}" location: { connect: { id: "${location.id}" } } } }
+                  }) { id company { id location { id } } }
+                }
+            `,
+                });
+                expect(errors).toBe(undefined);
+
+                const { Company, Location } = await getCompanyAndLocation(
+                  keystone,
+                  data.createLocation.company.id,
+                  data.createLocation.id
+                );
+                // Everything should now be connected
+                expect(Company.location.id.toString()).toBe(Location.id.toString());
+                expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+                const {
+                  data: { allLocations },
+                } = await graphqlRequest({
+                  keystone,
+                  query: `{ allLocations { id company { id location { id }} } }`,
+                });
+
+                // The nested company should not have a location
+                expect(
+                  allLocations.filter(({ id }) => id === Location.id)[0].company.location.id
+                ).toEqual(Company.id);
+                allLocations
+                  .filter(({ id }) => id !== Location.id)
+                  .forEach(location => {
+                    expect(location.company).toBe(null);
+                  });
+              })
+            );
+          }
 
           test(
             'With nested create',
@@ -327,7 +495,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         describe('Update', () => {
           test(
-            'With connect',
+            'With connect A',
             runner(setupKeystone, async ({ keystone }) => {
               // Manually setup a connected Company <-> Location
               const { location, company } = await createCompanyAndLocation(keystone);
@@ -360,8 +528,43 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             })
           );
 
+          if (adapterName !== 'mongoose') {
+            test(
+              'With connect B',
+              runner(setupKeystone, async ({ keystone }) => {
+                // Manually setup a connected Company <-> Location
+                const { location, company } = await createLocationAndCompany(keystone);
+
+                // Sanity check the links don't yet exist
+                // `...not.toBe(expect.anything())` allows null and undefined values
+                expect(company.location).not.toBe(expect.anything());
+                expect(location.company).not.toBe(expect.anything());
+
+                const { errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: { connect: { id: "${company.id}" } } }
+                  ) { id company { id } } }
+            `,
+                });
+                expect(errors).toBe(undefined);
+
+                const { Company, Location } = await getCompanyAndLocation(
+                  keystone,
+                  location.id,
+                  company.id
+                );
+                // Everything should now be connected
+                expect(Company.location.id.toString()).toBe(Location.id.toString());
+                expect(Location.company.id.toString()).toBe(Company.id.toString());
+              })
+            );
+          }
           test(
-            'With create',
+            'With create A',
             runner(setupKeystone, async ({ keystone }) => {
               const { companies } = await createInitialData(keystone);
               let company = companies[0];
@@ -392,7 +595,168 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           );
 
           test(
-            'With disconnect',
+            'With create B',
+            runner(setupKeystone, async ({ keystone }) => {
+              const { locations } = await createInitialData(keystone);
+              let location = locations[0];
+              const companyName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: { create: { name: "${companyName}" } } }
+                  ) { id company { id name } }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+
+              const { Company, Location } = await getCompanyAndLocation(
+                keystone,
+                data.updateLocation.company.id,
+                location.id
+              );
+
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+            })
+          );
+
+          test(
+            'With recreate A',
+            runner(setupKeystone, async ({ keystone }) => {
+              const { companies } = await createInitialData(keystone);
+              let company = companies[0];
+              const locationName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { location: { create: { name: "${locationName}" } } }
+                  ) { id location { id name } }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+
+              const { Company, Location } = await getCompanyAndLocation(
+                keystone,
+                company.id,
+                data.updateCompany.location.id
+              );
+
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+              const originalLocationId = Location.id;
+              await (async () => {
+                const locationName = sampleOne(alphanumGenerator);
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    updateCompany(
+                      id: "${company.id}",
+                      data: { location: { create: { name: "${locationName}" } } }
+                    ) { id location { id name } }
+                  }
+              `,
+                });
+                expect(errors).toBe(undefined);
+
+                const { Company, Location } = await getCompanyAndLocation(
+                  keystone,
+                  company.id,
+                  data.updateCompany.location.id
+                );
+
+                // Everything should now be connected
+                expect(Company.location.id.toString()).toBe(Location.id.toString());
+                expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+                const result = await graphqlRequest({
+                  keystone,
+                  query: `{ Location(where: { id: "${originalLocationId}" }) { id company { id } } }`,
+                });
+                expect(result.errors).toBe(undefined);
+                expect(result.data.Location.company).toBe(null);
+              })();
+            })
+          );
+
+          test(
+            'With recreate B',
+            runner(setupKeystone, async ({ keystone }) => {
+              const { locations } = await createInitialData(keystone);
+              let location = locations[0];
+              const companyName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: { create: { name: "${companyName}" } } }
+                  ) { id company { id name } }
+                }
+            `,
+              });
+              expect(errors).toBe(undefined);
+
+              const { Company, Location } = await getCompanyAndLocation(
+                keystone,
+                data.updateLocation.company.id,
+                location.id
+              );
+
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+              const originalCompanyId = Company.id;
+              await (async () => {
+                const companyName = sampleOne(alphanumGenerator);
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    updateLocation(
+                      id: "${location.id}",
+                      data: { company: { create: { name: "${companyName}" } } }
+                    ) { id company { id name } }
+                  }
+              `,
+                });
+                expect(errors).toBe(undefined);
+
+                const { Company, Location } = await getCompanyAndLocation(
+                  keystone,
+                  data.updateLocation.company.id,
+                  location.id
+                );
+
+                // Everything should now be connected
+                expect(Company.location.id.toString()).toBe(Location.id.toString());
+                expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+                const result = await graphqlRequest({
+                  keystone,
+                  query: `{ Company(where: { id: "${originalCompanyId}" }) { id location { id } } }`,
+                });
+                expect(result.errors).toBe(undefined);
+                expect(result.data.Company.location).toBe(null);
+              })();
+            })
+          );
+
+          test(
+            'With disconnect A',
             runner(setupKeystone, async ({ keystone }) => {
               // Manually setup a connected Company <-> Location
               const { location, company } = await createCompanyAndLocation(keystone);
@@ -420,8 +784,38 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             })
           );
 
+          if (adapterName !== 'mongoose') {
+            test(
+              'With disconnect B',
+              runner(setupKeystone, async ({ keystone }) => {
+                // Manually setup a connected Company <-> Location
+                const { location, company } = await createLocationAndCompany(keystone);
+
+                // Run the query to disconnect the location from company
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: { disconnect: { id: "${company.id}" } } }
+                  ) { id company { id name } }
+                }
+            `,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.updateLocation.id).toEqual(location.id);
+                expect(data.updateLocation.company).toBe(null);
+
+                // Check the link has been broken
+                const result = await getCompanyAndLocation(keystone, company.id, location.id);
+                expect(result.Company.location).toBe(null);
+                expect(result.Location.company).toBe(null);
+              })
+            );
+          }
           test(
-            'With disconnectAll',
+            'With disconnectAll A',
             runner(setupKeystone, async ({ keystone }) => {
               // Manually setup a connected Company <-> Location
               const { location, company } = await createCompanyAndLocation(keystone);
@@ -448,11 +842,42 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(result.Location.company).toBe(null);
             })
           );
+
+          if (adapterName !== 'mongoose') {
+            test(
+              'With disconnectAll B',
+              runner(setupKeystone, async ({ keystone }) => {
+                // Manually setup a connected Company <-> Location
+                const { location, company } = await createLocationAndCompany(keystone);
+
+                // Run the query to disconnect the location from company
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: { disconnectAll: true } }
+                  ) { id company { id name } }
+                }
+            `,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.updateLocation.id).toEqual(location.id);
+                expect(data.updateLocation.company).toBe(null);
+
+                // Check the link has been broken
+                const result = await getCompanyAndLocation(keystone, company.id, location.id);
+                expect(result.Company.location).toBe(null);
+                expect(result.Location.company).toBe(null);
+              })
+            );
+          }
         });
 
         describe('Delete', () => {
           test(
-            'delete',
+            'delete A',
             runner(setupKeystone, async ({ keystone }) => {
               // Manually setup a connected Company <-> Location
               const { location, company } = await createCompanyAndLocation(keystone);
@@ -471,6 +896,29 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(result.Location.company).toBe(null);
             })
           );
+
+          if (adapterName !== 'mongoose') {
+            test(
+              'delete B',
+              runner(setupKeystone, async ({ keystone }) => {
+                // Manually setup a connected Company <-> Location
+                const { location, company } = await createLocationAndCompany(keystone);
+
+                // Run the query to disconnect the location from company
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `mutation { deleteLocation(id: "${location.id}") { id } } `,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.deleteLocation.id).toBe(location.id);
+
+                // Check the link has been broken
+                const result = await getCompanyAndLocation(keystone, company.id, location.id);
+                expect(result.Company.location).toBe(null);
+                expect(result.Location).toBe(null);
+              })
+            );
+          }
         });
       });
     });

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -310,6 +310,22 @@ class KnexListAdapter extends BaseListAdapter {
     );
   }
 
+  async _unsetForeignOneToOneValues(data, id) {
+    // If there's a 1:1 FK in the data on a different list we need to go and
+    // delete it from any other item;
+    await Promise.all(
+      Object.keys(data)
+        .map(key => ({ adapter: this.fieldAdaptersByPath[key] }))
+        .filter(({ adapter }) => adapter && adapter.isRelationship)
+        .filter(
+          ({ adapter: { rel } }) => rel.cardinality === '1:1' && rel.tableName !== this.tableName
+        )
+        .map(({ adapter: { rel: { tableName, columnName } } }) =>
+          this._setNullByValue({ tableName, columnName, value: id })
+        )
+    );
+  }
+
   async _processNonRealFields(data, processFunction) {
     return resolveAllKeys(
       arrayToObject(
@@ -411,6 +427,7 @@ class KnexListAdapter extends BaseListAdapter {
 
     // Unset any real 1:1 fields
     await this._unsetOneToOneValues(realData);
+    await this._unsetForeignOneToOneValues(data, id);
 
     // Update the real data
     const query = this._query()

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -262,6 +262,20 @@ class MongooseListAdapter extends BaseListAdapter {
     );
   }
 
+  async _unsetForeignOneToOneValues(data, id) {
+    // If there's a 1:1 FK in the data on a different list we need to go and
+    // delete it from any other item;
+    await Promise.all(
+      Object.keys(data)
+        .map(key => ({ adapter: this.fieldAdaptersByPath[key] }))
+        .filter(({ adapter }) => adapter && adapter.isRelationship)
+        .filter(({ adapter: { rel } }) => rel.cardinality === '1:1' && rel.tableName !== this.key)
+        .map(({ adapter: { rel: { tableName, columnName } } }) =>
+          this._setNullByValue({ tableName, columnName, value: id })
+        )
+    );
+  }
+
   async _processNonRealFields(data, processFunction) {
     return resolveAllKeys(
       arrayToObject(
@@ -361,6 +375,7 @@ class MongooseListAdapter extends BaseListAdapter {
 
     // Unset any real 1:1 fields
     await this._unsetOneToOneValues(realData);
+    await this._unsetForeignOneToOneValues(data, id);
 
     // Update the real data
     // Avoid any kind of injection attack by explicitly doing a `$set` operation


### PR DESCRIPTION
In the case where a 1:1 relationship was stored on the far table, updates were not correctly unsetting that value when a new value was set.