### PR TITLE
Use AuthedRelationship to power byTracking

### DIFF
--- a/.changeset/polite-baboons-fetch.md
+++ b/.changeset/polite-baboons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/list-plugins': minor
+---
+
+Leverage AuthedRelationship field within the byTracking plugin

--- a/packages/list-plugins/package.json
+++ b/packages/list-plugins/package.json
@@ -8,7 +8,8 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@keystonejs/fields": "^9.0.0"
+    "@keystonejs/fields": "^9.0.0",
+    "@keystonejs/fields-authed-relationship": "^1.0.2"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/packages/list-plugins"
 }


### PR DESCRIPTION
_NOTE: The failing test is due to a different bug fixed in https://github.com/keystonejs/keystone/pull/2813_

Noticed some of this logic was duplicated, so figured we could just re-use what exists to simplify the byTracking code.

Things `AuthedRelationship` handles for us:

- Setting the access control to `{ create: false, read: true, update: false }`
- Setting the `createdBy` value on creation

Things `AuthedRelationship` fixes for us:

- Merging different access control settings in using standard `access: { ... }` syntax. ie; to toggle `read: false`, all it takes is a `access: { read: false }` instead of currently which requires re-specifying all three options, potentially leading to subtle bugs which make the access too permissive.
- Correctly handling the `isRequired` flag on create