### PR TITLE
Singleton list

### DIFF
--- a/.changeset/wise-icons-shake.md
+++ b/.changeset/wise-icons-shake.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/keystone': minor
+'@keystonejs/list-plugins': minor
+---
+
+Added `singleton` list plugin which prevents creating more items for a list or delete the only item in the list.
+Added keystone and list key to the list config to make them accessible to plugin. Plugin now has access to `keystone` to make use of `executeQuery` or specific information about the list at run time.

--- a/.changeset/wise-icons-shake.md
+++ b/.changeset/wise-icons-shake.md
@@ -1,7 +1,14 @@
 ---
 '@keystonejs/keystone': minor
+'@keystonejs/app-admin-ui': minor
 '@keystonejs/list-plugins': minor
 ---
 
-Added `singleton` list plugin which prevents creating more items for a list or delete the only item in the list.
-Added keystone and list key to the list config to make them accessible to plugin. Plugin now has access to `keystone` to make use of `executeQuery` or specific information about the list at run time.
+* Added `singleton` list plugin which prevents creating more items for a list or delete the only item in the list.
+
+* Added keystone and list key to the list config to make them accessible to plugin. Plugin now has access to `keystone` to make use of `executeQuery` or specific information about the list at run time.
+
+* Updated `admin-ui` to 
+  - Redirect to singleton item if there is an item
+  - Hide `Search` field, `Back` and `AddNew` buttons on item details page
+  - Disable the `Delete` button on item details page if the access for delete is false.

--- a/packages/app-admin-ui/client/pages/Item/AddNewItem.js
+++ b/packages/app-admin-ui/client/pages/Item/AddNewItem.js
@@ -7,10 +7,13 @@ import { useList } from '../../providers/List';
 
 const AddNewItem = () => {
   let {
-    list: { access },
+    list: {
+      access,
+      adminConfig: { singleton = false },
+    },
     openCreateItemModal,
   } = useList();
-  if (!access.create) return null;
+  if (!access.create || singleton) return null;
   const cypressId = 'item-page-create-button';
   return (
     <Tooltip content="Create" hideOnMouseDown hideOnKeyDown>

--- a/packages/app-admin-ui/client/pages/Item/Footer.js
+++ b/packages/app-admin-ui/client/pages/Item/Footer.js
@@ -5,6 +5,8 @@ import { Button, LoadingButton } from '@arch-ui/button';
 import { colors, gridSize } from '@arch-ui/theme';
 import { alpha } from '@arch-ui/color-utils';
 
+import { useList } from '../../providers/List';
+
 const Toolbar = props => (
   <div
     css={{
@@ -77,6 +79,11 @@ function Reset({ canReset, onReset }) {
 
 export default memo(function Footer(props) {
   const { onSave, onDelete, canReset, updateInProgress, onReset, hasWarnings, hasErrors } = props;
+  const {
+    list: {
+      access: { delete: canDelete = true },
+    },
+  } = useList();
   const cypressId = 'item-page-save-button';
 
   return (
@@ -99,7 +106,7 @@ export default memo(function Footer(props) {
         <div>
           <Button
             appearance="danger"
-            isDisabled={updateInProgress}
+            isDisabled={updateInProgress || !canDelete}
             variant="nuance"
             onClick={onDelete}
           >

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.js
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.js
@@ -29,17 +29,21 @@ export const ItemTitle = memo(function ItemTitle({ titleText }) {
       <PageTitle>{titleText}</PageTitle>
       <ListDescription text={list.adminDoc} />
       <FlexGroup align="center" justify="space-between" css={{ marginBottom: '0.9rem' }}>
-        <div>
-          <IconButton
-            variant="subtle"
-            icon={ChevronLeftIcon}
-            to={list.getFullPersistentPath()}
-            css={{ marginLeft: -12 }}
-          >
-            {list.label}
-          </IconButton>
-          <Search list={list} />
-        </div>
+        {!list.adminConfig.singleton ? (
+          <div>
+            <IconButton
+              variant="subtle"
+              icon={ChevronLeftIcon}
+              to={list.getFullPersistentPath()}
+              css={{ marginLeft: -12 }}
+            >
+              {list.label}
+            </IconButton>
+            <Search list={list} />
+          </div>
+        ) : (
+          <div />
+        )}
         {itemHeaderActions ? (
           itemHeaderActions()
         ) : (

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -32,6 +32,7 @@ import Search from './Search';
 import Management, { ManageToolbar } from './Management';
 import { useListFilter, useListSelect, useListSort, useListUrlState } from './dataHooks';
 import { captureSuspensePromises } from '@keystonejs/utils';
+import { useAdminMeta } from '../../providers/AdminMeta';
 
 export function ListLayout(props) {
   const { items, itemCount, queryErrors, query } = props;
@@ -225,7 +226,7 @@ const ListPage = props => {
     queryErrorsParsed,
     query,
   } = useList();
-
+  const { adminPath } = useAdminMeta();
   const history = useHistory();
   const location = useLocation();
 
@@ -276,6 +277,10 @@ const ListPage = props => {
         <p>{message}</p>
       </PageError>
     );
+  }
+
+  if (list.adminConfig.singleton && itemCount > 0) {
+    history.push(`${adminPath}/${list.path}/${items[0].id}`);
   }
 
   // Success

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -306,7 +306,7 @@ module.exports = class Keystone {
       throw new Error(`Invalid list name "${key}". List names cannot start with an underscore.`);
     }
 
-    const list = new List(key, compose(config.plugins || [])(config), {
+    const list = new List(key, compose(config.plugins || [])({ ...config, key, keystone: this }), {
       getListByKey,
       queryHelper: this._buildQueryHelper.bind(this),
       adapter: adapters[adapterName],

--- a/packages/list-plugins/README.md
+++ b/packages/list-plugins/README.md
@@ -52,7 +52,7 @@ const { createdAt, updatedAt } = require('@keystonejs/list-plugins');
 
 _Note_: The API is the same.
 
-## byTracking
+# byTracking
 
 Adds `createdBy` and `updatedBy` fields to a list. These fields are read-only by will be updated automatically when items are created or updated.
 
@@ -103,3 +103,39 @@ const { createdBy, updatedBy } = require('@keystonejs/list-plugins');
 ```
 
 _Note_: The API is the same.
+
+# singleton
+
+This plugin makes a list singleton by allowing only one item in the list. Useful for list which must contain only one items.
+
+## Usage
+
+```js
+const { singleton } = require('@keystonejs/list-plugins');
+
+keystone.createList('ListWithPlugin', {
+  fields: {...},
+  plugins: [
+    singleton({...}),
+  ],
+});
+```
+
+## Config
+
+| Option          | Type      | Default | Description                                       |
+| --------------- | --------- | ------- | ------------------------------------------------- |
+| `preventDelete` | `Boolean` | `true`  | Prevents deletion of the (only) item in the list. |
+
+### `preventDelete`
+
+By default the plugin will prevent deletion of the only item in the list by setting `delete` access to false. If you want to control the access yourself, set this value to false.
+
+```javascript allowCopy=false showLanguage=false
+keystone.createList('ListWithPlugin', {
+  fields: {...},
+  plugins: [
+    singleton({ preventDelete: false }),
+  ],
+});
+```

--- a/packages/list-plugins/index.js
+++ b/packages/list-plugins/index.js
@@ -1,5 +1,6 @@
 const { atTracking, createdAt, updatedAt } = require('./lib/tracking/atTracking');
 const { byTracking, createdBy, updatedBy } = require('./lib/tracking/byTracking');
+const { singleton } = require('./lib/limiting/singleton');
 
 module.exports = {
   atTracking,
@@ -8,4 +9,5 @@ module.exports = {
   byTracking,
   createdBy,
   updatedBy,
+  singleton,
 };

--- a/packages/list-plugins/lib/limiting/singleton.js
+++ b/packages/list-plugins/lib/limiting/singleton.js
@@ -1,0 +1,24 @@
+const { composeHook } = require('../utils');
+
+exports.singleton = () => ({ key, keystone, hooks = {}, adminConfig = {}, ...rest }) => {
+  const newResolveInput = async ({ resolvedData, operation }) => {
+    if (operation === 'create') {
+      const list = keystone.getListByKey(key);
+      const query = `{${list.gqlNames.listQueryMetaName} { count }}`;
+      const {
+        data: { [list.gqlNames.listQueryMetaName]: listQuery } = {},
+        errors,
+      } = await keystone.executeQuery(query);
+      if (errors) {
+        throw errors;
+      }
+      if (listQuery && listQuery.count && listQuery.count > 0) {
+        throw new Error(`ItemLimit reached, This Singleton list can not add more item`);
+      }
+    }
+    return resolvedData;
+  };
+  const originalResolveInput = hooks.resolveInput;
+  hooks.resolveInput = composeHook(originalResolveInput, newResolveInput);
+  return { key, keystone, hooks, adminConfig: { ...adminConfig, singleton: true }, ...rest };
+};

--- a/packages/list-plugins/lib/utils.js
+++ b/packages/list-plugins/lib/utils.js
@@ -5,3 +5,27 @@ exports.composeHook = (originalHook, newHook) => async params => {
   }
   return newHook({ ...params, resolvedData });
 };
+
+exports.composeAccess = (originalAccess, newAccess = {}) => {
+  if (typeof originalAccess === 'undefined') {
+    return {
+      ...newAccess,
+    };
+  }
+
+  const isShorthand = typeof originalAccess === 'boolean';
+  if (isShorthand) {
+    return {
+      create: originalAccess,
+      read: originalAccess,
+      update: originalAccess,
+      delete: originalAccess,
+      auth: originalAccess,
+      ...newAccess,
+    };
+  }
+  return {
+    ...originalAccess,
+    ...newAccess,
+  };
+};

--- a/packages/list-plugins/singleton.md
+++ b/packages/list-plugins/singleton.md
@@ -1,0 +1,40 @@
+<!--[meta]
+section: list-plugins
+title: singletoon
+[meta]-->
+
+# singleton Plugin
+
+This plugin makes a list singleton by allowing only one item in the list. Useful for list which must contain only one items.
+
+## Usage
+
+```js
+const { singleton } = require('@keystonejs/list-plugins');
+
+keystone.createList('ListWithPlugin', {
+  fields: {...},
+  plugins: [
+    singleton({...}),
+  ],
+});
+```
+
+## Config
+
+| Option          | Type      | Default | Description                                       |
+| --------------- | --------- | ------- | ------------------------------------------------- |
+| `preventDelete` | `Boolean` | `true`  | Prevents deletion of the (only) item in the list. |
+
+### `preventDelete`
+
+By default the plugin will prevent deletion of the only item in the list by setting `delete` access to false. If you want to control the access yourself, set this value to false.
+
+```javascript allowCopy=false showLanguage=false
+keystone.createList('ListWithPlugin', {
+  fields: {...},
+  plugins: [
+    singleton({ preventDelete: false }),
+  ],
+});
+```


### PR DESCRIPTION
ref #1639 

> this pr is on top of #2837, see actual diff: https://github.com/gautamsi/keystone/compare/update-plugins...gautamsi:singleton-list

you can now use this plugin to prevent adding more than one item in a list and also disallow deletion of the item in the list.

```js
{
  fields: {....},
  plugins: [singleton({preventDelete: true}),
```

admin ui changes:

![image](https://user-images.githubusercontent.com/5769869/80323260-f43e4a80-8847-11ea-8f56-d037e53e2640.png)


I am also inclined to make another plugin which would limit `minItems` and `maxItems` to the list, it could be a part of list config natively, but adding a plugin should also be good. 

~TODO:~
* ~redirect from list page to item page~
* ~remove `Create` button when there is an item in the list.~
* ~remove delete button (should really be addressed separately as there is no way to prevent delete button based on access for now)~ - Disabled the button rather than removing it.