### PR TITLE
[RFC] Consolidate connection URL API for adapters

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
     "ENABLE_DEV_FEATURES": {
       "required": true
     },
-    "MONGODB_URI": {
+    "DATABASE_URL": {
       "required": true
     },
     "NPM_CONFIG_PRODUCTION": {

--- a/docs/guides/heroku.md
+++ b/docs/guides/heroku.md
@@ -53,7 +53,7 @@ KeystoneJS automatically fetches the database connection string from an environm
 
 - Go to your Heroku app in the dashboard, select Settings and press [Reveal config vars].
 
-- Create a new environment variable called `MONGO_URI` set it to the database connection string we got from MongoDB Atlas, e.g. `mongodb+srv://<username>:<password>@cluster0-szafh.azure.mongodb.net/test?retryWrites=true&w=majority`.
+- Create a new environment variable called `DATABASE_URL` set it to the database connection string we got from MongoDB Atlas, e.g. `mongodb+srv://<username>:<password>@cluster0-szafh.azure.mongodb.net/test?retryWrites=true&w=majority`.
 
 ### Push the KeystoneJS app to Heroku
 

--- a/docs/tutorials/new-project.md
+++ b/docs/tutorials/new-project.md
@@ -43,7 +43,7 @@ const { Keystone } = require('@keystonejs/keystone');
 const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
-  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/keystone' }),
+  adapter: new MongooseAdapter({ url: 'mongodb://localhost/keystone' }),
 });
 ```
 

--- a/examples/blog/.env.example
+++ b/examples/blog/.env.example
@@ -1,4 +1,4 @@
 # Get a free account at https://iframely.com
 # IFRAMELY_API_KEY=dbe1ea593160b55639528a
 
-CONNECT_TO=mongodb://localhost:27017/keystone-demo-blog
+DATABASE_URL=mongodb://localhost:27017/keystone-demo-blog

--- a/examples/blog/index.js
+++ b/examples/blog/index.js
@@ -12,7 +12,7 @@ const { staticRoute, staticPath, distDir } = require('./config');
 const { User, Post, PostCategory, Comment } = require('./schema');
 
 const keystone = new Keystone({
-  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/keystone-demo-blog' }),
+  adapter: new MongooseAdapter({ url: 'mongodb://localhost/keystone-demo-blog' }),
   onConnect: async () => {
     // Initialise some data.
     // NOTE: This is only for demo purposes and should not be used in production

--- a/examples/custom-fields/index.js
+++ b/examples/custom-fields/index.js
@@ -7,7 +7,7 @@ const Stars = require('./fields/Stars');
 const MultiCheck = require('./fields/MultiCheck');
 
 const keystone = new Keystone({
-  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/custom-field' }),
+  adapter: new MongooseAdapter({ url: 'mongodb://localhost/custom-field' }),
 });
 
 keystone.createList('Movie', {

--- a/examples/meetup/index.js
+++ b/examples/meetup/index.js
@@ -22,7 +22,7 @@ const MEETUP = require('./meetupConfig');
 const initialiseData = require('./initialData');
 
 const keystone = new Keystone({
-  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/meetup' }),
+  adapter: new MongooseAdapter({ url: 'mongodb://localhost/meetup' }),
   onConnect: initialiseData,
 });
 

--- a/examples/todo/index.js
+++ b/examples/todo/index.js
@@ -6,7 +6,7 @@ const { AdminUIApp } = require('@keystonejs/app-admin-ui');
 const { StaticApp } = require('@keystonejs/app-static');
 
 const keystone = new Keystone({
-  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/todo' }),
+  adapter: new MongooseAdapter({ url: 'mongodb://localhost/todo' }),
 });
 
 keystone.createList('Todo', {

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -46,7 +46,7 @@ _**Default:**_
 ```javascript
 {
   client: 'postgres',
-  connection: process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI
+  connection: process.env.DATABASE_URL
 }
 ```
 

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -26,16 +26,9 @@ class KnexAdapter extends BaseKeystoneAdapter {
 
   async _connect() {
     const { knexOptions = {} } = this.config;
-    const { connection } = knexOptions;
-    let knexConnection =
-      connection || process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI;
-
-    if (!knexConnection) {
-      throw new Error(`No Knex connection URI specified.`);
-    }
     this.knex = knex({
       client: this.client,
-      connection: knexConnection,
+      connection: this.url,
       ...knexOptions,
     });
 
@@ -45,19 +38,8 @@ class KnexAdapter extends BaseKeystoneAdapter {
       error: result.error || result,
     }));
     if (connectResult.error) {
-      const connectionError = connectResult.error;
-      let dbName;
-      if (typeof knexConnection === 'string') {
-        dbName = knexConnection.split('/').pop();
-      } else {
-        dbName = knexConnection.database;
-      }
-      console.error(`Could not connect to database: '${dbName}'`);
-      console.warn(
-        `If this is the first time you've run Keystone, you can create your database with the following command:`
-      );
-      console.warn(`createdb ${dbName}`);
-      throw connectionError;
+      console.error(`Could not connect to database: '${this.url}'`);
+      throw connectResult.error;
     }
     return true;
   }

--- a/packages/adapter-knex/tests/adapter-knex.test.js
+++ b/packages/adapter-knex/tests/adapter-knex.test.js
@@ -8,9 +8,7 @@ global.console = {
 
 describe('Knex Adapter', () => {
   test('throws when database cannot be found using connection string', async () => {
-    const testAdapter = new KnexAdapter({
-      knexOptions: { connection: 'postgres://localhost/undefined_database' },
-    });
+    const testAdapter = new KnexAdapter({ uri: 'postgres://localhost/undefined_database' });
     const result = await testAdapter._connect().catch(result => result);
 
     expect(result).toBeInstanceOf(Error);

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -20,22 +20,16 @@ const keystone = new Keystone({
 
 ## Config
 
-### `mongoUri` (required)
+### `url` (required)
 
+The URL of your database.
 This is used as the `uri` parameter for `mongoose.connect()`.
 
 _**Default:**_ Environment variable (see below) or `'mongodb://localhost/<DATABASE_NAME>'`
 
 If not specified, KeystoneJS will look for one of the following environment variables:
 
-- `CONNECT_TO`
 - `DATABASE_URL`
-- `MONGO_URI`
-- `MONGODB_URI`
-- `MONGO_URL`
-- `MONGODB_URL`
-- `MONGOLAB_URI`
-- `MONGOLAB_URL`
 
 ### Mongoose options (optional)
 

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -35,24 +35,10 @@ class MongooseAdapter extends BaseKeystoneAdapter {
   }
 
   async _connect() {
-    const { mongoUri, ...mongooseConfig } = this.config;
+    const { url, ...mongooseConfig } = this.config;
     // Default to the localhost instance
-    let uri =
-      mongoUri ||
-      process.env.CONNECT_TO ||
-      process.env.DATABASE_URL ||
-      process.env.MONGO_URI ||
-      process.env.MONGODB_URI ||
-      process.env.MONGO_URL ||
-      process.env.MONGODB_URL ||
-      process.env.MONGOLAB_URI ||
-      process.env.MONGOLAB_URL;
 
-    if (!uri) {
-      throw new Error(`No MongoDB connection URI specified.`);
-    }
-
-    await this.mongoose.connect(uri, {
+    await this.mongoose.connect(this.url, {
       useNewUrlParser: true,
       useFindAndModify: false,
       useUnifiedTopology: true,

--- a/packages/create-keystone-app/lib/generate-code.js
+++ b/packages/create-keystone-app/lib/generate-code.js
@@ -11,7 +11,7 @@ const generateCode = async () => {
     Prisma: `const { PrismaAdapter: Adapter } = require('@keystonejs/adapter-prisma');`,
   }[adapterChoice.key];
 
-  return `${adapterRequire}
+  return `${adapterConfig}
 const PROJECT_NAME = '${projectName}';
 const adapterConfig = ${adapterConfig};
 `;

--- a/packages/create-keystone-app/lib/generate-code.js
+++ b/packages/create-keystone-app/lib/generate-code.js
@@ -1,17 +1,10 @@
 const { getProjectName } = require('./get-project-name');
-const { getAdapterChoice } = require('./get-adapter-choice');
 const { getAdapterConfig } = require('./get-adapter-config');
 
 const generateCode = async () => {
   const projectName = await getProjectName();
-
   const adapterChoice = await getAdapterChoice();
-  const adapterConfig = {
-    MongoDB: `{ mongoUri: '${await getAdapterConfig()}' }`,
-    PostgreSQL: `{ knexOptions: { connection: '${await getAdapterConfig()}' } }`,
-    Prisma: `{ url: '${await getAdapterConfig()}' }`,
-  }[adapterChoice.key];
-
+  const adapterConfig = `{ url: '${await getAdapterConfig()}' }`;
   const adapterRequire = {
     MongoDB: `const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');`,
     PostgreSQL: `const { KnexAdapter: Adapter } = require('@keystonejs/adapter-knex');`,

--- a/packages/create-keystone-app/lib/test-adapter-connection.js
+++ b/packages/create-keystone-app/lib/test-adapter-connection.js
@@ -51,11 +51,7 @@ const testAdapterConnection = async () => {
     const Adapter = { MongoDB: MongooseAdapter, PostgreSQL: KnexAdapter, Prisma: KnexAdapter }[
       adapterChoice.key
     ];
-    const adapterConfig = {
-      MongoDB: { mongoUri: config },
-      PostgreSQL: { knexOptions: { connection: config } },
-      Prisma: { knexOptions: { connection: config } },
-    }[adapterChoice.key];
+    const adapterConfig = { url: config };
     const adapter = new Adapter(adapterConfig);
     try {
       await adapter._connect();

--- a/packages/keystone/lib/adapters/index.js
+++ b/packages/keystone/lib/adapters/index.js
@@ -3,6 +3,12 @@ const pWaterfall = require('p-waterfall');
 class BaseKeystoneAdapter {
   constructor(config = {}) {
     this.config = { ...config };
+    this.url = config.url || process.env.DATABASE_URL;
+    if (!this.url) {
+      throw Error(
+        'No database URL provided. You must use the config option { url } or set the environment variable DATABASE_URL.'
+      );
+    }
     this.listAdapters = {};
     this.listAdapterClass = undefined;
   }


### PR DESCRIPTION
The way a developer currently specifies a connection string for their database adapter is either as:

```
{ mongoUri: 'mongodb://...` }
```

or

```
{ knexOptions: { connection: 'postgres://...' } }
```

Furthermore, for mongo there's a list of ~10 environment variables, and ~3 for knex, which are looked if there isn't an explicit connection string specified.

IMHO this is overly confusing and non-obvious. I would like to propose that both adapters (and any future adapters) allow the dev to specify either:
1. A config option called `url`, or
2. An environment variable called `DATABASE_URL`.

This will simplify the code, but more importantly simplify the docs, so that a user doesn't have to go digging deep through API docs to work out the exact config option to use.

This will obviously be a breaking change, and I'm not keen to push it through too soon on the heals of the Arcade release, but I want to put it out there as an idea.

The code in this PR is a five minute mock up of approximately what the changes would look like. I haven't actually run/tested it, so don't pick on it too hard :-)

Comments welcomed!