### PR TITLE
Admin UI: add adminIsReadOnly property to enable fields to appear read-only

### DIFF
--- a/.changeset/four-birds-sin.md
+++ b/.changeset/four-birds-sin.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/fields': minor
+---
+
+Added adminIsReadOnly property to field config, which makes fields with this property appear in the same manner as Cell view even INSIDE Item Details page, so the field value can't be (e.g. accidentally) changed from admin UI.

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -272,7 +272,9 @@ const ItemDetails = ({
             <Render key={field.path}>
               {() => {
                 const [Field] = field.adminMeta.readViews([field.views.Field]);
-                const [Cell] = field.views.Cell ? field.adminMeta.readViews([field.views.Cell]) : [];
+                const [Cell] = field.views.Cell
+                  ? field.adminMeta.readViews([field.views.Cell])
+                  : [];
 
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 const onChange = useCallback(
@@ -298,38 +300,41 @@ const ItemDetails = ({
                 );
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 return useMemo(
-                  () => field.config.adminIsReadOnly ? (
-                    <FieldContainer>
-                      <FieldLabel field={field} />
-                      <FieldDescription text={field.config.adminDoc} />
-                      {Cell ? (
-                        <Cell
-                          isSelected={false}
-                          list={list}
-                          data={item[field.path]}
-                          field={field}
-                          Link={LinkComponent(adminPath)}
-                        />
-                      ) : item[field.path]}
-                    </FieldContainer>
-                  ) : (
-                    <Field
-                      autoFocus={!i}
-                      field={field}
-                      list={list}
-                      item={item}
-                      errors={[
-                        ...(itemErrors[field.path] ? [itemErrors[field.path]] : []),
-                        ...(validationErrors[field.path] || []),
-                      ]}
-                      warnings={validationWarnings[field.path] || []}
-                      value={item[field.path]}
-                      savedValue={initialData[field.path]}
-                      onChange={onChange}
-                      renderContext="page"
-                      CreateItemModal={CreateItemModal}
-                    />
-                  ),
+                  () =>
+                    field.config.adminIsReadOnly ? (
+                      <FieldContainer>
+                        <FieldLabel field={field} />
+                        <FieldDescription text={field.config.adminDoc} />
+                        {Cell ? (
+                          <Cell
+                            isSelected={false}
+                            list={list}
+                            data={item[field.path]}
+                            field={field}
+                            Link={LinkComponent(adminPath)}
+                          />
+                        ) : (
+                          item[field.path]
+                        )}
+                      </FieldContainer>
+                    ) : (
+                      <Field
+                        autoFocus={!i}
+                        field={field}
+                        list={list}
+                        item={item}
+                        errors={[
+                          ...(itemErrors[field.path] ? [itemErrors[field.path]] : []),
+                          ...(validationErrors[field.path] || []),
+                        ]}
+                        warnings={validationWarnings[field.path] || []}
+                        value={item[field.path]}
+                        savedValue={initialData[field.path]}
+                        onChange={onChange}
+                        renderContext="page"
+                        CreateItemModal={CreateItemModal}
+                      />
+                    ),
                   [
                     i,
                     field,

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -13,6 +13,7 @@ class Field {
       schemaDoc,
       adminDoc,
       adminConfig,
+      adminIsReadOnly,
       ...config
     },
     { getListByKey, listKey, listAdapter, fieldAdapterClass, defaultAccess, schemaNames }
@@ -22,6 +23,7 @@ class Field {
     this.schemaDoc = schemaDoc;
     this.adminDoc = adminDoc;
     this.adminConfig = adminConfig;
+    this.adminIsReadOnly = adminIsReadOnly;
     this.config = config;
     this.isRequired = !!isRequired;
     this.defaultValue = defaultValue;
@@ -193,6 +195,7 @@ class Field {
         update: !!schemaAccess.update,
       },
       adminDoc: this.adminDoc,
+      adminIsReadOnly: this.adminIsReadOnly,
     });
   }
   extendAdminMeta(meta) {


### PR DESCRIPTION
Adds a property `adminIsReadOnly` to fields config, which enables the user to make certain fields appear read-only (although they remain changeable through GraphQL) inside the admin UI.
This leverages the same view as the cells in list tables.

Especially useful for data fields, which are only to be changed by the underlying system, and not by actual users of the Admin UI thus diminishing the chance of accidental corruption of data in those fields.