### PR TITLE
Include projects folder in the repo while ignoring sub folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,4 @@ tags
 
 # End of https://www.gitignore.io/api/vim
 
-projects/
 temp/

--- a/projects/.gitignore
+++ b/projects/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,5 @@
+# projects folder
+
+You can add your projects in this folder to work with keystone monorepo, contribute to Keystone but still wants to have separate test projects.
+
+This folder is not added to git except the .gitignore and README.md file.


### PR DESCRIPTION
improvement over #1832.

This adds `projects` folder in repo with readme and (git) ignores any other files/folders in projects folder. It is already included in workspace but not physically present

would be useful as many did not know it is there at their disposable and they have to use [symlinked and other hacks to get it working. ](https://github.com/keystonejs/keystone/issues/2836#issuecomment-619652717)  @Vultraz 


> Someone using this will need to make sure they are not polluting yarn.lock due to additional packages being used in those projects.

Don't think a changeset is needed but can add that if required.