### PR TITLE
Switched to mongodb-memory-server-core

### DIFF
--- a/.changeset/soft-wolves-invite.md
+++ b/.changeset/soft-wolves-invite.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/mongo-join-builder': patch
+'@keystonejs/test-utils': patch
+---
+
+Switched to mongodb-memory-server-core.

--- a/packages/mongo-join-builder/examples/database.js
+++ b/packages/mongo-join-builder/examples/database.js
@@ -1,5 +1,5 @@
 const { MongoClient } = require('mongodb');
-const MongoDBMemoryServer = require('mongodb-memory-server').default;
+const MongoDBMemoryServer = require('mongodb-memory-server-core').default;
 
 module.exports = async () => {
   const mongoServer = new MongoDBMemoryServer();

--- a/packages/mongo-join-builder/package.json
+++ b/packages/mongo-join-builder/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "mongodb": "^3.5.5",
-    "mongodb-memory-server": "^6.3.3"
+    "mongodb-memory-server-core": "^6.5.2"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/packages/mongo-join-builder"
 }

--- a/packages/mongo-join-builder/tests/mongo-results.test.js
+++ b/packages/mongo-join-builder/tests/mongo-results.test.js
@@ -2,7 +2,7 @@ const { queryParser, pipelineBuilder } = require('../');
 const { postsAdapter, listAdapter } = require('./utils');
 
 const { MongoClient } = require('mongodb');
-const MongoDBMemoryServer = require('mongodb-memory-server').default;
+const MongoDBMemoryServer = require('mongodb-memory-server-core').default;
 
 const mongoJoinBuilder = parserOptions => {
   return async (query, aggregate) => {

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const supertest = require('supertest-light');
-const MongoDBMemoryServer = require('mongodb-memory-server').default;
+const MongoDBMemoryServer = require('mongodb-memory-server-core').default;
 const pFinally = require('p-finally');
 const url = require('url');
 const { Keystone } = require('@keystonejs/keystone');

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,7 +13,7 @@
     "@keystonejs/app-graphql": "^5.1.5",
     "@keystonejs/keystone": "^8.1.2",
     "express": "^4.17.1",
-    "mongodb-memory-server": "^6.3.3",
+    "mongodb-memory-server-core": "^6.5.2",
     "p-finally": "^2.0.1",
     "supertest-light": "^1.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3362,13 +3362,6 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
-"@types/decompress@^4.2.3":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/@types/decompress/-/decompress-4.2.3.tgz#98eed48af80001038aa05690b2094915f296fe65"
-  integrity sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/dedent@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@types/dedent/-/dedent-0.7.0.tgz#155f339ca404e6dd90b9ce46a3f78fd69ca9b050"
@@ -5729,6 +5722,15 @@ bl@^3.0.0:
   dependencies:
     readable-stream "^3.0.1"
 
+bl@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
+  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 blob@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
@@ -6083,6 +6085,14 @@ buffer@^5.2.0, buffer@^5.2.1:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
   integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -12907,7 +12917,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -16431,14 +16441,13 @@ moment@2.24.0, moment@^2.10.3, moment@^2.21.0, moment@^2.24.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
-mongodb-memory-server-core@6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.3.3.tgz#bb446e9fcd1062042cb9c411a163fb25a6557ccd"
-  integrity sha512-X6ykRFK92tdX7w61+hTC+DXBbpNC9G76I3aOkV6HknNVG3U6/5Ht/NN6Wdh5CPATj78W2AaBS1smvby941fXpg==
+mongodb-memory-server-core@^6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-6.5.2.tgz#21c96b6e3104b999905ecb232f83d2432467a0f5"
+  integrity sha512-Cs1wB+GrL2KconDD2emk6ptU1OqdYia11I7fw5sOqnEWc8stTQ4rtptbRcLmHyTcTgRYC/fsQQvzbbd7DBf4DQ==
   dependencies:
     "@types/cross-spawn" "^6.0.1"
     "@types/debug" "^4.1.5"
-    "@types/decompress" "^4.2.3"
     "@types/dedent" "^0.7.0"
     "@types/find-cache-dir" "^3.2.0"
     "@types/find-package-json" "^1.1.1"
@@ -16451,7 +16460,6 @@ mongodb-memory-server-core@6.3.3:
     camelcase "^5.3.1"
     cross-spawn "^7.0.1"
     debug "^4.1.1"
-    decompress "^4.2.0"
     dedent "^0.7.0"
     find-cache-dir "3.3.1"
     find-package-json "^1.2.0"
@@ -16460,17 +16468,12 @@ mongodb-memory-server-core@6.3.3:
     lockfile "^1.0.4"
     md5-file "^4.0.0"
     mkdirp "^1.0.3"
+    tar-stream "^2.1.1"
     tmp "^0.1.0"
     uuid "^7.0.2"
+    yauzl "^2.10.0"
   optionalDependencies:
     mongodb "^3.5.4"
-
-mongodb-memory-server@^6.3.3:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-6.3.3.tgz#c80534ddd51a0aad47aad004b021d092d20d3b52"
-  integrity sha512-MS+MPTvJhaPUsYCWQ+H66C0A5BQWTgdT5PgN6P5WeinAgN6j+eOjH561UnPdXooj7bHXB4dlvVYaXaJrbegucA==
-  dependencies:
-    mongodb-memory-server-core "6.3.3"
 
 mongodb@3.5.5, mongodb@^3.5.4, mongodb@^3.5.5:
   version "3.5.5"
@@ -20421,7 +20424,7 @@ readable-stream@^2.3.0, readable-stream@^2.3.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.0.1, readable-stream@^3.1.1:
+readable-stream@^3.0.1, readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -23116,6 +23119,17 @@ tar-stream@^2.0.0:
   integrity sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==
   dependencies:
     bl "^3.0.0"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
+
+tar-stream@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
+  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+  dependencies:
+    bl "^4.0.1"
     end-of-stream "^1.4.1"
     fs-constants "^1.0.0"
     inherits "^2.0.3"


### PR DESCRIPTION
The only difference with `core` is it does *not* download a `mongod` binary when installing the package, but rather at runtime if a binary isn't found. I dunno if it's bad internet, but there have been times when I've waited literally over an hour for `mongodb-memory-server` to complete its install step for a package I'm not even going to need. 😒