### PR TITLE
Fix for incorrect Content-Type headers returned for Admin UI bundles

### DIFF
--- a/.changeset/lazy-clocks-try.md
+++ b/.changeset/lazy-clocks-try.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Static assets loaded for the Admin UI (eg. JS bundles) now have correct Content-Type response headers

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -160,7 +160,13 @@ class AdminUIApp {
         default: () => {
           next();
         },
+        // Without this, request with an 'Accept: */*' header get picked up by
+        // the 'text/html' handler rather than the default
         '*/*': () => {
+          // We need to reset the res 'Content-Type' otherwise it gets replaced by the format we've matched on: '*/*'.
+          // Returning a wildcard mimetype causes problems if a 'X-Content-Type-Options: nosniff' header is also set.
+          // See.. https://github.com/keystonejs/keystone/issues/2741
+          res.type(path.extname(req.url));
           next();
         },
         // For page loads, we want to redirect back to signin page

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -166,7 +166,8 @@ class AdminUIApp {
           // We need to reset the res 'Content-Type' otherwise it gets replaced by the format we've matched on: '*/*'.
           // Returning a wildcard mimetype causes problems if a 'X-Content-Type-Options: nosniff' header is also set.
           // See.. https://github.com/keystonejs/keystone/issues/2741
-          res.type(path.extname(req.url));
+          const extension = path.extname(req.url);
+          if (extension) res.type(extension);
           next();
         },
         // For page loads, we want to redirect back to signin page


### PR DESCRIPTION
Fixes #2741.

When the Express `res.format()` function matches a request (to a non-default function) it replaces the responses `Content-Type` header with the key it matched on. This causes our `*/*` format handler (which is basically a noop) to return requests with header of `Content-Type: */*`. This in turn causes problems if a `X-Content-Type-Options: nosniff` header is also set on the request (ie. somewhere else in the Express middleware, by a reverse proxy, etc.).

We can fix this by resetting the `Content-Type` header with a mime-type derived from the requested files extension.

Unfortunately, despite being quite redundant, we can't just remove the `*/*` handler. Doing so causes requests with an `Accept: */*` header or no `Accept` at all to fall though to the `text/html` handler, rather than the default.

The `default` handler itself doesn't require this additional logic as Express has already given the response a correct `Content-Type` header and doesn't override it when the `default` format handler is used. If the `text/html` handler is hit, the overridden `Content-Type` is correctly set to `text/html`.