### PR TITLE
Make the adminMeta object keys explicit

### DIFF
--- a/.changeset/tasty-numbers-turn.md
+++ b/.changeset/tasty-numbers-turn.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': major
+---
+
+Removed the method `AdminUIApp.getAdminMeta()` in favour of the more complete `AdminUIApp.getAdminUIMeta(keystone)`.

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -47,21 +47,6 @@ class AdminUIApp {
     };
   }
 
-  getAdminMeta() {
-    return {
-      adminPath: this.adminPath,
-      pages: this.pages,
-      hooks: this.hooks,
-      ...this.routes,
-      ...(this.authStrategy
-        ? {
-            authStrategy: this.authStrategy.getAdminMeta(),
-          }
-        : {}),
-      ...this._adminMeta,
-    };
-  }
-
   isAccessAllowed(req) {
     if (!this.authStrategy) {
       return true;
@@ -134,14 +119,23 @@ class AdminUIApp {
   }
 
   getAdminUIMeta(keystone) {
-    const { adminPath } = this;
-
+    // This is exposed as the global `KEYSTONE_ADMIN_META` in the client.
+    const { adminPath, apiPath, graphiqlPath, pages, hooks } = this;
+    const { signinPath, signoutPath } = this.routes;
+    const { lists, name } = keystone.getAdminMeta({ schemaName: this._schemaName });
+    const authStrategy = this.authStrategy ? this.authStrategy.getAdminMeta() : undefined;
     return {
       adminPath,
-      apiPath: this.apiPath,
-      graphiqlPath: this.graphiqlPath,
-      ...this.getAdminMeta(),
-      ...keystone.getAdminMeta({ schemaName: this._schemaName }),
+      apiPath,
+      graphiqlPath,
+      pages,
+      hooks,
+      signinPath,
+      signoutPath,
+      authStrategy,
+      lists,
+      name,
+      ...this._adminMeta,
     };
   }
 

--- a/packages/app-admin-ui/tests/server/AdminUI.test.js
+++ b/packages/app-admin-ui/tests/server/AdminUI.test.js
@@ -21,7 +21,7 @@ jest.doMock('html-webpack-plugin', () => {
 const { AdminUIApp } = require('../../');
 
 const keystone = {
-  getAdminMeta: jest.fn(),
+  getAdminMeta: jest.fn(() => ({ lists: [], name: 'test' })),
 };
 const adminPath = 'admin_path';
 


### PR DESCRIPTION
This also removes the otherwise obsolete `AdminUIApp.getAdminMeta()` method (which technically makes this a breaking change).