### PR TITLE
[WIP] Explicit fields loader

### DIFF
--- a/.changeset/tasty-numbers-turn.md
+++ b/.changeset/tasty-numbers-turn.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': major
+---
+
+Removed the method `AdminUIApp.getAdminMeta()` in favour of the more complete `AdminUIApp.getAdminUIMeta(keystone)`.

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -47,21 +47,6 @@ class AdminUIApp {
     };
   }
 
-  getAdminMeta() {
-    return {
-      adminPath: this.adminPath,
-      pages: this.pages,
-      hooks: this.hooks,
-      ...this.routes,
-      ...(this.authStrategy
-        ? {
-            authStrategy: this.authStrategy.getAdminMeta(),
-          }
-        : {}),
-      ...this._adminMeta,
-    };
-  }
-
   isAccessAllowed(req) {
     if (!this.authStrategy) {
       return true;
@@ -134,14 +119,23 @@ class AdminUIApp {
   }
 
   getAdminUIMeta(keystone) {
-    const { adminPath } = this;
-
+    // This is exposed as the global `KEYSTONE_ADMIN_META` in the client.
+    const { adminPath, apiPath, graphiqlPath, pages, hooks } = this;
+    const { signinPath, signoutPath } = this.routes;
+    const { lists, name } = keystone.getAdminMeta({ schemaName: this._schemaName });
+    const authStrategy = this.authStrategy ? this.authStrategy.getAdminMeta() : undefined;
     return {
       adminPath,
-      apiPath: this.apiPath,
-      graphiqlPath: this.graphiqlPath,
-      ...this.getAdminMeta(),
-      ...keystone.getAdminMeta({ schemaName: this._schemaName }),
+      apiPath,
+      graphiqlPath,
+      pages,
+      hooks,
+      signinPath,
+      signoutPath,
+      authStrategy,
+      lists,
+      name,
+      ...this._adminMeta,
     };
   }
 

--- a/packages/app-admin-ui/server/getWebpackConfig.js
+++ b/packages/app-admin-ui/server/getWebpackConfig.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const { enableDevFeatures, mode } = require('./env');
 
-module.exports = function({ adminMeta, entry, outputPath }) {
+module.exports = function({ adminMeta, adminViews, entry, outputPath }) {
   const templatePlugin = new HtmlWebpackPlugin({
     title: 'KeystoneJS',
     template: 'index.html',
@@ -55,15 +55,14 @@ module.exports = function({ adminMeta, entry, outputPath }) {
       type: 'javascript/auto',
     },
   ];
-  if (adminMeta.lists) {
+  if (adminViews) {
+    const { pages, hooks, listViews } = adminViews;
     rules.push({
       test: /FIELD_TYPES/,
       use: [
         {
           loader: '@keystonejs/field-views-loader',
-          options: {
-            adminMeta,
-          },
+          options: { pages, hooks, listViews },
         },
       ],
     });

--- a/packages/app-admin-ui/tests/server/AdminUI.test.js
+++ b/packages/app-admin-ui/tests/server/AdminUI.test.js
@@ -33,16 +33,9 @@ test('new AdminUIApp() - smoke test', () => {
 
 describe('Add Middleware', () => {
   test('Smoke test', () => {
-    const adminUI = new AdminUIApp({
-      adminPath,
-    });
-
+    const adminUI = new AdminUIApp({ adminPath });
     const adminMeta = adminUI.getAdminUIMeta(keystone);
-
-    expect(
-      adminUI.createDevMiddleware({
-        adminMeta,
-      })
-    ).not.toBe(null);
+    const adminViews = adminUI.getAdminViews(keystone);
+    expect(adminUI.createDevMiddleware({ adminMeta, adminViews })).not.toBe(null);
   });
 });

--- a/packages/field-views-loader/index.js
+++ b/packages/field-views-loader/index.js
@@ -37,8 +37,7 @@ function findPageComponents(pages, pageComponents = {}) {
 }
 
 module.exports = function() {
-  const options = loaderUtils.getOptions(this);
-  const adminMeta = options.adminMeta;
+  const { pages, hooks, listViews } = loaderUtils.getOptions(this);
 
   /* adminMeta gives us a `lists` object in the shape:
     {
@@ -85,18 +84,12 @@ module.exports = function() {
   }
    */
 
+  const allViews = {
+    ...listViews,
+    __pages__: findPageComponents(pages),
+    __hooks__: fs.existsSync(hooks) ? hooks : {},
+  };
   let allPaths = new Set();
-  let pageComponents = findPageComponents(adminMeta.pages);
-  let hooks = fs.existsSync(adminMeta.hooks) ? adminMeta.hooks : {};
-
-  let allViews = Object.entries(adminMeta.lists).reduce(
-    (obj, [listPath, { views }]) => {
-      obj[listPath] = views;
-      return obj;
-    },
-    { __pages__: pageComponents, __hooks__: hooks }
-  );
-
   const stringifiedObject = serialize(allViews, allPaths);
 
   let loaders = `{\n${[...allPaths]


### PR DESCRIPTION
This PR makes explicit exactly which values are passed through to the `fields-views-loader` function. It also removes `hooks` and `pages` from the `adminMeta` passed to the client, since they were never actually used there.

(Builds on top of #2869, which should be merged before this is considered).