### PR TITLE
Admin UI: Improvements to Update workflow

### DIFF
--- a/.changeset/chilly-adults-search.md
+++ b/.changeset/chilly-adults-search.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Improved Update workflow.
+Refactored `UpdateManyModal` component.

--- a/.changeset/chilly-adults-search.md
+++ b/.changeset/chilly-adults-search.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Improved Update workflow.

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -383,7 +383,7 @@ const ActionItems = ({ mouseIsOverNav }) => {
       ...(ENABLE_DEV_FEATURES
         ? [
             {
-              label: 'GraphiQL Playground',
+              label: 'GraphQL Playground',
               to: graphiqlPath,
               icon: TerminalIcon,
               target: '_blank',

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -154,6 +154,7 @@ const UpdateManyModal = ({ list, items, isOpen, onUpdate, onClose }) => {
             <Render>
               {() => {
                 const [Field] = field.adminMeta.readViews([field.views.Field]);
+                // eslint-disable-next-line react-hooks/rules-of-hooks
                 const onChange = useCallback(
                   value => {
                     setItem(prev => ({ ...prev, [field.path]: value }));
@@ -162,6 +163,7 @@ const UpdateManyModal = ({ list, items, isOpen, onUpdate, onClose }) => {
                   },
                   [field]
                 );
+                // eslint-disable-next-line react-hooks/rules-of-hooks
                 return useMemo(
                   () => (
                     <Field

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -1,35 +1,35 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { Component, Fragment, useMemo, useCallback, Suspense } from 'react';
+import { Fragment, useMemo, useCallback, Suspense, useState } from 'react';
 import { useMutation } from '@apollo/react-hooks';
+import { useToasts } from 'react-toast-notifications';
+import { omit, arrayToObject, countArrays } from '@keystonejs/utils';
+
 import { Button, LoadingButton } from '@arch-ui/button';
 import Drawer from '@arch-ui/drawer';
 import { FieldContainer, FieldLabel, FieldInput } from '@arch-ui/fields';
-import Select from '@arch-ui/select';
-import { omit, arrayToObject, countArrays } from '@keystonejs/utils';
 import { LoadingIndicator } from '@arch-ui/loading';
+import Select from '@arch-ui/select';
 
-import { validateFields } from '../util';
+import { validateFields, handleCreateUpdateMutationError } from '../util';
 import CreateItemModal from './CreateItemModal';
 
-let Render = ({ children }) => children();
+const Render = ({ children }) => children();
 
-class UpdateManyModal extends Component {
-  constructor(props) {
-    super(props);
-    const { list } = props;
-    const selectedFields = [];
-    const item = list.getInitialItemData();
-    const validationErrors = {};
-    const validationWarnings = {};
+const UpdateManyModal = ({ list, items, isOpen, onUpdate, onClose }) => {
+  const { addToast } = useToasts();
+  const [updateItem, { loading }] = useMutation(list.updateManyMutation, {
+    errorPolicy: 'all',
+    onError: error => handleCreateUpdateMutationError({ error, addToast }),
+  });
 
-    this.state = { item, selectedFields, validationErrors, validationWarnings };
-  }
-  onUpdate = async () => {
-    const { updateItem, isLoading, items } = this.props;
-    const { item, selectedFields, validationErrors, validationWarnings } = this.state;
-    if (isLoading) return;
-    if (countArrays(validationErrors)) {
+  const [item, setItem] = useState({});
+  const [selectedFields, setSelectedFields] = useState([]);
+  const [validationErrors, setValidationErrors] = useState({});
+  const [validationWarnings, setValidationWarnings] = useState({});
+
+  const handleUpdate = async () => {
+    if (loading || countArrays(validationErrors)) {
       return;
     }
 
@@ -39,171 +39,161 @@ class UpdateManyModal extends Component {
       const { errors, warnings } = await validateFields(selectedFields, item, data);
 
       if (countArrays(errors) + countArrays(warnings) > 0) {
-        this.setState(() => ({
-          validationErrors: errors,
-          validationWarnings: warnings,
-        }));
+        setValidationErrors(errors);
+        setValidationWarnings(warnings);
 
         return;
       }
     }
 
-    updateItem({
+    const result = await updateItem({
       variables: {
         data: items.map(id => ({ id, data })),
       },
-    }).then(() => {
-      this.props.onUpdate();
-      this.resetState();
     });
+
+    // Result will be undefined if a GraphQL error occurs (such as failed validation)
+    // Leave the modal open in that case
+    if (!result) return;
+
+    resetState();
+    onUpdate();
   };
 
-  resetState = () => {
-    this.setState({ item: this.props.list.getInitialItemData({}), selectedFields: [] });
+  const resetState = () => {
+    setItem(list.getInitialItemData({}));
+    setSelectedFields([]);
   };
-  onClose = () => {
-    const { isLoading } = this.props;
-    if (isLoading) return;
-    this.resetState();
-    this.props.onClose();
+
+  const handleClose = () => {
+    if (loading) return;
+    resetState();
+    onClose();
   };
-  onKeyDown = event => {
+
+  const onKeyDown = event => {
     if (event.defaultPrevented) return;
     switch (event.key) {
       case 'Escape':
-        return this.onClose();
+        return handleClose();
       case 'Enter':
-        return this.onUpdate();
+        return handleUpdate();
     }
   };
-  handleSelect = selected => {
-    const { list } = this.props;
-    const selectedFields = selected.map(({ path, value }) => {
-      return list.fields
-        .filter(({ isPrimaryKey }) => !isPrimaryKey)
-        .find(f => f.path === path || f.path === value);
-    });
-    this.setState({ selectedFields });
-  };
-  getOptionValue = option => {
-    return option.path || option.value;
-  };
-  getOptionValue = option => {
-    return option.path || option.value;
-  };
-  getOptions = () => {
-    const { list } = this.props;
-    // remove the `options` key from select type fields
-    return list.fields.filter(({ isPrimaryKey }) => !isPrimaryKey).map(f => omit(f, ['options']));
-  };
-  render() {
-    const { isLoading, isOpen, items, list } = this.props;
-    const { item, selectedFields, validationErrors, validationWarnings } = this.state;
-    const options = this.getOptions();
 
-    const hasWarnings = countArrays(validationWarnings);
-    const hasErrors = countArrays(validationErrors);
-
-    return (
-      <Drawer
-        isOpen={isOpen}
-        onClose={this.onClose}
-        closeOnBlanketClick
-        heading={`Update ${list.formatCount(items)}`}
-        onKeyDown={this.onKeyDown}
-        slideInFrom="left"
-        footer={
-          <Fragment>
-            <LoadingButton
-              appearance={hasWarnings && !hasErrors ? 'warning' : 'primary'}
-              isDisabled={hasErrors}
-              isLoading={isLoading}
-              onClick={this.onUpdate}
-            >
-              {hasWarnings && !hasErrors ? 'Ignore Warnings and Update' : 'Update'}
-            </LoadingButton>
-            <Button appearance="warning" variant="subtle" onClick={this.onClose}>
-              Cancel
-            </Button>
-          </Fragment>
-        }
-      >
-        <FieldContainer>
-          <FieldLabel field={{ label: 'Fields', config: { isRequired: false } }} />
-          <FieldInput>
-            <Select
-              autoFocus
-              isMulti
-              menuPosition="fixed"
-              onChange={this.handleSelect}
-              options={options}
-              tabSelectsValue={false}
-              value={selectedFields}
-              getOptionValue={this.getOptionValue}
-              filterOption={this.filterOption}
-            />
-          </FieldInput>
-        </FieldContainer>
-        {selectedFields.map((field, i) => {
-          return (
-            <Suspense
-              fallback={<LoadingIndicator css={{ height: '3em' }} size={12} />}
-              key={field.path}
-            >
-              <Render>
-                {() => {
-                  let [Field] = field.adminMeta.readViews([field.views.Field]);
-                  let onChange = useCallback(
-                    value => {
-                      this.setState(({ item }) => ({
-                        item: {
-                          ...item,
-                          [field.path]: value,
-                        },
-                        validationErrors: {},
-                        validationWarnings: {},
-                      }));
-                    },
-                    [field]
-                  );
-                  return useMemo(
-                    () => (
-                      <Field
-                        autoFocus={!i}
-                        field={field}
-                        value={item[field.path]}
-                        // Explicitly pass undefined here as it doesn't make
-                        // sense to pass in any one 'saved' value
-                        savedValue={undefined}
-                        errors={validationErrors[field.path] || []}
-                        warnings={validationWarnings[field.path] || []}
-                        onChange={onChange}
-                        renderContext="dialog"
-                        CreateItemModal={CreateItemModal}
-                      />
-                    ),
-                    [
-                      i,
-                      field,
-                      item[field.path],
-                      validationErrors[field.path],
-                      validationWarnings[field.path],
-                      onChange,
-                    ]
-                  );
-                }}
-              </Render>
-            </Suspense>
-          );
-        })}
-      </Drawer>
+  const handleSelect = selected => {
+    setSelectedFields(
+      selected
+        ? selected.map(({ path, value }) => {
+            return list.fields
+              .filter(({ isPrimaryKey }) => !isPrimaryKey)
+              .find(f => f.path === path || f.path === value);
+          })
+        : []
     );
-  }
-}
+  };
 
-export default function UpdateManyModalWithMutation(props) {
-  const { list } = props;
-  const [updateItem, { loading }] = useMutation(list.updateManyMutation);
+  const getOptionValue = option => {
+    return option.path || option.value;
+  };
 
-  return <UpdateManyModal updateItem={updateItem} isLoading={loading} {...props} />;
-}
+  const options = useMemo(
+    // remove the `options` key from select type fields
+    () => list.fields.filter(({ isPrimaryKey }) => !isPrimaryKey).map(f => omit(f, ['options'])),
+    []
+  );
+
+  const hasWarnings = countArrays(validationWarnings);
+  const hasErrors = countArrays(validationErrors);
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onClose={handleClose}
+      closeOnBlanketClick
+      heading={`Update ${list.formatCount(items)}`}
+      onKeyDown={onKeyDown}
+      slideInFrom="left"
+      footer={
+        <Fragment>
+          <LoadingButton
+            appearance={hasWarnings && !hasErrors ? 'warning' : 'primary'}
+            isDisabled={hasErrors}
+            isLoading={loading}
+            onClick={handleUpdate}
+          >
+            {hasWarnings && !hasErrors ? 'Ignore Warnings and Update' : 'Update'}
+          </LoadingButton>
+          <Button appearance="warning" variant="subtle" onClick={handleClose}>
+            Cancel
+          </Button>
+        </Fragment>
+      }
+    >
+      <FieldContainer>
+        <FieldLabel field={{ label: 'Fields', config: { isRequired: false } }} />
+        <FieldInput>
+          <Select
+            autoFocus
+            isMulti
+            menuPosition="fixed"
+            onChange={handleSelect}
+            options={options}
+            tabSelectsValue={false}
+            value={selectedFields}
+            getOptionValue={getOptionValue}
+          />
+        </FieldInput>
+      </FieldContainer>
+      {selectedFields.map((field, i) => {
+        return (
+          <Suspense
+            fallback={<LoadingIndicator css={{ height: '3em' }} size={12} />}
+            key={field.path}
+          >
+            <Render>
+              {() => {
+                const [Field] = field.adminMeta.readViews([field.views.Field]);
+                const onChange = useCallback(
+                  value => {
+                    setItem(prev => ({ ...prev, [field.path]: value }));
+                    setValidationErrors({});
+                    setValidationWarnings({});
+                  },
+                  [field]
+                );
+                return useMemo(
+                  () => (
+                    <Field
+                      autoFocus={!i}
+                      field={field}
+                      value={item[field.path]}
+                      // Explicitly pass undefined here as it doesn't make
+                      // sense to pass in any one 'saved' value
+                      savedValue={undefined}
+                      errors={validationErrors[field.path] || []}
+                      warnings={validationWarnings[field.path] || []}
+                      onChange={onChange}
+                      renderContext="dialog"
+                      CreateItemModal={CreateItemModal}
+                    />
+                  ),
+                  [
+                    i,
+                    field,
+                    item[field.path],
+                    validationErrors[field.path],
+                    validationWarnings[field.path],
+                    onChange,
+                  ]
+                );
+              }}
+            </Render>
+          </Suspense>
+        );
+      })}
+    </Drawer>
+  );
+};
+
+export default UpdateManyModal;

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -17,74 +17,75 @@ export const ManageToolbar = styled.div(({ isVisible }) => ({
   marginTop: gridSize,
   visibility: isVisible ? 'visible' : 'hidden',
 }));
-const SelectedCount = styled.div({
-  color: colors.N40,
-  marginRight: gridSize,
-});
 
-export default function ListManage(props) {
-  const { onDeleteMany, onUpdateMany, selectedItems } = props;
-  const [deleteModalIsVisible, setDeleteModal] = useState(false);
-  const [updateModalIsVisible, setUpdateModal] = useState(false);
+const SelectedCount = styled.div`
+  color: ${colors.N40};
+  margin-right: ${gridSize}px;
+`;
+
+const ListManage = ({ list, pageSize, totalItems, selectedItems, onDeleteMany, onUpdateMany }) => {
+  const [deleteModalIsVisible, setDeleteModalIsVisible] = useState(false);
+  const [updateModalIsVisible, setUpdateModalIsVisible] = useState(false);
 
   const handleDelete = () => {
-    setDeleteModal(false);
+    setDeleteModalIsVisible(false);
     onDeleteMany();
   };
+
   const handleUpdate = () => {
-    setUpdateModal(false);
+    setUpdateModalIsVisible(false);
     onUpdateMany();
   };
-
-  const { list, pageSize, totalItems } = props;
-  const selectedCount = selectedItems.length;
 
   return (
     <Fragment>
       <FlexGroup align="center">
         <SelectedCount>
-          {selectedCount} of {Math.min(pageSize, totalItems)} Selected
+          {`${selectedItems.length} of ${Math.min(pageSize, totalItems)} Selected`}
         </SelectedCount>
-        {ENABLE_DEV_FEATURES ? (
-          list.access.update ? (
-            <IconButton
-              appearance="primary"
-              icon={SettingsIcon}
-              onClick={() => setUpdateModal(true)}
-              variant="nuance"
-              data-test-name="update"
-            >
-              Update
-            </IconButton>
-          ) : null
-        ) : null}
-        {list.access.update ? (
+
+        {ENABLE_DEV_FEATURES && list.access.update && (
+          <IconButton
+            appearance="primary"
+            icon={SettingsIcon}
+            onClick={() => setUpdateModalIsVisible(true)}
+            variant="nuance"
+            data-test-name="update"
+          >
+            Update
+          </IconButton>
+        )}
+
+        {list.access.update && (
           <IconButton
             appearance="danger"
             icon={TrashcanIcon}
-            onClick={() => setDeleteModal(true)}
+            onClick={() => setDeleteModalIsVisible(true)}
             variant="nuance"
             data-test-name="delete"
           >
             Delete
           </IconButton>
-        ) : null}
+        )}
       </FlexGroup>
 
       <UpdateManyItemsModal
         isOpen={updateModalIsVisible}
         items={selectedItems}
         list={list}
-        onClose={() => setUpdateModal(false)}
+        onClose={() => setUpdateModalIsVisible(false)}
         onUpdate={handleUpdate}
       />
+
       <DeleteManyItemsModal
         isOpen={deleteModalIsVisible}
         itemIds={selectedItems}
         list={list}
-        onClose={() => setDeleteModal(false)}
+        onClose={() => setDeleteModalIsVisible(false)}
         onDelete={handleDelete}
       />
     </Fragment>
   );
-}
+};
+
+export default ListManage;

--- a/test-projects/basic/cypress/integration/nav-bar_spec.js
+++ b/test-projects/basic/cypress/integration/nav-bar_spec.js
@@ -14,7 +14,7 @@ describe('Nav Bar', () => {
       target: 'https://github.com/keystonejs/keystone',
       newTab: true,
     },
-    { text: 'GraphiQL Playground', target: '/admin/graphiql', newTab: true },
+    { text: 'GraphQL Playground', target: '/admin/graphiql', newTab: true },
   ].forEach(({ text, target, newTab = false }) => {
     it(`${newTab ? 'Check' : 'Click'} ${text}`, () => {
       cy.visit('/admin');


### PR DESCRIPTION
- Converted `UpdateManyModal` to a functional component. Dropped `UpdateManyModalWithMutation` in the process.
- Cleaned up `ListManage` a bit
- Surface update errors in a toast. Same behavior as the Create modal
- Ensured an error wouldn't dismiss the Update popout
- Fixed an error making it impossible to deselect the final selected field