### PR TITLE
Admin UI: explicit list config

### DIFF
--- a/.changeset/curly-llamas-compare.md
+++ b/.changeset/curly-llamas-compare.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Cleaned up duplicated and/or unnecessary list config data.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -7,14 +7,22 @@ export const gqlCountQueries = lists => gql`{
 }`;
 
 export default class List {
-  constructor(config, adminMeta, views) {
-    this.config = config;
-    this.adminMeta = adminMeta;
+  constructor(
+    { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
+    adminMeta,
+    views
+  ) {
+    this.access = access;
+    this.adminConfig = adminConfig;
+    this.adminDoc = adminDoc;
+    this.gqlNames = gqlNames;
+    this.key = key;
+    this.label = label;
+    this.path = path;
+    this.plural = plural;
+    this.singular = singular;
 
-    // TODO: undo this
-    Object.assign(this, config);
-
-    this.fields = config.fields.map(fieldConfig => {
+    this.fields = fields.map(fieldConfig => {
       const [Controller] = adminMeta.readViews([views[fieldConfig.path].Controller]);
       return new Controller(fieldConfig, this, adminMeta, views[fieldConfig.path]);
     });
@@ -144,9 +152,9 @@ export default class List {
     return count === 1 ? `1 ${this.singular}` : `${count} ${this.plural}`;
   }
   getPersistedSearch() {
-    return localStorage.getItem(`search:${this.config.path}`);
+    return localStorage.getItem(`search:${this.path}`);
   }
   setPersistedSearch(value) {
-    localStorage.setItem(`search:${this.config.path}`, value);
+    localStorage.setItem(`search:${this.path}`, value);
   }
 }


### PR DESCRIPTION
The client-side `List` objects were storing a *ton* of duplicated and unnecessary data.

Here's what one of the Admin UI `List` objects looked like before:
![image](https://user-images.githubusercontent.com/3558659/80867123-233c3c80-8cde-11ea-9eb6-c12baf3b2406.png)

Notice how not only was the *entire* `adminMeta` object duplicated in every list, but the `config` object was being saved despite being `assigned`ed to the `List` object. This meant that the entire config object was being saved twice, *and* it also meant completely unnecessary keys like `views` were being saved too (these are used by the field view loader and aren't needed here).

This removes the copy of `adminMeta` (it wasn't used anywhere) and the `config` copy + assignment in favor of explicitly picking out the pieces of `config` we want to save. Note this does mean the raw field config is no longer accessible at `list.config.fields`, but it's still available via the field controller in `list.fields`.

Lot cleaner!