### PR TITLE
DateTimeUtc: null string means null date too

### DIFF
--- a/.changeset/purple-cherries-wave.md
+++ b/.changeset/purple-cherries-wave.md
@@ -1,0 +1,5 @@
+---
+"@keystonejs/fields-datetime-utc": patch
+---
+
+Fixed an issue with filtering by null values.

--- a/packages/fields-datetime-utc/src/Implementation.js
+++ b/packages/fields-datetime-utc/src/Implementation.js
@@ -38,6 +38,9 @@ export class DateTimeUtcImplementation extends Implementation {
 
 // All values must have an offset
 const toDate = str => {
+  if (str === null) {
+    return null;
+  }
   if (!str.match(/([zZ]|[\+\-][0-9]+(\:[0-9]+)?)$/)) {
     throw `Value supplied (${str}) is not a valid date time with offset.`;
   }


### PR DESCRIPTION
when the string received in toDate is null, the date returned should also be null

# Bug report
It seems that you cannot filter on null in graphQL when using DateTimeUtc
## Describe the bug

I defined a field of type DateTimeUtc and I cannot filter this field to be null.

## To Reproduce

Define a list like this:

todo.js:

```
module.exports = {
  fields: {
    name: {
      type: Text,
      isRequired: true,
    },
    completedAt: {
      type: DateTimeUtc
    }
}
```

Then start the server and go to the graphiql interface and execute the following query:
```
query {
    allTodos(where: {completedAt: null} ) {
      id
    }
  }
```

This will result in the following error:
```
{
  "errors": [
    {
      "message": "Cannot read property 'match' of null",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "allTodos"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "stacktrace": [
            "TypeError: Cannot read property 'match' of null",
            "    at toDate (/backend/node_modules/@keystonejs/fields-datetime-utc/dist/fields-datetime-utc.cjs.js:97:12)",
            "    at Object.completedAt (/backend/node_modules/@keystonejs/adapter-mongoose/lib/adapter-mongoose.js:647:49)",
            "    at simpleTokenizer (/backend/node_modules/@keystonejs/mongo-join-builder/lib/tokenizers.js:103:43)",
            "    at /backend/node_modules/@keystonejs/mongo-join-builder/lib/query-parser.js:55:27",
            "    at Array.map (<anonymous>)",
            "    at queryParser (/backend/node_modules/@keystonejs/mongo-join-builder/lib/query-parser.js:27:47)",
            "    at MongooseListAdapter._itemsQuery (/backend/node_modules/@keystonejs/adapter-mongoose/lib/adapter-mongoose.js:550:23)",
            "    at MongooseListAdapter.itemsQuery (/backend/node_modules/@keystonejs/keystone/lib/adapters/index.js:139:32)",
            "    at List._itemsQuery (/backend/node_modules/@keystonejs/keystone/lib/List/index.js:932:40)",
            "    at List.listQuery (/backend/node_modules/@keystonejs/keystone/lib/List/index.js:818:17)",
            "    at allTodos (/backend/node_modules/@keystonejs/keystone/lib/List/index.js:800:16)",
            "    at field.resolve (/backend/node_modules/graphql-extensions/dist/index.js:133:26)",
            "    at resolveFieldValueOrError (/backend/node_modules/graphql/execution/execute.js:467:18)",
            "    at resolveField (/backend/node_modules/graphql/execution/execute.js:434:16)",
            "    at executeFields (/backend/node_modules/graphql/execution/execute.js:275:18)",
            "    at executeOperation (/backend/node_modules/graphql/execution/execute.js:219:122)"
          ]
        }
      },
      "uid": "ck9sw28c7000iz8s63o0yg6fm",
      "name": "GraphQLError"
    }
  ],
  "data": {
    "allTodos": null
  }
}
```

## Expected behaviour

To receive all Todo items where the completedAt field is null

## System information

- OS: macOs
- Browser: chrome
