### PR TITLE
Remove AdminUIApp.createSessionMiddleware

### DIFF
--- a/.changeset/gorgeous-lemons-peel.md
+++ b/.changeset/gorgeous-lemons-peel.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': major
+---
+
+Removed `AdminUIApp.createSessionMiddleware()`. No need to take an action if you were explicitly using this method.

--- a/packages/app-admin-ui/index.js
+++ b/packages/app-admin-ui/index.js
@@ -58,22 +58,6 @@ class AdminUIApp {
     );
   }
 
-  createSessionMiddleware() {
-    const { signinPath } = this.routes;
-
-    const app = express();
-
-    // Short-circuit GET requests when the user already signed in (avoids
-    // downloading UI bundle, doing a client side redirect, etc)
-    app.get(signinPath, (req, res, next) =>
-      this.isAccessAllowed(req) ? res.redirect(this.adminPath) : next()
-    );
-
-    // TODO: Attach a server-side signout to signoutPath
-
-    return app;
-  }
-
   build({ keystone, distDir }) {
     const builtAdminRoot = path.join(distDir, 'admin');
 
@@ -195,7 +179,12 @@ class AdminUIApp {
     }
 
     if (this.authStrategy) {
-      app.use(this.createSessionMiddleware());
+      // Short-circuit GET requests when the user already signed in (avoids
+      // downloading UI bundle, doing a client side redirect, etc)
+      app.get(this.routes.signinPath, (req, res, next) =>
+        this.isAccessAllowed(req) ? res.redirect(this.adminPath) : next()
+      );
+
       for (const pair of middlewarePairs) {
         app.use(mountPath, (req, res, next) => {
           return this.isAccessAllowed(req)


### PR DESCRIPTION
This method was a vestigial remnant from earlier code, there's no reason for it to be anything other than inline code.