### PR TITLE
Don't save list in Field controllers

### DIFF
--- a/.changeset/chatty-garlics-applaud.md
+++ b/.changeset/chatty-garlics-applaud.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/fields': minor
+---
+
+The base `FieldController` class no longer takes the owning list as a second argument.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -24,7 +24,7 @@ export default class List {
 
     this.fields = fields.map(fieldConfig => {
       const [Controller] = adminMeta.readViews([views[fieldConfig.path].Controller]);
-      return new Controller(fieldConfig, this, adminMeta, views[fieldConfig.path]);
+      return new Controller(fieldConfig, adminMeta, views[fieldConfig.path]);
     });
 
     this._fieldsByPath = arrayToObject(this.fields, 'path');

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -1,14 +1,13 @@
 import isEqual from 'lodash.isequal';
 
 export default class FieldController {
-  constructor(config, list, adminMeta, views) {
+  constructor(config, adminMeta, views) {
     this.config = config;
     this.label = config.label;
     this.path = config.path;
     this.type = config.type;
     this.maybeAccess = config.access;
     this.isPrimaryKey = config.isPrimaryKey;
-    this.list = list;
     this.adminMeta = adminMeta;
     this.views = views;
 

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -65,7 +65,6 @@ describe('getDefaultValue()', () => {
   test('Default defined as `undefined`', () => {
     const controller = new FieldController(
       { ...config, defaultValue: undefined },
-
       'adminMeta'
     );
     const value = controller.getDefaultValue({});
@@ -81,7 +80,6 @@ describe('getDefaultValue()', () => {
   test('Default defined as a string', () => {
     const controller = new FieldController(
       { ...config, defaultValue: 'default' },
-
       'adminMeta'
     );
     const value = controller.getDefaultValue({});
@@ -92,7 +90,6 @@ describe('getDefaultValue()', () => {
     test('function is executed', () => {
       const controller = new FieldController(
         { ...config, defaultValue: () => 'default' },
-
         'adminMeta'
       );
       const value = controller.getDefaultValue({});

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -63,10 +63,7 @@ describe('getDefaultValue()', () => {
   });
 
   test('Default defined as `undefined`', () => {
-    const controller = new FieldController(
-      { ...config, defaultValue: undefined },
-      'adminMeta'
-    );
+    const controller = new FieldController({ ...config, defaultValue: undefined }, 'adminMeta');
     const value = controller.getDefaultValue({});
     expect(value).toEqual(undefined);
   });
@@ -78,10 +75,7 @@ describe('getDefaultValue()', () => {
   });
 
   test('Default defined as a string', () => {
-    const controller = new FieldController(
-      { ...config, defaultValue: 'default' },
-      'adminMeta'
-    );
+    const controller = new FieldController({ ...config, defaultValue: 'default' }, 'adminMeta');
     const value = controller.getDefaultValue({});
     expect(value).toEqual('default');
   });

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -10,19 +10,18 @@ const config = {
 
 describe('new Controller()', () => {
   test('new Controller() - Smoke test', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     expect(controller).not.toBeNull();
 
     expect(controller.config).toEqual(config);
     expect(controller.label).toEqual('label');
     expect(controller.type).toEqual('type');
-    expect(controller.list).toEqual('list');
     expect(controller.adminMeta).toEqual('adminMeta');
   });
 });
 
 test('getQueryFragment()', () => {
-  const controller = new FieldController(config, 'list', 'adminMeta');
+  const controller = new FieldController(config, 'adminMeta');
 
   const value = controller.getQueryFragment();
   expect(value).toEqual('path');
@@ -30,13 +29,13 @@ test('getQueryFragment()', () => {
 
 describe('serialize()', () => {
   test('serialize() - path exists', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     let value = controller.serialize({ path: 'some_value' });
     expect(value).toEqual('some_value');
   });
 
   test('serialize() - path does not exist', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     const value = controller.serialize({});
     expect(value).toEqual(null);
   });
@@ -44,13 +43,13 @@ describe('serialize()', () => {
 
 describe('deserialize()', () => {
   test('deserialize() - path exists', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     let value = controller.deserialize({ path: 'some_value' });
     expect(value).toEqual('some_value');
   });
 
   test('deserialize() - path does not exist', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     const value = controller.deserialize({});
     expect(value).toEqual(undefined);
   });
@@ -58,7 +57,7 @@ describe('deserialize()', () => {
 
 describe('getDefaultValue()', () => {
   test('No default', () => {
-    const controller = new FieldController(config, 'list', 'adminMeta');
+    const controller = new FieldController(config, 'adminMeta');
     const value = controller.getDefaultValue({});
     expect(value).toEqual(undefined);
   });
@@ -66,7 +65,7 @@ describe('getDefaultValue()', () => {
   test('Default defined as `undefined`', () => {
     const controller = new FieldController(
       { ...config, defaultValue: undefined },
-      'list',
+
       'adminMeta'
     );
     const value = controller.getDefaultValue({});
@@ -74,7 +73,7 @@ describe('getDefaultValue()', () => {
   });
 
   test('Default defined as `null`', () => {
-    const controller = new FieldController({ ...config, defaultValue: null }, 'list', 'adminMeta');
+    const controller = new FieldController({ ...config, defaultValue: null }, 'adminMeta');
     const value = controller.getDefaultValue({});
     expect(value).toEqual(null);
   });
@@ -82,7 +81,7 @@ describe('getDefaultValue()', () => {
   test('Default defined as a string', () => {
     const controller = new FieldController(
       { ...config, defaultValue: 'default' },
-      'list',
+
       'adminMeta'
     );
     const value = controller.getDefaultValue({});
@@ -93,7 +92,7 @@ describe('getDefaultValue()', () => {
     test('function is executed', () => {
       const controller = new FieldController(
         { ...config, defaultValue: () => 'default' },
-        'list',
+
         'adminMeta'
       );
       const value = controller.getDefaultValue({});
@@ -104,7 +103,7 @@ describe('getDefaultValue()', () => {
       const originalInput = {};
       const prefill = {};
       const defaultValue = jest.fn(() => 'default');
-      const controller = new FieldController({ ...config, defaultValue }, 'list', 'adminMeta');
+      const controller = new FieldController({ ...config, defaultValue }, 'adminMeta');
       controller.getDefaultValue({ originalInput, prefill });
       expect(defaultValue).toHaveBeenCalledWith({ originalInput, prefill });
     });


### PR DESCRIPTION
This was unused and all it did was create a circular reference wherein you could access the list which contained the fields from the fields. 😝 