### PR TITLE
Explicit FieldController config, elevated some keys

### DIFF
--- a/.changeset/soft-dogs-rest.md
+++ b/.changeset/soft-dogs-rest.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/fields': minor
+'@keystonejs/demo-custom-fields': patch
+'@keystonejs/app-admin-ui': patch
+---
+
+Elevated isOrderable, isRequired, and adminDoc keys to direct FieldController properties.

--- a/demo-projects/custom-fields/fields/MultiCheck/views/Field.js
+++ b/demo-projects/custom-fields/fields/MultiCheck/views/Field.js
@@ -41,8 +41,8 @@ const MultiCheckField = ({ onChange, autoFocus, field, value, errors }) => {
       {accessError ? (
         <ShieldIcon title={accessError.message} css={{ color: colors.N20, marginRight: '1em' }} />
       ) : null}
-      {field.config.isRequired ? <Lozenge appearance="primary"> Required </Lozenge> : null}
-      <FieldDescription text={field.config.adminDoc} />
+      {field.isRequired ? <Lozenge appearance="primary"> Required </Lozenge> : null}
+      <FieldDescription text={field.adminDoc} />
       <div>
         {field.config.options.map(label => (
           <Checkbox

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -80,7 +80,7 @@ function CreateItemModal({ prefillData = {}, isLoading, createItem, onClose, onC
     // that we don't omit the required fields for client-side input validation.
     function hasnotChangedAndIsNotRequired(path) {
       const hasChanged = fieldsObject[path].hasChanged(initialValues, currentValues);
-      const isRequired = fieldsObject[path].config.isRequired;
+      const isRequired = fieldsObject[path].isRequired;
       return !hasChanged && !isRequired;
     }
 

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -350,7 +350,7 @@ export default function ListTable(props) {
               <SortLink
                 data-field={field.path}
                 key={field.path}
-                sortable={field.path !== '_label_' && field.config.isOrderable}
+                sortable={field.path !== '_label_' && field.isOrderable}
                 field={field}
                 handleSortChange={onSortChange}
                 active={sortBy ? sortBy.field.path === field.path : false}

--- a/packages/app-admin-ui/client/pages/List/url-state.js
+++ b/packages/app-admin-ui/client/pages/List/url-state.js
@@ -48,7 +48,7 @@ const parseSortBy = (sortBy, list) => {
     direction = 'DESC';
   }
 
-  const field = list.fields.filter(field => field.config.isOrderable).find(f => f.path === key);
+  const field = list.fields.filter(field => field.isOrderable).find(f => f.path === key);
   if (!field) {
     return null;
   }

--- a/packages/arch/packages/fields/src/index.js
+++ b/packages/arch/packages/fields/src/index.js
@@ -31,7 +31,7 @@ export const FieldLabel = props => {
       {accessError ? (
         <ShieldIcon title={accessError.message} css={{ color: colors.N20, marginRight: '1em' }} />
       ) : null}{' '}
-      {props.field.config.isRequired ? <Lozenge appearance="primary"> Required </Lozenge> : null}
+      {props.field.isRequired ? <Lozenge appearance="primary"> Required </Lozenge> : null}
     </label>
   );
 };

--- a/packages/fields-markdown/src/views/Field.js
+++ b/packages/fields-markdown/src/views/Field.js
@@ -102,7 +102,7 @@ export default function MarkdownField({ field, errors, value, onChange }) {
       ]}
     >
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <div
         css={{
           border: `1px ${colors.N20} solid`,

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -1,14 +1,22 @@
 import isEqual from 'lodash.isequal';
 
 export default class FieldController {
-  constructor(config, list, adminMeta, views) {
+  constructor(
+    { label, path, type, access, isOrderable, isPrimaryKey, isRequired, adminDoc, ...config },
+    list,
+    adminMeta,
+    views
+  ) {
     this.config = config;
-    this.label = config.label;
-    this.path = config.path;
-    this.type = config.type;
-    this.maybeAccess = config.access;
-    this.isPrimaryKey = config.isPrimaryKey;
+    this.label = label;
+    this.path = path;
+    this.type = type;
+    this.maybeAccess = access;
+    this.isOrderable = isOrderable;
+    this.isPrimaryKey = isPrimaryKey;
+    this.isRequired = isRequired;
     this.list = list;
+    this.adminDoc = adminDoc;
     this.adminMeta = adminMeta;
     this.views = views;
 

--- a/packages/fields/src/types/CalendarDay/views/Field.js
+++ b/packages/fields/src/types/CalendarDay/views/Field.js
@@ -12,7 +12,7 @@ const CalendarDayField = ({ autoFocus, field, value, errors, onChange }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <TextDayPicker
           id={htmlID}

--- a/packages/fields/src/types/Checkbox/views/Field.js
+++ b/packages/fields/src/types/Checkbox/views/Field.js
@@ -16,7 +16,7 @@ const CheckboxField = ({ onChange, autoFocus, field, value, errors }) => {
 
   return (
     <FieldContainer>
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput css={{ height: 35, alignItems: 'center' }}>
         <CheckboxPrimitive
           autoFocus={autoFocus}

--- a/packages/fields/src/types/CloudinaryImage/views/Field.js
+++ b/packages/fields/src/types/CloudinaryImage/views/Field.js
@@ -233,7 +233,7 @@ export default class FileField extends Component {
     return (
       <FieldContainer>
         <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-        <FieldDescription text={field.config.adminDoc} />
+        <FieldDescription text={field.adminDoc} />
         <FieldInput>
           {!isEmpty && imagePath ? (
             <Wrapper>

--- a/packages/fields/src/types/Color/views/Field.js
+++ b/packages/fields/src/types/Color/views/Field.js
@@ -61,7 +61,7 @@ const ColorField = ({ field, value: serverValue, errors, onChange }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Popout width={220} target={target}>
           <SketchPicker

--- a/packages/fields/src/types/DateTime/views/Field.js
+++ b/packages/fields/src/types/DateTime/views/Field.js
@@ -11,7 +11,7 @@ const DateTimeField = ({ autoFocus, field, onChange, value, errors }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <TextDayTimePicker id={htmlID} date={value} onChange={onChange} autoFocus={autoFocus} />
       </FieldInput>

--- a/packages/fields/src/types/Decimal/views/Field.js
+++ b/packages/fields/src/types/Decimal/views/Field.js
@@ -37,7 +37,7 @@ const DecimalField = ({ onChange, autoFocus, field, value, errors }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         {symbol && <Currency>{symbol}</Currency>}
         <Input

--- a/packages/fields/src/types/File/views/Field.js
+++ b/packages/fields/src/types/File/views/Field.js
@@ -224,7 +224,7 @@ export default class FileField extends Component {
     return (
       <FieldContainer>
         <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-        <FieldDescription text={field.config.adminDoc} />
+        <FieldDescription text={field.adminDoc} />
         <FieldInput>
           {file ? (
             <Wrapper>

--- a/packages/fields/src/types/Float/views/Field.js
+++ b/packages/fields/src/types/Float/views/Field.js
@@ -17,7 +17,7 @@ const FloatField = ({ onChange, autoFocus, field, value, errors }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Integer/views/Field.js
+++ b/packages/fields/src/types/Integer/views/Field.js
@@ -26,7 +26,7 @@ const IntegerField = ({ onChange, autoFocus, field, value, errors }) => {
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Location/views/Field.js
+++ b/packages/fields/src/types/Location/views/Field.js
@@ -75,7 +75,7 @@ const LocationField = ({ field, value: serverValue, errors, onChange, google, re
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput css={{ flexDirection: 'column' }}>
         <Select
           isAsync

--- a/packages/fields/src/types/OEmbed/views/Field.js
+++ b/packages/fields/src/types/OEmbed/views/Field.js
@@ -57,7 +57,7 @@ const OEmbedField = ({ onChange, autoFocus, field, value = null, savedValue = nu
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Password/views/Controller.js
+++ b/packages/fields/src/types/Password/views/Controller.js
@@ -28,9 +28,9 @@ export default class PasswordController extends FieldController {
   };
 
   validateInput = ({ originalInput, addFieldValidationError }) => {
-    const { isRequired, minLength } = this.config;
+    const { minLength } = this.config;
 
-    if (isRequired) {
+    if (this.isRequired) {
       if (!originalInput[this.path] || !originalInput[this.path].inputPassword) {
         return addFieldValidationError(`Password is required`);
       }

--- a/packages/fields/src/types/Password/views/Field.js
+++ b/packages/fields/src/types/Password/views/Field.js
@@ -65,7 +65,7 @@ const PasswordField = ({
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         {isEditing ? (
           <FlexGroup growIndexes={[0, 1]}>

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -187,7 +187,7 @@ const RelationshipField = ({
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <div css={{ flex: 1 }}>
           <RelationshipSelect

--- a/packages/fields/src/types/Select/views/Field.js
+++ b/packages/fields/src/types/Select/views/Field.js
@@ -28,7 +28,7 @@ const SelectField = ({ onChange, autoFocus, field, value: serverValue, renderCon
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <div css={{ flex: 1 }}>
           <Select

--- a/packages/fields/src/types/Text/views/Field.js
+++ b/packages/fields/src/types/Text/views/Field.js
@@ -21,7 +21,7 @@ const TextField = ({ onChange, autoFocus, field, errors, value: serverValue }) =
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Unsplash/views/Field.js
+++ b/packages/fields/src/types/Unsplash/views/Field.js
@@ -20,7 +20,7 @@ const UnsplashField = ({ onChange, autoFocus, field, errors, value: serverValue 
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Url/views/Field.js
+++ b/packages/fields/src/types/Url/views/Field.js
@@ -20,7 +20,7 @@ const UrlField = ({ onChange, autoFocus, field, value: serverValue, errors }) =>
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Uuid/views/Field.js
+++ b/packages/fields/src/types/Uuid/views/Field.js
@@ -20,7 +20,7 @@ const UuidField = ({ onChange, autoFocus, field, errors, value: serverValue }) =
   return (
     <FieldContainer>
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <FieldInput>
         <Input
           autoComplete="off"

--- a/packages/fields/src/types/Virtual/views/Field.js
+++ b/packages/fields/src/types/Virtual/views/Field.js
@@ -42,7 +42,7 @@ const VirtualField = ({ field, errors, value: serverValue }) => {
   return (
     <FieldContainer>
       <FieldLabel field={field} errors={errors} />
-      <FieldDescription text={field.config.adminDoc} />
+      <FieldDescription text={field.adminDoc} />
       <PrettyData data={canRead ? value : undefined} />
     </FieldContainer>
   );

--- a/packages/fields/tests/Controller.test.js
+++ b/packages/fields/tests/Controller.test.js
@@ -4,8 +4,6 @@ const config = {
   path: 'path',
   label: 'label',
   type: 'type',
-  list: 'list',
-  adminMeta: 'adminMeta',
 };
 
 describe('new Controller()', () => {
@@ -13,7 +11,7 @@ describe('new Controller()', () => {
     const controller = new FieldController(config, 'list', 'adminMeta');
     expect(controller).not.toBeNull();
 
-    expect(controller.config).toEqual(config);
+    expect(controller.config).toEqual({});
     expect(controller.label).toEqual('label');
     expect(controller.type).toEqual('type');
     expect(controller.list).toEqual('list');


### PR DESCRIPTION
This adds `isOrderable`, `isRequired`, and `adminDoc` as top-level `FieldController` properties (previously they were only available in `config` despite other keys like `isPrimaryKey` being explicitly set. It also removes the duplicate keys between `field` and `field.config`.

This leaves `field.config` containing only type-specific config options (see below, for example) plus any options the user passed through with field-level `adminConfig`.

![image](https://user-images.githubusercontent.com/3558659/81042314-940c7000-8efb-11ea-8473-8130afdcdd92.png)
