### PR TITLE
Fixed Admin UI sometimes using the wrong auth mutation name

### DIFF
--- a/.changeset/late-countries-yell.md
+++ b/.changeset/late-countries-yell.md
@@ -1,6 +1,7 @@
 ---
 '@keystonejs/app-admin-ui': patch
 '@keystonejs/auth-password': patch
+'@keystonejs/keystone': patch
 ---
 
 Fixed Admin UI sometimes using the wrong auth mutation name.

--- a/.changeset/late-countries-yell.md
+++ b/.changeset/late-countries-yell.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@keystonejs/auth-password': patch
+---
+
+Fixed Admin UI sometimes using the wrong auth mutation name.

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -314,11 +314,11 @@ const UserIcon = styled.div`
   margin-right: ${PRIMARY_NAV_GUTTER}px;
 `;
 
-const UserInfo = ({ authListKey, authListPath }) => {
+const UserInfo = ({ authQueryName, authListPath }) => {
   // We're assuming the user list as a 'name' field
   const AUTHED_USER_QUERY = gql`
     query {
-      user: authenticated${authListKey} {
+      user: authenticated${authQueryName} {
         id
         name
       }
@@ -423,7 +423,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
     listKeys,
     name,
     pages,
-    authStrategy: { listKey: authListKey } = {},
+    authStrategy: { itemQueryName: authQueryName, listKey: authListKey } = {},
   } = useAdminMeta();
   return (
     <Inner>
@@ -444,7 +444,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
       </Title>
       {authListKey && (
         <UserInfo
-          authListKey={authListKey}
+          authQueryName={authQueryName}
           authListPath={`${adminPath}/${getListByKey(authListKey).path}`}
         />
       )}

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -318,7 +318,7 @@ const UserInfo = ({ authQueryName, authListPath }) => {
   // We're assuming the user list as a 'name' field
   const AUTHED_USER_QUERY = gql`
     query {
-      user: authenticated${authQueryName} {
+      user: ${authQueryName} {
         id
         name
       }
@@ -423,7 +423,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
     listKeys,
     name,
     pages,
-    authStrategy: { itemQueryName: authQueryName, listKey: authListKey } = {},
+    authStrategy: { gqlNames: { authenticatedQueryName }, listKey: authListKey } = {},
   } = useAdminMeta();
   return (
     <Inner>
@@ -444,7 +444,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
       </Title>
       {authListKey && (
         <UserInfo
-          authQueryName={authQueryName}
+          authQueryName={authenticatedQueryName}
           authListPath={`${adminPath}/${getListByKey(authListKey).path}`}
         />
       )}

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -314,11 +314,17 @@ const UserIcon = styled.div`
   margin-right: ${PRIMARY_NAV_GUTTER}px;
 `;
 
-const UserInfo = ({ authQueryName, authListPath }) => {
+const UserInfo = ({ authListPath }) => {
+  const {
+    authStrategy: {
+      gqlNames: { authenticatedQueryName },
+    },
+  } = useAdminMeta();
+
   // We're assuming the user list as a 'name' field
   const AUTHED_USER_QUERY = gql`
     query {
-      user: ${authQueryName} {
+      user: ${authenticatedQueryName} {
         id
         name
       }
@@ -423,7 +429,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
     listKeys,
     name,
     pages,
-    authStrategy: { gqlNames: { authenticatedQueryName }, listKey: authListKey } = {},
+    authStrategy: { listKey: authListKey } = {},
   } = useAdminMeta();
   return (
     <Inner>
@@ -442,12 +448,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
       >
         {name}
       </Title>
-      {authListKey && (
-        <UserInfo
-          authQueryName={authenticatedQueryName}
-          authListPath={`${adminPath}/${getListByKey(authListKey).path}`}
-        />
-      )}
+      {authListKey && <UserInfo authListPath={`${adminPath}/${getListByKey(authListKey).path}`} />}
       <ActionItems mouseIsOverNav={mouseIsOverNav} />
       <PrimaryNavItems
         adminPath={adminPath}

--- a/packages/app-admin-ui/client/pages/Signin.js
+++ b/packages/app-admin-ui/client/pages/Signin.js
@@ -72,7 +72,11 @@ const Spacer = styled.div({
 const SignInPage = () => {
   const {
     name: siteName,
-    authStrategy: { itemQueryName, identityField, secretField },
+    authStrategy: {
+      gqlNames: { authenticateMutationName },
+      identityField,
+      secretField,
+    },
   } = useAdminMeta();
 
   const { logo: getCustomLogo } = useUIHooks();
@@ -83,7 +87,7 @@ const SignInPage = () => {
 
   const AUTH_MUTATION = gql`
     mutation signin($identity: String, $secret: String) {
-      authenticate: authenticate${itemQueryName}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
+      authenticate: ${authenticateMutationName}(${identityField}: $identity, ${secretField}: $secret) {
         item {
           id
         }

--- a/packages/app-admin-ui/client/pages/Signin.js
+++ b/packages/app-admin-ui/client/pages/Signin.js
@@ -72,7 +72,7 @@ const Spacer = styled.div({
 const SignInPage = () => {
   const {
     name: siteName,
-    authStrategy: { listKey, identityField, secretField },
+    authStrategy: { itemQueryName, identityField, secretField },
   } = useAdminMeta();
 
   const { logo: getCustomLogo } = useUIHooks();
@@ -83,7 +83,7 @@ const SignInPage = () => {
 
   const AUTH_MUTATION = gql`
     mutation signin($identity: String, $secret: String) {
-      authenticate: authenticate${listKey}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
+      authenticate: authenticate${itemQueryName}WithPassword(${identityField}: $identity, ${secretField}: $secret) {
         item {
           id
         }

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -40,13 +40,15 @@ const SignOutPageButton = styled(Button)`
 
 const SignedOutPage = () => {
   const {
-    authStrategy: { listKey },
+    authStrategy: {
+      gqlNames: { unauthenticateMutationName },
+    },
     signinPath,
   } = useAdminMeta();
 
   const UNAUTH_MUTATION = gql`
     mutation {
-      unauthenticate: unauthenticate${listKey} {
+      unauthenticate: ${unauthenticateMutationName} {
         success
       }
     }

--- a/packages/auth-password/index.js
+++ b/packages/auth-password/index.js
@@ -118,8 +118,9 @@ class PasswordAuthStrategy {
 
   getAdminMeta() {
     const { listKey } = this;
+    const { itemQueryName } = this.getList().gqlNames;
     const { identityField, secretField } = this.config;
-    return { listKey, identityField, secretField };
+    return { listKey, itemQueryName, identityField, secretField };
   }
 }
 

--- a/packages/auth-password/index.js
+++ b/packages/auth-password/index.js
@@ -8,6 +8,7 @@ class PasswordAuthStrategy {
   constructor(keystone, listKey, config) {
     this.keystone = keystone;
     this.listKey = listKey;
+    this.gqlNames = {}; // Set by the auth provider
     this.config = {
       identityField: 'email',
       secretField: 'password',
@@ -117,10 +118,9 @@ class PasswordAuthStrategy {
   }
 
   getAdminMeta() {
-    const { listKey } = this;
-    const { itemQueryName } = this.getList().gqlNames;
+    const { listKey, gqlNames } = this;
     const { identityField, secretField } = this.config;
-    return { listKey, itemQueryName, identityField, secretField };
+    return { listKey, gqlNames, identityField, secretField };
   }
 }
 

--- a/packages/keystone/lib/providers/listAuth.js
+++ b/packages/keystone/lib/providers/listAuth.js
@@ -19,6 +19,9 @@ class ListAuthProvider {
       authenticateOutputName: `authenticate${itemQueryName}Output`,
       unauthenticateOutputName: `unauthenticate${itemQueryName}Output`,
     };
+
+    // Record GQL names in the strategy
+    authStrategy.gqlNames = this.gqlNames;
   }
 
   getTypes({ schemaName }) {


### PR DESCRIPTION
Fixes #2900

The auth provider uses `itemQueryName` to conjugate the mutation name:
```js
authenticateMutationName: `authenticate${itemQueryName}With${upcase(authStrategy.authType)}`,
```
As seen in the above issue, that's not *necessarily* always the same as `listKey`.

This saves a copy of the auth gql names in the strategy which are then passed to the admin meta. Design-wise, it's consistent with how the general CRUD gql names are handled. 