### PR TITLE
Fixed several access control input issues

### DIFF
--- a/.changeset/light-tips-train.md
+++ b/.changeset/light-tips-train.md
@@ -1,0 +1,10 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Fixed several access control input issues:
+- `itemIds` is now properly set in list-level updateMany mutation checks. Previoiusly this data was incorrectly assigned to `itemId` which is now `undefined` in list-level checks.
+- `itemIds` is now set in field-level updateMany mutation checks (previously `undefined`).
+- `itemId` is now set in field-level updateMany mutation checks (previously `undefined`). This is the ID of the item currently being checked.
+- `itemId` is now properly set in field-level updateSingle mutation checks (previously `undefined`). 
+- All field-level access control checks now have `gqlName` properly set (previously `undefined`). 

--- a/.changeset/light-tips-train.md
+++ b/.changeset/light-tips-train.md
@@ -3,7 +3,7 @@
 ---
 
 Fixed several access control input issues:
-- `itemIds` is now properly set in list-level updateMany mutation checks. Previoiusly this data was incorrectly assigned to `itemId` which is now `undefined` in list-level checks.
+- `itemIds` is now properly set in list-level updateMany mutation checks. Previously this data was incorrectly assigned to `itemId` which is now `undefined` in list-level checks.
 - `itemIds` is now set in field-level updateMany mutation checks (previously `undefined`).
 - `itemId` is now set in field-level updateMany mutation checks (previously `undefined`). This is the ID of the item currently being checked.
 - `itemId` is now properly set in field-level updateSingle mutation checks (previously `undefined`). 

--- a/.changeset/light-tips-train.md
+++ b/.changeset/light-tips-train.md
@@ -1,5 +1,5 @@
 ---
-'@keystonejs/keystone': patch
+'@keystonejs/keystone': major
 ---
 
 Fixed several access control input issues:

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -642,10 +642,10 @@ module.exports = class List {
     return mutations;
   }
 
-  checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData = {} }) {
+  checkFieldAccess(operation, itemsToUpdate, context, { gqlName, ...extraInternalData }) {
     const restrictedFields = [];
 
-    itemsToUpdate.forEach(({ existingItem, data }) => {
+    itemsToUpdate.forEach(({ existingItem, id, data }) => {
       this.fields
         .filter(field => field.path in data)
         .forEach(field => {
@@ -654,7 +654,8 @@ module.exports = class List {
             field.path,
             data,
             existingItem,
-            operation
+            operation,
+            { gqlName, itemId: id, ...extraInternalData }
           );
           if (!access) {
             restrictedFields.push(field.path);
@@ -662,7 +663,9 @@ module.exports = class List {
         });
     });
     if (restrictedFields.length) {
-      throwAccessDenied(opToType[operation], context, gqlName, extraData, { restrictedFields });
+      throwAccessDenied(opToType[operation], context, gqlName, extraInternalData, {
+        restrictedFields,
+      });
     }
   }
 
@@ -1384,9 +1387,9 @@ module.exports = class List {
   async updateMutation(id, data, context, mutationState) {
     const operation = 'update';
     const gqlName = this.gqlNames.updateMutationName;
-    const extraData = { itemId: id };
+    const extraData = { gqlName, itemId: id };
 
-    const access = this.checkListAccess(context, data, operation, { gqlName, ...extraData });
+    const access = this.checkListAccess(context, data, operation, extraData);
 
     const existingItem = await this.getAccessControlledItem(id, access, {
       context,
@@ -1396,7 +1399,7 @@ module.exports = class List {
 
     const itemsToUpdate = [{ existingItem, data }];
 
-    this.checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData });
+    this.checkFieldAccess(operation, itemsToUpdate, context, extraData);
 
     return await this._updateSingle(id, data, existingItem, context, mutationState);
   }
@@ -1405,20 +1408,20 @@ module.exports = class List {
     const operation = 'update';
     const gqlName = this.gqlNames.updateManyMutationName;
     const ids = data.map(d => d.id);
-    const extraData = { itemId: ids };
+    const extraData = { gqlName, itemIds: ids };
 
-    const access = this.checkListAccess(context, data, operation, { gqlName, ...extraData });
+    const access = this.checkListAccess(context, data, operation, extraData);
 
     const existingItems = await this.getAccessControlledItems(ids, access);
 
     const itemsToUpdate = zipObj({
       existingItem: existingItems,
-      id: ids,
+      id: ids, // itemId is taken from here in checkFieldAccess
       data: data.map(d => d.data),
     });
 
     // FIXME: We should do all of these in parallel and return *all* the field access violations
-    this.checkFieldAccess(operation, itemsToUpdate, context, { gqlName, extraData });
+    this.checkFieldAccess(operation, itemsToUpdate, context, extraData);
 
     return Promise.all(
       itemsToUpdate.map(({ existingItem, id, data }) =>

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -877,7 +877,7 @@ test('checkFieldAccess', () => {
       'read',
       [{ existingItem: { makeFalse: true }, data: { name: 'a', email: 'a@example.com' } }],
       context,
-      { gqlName: 'testing', extraData: { extra: 1 } }
+      { gqlName: 'testing', extra: 1 }
     );
   } catch (error) {
     thrownError = error;


### PR DESCRIPTION
Fixes #2899 along with a bunch of other issues I discovered:

- `itemIds` is now properly set in list-level updateMany mutation checks. Previously this data was incorrectly assigned to `itemId` which is now `undefined` in list-level checks.
- `itemIds` is now set in field-level updateMany mutation checks (previously `undefined`).
- `itemId` is now set in field-level updateMany mutation checks (previously `undefined`). This is the ID of the item currently being checked.
- `itemId` is now properly set in field-level updateSingle mutation checks (previously `undefined`). 
- All field-level access control checks now have `gqlName` properly set (previously `undefined`). 
