### PR TITLE
AnimateHeight fixes for calculating the node height

### DIFF
--- a/.changeset/gorgeous-fireants-approve.md
+++ b/.changeset/gorgeous-fireants-approve.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed reading of `AnimateHeight` node height which because of the rounding-down nature of `scrollHeight` property value could sometimes cause scrollbar to be present in the filter popout.
+
+Provided correct value for `AnimateHeight` css transition property's disabled state.

--- a/packages/app-admin-ui/client/components/AnimateHeight.js
+++ b/packages/app-admin-ui/client/components/AnimateHeight.js
@@ -80,8 +80,7 @@ export default class AnimateHeight extends Component {
           height,
           transition: isTransitioning
             ? 'height 220ms cubic-bezier(0.2, 0, 0, 1)'
-            : // idk why this is necessary but having this be null makes the transition break
-              'height 0s',
+            : 'none',
           overflow,
         }}
         onTransitionEnd={event => {

--- a/packages/app-admin-ui/client/components/AnimateHeight.js
+++ b/packages/app-admin-ui/client/components/AnimateHeight.js
@@ -78,9 +78,7 @@ export default class AnimateHeight extends Component {
       <div
         css={{
           height,
-          transition: isTransitioning
-            ? 'height 220ms cubic-bezier(0.2, 0, 0, 1)'
-            : 'none',
+          transition: isTransitioning ? 'height 220ms cubic-bezier(0.2, 0, 0, 1)' : 'none',
           overflow,
         }}
         onTransitionEnd={event => {

--- a/packages/app-admin-ui/client/components/AnimateHeight.js
+++ b/packages/app-admin-ui/client/components/AnimateHeight.js
@@ -27,7 +27,7 @@ export default class AnimateHeight extends Component {
   }
   calculateHeight = () => {
     const { autoScroll, initialHeight, onChange } = this.props;
-    const height = this.node ? this.node.scrollHeight : initialHeight;
+    const height = this.node ? this.node.offsetHeight : initialHeight;
 
     if (height !== this.state.height) {
       this.setState({ height });


### PR DESCRIPTION
This fixes an issue with reading the height of the `AnimateHeight `node. Before `scrollHeight` was used which by default rounds the height value down to an integer ([mentioned here @MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight#content)) which sometimes for certain OS/browser/zoom-level/font combinations could cause the scrollbar to be visible in the filter add/edit popouts if the height of the node was not an integer. 

Recommended at MDN `getBoundingClientRect().height` was not providing correct value reliably for the initial state of the node and only offsetHeight did work correctly in my tests for each case.

Also provided proper value `none` for no transition CSS transition property.

![scroll-visible](https://user-images.githubusercontent.com/112270/81205712-5ecf5300-8fcb-11ea-8721-6a8150b72d73.jpg)
