### PR TITLE
Cleaned up handling of defaultValue in field controllers

### DIFF
--- a/.changeset/quick-melons-occur.md
+++ b/.changeset/quick-melons-occur.md
@@ -1,6 +1,6 @@
 ---
 '@keystonejs/fields': patch
+'@keystonejs/field-content': patch
 ---
 
 Cleaned up handling of defaultValue in field controllers.
-

--- a/.changeset/quick-melons-occur.md
+++ b/.changeset/quick-melons-occur.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': patch
+---
+
+Cleaned up handling of defaultValue in field controllers.
+

--- a/packages/field-content/src/views/Controller.js
+++ b/packages/field-content/src/views/Controller.js
@@ -33,9 +33,7 @@ const flattenBlocks = inputBlocks =>
   }, {});
 
 export default class ContentController extends Controller {
-  constructor(config, ...args) {
-    const defaultValue =
-      'defaultValue' in config ? config.defaultValue : Value.fromJSON(initialValue);
+  constructor({ defaultValue = Value.fromJSON(initialValue), ...config }, ...args) {
     super({ ...config, defaultValue }, ...args);
 
     // Attach this as a memoized member function to avoid two pitfalls;

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -2,7 +2,18 @@ import isEqual from 'lodash.isequal';
 
 export default class FieldController {
   constructor(
-    { label, path, type, access, isOrderable, isPrimaryKey, isRequired, adminDoc, ...config },
+    {
+      label,
+      path,
+      type,
+      access,
+      isOrderable,
+      isPrimaryKey,
+      isRequired,
+      adminDoc,
+      defaultValue,
+      ...config
+    },
     adminMeta,
     views
   ) {
@@ -18,15 +29,11 @@ export default class FieldController {
     this.adminMeta = adminMeta;
     this.views = views;
 
-    if ('defaultValue' in config) {
-      if (typeof config.defaultValue !== 'function') {
-        this._getDefaultValue = ({ prefill }) => prefill[this.path] || config.defaultValue;
-      } else {
-        this._getDefaultValue = config.defaultValue;
-      }
-    } else {
+    if (typeof defaultValue !== 'function') {
       // By default, the default value is undefined
-      this._getDefaultValue = ({ prefill }) => prefill[this.path] || undefined;
+      this._getDefaultValue = ({ prefill }) => prefill[this.path] || defaultValue;
+    } else {
+      this._getDefaultValue = defaultValue;
     }
   }
 
@@ -97,7 +104,6 @@ export default class FieldController {
   hasChanged = (initialData, currentData) =>
     !isEqual(initialData[this.path], currentData[this.path]);
 
-  // eslint-disable-next-line no-unused-vars
   getDefaultValue = ({ originalInput = {}, prefill = {} } = {}) => {
     return this._getDefaultValue({ originalInput, prefill });
   };

--- a/packages/fields/src/types/Checkbox/views/Controller.js
+++ b/packages/fields/src/types/Checkbox/views/Controller.js
@@ -1,8 +1,7 @@
 import FieldController from '../../../Controller';
 
 export default class CheckboxController extends FieldController {
-  constructor(config, ...args) {
-    const defaultValue = 'defaultValue' in config ? config.defaultValue : false;
+  constructor({ defaultValue = false, ...config }, ...args) {
     super({ ...config, defaultValue }, ...args);
   }
   serialize = data => data[this.path];

--- a/packages/fields/src/types/Relationship/views/Controller.js
+++ b/packages/fields/src/types/Relationship/views/Controller.js
@@ -2,7 +2,7 @@ import FieldController from '../../../Controller';
 
 export default class RelationshipController extends FieldController {
   constructor(config, ...args) {
-    const defaultValue = 'defaultValue' in config ? config.defaultValue : config.many ? [] : null;
+    const { defaultValue = config.many ? [] : null } = config;
     super({ ...config, defaultValue }, ...args);
   }
   getRefList() {

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -1,8 +1,7 @@
 import FieldController from '../../../Controller';
 
 export default class SelectController extends FieldController {
-  constructor(config, ...args) {
-    const defaultValue = 'defaultValue' in config ? config.defaultValue : null;
+  constructor({ defaultValue = null, ...config }, ...args) {
     super({ ...config, defaultValue }, ...args);
     this.options = config.options;
     this.dataType = config.dataType;


### PR DESCRIPTION
- `defaultValue` is no longer saved in `field.config`.
- Cleaned up field-specific default handling
- Removed a redundant check (`defaultValue` will always be `undefined` if not specified in the passed-in config, so no need for an extra condition)