### PR TITLE
Admin UI: used _label_ query for logged-in-user display

### DIFF
--- a/.changeset/quick-wolves-swim.md
+++ b/.changeset/quick-wolves-swim.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Used _label_ query for logged-in-user display.

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -319,12 +319,11 @@ const UserInfo = ({ authListPath }) => {
     },
   } = useAdminMeta();
 
-  // We're assuming the user list as a 'name' field
   const AUTHED_USER_QUERY = gql`
     query {
       user: ${authenticatedQueryName} {
         id
-        name
+        _label_
       }
     }
   `;
@@ -353,7 +352,7 @@ const UserInfo = ({ authListPath }) => {
             to={`${authListPath}/${user.id}`}
             css={{ fontWeight: 'bold', color: colors.N90 }}
           >
-            {user.name}
+            {user._label_}
           </Truncate>
         )}
       </div>


### PR DESCRIPTION
As says. Using `name` causes issues if `name` isn't present and `_label_` is more consistent with the rest of the Admin UI anyway. If `name` *is* present the result is the same.

@ra-external should fix the issue you were seeing, I think