### PR TITLE
Fixed error when Relationship field was passed an undefined or null value

### DIFF
--- a/.changeset/healthy-shirts-pay.md
+++ b/.changeset/healthy-shirts-pay.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed error when Relationship field was passed an undefined or null value.

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -161,7 +161,7 @@ function CreateAndAddItem({ field, item, onCreate }) {
 const RelationshipField = ({
   autoFocus,
   field,
-  value,
+  value = [],
   renderContext,
   errors,
   onChange,
@@ -203,7 +203,7 @@ const RelationshipField = ({
         <ListProvider list={relatedList}>
           <CreateAndAddItem
             onCreate={item => {
-              onChange(many ? (value || []).concat(item) : item);
+              onChange(many ? value.concat(item) : item);
             }}
             field={field}
             item={item}
@@ -214,7 +214,7 @@ const RelationshipField = ({
           <SetAsCurrentUser
             many={many}
             onAddUser={user => {
-              onChange(many ? (value || []).concat(user) : user);
+              onChange(many ? value.concat(user) : user);
             }}
             value={value}
             listKey={authStrategy.listKey}


### PR DESCRIPTION
Fixes #2642, closes #2644.

While looking into #2941 I came across #2642 again (or at least, something with the same fix). @justintemps 's original fix (#2644) worked, but it hadn't been updated and it was still sans changeset. This just applies my suggested change and adds a changeset.

I'm not sure this deals with #2941 or not, but it'll be a lot easier to investigate without this in the way.