### PR TITLE
Admin UI: improved error handling on signin page

### DIFF
--- a/.changeset/rich-trees-roll.md
+++ b/.changeset/rich-trees-roll.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Improved error handling on Signin page.

--- a/packages/app-admin-ui/client/pages/Signin.js
+++ b/packages/app-admin-ui/client/pages/Signin.js
@@ -94,11 +94,7 @@ const SignInPage = () => {
 
   const [signIn, { error, loading, client }] = useMutation(AUTH_MUTATION, {
     variables: { identity, secret },
-    onCompleted: ({ error }) => {
-      if (error) {
-        throw error;
-      }
-
+    onCompleted: () => {
       // Ensure there's no old unauthenticated data hanging around
       client.resetStore();
 
@@ -108,7 +104,7 @@ const SignInPage = () => {
       // Let the server-side redirects kick in to send the user to the right place
       window.location.reload(true);
     },
-    onError: console.error,
+    onError: () => {}, // Remove once a bad password no longer throws an error
   });
 
   const onSubmit = e => {

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -55,15 +55,10 @@ const SignedOutPage = () => {
   `;
 
   const [signOut, { loading, client, called }] = useMutation(UNAUTH_MUTATION, {
-    onCompleted: ({ error }) => {
-      if (error) {
-        throw error;
-      }
-
+    onCompleted: () => {
       // Ensure there's no old authenticated data hanging around
       client.resetStore();
     },
-    onError: console.error,
   });
 
   if (!called) {


### PR DESCRIPTION
Related to #2300

A graphql error is still raised, but no we no longer have a big red console error as well 😬 v
![image](https://user-images.githubusercontent.com/3558659/81615929-41b4dd00-942e-11ea-9e25-e0e63358c723.png)
 
As for the `onCompleted` parameter, those were never used (no `error` in the query). Turns out I added those by mistake when I was converting these to functional components last year (I didn't realize `onCompleted` takes only the `data` result). 