### PR TITLE
Admin UI: don't include non-orderable field in Sort selection dropdown

### DIFF
--- a/.changeset/breezy-singers-watch.md
+++ b/.changeset/breezy-singers-watch.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Don't include non-orderable field in Sort selection dropdown.

--- a/packages/app-admin-ui/client/pages/List/SortSelect.js
+++ b/packages/app-admin-ui/client/pages/List/SortSelect.js
@@ -32,7 +32,13 @@ export default function SortPopout() {
     popoutRef.current.close();
   };
 
-  const cachedOptions = useMemo(() => list.fields.map(({ options, ...field }) => field), [list]);
+  const cachedOptions = useMemo(
+    () =>
+      list.fields
+        .filter(({ isOrderable }) => isOrderable) // TODO: should we include ID fields here?
+        .map(({ options, ...field }) => field),
+    [list]
+  );
 
   const cypressId = 'list-page-sort-button';
 


### PR DESCRIPTION
Using the non-orderable options would just fall back to the first field which was confusing.