### PR TITLE
Admin UI: fixed corner case where a non-orderable default could be selected

### DIFF
--- a/.changeset/large-dodos-pull.md
+++ b/.changeset/large-dodos-pull.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed corner case where a non-orderable default could be selected.

--- a/packages/app-admin-ui/client/pages/List/url-state.js
+++ b/packages/app-admin-ui/client/pages/List/url-state.js
@@ -7,15 +7,23 @@ import { pseudoLabelField } from './FieldSelect';
 
 const allowedSearchParams = ['currentPage', 'pageSize', 'search', 'fields', 'sortBy', 'filters'];
 
-const getSearchDefaults = props => {
-  const { defaultColumns, defaultSort, defaultPageSize } = props.list.adminConfig;
+const getSearchDefaults = ({ list }) => {
+  const { defaultColumns, defaultSort, defaultPageSize } = list.adminConfig;
 
-  // Dynamic defaults
-  const fields = parseFields(defaultColumns, props.list);
-  const sortBy =
-    parseSortBy(defaultSort, props.list) ||
-    (fields[0] ? { field: fields[0], direction: 'ASC' } : null);
+  // Look for the default sort-by fields
+  const fields = parseFields(defaultColumns, list);
+
+  // If defaultSort isn't a valid sortable field, fall back to the first such field, or none.
+  let sortBy = parseSortBy(defaultSort, list);
+  if (!sortBy) {
+    // TODO: should we include ID fields here?
+    const firstSortableField = fields.find(({ isOrderable }) => isOrderable);
+    sortBy = firstSortableField ? { field: firstSortableField, direction: 'ASC' } : null;
+  }
+
+  // Move the _label_ first
   fields.unshift(pseudoLabelField);
+
   return {
     currentPage: 1,
     pageSize: defaultPageSize,


### PR DESCRIPTION
@ra-external came across a bug revealed by the move to `sortBy` in the admin ui. If a list has *only* non-orderable fields (such as a list with only a `File`) field, you won't be able to access it since a graphql validation error will be thrown. This was due to blind selection of the first default field for sorting regardless of whether it was actually orderable or not. This was hidden due to the lack of validation with `orderBy`, but now cropped up.

This might be better done server-side when `defaultSort` is set. Thoughts? Thought I might do that separately. This is really just a hotfix.