### PR TITLE
Fix delete item bug

### DIFF
--- a/.changeset/quick-planets-cover.md
+++ b/.changeset/quick-planets-cover.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/adapter-knex': patch
+'@keystonejs/adapter-mongoose': patch
+---
+
+Fixed a bug which could lead to data loss (knex adapter only) when deleting items from a list which was the `1` side of a `1:N` relationship.

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -526,7 +526,10 @@ class KnexListAdapter extends BaseListAdapter {
     // Now traverse all self-referential relationships and sort them right out.
     await Promise.all(
       this.rels
-        .filter(({ tableName }) => tableName === this.key)
+        .filter(
+          ({ tableName, left, right }) =>
+            tableName === this.key && right && left.refListKey === right.refListKey
+        )
         .map(({ columnName, tableName }) =>
           this._setNullByValue({ tableName, columnName, value: id })
         )

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -474,7 +474,10 @@ class MongooseListAdapter extends BaseListAdapter {
     // Now traverse all self-referential relationships and sort them right out.
     await Promise.all(
       this.rels
-        .filter(({ tableName }) => tableName === this.key)
+        .filter(
+          ({ tableName, left, right }) =>
+            tableName === this.key && right && left.refListKey === right.refListKey
+        )
         .map(({ columnName, tableName }) =>
           this._setNullByValue({ tableName, columnName, value: id })
         )


### PR DESCRIPTION
In a one to many relationships (e.g. author: Post -> User), deleting a particular post could lead to the author of a different post being set to null. In particular, if you attempted to delete the post with `id = 37`, then any post with `author = 37` would have its author set to null. This only impacted the knex adapter and only if auto-incrementing IDs were used.