### PR TITLE
Admin UI: big cleanup of query construction

### DIFF
--- a/.changeset/few-bears-eat.md
+++ b/.changeset/few-bears-eat.md
@@ -1,8 +1,8 @@
 ---
-'@keystonejs/app-admin-ui': minor
-'@keystonejs/field-content': patch
-'@keystonejs/fields': patch
-'@keystonejs/fields-mongoid': patch
+'@keystonejs/app-admin-ui': major
+'@keystonejs/field-content': major
+'@keystonejs/fields': major
+'@keystonejs/fields-mongoid': major
 ---
 
-Refactored how list and item queries and generated.
+Refactored how list and item queries and generated. Field controllers' `getFilterGraphQL` method now returns an object in the format { filter: value } rather than a GraphQL string.

--- a/.changeset/few-bears-eat.md
+++ b/.changeset/few-bears-eat.md
@@ -1,0 +1,8 @@
+---
+'@keystonejs/app-admin-ui': minor
+'@keystonejs/field-content': patch
+'@keystonejs/fields': patch
+'@keystonejs/fields-mongoid': patch
+---
+
+Refactored how list and item queries and generated.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -103,11 +103,12 @@ export default class List {
     `;
   }
 
+  static requiredFields = ['_label_', 'id'];
+
   getListQuery(fields = []) {
-    const safeFields = fields.filter(field => field.path !== '_label_');
-    const requiredFields = ['_label_', 'id'].filter(
-      field => !safeFields.find(({ path }) => path === field)
-    );
+    const queryContents = fields
+      .filter(field => !List.requiredFields.includes(field.path))
+      .map(field => field.getQueryFragment().trim());
 
     return gql`
       query getList(
@@ -124,8 +125,8 @@ export default class List {
           first: $first,
           skip: $skip
         ) {
-          ${requiredFields.join('\n')}
-          ${safeFields.map(field => field.getQueryFragment()).join('\n')}
+          ${List.requiredFields.join('\n')}
+          ${queryContents.join('\n')}
         }
 
         ${this.gqlNames.listQueryMetaName}(where: $where, search: $search) {

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -2,10 +2,6 @@ import gql from 'graphql-tag';
 
 import { arrayToObject, mapKeys, omit } from '@keystonejs/utils';
 
-export const gqlCountQueries = lists => gql`{
-  ${lists.map(list => list.countQuery()).join('\n')}
-}`;
-
 export default class List {
   constructor(
     { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
@@ -34,9 +30,32 @@ export default class List {
 
     this._fieldsByPath = arrayToObject(this.fields, 'path');
 
+    const {
+      itemQueryName,
+      createInputName,
+      createMutationName,
+      createManyInputName,
+      createManyMutationName,
+      updateInputName,
+      updateMutationName,
+      updateManyInputName,
+      updateManyMutationName,
+      deleteMutationName,
+      deleteManyMutationName,
+    } = this.gqlNames;
+
+    this.itemQuery = gql`
+      query getItem($id: ID!) {
+        ${itemQueryName}(where: { id: $id }) {
+          _label_
+          ${this.fields.map(field => field.getQueryFragment()).join('\n')}
+        }
+      }
+    `;
+
     this.createMutation = gql`
-      mutation create($data: ${this.gqlNames.createInputName}!) {
-        ${this.gqlNames.createMutationName}(data: $data) {
+      mutation create($data: ${createInputName}!) {
+        ${createMutationName}(data: $data) {
           id
           _label_
         }
@@ -44,24 +63,24 @@ export default class List {
     `;
 
     this.createManyMutation = gql`
-      mutation createMany($data: ${this.gqlNames.createManyInputName}!) {
-        ${this.gqlNames.createManyMutationName}(data: $data) {
+      mutation createMany($data: ${createManyInputName}!) {
+        ${createManyMutationName}(data: $data) {
           id
         }
       }
     `;
 
     this.updateMutation = gql`
-      mutation update($id: ID!, $data: ${this.gqlNames.updateInputName}) {
-        ${this.gqlNames.updateMutationName}(id: $id, data: $data) {
+      mutation update($id: ID!, $data: ${updateInputName}) {
+        ${updateMutationName}(id: $id, data: $data) {
           id
         }
       }
     `;
 
     this.updateManyMutation = gql`
-      mutation updateMany($data: [${this.gqlNames.updateManyInputName}]) {
-        ${this.gqlNames.updateManyMutationName}(data: $data) {
+      mutation updateMany($data: [${updateManyInputName}]) {
+        ${updateManyMutationName}(data: $data) {
           id
         }
       }
@@ -69,7 +88,7 @@ export default class List {
 
     this.deleteMutation = gql`
       mutation delete($id: ID!) {
-        ${this.gqlNames.deleteMutationName}(id: $id) {
+        ${deleteMutationName}(id: $id) {
           id
         }
       }
@@ -77,63 +96,43 @@ export default class List {
 
     this.deleteManyMutation = gql`
       mutation deleteMany($ids: [ID!]) {
-        ${this.gqlNames.deleteManyMutationName}(ids: $ids) {
+        ${deleteManyMutationName}(ids: $ids) {
           id
         }
       }
     `;
   }
 
-  buildQuery(queryName, queryArgs = '', fields = []) {
-    let requiredFields = ['id', '_label_'];
-    return `
-      ${queryName}${queryArgs} {
-        ${requiredFields
-          .filter(requiredField => !fields.find(({ path }) => path === requiredField))
-          .join(' ')}
-        ${fields.map(field => field.getQueryFragment()).join(' ')}
-      }`;
-  }
-
-  static getQueryArgs = ({ filters, sortBy, ...args }) => {
-    const queryArgs = Object.keys(args).map(
-      // Using stringify to get the correct quotes depending on type
-      argName => `${argName}: ${JSON.stringify(args[argName])}`
-    );
-    if (filters) {
-      const filterArgs = filters.map(filter => filter.field.getFilterGraphQL(filter));
-      if (filterArgs.length) {
-        queryArgs.push(`where: { ${filterArgs.join(', ')} }`);
-      }
-    }
-    if (sortBy) {
-      queryArgs.push(`sortBy: ${sortBy.field.path}_${sortBy.direction}`);
-    }
-    return queryArgs.length ? `(${queryArgs.join(' ')})` : '';
-  };
-
-  getItemQuery(itemId) {
-    return gql`{
-      ${this.buildQuery(this.gqlNames.itemQueryName, `(where: { id: "${itemId}" })`, this.fields)}
-    }`;
-  }
-
-  getQuery(args) {
-    const { fields, filters, search, sortBy, skip, first } = args;
-    const sanatisedQueryArgs = Object.keys({ first, filters, search, skip, sortBy })
-      .filter(key => args[key])
-      .reduce((acc, key) => ({ ...acc, [key]: args[key] }), {});
-    const queryArgs = List.getQueryArgs(sanatisedQueryArgs);
-    const metaQueryArgs = List.getQueryArgs({ filters, search });
+  getListQuery(fields = []) {
     const safeFields = fields.filter(field => field.path !== '_label_');
-    return gql`{
-      ${this.buildQuery(this.gqlNames.listQueryName, queryArgs, safeFields)}
-      ${this.countQuery(metaQueryArgs)}
-    }`;
-  }
+    const requiredFields = ['_label_', 'id'].filter(
+      field => !safeFields.find(({ path }) => path === field)
+    );
 
-  countQuery(metaQueryArgs = '') {
-    return `${this.gqlNames.listQueryMetaName}${metaQueryArgs} { count }`;
+    return gql`
+      query getList(
+        $where: ${this.gqlNames.whereInputName}
+        $search: String,
+        $sortBy: [${this.gqlNames.listSortName}!]
+        $first: Int,
+        $skip: Int
+      ) {
+        ${this.gqlNames.listQueryName}(
+          where: $where,
+          search: $search,
+          sortBy: $sortBy,
+          first: $first,
+          skip: $skip
+        ) {
+          ${requiredFields.join('\n')}
+          ${safeFields.map(field => field.getQueryFragment()).join('\n')}
+        }
+
+        ${this.gqlNames.listQueryMetaName}(where: $where, search: $search) {
+          count
+        }
+      }
+    `;
   }
 
   getInitialItemData({ originalInput = {}, prefill = {} } = {}) {

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -9,12 +9,22 @@ import { ListProvider } from '../../providers/List';
 import DocTitle from '../../components/DocTitle';
 import PageError from '../../components/PageError';
 import { Box, HeaderInset } from './components';
-import { gqlCountQueries } from '../../classes/List';
 
 import { useAdminMeta } from '../../providers/AdminMeta';
 
 import useResizeObserver from 'use-resize-observer';
 import throttle from 'lodash.throttle';
+import gql from 'graphql-tag';
+
+const getCountQuery = lists => {
+  if (!lists) return null;
+
+  return gql`
+    query getAllListCounts {
+      ${lists.map(({ gqlNames }) => `${gqlNames.listQueryMetaName} { count }`).join('\n')}
+    }
+  `;
+};
 
 const Homepage = () => {
   const { getListByKey, listKeys, adminPath } = useAdminMeta();
@@ -22,8 +32,7 @@ const Homepage = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
-  const query = lists.length !== 0 ? gqlCountQueries(lists) : null;
-  const [getLists, { data, error, called }] = useLazyQuery(query, {
+  const [getLists, { data, error, called }] = useLazyQuery(getCountQuery(lists), {
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
   });

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -355,15 +355,14 @@ const ItemNotFound = ({ errorMessage, list }) => (
 const ItemPage = ({ itemId }) => {
   const { list } = useList();
 
-  const itemQuery = list.getItemQuery(itemId);
-
   // network-only because the data we mutate with is important for display
   // in the UI, and may be different than what's in the cache
   // NOTE: We specifically trigger this query here, before the later code which
   // could Suspend which allows the code and data to load in parallel.
-  const { loading, error, data, refetch } = useQuery(itemQuery, {
+  const { loading, error, data, refetch } = useQuery(list.itemQuery, {
     fetchPolicy: 'network-only',
     errorPolicy: 'all',
+    variables: { id: itemId },
   });
 
   // Now that the network request for data has been triggered, we

--- a/packages/app-admin-ui/client/providers/List.js
+++ b/packages/app-admin-ui/client/providers/List.js
@@ -1,4 +1,4 @@
-import React, { useContext, createContext, useState, useMemo } from 'react';
+import React, { useContext, createContext, useState } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
 import { useListUrlState } from '../pages/List/dataHooks';

--- a/packages/field-content/src/views/Controller.js
+++ b/packages/field-content/src/views/Controller.js
@@ -67,7 +67,7 @@ export default class ContentController extends Controller {
 
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: "${value}"`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields-mongoid/src/views/Controller.js
+++ b/packages/fields-mongoid/src/views/Controller.js
@@ -4,22 +4,16 @@ export default class MongoIdController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     switch (type) {
       case 'is': {
-        return `${this.path}: "${value}"`;
+        return { [this.path]: value };
       }
       case 'not': {
-        return `${this.path}_not: "${value}"`;
+        return { [`${this.path}_not`]: value };
       }
       case 'in': {
-        return `${this.path}_in: [${value
-          .split(',')
-          .map(value => `"${value.trim()}"`)
-          .join(',')}]`;
+        return { [`${this.path}_in`]: value.split(',').map(value => value.trim()) };
       }
       case 'not_in': {
-        return `${this.path}_not_in: [${value
-          .split(',')
-          .map(value => `"${value.trim()}"`)
-          .join(',')}]`;
+        return { [`${this.path}_not_in`]: value.split(',').map(value => value.trim()) };
       }
     }
   };

--- a/packages/fields/src/types/CalendarDay/views/Controller.js
+++ b/packages/fields/src/types/CalendarDay/views/Controller.js
@@ -4,7 +4,7 @@ import { getYear, parseISO } from 'date-fns';
 export default class CalendarDayController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: "${value}"`;
+    return { [key]: value };
   };
 
   getFilterLabel = ({ label }) => {

--- a/packages/fields/src/types/Checkbox/views/Controller.js
+++ b/packages/fields/src/types/Checkbox/views/Controller.js
@@ -8,7 +8,7 @@ export default class CheckboxController extends FieldController {
   deserialize = data => data[this.path];
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: ${value}`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/DateTime/views/Controller.js
+++ b/packages/fields/src/types/DateTime/views/Controller.js
@@ -4,7 +4,7 @@ import FieldController from '../../../Controller';
 export default class DateTimeController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: "${value}"`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/Decimal/views/Controller.js
+++ b/packages/fields/src/types/Decimal/views/Controller.js
@@ -3,7 +3,7 @@ import FieldController from '../../../Controller';
 export default class DecimalController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: "${value}"`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/Float/views/Controller.js
+++ b/packages/fields/src/types/Float/views/Controller.js
@@ -3,7 +3,7 @@ import FieldController from '../../../Controller';
 export default class FloatController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return `${key}: ${value}`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/Float/views/Controller.js
+++ b/packages/fields/src/types/Float/views/Controller.js
@@ -3,7 +3,7 @@ import FieldController from '../../../Controller';
 export default class FloatController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is' ? `${this.path}` : `${this.path}_${type}`;
-    return { [key]: value };
+    return { [key]: parseFloat(value) };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/Integer/views/Controller.js
+++ b/packages/fields/src/types/Integer/views/Controller.js
@@ -5,7 +5,9 @@ export default class IntegerController extends FieldController {
     const key = type === 'is' ? path : `${path}_${type}`;
     let arg = value.replace(/\s/g, '');
     if (['in', 'not_in'].includes(type)) {
-      arg = `[${arg}]`;
+      arg = arg.split(',').map(i => parseInt(i));
+    } else {
+      arg = parseInt(arg);
     }
     return { [key]: arg };
   };

--- a/packages/fields/src/types/Integer/views/Controller.js
+++ b/packages/fields/src/types/Integer/views/Controller.js
@@ -7,7 +7,7 @@ export default class IntegerController extends FieldController {
     if (['in', 'not_in'].includes(type)) {
       arg = `[${arg}]`;
     }
-    return `${key}: ${arg}`;
+    return { [key]: arg };
   };
   getFilterLabel = ({ label, type }) => {
     const suffix = ['in', 'not_in'].includes(type) ? ' (comma separated)' : '';

--- a/packages/fields/src/types/Password/views/Controller.js
+++ b/packages/fields/src/types/Password/views/Controller.js
@@ -2,7 +2,7 @@ import FieldController from '../../../Controller';
 
 export default class PasswordController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
-    return { [`${this.path}_${type}`]: value ? 'true' : 'false' };
+    return { [`${this.path}_${type}`]: value };
   };
   getFilterLabel = () => {
     return `${this.label}`;

--- a/packages/fields/src/types/Password/views/Controller.js
+++ b/packages/fields/src/types/Password/views/Controller.js
@@ -2,7 +2,7 @@ import FieldController from '../../../Controller';
 
 export default class PasswordController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
-    return `${this.path}_${type}: ${value ? 'true' : 'false'}`;
+    return { [`${this.path}_${type}`]: value ? 'true' : 'false' };
   };
   getFilterLabel = () => {
     return `${this.label}`;

--- a/packages/fields/src/types/Relationship/views/Controller.js
+++ b/packages/fields/src/types/Relationship/views/Controller.js
@@ -18,9 +18,9 @@ export default class RelationshipController extends FieldController {
   };
   getFilterGraphQL = ({ type, value }) => {
     if (type === 'contains') {
-      return `${this.path}_some: {id: "${value}"}`;
+      return { [`${this.path}_some`]: { id: value } };
     } else if (type === 'is') {
-      return `${this.path}: {id: "${value}"}`;
+      return { [`${this.path}`]: { id: value } };
     }
   };
   getFilterLabel = ({ label }) => {

--- a/packages/fields/src/types/Relationship/views/RelationshipSelect.js
+++ b/packages/fields/src/types/Relationship/views/RelationshipSelect.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useQuery } from '@apollo/react-hooks';
-import gql from 'graphql-tag';
 import Select from '@arch-ui/select';
 import { components } from 'react-select';
 import 'intersection-observer';
@@ -18,7 +17,7 @@ function useIntersectionObserver(cb, ref) {
   });
 }
 
-const initalItemsToLoad = 10;
+const initialItemsToLoad = 10;
 const subsequentItemsToLoad = 50;
 
 // to use hooks in render props
@@ -80,12 +79,10 @@ const Relationship = forwardRef(
           useIntersectionObserver(([{ isIntersecting }]) => {
             if (!props.isLoading && isIntersecting && props.options.length < count) {
               fetchMore({
-                query: gql`query RelationshipSelectMore($search: String!, $skip: Int!) {${refList.buildQuery(
-                  refList.gqlNames.listQueryName,
-                  `(first: ${subsequentItemsToLoad}, search: $search, skip: $skip)`
-                )}}`,
+                query: refList.getListQuery(),
                 variables: {
                   search,
+                  first: subsequentItemsToLoad,
                   skip: props.options.length,
                 },
                 updateQuery: (prev, { fetchMoreResult }) => {
@@ -153,10 +150,7 @@ const RelationshipSelect = ({
 }) => {
   const [search, setSearch] = useState('');
   const refList = field.getRefList();
-  const query = gql`query RelationshipSelect($search: String!, $skip: Int!) {${refList.buildQuery(
-    refList.gqlNames.listQueryName,
-    `(first: ${initalItemsToLoad}, search: $search, skip: $skip)`
-  )}${refList.countQuery(`(search: $search)`)}}`;
+  const query = refList.getListQuery();
 
   const canRead =
     !serverErrors ||
@@ -164,7 +158,7 @@ const RelationshipSelect = ({
   const selectProps = renderContext === 'dialog' ? { menuShouldBlockScroll: true } : null;
 
   const { data, error, loading, fetchMore } = useQuery(query, {
-    variables: { search, skip: 0 },
+    variables: { search, first: initialItemsToLoad, skip: 0 },
   });
 
   // TODO: better error UI

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -24,7 +24,7 @@ export default class SelectController extends FieldController {
 
     const value = isMulti ? `[${options.map(x => x.value).join(',')}]` : options[0].value;
 
-    return this.dataType === 'string' ? `${key}: "${value}"` : `${key}: ${value}`;
+    return { [key]: value };
   };
   getFilterLabel = (/*{ value }*/) => {
     return this.label;

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -22,7 +22,7 @@ export default class SelectController extends FieldController {
       key = `${this.path}_not`;
     }
 
-    const value = isMulti ? `[${options.map(x => x.value).join(',')}]` : options[0].value;
+    const value = isMulti ? options.map(x => x.value) : options[0].value;
 
     return { [key]: value };
   };

--- a/packages/fields/src/types/Text/views/Controller.js
+++ b/packages/fields/src/types/Text/views/Controller.js
@@ -3,7 +3,7 @@ import FieldController from '../../../Controller';
 export default class TextController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     const key = type === 'is_i' ? `${this.path}_i` : `${this.path}_${type}`;
-    return `${key}: "${value}"`;
+    return { [key]: value };
   };
   getFilterLabel = ({ label }) => {
     return `${this.label} ${label.toLowerCase()}`;

--- a/packages/fields/src/types/Uuid/views/Controller.js
+++ b/packages/fields/src/types/Uuid/views/Controller.js
@@ -4,22 +4,16 @@ export default class UuidController extends FieldController {
   getFilterGraphQL = ({ type, value }) => {
     switch (type) {
       case 'is': {
-        return `${this.path}: "${value}"`;
+        return { [this.path]: value };
       }
       case 'not': {
-        return `${this.path}_not: "${value}"`;
+        return { [`${this.path}_not`]: value };
       }
       case 'in': {
-        return `${this.path}_in: [${value
-          .split(',')
-          .map(value => `"${value.trim()}"`)
-          .join(',')}]`;
+        return { [`${this.path}_in`]: value.split(',').map(value => value.trim()) };
       }
       case 'not_in': {
-        return `${this.path}_not_in: [${value
-          .split(',')
-          .map(value => `"${value.trim()}"`)
-          .join(',')}]`;
+        return { [`${this.path}_not_in`]: value.split(',').map(value => value.trim()) };
       }
     }
   };


### PR DESCRIPTION
And now, my big weekend PR.

This refactors the Admin UI's list and item query construction. Instead of using complicated and very hard-to-read string concatenation, this makes use of query variables wherever possible.

- All queries are now named (prep for another change I have coming)!
- Changes the item query to a single, static query (since we're always fetching all fields) taking an `id` argument.
- List queries now use variables for all input (`search`, `where`, `skip`, `first,` and `sortBy`). The new `getListQuery` function only takes `fields` to control which fields we're querying since that can't be done via variables. Even better, using variables makes it clear exactly what arguments are accepted and their types.
- Since `where` filters are just passed in via variables now, `getFilterGraphQL` doesn't need to handle messy strings anymore and can just return plain objects!
- `gqlCountQueries` was removed and replaced with a helper in `Home/index.js`.