### PR TITLE
Admin UI: refactored how query refetches are handled

### DIFF
--- a/.changeset/pink-radios-join.md
+++ b/.changeset/pink-radios-join.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Refactored how query refetches are handled.

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -54,6 +54,7 @@ const CreateItemModal = ({ prefillData = {}, onClose, onCreate }) => {
   const [createItem, { loading }] = useMutation(list.createMutation, {
     errorPolicy: 'all',
     onError: error => handleCreateUpdateMutationError({ error, addToast }),
+    refetchQueries: ['getList', 'RelationshipSelect'],
   });
 
   const { fields } = list;

--- a/packages/app-admin-ui/client/components/DeleteItemModal.js
+++ b/packages/app-admin-ui/client/components/DeleteItemModal.js
@@ -4,7 +4,10 @@ import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
 
 export default function DeleteItemModal({ isOpen, item, list, onClose, onDelete }) {
-  const [deleteItem, { loading }] = useMutation(list.deleteMutation);
+  const [deleteItem, { loading }] = useMutation(list.deleteMutation, {
+    refetchQueries: ['getList'],
+  });
+
   return (
     <Confirm
       isOpen={isOpen}
@@ -21,9 +24,10 @@ export default function DeleteItemModal({ isOpen, item, list, onClose, onDelete 
         <Button
           appearance="danger"
           variant="ghost"
-          onClick={() => {
+          onClick={async () => {
             if (loading) return;
-            onDelete(deleteItem({ variables: { id: item.id } }));
+            await deleteItem({ variables: { id: item.id } });
+            onDelete();
           }}
         >
           Delete

--- a/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
@@ -4,7 +4,10 @@ import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
 
 export default function DeleteManyModal({ isOpen, itemIds, list, onClose, onDelete }) {
-  const [deleteItems, { loading }] = useMutation(list.deleteManyMutation);
+  const [deleteItems, { loading }] = useMutation(list.deleteManyMutation, {
+    refetchQueries: ['getList'],
+  });
+
   return (
     <Confirm
       isOpen={isOpen}
@@ -21,11 +24,10 @@ export default function DeleteManyModal({ isOpen, itemIds, list, onClose, onDele
         <Button
           appearance="danger"
           variant="ghost"
-          onClick={() => {
+          onClick={async () => {
             if (loading) return;
-            deleteItems({
-              variables: { ids: itemIds },
-            }).then(onDelete);
+            await deleteItems({ variables: { ids: itemIds } });
+            onDelete();
           }}
         >
           Delete

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -20,6 +20,7 @@ const UpdateManyModal = ({ list, items, isOpen, onUpdate, onClose }) => {
   const [updateItem, { loading }] = useMutation(list.updateManyMutation, {
     errorPolicy: 'all',
     onError: error => handleCreateUpdateMutationError({ error, addToast }),
+    refetchQueries: ['getList'],
   });
 
   const [item, setItem] = useState({});

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -30,7 +30,6 @@ import Footer from './Footer';
 import {
   deconstructErrorsToDataShape,
   toastItemSuccess,
-  toastError,
   validateFields,
   handleCreateUpdateMutationError,
 } from '../../util';
@@ -73,8 +72,6 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
   const history = useHistory();
   const { addToast } = useToasts();
 
-  const { query: listQuery } = useList();
-
   const [updateItem, { loading: updateInProgress }] = useMutation(list.updateMutation, {
     errorPolicy: 'all',
     onError: error => handleCreateUpdateMutationError({ error, addToast }),
@@ -114,25 +111,14 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
     }
   };
 
-  const onDelete = async deletePromise => {
+  const onDelete = () => {
     deleteConfirmed.current = true;
-
-    try {
-      await deletePromise;
-      const refetch = listQuery.refetch();
-
-      if (mounted) {
-        setShowDeleteModal(false);
-      }
-
-      toastItemSuccess({ addToast }, initialData, 'Deleted successfully');
-
-      // Wait for the refetch to finish before returning to the list
-      await refetch;
-      history.replace(list.fullPath);
-    } catch (error) {
-      toastError({ addToast }, error);
+    if (mounted) {
+      setShowDeleteModal(false);
     }
+
+    toastItemSuccess({ addToast }, initialData, 'Deleted successfully');
+    history.replace(list.fullPath);
   };
 
   const openDeleteModal = () => {

--- a/packages/app-admin-ui/client/pages/List/dataHooks.js
+++ b/packages/app-admin-ui/client/pages/List/dataHooks.js
@@ -375,13 +375,6 @@ export function useListSelect(items) {
     }
   };
 
-  // TODO: deal with this elsewhere
-  // const deleteSelectedItems = () => {
-  //   const { query } = this.props;
-  //   if (query.refetch) query.refetch();
-  //   setSelectedItems([]);
-  // };
-
   return [selectedItems, onSelect];
 }
 

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -54,20 +54,15 @@ export function ListLayout(props) {
   // ------------------------------
 
   const onDeleteSelectedItems = () => {
-    query.refetch();
     onSelectChange([]);
   };
-  const onDeleteItem = () => {
-    query.refetch();
-  };
-  const onUpdateSelectedItems = () => {
-    query.refetch();
-  };
+
+  const onDeleteItem = () => {};
+  const onUpdateSelectedItems = () => {};
+
   const onCreate = ({ data }) => {
     const id = data[list.gqlNames.createMutationName].id;
-    query.refetch().then(() => {
-      history.push(`${list.fullPath}/${id}`);
-    });
+    history.push(`${list.fullPath}/${id}`);
   };
 
   // Success


### PR DESCRIPTION
Relies on #2976. Fixes #2795 

Instead of manually using `refech`, use the nice `refetchQueries` functionality Apollo provides. This is what the named queries in #2976 was for.

Relevant commit: https://github.com/keystonejs/keystone/commit/e4e372ec3cacc072b8cd43ce0bf8ba1c4fa214d0