### PR TITLE
Admin UI: fixed duplicate Access Denied errors appearing for lists

### DIFF
--- a/.changeset/shiny-fishes-tie.md
+++ b/.changeset/shiny-fishes-tie.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed duplicate Access Denied errors appearing for lists.

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -270,7 +270,7 @@ const ListPage = props => {
   // Only show error page if there is no data
   // (ie; there could be partial data + partial errors)
   if (query.error && (!query.data || !items || !Object.keys(items).length)) {
-    let message = query.error.message;
+    let message = queryErrorsParsed.message;
 
     // If there was an error returned by GraphQL, use that message instead
     // FIXME: convert this to an optional chaining operator at some point


### PR DESCRIPTION
Fixes #1615 

Here, `queryErrorsParsed` is pulling the error from just the list query (`deconstructErrorsToDataShape(error)[listQueryName])`.

![image](https://user-images.githubusercontent.com/3558659/82143197-cf108b00-988d-11ea-9052-07076e0e85ce.png)

Includes a minor cleanup of `deconstructErrorsToDataShape`.