### PR TITLE
Admin UI: moved no-lists-found display to a better location, fixed a warning

### DIFF
--- a/.changeset/hungry-fans-exist.md
+++ b/.changeset/hungry-fans-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed an issue with the no-lists-defined display.

--- a/packages/app-admin-ui/client/components/PageError.js
+++ b/packages/app-admin-ui/client/components/PageError.js
@@ -5,7 +5,7 @@ import { StopIcon } from '@arch-ui/icons';
 import { colors } from '@arch-ui/theme';
 import { Container } from '@arch-ui/layout';
 
-export default function PageError({ children, Icon = StopIcon, ...props }) {
+export default function PageError({ children, icon: Icon = StopIcon, ...props }) {
   return (
     <Container>
       <div

--- a/packages/app-admin-ui/client/index.js
+++ b/packages/app-admin-ui/client/index.js
@@ -63,7 +63,7 @@ export const KeystoneAdminUI = () => {
           return (
             <Fragment>
               <DocTitle title="Home" />
-              <PageError Icon={InfoIcon}>
+              <PageError icon={InfoIcon}>
                 <p>
                   No lists defined.{' '}
                   <a target="_blank" href="https://keystonejs.com/tutorials/add-lists">

--- a/packages/app-admin-ui/client/index.js
+++ b/packages/app-admin-ui/client/index.js
@@ -1,4 +1,4 @@
-import React, { Suspense, useMemo } from 'react';
+import React, { Fragment, Suspense, useMemo } from 'react';
 import ReactDOM from 'react-dom';
 import { ApolloProvider } from '@apollo/react-hooks';
 import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
@@ -6,6 +6,7 @@ import { ToastProvider } from 'react-toast-notifications';
 import { Global } from '@emotion/core';
 
 import { globalStyles } from '@arch-ui/theme';
+import { InfoIcon } from '@arch-ui/icons';
 
 import { initApolloClient } from './apolloClient';
 import Nav from './components/Nav';
@@ -14,6 +15,8 @@ import ConnectivityListener from './components/ConnectivityListener';
 import KeyboardShortcuts from './components/KeyboardShortcuts';
 import PageLoading from './components/PageLoading';
 import ToastContainer from './components/ToastContainer';
+import DocTitle from './components/DocTitle';
+import PageError from './components/PageError';
 import { AdminMetaProvider, useAdminMeta } from './providers/AdminMeta';
 import { ListProvider } from './providers/List';
 import { HooksProvider } from './providers/Hooks';
@@ -27,6 +30,7 @@ import SignoutPage from './pages/Signout';
 
 export const KeystoneAdminUI = () => {
   const {
+    listKeys,
     getListByPath,
     adminPath,
     signinPath,
@@ -54,7 +58,25 @@ export const KeystoneAdminUI = () => {
       }),
     {
       path: `${adminPath}`,
-      component: () => <HomePage />,
+      component: () => {
+        if (listKeys.length === 0) {
+          return (
+            <Fragment>
+              <DocTitle title="Home" />
+              <PageError Icon={InfoIcon}>
+                <p>
+                  No lists defined.{' '}
+                  <a target="_blank" href="https://keystonejs.com/tutorials/add-lists">
+                    Get started by creating your first list.
+                  </a>
+                </p>
+              </PageError>
+            </Fragment>
+          );
+        }
+
+        return <HomePage />;
+      },
       exact: true,
     },
     {

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -1,6 +1,5 @@
 import React, { Fragment, useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import { useLazyQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/react-hooks';
 
 import { Container, Grid, Cell } from '@arch-ui/layout';
 import { PageTitle } from '@arch-ui/typography';
@@ -32,7 +31,7 @@ const Homepage = () => {
   // TODO: A permission query to limit which lists are visible
   const lists = listKeys.map(key => getListByKey(key));
 
-  const [getLists, { data, error, called }] = useLazyQuery(getCountQuery(lists), {
+  const { data, error } = useQuery(getCountQuery(lists), {
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
   });
@@ -51,26 +50,6 @@ const Homepage = () => {
       );
     },
   });
-
-  if (lists.length === 0) {
-    return (
-      <Fragment>
-        <DocTitle title="Home" />
-        <PageError>
-          <p>
-            No lists defined.{' '}
-            <Link href="https://keystonejs.com/tutorials/add-lists">
-              Get started by creating your first list.
-            </Link>
-          </p>
-        </PageError>
-      </Fragment>
-    );
-  }
-
-  if (!called) {
-    getLists();
-  }
 
   let allowedLists = lists;
 

--- a/packages/app-admin-ui/client/pages/ListNotFound.js
+++ b/packages/app-admin-ui/client/pages/ListNotFound.js
@@ -10,7 +10,7 @@ const ListNotFoundPage = ({ listKey }) => {
   const { adminPath } = useAdminMeta();
 
   return (
-    <PageError Icon={IssueOpenedIcon}>
+    <PageError icon={IssueOpenedIcon}>
       <p>
         The list &ldquo;
         {listKey}


### PR DESCRIPTION
- Moved the no-lists-found handling out of `Homepage`. Now the latter always assumes there is at least one list
- Made tutorial link open in a new tab
- Used the Info icon instead of the Stop icon (since this isn't an error condition).
- Fixed this caused by bad use of `Link`:
![image](https://user-images.githubusercontent.com/3558659/82164621-36195880-98fd-11ea-9493-23080decc2ff.png)
- Fixed case on `PageError`'s `icon` prop