### PR TITLE
Admin UI: navigate directly to full persistent list path

### DIFF
--- a/.changeset/tasty-hats-guess.md
+++ b/.changeset/tasty-hats-guess.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Include persistent search state when navigating back to list.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -168,4 +168,8 @@ export default class List {
   setPersistedSearch(value) {
     localStorage.setItem(`search:${this.path}`, value);
   }
+
+  getFullPersistentPath() {
+    return `${this.fullPath}${this.getPersistedSearch() || ''}`;
+  }
 }

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -212,7 +212,6 @@ function renderChildren(
   }
 
   const label = node.label || list.plural;
-  const maybeSearchParam = list.getPersistedSearch() || '';
   const isSelected = list.fullPath === getPath(location.pathname);
   const id = `ks-nav-${list.path}`;
 
@@ -222,7 +221,7 @@ function renderChildren(
       depth={depth}
       id={id}
       isSelected={isSelected}
-      to={`${list.fullPath}${maybeSearchParam}`}
+      to={list.getFullPersistentPath()}
       mouseIsOverNav={mouseIsOverNav}
     >
       {label}

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.js
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.js
@@ -33,7 +33,7 @@ export const ItemTitle = memo(function ItemTitle({ titleText }) {
           <IconButton
             variant="subtle"
             icon={ChevronLeftIcon}
-            to={list.fullPath}
+            to={list.getFullPersistentPath()}
             css={{ marginLeft: -12 }}
           >
             {list.label}

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -118,7 +118,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
     }
 
     toastItemSuccess({ addToast }, initialData, 'Deleted successfully');
-    history.replace(list.fullPath);
+    history.replace(list.getFullPersistentPath());
   };
 
   const openDeleteModal = () => {

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -247,11 +247,12 @@ const ListPage = props => {
   // ------------------------------
   useEffect(() => {
     const maybePersistedSearch = list.getPersistedSearch();
+    if (location.search === maybePersistedSearch) {
+      return;
+    }
 
     if (location.search) {
-      if (location.search !== maybePersistedSearch) {
-        list.setPersistedSearch(location.search);
-      }
+      list.setPersistedSearch(location.search);
     } else if (maybePersistedSearch) {
       history.replace({
         ...location,


### PR DESCRIPTION
Fixes an extra render with no search before the persistent `useEffect` kicks in.