### PR TITLE
Fixed React warning about controlled handling in the Float field

### DIFF
--- a/.changeset/five-lies-admire.md
+++ b/.changeset/five-lies-admire.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed React warning about controlled handling in the Float field.

--- a/packages/fields/src/types/Float/views/Field.js
+++ b/packages/fields/src/types/Float/views/Field.js
@@ -12,6 +12,18 @@ const FloatField = ({ onChange, autoFocus, field, value, errors }) => {
     }
   };
 
+  const valueToString = value => {
+    // Make the value a string to keep react happy.
+    if (typeof value === 'string') {
+      return value;
+    } else if (typeof value === 'number') {
+      return String(value);
+    } else {
+      // If it is neither string nor number then it must be empty.
+      return '';
+    }
+  };
+
   const htmlID = `ks-input-${field.path}`;
 
   return (
@@ -23,7 +35,7 @@ const FloatField = ({ onChange, autoFocus, field, value, errors }) => {
           autoComplete="off"
           autoFocus={autoFocus}
           type="text"
-          value={value}
+          value={valueToString(value)}
           onChange={handleChange}
           id={htmlID}
         />


### PR DESCRIPTION
Fixes
![image](https://user-images.githubusercontent.com/3558659/82376385-bf4f9d00-9a6d-11ea-981b-bb3cc95501b0.png)

Also fixes being able to input non-numeric values to the field until it became controlled.

I just copied this block from the `Integer` and `Decimal` fields since it's shared by both.