### PR TITLE
Admin UI: fixed navbar list being sorted by list key instead of label

### DIFF
--- a/.changeset/violet-birds-own.md
+++ b/.changeset/violet-birds-own.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed navbar list being sorted by list key instead of label.

--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -442,6 +442,16 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
     pages,
     authStrategy: { listKey: authListKey } = {},
   } = useAdminMeta();
+
+  const sortedListKeys = useMemo(
+    () =>
+      listKeys
+        .map(key => getListByKey(key))
+        .sort(({ label: a }, { label: b }) => a.localeCompare(b)) // TODO: locale options once intl support is added
+        .map(({ key }) => key),
+    [listKeys]
+  );
+
   return (
     <Inner>
       <Title
@@ -465,7 +475,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
         adminPath={adminPath}
         authListKey={authListKey}
         getListByKey={getListByKey}
-        listKeys={listKeys.sort()}
+        listKeys={sortedListKeys}
         pages={pages}
         mouseIsOverNav={mouseIsOverNav}
       />


### PR DESCRIPTION
Before (note `UserGroups` and `PassportSessions`):
![image](https://user-images.githubusercontent.com/3558659/82405456-b41d6100-9aaf-11ea-9a0f-bb035c5fad35.png)

After:
![image](https://user-images.githubusercontent.com/3558659/82405464-bd0e3280-9aaf-11ea-9b40-45dca32932b9.png)
