### PR TITLE
Admin UI: made ID list table cells render in monospace font

### DIFF
--- a/.changeset/nasty-ravens-decide.md
+++ b/.changeset/nasty-ravens-decide.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Made ID list table cells render in monospace font.

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -278,7 +278,14 @@ const ListRow = ({
           content = item[path];
         }
 
-        return <BodyCellTruncated key={path}>{content}</BodyCellTruncated>;
+        return (
+          <BodyCellTruncated
+            key={path}
+            css={{ fontFamily: field.isPrimaryKey ? 'Monaco, Consolas, monospace' : null }}
+          >
+            {content}
+          </BodyCellTruncated>
+        );
       })}
       <BodyCell css={{ padding: 0 }}>
         <Dropdown


### PR DESCRIPTION
🎉 3000! 😄 

Consistent with the ID presentation in the Details view.

Before:
![image](https://user-images.githubusercontent.com/3558659/82414268-868de300-9ac2-11ea-8539-4f631ae52bae.png)

After:
![image](https://user-images.githubusercontent.com/3558659/82414292-8e4d8780-9ac2-11ea-9a3e-05528ed74afc.png)
