### PR TITLE
Fixed minor layout issues in FieldLabel

### DIFF
--- a/.changeset/perfect-impalas-teach.md
+++ b/.changeset/perfect-impalas-teach.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/fields': patch
+---
+
+Fixed minor layout issues with the FieldLabel component.

--- a/packages/arch/packages/fields/src/index.js
+++ b/packages/arch/packages/fields/src/index.js
@@ -9,10 +9,11 @@ export const FieldContainer = props => (
   <div data-selector="field-container" css={{ marginBottom: gridSize * 2 }} {...props} />
 );
 
-export const FieldLabel = props => {
-  const accessError = (props.errors || []).find(
+export const FieldLabel = ({ errors = [], field, ...props }) => {
+  const accessError = errors.find(
     error => error instanceof Error && error.name === 'AccessDeniedError'
   );
+
   return (
     <label
       css={{
@@ -24,14 +25,15 @@ export const FieldLabel = props => {
         flexDirection: 'row',
         justifyContent: 'space-between',
       }}
-      className={props.className}
-      htmlFor={props.htmlFor}
+      {...props}
     >
-      {props.field.label}{' '}
-      {accessError ? (
-        <ShieldIcon title={accessError.message} css={{ color: colors.N20, marginRight: '1em' }} />
-      ) : null}{' '}
-      {props.field.isRequired ? <Lozenge appearance="primary"> Required </Lozenge> : null}
+      {field.label}
+      <span>
+        {field.isRequired && <Lozenge appearance="primary">Required</Lozenge>}
+        {accessError && (
+          <ShieldIcon title={accessError.message} css={{ color: colors.N20, margin: '0 1em' }} />
+        )}
+      </span>
     </label>
   );
 };


### PR DESCRIPTION
Previously, if you for some reason managed to have a required field you couldn't view, it would look like this:
![image](https://user-images.githubusercontent.com/3558659/82514819-69105600-9b62-11ea-91fb-dfc9745f1003.png)

After:
![image](https://user-images.githubusercontent.com/3558659/82514851-804f4380-9b62-11ea-9c4f-03a69766cfc8.png)
