### PR TITLE
Added client-side is-required input flag to most fields

### DIFF
--- a/.changeset/itchy-ducks-fold.md
+++ b/.changeset/itchy-ducks-fold.md
@@ -1,0 +1,6 @@
+---
+'@arch-ui/input': patch
+'@keystonejs/fields': patch
+---
+
+Added client-side is-required flag to most fields.

--- a/packages/arch/packages/input/src/Input.js
+++ b/packages/arch/packages/input/src/Input.js
@@ -26,6 +26,11 @@ export const inputStyles = (props = {}) => ({
     outline: 0,
   },
 
+  ':invalid': {
+    borderColor: colors.danger,
+    outline: 0,
+  },
+
   '&[disabled]': {
     borderColor: colors.N15,
     backgroundColor: colors.N05,

--- a/packages/fields/src/types/Decimal/views/Field.js
+++ b/packages/fields/src/types/Decimal/views/Field.js
@@ -43,6 +43,7 @@ const DecimalField = ({ onChange, autoFocus, field, value, errors }) => {
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={valueToString(value)}
           onChange={handleChange}

--- a/packages/fields/src/types/Float/views/Field.js
+++ b/packages/fields/src/types/Float/views/Field.js
@@ -34,6 +34,7 @@ const FloatField = ({ onChange, autoFocus, field, value, errors }) => {
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={valueToString(value)}
           onChange={handleChange}

--- a/packages/fields/src/types/Integer/views/Field.js
+++ b/packages/fields/src/types/Integer/views/Field.js
@@ -31,6 +31,7 @@ const IntegerField = ({ onChange, autoFocus, field, value, errors }) => {
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={valueToString(value)}
           onChange={handleChange}

--- a/packages/fields/src/types/OEmbed/views/Field.js
+++ b/packages/fields/src/types/OEmbed/views/Field.js
@@ -62,6 +62,7 @@ const OEmbedField = ({ onChange, autoFocus, field, value = null, savedValue = nu
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="url"
           value={(canRead && value && value.originalUrl) || ''}
           placeholder={canRead ? undefined : error.message}

--- a/packages/fields/src/types/Text/views/Field.js
+++ b/packages/fields/src/types/Text/views/Field.js
@@ -26,6 +26,7 @@ const TextField = ({ onChange, autoFocus, field, errors, value: serverValue }) =
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={canRead ? value : undefined}
           placeholder={canRead ? undefined : error.message}

--- a/packages/fields/src/types/Unsplash/views/Field.js
+++ b/packages/fields/src/types/Unsplash/views/Field.js
@@ -25,6 +25,7 @@ const UnsplashField = ({ onChange, autoFocus, field, errors, value: serverValue 
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={canRead ? value : undefined}
           placeholder={canRead ? 'Unsplash Image ID' : error.message}

--- a/packages/fields/src/types/Url/views/Field.js
+++ b/packages/fields/src/types/Url/views/Field.js
@@ -25,6 +25,7 @@ const UrlField = ({ onChange, autoFocus, field, value: serverValue, errors }) =>
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="url"
           value={canRead ? value : undefined}
           placeholder={canRead ? undefined : error.message}

--- a/packages/fields/src/types/Uuid/views/Field.js
+++ b/packages/fields/src/types/Uuid/views/Field.js
@@ -25,6 +25,7 @@ const UuidField = ({ onChange, autoFocus, field, errors, value: serverValue }) =
         <Input
           autoComplete="off"
           autoFocus={autoFocus}
+          required={field.isRequired}
           type="text"
           value={canRead ? value : undefined}
           placeholder={canRead ? undefined : error.message}


### PR DESCRIPTION
See #1270. This doesn't cover *all* fields, only those using `Input`, but it's an improvement.

How it looks (the popup appears when submitting with an invalid form. It looks slightly different on Firefox):
![image](https://user-images.githubusercontent.com/3558659/82515667-7fb7ac80-9b64-11ea-8137-ab2c098df507.png)
