### PR TITLE
Refactored out adminPath and authStrategy from field controller base

### DIFF
--- a/.changeset/fresh-bags-hear.md
+++ b/.changeset/fresh-bags-hear.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@keystonejs/fields': patch
+---
+
+Removed adminPath and authStrategy members from base field Controller class.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -5,7 +5,7 @@ import { arrayToObject, mapKeys, omit } from '@keystonejs/utils';
 export default class List {
   constructor(
     { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
-    { readViews, preloadViews, getListByKey, adminPath, authStrategy },
+    { readViews, preloadViews, getListByKey, adminPath },
     views
   ) {
     this.access = access;
@@ -23,7 +23,7 @@ export default class List {
       const [Controller] = readViews([views[fieldConfig.path].Controller]);
       return new Controller(
         fieldConfig,
-        { readViews, preloadViews, getListByKey, adminPath, authStrategy },
+        { readViews, preloadViews, getListByKey },
         views[fieldConfig.path]
       );
     });

--- a/packages/app-admin-ui/client/providers/AdminMeta.js
+++ b/packages/app-admin-ui/client/providers/AdminMeta.js
@@ -70,7 +70,7 @@ export const AdminMetaProvider = ({ children }) => {
     ([key, { access, adminConfig, adminDoc, fields, gqlNames, label, path, plural, singular }]) => {
       const list = new List(
         { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
-        { readViews, preloadViews, getListByKey, apiPath, adminPath, authStrategy },
+        { readViews, preloadViews, getListByKey, apiPath, adminPath },
         views[key]
       );
       listsByKey[key] = list;

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -14,7 +14,7 @@ export default class FieldController {
       defaultValue,
       ...config
     },
-    { readViews, preloadViews, getListByKey, adminPath, authStrategy },
+    { readViews, preloadViews, getListByKey },
     views
   ) {
     this.config = config;
@@ -29,8 +29,6 @@ export default class FieldController {
     this.readViews = readViews;
     this.preloadViews = preloadViews;
     this.getListByKey = getListByKey;
-    this.adminPath = adminPath;
-    this.authStrategy = authStrategy;
     this.views = views;
 
     if (typeof defaultValue !== 'function') {
@@ -45,10 +43,12 @@ export default class FieldController {
   // by the implementations gqlOutputFields
   getQueryFragment = () => this.path;
 
-  // Prepare data for this field to be sent to the server as part of a GraphQL
-  // mutation. It must be serialized into the format expected within the field's
-  // Implementation#gqlCreateInputFields()/Implementation#gqlUpdateInputFields()
-  // NOTE: This function is run synchronously
+  /**
+   * Prepare data for this field to be sent to the server as part of a GraphQL
+   * mutation. It must be serialized into the format expected within the field's
+   * `Implementation#gqlCreateInputFields()`/`Implementation#gqlUpdateInputFields()`
+   * NOTE: This function is run synchronously
+   */
   serialize = data => data[this.path] || null;
 
   /**
@@ -66,7 +66,7 @@ export default class FieldController {
    * mutation. Any errors or warnings raised will abort the mutation and
    * re-render the `Field` view with a new `error` prop.
    *
-   * This method is only called on fields whos `.hasChanged()` property returns
+   * This method is only called on fields whose `.hasChanged()` property returns
    * truthy.
    *
    * If only warnings are raised, the Admin UI will allow the user to confirm
@@ -86,21 +86,23 @@ export default class FieldController {
    */
   validateInput = () => {};
 
-  // When receiving data from the server, it needs to be processed into a
-  // format ready for display. The format received will be the same as specified
-  // in the field's Implementation#gqlOutputFields()
-  // NOTE: This function is run synchronously
+  /**
+   * When receiving data from the server, it needs to be processed into a
+   * format ready for display. The format received will be the same as specified
+   * in the field's Implementation#gqlOutputFields()
+   * NOTE: This function is run synchronously
+   */
   deserialize = data => data[this.path];
 
   /**
-   * @description Before sending data to the GraphQL server, this check is run to exclude
+   * Before sending data to the GraphQL server, this check is run to exclude
    * possibly expensive data from being sent. It also prevents issues where "no
    * change" can be destructive (eg; uploading a file - we no longer have the
    * file, so cannot update it and may accidentally send `null`).
-   * @param initialData {Object} An object containing the most recently received
+   * @param {Object} initialData An object containing the most recently received
    * data from the server, keyed by the field's path. The values have already
    * been passed to this.serialize() for you.
-   * @param currentData {Object} An object containing all of the data for the
+   * @param {Object} currentData An object containing all of the data for the
    * current item, keyed by the field's path. The values have already been
    * passed to this.serialize() for you
    * @return boolean
@@ -114,26 +116,23 @@ export default class FieldController {
 
   initCellView = () => {
     const { Cell } = this.views;
-    if (!Cell) {
-      return;
+    if (Cell) {
+      this.readViews([Cell]);
     }
-    this.readViews([Cell]);
   };
 
   initFieldView = () => {
     const { Field } = this.views;
-    if (!Field) {
-      return;
+    if (Field) {
+      this.readViews([Field]);
     }
-    this.readViews([Field]);
   };
 
   initFilterView = () => {
     const { Filter } = this.views;
-    if (!Filter) {
-      return;
+    if (Filter) {
+      this.readViews([Filter]);
     }
-    this.readViews([Filter]);
   };
 
   getFilterTypes = () => [];

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -12,7 +12,12 @@ import { IconButton } from '@arch-ui/button';
 import Tooltip from '@arch-ui/tooltip';
 
 import RelationshipSelect from './RelationshipSelect';
-import { CreateItemModal, ListProvider, useList } from '@keystonejs/app-admin-ui/components';
+import {
+  CreateItemModal,
+  ListProvider,
+  useList,
+  useAdminMeta,
+} from '@keystonejs/app-admin-ui/components';
 
 const MAX_IDS_IN_FILTER = 100;
 
@@ -57,11 +62,10 @@ function SetAsCurrentUser({ listKey, value, onAddUser, many }) {
 
 function LinkToRelatedItems({ field, value }) {
   const { many } = field.config;
-  const { adminPath } = field;
-  const { path } = field.getRefList();
+  const { fullPath } = field.getRefList();
   let isDisabled = false;
   let label;
-  let link = `${adminPath}/${path}`;
+  let link = fullPath;
   if (many) {
     label = 'View List of Related Items';
 
@@ -178,7 +182,7 @@ const RelationshipField = ({
   };
 
   const { many, ref } = field.config;
-  const { authStrategy } = field;
+  const { authStrategy } = useAdminMeta();
   const htmlID = `ks-input-${field.path}`;
 
   const relatedList = field.getRefList();


### PR DESCRIPTION
@timleslie `list.fullPath` was such a good addition. 💯 

Both `adminPath` and `authStrategy` were only used by the Relationship field. `adminPath` + `path` could be replaced with `fullPath` and `authStrategy` could be fetched with `useAdminMeta`.

Includes a few other minor doc and code formatting changes in `Controller`.