### PR TITLE
Admin UI: fixed regression in dashboard sort order

### DIFF
--- a/packages/app-admin-ui/client/components/Nav/index.js
+++ b/packages/app-admin-ui/client/components/Nav/index.js
@@ -443,15 +443,6 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
     authStrategy: { listKey: authListKey } = {},
   } = useAdminMeta();
 
-  const sortedListKeys = useMemo(
-    () =>
-      listKeys
-        .map(key => getListByKey(key))
-        .sort(({ label: a }, { label: b }) => a.localeCompare(b)) // TODO: locale options once intl support is added
-        .map(({ key }) => key),
-    [listKeys]
-  );
-
   return (
     <Inner>
       <Title
@@ -475,7 +466,7 @@ const PrimaryNavContent = ({ mouseIsOverNav }) => {
         adminPath={adminPath}
         authListKey={authListKey}
         getListByKey={getListByKey}
-        listKeys={sortedListKeys}
+        listKeys={listKeys}
         pages={pages}
         mouseIsOverNav={mouseIsOverNav}
       />

--- a/packages/app-admin-ui/client/providers/AdminMeta.js
+++ b/packages/app-admin-ui/client/providers/AdminMeta.js
@@ -78,6 +78,10 @@ export const AdminMetaProvider = ({ children }) => {
     }
   );
 
+  const listKeys = Object.values(listsByKey)
+    .sort(({ label: a }, { label: b }) => a.localeCompare(b)) // TODO: locale options once intl support is added
+    .map(({ key }) => key);
+
   let hookViews = {};
   if (typeof hookView === 'function') {
     [hookViews] = readViews([hookView]);
@@ -94,7 +98,7 @@ export const AdminMetaProvider = ({ children }) => {
     signoutPath,
     authStrategy,
     name,
-    listKeys: Object.keys(lists || {}),
+    listKeys,
     getListByKey,
     getListByPath: path => listsByPath[path],
     hooks: hookViews,

--- a/test-projects/basic/cypress/integration/create-buttons_spec.js
+++ b/test-projects/basic/cypress/integration/create-buttons_spec.js
@@ -18,7 +18,11 @@ describe('Home page', () => {
   it('Create list buttons exists', () => {
     cy.visit('/admin');
     [{ text: 'User' }, { text: 'Post' }, { text: 'Post Category' }].forEach(({ text }) => {
-      cy.contains('button', `Create ${text}`).should('have.attr', 'title', `Create ${text}`);
+      cy.contains('button', new RegExp(`^Create ${text}$g`)).should(
+        'have.attr',
+        'title',
+        `Create ${text}`
+      );
     });
   });
 
@@ -35,7 +39,7 @@ describe('Home page', () => {
       },
       { text: 'Post Category', labels: ['Name', 'Slug'] },
     ].forEach(({ text, labels }) => {
-      cy.contains('button', `Create ${text}`).click({ force: true });
+      cy.contains('button', new RegExp(`^Create ${text}$g`)).click({ force: true });
       cy.contains('div', `Create ${text} Dialog`).contains('h3', `Create ${text}`);
       cy.contains('div', `Create ${text} Dialog`).contains('button', 'Create');
       labels.forEach(label => {

--- a/test-projects/basic/cypress/integration/create-buttons_spec.js
+++ b/test-projects/basic/cypress/integration/create-buttons_spec.js
@@ -18,7 +18,7 @@ describe('Home page', () => {
   it('Create list buttons exists', () => {
     cy.visit('/admin');
     [{ text: 'User' }, { text: 'Post' }, { text: 'Post Category' }].forEach(({ text }) => {
-      cy.contains('button', new RegExp(`^Create ${text}$g`)).should(
+      cy.contains('button', new RegExp(`^Create ${text}$`)).should(
         'have.attr',
         'title',
         `Create ${text}`
@@ -39,7 +39,7 @@ describe('Home page', () => {
       },
       { text: 'Post Category', labels: ['Name', 'Slug'] },
     ].forEach(({ text, labels }) => {
-      cy.contains('button', new RegExp(`^Create ${text}$g`)).click({ force: true });
+      cy.contains('button', new RegExp(`^Create ${text}$`)).click({ force: true });
       cy.contains('div', `Create ${text} Dialog`).contains('h3', `Create ${text}`);
       cy.contains('div', `Create ${text} Dialog`).contains('button', 'Create');
       labels.forEach(label => {


### PR DESCRIPTION
I forgot that `Array.sort` operates in-place. Turns out that `listKeys.sort()` call I removed in #2998 had the side effect (unintuitive!) of sorting `listKeys` so when it was used to populate the dashboard, the cards appeared in the same order as the sidebar. This fixes it by moving the sorting to the admin meta provider so all uses of `listKeys` use the same ordering.