### PR TITLE
List plugin improvement

### DIFF
--- a/.changeset/gentle-deers-knock.md
+++ b/.changeset/gentle-deers-knock.md
@@ -1,0 +1,8 @@
+---
+'@keystonejs/keystone': major
+'@keystonejs/utils': minor
+---
+
+Added additional parameters to list plugins which expose `{ listKey, keystone }` to plugins. This helps plugin know name of list and keystone instance. Existing plugins are not affected by this change.
+
+New plugin signature: `(config, { listKey, keystone }) => config`

--- a/.changeset/gentle-deers-knock.md
+++ b/.changeset/gentle-deers-knock.md
@@ -1,6 +1,5 @@
 ---
-'@keystonejs/keystone': major
-'@keystonejs/utils': minor
+'@keystonejs/keystone': minor
 ---
 
 Added additional parameters to list plugins which expose `{ listKey, keystone }` to plugins. This helps plugin know name of list and keystone instance. Existing plugins are not affected by this change.

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -286,9 +286,8 @@ Changes the path in the Admin UI. Updating `plural` and `singular` values will n
 
 ### `plugins`
 
-An array of functions that modify config values. Plugin functions receive a config object and can modify or extend this. They should return a valid list config. starting Keystone version 10.0.0, plugins receives second parameter with `{ listKey, keystone}`. Where listKey is the name of list and keystone instance.
+An array of functions that modify config values. Plugin functions receive `(config, { listKey, keystone })`, where `config` is the a list config object, `listKey` is the name of the list, and `keystone` is the keystone object. They should return a valid list config. Plugin functions are executed in the order provided in the list, with the output config of one being passed as input to the next. The output of the final plugin is used to construct the `List` instance.
 
-> This keystone instance is not fully functional when plugins are initialised. Features like `executeQuery` is ready only after `keystone.connect` is run. You can use keystone instance from within hooks and access control methods.
 
 ```javascript
 const setupUserList = ({ fields, ...config }) => {

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -286,7 +286,9 @@ Changes the path in the Admin UI. Updating `plural` and `singular` values will n
 
 ### `plugins`
 
-An array of functions that modify config values. Plugin functions receive a config object and can modify or extend this. They should return a valid list config.
+An array of functions that modify config values. Plugin functions receive a config object and can modify or extend this. They should return a valid list config. starting Keystone version 10.0.0, plugins receives second parameter with `{ listKey, keystone}`. Where listKey is the name of list and keystone instance.
+
+> This keystone instance is not fully functional when plugins are initialised. Features like `executeQuery` is ready only after `keystone.connect` is run. You can use keystone instance from within hooks and access control methods.
 
 ```javascript
 const setupUserList = ({ fields, ...config }) => {

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -14,7 +14,6 @@ const {
   flatten,
   unique,
   filterValues,
-  composePlugins,
 } = require('@keystonejs/utils');
 const {
   validateFieldAccessControl,
@@ -33,6 +32,9 @@ const {
 const List = require('../List');
 const { DEFAULT_DIST_DIR } = require('../../constants');
 const { CustomProvider, ListAuthProvider, ListCRUDProvider } = require('../providers');
+
+// composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
+export const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
 
 module.exports = class Keystone {
   constructor({

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -14,7 +14,7 @@ const {
   flatten,
   unique,
   filterValues,
-  compose,
+  composePlugins,
 } = require('@keystonejs/utils');
 const {
   validateFieldAccessControl,
@@ -306,23 +306,27 @@ module.exports = class Keystone {
       throw new Error(`Invalid list name "${key}". List names cannot start with an underscore.`);
     }
 
-    const list = new List(key, compose(config.plugins || [])(config), {
-      getListByKey,
-      queryHelper: this._buildQueryHelper.bind(this),
-      adapter: adapters[adapterName],
-      defaultAccess: this.defaultAccess,
-      registerType: type => this.registeredTypes.add(type),
-      isAuxList,
-      createAuxList: (auxKey, auxConfig) => {
-        if (isAuxList) {
-          throw new Error(
-            `Aux list "${key}" shouldn't be creating more aux lists ("${auxKey}"). Something's probably not right here.`
-          );
-        }
-        return this.createList(auxKey, auxConfig, { isAuxList: true });
-      },
-      schemaNames: this._schemaNames,
-    });
+    const list = new List(
+      key,
+      composePlugins(config.plugins || [])(config, { listKey: key, keystone: this }),
+      {
+        getListByKey,
+        queryHelper: this._buildQueryHelper.bind(this),
+        adapter: adapters[adapterName],
+        defaultAccess: this.defaultAccess,
+        registerType: type => this.registeredTypes.add(type),
+        isAuxList,
+        createAuxList: (auxKey, auxConfig) => {
+          if (isAuxList) {
+            throw new Error(
+              `Aux list "${key}" shouldn't be creating more aux lists ("${auxKey}"). Something's probably not right here.`
+            );
+          }
+          return this.createList(auxKey, auxConfig, { isAuxList: true });
+        },
+        schemaNames: this._schemaNames,
+      }
+    );
     this.lists[key] = list;
     this.listsArray.push(list);
     this._listCRUDProvider.lists.push(list);

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -34,7 +34,7 @@ const { DEFAULT_DIST_DIR } = require('../../constants');
 const { CustomProvider, ListAuthProvider, ListCRUDProvider } = require('../providers');
 
 // composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
-export const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
+const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
 
 module.exports = class Keystone {
   constructor({

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -33,9 +33,6 @@ const List = require('../List');
 const { DEFAULT_DIST_DIR } = require('../../constants');
 const { CustomProvider, ListAuthProvider, ListCRUDProvider } = require('../providers');
 
-// composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
-const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
-
 module.exports = class Keystone {
   constructor({
     defaultAccess,
@@ -307,6 +304,9 @@ module.exports = class Keystone {
     if (isReservedName) {
       throw new Error(`Invalid list name "${key}". List names cannot start with an underscore.`);
     }
+
+    // composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
+    const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
 
     const list = new List(
       key,

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -110,9 +110,6 @@ export const zipObj = obj =>
 // compose([f, g, h])(o) = h(g(f(o)))
 export const compose = fns => o => fns.reduce((acc, fn) => fn(acc), o);
 
-// composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
-export const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
-
 export const mergeWhereClause = (queryArgs, whereClauseToMergeIn) => {
   if (
     getType(whereClauseToMergeIn) !== 'Object' ||

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -110,6 +110,9 @@ export const zipObj = obj =>
 // compose([f, g, h])(o) = h(g(f(o)))
 export const compose = fns => o => fns.reduce((acc, fn) => fn(acc), o);
 
+// composePlugins([f, g, h])(o, e) = h(g(f(o, e), e), e)
+export const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
+
 export const mergeWhereClause = (queryArgs, whereClauseToMergeIn) => {
   if (
     getType(whereClauseToMergeIn) !== 'Object' ||


### PR DESCRIPTION
ref: #2838 
This is split from #2838 and works on single feature of adding additional parameter to list plugins.

additional parameter is `{listKey, keystone}` name of the list helps in setting up further if want to build dynamic queries or logging. `keystone` parameter further help add feature in plugin which may need keystone instance. for example some list author can create additional list or meta list. 

( I can think of a list history plugin which can create a list by name of `${listkey}History` and use beforeChange/afterChange hooks to copy changed content to history list). 

[best viewed whitespace off](https://github.com/keystonejs/keystone/pull/3011/files?diff=unified&w=1)