### PR TITLE
Disable ui elements based on access control

### DIFF
--- a/.changeset/slimy-pigs-knock.md
+++ b/.changeset/slimy-pigs-knock.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Disabled Item Detail page Foote action based on access control. Also fixes a bug where `Delete` action for multiple item in the list view removed when you have delete access but no update access.
+Disabled Item Detail page Footer action based on access control. Also fixes a bug where `Delete` action for multiple item in the list view removed when you have delete access but no update access.

--- a/.changeset/slimy-pigs-knock.md
+++ b/.changeset/slimy-pigs-knock.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Disabled Item Detail page Foote action based on access control. Also fixes a bug where `Delete` action for multiple item in the list view removed when you have delete access but no update access.

--- a/.changeset/slimy-pigs-knock.md
+++ b/.changeset/slimy-pigs-knock.md
@@ -2,4 +2,6 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Disabled Item Detail page Footer action based on access control. Also fixes a bug where `Delete` action for multiple item in the list view removed when you have delete access but no update access.
+* Disables all the field in Item detail page when `update` access is false. Earlier it would not show any fields in detail page.
+* Disabled Item Detail page Footer actions based on access control.
+* Also fixes a bug where `Delete` action for multiple item in the list view removed when you have delete access but no update access.

--- a/packages/app-admin-ui/client/pages/Item/Footer.js
+++ b/packages/app-admin-ui/client/pages/Item/Footer.js
@@ -97,7 +97,7 @@ export default memo(
             >
               {hasWarnings && !hasErrors ? 'Ignore Warnings and Save Changes' : 'Save Changes'}
             </LoadingButton>
-            <Reset canReset={canReset && !list.access.update} onReset={onReset} />
+            <Reset canReset={canReset} onReset={onReset} />
           </div>
           <div>
             <Button

--- a/packages/app-admin-ui/client/pages/Item/Footer.js
+++ b/packages/app-admin-ui/client/pages/Item/Footer.js
@@ -5,6 +5,8 @@ import { Button, LoadingButton } from '@arch-ui/button';
 import { colors, gridSize } from '@arch-ui/theme';
 import { alpha } from '@arch-ui/color-utils';
 
+import { useList } from '../../providers/List';
+
 const Toolbar = props => (
   <div
     css={{
@@ -75,38 +77,40 @@ function Reset({ canReset, onReset }) {
   );
 }
 
-export default memo(function Footer(props) {
-  const { onSave, onDelete, canReset, updateInProgress, onReset, hasWarnings, hasErrors } = props;
-  const cypressId = 'item-page-save-button';
+export default memo(
+  ({ onSave, onDelete, canReset, updateInProgress, onReset, hasWarnings, hasErrors }) => {
+    const { list } = useList();
+    const cypressId = 'item-page-save-button';
 
-  return (
-    <Fragment>
-      <Toolbar key="footer">
-        <div css={{ display: 'flex', alignItems: 'center' }}>
-          <LoadingButton
-            appearance={hasWarnings && !hasErrors ? 'warning' : 'primary'}
-            id={cypressId}
-            isDisabled={updateInProgress || hasErrors}
-            isLoading={updateInProgress}
-            onClick={onSave}
-            style={{ marginRight: 8 }}
-            type="submit"
-          >
-            {hasWarnings && !hasErrors ? 'Ignore Warnings and Save Changes' : 'Save Changes'}
-          </LoadingButton>
-          <Reset canReset={canReset} onReset={onReset} />
-        </div>
-        <div>
-          <Button
-            appearance="danger"
-            isDisabled={updateInProgress}
-            variant="nuance"
-            onClick={onDelete}
-          >
-            Delete
-          </Button>
-        </div>
-      </Toolbar>
-    </Fragment>
-  );
-});
+    return (
+      <Fragment>
+        <Toolbar key="footer">
+          <div css={{ display: 'flex', alignItems: 'center' }}>
+            <LoadingButton
+              appearance={hasWarnings && !hasErrors ? 'warning' : 'primary'}
+              id={cypressId}
+              isDisabled={updateInProgress || hasErrors || !list.access.update}
+              isLoading={updateInProgress}
+              onClick={onSave}
+              style={{ marginRight: 8 }}
+              type="submit"
+            >
+              {hasWarnings && !hasErrors ? 'Ignore Warnings and Save Changes' : 'Save Changes'}
+            </LoadingButton>
+            <Reset canReset={canReset && !list.access.update} onReset={onReset} />
+          </div>
+          <div>
+            <Button
+              appearance="danger"
+              isDisabled={updateInProgress || !list.access.delete}
+              variant="nuance"
+              onClick={onDelete}
+            >
+              Delete
+            </Button>
+          </div>
+        </Toolbar>
+      </Fragment>
+    );
+  }
+);

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -299,7 +299,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
         <Footer
           onSave={onSave}
           onDelete={openDeleteModal}
-          canReset={itemHasChanged.current && !updateInProgress}
+          canReset={itemHasChanged.current && !updateInProgress && list.access.update}
           onReset={onReset}
           updateInProgress={updateInProgress}
           hasWarnings={countArrays(validationWarnings)}

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -235,7 +235,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
             <Render key={field.path}>
               {() => {
                 const [Field] = field.readViews([field.views.Field]);
-                const isReadOnly = checkIsReadOnly(field);
+                const isReadOnly = checkIsReadOnly(field) || !list.access.update;
                 // eslint-disable-next-line react-hooks/rules-of-hooks
                 const onChange = useCallback(
                   value => {
@@ -299,7 +299,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
         <Footer
           onSave={onSave}
           onDelete={openDeleteModal}
-          canReset={itemHasChanged.current && !updateInProgress && list.access.update}
+          canReset={itemHasChanged.current && !updateInProgress}
           onReset={onReset}
           updateInProgress={updateInProgress}
           hasWarnings={countArrays(validationWarnings)}

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -60,7 +60,7 @@ const ListManage = ({ list, pageSize, totalItems, selectedItems, onDeleteMany, o
           </IconButton>
         )}
 
-        {list.access.update && (
+        {list.access.delete && (
           <IconButton
             appearance="danger"
             icon={TrashcanIcon}


### PR DESCRIPTION
ref: #2838, built on top of #3011.

Item Details page Footer now respects the access control for update and delete.

If List `update` access is set to false then it will render all fields as disabled.

notice all buttons are disabled in Footer when update and delete both access are set to false.
![image](https://user-images.githubusercontent.com/5769869/82635485-e947c180-9c1d-11ea-9f61-31ff73b8204c.png)


[best viewed with whitespace off](https://github.com/keystonejs/keystone/pull/3012/files?diff=unified&w=1)