### PR TITLE
Refactor test internals to supprt future tests

### DIFF
--- a/.changeset/pink-bugs-walk.md
+++ b/.changeset/pink-bugs-walk.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': patch
+---
+
+Refactored internals to allow for future extension of nested-mutation tests.


### PR DESCRIPTION
This gets us closer to what's in #2271. This PR doesn't change any behaviour, it just rearranges the code to be more extensible so that we can add the test cases required by #2271. There will be more PRs coming closely on the heels of this one.