### PR TITLE
[WIP] Refactored preloadViews out of field controller base

### DIFF
--- a/.changeset/fresh-bags-hear.md
+++ b/.changeset/fresh-bags-hear.md
@@ -3,4 +3,4 @@
 '@keystonejs/fields': patch
 ---
 
-Removed adminPath and authStrategy members from base field Controller class.
+Removed adminPath, authStrategy, and preloadViews members from base field Controller class.

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -5,7 +5,7 @@ import { arrayToObject, mapKeys, omit } from '@keystonejs/utils';
 export default class List {
   constructor(
     { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
-    { readViews, preloadViews, getListByKey, adminPath },
+    { readViews, getListByKey, adminPath },
     views
   ) {
     this.access = access;
@@ -21,11 +21,7 @@ export default class List {
 
     this.fields = fields.map(fieldConfig => {
       const [Controller] = readViews([views[fieldConfig.path].Controller]);
-      return new Controller(
-        fieldConfig,
-        { readViews, preloadViews, getListByKey },
-        views[fieldConfig.path]
-      );
+      return new Controller(fieldConfig, { readViews, getListByKey }, views[fieldConfig.path]);
     });
 
     this._fieldsByPath = arrayToObject(this.fields, 'path');

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -16,6 +16,7 @@ import FieldSelect from '../FieldSelect';
 import PopoutForm from './PopoutForm';
 import { DisclosureArrow, POPOUT_GUTTER } from '../../../components/Popout';
 import { ErrorBoundary } from '../../../components/ErrorBoundary';
+import { preloadViews } from '../../../providers/AdminMeta';
 
 const EventCatcher = props => (
   <div
@@ -233,9 +234,7 @@ export default class AddFilterPopout extends Component<Props, State> {
             exiting: { transform: 'translateX(-100%)' },
             exited: { transform: 'translateX(-100%)' },
           };
-          this.props.fields[0].preloadViews(
-            this.props.fields.map(({ views }) => views.Filter).filter(x => x)
-          );
+          preloadViews(this.props.fields.map(({ views }) => views.Filter).filter(x => x));
 
           const style = { ...base, ...states[state] };
           return (

--- a/packages/app-admin-ui/client/providers/AdminMeta.js
+++ b/packages/app-admin-ui/client/providers/AdminMeta.js
@@ -5,6 +5,9 @@ import { views, readViews, preloadViews } from '../FIELD_TYPES';
 
 import React, { useContext, createContext } from 'react';
 
+// Re-export these here for convenience
+export { readViews, preloadViews };
+
 const { __pages__: pageViews, __hooks__: hookView, ...listViews } = views;
 
 // TODO: Pull this off `window.X` to support server side permission queries
@@ -70,7 +73,7 @@ export const AdminMetaProvider = ({ children }) => {
     ([key, { access, adminConfig, adminDoc, fields, gqlNames, label, path, plural, singular }]) => {
       const list = new List(
         { access, adminConfig, adminDoc, fields, gqlNames, key, label, path, plural, singular },
-        { readViews, preloadViews, getListByKey, apiPath, adminPath },
+        { readViews, getListByKey, adminPath },
         views[key]
       );
       listsByKey[key] = list;

--- a/packages/fields/src/Controller.js
+++ b/packages/fields/src/Controller.js
@@ -15,7 +15,7 @@ export default class FieldController {
       defaultValue,
       ...config
     },
-    { readViews, preloadViews, getListByKey },
+    { readViews, getListByKey },
     views
   ) {
     this.config = config;
@@ -29,7 +29,6 @@ export default class FieldController {
     this.isReadOnly = isReadOnly;
     this.adminDoc = adminDoc;
     this.readViews = readViews;
-    this.preloadViews = preloadViews;
     this.getListByKey = getListByKey;
     this.views = views;
 


### PR DESCRIPTION
`preloadViews` is a purely admin ui-side function. Storing it in the field controller just to access it later though `AddFilterPopout` is extremely roundabout.

No changeset since this just amends the one from #3009.