### PR TITLE
Rename Field View prop from isReadOnly to isDisabled

### DIFF
--- a/.changeset/blue-ways-work.md
+++ b/.changeset/blue-ways-work.md
@@ -9,6 +9,7 @@
 
 * Added `isReadOnly` option on field's `adminConfig`. Fields with this option set will be excluded from the `create` form, and set as disabled in the `update` form in the Admin UI.
 * Updated the item detail page to include fields with access `{ update: false }` in a disabled state, rather than excluded the form.
+* Updated all Field Views to accept `isDisabled` prop. When set to `true` this will disable the field input.
 
 Example:
 

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -268,7 +268,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
                         field={field}
                         list={list}
                         item={item}
-                        isReadOnly={isReadOnly}
+                        isDisabled={isReadOnly}
                         errors={[
                           ...(itemErrors[field.path] ? [itemErrors[field.path]] : []),
                           ...(validationErrors[field.path] || []),

--- a/packages/field-content/src/views/Field.js
+++ b/packages/field-content/src/views/Field.js
@@ -24,7 +24,7 @@ class ErrorBoundary extends Component {
   }
 }
 
-let ContentField = ({ field, value, onChange, autoFocus, errors, isReadOnly }) => {
+let ContentField = ({ field, value, onChange, autoFocus, errors, isDisabled }) => {
   const htmlID = `ks-content-editor-${field.path}`;
 
   return (
@@ -62,7 +62,7 @@ let ContentField = ({ field, value, onChange, autoFocus, errors, isReadOnly }) =
                   padding: '16px 32px',
                   minHeight: 200,
                 }}
-                isReadOnly={isReadOnly}
+                isDisabled={isDisabled}
               />
             )}
         </ErrorBoundary>

--- a/packages/field-content/src/views/editor/index.js
+++ b/packages/field-content/src/views/editor/index.js
@@ -32,7 +32,7 @@ function getSchema(blocks) {
   return schema;
 }
 
-function Stories({ value: editorState, onChange, blocks, className, id, isReadOnly }) {
+function Stories({ value: editorState, onChange, blocks, className, id, isDisabled }) {
   let schema = useMemo(() => {
     return getSchema(blocks);
   }, [blocks]);
@@ -75,7 +75,7 @@ function Stories({ value: editorState, onChange, blocks, className, id, isReadOn
         onChange={({ value }) => {
           onChange(value);
         }}
-        readOnly={isReadOnly}
+        readOnly={isDisabled}
       />
       <AddBlock editor={editor} editorState={editorState} blocks={blocks} />
       <Toolbar {...{ editorState, editor, blocks }} />

--- a/packages/fields-markdown/src/views/Field.js
+++ b/packages/fields-markdown/src/views/Field.js
@@ -62,7 +62,7 @@ const IconToolbarButton = ({ isActive, label, icon, tooltipPlacement = 'top', ..
   );
 };
 
-export default function MarkdownField({ field, errors, value, onChange, isReadOnly }) {
+export default function MarkdownField({ field, errors, value, onChange, isDisabled }) {
   const htmlID = `ks-input-${field.path}`;
   const accessError = errors.find(
     error => error instanceof Error && error.name === 'AccessDeniedError'
@@ -87,7 +87,7 @@ export default function MarkdownField({ field, errors, value, onChange, isReadOn
               icon={<Icon />}
               onClick={action}
               label={label}
-              disabled={isReadOnly}
+              disabled={isDisabled}
             />
           );
         })}
@@ -130,7 +130,7 @@ export default function MarkdownField({ field, errors, value, onChange, isReadOn
             tabSize: '2',
             lineWrapping: true,
             addModeClass: true,
-            readOnly: isReadOnly,
+            readOnly: isDisabled,
           }}
           editorDidMount={editor => {
             setTools(getTools(editor));

--- a/packages/fields-wysiwyg-tinymce/src/views/Field.js
+++ b/packages/fields-wysiwyg-tinymce/src/views/Field.js
@@ -37,7 +37,7 @@ const GlobalStyles = () => (
   />
 );
 
-const WysiwygField = ({ onChange, autoFocus, field, errors, value: serverValue, isReadOnly }) => {
+const WysiwygField = ({ onChange, autoFocus, field, errors, value: serverValue, isDisabled }) => {
   const handleChange = value => {
     if (typeof value === 'string') {
       onChange(value);
@@ -63,7 +63,7 @@ const WysiwygField = ({ onChange, autoFocus, field, errors, value: serverValue, 
           init={{ ...defaultOptions, auto_focus: autoFocus, ...overrideOptions }}
           onEditorChange={handleChange}
           value={value}
-          isDisabled={isReadOnly}
+          disabled={isDisabled}
         />
       </div>
     </FieldContainer>

--- a/packages/fields/src/types/CalendarDay/views/Field.js
+++ b/packages/fields/src/types/CalendarDay/views/Field.js
@@ -6,7 +6,7 @@ import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-
 import { TextDayPicker } from '@arch-ui/day-picker';
 import { Alert } from '@arch-ui/alert';
 
-const CalendarDayField = ({ autoFocus, field, value, errors, onChange, isReadOnly }) => {
+const CalendarDayField = ({ autoFocus, field, value, errors, onChange, isDisabled }) => {
   const htmlID = `ks-daypicker-${field.path}`;
 
   return (
@@ -20,7 +20,7 @@ const CalendarDayField = ({ autoFocus, field, value, errors, onChange, isReadOnl
           date={value}
           format={field.config.format}
           onChange={onChange}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
 

--- a/packages/fields/src/types/Checkbox/views/Field.js
+++ b/packages/fields/src/types/Checkbox/views/Field.js
@@ -6,7 +6,7 @@ import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-
 
 import { CheckboxPrimitive } from '@arch-ui/controls';
 
-const CheckboxField = ({ onChange, autoFocus, field, value, errors, isReadOnly }) => {
+const CheckboxField = ({ onChange, autoFocus, field, value, errors, isDisabled }) => {
   const handleChange = event => {
     onChange(event.target.checked);
   };
@@ -23,7 +23,7 @@ const CheckboxField = ({ onChange, autoFocus, field, value, errors, isReadOnly }
           checked={checked}
           onChange={handleChange}
           id={htmlID}
-          isDisabled={isReadOnly}
+          isDisabled={isDisabled}
         />
         <FieldLabel
           htmlFor={htmlID}

--- a/packages/fields/src/types/CloudinaryImage/views/Field.js
+++ b/packages/fields/src/types/CloudinaryImage/views/Field.js
@@ -187,7 +187,7 @@ export default class CloudinaryImageField extends Component {
   // ==============================
 
   renderUploadButton = () => {
-    const { uploadButtonLabel, isReadOnly } = this.props;
+    const { uploadButtonLabel, isDisabled } = this.props;
     const { changeStatus, isLoading } = this.state;
 
     return (
@@ -195,14 +195,14 @@ export default class CloudinaryImageField extends Component {
         onClick={this.openFileBrowser}
         isLoading={isLoading}
         variant="ghost"
-        isDisabled={isReadOnly}
+        isDisabled={isDisabled}
       >
         {uploadButtonLabel({ status: changeStatus })}
       </LoadingButton>
     );
   };
   renderCancelButton = () => {
-    const { cancelButtonLabel, isReadOnly } = this.props;
+    const { cancelButtonLabel, isDisabled } = this.props;
     const { changeStatus } = this.state;
 
     // possible states; no case for 'empty' as cancel is not rendered
@@ -219,14 +219,14 @@ export default class CloudinaryImageField extends Component {
     }
 
     return (
-      <Button onClick={onClick} variant="subtle" appearance={appearance} isDisabled={isReadOnly}>
+      <Button onClick={onClick} variant="subtle" appearance={appearance} isDisabled={isDisabled}>
         {cancelButtonLabel({ status: changeStatus })}
       </Button>
     );
   };
 
   render() {
-    const { autoFocus, field, statusMessage, errors, isReadOnly } = this.props;
+    const { autoFocus, field, statusMessage, errors, isDisabled } = this.props;
     const { changeStatus, errorMessage } = this.state;
 
     const { file } = this.getFile();
@@ -274,7 +274,7 @@ export default class CloudinaryImageField extends Component {
             name={field.path}
             onChange={this.onChange}
             type="file"
-            disabled={isReadOnly}
+            disabled={isDisabled}
           />
         </FieldInput>
       </FieldContainer>

--- a/packages/fields/src/types/Color/views/Field.js
+++ b/packages/fields/src/types/Color/views/Field.js
@@ -6,7 +6,7 @@ import Popout from '@arch-ui/popout';
 import { Button } from '@arch-ui/button';
 import SketchPicker from 'react-color/lib/Sketch';
 
-const ColorField = ({ field, value: serverValue, errors, onChange, isReadOnly }) => {
+const ColorField = ({ field, value: serverValue, errors, onChange, isDisabled }) => {
   const value = serverValue || '';
   const htmlID = `ks-input-${field.path}`;
 
@@ -24,7 +24,7 @@ const ColorField = ({ field, value: serverValue, errors, onChange, isReadOnly })
   }, [value]);
 
   const target = props => (
-    <Button {...props} variant="ghost" isDisabled={isReadOnly}>
+    <Button {...props} variant="ghost" isDisabled={isDisabled}>
       {value ? (
         <Fragment>
           <div

--- a/packages/fields/src/types/DateTime/views/Field.js
+++ b/packages/fields/src/types/DateTime/views/Field.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { TextDayTimePicker } from '@arch-ui/day-picker';
 
-const DateTimeField = ({ autoFocus, field, onChange, value, errors, isReadOnly }) => {
+const DateTimeField = ({ autoFocus, field, onChange, value, errors, isDisabled }) => {
   const htmlID = `ks-input-${field.path}`;
 
   return (
@@ -18,7 +18,7 @@ const DateTimeField = ({ autoFocus, field, onChange, value, errors, isReadOnly }
           date={value}
           onChange={onChange}
           autoFocus={autoFocus}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Decimal/views/Field.js
+++ b/packages/fields/src/types/Decimal/views/Field.js
@@ -9,7 +9,7 @@ import {
 } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const DecimalField = ({ onChange, autoFocus, field, value, errors, isReadOnly }) => {
+const DecimalField = ({ onChange, autoFocus, field, value, errors, isDisabled }) => {
   const handleChange = event => {
     const value = event.target.value;
     onChange(value.replace(/[^0-9.,]+/g, ''));
@@ -48,7 +48,7 @@ const DecimalField = ({ onChange, autoFocus, field, value, errors, isReadOnly })
           value={valueToString(value)}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/File/views/Field.js
+++ b/packages/fields/src/types/File/views/Field.js
@@ -179,7 +179,7 @@ export default class FileField extends Component {
   // ==============================
 
   renderUploadButton = () => {
-    const { uploadButtonLabel, isReadOnly } = this.props;
+    const { uploadButtonLabel, isDisabled } = this.props;
     const { changeStatus, isLoading } = this.state;
 
     return (
@@ -187,14 +187,14 @@ export default class FileField extends Component {
         onClick={this.openFileBrowser}
         isLoading={isLoading}
         variant="ghost"
-        isDisabled={isReadOnly}
+        isDisabled={isDisabled}
       >
         {uploadButtonLabel({ status: changeStatus })}
       </LoadingButton>
     );
   };
   renderCancelButton = () => {
-    const { cancelButtonLabel, isReadOnly } = this.props;
+    const { cancelButtonLabel, isDisabled } = this.props;
     const { changeStatus } = this.state;
 
     // possible states; no case for 'empty' as cancel is not rendered
@@ -211,14 +211,14 @@ export default class FileField extends Component {
     }
 
     return (
-      <Button onClick={onClick} variant="subtle" appearance={appearance} isDisabled={isReadOnly}>
+      <Button onClick={onClick} variant="subtle" appearance={appearance} isDisabled={isDisabled}>
         {cancelButtonLabel({ status: changeStatus })}
       </Button>
     );
   };
 
   render() {
-    const { autoFocus, field, statusMessage, errors, isReadOnly } = this.props;
+    const { autoFocus, field, statusMessage, errors, isDisabled } = this.props;
     const { changeStatus, errorMessage } = this.state;
 
     const { file } = this.getFile();
@@ -265,7 +265,7 @@ export default class FileField extends Component {
             name={field.path}
             onChange={this.onChange}
             type="file"
-            disabled={isReadOnly}
+            disabled={isDisabled}
           />
         </FieldInput>
       </FieldContainer>

--- a/packages/fields/src/types/Float/views/Field.js
+++ b/packages/fields/src/types/Float/views/Field.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const FloatField = ({ onChange, autoFocus, field, value, errors, isReadOnly }) => {
+const FloatField = ({ onChange, autoFocus, field, value, errors, isDisabled }) => {
   const handleChange = event => {
     const value = event.target.value;
     // Similar implementation as per old Keystone version
@@ -39,7 +39,7 @@ const FloatField = ({ onChange, autoFocus, field, value, errors, isReadOnly }) =
           value={valueToString(value)}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Integer/views/Field.js
+++ b/packages/fields/src/types/Integer/views/Field.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const IntegerField = ({ onChange, autoFocus, field, value, errors, isReadOnly }) => {
+const IntegerField = ({ onChange, autoFocus, field, value, errors, isDisabled }) => {
   const handleChange = event => {
     const value = event.target.value;
     onChange(value.replace(/\D/g, ''));
@@ -36,7 +36,7 @@ const IntegerField = ({ onChange, autoFocus, field, value, errors, isReadOnly })
           value={valueToString(value)}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Location/views/Field.js
+++ b/packages/fields/src/types/Location/views/Field.js
@@ -13,7 +13,7 @@ const LocationField = ({
   onChange,
   google,
   renderContext,
-  isReadOnly,
+  isDisabled,
 }) => {
   const { googlePlaceID, formattedAddress, lat, lng } = serverValue || {};
   const htmlID = `ks-input-${field.path}`;
@@ -97,7 +97,7 @@ const LocationField = ({
           inputId={htmlID}
           instanceId={htmlID}
           css={{ width: '100%' }}
-          isDisabled={isReadOnly}
+          isDisabled={isDisabled}
           {...selectProps}
         />
         {marker && (

--- a/packages/fields/src/types/OEmbed/views/Field.js
+++ b/packages/fields/src/types/OEmbed/views/Field.js
@@ -47,7 +47,7 @@ const OEmbedField = ({
   value = null,
   savedValue = null,
   errors,
-  isReadOnly,
+  isDisabled,
 }) => {
   const handleChange = event => {
     onChange({
@@ -76,7 +76,7 @@ const OEmbedField = ({
           placeholder={canRead ? undefined : error.message}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
       {value && value.originalUrl && hasChanged && (

--- a/packages/fields/src/types/Password/views/Field.js
+++ b/packages/fields/src/types/Password/views/Field.js
@@ -18,7 +18,7 @@ const PasswordField = ({
   item: { password_is_set } = {},
   errors,
   warnings,
-  isReadOnly,
+  isDisabled,
 }) => {
   const focusTarget = useRef();
 
@@ -80,7 +80,7 @@ const PasswordField = ({
               placeholder="New Password"
               type={showInputValue ? 'text' : 'password'}
               value={inputPassword}
-              disabled={isReadOnly}
+              disabled={isDisabled}
             />
             <Input
               autoComplete="off"
@@ -91,14 +91,14 @@ const PasswordField = ({
               placeholder="Confirm Password"
               type={showInputValue ? 'text' : 'password'}
               value={inputConfirm}
-              disabled={isReadOnly}
+              disabled={isDisabled}
             />
             <Button
               isActive={showInputValue}
               onClick={toggleMode}
               title={showInputValue ? 'Hide Text' : 'Show Text'}
               variant="ghost"
-              isDisabled={isReadOnly}
+              isDisabled={isDisabled}
             >
               <A11yText>{showInputValue ? 'Hide Text' : 'Show Text'}</A11yText>
               <div css={{ width: 20 }}>{showInputValue ? <LockIcon /> : <EyeIcon />}</div>
@@ -109,7 +109,7 @@ const PasswordField = ({
             id={`${htmlID}-button`}
             onClick={toggleInterface}
             variant="ghost"
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled}
           >
             {password_is_set ? 'Update Password' : 'Set Password'}
           </Button>

--- a/packages/fields/src/types/Relationship/views/Field.js
+++ b/packages/fields/src/types/Relationship/views/Field.js
@@ -173,7 +173,7 @@ const RelationshipField = ({
   onChange,
   item,
   list,
-  isReadOnly,
+  isDisabled,
 }) => {
   const handleChange = option => {
     const { many } = field.config;
@@ -205,7 +205,7 @@ const RelationshipField = ({
             renderContext={renderContext}
             htmlID={htmlID}
             onChange={handleChange}
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled}
           />
         </div>
         <ListProvider list={relatedList}>
@@ -216,7 +216,7 @@ const RelationshipField = ({
             field={field}
             item={item}
             list={list}
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled}
           />
         </ListProvider>
         {authStrategy && ref === authStrategy.listKey && (
@@ -227,7 +227,7 @@ const RelationshipField = ({
             }}
             value={value}
             listKey={authStrategy.listKey}
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled}
           />
         )}
         <LinkToRelatedItems field={field} value={value} />

--- a/packages/fields/src/types/Select/views/Field.js
+++ b/packages/fields/src/types/Select/views/Field.js
@@ -12,7 +12,7 @@ const SelectField = ({
   value: serverValue,
   renderContext,
   errors,
-  isReadOnly,
+  isDisabled,
 }) => {
   const handleChange = option => {
     onChange(option ? option.value : null);
@@ -49,7 +49,7 @@ const SelectField = ({
             id={`react-select-${htmlID}`}
             inputId={htmlID}
             instanceId={htmlID}
-            isDisabled={isReadOnly}
+            isDisabled={isDisabled}
             {...selectProps}
           />
         </div>

--- a/packages/fields/src/types/Text/views/Field.js
+++ b/packages/fields/src/types/Text/views/Field.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const TextField = ({ onChange, autoFocus, field, errors, value: serverValue, isReadOnly }) => {
+const TextField = ({ onChange, autoFocus, field, errors, value: serverValue, isDisabled }) => {
   const handleChange = event => {
     onChange(event.target.value);
   };
@@ -33,7 +33,7 @@ const TextField = ({ onChange, autoFocus, field, errors, value: serverValue, isR
           onChange={handleChange}
           id={htmlID}
           isMultiline={isMultiline}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Unsplash/views/Field.js
+++ b/packages/fields/src/types/Unsplash/views/Field.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const UnsplashField = ({ onChange, autoFocus, field, errors, value: serverValue, isReadOnly }) => {
+const UnsplashField = ({ onChange, autoFocus, field, errors, value: serverValue, isDisabled }) => {
   const handleChange = event => {
     onChange(event.target.value);
   };
@@ -31,7 +31,7 @@ const UnsplashField = ({ onChange, autoFocus, field, errors, value: serverValue,
           placeholder={canRead ? 'Unsplash Image ID' : error.message}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Url/views/Field.js
+++ b/packages/fields/src/types/Url/views/Field.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const UrlField = ({ onChange, autoFocus, field, value: serverValue, errors, isReadOnly }) => {
+const UrlField = ({ onChange, autoFocus, field, value: serverValue, errors, isDisabled }) => {
   const handleChange = event => {
     onChange(event.target.value);
   };
@@ -31,7 +31,7 @@ const UrlField = ({ onChange, autoFocus, field, value: serverValue, errors, isRe
           placeholder={canRead ? undefined : error.message}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/packages/fields/src/types/Uuid/views/Field.js
+++ b/packages/fields/src/types/Uuid/views/Field.js
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const UuidField = ({ onChange, autoFocus, field, errors, value: serverValue, isReadOnly }) => {
+const UuidField = ({ onChange, autoFocus, field, errors, value: serverValue, isDisabled }) => {
   const handleChange = event => {
     onChange(event.target.value);
   };
@@ -31,7 +31,7 @@ const UuidField = ({ onChange, autoFocus, field, errors, value: serverValue, isR
           placeholder={canRead ? undefined : error.message}
           onChange={handleChange}
           id={htmlID}
-          disabled={isReadOnly}
+          disabled={isDisabled}
         />
       </FieldInput>
     </FieldContainer>

--- a/test-projects/basic/cypress/integration/readOnly_spec.js
+++ b/test-projects/basic/cypress/integration/readOnly_spec.js
@@ -25,5 +25,19 @@ describe('ReadOnly Fields', () => {
             cy.get('button').should('be.disabled');
           });
       });
+
+    // wysiwyg field rendering
+    cy.get(`label[for="ks-input-wysiwygValue"]`)
+      .should('exist')
+      .then($label => {
+        cy.get($label)
+          .next()
+          .within(() => {
+            cy.get('iframe').then($iframe => {
+              const iframe = $iframe.contents();
+              cy.wrap(iframe.find('#tinymce')).should('have.attr', 'contenteditable', 'false');
+            });
+          });
+      });
   });
 });

--- a/test-projects/basic/data.js
+++ b/test-projects/basic/data.js
@@ -110,6 +110,11 @@ module.exports = {
   ReadOnlyList: [
     {
       name: 'ReadOnly',
+      price: '25.25',
+      markdownValue: '# markdown header',
+      wysiwygValue: '<h1>html header</h1>',
+      views: '25',
+      currency: 'AUD',
     },
   ],
   User: users.map(user => ({ ...user, password: 'password' })),

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -21,6 +21,7 @@ const {
 const { Content } = require('@keystonejs/field-content');
 const { CloudinaryAdapter, LocalFileAdapter } = require('@keystonejs/file-adapters');
 const { Markdown } = require('@keystonejs/fields-markdown');
+const { Wysiwyg } = require('@keystonejs/fields-wysiwyg-tinymce');
 const { GraphQLApp } = require('@keystonejs/app-graphql');
 const { AdminUIApp } = require('@keystonejs/app-admin-ui');
 const { StaticApp } = require('@keystonejs/app-static');
@@ -229,6 +230,7 @@ keystone.createList('ReadOnlyList', {
     currency: { type: Text, adminConfig: { isReadOnly: true } },
     hero: { type: File, adapter: fileAdapter, adminConfig: { isReadOnly: true } },
     markdownValue: { type: Markdown, adminConfig: { isReadOnly: true } },
+    wysiwygValue: { type: Wysiwyg, adminConfig: { isReadOnly: true } },
     value: {
       type: Content,
       blocks: [

--- a/test-projects/basic/package.json
+++ b/test-projects/basic/package.json
@@ -27,6 +27,7 @@
     "@keystonejs/field-content": "^6.0.1",
     "@keystonejs/fields": "^11.0.0",
     "@keystonejs/fields-markdown": "^5.1.11",
+    "@keystonejs/fields-wysiwyg-tinymce": "^5.2.8",
     "@keystonejs/file-adapters": "^6.0.1",
     "@keystonejs/keystone": "^9.0.1",
     "@keystonejs/oembed-adapters": "^5.1.4",


### PR DESCRIPTION
ref #2258

It makes more sense to have Field View to use `isDisabled` prop rather than `isReadOnly`


this PR:

* renames prop for Field Views (only) to `isDisabled` from `isReadOnly`
  - Does not change the api for public, it remains `adminConfig: { isReadOnly: true }`
* fixes disable issue in `wysiwyg` field.
* added test for `wysiwyg` field being read only.


I have not added changeset as this should be merged to #2258 for release.
updated changeset for #2258 to reflect the change.