### PR TITLE
Renamed two keys in _ksListMeta for clarity (no breakage)

### DIFF
--- a/.changeset/healthy-trains-sin.md
+++ b/.changeset/healthy-trains-sin.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Renamed some keys in the `_ksListsMeta` query for clarity.

--- a/.changeset/healthy-trains-sin.md
+++ b/.changeset/healthy-trains-sin.md
@@ -2,4 +2,4 @@
 '@keystonejs/keystone': patch
 ---
 
-Renamed some keys in the `_ksListsMeta` query for clarity.
+Added `key` and `path` fields to replace `name` in `_ListMeta` and `_ListSchemaFields`, respectively. `name` in both types has been deprecated.

--- a/packages/keystone/lib/List/index.js
+++ b/packages/keystone/lib/List/index.js
@@ -864,6 +864,7 @@ module.exports = class List {
 
   listMeta(context) {
     return {
+      key: this.key,
       name: this.key,
       // Return these as functions so they're lazily evaluated depending
       // on what the user requested

--- a/packages/keystone/lib/providers/listCRUD.js
+++ b/packages/keystone/lib/providers/listCRUD.js
@@ -42,8 +42,11 @@ class ListCRUDProvider {
         auth: JSON
       }`,
       `type _ListSchemaFields {
+        """ The path of the field in its list. """
+        path: String
+
         """The name of the field in its list."""
-        name: String
+        name: String @deprecated(reason: "Use \`path\` instead")
 
         """The field type (ie, Checkbox, Text, etc)"""
         type: String
@@ -71,8 +74,11 @@ class ListCRUDProvider {
         relatedFields: [_ListSchemaRelatedFields]
       }`,
       `type _ListMeta {
+        """ The Keystone list key """
+        key: String
+
         """The Keystone List name"""
-        name: String
+        name: String @deprecated(reason: "Use \`key\` instead")
 
         """Access control configuration for the currently authenticated
            request"""
@@ -140,6 +146,7 @@ class ListCRUDProvider {
           .getAllFieldsWithAccess({ schemaName, access: 'read' })
           .filter(field => !type || field.constructor.name === type)
           .map(field => ({
+            path: field.path,
             name: field.path,
             type: field.constructor.name,
           }));


### PR DESCRIPTION
Renamed `name` for lists to `key`. Likewise `path` for fields. These better match their usages throughout the codebase.

The old `name` keys still work, they're just marked as deprecated.