### PR TITLE
Admin UI: fixed issues with checkbox field filter

### DIFF
--- a/.changeset/few-bears-eat.md
+++ b/.changeset/few-bears-eat.md
@@ -5,4 +5,4 @@
 '@keystonejs/fields-mongoid': major
 ---
 
-Refactored how list and item queries and generated. Field controllers' `getFilterGraphQL` method now returns an object in the format { filter: value } rather than a GraphQL string.
+Refactored how list and item queries and generated. Field controllers' `getFilterGraphQL` method now returns an object in the format { filter: value } rather than a GraphQL string. Additionally, `getFilterValue` should now return `undefined` instead of `null` if the filter should not be submitted.

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -182,7 +182,7 @@ export default class AddFilterPopout extends Component<Props, State> {
     const { field, filter, value } = this.state;
 
     event.preventDefault();
-    if (!filter || value === null || field.getFilterValue(value) === null) return;
+    if (!filter) return;
 
     onChange({ field, label: filter.label, type: filter.type, value });
   };

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -182,7 +182,7 @@ export default class AddFilterPopout extends Component<Props, State> {
     const { field, filter, value } = this.state;
 
     event.preventDefault();
-    if (!filter) return;
+    if (!filter || field.getFilterValue(value) === undefined) return;
 
     onChange({ field, label: filter.label, type: filter.type, value });
   };

--- a/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -8,6 +8,7 @@ const EditFilterPopout = ({ filter, target, onChange }) => {
   const [value, setValue] = useState(filter.value);
 
   const onSubmit = () => {
+    if (filter.field.getFilterValue(value) === undefined) return;
     onChange({
       field: filter.field,
       label: filter.label,

--- a/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/EditFilterPopout.js
@@ -8,7 +8,6 @@ const EditFilterPopout = ({ filter, target, onChange }) => {
   const [value, setValue] = useState(filter.value);
 
   const onSubmit = () => {
-    if (value === null || filter.field.getFilterValue(value) === null) return;
     onChange({
       field: filter.field,
       label: filter.label,

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -252,7 +252,10 @@ const ListPage = props => {
   // Only show error page if there is no data
   // (ie; there could be partial data + partial errors)
   if (query.error && (!query.data || !items || !Object.keys(items).length)) {
-    let message = queryErrorsParsed.message;
+    let message = '';
+    if (queryErrorsParsed) {
+      message = queryErrorsParsed.message;
+    }
 
     // If there was an error returned by GraphQL, use that message instead
     // FIXME: convert this to an optional chaining operator at some point

--- a/packages/fields/src/types/Checkbox/views/Controller.js
+++ b/packages/fields/src/types/Checkbox/views/Controller.js
@@ -14,18 +14,18 @@ export default class CheckboxController extends FieldController {
     return `${this.label} ${label.toLowerCase()}`;
   };
   formatFilter = ({ label, value }) => {
-    return `${this.getFilterLabel({ label })}: "${value}"`;
+    return `${this.getFilterLabel({ label })}: ${value}`;
   };
   getFilterTypes = () => [
     {
       type: 'is',
       label: 'Is',
-      getInitialValue: () => 'true',
+      getInitialValue: () => true,
     },
     {
       type: 'not',
       label: 'Is not',
-      getInitialValue: () => 'true',
+      getInitialValue: () => true,
     },
   ];
 }

--- a/packages/fields/src/types/Checkbox/views/Filter.js
+++ b/packages/fields/src/types/Checkbox/views/Filter.js
@@ -1,14 +1,25 @@
 import React from 'react';
 import { RadioGroup, Radio } from '@arch-ui/filters';
 
+const inputMap = {
+  is_true: true,
+  is_false: false,
+  is_null: null,
+};
+
 const CheckboxFilterView = ({ onChange, filter, value }) => {
+  const handleChange = newValue => {
+    onChange(inputMap[newValue]);
+  };
+
+  const textValue = Object.entries(inputMap).find(([_, v]) => v === value)[0];
   if (!filter) return null;
 
   return (
-    <RadioGroup onChange={onChange} value={value}>
-      <Radio value="true">Checked</Radio>
-      <Radio value="false">Unchecked</Radio>
-      <Radio value="null">Not set</Radio>
+    <RadioGroup onChange={handleChange} value={textValue}>
+      <Radio value="is_true">True</Radio>
+      <Radio value="is_false">False</Radio>
+      <Radio value="is_null">Not set</Radio>
     </RadioGroup>
   );
 };

--- a/packages/fields/src/types/Checkbox/views/Filter.js
+++ b/packages/fields/src/types/Checkbox/views/Filter.js
@@ -12,7 +12,7 @@ const CheckboxFilterView = ({ onChange, filter, value }) => {
     onChange(inputMap[newValue]);
   };
 
-  const textValue = Object.entries(inputMap).find(([, v]) => v === value)[0];
+  const textValue = value === true ? 'is_true' : value === false ? 'is_false' : 'is_null';
   if (!filter) return null;
 
   return (

--- a/packages/fields/src/types/Checkbox/views/Filter.js
+++ b/packages/fields/src/types/Checkbox/views/Filter.js
@@ -12,7 +12,7 @@ const CheckboxFilterView = ({ onChange, filter, value }) => {
     onChange(inputMap[newValue]);
   };
 
-  const textValue = Object.entries(inputMap).find(([_, v]) => v === value)[0];
+  const textValue = Object.entries(inputMap).find(([, v]) => v === value)[0];
   if (!filter) return null;
 
   return (

--- a/packages/fields/src/types/Select/views/Controller.js
+++ b/packages/fields/src/types/Select/views/Controller.js
@@ -45,7 +45,7 @@ export default class SelectController extends FieldController {
       : `${this.label} is ${optionLabel}`;
   };
   getFilterValue = value => {
-    return value && value.options && value.options.length ? value : null;
+    return value && value.options && value.options.length ? value : undefined;
   };
   getFilterTypes = () => [
     {


### PR DESCRIPTION
This one turned out way more complicated than I expected... Adding on to the changeset from #2976 since it's related.

Fixed the checkbox filter being broken since it was still using strings. In order to do that, I needed to make the filter API take `null` as a valid filter value (since it is). `getFilterValue` now should return `undefined` if you want to not submit the filter at all.

Also tweaked the presentation of the checkbox filter:
- "Checked" -> "True"
- "Unchecked" -> "False"
- Formatting display no longer put quotes around the value

Includes a fix for error messages sometimes not showing in the list view.