### PR TITLE
Admin UI: fixed error clearing Select filter

### DIFF
--- a/.changeset/many-dogs-occur.md
+++ b/.changeset/many-dogs-occur.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed an error when clearing the last selection in the Select field filter.

--- a/packages/fields/src/types/Select/views/Filter.js
+++ b/packages/fields/src/types/Select/views/Filter.js
@@ -25,10 +25,8 @@ const SelectFilterView = ({ innerRef, field, value, onChange }) => {
   };
 
   const handleSelectChange = newValue => {
-    if (newValue.length) {
-      const options = [...newValue]; // ensure consistent data shape
-      onChange({ ...value, options });
-    }
+    const options = [...(newValue || [])]; // ensure consistent data shape
+    onChange({ ...value, options });
   };
 
   const radioValue = value.inverted ? 'does_not_match' : 'does_match';


### PR DESCRIPTION
Fixes this when trying to clear the last selected option:
![image](https://user-images.githubusercontent.com/3558659/82776431-ae9c8e00-9e96-11ea-957a-a79fcad224ba.png)
