### PR TITLE
Admin UI: fixed unnecessary Dashboard API queries

### DIFF
--- a/.changeset/two-ears-live.md
+++ b/.changeset/two-ears-live.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed unnecessary API Dashboard API queries.

--- a/packages/app-admin-ui/client/pages/Home/index.js
+++ b/packages/app-admin-ui/client/pages/Home/index.js
@@ -97,7 +97,7 @@ const Homepage = () => {
             const { key, path } = list;
             const meta = data && data[list.gqlNames.listQueryMetaName];
             return (
-              <ListProvider list={list} key={key}>
+              <ListProvider list={list} key={key} skipQuery>
                 <Cell width={cellWidth}>
                   <Box to={`${adminPath}/${path}`} meta={meta} />
                 </Cell>

--- a/packages/app-admin-ui/client/providers/List.js
+++ b/packages/app-admin-ui/client/providers/List.js
@@ -10,7 +10,7 @@ export const useList = () => {
   return useContext(ListContext);
 };
 
-export const ListProvider = ({ list, skipQuery = false, children }) => {
+export const ListProvider = ({ children, list, skipQuery = false }) => {
   // ==============================
   // Modal handlers
   // ==============================

--- a/packages/app-admin-ui/client/providers/List.js
+++ b/packages/app-admin-ui/client/providers/List.js
@@ -10,7 +10,7 @@ export const useList = () => {
   return useContext(ListContext);
 };
 
-export const ListProvider = ({ list, children }) => {
+export const ListProvider = ({ list, skipQuery = false, children }) => {
   // ==============================
   // Modal handlers
   // ==============================
@@ -37,6 +37,7 @@ export const ListProvider = ({ list, children }) => {
   const query = useQuery(list.getListQuery(fields), {
     fetchPolicy: 'cache-and-network',
     errorPolicy: 'all',
+    skip: skipQuery,
     variables: {
       where: formatFilter(filters),
       search,


### PR DESCRIPTION
The Dashboard uses one `ListProvider` per card, but there's no need to run the items query yet at that point.