### PR TITLE
Improved image-not-loaded File field display

### DIFF
--- a/.changeset/loud-dogs-applaud.md
+++ b/.changeset/loud-dogs-applaud.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Improved File field image-not-found display.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -64,6 +64,7 @@
     "react": "^16.13.1",
     "react-color": "^2.17.3",
     "react-dom": "^16.13.1",
+    "react-image": "^4.0.0",
     "react-select": "^3.1.0",
     "react-toast-notifications": "^2.3.0",
     "slate": "^0.47.4",

--- a/packages/fields/src/types/File/views/Field.js
+++ b/packages/fields/src/types/File/views/Field.js
@@ -309,7 +309,7 @@ const ChangeInfo = ({ status = 'default', ...props }) => {
 
 const Image = ({ src: imgSrc, alt }) => {
   const { src } = useImage({ srcList: imgSrc });
-  return <img css={{ height: 'auto', maxWidth: '100%' }} src={src} alt={alt} />;
+  return <img css={{ display: 'block', height: 'auto', maxWidth: '100%' }} src={src} alt={alt} />;
 };
 
 const ImageContainer = props => {
@@ -325,7 +325,6 @@ const ImageContainer = props => {
         position: 'relative',
         textAlign: 'center',
         width: 130, // 120px image + chrome
-        lineHeight: 0,
       }}
     >
       <ImageErrorBoundary>
@@ -349,7 +348,7 @@ class ImageErrorBoundary extends Component {
   render() {
     if (this.state.hasError) {
       return (
-        <div css={{ padding: '4px 0', color: colors.N40, lineHeight: 'initial' }}>
+        <div css={{ padding: '4px 0', color: colors.N40 }}>
           <div>
             <FileMediaIcon />
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -20147,6 +20147,11 @@ react-hot-loader@^4.12.5:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
+react-image@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-image/-/react-image-4.0.0.tgz#328ed515d0f5a39feb7a3f1f14709b07c9eda97a"
+  integrity sha512-8mhwtONmJT+dZN7Xe5Cbmm1qaSz/Dc1uFfQRNZLJ/Q15SeuyTt3ED1Fq0WWYz9qgJwvaMIDw6xnr1cJrJ0CkLQ==
+
 react-immutable-proptypes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"


### PR DESCRIPTION
Utilizes [`react-image`](https://github.com/mbrevda/react-image).

Before:
![image](https://user-images.githubusercontent.com/3558659/83335652-f473af00-a2f9-11ea-8c7a-dd0f4cc56ce6.png)

After:
![image](https://user-images.githubusercontent.com/3558659/83335642-e887ed00-a2f9-11ea-9a0d-6c3464056bef.png)

This also means there's now a loading indicator while the image is loading.