### PR TITLE
Removed stray innerRef prop on a <Link>

### DIFF
--- a/.changeset/two-spies-occur.md
+++ b/.changeset/two-spies-occur.md
@@ -1,0 +1,5 @@
+---
+'@arch-ui/button': patch
+---
+
+Removed stray innerRef prop on a <Link>.

--- a/packages/arch/packages/button/src/primitives.js
+++ b/packages/arch/packages/button/src/primitives.js
@@ -71,7 +71,7 @@ function ButtonElementComponent(props, ref) {
   const variant = makeVariant(props);
 
   if (rest.to) {
-    return <Link innerRef={ref} css={variant} {...rest} />;
+    return <Link ref={ref} css={variant} {...rest} />;
   }
 
   if (rest.href) {


### PR DESCRIPTION
According to the `react-router` docs RE `innerRef`:
> As of React Router 5.1, if you are using React 16 you should not need this prop because we forward the ref to the underlying <a>. Use a normal ref instead.