### PR TITLE
Fix icon imports

### DIFF
--- a/.changeset/loud-squids-collect.md
+++ b/.changeset/loud-squids-collect.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@keystonejs/fields': patch
+---
+
+Fixed an issue with the AdminUI where some icons were throwing errors.

--- a/packages/app-admin-ui/client/components/UpdateItems.js
+++ b/packages/app-admin-ui/client/components/UpdateItems.js
@@ -3,7 +3,7 @@
 import React, { Fragment, useState } from 'react';
 
 import { IconButton } from '@arch-ui/button';
-import { SettingsIcon } from '@arch-ui/icons/src';
+import { SettingsIcon } from '@arch-ui/icons';
 
 import { useList } from '../providers/List';
 import { UpdateManyItemsModal } from '../../components';

--- a/packages/fields/src/types/File/views/Field.js
+++ b/packages/fields/src/types/File/views/Field.js
@@ -6,14 +6,13 @@ import { useImage } from 'react-image';
 import PropTypes from 'prop-types';
 
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
-import { AlertIcon } from '@arch-ui/icons';
+import { AlertIcon, FileMediaIcon } from '@arch-ui/icons';
 import { HiddenInput } from '@arch-ui/input';
 import { LoadingIndicator } from '@arch-ui/loading';
 import { Lozenge } from '@arch-ui/lozenge';
 import { Button, LoadingButton } from '@arch-ui/button';
 import { FlexGroup } from '@arch-ui/layout';
 import { borderRadius, colors, gridSize } from '@arch-ui/theme';
-import { FileMediaIcon } from '@arch-ui/icons/src';
 
 function uploadButtonLabelFn({ status }) {
   return status === 'empty' ? 'Upload File' : 'Change File';


### PR DESCRIPTION
importing icons from /src was causing the adminUI to throw errors outside the monoreop because they were not compiled.