### PR TITLE
Update Docker deployment guide

### DIFF
--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -1,16 +1,12 @@
 <!--[meta]
 section: guides
-title: Deployment recommendations
+title: Docker
 subSection: deployment
 [meta]-->
 
-# Deployment recommendations
-
-## General
+# Docker
 
 Keystone files need to be built with `keystone build` before running in production mode.
-
-## Docker
 
 Keystone can be easily built as a Docker container image, suitable for deploying on Kubernetes or other environments.
 


### PR DESCRIPTION
Title was confusing. Seems like Docker was our recommended deployment method. Changed to match other guides.