### PR TITLE
adapter-knex: self-referential patch

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -544,8 +544,8 @@ class KnexListAdapter extends BaseListAdapter {
     await Promise.all(
       this.rels
         .filter(
-          ({ tableName, left, right }) =>
-            tableName === this.key && right && left.refListKey === right.refListKey
+          ({ tableName, left }) =>
+            tableName === this.key && left.listKey === left.refListKey
         )
         .map(({ columnName, tableName }) =>
           this._setNullByValue({ tableName, columnName, value: id })

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -543,9 +543,8 @@ class KnexListAdapter extends BaseListAdapter {
     // Now traverse all self-referential relationships and sort them right out.
     await Promise.all(
       this.rels
-        .filter(
-          ({ tableName, left }) =>
-            tableName === this.key && left.listKey === left.refListKey
+        .filter(({ tableName, left }) => 
+          tableName === this.key && left.listKey === left.refListKey
         )
         .map(({ columnName, tableName }) =>
           this._setNullByValue({ tableName, columnName, value: id })

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -543,9 +543,7 @@ class KnexListAdapter extends BaseListAdapter {
     // Now traverse all self-referential relationships and sort them right out.
     await Promise.all(
       this.rels
-        .filter(({ tableName, left }) =>
-          tableName === this.key && left.listKey === left.refListKey
-        )
+        .filter(({ tableName, left }) => tableName === this.key && left.listKey === left.refListKey)
         .map(({ columnName, tableName }) =>
           this._setNullByValue({ tableName, columnName, value: id })
         )

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -543,7 +543,7 @@ class KnexListAdapter extends BaseListAdapter {
     // Now traverse all self-referential relationships and sort them right out.
     await Promise.all(
       this.rels
-        .filter(({ tableName, left }) => 
+        .filter(({ tableName, left }) =>
           tableName === this.key && left.listKey === left.refListKey
         )
         .map(({ columnName, tableName }) =>


### PR DESCRIPTION
At the moment it looks like no self-referential relationships are set to NULL.

![image](https://user-images.githubusercontent.com/1394025/83885730-34a2b980-a760-11ea-8223-87fc900185df.png)

I've tested it on my code. I really have 4 self-referential relationships. And the current logic is not detecting these relations.

# my Test model example #
```
keystone.createList('Test', {
    fields: {
        ...
        related: {
            type: Relationship,
            ref: 'Test',
            many: true,
        },
        self: {
            type: Relationship,
            ref: 'Test',
            many: false,
        },
    },
})
...
```
![image](https://user-images.githubusercontent.com/1394025/83887289-ad564580-a761-11ea-8a9b-579e1a7777da.png)
![image](https://user-images.githubusercontent.com/1394025/83887737-4c7b3d00-a762-11ea-8a5d-3df98f8b4636.png)

As you can see there is no `right` object here. Just `left` for all self-referential relations.