### PR TITLE
Admin UI: fixed a regression in the Create Relationship workflow

### DIFF
--- a/.changeset/lovely-rockets-hunt.md
+++ b/.changeset/lovely-rockets-hunt.md
@@ -1,6 +1,5 @@
 ---
 '@keystonejs/app-admin-ui': patch
-'@arch-ui/drawer': patch
 ---
 
 Fixed a regression in the Create Relationship workflow.

--- a/.changeset/lovely-rockets-hunt.md
+++ b/.changeset/lovely-rockets-hunt.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@arch-ui/drawer': patch
+---
+
+Fixed a regression in the Create Relationship workflow.

--- a/packages/app-admin-ui/client/components/CreateItemModal.js
+++ b/packages/app-admin-ui/client/components/CreateItemModal.js
@@ -46,7 +46,7 @@ const useEventCallback = callback => {
   return cb;
 };
 
-const CreateItemModal = ({ prefillData = {}, onClose, onCreate }) => {
+const CreateItemModal = ({ prefillData = {}, onClose, onCreate, viewOnSave }) => {
   const { list, closeCreateItemModal, isCreateItemModalOpen } = useList();
 
   const [item, setItem] = useState(list.getInitialItemData({ prefill: prefillData }));
@@ -123,8 +123,10 @@ const CreateItemModal = ({ prefillData = {}, onClose, onCreate }) => {
       onCreate(savedData);
     }
 
-    const newItemID = savedData.data[list.gqlNames.createMutationName].id;
-    history.push(`${list.fullPath}/${newItemID}`);
+    if (viewOnSave) {
+      const newItemID = savedData.data[list.gqlNames.createMutationName].id;
+      history.push(`${list.fullPath}/${newItemID}`);
+    }
   });
 
   const _onClose = () => {

--- a/packages/app-admin-ui/client/pages/Home/components.js
+++ b/packages/app-admin-ui/client/pages/Home/components.js
@@ -65,7 +65,7 @@ const BoxComponent = ({ focusOrigin, isActive, isHover, isFocus, meta, ...props 
           <A11yText>Create {singular}</A11yText>
         </CreateButton>
       </BoxElement>
-      <CreateItemModal />
+      <CreateItemModal viewOnSave />
     </Fragment>
   );
 };

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -322,7 +322,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
         />
       </Card>
 
-      <CreateItemModal />
+      <CreateItemModal viewOnSave />
       <DeleteItemModal
         isOpen={showDeleteModal}
         item={initialData}

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -151,7 +151,7 @@ export function ListLayout(props) {
         </HeaderInset>
       </Container>
 
-      <CreateItemModal />
+      <CreateItemModal viewOnSave />
 
       <Container isFullWidth>
         <ListTable


### PR DESCRIPTION
Fixes #3118. Regression from #2984. It was the lack of onCreate callback prop in the Relationship sub-dialog that made the original behavior worked. I added a new `viewOnSave` prop that the toplevel uses of `CreateItemModal` pass in (same place the callback was passed in before).