### PR TITLE
Expanding and better surfacing field type docs

### DIFF
--- a/.changeset/chilled-apes-join.md
+++ b/.changeset/chilled-apes-join.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/field-content': patch
+'@keystonejs/fields-markdown': patch
+'@keystonejs/fields-mongoid': patch
+'@keystonejs/fields-wysiwyg-tinymce': patch
+'@keystonejs/fields': patch
+---
+
+Improving field type list and adding some missing field docs

--- a/packages/field-content/README.md
+++ b/packages/field-content/README.md
@@ -4,7 +4,7 @@ subSection: field-types
 title: Content
 [meta]-->
 
-# Content Field
+# Content
 
 A Block-based Content Field for composing rich text such as blog posts, wikis,
 and even complete pages.

--- a/packages/fields-markdown/README.md
+++ b/packages/fields-markdown/README.md
@@ -4,7 +4,7 @@ subSection: field-types
 title: Markdown
 [meta]-->
 
-# Markdown Field
+# Markdown
 
 This field inserts a string path into your schema based on the `Text` field type implementation, and renders a Markdown editor using [CodeMirror](https://codemirror.net/).
 

--- a/packages/fields-mongoid/README.md
+++ b/packages/fields-mongoid/README.md
@@ -1,12 +1,12 @@
 <!--[meta]
 section: api
 subSection: field-types
-title: MongoID
+title: MongoId
 [meta]-->
 
-# MongoID
+# MongoId
 
-This field allows arbitrary MongoID fields to be added to your lists.
+This field allows arbitrary Mongo `ObjectId` fields to be added to your lists.
 
 It supports the core Mongoose and Knex adapters:
 

--- a/packages/fields-wysiwyg-tinymce/README.md
+++ b/packages/fields-wysiwyg-tinymce/README.md
@@ -4,7 +4,7 @@ subSection: field-types
 title: Wysiwyg
 [meta]-->
 
-# WYSIWYG
+# Wysiwyg
 
 This field inserts a string path into your schema based on the `Text` field type implementation, and renders a WYSIWYG editor in the Admin UI using [TinyMCE](https://www.tiny.cloud/)
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -6,32 +6,44 @@ order: 3
 
 # Fields
 
-Keystone contains a set of primitive fields types that can be imported from `@keystonejs/fields`. These include:
+Keystone contains a set of primitive fields types that can be imported from the `@keystonejs/fields` package:
 
-- [CalendarDay](https://keystonejs.com/keystonejs/fields/src/types/calendar-day)
-- [Checkbox](https://keystonejs.com/keystonejs/fields/src/types/checkbox)
-- [CloudinaryImage](https://keystonejs.com/keystonejs/fields/src/types/cloudinary-image)
-- [Color](https://keystonejs.com/keystonejs/fields/src/types/color)
-- [Content](https://keystonejs.com/keystonejs/field-content)
-- [DateTime](https://keystonejs.com/keystonejs/fields/src/types/date-time)
-- [Decimal](https://keystonejs.com/keystonejs/fields/src/types/decimal)
-- [File](https://keystonejs.com/keystonejs/fields/src/types/file)
-- [Float](https://keystonejs.com/keystonejs/fields/src/types/float)
-- [Integer](https://keystonejs.com/keystonejs/fields/src/types/integer)
-- [Location](https://keystonejs.com/keystonejs/fields/src/types/location)
-- [OEmbed](https://keystonejs.com/keystonejs/fields/src/types/o-embed)
-- [Password](https://keystonejs.com/keystonejs/fields/src/types/password)
-- [Relationship](https://keystonejs.com/keystonejs/fields/src/types/relationship)
-- [Select](https://keystonejs.com/keystonejs/fields/src/types/select)
-- [Slug](https://keystonejs.com/keystonejs/fields/src/types/slug)
-- [Text](https://keystonejs.com/keystonejs/fields/src/types/text)
-- [Unsplash](https://keystonejs.com/keystonejs/fields/src/types/unsplash)
-- [Url](https://keystonejs.com/keystonejs/fields/src/types/url)
-- [Uuid](https://keystonejs.com/keystonejs/fields/src/types/uuid)
+| Field type                                                          | Description                                                                                                                                            |
+|:--------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`CalendarDay`](/packages/fields/src/types/CalendarDay/README.md)   | An abstract "day" value; useful for Birthdays and other all-day events always celebrated in the local time zone                                        |
+| [`Checkbox`](/packages/fields/src/types/Checkbox/README.md)         | A single Boolean value                                                                                                                                 |
+| [`CloudinaryImage`](/packages/fields/src/types/CloudinaryImage)     | Allows uploading images to the [Cloudinary](https://cloudinary.com/) image hosting service                                                             |
+| [`Color`](/packages/fields/src/types/Color/README.md)               | Hexidecimal RGBA color values; uses a color picker in the Admin UI                                                                                     |
+| [`DateTime`](/packages/fields/src/types/DateTime/README.md)         | A point in time and a time zone offset                                                                                                                 |
+| [`Decimal`](/packages/fields/src/types/Decimal/README.md)           | Exact, numeric values in base-10; useful for currency, etc.                                                                                            |
+| [`File`](/packages/fields/src/types/File/README.md)                 | Files backed various storage mediums: local filesystem, cloud based hosting, etc.                                                                      |
+| [`Float`](/packages/fields/src/types/Float/README.md)               | An imprecise numeric value, stored as a floating point                                                                                                 |
+| [`Integer`](/packages/fields/src/types/Integer/README.md)           | A whole number                                                                                                                                         |
+| [`Location`](/packages/fields/src/types/Location/README.md)         | Data from the [Google Maps API](https://developers.google.com/maps/documentation/javascript/reference)                                                 |
+| [`OEmbed`](/packages/fields/src/types/OEmbed/README.md)             | Data in the [oEmbed format](https://oembed.com/); allowing an embedded representation of a URL on third party sites                                    |
+| [`Password`](/packages/fields/src/types/Password/README.md)         | A [`bcrypt`](https://en.wikipedia.org/wiki/Bcrypt) hash of the value supplied; used by the [Password auth strategy](/packages/auth-password/README.md) |
+| [`Relationship`](/packages/fields/src/types/Relationship/README.md) | A link between the current list and others, often paired with a field on the other list                                                                |
+| [`Select`](/packages/fields/src/types/Select/README.md)             | One of several predefined string values, presented as a dropdown                                                                                       |
+| [`Slug`](/packages/fields/src/types/Slug/README.md)                 | Generate unique slugs (aka. keys, url segments) based on the item's data                                                                               |
+| [`Text`](/packages/fields/src/types/Text/README.md)                 | A basic but versatile text field of arbitrary length                                                                                                   |
+| [`Unsplash`](/packages/fields/src/types/Unsplash/README.md)         | Meta data from the [Unsplash API](https://unsplash.com/developers) and generates URLs to dynamically transformed images                                |
+| [`Url`](/packages/fields/src/types/Url/README.md)                   | Extends the [`Text`](/packages/fields/src/types/Text/README.md) type to store HTTP URLs                                                                |
+| [`Uuid`](/packages/fields/src/types/Uuid/README.md)                 | [Universally Unique Identifiers](https://en.wikipedia.org/wiki/Universally_unique_identifier) (UUIDs); useful for `id` fields                          |
+| [`Virtual`](/packages/fields/src/types/Virtual/README.md)           | Read-only field with a developer-defined resolver, executed on read                                                                                    |
 
-In addition to these are some other complex types that have their own package such as `Markdown` and `Wysiwyg`.
+In addition to these, some complex types are packaged separately:
 
-> **Tip:** Need more? See our guide on [custom field types](https://keystonejs.com/guides/custom-field-types/)
+| Field type                                                             | Description                                                                                                                                                           |
+|:-----------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`Content`](/packages/field-content/README.md)                         | Block-based content for composing rich text such as blog posts, wikis, and even complete pages                                                                        |
+| [`AuthedRelationship`](/packages/fields-authed-relationship/README.md) | Extendes the [`Relationship`](/packages/fields/src/types/Relationship/README.md) type; automatically set to the currently authenticated item during a create mutation |
+| [`AutoIncrement`](/packages/fields-auto-increment/README.md)           | An automatically incrementing integer; the default type for `id` fields when using the Knex DB adapter                                                                |
+| [`DateTimeUtc`](/packages/fields-datetime-utc/README.md)               | Represents points in time, stored in UTC                                                                                                                              |
+| [`Markdown`](/packages/fields-markdown/README.md)                      | Markdown content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [CodeMirror](https://codemirror.net/) editor in the Admin UI    |
+| [`MongoId`](/packages/fields-mongoid/README.md)                        | Arbitrary [Mongo `ObjectId`](https://docs.mongodb.com/manual/reference/method/ObjectId/) values; the default type for `id` fields when using the Mongoose DB adapter  |
+| [`Wysiwyg`](/packages/fields-wysiwyg-tinymce/README.md)                | Rich text content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [TinyMCE](https://www.tiny.cloud/) editor in the Admin UI      |
+
+> **Tip:** Need something else? Keystone lets you create [custom field types](/docs/guides/custom-field-types.md) to support almost any use case.
 
 ## Usage
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -9,7 +9,7 @@ order: 3
 Keystone contains a set of primitive fields types that can be imported from the `@keystonejs/fields` package:
 
 | Field type                                                          | Description                                                                                                                                            |
-|:--------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :------------------------------------------------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`CalendarDay`](/packages/fields/src/types/CalendarDay/README.md)   | An abstract "day" value; useful for Birthdays and other all-day events always celebrated in the local time zone                                        |
 | [`Checkbox`](/packages/fields/src/types/Checkbox/README.md)         | A single Boolean value                                                                                                                                 |
 | [`CloudinaryImage`](/packages/fields/src/types/CloudinaryImage)     | Allows uploading images to the [Cloudinary](https://cloudinary.com/) image hosting service                                                             |
@@ -34,7 +34,7 @@ Keystone contains a set of primitive fields types that can be imported from the 
 In addition to these, some complex types are packaged separately:
 
 | Field type                                                             | Description                                                                                                                                                           |
-|:-----------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| :--------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`Content`](/packages/field-content/README.md)                         | Block-based content for composing rich text such as blog posts, wikis, and even complete pages                                                                        |
 | [`AuthedRelationship`](/packages/fields-authed-relationship/README.md) | Extendes the [`Relationship`](/packages/fields/src/types/Relationship/README.md) type; automatically set to the currently authenticated item during a create mutation |
 | [`AutoIncrement`](/packages/fields-auto-increment/README.md)           | An automatically incrementing integer; the default type for `id` fields when using the Knex DB adapter                                                                |

--- a/packages/fields/src/types/CalendarDay/README.md
+++ b/packages/fields/src/types/CalendarDay/README.md
@@ -6,6 +6,9 @@ title: CalendarDay
 
 # CalendarDay
 
+Stores an abstract "day" value; like a date but _independant of any time zone_.
+Useful for Birthdays and other all-day events always celebrated in the local time zone.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/Color/README.md
+++ b/packages/fields/src/types/Color/README.md
@@ -6,6 +6,9 @@ title: Color
 
 # Color
 
+Stores hexidecimal RGBA (Red, Green, Blue, Alpha) color values.
+Presents in the Admin UI as an interactive color picker.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/DateTime/README.md
+++ b/packages/fields/src/types/DateTime/README.md
@@ -6,6 +6,8 @@ title: DateTime
 
 # DateTime
 
+Stores a point in time and a time zone offset.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/File/README.md
+++ b/packages/fields/src/types/File/README.md
@@ -8,7 +8,9 @@ title: File
 
 Support files hosted in a range of different contexts, e.g. in the local filesystem, or on a cloud based file server.
 
-> **Important:** As of this writing (April 2020), an upstream [issue](https://github.com/apollographql/apollo-server/issues/3508) with `apollo-server`'s dependencies can cause a server crash when using this field (regardless of adapter) with **Node 13 only**. To work around this, use Node 12 or below _or_ add the following to your `package.json`:
+> **Important:** As of this writing (April 2020), an upstream [issue](https://github.com/apollographql/apollo-server/issues/3508)
+> with `apollo-server`'s dependencies can cause a server crash when using this field (regardless of adapter) with **Node 13 only**.
+> To work around this, use Node 12 or below _or_ add the following to your `package.json`:
 >
 > ```js title=package.json
 > "resolutions": {
@@ -43,5 +45,5 @@ keystone.createList('Applicant', {
 
 | Option       | Type      | Default  | Description                                                                                            |
 | ------------ | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| `adapter`    | `Object`  | Required | See the [File Adapters](https://keystonejs.com/keystonejs/file-adapters/) page for available adapters. |
+| `adapter`    | `Object`  | Required | See the [File Adapters](/packages/file-adapters/README.md) page for available adapters. |
 | `isRequired` | `Boolean` | `false`  | Does this field require a value?                                                                       |

--- a/packages/fields/src/types/File/README.md
+++ b/packages/fields/src/types/File/README.md
@@ -43,7 +43,7 @@ keystone.createList('Applicant', {
 
 ### Config
 
-| Option       | Type      | Default  | Description                                                                                            |
-| ------------ | --------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| Option       | Type      | Default  | Description                                                                             |
+| ------------ | --------- | -------- | --------------------------------------------------------------------------------------- |
 | `adapter`    | `Object`  | Required | See the [File Adapters](/packages/file-adapters/README.md) page for available adapters. |
-| `isRequired` | `Boolean` | `false`  | Does this field require a value?                                                                       |
+| `isRequired` | `Boolean` | `false`  | Does this field require a value?                                                        |

--- a/packages/fields/src/types/Float/README.md
+++ b/packages/fields/src/types/Float/README.md
@@ -6,6 +6,8 @@ title: Float
 
 # Float
 
+An imprecise numeric value, stored as a floating point.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/Integer/README.md
+++ b/packages/fields/src/types/Integer/README.md
@@ -6,6 +6,8 @@ title: Integer
 
 # Integer
 
+A whole number.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/OEmbed/README.md
+++ b/packages/fields/src/types/OEmbed/README.md
@@ -11,7 +11,7 @@ Stores data in the oEmbed format:
 > `oEmbed` is a format for allowing an embedded representation of a URL on third party sites.
 > The simple API allows a website to display embedded content (such as photos or videos)
 > when a user posts a link to that resource, without having to parse the resource directly.
-> --- The [oEmbed Spec](https://oembed.com/)
+> \--- The [oEmbed Spec](https://oembed.com/)
 
 ## Usage
 

--- a/packages/fields/src/types/OEmbed/README.md
+++ b/packages/fields/src/types/OEmbed/README.md
@@ -6,12 +6,12 @@ title: OEmbed
 
 # OEmbed
 
-`oEmbed` is a format for allowing an embedded representation of a URL on third
-party sites. The simple API allows a website to display embedded content (such
-as photos or videos) when a user posts a link to that resource, without having
-to parse the resource directly.
+Stores data in the oEmbed format:
 
-> View the [oEmbed Spec](https://oembed.com/) for more information
+> `oEmbed` is a format for allowing an embedded representation of a URL on third party sites.
+> The simple API allows a website to display embedded content (such as photos or videos)
+> when a user posts a link to that resource, without having to parse the resource directly.
+> --- The [oEmbed Spec](https://oembed.com/)
 
 ## Usage
 

--- a/packages/fields/src/types/Relationship/README.md
+++ b/packages/fields/src/types/Relationship/README.md
@@ -6,6 +6,11 @@ title: Relationship
 
 # Relationship
 
+A link between the current list and others, often paired with a field on the other list.
+The relationships cardinality is determined by the `many` and `isRequire` configuring on either side.
+
+See the [Configuring Relationships](/docs/guides/relationships.md) guide for more information.
+
 ## Usage
 
 ```javascript

--- a/packages/fields/src/types/Select/README.md
+++ b/packages/fields/src/types/Select/README.md
@@ -23,12 +23,12 @@ keystone.createList('Orders', {
 
 ## Config
 
-| Option       | Type      | Default | Description                                                                                 |
-| ------------ | --------- | ------- | ------------------------------------------------------------------------------------------- |
+| Option       | Type        | Default | Description                                                                                 |
+| ------------ | ----------- | ------- | ------------------------------------------------------------------------------------------- |
 | `options`    | (see below) | `null`  | Defines the values (and labels) that can be be selected from, see below                     |
-| `dataType`   | `String`  | `enum`  | Controls the data type stored in the database, and defined in the GraphQL schema, see below |
-| `isRequired` | `Boolean` | `false` | Does this field require a value?                                                            |
-| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored                             |
+| `dataType`   | `String`    | `enum`  | Controls the data type stored in the database, and defined in the GraphQL schema, see below |
+| `isRequired` | `Boolean`   | `false` | Does this field require a value?                                                            |
+| `isUnique`   | `Boolean`   | `false` | Adds a unique index that allows only unique values to be stored                             |
 
 ### `options`
 

--- a/packages/fields/src/types/Select/README.md
+++ b/packages/fields/src/types/Select/README.md
@@ -6,6 +6,9 @@ title: Select
 
 # Select
 
+Stores one of several predefined string values.
+Presented as a dropdown in the Admin UI.
+
 ## Usage
 
 ```js
@@ -22,7 +25,7 @@ keystone.createList('Orders', {
 
 | Option       | Type      | Default | Description                                                                                 |
 | ------------ | --------- | ------- | ------------------------------------------------------------------------------------------- |
-| `options`    | \*        | `null`  | Defines the values (and labels) that can be be selected from, see below                     |
+| `options`    | (see below) | `null`  | Defines the values (and labels) that can be be selected from, see below                     |
 | `dataType`   | `String`  | `enum`  | Controls the data type stored in the database, and defined in the GraphQL schema, see below |
 | `isRequired` | `Boolean` | `false` | Does this field require a value?                                                            |
 | `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored                             |

--- a/packages/fields/src/types/Text/README.md
+++ b/packages/fields/src/types/Text/README.md
@@ -6,6 +6,8 @@ title: Text
 
 # Text
 
+A basic but versatile text field of arbitrary length.
+
 ## Usage
 
 ```js

--- a/packages/fields/src/types/Url/README.md
+++ b/packages/fields/src/types/Url/README.md
@@ -6,6 +6,7 @@ title: Url
 
 # Url
 
-<!-- TODO -->
+Extends the `Text` type to store HTTP URLs.
+Adds some interface niceties, like links from the Admin UI table view.
 
-The URL field type needs documentation.
+For usage and config, see the [`Text` field type](/packages/fields/src/types/Text/README.md) docs.


### PR DESCRIPTION
Replacing the flat list of field types in the `/packages/fields/README.md` with a table that includes a one line description of the type. I've also added a section that links to the other field packages (replacing a of text that mentioned a few but didn't link).

Some of the field type `README.md` docs have been expanding (so they at least all have a high level description) plus a few minor consistency fixes.