### PR TITLE
[WIP] Access control query helper

### DIFF
--- a/packages/access-control/lib/access-control.js
+++ b/packages/access-control/lib/access-control.js
@@ -159,6 +159,7 @@ module.exports = {
     access,
     authentication = {},
     gqlName,
+    queryHelper
   }) {
     // Either a boolean or an object describing a where clause
     let result;
@@ -172,6 +173,7 @@ module.exports = {
         info,
         authentication: authentication.item ? authentication : {},
         gqlName,
+        action: { query: queryHelper },
       });
     }
     const type = getType(result);
@@ -193,6 +195,7 @@ module.exports = {
     gqlName,
     itemId,
     itemIds,
+    queryHelper
   }) {
     // Either a boolean or an object describing a where clause
     let result;
@@ -207,6 +210,7 @@ module.exports = {
         gqlName,
         itemId,
         itemIds,
+        action: { query: queryHelper },
       });
     }
 
@@ -239,6 +243,7 @@ module.exports = {
     gqlName,
     itemId,
     itemIds,
+    queryHelper,
   }) {
     let result;
     if (typeof access[operation] !== 'function') {
@@ -254,6 +259,7 @@ module.exports = {
         gqlName,
         itemId,
         itemIds,
+        action: { query: queryHelper },
       });
     }
 
@@ -268,7 +274,7 @@ module.exports = {
     return result;
   },
 
-  async validateAuthAccessControl({ access, listKey, authentication = {}, gqlName }) {
+  async validateAuthAccessControl({ access, listKey, authentication = {}, gqlName, queryHelper }) {
     const operation = 'auth';
     // Either a boolean or an object describing a where clause
     let result;
@@ -280,6 +286,7 @@ module.exports = {
         listKey,
         operation,
         gqlName,
+        action: { query: queryHelper },
       });
     }
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -152,6 +152,7 @@ module.exports = class Keystone {
       getFieldAccessControlForUser = () => true;
       getAuthAccessControlForUser = () => true;
     } else {
+      const buildQueryHelper = this._buildQueryHelper.bind(this);
       // memoizing to avoid requests that hit the same type multiple times.
       // We do it within the request callback so we can resolve it based on the
       // request info ( like who's logged in right now, etc)
@@ -165,13 +166,14 @@ module.exports = class Keystone {
             access: access[schemaName],
             authentication: { item: req.user, listKey: req.authedListKey },
             gqlName,
+            queryHelper: buildQueryHelper(context),
           });
         },
         { isPromise: true }
       );
 
       getListAccessControlForUser = memoize(
-        async (listKey, originalInput, operation, { gqlName, itemId, itemIds } = {}) => {
+        async (listKey, originalInput, operation, { gqlName, itemId, itemIds } = {}, context = {}) => {
           return validateListAccessControl({
             access: this.lists[listKey].access[schemaName],
             originalInput,
@@ -181,6 +183,7 @@ module.exports = class Keystone {
             gqlName,
             itemId,
             itemIds,
+            queryHelper: buildQueryHelper(context),
           });
         },
         { isPromise: true }
@@ -193,7 +196,8 @@ module.exports = class Keystone {
           originalInput,
           existingItem,
           operation,
-          { gqlName, itemId, itemIds } = {}
+          { gqlName, itemId, itemIds } = {},
+          context = {}
         ) => {
           return validateFieldAccessControl({
             access: this.lists[listKey].fieldsByPath[fieldKey].access[schemaName],
@@ -206,18 +210,20 @@ module.exports = class Keystone {
             gqlName,
             itemId,
             itemIds,
+            queryHelper: buildQueryHelper(context),
           });
         },
         { isPromise: true }
       );
 
       getAuthAccessControlForUser = memoize(
-        async (listKey, { gqlName } = {}) => {
+        async (listKey, { gqlName } = {}, context = {}) => {
           return validateAuthAccessControl({
             access: this.lists[listKey].access[schemaName],
             authentication: { item: req.user, listKey: req.authedListKey },
             listKey,
             gqlName,
+            queryHelper: buildQueryHelper(context),
           });
         },
         { isPromise: true }

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -437,7 +437,8 @@ module.exports = class List {
           data,
           existingItem,
           operation,
-          { gqlName, itemId: id, ...extraInternalData }
+          { gqlName, itemId: id, ...extraInternalData },
+          context
         );
         if (!access) {
           restrictedFields.push(field.path);
@@ -455,7 +456,7 @@ module.exports = class List {
     const access = await context.getListAccessControlForUser(this.key, originalInput, operation, {
       gqlName,
       ...extraInternalData,
-    });
+    }, context);
     if (!access) {
       graphqlLogger.debug(
         { operation, access, gqlName, ...extraInternalData },
@@ -1483,11 +1484,11 @@ module.exports = class List {
       // NOTE: These could return a Boolean or a JSON object (if using the
       // declarative syntax)
       getAccess: () => ({
-        getCreate: () => context.getListAccessControlForUser(this.key, undefined, 'create'),
-        getRead: () => context.getListAccessControlForUser(this.key, undefined, 'read'),
-        getUpdate: () => context.getListAccessControlForUser(this.key, undefined, 'update'),
-        getDelete: () => context.getListAccessControlForUser(this.key, undefined, 'delete'),
-        getAuth: () => context.getAuthAccessControlForUser(this.key),
+        getCreate: () => context.getListAccessControlForUser(this.key, undefined, 'create', undefined, context),
+        getRead: () => context.getListAccessControlForUser(this.key, undefined, 'read', undefined, context),
+        getUpdate: () => context.getListAccessControlForUser(this.key, undefined, 'update', undefined, context),
+        getDelete: () => context.getListAccessControlForUser(this.key, undefined, 'delete', undefined, context),
+        getAuth: () => context.getAuthAccessControlForUser(this.key, undefined, context),
       }),
 
       getSchema: () => {

--- a/packages/keystone/lib/providers/listAuth.js
+++ b/packages/keystone/lib/providers/listAuth.js
@@ -138,7 +138,7 @@ class ListAuthProvider {
 
   async checkAccess(context, type, { gqlName }) {
     const operation = 'auth';
-    const access = await context.getAuthAccessControlForUser(this.list.key, { gqlName });
+    const access = await context.getAuthAccessControlForUser(this.list.key, { gqlName }, context);
     if (!access) {
       graphqlLogger.debug({ operation, access, gqlName }, 'Access statically or implicitly denied');
       graphqlLogger.info({ operation, gqlName }, 'Access Denied');


### PR DESCRIPTION
I have seen lot of request and query regarding how you can have gql query inside access control. 

seems like it was not easy. 
this is an effort to add this feature and guidelines as if there is lot of gql query it may slow down the app, there are lot of call to access control functions.


@timleslie do you think we should do this? or have some other pattern. I see there are hacks available to do it (wrap the schema in function accepting keyston instance and hold it there when returning the list config)