### PR TITLE
Reexported gql from apollo server via app-graphql

### DIFF
--- a/.changeset/gorgeous-toes-stare.md
+++ b/.changeset/gorgeous-toes-stare.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-graphql': minor
+---
+
+Reexported `gql` template literal from Apollo Server.

--- a/packages/app-graphql/index.js
+++ b/packages/app-graphql/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { GraphQLPlaygroundApp } = require('@keystonejs/app-graphql-playground');
+const { gql } = require('apollo-server-express');
 const { createApolloServer } = require('./lib/apolloServer');
 const validation = require('./validation');
 
@@ -48,4 +49,5 @@ class GraphQLApp {
 module.exports = {
   GraphQLApp,
   validation,
+  gql,
 };


### PR DESCRIPTION
I pulled it from Apollo Server instead of `graphql-tag` since the former [exports it as of v2](https://www.apollographql.com/docs/apollo-server/migration-two-dot/#the-gql-tag) and it's encouraged to use it.