### PR TITLE
Add account config params in destroy method

### DIFF
--- a/.changeset/cyan-keys-sniff.md
+++ b/.changeset/cyan-keys-sniff.md
@@ -7,6 +7,6 @@
 We are not setting global configuration (api_key, api_secret, and cloud_name) in our cloudinary SDK. 
 We are relying on passing these mandatory config settings in the options param of the upload API.
 But in the case of destroy method, we are omitting them and passing ondefault empty options object as an argument.
-This results in a rejectedpromise. To fix this issue, we are now injecting these values in the providedoptions object. 
+This results in a rejected promise. To fix this issue, we are now injecting these values in the provided options object. 
 
 NOTE: User can still override these values if required.

--- a/.changeset/cyan-keys-sniff.md
+++ b/.changeset/cyan-keys-sniff.md
@@ -1,0 +1,12 @@
+---
+'@keystonejs/file-adapters': patch
+---
+
+**Fix**: delete function not passing required config params
+
+We are not setting global configuration (api_key, api_secret, andcloud_name) in our cloudinary SDK. 
+We are relying on passing these mandatory config settings in the options param of the upload API.
+But in the case of destroy method, we are omitting them and passing ondefault empty options object as an argument.
+This results in a rejectedpromise. To fix this issue, we are now injecting these values in the providedoptions object. 
+
+NOTE: User can still override these values if required.

--- a/.changeset/cyan-keys-sniff.md
+++ b/.changeset/cyan-keys-sniff.md
@@ -4,7 +4,7 @@
 
 **Fix**: delete function not passing required config params
 
-We are not setting global configuration (api_key, api_secret, andcloud_name) in our cloudinary SDK. 
+We are not setting global configuration (api_key, api_secret, and cloud_name) in our cloudinary SDK. 
 We are relying on passing these mandatory config settings in the options param of the upload API.
 But in the case of destroy method, we are omitting them and passing ondefault empty options object as an argument.
 This results in a rejectedpromise. To fix this issue, we are now injecting these values in the providedoptions object. 

--- a/packages/file-adapters/lib/cloudinary.js
+++ b/packages/file-adapters/lib/cloudinary.js
@@ -51,9 +51,17 @@ module.exports = class CloudinaryAdapter {
    *                For available options refer to the [Cloudinary destroy API](https://cloudinary.com/documentation/image_upload_api_reference#destroy_method).
    */
   delete(file, options = {}) {
+    const destroyOptions = {
+      // Auth
+      api_key: this.apiKey,
+      api_secret: this.apiSecret,
+      cloud_name: this.cloudName,
+      ...options,
+    };
+
     return new Promise((resolve, reject) => {
       if (file) {
-        cloudinary.v2.uploader.destroy(file.id, options, (error, result) => {
+        cloudinary.v2.uploader.destroy(file.id, destroyOptions, (error, result) => {
           if (error) {
             reject(error);
           } else {


### PR DESCRIPTION
We are not setting global configuration (api_key, api_secret, and
cloud_name) in our Cloudinary SDK. We are relying on passing these
mandatory config settings in the options param of the upload API.

But in the case of destroy method, we are omitting them and passing on
default empty options object as an argument. This results in a rejected
promise.

To fix this issue, we are now injecting these values in the provided
options object. Users can still override these values if required.

close: #2821 