### PR TITLE
Fix appending wrong search query when routing

### DIFF
--- a/.changeset/lovely-keys-rule.md
+++ b/.changeset/lovely-keys-rule.md
@@ -1,0 +1,12 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+**Fix**
+
+Upon filtering out the lists based on the ids, an error could occur. Irrespective of the error, we were still storing the search value into the localStorage.
+And when user transit back to this list page, the error would persist as we append the search query onto the url. 
+
+This fix looks into any api error, and removes the localStorage search value `location.search`, which gets set when **Filter** form is submitted. 
+
+See #3075

--- a/packages/app-admin-ui/client/classes/List.js
+++ b/packages/app-admin-ui/client/classes/List.js
@@ -169,6 +169,10 @@ export default class List {
     localStorage.setItem(`search:${this.path}`, value);
   }
 
+  removePersistedSearch() {
+    localStorage.removeItem(`search:${this.path}`);
+  }
+
   getFullPersistentPath() {
     return `${this.fullPath}${this.getPersistedSearch() || ''}`;
   }

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -207,9 +207,18 @@ const ListPage = props => {
   const history = useHistory();
   const location = useLocation();
 
+  const hasErrorWithNoData = query.error && (!query.data || !items || !Object.keys(items).length);
+
   // Mount with Persisted Search
   // ------------------------------
   useEffect(() => {
+    // Remove the persisted search from localStorage if error occurs.
+    // This is to avoid appending the error-prone search query, which only renders the Error page.
+    if (hasErrorWithNoData) {
+      list.removePersistedSearch();
+      return;
+    }
+
     const maybePersistedSearch = list.getPersistedSearch();
     if (location.search === maybePersistedSearch) {
       return;
@@ -223,13 +232,13 @@ const ListPage = props => {
         search: maybePersistedSearch,
       });
     }
-  }, []);
+  }, [hasErrorWithNoData]);
 
   // Error
   // ------------------------------
   // Only show error page if there is no data
   // (ie; there could be partial data + partial errors)
-  if (query.error && (!query.data || !items || !Object.keys(items).length)) {
+  if (hasErrorWithNoData) {
     let message = '';
     if (queryErrorsParsed) {
       message = queryErrorsParsed.message;


### PR DESCRIPTION
Upon filtering out the lists based on the ids, an error could occur.
Irrespective of the error, we were still storing the search value into
the localStorage.
And when user transit back to this list page, the error would persist as
we append the search query onto the URL.

This fix looks into any API error, and removes the localStorage search
value `location.search`, which gets set when **Filter** form is
submitted.

See issue: #3075 