### PR TITLE
Remove support for multiple database adapters in a single Keystone system

### DIFF
--- a/.changeset/smart-deers-trade.md
+++ b/.changeset/smart-deers-trade.md
@@ -1,0 +1,13 @@
+---
+'@keystonejs/keystone': major
+'@keystone-next/keystone': patch
+'@keystone-next/types': patch
+'@keystonejs/demo-project-meetup': patch
+'@keystonejs/cypress-project-access-control': patch
+'@keystonejs/cypress-project-basic': patch
+'@keystonejs/cypress-project-client-validation': patch
+'@keystonejs/cypress-project-login': patch
+'@keystonejs/cypress-project-social-login': patch
+---
+
+Removed support for multiple database adapters in a single `Keystone` system. The `adapters` and `defaultAdapter` config options were removed from the `Keystone()` constructor.

--- a/docs/guides/prisma.md
+++ b/docs/guides/prisma.md
@@ -96,7 +96,7 @@ keystone.extendGraphQLSchema({
     {
       schema: 'allComplete: Boolean',
       resolver: async () => {
-        const { prisma } = keystone.adapters.PrismaAdapter;
+        const { prisma } = keystone.adapter;
         const unfinished = await prisma.todo.count({ where: { isComplete: { equals: false } } });
         return unfinished === 0;
       },
@@ -105,7 +105,7 @@ keystone.extendGraphQLSchema({
 });
 ```
 
-This query is using the `PrismaClient` object stored at `keystone.adapters.PrismaAdapter.prisma` to directly run this query against the database.
+This query is using the `PrismaClient` object stored at `keystone.adapterr.prisma` to directly run this query against the database.
 For more information on the Prisma Client API please consult the [Prisma docs](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client).
 
 > **Tip:** For full details on how to use up the Prisma Adapter, see the [Prisma Adapter API Docs](/packages/adapter-prisma/README.md)

--- a/examples/meetup/initialData.js
+++ b/examples/meetup/initialData.js
@@ -28,7 +28,7 @@ module.exports = async keystone => {
     // Ensure a valid initial password is available to be used
     validatePassword();
     // Drop the connected database to ensure no existing collections remain
-    await Promise.all(Object.values(keystone.adapters).map(adapter => adapter.dropDatabase()));
+    await keystone.adapter.dropDatabase();
     console.log('💾 Creating initial data...');
     await seedData(initialData, keystone);
   }

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -65,9 +65,9 @@ export function makeCreateContext({
       keystone,
       // Only one of these will be available on any given context
       // TODO: Capture that in the type
-      knex: keystone.adapters.KnexAdapter?.knex,
-      mongoose: keystone.adapters.MongooseAdapter?.mongoose,
-      prisma: keystone.adapters.PrismaAdapter?.prisma,
+      knex: keystone.adapter.knex,
+      mongoose: keystone.adapter.mongoose,
+      prisma: keystone.adapter.prisma,
       graphql: {
         createContext,
         raw: rawGraphQL,

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -44,8 +44,6 @@ export function createKeystone(config: KeystoneConfig, dotKeystonePath: string, 
     // FIXME: Unsupported options: Need to work which of these we want to support with backwards
     // compatibility options.
     // defaultAccess
-    // adapters
-    // defaultAdapter
     // sessionStore
     // cookie
     // schemaNames

--- a/packages-next/keystone/src/scripts/build/build.ts
+++ b/packages-next/keystone/src/scripts/build/build.ts
@@ -26,5 +26,7 @@ export async function build({ dotKeystonePath, projectAdminPath }: StaticPaths) 
   // FIXME: This should never generate a migratration... right?
   // FIXME: This needs to generate clients for the correct build target using binaryTarget
   // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#binarytargets-options
-  await keystone.adapters.PrismaAdapter._generateClient(keystone._consolidateRelationships());
+  if (keystone.adapter.name === 'prisma') {
+    await keystone.adapter._generateClient(keystone._consolidateRelationships());
+  }
 }

--- a/packages-next/keystone/src/scripts/migrate/deploy.ts
+++ b/packages-next/keystone/src/scripts/migrate/deploy.ts
@@ -11,5 +11,5 @@ export const deploy = async ({ dotKeystonePath }: StaticPaths) => {
   const keystone = createKeystone(config, dotKeystonePath, 'deploy');
 
   console.log('✨ Deploying migrations');
-  await keystone.adapters.PrismaAdapter.deploy(keystone._consolidateRelationships());
+  await keystone.adapter.deploy(keystone._consolidateRelationships());
 };

--- a/packages-next/keystone/src/scripts/migrate/reset.ts
+++ b/packages-next/keystone/src/scripts/migrate/reset.ts
@@ -11,6 +11,6 @@ export const reset = async ({ dotKeystonePath }: StaticPaths) => {
   const keystone = createKeystone(config, dotKeystonePath, 'reset');
 
   console.log('✨ Resetting database');
-  await keystone.adapters.PrismaAdapter._prepareSchema(keystone._consolidateRelationships());
-  await keystone.adapters.PrismaAdapter.dropDatabase();
+  await keystone.adapter._prepareSchema(keystone._consolidateRelationships());
+  await keystone.adapter.dropDatabase();
 };

--- a/packages-next/types/src/base.ts
+++ b/packages-next/types/src/base.ts
@@ -4,7 +4,7 @@ import type { BaseGeneratedListTypes, GqlNames } from './utils';
 // TODO: This is only a partial typing of the core Keystone class.
 // We should definitely invest some time into making this more correct.
 export type BaseKeystone = {
-  adapters: Record<string, any>;
+  adapter: Record<string, any>;
   createList: (
     key: string,
     config: {

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -13,12 +13,10 @@ const { Keystone } = require('@keystonejs/keystone');
 
 const keystone = new Keystone({
   adapter,
-  adapters,
   appVersion,
   cookie,
   cookieSecret,
   defaultAccess,
-  defaultAdapter,
   onConnect,
   queryLimits,
   sessionStore,
@@ -89,12 +87,6 @@ _**Default:**_
 
 Default list and field access. See the [Access Control](https://www.keystonejs.com/api/access-control#defaults) page for more details.
 
-### `defaultAdapter`
-
-_**Default:**_ `undefined`
-
-The name of the database adapter to use by default if multiple are provided.
-
 ### `onConnect`
 
 _**Default:**_ `undefined`
@@ -140,16 +132,16 @@ _**Default:**_ `['public']`
 
 ## Methods
 
-| Method                | Description                                                                  |
-| --------------------- | ---------------------------------------------------------------------------- |
-| `connect`             | Manually connect to Adapters.                                                |
-| `createAuthStrategy`  | Creates a new authentication middleware instance.                            |
-| `createList`          | Add a list to the `Keystone` schema.                                         |
-| `disconnect`          | Disconnect from all adapters.                                                |
-| `extendGraphQLSchema` | Extend keystones generated schema with custom types, queries, and mutations. |
-| `prepare`             | Manually prepare `Keystone` middlewares.                                     |
-| `createContext`       | Create a `context` object that can be used with `executeGraphQL()`.          |
-| `executeGraphQL`      | Execute a server-side GraphQL operation within the given context.            |
+| Method                | Description                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `connect`             | Manually connect to Adapter.                                                           |
+| `createAuthStrategy`  | Creates a new authentication middleware instance.                                      |
+| `createList`          | Add a list to the `Keystone` schema.                                                   |
+| `disconnect`          | Disconnect from the adapter.                                                           |
+| `extendGraphQLSchema` | Extend keystones generated schema with custom types, queries, and mutations.           |
+| `prepare`             | Manually prepare `Keystone` middlewares.                                               |
+| `createContext`       | Create a `context` object that can be used with `executeGraphQL()`.                    |
+| `executeGraphQL`      | Execute a server-side GraphQL operation within the given context.                      |
 
 <!--
 ## Super secret methods
@@ -167,7 +159,7 @@ Please note: We use these internally but provide no support or assurance if used
 
 ### `connect()`
 
-Manually connect Keystone to the adapters. See [Custom Server](https://keystonejs.com/guides/custom-server).
+Manually connect Keystone to the adapter. See [Custom Server](https://keystonejs.com/guides/custom-server).
 
 ```javascript allowCopy=false showLanguage=false
 keystone.connect();
@@ -206,7 +198,7 @@ keystone.createList('Posts', {...});
 
 ### `disconnect()`
 
-Disconnect all adapters.
+Disconnect the adapter.
 
 ### `extendGraphQLSchema(config)`
 

--- a/packages/keystone/bin/commands/upgrade-relationships.js
+++ b/packages/keystone/bin/commands/upgrade-relationships.js
@@ -66,7 +66,7 @@ const strategySummary = (
   keystone,
   migration
 ) => {
-  const mongo = !!keystone.adapters.MongooseAdapter;
+  const mongo = keystone.adapter.name === 'mongoose';
 
   if (!migration) {
     console.log('\n', chalk.bold('One-sided: one to many'));
@@ -80,11 +80,11 @@ const strategySummary = (
     const { near, far } = columnNames[`${left.listKey}.${left.path}`];
     printArrow({ migration, left });
     if (mongo) {
-      const { _pluralize } = keystone.adapters.MongooseAdapter.mongoose;
+      const { _pluralize } = keystone.adapter.mongoose;
       console.log(moveData(migration, left, tableName, near, far, _pluralize));
       console.log(deleteField(migration, left, _pluralize));
     } else {
-      const { schemaName } = keystone.adapters.KnexAdapter;
+      const { schemaName } = keystone.adapter;
       console.log(renameTable(migration, `${left.listKey}_${left.path}`, tableName, schemaName));
       console.log(renameColumn(migration, `${left.listKey}_id`, near, schemaName, tableName));
       console.log(renameColumn(migration, `${left.refListKey}_id`, far, schemaName, tableName));
@@ -97,10 +97,10 @@ const strategySummary = (
   two_one_to_one.forEach(({ left, right }) => {
     printArrow({ migration, left, right });
     if (mongo) {
-      const { _pluralize } = keystone.adapters.MongooseAdapter.mongoose;
+      const { _pluralize } = keystone.adapter.mongoose;
       console.log(deleteField(migration, right, _pluralize));
     } else {
-      const { schemaName } = keystone.adapters.KnexAdapter;
+      const { schemaName } = keystone.adapter;
       console.log(dropColumn(migration, right.listKey, right.path, schemaName));
     }
   });
@@ -112,10 +112,10 @@ const strategySummary = (
     const dropper = left.listKey === tableName ? right : left;
     printArrow({ migration, left, right });
     if (mongo) {
-      const { _pluralize } = keystone.adapters.MongooseAdapter.mongoose;
+      const { _pluralize } = keystone.adapter.mongoose;
       console.log(deleteField(migration, dropper, _pluralize));
     } else {
-      const { schemaName } = keystone.adapters.KnexAdapter;
+      const { schemaName } = keystone.adapter;
       console.log(dropTable(migration, `${dropper.listKey}_${dropper.path}`, schemaName));
     }
   });
@@ -127,12 +127,12 @@ const strategySummary = (
     const { near, far } = columnNames[`${left.listKey}.${left.path}`];
     printArrow({ migration, left, right });
     if (mongo) {
-      const { _pluralize } = keystone.adapters.MongooseAdapter.mongoose;
+      const { _pluralize } = keystone.adapter.mongoose;
       console.log(moveData(migration, left, tableName, near, far, _pluralize));
       console.log(deleteField(migration, left, _pluralize));
       console.log(deleteField(migration, right, _pluralize));
     } else {
-      const { schemaName } = keystone.adapters.KnexAdapter;
+      const { schemaName } = keystone.adapter;
       console.log(dropTable(migration, `${right.listKey}_${right.path}`, schemaName));
       console.log(renameTable(migration, `${left.listKey}_${left.path}`, tableName, schemaName));
       console.log(renameColumn(migration, `${left.listKey}_id`, near, schemaName, tableName));
@@ -172,7 +172,7 @@ const upgradeRelationships = async (args, entryFile) => {
   ttyLink('https://www.keystonejs.com/discussions/relationships', 'More info on relationships');
 
   if (!migration) {
-    const mongo = !!keystone.adapters.MongooseAdapter;
+    const mongo = keystone.adapter.name === 'mongoose';
     console.log('');
     console.log(
       chalk.green(

--- a/packages/keystone/bin/utils.js
+++ b/packages/keystone/bin/utils.js
@@ -152,10 +152,9 @@ async function executeDefaultServer(args, entryFile, distDir, spinner) {
   await keystone.connect();
   spinner.succeed('Connected to database');
 
-  const isKnex = !!(keystone.adapters && keystone.adapters.KnexAdapter);
-  if (isKnex) {
+  if (keystone.adapter && keystone.adapter.name === 'knex') {
     spinner.start('Verifying tables');
-    const verifyTableResults = await keystone.adapters.KnexAdapter._verifyTables();
+    const verifyTableResults = await keystone.adapter._verifyTables();
     verifyTableMessages(verifyTableResults);
     spinner.succeed('Verifying tables');
   }

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -5,15 +5,7 @@ const falsey = require('falsey');
 const createCorsMiddleware = require('cors');
 const { execute, print } = require('graphql');
 const { GraphQLUpload } = require('graphql-upload');
-const {
-  resolveAllKeys,
-  arrayToObject,
-  mapKeys,
-  objMerge,
-  flatten,
-  unique,
-  filterValues,
-} = require('@keystonejs/utils');
+const { arrayToObject, objMerge, flatten, unique, filterValues } = require('@keystonejs/utils');
 const {
   validateFieldAccessControl,
   validateListAccessControl,
@@ -34,9 +26,7 @@ const composePlugins = fns => (o, e) => fns.reduce((acc, fn) => fn(acc, e), o);
 module.exports = class Keystone {
   constructor({
     defaultAccess,
-    adapters,
     adapter,
-    defaultAdapter,
     onConnect,
     cookieSecret,
     sessionStore,
@@ -81,12 +71,8 @@ module.exports = class Keystone {
       }),
     ];
 
-    if (adapters) {
-      this.adapters = adapters;
-      this.defaultAdapter = defaultAdapter;
-    } else if (adapter) {
-      this.adapters = { [adapter.constructor.name]: adapter };
-      this.defaultAdapter = adapter.constructor.name;
+    if (adapter) {
+      this.adapter = adapter;
     } else {
       throw new Error('No database adapter provided');
     }
@@ -261,8 +247,7 @@ module.exports = class Keystone {
   }
 
   createList(key, config, { isAuxList = false } = {}) {
-    const { getListByKey, adapters } = this;
-    const adapterName = config.adapterName || this.defaultAdapter;
+    const { getListByKey, adapter } = this;
     const isReservedName = !isAuxList && key[0] === '_';
 
     if (isReservedName) {
@@ -288,7 +273,7 @@ module.exports = class Keystone {
       composePlugins(config.plugins || [])(config, { listKey: key, keystone: this }),
       {
         getListByKey,
-        adapter: adapters[adapterName],
+        adapter,
         defaultAccess: this.defaultAccess,
         registerType: type => this.registeredTypes.add(type),
         isAuxList,
@@ -445,9 +430,7 @@ module.exports = class Keystone {
    * constructor, or `undefined` if no `onConnect` method specified.
    */
   async connect(args) {
-    const { adapters } = this;
-    const rels = this._consolidateRelationships();
-    await resolveAllKeys(mapKeys(adapters, adapter => adapter.connect({ rels })));
+    await this.adapter.connect({ rels: this._consolidateRelationships() });
 
     if (this.eventHandlers.onConnect) {
       return this.eventHandlers.onConnect(this, args);
@@ -492,7 +475,7 @@ module.exports = class Keystone {
    * @return Promise<null>
    */
   async disconnect() {
-    await resolveAllKeys(mapKeys(this.adapters, adapter => adapter.disconnect()));
+    await this.adapter.disconnect();
   }
 
   getAdminMeta({ schemaName }) {

--- a/packages/keystone/lib/adapters/README.md
+++ b/packages/keystone/lib/adapters/README.md
@@ -14,10 +14,8 @@ by adapters for different data stores (e.g. Mongoose, Postgres, etc).
 
 ## Usage
 
-### Single adapter
-
-Every `Keystone` system requires at least one adapter.
-To use a single adapter in your project, provide an instance of your adapter of choice as the `adapter` config item.
+Every `Keystone` system requires a database adapter.
+You need to provide an instance of your adapter of choice as the `adapter` config item when creating your `Keystone` object.
 
 ```js
 const keystone = new Keystone({
@@ -26,30 +24,6 @@ const keystone = new Keystone({
 ```
 
 All the `Lists` in your system will be backed by this adapter.
-
-### Multiple adapters
-
-If you want to use multiple adapters in your system (e.g. a different database for content management and business data),
-you can provide an `adapters` object in your config, along with a `defaultAdapter`.
-
-```js
-const keystone = new Keystone({
-  adapters: {
-    content: new MongooseAdapter(),
-    data: new PostgresAdapter(),
-  },
-  defaultAdapter: 'data',
-});
-```
-
-When you create your lists, the default adapter will be used unless your specify an `adapterName` in the config.
-
-```js
-keystone.createList('Pages', {
-  adapterName: 'content',
-  fields: {...},
-});
-```
 
 ## The adapter data model
 

--- a/tests/test-projects/access-control/server.js
+++ b/tests/test-projects/access-control/server.js
@@ -17,7 +17,7 @@ keystone
     // NOTE: This is only for test purposes and should not be used in production
     const users = await keystone.lists.User.adapter.findAll();
     if (!users.length) {
-      await Promise.all(Object.values(keystone.adapters).map(adapter => adapter.dropDatabase()));
+      await keystone.adapter.dropDatabase();
       const context = keystone.createContext({ schemaName: 'internal' });
       for (const [listKey, items] of Object.entries(initialData)) {
         await createItems({ keystone, listKey, items: items.map(x => ({ data: x })), context });
@@ -27,7 +27,7 @@ keystone
     const app = express();
 
     app.get('/reset-db', async (req, res) => {
-      await Promise.all(Object.values(keystone.adapters).map(adapter => adapter.dropDatabase()));
+      await keystone.adapter.dropDatabase();
       const context = keystone.createContext({ schemaName: 'internal' });
       for (const [listKey, items] of Object.entries(initialData)) {
         await createItems({ keystone, listKey, items: items.map(x => ({ data: x })), context });

--- a/tests/test-projects/basic/server.js
+++ b/tests/test-projects/basic/server.js
@@ -17,14 +17,14 @@ keystone
     // NOTE: This is only for test purposes and should not be used in production
     const users = await keystone.lists.User.adapter.findAll();
     if (!users.length) {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await createItems({ keystone, listKey: 'User', items: initialData.User });
     }
 
     const app = express();
 
     app.get('/reset-db', async (req, res) => {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await seedData(initialData);
       res.redirect('/admin');
     });
@@ -39,14 +39,6 @@ keystone
     console.error(error);
     process.exit(1);
   });
-
-/**
- * @param {object} list of all the keystone adapters passed in while configuring the app.
- * @returns {Promise[]} array of Promises for dropping the keystone databases.
- */
-function dropAllDatabases(adapters) {
-  return Promise.all(Object.values(adapters).map(adapter => adapter.dropDatabase()));
-}
 
 /*
  * Seed the initial data using `createItem` API

--- a/tests/test-projects/client-validation/server.js
+++ b/tests/test-projects/client-validation/server.js
@@ -17,14 +17,14 @@ keystone
     // NOTE: This is only for test purposes and should not be used in production
     const users = await keystone.lists.User.adapter.findAll();
     if (!users.length) {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await seedData(initialData);
     }
 
     const app = express();
 
     app.get('/reset-db', async (req, res) => {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await seedData(initialData);
       res.redirect('/admin');
     });
@@ -39,14 +39,6 @@ keystone
     console.error(error);
     process.exit(1);
   });
-
-/**
- * @param {object} list of all the keystone adapters passed in while configuring the app.
- * @returns {Promise[]} array of Promises for dropping the keystone databases.
- */
-function dropAllDatabases(adapters) {
-  return Promise.all(Object.values(adapters).map(adapter => adapter.dropDatabase()));
-}
 
 async function seedData(initialData) {
   return createItems({

--- a/tests/test-projects/login/server.js
+++ b/tests/test-projects/login/server.js
@@ -13,14 +13,14 @@ keystone
     // NOTE: This is only for test purposes and should not be used in production
     const users = await keystone.lists.User.adapter.findAll();
     if (!users.length) {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await seedData(initialData);
     }
 
     const app = express();
 
     app.get('/reset-db', async (req, res) => {
-      await dropAllDatabases(keystone.adapters);
+      await keystone.adapter.dropDatabase();
       await seedData(initialData);
       res.redirect('/admin');
     });
@@ -35,14 +35,6 @@ keystone
     console.error(error);
     process.exit(1);
   });
-
-/**
- * @param {object} list of all the keystone adapters passed in while configuring the app.
- * @returns {Promise[]} array of Promises for dropping the keystone databases.
- */
-function dropAllDatabases(adapters) {
-  return Promise.all(Object.values(adapters).map(adapter => adapter.dropDatabase()));
-}
 
 async function seedData(initialData) {
   return createItems({

--- a/tests/test-projects/social-login/server.js
+++ b/tests/test-projects/social-login/server.js
@@ -202,9 +202,7 @@ keystone
     // NOTE: This is only for test purposes and should not be used in production
     const users = await keystone.lists.User.adapter.findAll();
     if (!users.length) {
-      Object.values(keystone.adapters).forEach(async adapter => {
-        await adapter.dropDatabase();
-      });
+      await keystone.adapter.dropDatabase();
       await createItems({
         keystone,
         listKey: 'User',
@@ -246,9 +244,7 @@ keystone
     });
 
     app.get('/reset-db', async (req, res) => {
-      Object.values(keystone.adapters).forEach(async adapter => {
-        await adapter.dropDatabase();
-      });
+      await keystone.adapter.dropDatabase();
       for (const [listKey, _items] of Object.entries(initialData)) {
         await createItems({
           keystone,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6127,7 +6127,7 @@ babel-plugin-macros@2.8.0, babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-remove-graphql-queries@^2.7.2:
+babel-plugin-remove-graphql-queries@2.7.2, babel-plugin-remove-graphql-queries@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.2.tgz#101c8b26567e35c217e817e892135a9a04a5a805"
   integrity sha512-kkIqi2+oZ7YCLbZbrhOGxPA/HuWpfvzRUxbD75SHqwxl9fZVWSLQhOUl72GEpAuEt4MeCEguKpMX100oDN3MQA==
@@ -11645,11 +11645,6 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
-fs-capacitor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
-  integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
-
 fs-capacitor@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-6.2.0.tgz#fa79ac6576629163cb84561995602d8999afb7f5"
@@ -11840,7 +11835,7 @@ gatsby-graphiql-explorer@^0.2.3:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-gatsby-link@^2.2.2:
+gatsby-link@2.2.2, gatsby-link@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.2.2.tgz#789260f82ce0fdb657d1bd558a5863407def86bd"
   integrity sha512-5OHtZZ6V4k0dy+nHe51NVyWzBcHECA4Jx87qqqRja3s+ZKgcYHk4mAhPjt8bZl4sCIW51p+PyfsoKU7Verqd2Q==
@@ -11929,7 +11924,7 @@ gatsby-plugin-mdx@1.2.47:
     unist-util-remove "^1.0.3"
     unist-util-visit "^1.4.1"
 
-gatsby-plugin-page-creator@^2.1.5:
+gatsby-plugin-page-creator@2.1.5, gatsby-plugin-page-creator@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.5.tgz#723fc0392a67978cab649a402ad88f6f06b74e4c"
   integrity sha512-nUcsaJAaMy9UQS66QY0Dys6Xx+2CGG2EVyvDQ4NQ713la62jicOU764Bmi5G7sE2QGgpNoBtUQCW+aE6UMGpLQ==
@@ -12906,7 +12901,7 @@ graphql-type-json@^0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql-upload@^11.0.0:
+graphql-upload@^11.0.0, graphql-upload@^8.0.2:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-11.0.0.tgz#24b245ff18f353bab6715e8a055db9fd73035e10"
   integrity sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==
@@ -12915,16 +12910,6 @@ graphql-upload@^11.0.0:
     fs-capacitor "^6.1.0"
     http-errors "^1.7.3"
     isobject "^4.0.0"
-    object-path "^0.11.4"
-
-graphql-upload@^8.0.2:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"
-  integrity sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==
-  dependencies:
-    busboy "^0.3.1"
-    fs-capacitor "^2.0.4"
-    http-errors "^1.7.3"
     object-path "^0.11.4"
 
 graphql@^14.1.1, graphql@^14.5.8:
@@ -26335,10 +26320,8 @@ watchpack@^1.5.0, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
One of Keystone's perhaps lesser used features is the ability to connect to more than one database at a time. This feature was added very early in development in anticipation that this might be a feature that we needed. In practice, none of the systems we have built have ever come close to requiring this feature. I'm not aware of any systems using it in the wild.

I would like to remove support for this feature, as it adds complexity to the code, surface area to the API, and potentially confusion to developers trying to get a solid mental model of a Keystone system.

I'm putting up this PR as an RFC to see if there is any vocal support for keeping this feature. Ideally I'd love to hear a practical example of this being used in a production context.