### PR TITLE
Remove default database connection string

### DIFF
--- a/.changeset/sixty-cameras-invite.md
+++ b/.changeset/sixty-cameras-invite.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/adapter-knex': major
+'@keystonejs/adapter-mongoose': major
+'create-keystone-app': patch
+---
+
+Adapters must now be explicitly configured with a connection string. A default based on the project name is no longer used. See the docs for [`adapter-knex`](/packages/adapter-knex/README.md) and [`adapter-mongoose`](/packages/adapter-mongoose/README.md).

--- a/demo-projects/blog/index.js
+++ b/demo-projects/blog/index.js
@@ -12,7 +12,7 @@ const { User, Post, PostCategory, Comment } = require('./schema');
 
 const keystone = new Keystone({
   name: 'Keystone Demo Blog',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/keystone-demo-blog' }),
   onConnect: async () => {
     // Initialise some data.
     // NOTE: This is only for demo purposes and should not be used in production

--- a/demo-projects/custom-fields/index.js
+++ b/demo-projects/custom-fields/index.js
@@ -8,7 +8,7 @@ const MultiCheck = require('./fields/MultiCheck');
 
 const keystone = new Keystone({
   name: 'custom-field',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/custom-field' }),
 });
 
 keystone.createList('Movie', {

--- a/demo-projects/meetup/index.js
+++ b/demo-projects/meetup/index.js
@@ -23,7 +23,7 @@ const initialiseData = require('./initialData');
 
 const keystone = new Keystone({
   name: MEETUP.name,
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/meetup' }),
   onConnect: initialiseData,
 });
 

--- a/demo-projects/todo/index.js
+++ b/demo-projects/todo/index.js
@@ -7,7 +7,7 @@ const { StaticApp } = require('@keystonejs/app-static');
 
 const keystone = new Keystone({
   name: 'Keystone To-Do List',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/todo' }),
 });
 
 keystone.createList('Todo', {

--- a/docs/tutorials/new-project.md
+++ b/docs/tutorials/new-project.md
@@ -44,7 +44,7 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
   name: 'New Project',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/keystone' }),
 });
 ```
 

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -47,17 +47,9 @@ _**Default:**_
 ```javascript
 {
   client: 'postgres',
-  connection: '<DEFAULT_CONNECTION_URL>'
+  connection: 'process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI'
 }
 ```
-
-The `DEFAULT_CONNECTION_URL` will be either one of the following environmental variables:
-
-- `CONNECT_TO`,
-- `DATABASE_URL`,
-- `KNEX_URI`
-
-or `'postgres://localhost/<DATABASE_NAME>'`where `DATABASE_NAME` is be derived from the KeystoneJS project name.
 
 ## Debugging
 

--- a/packages/adapter-knex/README.md
+++ b/packages/adapter-knex/README.md
@@ -47,7 +47,7 @@ _**Default:**_
 ```javascript
 {
   client: 'postgres',
-  connection: 'process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI'
+  connection: process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI
 }
 ```
 

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -3,7 +3,6 @@ const { versionGreaterOrEqualTo } = require('@keystonejs/utils');
 const knex = require('knex');
 const pSettle = require('p-settle');
 const { BaseKeystoneAdapter, BaseListAdapter, BaseFieldAdapter } = require('@keystonejs/keystone');
-const logger = require('@keystonejs/logger').logger('knex');
 
 const {
   escapeRegExp,
@@ -13,7 +12,6 @@ const {
   resolveAllKeys,
   identity,
 } = require('@keystonejs/utils');
-const slugify = require('@sindresorhus/slugify');
 
 class KnexAdapter extends BaseKeystoneAdapter {
   constructor({ knexOptions = {}, schemaName = 'public' } = {}) {
@@ -26,16 +24,14 @@ class KnexAdapter extends BaseKeystoneAdapter {
     this.rels = undefined;
   }
 
-  async _connect({ name }) {
+  async _connect() {
     const { knexOptions = {} } = this.config;
     const { connection } = knexOptions;
     let knexConnection =
       connection || process.env.CONNECT_TO || process.env.DATABASE_URL || process.env.KNEX_URI;
 
     if (!knexConnection) {
-      const defaultDbName = slugify(name, { separator: '_' }) || 'keystone';
-      knexConnection = `postgres://localhost/${defaultDbName}`;
-      logger.warn(`No Knex connection URI specified. Defaulting to '${knexConnection}'`);
+      throw new Error(`No Knex connection URI specified.`);
     }
     this.knex = knex({
       client: this.client,

--- a/packages/adapter-knex/tests/adapter-knex.test.js
+++ b/packages/adapter-knex/tests/adapter-knex.test.js
@@ -11,9 +11,7 @@ describe('Knex Adapter', () => {
     const testAdapter = new KnexAdapter({
       knexOptions: { connection: 'postgres://localhost/undefined_database' },
     });
-    const result = await testAdapter
-      ._connect({ name: 'undefined-database' })
-      .catch(result => result);
+    const result = await testAdapter._connect().catch(result => result);
 
     expect(result).toBeInstanceOf(Error);
     expect(global.console.error).toHaveBeenCalledWith(
@@ -32,9 +30,7 @@ describe('Knex Adapter', () => {
         },
       },
     });
-    const result = await testAdapter
-      ._connect({ name: 'undefined-database' })
-      .catch(result => result);
+    const result = await testAdapter._connect().catch(result => result);
 
     expect(result).toBeInstanceOf(Error);
     expect(global.console.error).toHaveBeenCalledWith(
@@ -45,7 +41,7 @@ describe('Knex Adapter', () => {
   describe('checkDatabaseVersion', () => {
     test('throws when database version is unsupported', async () => {
       const testAdapter = new KnexAdapter();
-      await testAdapter._connect({ name: 'postgres' });
+      await testAdapter._connect();
       testAdapter.minVer = '50.5.5';
       const result = await testAdapter.checkDatabaseVersion().catch(result => result);
       expect(result).toBeInstanceOf(Error);
@@ -54,7 +50,7 @@ describe('Knex Adapter', () => {
 
     test('does not throw when database version is supported', async () => {
       const testAdapter = new KnexAdapter();
-      await testAdapter._connect({ name: 'postgres' });
+      await testAdapter._connect();
       testAdapter.minVer = '1.0.0';
       const result = await testAdapter.checkDatabaseVersion().catch(result => result);
       expect(result).not.toBeInstanceOf(Error);

--- a/packages/adapter-mongoose/README.md
+++ b/packages/adapter-mongoose/README.md
@@ -21,13 +21,13 @@ const keystone = new Keystone({
 
 ## Config
 
-### `mongoUri` (optional)
+### `mongoUri` (required)
 
 This is used as the `uri` parameter for `mongoose.connect()`.
 
-_**Default:**_ Environmental variable (see below) or `'mongodb://localhost/<DATABASE_NAME>'`
+_**Default:**_ Environment variable (see below) or `'mongodb://localhost/<DATABASE_NAME>'`
 
-If not specified, KeystoneJS will first look for one of the following environmental variables:
+If not specified, KeystoneJS will look for one of the following environment variables:
 
 - `CONNECT_TO`
 - `DATABASE_URL`
@@ -37,8 +37,6 @@ If not specified, KeystoneJS will first look for one of the following environmen
 - `MONGODB_URL`
 - `MONGOLAB_URI`
 - `MONGOLAB_URL`
-
-If none of these are found a connection string is derived with a `DATABASE_NAME` from the KeystoneJS project name.
 
 ### Mongoose options (optional)
 

--- a/packages/adapter-mongoose/lib/adapter-mongoose.js
+++ b/packages/adapter-mongoose/lib/adapter-mongoose.js
@@ -17,9 +17,6 @@ const {
 
 const { BaseKeystoneAdapter, BaseListAdapter, BaseFieldAdapter } = require('@keystonejs/keystone');
 const { queryParser, pipelineBuilder } = require('@keystonejs/mongo-join-builder');
-const logger = require('@keystonejs/logger').logger('mongoose');
-
-const slugify = require('@sindresorhus/slugify');
 
 const debugMongoose = () => !!process.env.DEBUG_MONGOOSE;
 
@@ -36,7 +33,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
     this._manyModels = {};
   }
 
-  async _connect({ name }) {
+  async _connect() {
     const { mongoUri, ...mongooseConfig } = this.config;
     // Default to the localhost instance
     let uri =
@@ -51,9 +48,7 @@ class MongooseAdapter extends BaseKeystoneAdapter {
       process.env.MONGOLAB_URL;
 
     if (!uri) {
-      const defaultDbName = slugify(name) || 'keystone';
-      uri = `mongodb://localhost/${defaultDbName}`;
-      logger.warn(`No MongoDB connection URI specified. Defaulting to '${uri}'`);
+      throw new Error(`No MongoDB connection URI specified.`);
     }
 
     await this.mongoose.connect(uri, {

--- a/packages/create-keystone-app/lib/test-adapter-connection.js
+++ b/packages/create-keystone-app/lib/test-adapter-connection.js
@@ -6,7 +6,6 @@ const { error, tick } = require('./util');
 const { getArgs } = require('./get-args');
 const { getAdapterChoice } = require('./get-adapter-choice');
 const { getAdapterConfig } = require('./get-adapter-config');
-const { getProjectName } = require('../lib/get-project-name');
 
 let TEST_CONNECTION;
 
@@ -53,7 +52,7 @@ const testAdapterConnection = async () => {
         : { knexOptions: { connection: config } };
     const adapter = new Adapter(adapterConfig);
     try {
-      await adapter._connect({ name: await getProjectName() });
+      await adapter._connect();
       adapter.disconnect();
       tick(`Successfully connected to ${config}`);
     } catch (err) {

--- a/test-projects/access-control/cypress/plugins/index.js
+++ b/test-projects/access-control/cypress/plugins/index.js
@@ -8,7 +8,6 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 const mongoose = require('mongoose');
-const inflection = require('inflection');
 
 const appConfig = require('../../config');
 
@@ -19,10 +18,9 @@ module.exports = async (on, config) => {
   config.baseUrl = `http://localhost:${appConfig.port}`;
 
   const mongooseInstance = new mongoose.Mongoose();
-  await mongooseInstance.connect(
-    `mongodb://localhost:27017/${inflection.dasherize(appConfig.projectName).toLowerCase()}`,
-    { useNewUrlParser: true }
-  );
+  await mongooseInstance.connect('mongodb://localhost/cypress-test-project', {
+    useNewUrlParser: true,
+  });
 
   const dbConnection = mongooseInstance.connection.db;
 

--- a/test-projects/access-control/index.js
+++ b/test-projects/access-control/index.js
@@ -19,7 +19,7 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
   name: projectName,
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/cypress-test-project' }),
   cookieSecret: 'qwerty',
 });
 

--- a/test-projects/basic/index.js
+++ b/test-projects/basic/index.js
@@ -44,7 +44,7 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
   name: 'Cypress Test Project Basic',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/cypress-test-project' }),
   cookieSecret: 'qwerty',
 });
 

--- a/test-projects/client-validation/index.js
+++ b/test-projects/client-validation/index.js
@@ -10,7 +10,7 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
   name: 'Cypress Test Project Client Validation',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/cypress-test-project' }),
   cookieSecret: 'qwerty',
 });
 

--- a/test-projects/login/index.js
+++ b/test-projects/login/index.js
@@ -18,7 +18,7 @@ const defaultAccess = ({ authentication: { item } }) => !!item;
 
 const keystone = new Keystone({
   name: 'Cypress Test Project For Login',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/cypress-test-project' }),
   cookieSecret: 'qwerty',
   defaultAccess: {
     list: defaultAccess,

--- a/test-projects/social-login/index.js
+++ b/test-projects/social-login/index.js
@@ -24,7 +24,7 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 const keystone = new Keystone({
   name: 'Cypress Test for Social Login',
-  adapter: new MongooseAdapter(),
+  adapter: new MongooseAdapter({ mongoUri: 'mongodb://localhost/cypress-test-project' }),
   cookieSecret,
 });
 


### PR DESCRIPTION
If a dev does not supply a connection string for their database then Keystone will go looking at certain environment variables, and failing that will just make something up based on the value of `name` passed to the `Keystone()` constructor.

Defaulting to a connection based on the name of the project is not particularly elegant, and does not set up devs for success. It is important that they explicitly state where the database is and have control over this. There's no good reason keystone should be guessing.

The `create-keystone-app` package now ensures that the dev has set up this connection string, so very few users should be relying on this "feature", and those who are can very easily update their project to have an explicit connection string.