### PR TITLE
[WIP] Apply cache hints to mutation resolvers.

### DIFF
--- a/.changeset/funny-students-smash.md
+++ b/.changeset/funny-students-smash.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': minor
+'@keystonejs/keystone': minor
+---
+
+Applied cache hints to all Mutation resolvers.

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -166,7 +166,7 @@ export class Relationship extends Implementation {
    * previous stored values, which means indecies may not match those passed in
    * `operations`.
    */
-  async resolveNestedOperations(operations, item, context, getItem, mutationState) {
+  async resolveNestedOperations(operations, item, context, getItem, mutationState, info) {
     const { refList, refField } = this.tryResolveRefList();
     const listInfo = {
       local: { list: this.getListByKey(this.listKey), field: this },
@@ -222,6 +222,7 @@ export class Relationship extends Implementation {
       many: this.many,
       context,
       mutationState,
+      info,
     });
 
     return { create, connect, disconnect, currentValue };

--- a/packages/keystone/lib/providers/listAuth.js
+++ b/packages/keystone/lib/providers/listAuth.js
@@ -118,7 +118,8 @@ class ListAuthProvider {
     return this.list.itemQuery(
       mergeWhereClause({ where: { id: context.authedItem.id } }, access),
       context,
-      this.gqlNames.authenticatedQueryName
+      this.gqlNames.authenticatedQueryName,
+      info
     );
   }
 

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -888,43 +888,43 @@ test('getAccessControlledItem', async () => {
 
 test('getAccessControlledItems', async () => {
   const list = setup();
-  expect(await list.getAccessControlledItems([], true)).toEqual([]);
-  expect(await list.getAccessControlledItems([1, 2], true)).toEqual([
+  expect(await list.getAccessControlledItems([], true, {})).toEqual([]);
+  expect(await list.getAccessControlledItems([1, 2], true, {})).toEqual([
     { name: 'b', email: 'b@example.com', index: 1 },
     { name: 'c', email: 'c@example.com', index: 2 },
   ]);
-  expect(await list.getAccessControlledItems([1, 2, 1, 2], true)).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
-  ]);
-
-  expect(await list.getAccessControlledItems([1, 2], { id: 1 })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-  ]);
-  expect(await list.getAccessControlledItems([1, 2], { id: 3 })).toEqual([]);
-
-  expect(await list.getAccessControlledItems([1, 2], { id_in: [1, 2, 3] })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
-  ]);
-  expect(await list.getAccessControlledItems([1, 2], { id_in: [2, 3] })).toEqual([
-    { name: 'c', email: 'c@example.com', index: 2 },
-  ]);
-  expect(await list.getAccessControlledItems([1, 2], { id_in: [3, 4] })).toEqual([]);
-
-  expect(await list.getAccessControlledItems([1, 2], { id_not: 2 })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-  ]);
-  expect(await list.getAccessControlledItems([1, 2], { id_not: 3 })).toEqual([
+  expect(await list.getAccessControlledItems([1, 2, 1, 2], true, {})).toEqual([
     { name: 'b', email: 'b@example.com', index: 1 },
     { name: 'c', email: 'c@example.com', index: 2 },
   ]);
 
-  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [1, 2, 3] })).toEqual([]);
-  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [2, 3] })).toEqual([
+  expect(await list.getAccessControlledItems([1, 2], { id: 1 }, {})).toEqual([
     { name: 'b', email: 'b@example.com', index: 1 },
   ]);
-  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [3, 4] })).toEqual([
+  expect(await list.getAccessControlledItems([1, 2], { id: 3 }, {})).toEqual([]);
+
+  expect(await list.getAccessControlledItems([1, 2], { id_in: [1, 2, 3] }, {})).toEqual([
+    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'c', email: 'c@example.com', index: 2 },
+  ]);
+  expect(await list.getAccessControlledItems([1, 2], { id_in: [2, 3] }, {})).toEqual([
+    { name: 'c', email: 'c@example.com', index: 2 },
+  ]);
+  expect(await list.getAccessControlledItems([1, 2], { id_in: [3, 4] }, {})).toEqual([]);
+
+  expect(await list.getAccessControlledItems([1, 2], { id_not: 2 }, {})).toEqual([
+    { name: 'b', email: 'b@example.com', index: 1 },
+  ]);
+  expect(await list.getAccessControlledItems([1, 2], { id_not: 3 }, {})).toEqual([
+    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'c', email: 'c@example.com', index: 2 },
+  ]);
+
+  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [1, 2, 3] }, {})).toEqual([]);
+  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [2, 3] }, {})).toEqual([
+    { name: 'b', email: 'b@example.com', index: 1 },
+  ]);
+  expect(await list.getAccessControlledItems([1, 2], { id_not_in: [3, 4] }, {})).toEqual([
     { name: 'b', email: 'b@example.com', index: 1 },
     { name: 'c', email: 'c@example.com', index: 2 },
   ]);


### PR DESCRIPTION
This change passes the `info` object down into `_itemsQuery` in mutations to allow `cacheHints` to be utilised in these cases.