### PR TITLE
Directly access adapter to find authed item

### DIFF
--- a/.changeset/five-cherries-shout.md
+++ b/.changeset/five-cherries-shout.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/session': patch
+---
+
+Updated middleware to directly access the data adapter to find the authorised item.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,8 +275,11 @@ We also build commonjs builds to run in node (for testing with jest or etc.) and
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 <!-- prettier-ignore-start -->
+
 <!-- markdownlint-disable -->
+
 <table>
   <tr>
     <td align="center"><a href="http://www.thinkmill.com.au"><img src="https://avatars3.githubusercontent.com/u/872310?v=4" width="80px;" alt=""/><br /><sub><b>Jed Watson</b></sub></a><br /><a href="https://github.com/keystonejs/keystone/commits?author=JedWatson" title="Code">💻</a></td>
@@ -342,7 +345,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 </table>
 
 <!-- markdownlint-enable -->
+
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -77,8 +77,11 @@ We'd like to start by thanking all our wonderful contributors:
 ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 <!-- prettier-ignore-start -->
+
 <!-- markdownlint-disable -->
+
 <table>
   <tr>
     <td align="center"><a href="http://www.thinkmill.com.au"><img src="https://avatars3.githubusercontent.com/u/872310?v=4" width="80px;" alt=""/><br /><sub><b>Jed Watson</b></sub></a><br /><a href="https://github.com/keystonejs/keystone/commits?author=JedWatson" title="Code">💻</a></td>
@@ -144,7 +147,9 @@ We'd like to start by thanking all our wonderful contributors:
 </table>
 
 <!-- markdownlint-enable -->
+
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ### Demo Projects

--- a/packages/auth-passport/README.md
+++ b/packages/auth-passport/README.md
@@ -307,23 +307,25 @@ keystone
     process.exit(1);
   });
 ```
+
 Sometimes you just need to get the profile data provided by the auth provider. In that case, you
 have to call the `resolveCreateData` with `serviceProfile` property. See an example below:
 
 ```javascript
 // Here we wait for our serviceProfile to get the data provided by the auth provider
-resolveCreateData: ({ createData,  serviceProfile }) => { 
+resolveCreateData: ({ createData, serviceProfile }) => {
   // Once we had our seviceProfile, we set it on our list fields
-    
+
   // Google will return the profile data inside the _json key
   // Each provider can return the user profile data in a different way.
   // Check how it's returned on your provider documentation
-  createData.name = serviceProfile._json.name
-  createData.profilePicture = serviceProfile._json.picture 
-    
+  createData.name = serviceProfile._json.name;
+  createData.profilePicture = serviceProfile._json.picture;
+
   return createData;
-}
+};
 ```
+
 ## Using other Passport strategies
 
 You can create your own strategies to work with Keystone by extending the

--- a/packages/session/lib/session.js
+++ b/packages/session/lib/session.js
@@ -101,11 +101,7 @@ class SessionManager {
     }
     let item;
     try {
-      item = await list.getAccessControlledItem(req.session.keystoneItemId, true, {
-        operation: 'read',
-        context: {},
-        info: {},
-      });
+      item = (await list.adapter.itemsQuery({ where: { id: req.session.keystoneItemId } }))[0];
     } catch (e) {
       return;
     }


### PR DESCRIPTION
The session should be directly accessing the database, rather than going through a number of layer of abstraction related to resolving graphQL queries.