### PR TITLE
Add new email field type

### DIFF
--- a/.changeset/calm-pans-leave.md
+++ b/.changeset/calm-pans-leave.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Add `React.useCallback` and `React.useMem` inside of Text field view

--- a/.changeset/calm-pans-leave.md
+++ b/.changeset/calm-pans-leave.md
@@ -2,4 +2,4 @@
 '@keystonejs/fields': patch
 ---
 
-Add `React.useCallback` and `React.useMem` inside of Text field view
+Add `React.useCallback` and `React.useMemo` inside of Text field view

--- a/.changeset/late-eagles-lie.md
+++ b/.changeset/late-eagles-lie.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Updated the `Text` field view to accept a `type` prop so it can be used by other input types

--- a/.changeset/tough-ads-kiss.md
+++ b/.changeset/tough-ads-kiss.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Created a new `Email` field type

--- a/packages/fields/src/index.js
+++ b/packages/fields/src/index.js
@@ -6,6 +6,7 @@ export { default as CloudinaryImage } from './types/CloudinaryImage';
 export { default as Color } from './types/Color';
 export { default as DateTime } from './types/DateTime';
 export { default as Decimal } from './types/Decimal';
+export { default as Email } from './types/Email';
 export { default as File } from './types/File';
 export { default as Float } from './types/Float';
 export { default as Integer } from './types/Integer';

--- a/packages/fields/src/types/Email/Implementation.js
+++ b/packages/fields/src/types/Email/Implementation.js
@@ -15,6 +15,7 @@ export class Email extends Text {
   }
 
   isValidEmail(email) {
-    return /\S+@\S+\.\S+/.test(email);
+    // https://www.w3.org/TR/2012/WD-html-markup-20120329/input.email.html#input.email.attrs.value.single
+    return /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/.test(email);
   }
 }

--- a/packages/fields/src/types/Email/Implementation.js
+++ b/packages/fields/src/types/Email/Implementation.js
@@ -1,0 +1,20 @@
+import { Text } from '../Text/Implementation';
+
+export class Email extends Text {
+  validateInput({ resolvedData, addFieldValidationError }) {
+    const fieldValue = resolvedData[this.path];
+
+    if (!this.isRequired && !fieldValue) {
+      // If the field isn't required and we don't have a value we can skip any validation checks
+      return;
+    }
+
+    if (!this.isValidEmail(fieldValue)) {
+      addFieldValidationError(`Invalid email`, { value: fieldValue });
+    }
+  }
+
+  isValidEmail(email) {
+    return /\S+@\S+\.\S+/.test(email);
+  }
+}

--- a/packages/fields/src/types/Email/README.md
+++ b/packages/fields/src/types/Email/README.md
@@ -1,0 +1,28 @@
+<!--[meta]
+section: api
+subSection: field-types
+title: Email
+[meta]-->
+
+# Email
+
+The `Email` field type is similar to the `Text` field, but it will validate against non valid email addresses
+
+## Usage
+
+```js
+const { Email } = require('@keystonejs/fields');
+
+keystone.createList('User', {
+  fields: {
+    email: { type: Email },
+  },
+});
+```
+
+## Config
+
+| Option       | Type      | Default | Description                                                     |
+| ------------ | --------- | ------- | --------------------------------------------------------------- |
+| `isRequired` | `Boolean` | `false` | Does this field require a value?                                |
+| `isUnique`   | `Boolean` | `false` | Adds a unique index that allows only unique values to be stored |

--- a/packages/fields/src/types/Email/index.js
+++ b/packages/fields/src/types/Email/index.js
@@ -1,0 +1,17 @@
+import { importView } from '@keystonejs/build-field-types';
+import { MongoTextInterface, KnexTextInterface } from '../Text/Implementation';
+import { Email } from './Implementation';
+
+export default {
+  type: 'Email',
+  implementation: Email,
+  views: {
+    Controller: importView('../Text/views/Controller'),
+    Field: importView('./views/Field'),
+    Filter: importView('../Text/views/Filter'),
+  },
+  adapters: {
+    mongoose: MongoTextInterface,
+    knex: KnexTextInterface,
+  },
+};

--- a/packages/fields/src/types/Email/views/Field.js
+++ b/packages/fields/src/types/Email/views/Field.js
@@ -1,0 +1,9 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import TextField from '../../Text/views/Field';
+
+const EmailField = props => {
+  return <TextField {...props} type="email" />;
+};
+
+export default EmailField;

--- a/packages/fields/src/types/Text/views/Field.js
+++ b/packages/fields/src/types/Text/views/Field.js
@@ -1,9 +1,12 @@
 /** @jsx jsx */
 
 import { jsx } from '@emotion/core';
+import { useCallback, useMemo } from 'react';
 
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
+
+const isAccessDeniedError = error => error instanceof Error && error.name === 'AccessDeniedError';
 
 const TextField = ({
   onChange,
@@ -14,16 +17,17 @@ const TextField = ({
   isDisabled,
   type = 'text',
 }) => {
-  const handleChange = event => {
-    onChange(event.target.value);
-  };
-
   const { isMultiline } = field.config;
   const htmlID = `ks-input-${field.path}`;
-  const canRead = errors.every(
-    error => !(error instanceof Error && error.name === 'AccessDeniedError')
+  const canRead = useMemo(() => errors.every(error => !isAccessDeniedError(error)), [errors]);
+  const error = useMemo(() => errors.find(isAccessDeniedError), [errors]);
+
+  const handleChange = useCallback(
+    event => {
+      onChange(event.target.value);
+    },
+    [onChange]
   );
-  const error = errors.find(error => error instanceof Error && error.name === 'AccessDeniedError');
 
   return (
     <FieldContainer>

--- a/packages/fields/src/types/Text/views/Field.js
+++ b/packages/fields/src/types/Text/views/Field.js
@@ -5,7 +5,15 @@ import { jsx } from '@emotion/core';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import { Input } from '@arch-ui/input';
 
-const TextField = ({ onChange, autoFocus, field, errors, value = '', isDisabled }) => {
+const TextField = ({
+  onChange,
+  autoFocus,
+  field,
+  errors,
+  value = '',
+  isDisabled,
+  type = 'text',
+}) => {
   const handleChange = event => {
     onChange(event.target.value);
   };
@@ -26,7 +34,7 @@ const TextField = ({ onChange, autoFocus, field, errors, value = '', isDisabled 
           autoComplete="off"
           autoFocus={autoFocus}
           required={field.isRequired}
-          type="text"
+          type={type}
           value={canRead ? value : undefined}
           placeholder={canRead ? undefined : error.message}
           onChange={handleChange}


### PR DESCRIPTION
This PR adds a new field type `Email`. This is essentially the same as the `Text` field type, but with some built-in email validation.

### Screenshots

Show a warning when creating an item with an invalid email address. The tooltip is native to the browser and happens because we've added `type="email` to the input.

<img width="646" alt="Screen Shot 2020-07-08 at 11 13 23 am" src="https://user-images.githubusercontent.com/6265154/86862183-0f60ec80-c10c-11ea-9f83-fb15821ff0c0.png">

Show a warning when trying to update an item with an invalid email address.

<img width="1853" alt="Screen Shot 2020-07-08 at 11 09 10 am" src="https://user-images.githubusercontent.com/6265154/86862139-f48e7800-c10b-11ea-88f6-155556fe81e0.png">


### GraphQL errors

Using this list

```js
keystone.createList('User', {
  fields: {
    email: { type: Email, isRequired: true },
  },
});
```

```
mutation {
  createUser(data: { email: "__invalid__email" }) {
    id
    email
  }
}


// Returns

{
  "errors": [
    {
      "message": "You attempted to perform an invalid mutation",
      "name": "ValidationFailureError",
      "time_thrown": "2020-07-09T01:21:24.941Z",
      "data": {
        "messages": [
          "Invalid email"
        ],
        "errors": [
          {
            "value": "__invalid__email"
          }
        ],
        "listKey": "User",
        "operation": "create"
      },
      "path": [
        "createUser"
      ],
      "uid": "ckce3v2ll0001creff2e019iu"
    }
  ],
  "data": {
    "createUser": null
  }
}
```