### PR TITLE
Add more checks for errors being undefined

### DIFF
--- a/.changeset/poor-bananas-train.md
+++ b/.changeset/poor-bananas-train.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': patch
+---
+
+Added more checks for errors being undefined when returned from a graphQL request.

--- a/api-tests/CalendarDay.test.js
+++ b/api-tests/CalendarDay.test.js
@@ -21,11 +21,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'Valid date passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `mutation { createUser(data: { birthday: "2001-01-01" }) { birthday } }`,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('createUser.birthday', '2001-01-01');
         })
       );
@@ -33,10 +33,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'date === dateTo passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `mutation { createUser(data: { birthday: "2020-01-01" }) { birthday } }`,
           });
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('createUser.birthday', '2020-01-01');
         })
       );
@@ -44,10 +45,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'date === dateFrom passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `mutation { createUser(data: { birthday: "2020-01-01" }) { birthday } }`,
           });
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('createUser.birthday', '2020-01-01');
         })
       );
@@ -55,13 +57,14 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'Invalid date failsvalidation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { errors } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `mutation { createUser(data: { birthday: "3000-01-01" }) { birthday } }`,
           });
           expect(errors).toHaveLength(1);
           const error = errors[0];
           expect(error.message).toEqual('You attempted to perform an invalid mutation');
+          expect(data.createUser).toBe(null);
         })
       );
     });

--- a/api-tests/DateTime.test.js
+++ b/api-tests/DateTime.test.js
@@ -23,6 +23,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Introspection query
           const {
             data: { __schema },
+            errors,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -42,7 +43,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
       `,
           });
-
+          expect(errors).toBe(undefined);
           expect(__schema).toHaveProperty('types');
           expect(__schema.types).toMatchObject(
             expect.arrayContaining([
@@ -79,7 +80,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         query {
@@ -89,7 +90,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('Post.postedAt', postedAt);
         })
       );
@@ -125,7 +126,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -135,7 +136,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('updatePost.postedAt', updatedPostedAt);
         })
       );
@@ -148,7 +149,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await create('Post', { postedAt });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -158,7 +159,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('updatePost.postedAt', null);
         })
       );
@@ -167,7 +168,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'allows initialising to null',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -177,7 +178,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('createPost.postedAt', null);
         })
       );
@@ -191,7 +192,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await create('Post', { postedAt, title });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -201,7 +202,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('updatePost.postedAt', postedAt);
         })
       );

--- a/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
@@ -7,7 +7,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 jest.setTimeout(6000000);
 
 const createInitialData = async keystone => {
-  const { data } = await graphqlRequest({
+  const { data, errors } = await graphqlRequest({
     keystone,
     query: `
 mutation {
@@ -19,12 +19,14 @@ mutation {
 }
 `,
   });
+  expect(errors).toBe(undefined);
   return { users: data.createUsers };
 };
 
 const createUserAndFriend = async keystone => {
   const {
     data: { createUser },
+    errors,
   } = await graphqlRequest({
     keystone,
     query: `
@@ -34,6 +36,7 @@ mutation {
   }) { id friend { id } }
 }`,
   });
+  expect(errors).toBe(undefined);
   const { User, Friend } = await getUserAndFriend(keystone, createUser.id, createUser.friend.id);
 
   // Sanity check the links are setup correctly
@@ -81,8 +84,9 @@ const createComplexData = async keystone => {
 
   const {
     data: { allUsers },
+    errors: errors2,
   } = await graphqlRequest({ keystone, query: '{ allUsers { id name friend { id name } } }' });
-
+  expect(errors2).toBe(undefined);
   return { users: allUsers };
 };
 

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -7,7 +7,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 jest.setTimeout(6000000);
 
 const createInitialData = async keystone => {
-  const { data } = await graphqlRequest({
+  const { data, errors } = await graphqlRequest({
     keystone,
     query: `
 mutation {
@@ -19,12 +19,14 @@ mutation {
 }
 `,
   });
+  expect(errors).toBe(undefined);
   return { users: data.createUsers };
 };
 
 const createUserAndFriend = async keystone => {
   const {
     data: { createUser },
+    errors,
   } = await graphqlRequest({
     keystone,
     query: `
@@ -35,6 +37,7 @@ mutation {
   }) { id name friend { id name } }
 }`,
   });
+  expect(errors).toBe(undefined);
   const { User, Friend } = await getUserAndFriend(keystone, createUser.id, createUser.friend.id);
 
   // Sanity check the links are setup correctly
@@ -269,11 +272,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
               const {
                 data: { allUsers },
+                errors: errors2,
               } = await graphqlRequest({
                 keystone,
                 query: `{ allUsers { id friend { id friendOf { id }} } }`,
               });
-
+              expect(errors2).toBe(undefined);
               // The nested company should not have a location
               expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
                 User.id
@@ -316,10 +320,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               // The nested company should not have a location
               const {
                 data: { allUsers },
+                errors: errors2,
               } = await graphqlRequest({
                 keystone,
                 query: `{ allUsers { id friend { id friendOf { id }} } }`,
               });
+              expect(errors2).toBe(undefined);
               expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
                 User.id
               );

--- a/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -7,7 +7,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 jest.setTimeout(6000000);
 
 const createInitialData = async keystone => {
-  const { data } = await graphqlRequest({
+  const { data, errors } = await graphqlRequest({
     keystone,
     query: `
 mutation {
@@ -24,12 +24,14 @@ mutation {
 }
 `,
   });
+  expect(errors).toBe(undefined);
   return { locations: data.createLocations, companies: data.createCompanies };
 };
 
 const createCompanyAndLocation = async keystone => {
   const {
     data: { createCompany },
+    errors,
   } = await graphqlRequest({
     keystone,
     query: `
@@ -39,6 +41,7 @@ mutation {
   }) { id location { id } }
 }`,
   });
+  expect(errors).toBe(undefined);
   const { Company, Location } = await getCompanyAndLocation(
     keystone,
     createCompany.id,
@@ -88,8 +91,9 @@ const createComplexData = async keystone => {
 
   const {
     data: { allLocations },
+    errors: errors2,
   } = await graphqlRequest({ keystone, query: '{ allLocations { id name } }' });
-
+  expect(errors2).toBe(undefined);
   return {
     companies: [...data.createCompanies, result.data.createCompany],
     locations: allLocations,

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -7,7 +7,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 jest.setTimeout(6000000);
 
 const createInitialData = async keystone => {
-  const { data } = await graphqlRequest({
+  const { data, errors } = await graphqlRequest({
     keystone,
     query: `
 mutation {
@@ -24,12 +24,14 @@ mutation {
 }
 `,
   });
+  expect(errors).toBe(undefined);
   return { locations: data.createLocations, companies: data.createCompanies };
 };
 
 const createCompanyAndLocation = async keystone => {
   const {
     data: { createCompany },
+    errors,
   } = await graphqlRequest({
     keystone,
     query: `
@@ -40,6 +42,7 @@ mutation {
   }) { id name location { id name } }
 }`,
   });
+  expect(errors).toBe(undefined);
   const { Company, Location } = await getCompanyAndLocation(
     keystone,
     createCompany.id,
@@ -56,6 +59,7 @@ mutation {
 const createLocationAndCompany = async keystone => {
   const {
     data: { createLocation },
+    errors,
   } = await graphqlRequest({
     keystone,
     query: `
@@ -66,6 +70,7 @@ mutation {
   }) { id name company { id name } }
 }`,
   });
+  expect(errors).toBe(undefined);
   const { Company, Location } = await getCompanyAndLocation(
     keystone,
     createLocation.company.id,
@@ -372,11 +377,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
               const {
                 data: { allCompanies },
+                errors: errors2,
               } = await graphqlRequest({
                 keystone,
                 query: `{ allCompanies { id location { id company { id }} } }`,
               });
-
+              expect(errors2).toBe(undefined);
               // The nested company should not have a location
               expect(
                 allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
@@ -418,11 +424,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
               const {
                 data: { allLocations },
+                errors: errors2,
               } = await graphqlRequest({
                 keystone,
                 query: `{ allLocations { id company { id location { id }} } }`,
               });
-
+              expect(errors2).toBe(undefined);
               // The nested company should not have a location
               expect(
                 allLocations.filter(({ id }) => id === Location.id)[0].company.location.id
@@ -465,10 +472,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               // The nested company should not have a location
               const {
                 data: { allCompanies },
+                errors: errors2,
               } = await graphqlRequest({
                 keystone,
                 query: `{ allCompanies { id location { id company { id }} } }`,
               });
+              expect(errors2).toBe(undefined);
               expect(
                 allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
               ).toEqual(Company.id);

--- a/api-tests/relationships/nested-mutations/connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/connect-many.test.js
@@ -95,6 +95,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create an item that does the linking
           const {
             data: { createUser },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -109,7 +110,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(createUser).toMatchObject({
             id: expect.any(String),
             notes: expect.any(Array),
@@ -130,6 +131,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+          expect(result.errors).toBe(undefined);
           expect(result.data.createUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -220,6 +222,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Update the item and link multiple relationship fields
           const {
             data: { updateUser },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -242,7 +245,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(updateUser).toMatchObject({
             id: expect.any(String),
             notes: [

--- a/api-tests/relationships/nested-mutations/connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/connect-singular.test.js
@@ -148,13 +148,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create an item to update
           const {
             data: { createEvent },
+            errors,
           } = await graphqlRequest({
             keystone,
             query: 'mutation { createEvent(data: { title: "A thing", }) { id } }',
           });
+          expect(errors).toBe(undefined);
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
+          const { data, errors: errors2 } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -174,7 +176,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(data).toMatchObject({
             updateEvent: {
               id: expect.any(String),
@@ -184,7 +186,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               },
             },
           });
-          expect(errors).toBe(undefined);
         })
       );
     });

--- a/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
@@ -108,6 +108,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Sanity check that the items are actually created
           const {
             data: { allNotes },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -121,7 +122,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(allNotes).toHaveLength(data.createUser.notes.length);
         })
       );
@@ -183,6 +184,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Sanity check that the items are actually created
           const {
             data: { allNotes },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -196,7 +198,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(allNotes).toHaveLength(data.updateUser.notes.length);
         })
       );

--- a/api-tests/relationships/nested-mutations/create-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-many.test.js
@@ -105,6 +105,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create an item that does the nested create
           const {
             data: { createUser },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -124,7 +125,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(createUser).toMatchObject({
             id: expect.any(String),
             notes: [
@@ -142,6 +143,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Sanity check that the items are actually created
           const {
             data: { allNotes },
+            errors: errors3,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -153,7 +155,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors3).toBe(undefined);
           expect(allNotes).toHaveLength(createUser.notes.length);
 
           // Test an empty list of related notes
@@ -171,7 +173,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(result.errors).toBe(undefined);
           expect(result.data.createUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -190,7 +192,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', { username: 'A thing' });
 
           // Update an item that does the nested create
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -210,7 +212,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
@@ -225,7 +227,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           const {
             data: { updateUser },
-            errors,
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -252,7 +254,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     `,
           });
 
-          expect(errors).toBe(undefined);
+          expect(errors2).toBe(undefined);
           expect(updateUser).toMatchObject({
             id: expect.any(String),
             notes: [
@@ -274,6 +276,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Sanity check that the items are actually created
           const {
             data: { allNotes },
+            errors: errors3,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -285,7 +288,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors3).toBe(undefined);
           expect(allNotes).toHaveLength(updateUser.notes.length);
         })
       );
@@ -421,6 +424,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Confirm it didn't insert either of the records anyway
             const {
               data: { allNoteNoCreates, allUserToNotesNoCreates },
+              errors: errors2,
             } = await graphqlRequest({
               keystone,
               query: `
@@ -436,7 +440,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
-
+            expect(errors2).toBe(undefined);
             expect(allNoteNoCreates).toMatchObject([]);
             expect(allUserToNotesNoCreates).toMatchObject([]);
           })
@@ -487,6 +491,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Confirm it didn't insert the record anyway
             const {
               data: { allNoteNoCreates },
+              errors: errors2,
             } = await graphqlRequest({
               keystone,
               query: `
@@ -498,7 +503,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
             });
-
+            expect(errors2).toBe(undefined);
             expect(allNoteNoCreates).toMatchObject([]);
           })
         );

--- a/api-tests/relationships/nested-mutations/create-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-singular.test.js
@@ -146,6 +146,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           const {
             data: { Group },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -157,7 +158,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }
           `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(Group).toMatchObject({
             id: data.createEvent.group.id,
             name: groupName,
@@ -208,6 +209,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           const {
             data: { Group },
+            errors: errors2,
           } = await graphqlRequest({
             keystone,
             query: `
@@ -219,7 +221,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }
           `,
           });
-
+          expect(errors2).toBe(undefined);
           expect(Group).toMatchObject({
             id: data.updateEvent.group.id,
             name: groupName,
@@ -370,7 +372,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     }
                 `,
                 });
-
+                expect(result.errors).toBe(undefined);
                 expect(result.data[`all${group.name}s`]).toMatchObject([]);
 
                 // Confirm it didn't insert either of the records anyway
@@ -385,7 +387,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     }
                 `,
                 });
-
+                expect(result2.errors).toBe(undefined);
                 expect(result2.data[`allEventTo${group.name}s`]).toMatchObject([]);
               })
             );
@@ -448,7 +450,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     }
                 `,
                 });
-
+                expect(result.errors).toBe(undefined);
                 expect(result.data[`all${group.name}s`]).toMatchObject([]);
               })
             );

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -191,6 +191,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             `,
               variables: { userId: createUser.id },
             });
+            expect(result.errors).toBe(undefined);
             expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );

--- a/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
@@ -103,7 +103,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -120,7 +120,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.createEvent).toMatchObject({
             id: expect.any(String),
             group: null,
@@ -136,7 +136,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await create('Event', {});
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -156,7 +156,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({
             id: expect.any(String),
             group: null,

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -123,7 +123,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -140,7 +140,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.createUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -160,7 +160,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await create('User', {});
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -180,7 +180,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.updateUser).toMatchObject({
             id: expect.any(String),
             notes: [],
@@ -291,6 +291,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             `,
               variables: { userId: createUser.id },
             });
+            expect(result.errors).toBe(undefined);
             expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );

--- a/api-tests/relationships/nested-mutations/disconnect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-singular.test.js
@@ -105,7 +105,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -122,6 +122,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
+          expect(errors).toBe(undefined);
 
           expect(data.createEvent).toMatchObject({
             id: expect.any(String),
@@ -140,7 +141,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await create('Event', {});
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -160,7 +161,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({
             id: expect.any(String),
             group: null,
@@ -180,7 +181,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await create('Event', { group: createGroup.id });
 
           // Create an item that does the linking
-          const { data } = await graphqlRequest({
+          const { data, errors } = await graphqlRequest({
             keystone,
             query: `
         mutation {
@@ -200,7 +201,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
     `,
           });
-
+          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({
             id: expect.any(String),
             group: { id: createGroup.id },

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
@@ -31,33 +31,34 @@ function setupKeystone(adapterName) {
   });
 }
 
-const getTeacher = async (keystone, teacherId) =>
-  (
-    await graphqlRequest({
-      keystone,
-      query: `query getTeacher($teacherId: ID!){
+const getTeacher = async (keystone, teacherId) => {
+  const { data, errors } = await graphqlRequest({
+    keystone,
+    query: `query getTeacher($teacherId: ID!){
   Teacher(where: { id: $teacherId }) {
     id
     students { id }
   }
 }`,
-      variables: { teacherId },
-    })
-  ).data.Teacher;
+    variables: { teacherId },
+  });
+  expect(errors).toBe(undefined);
+  return data.Teacher;
+};
 
-const getStudent = async (keystone, studentId) =>
-  (
-    await graphqlRequest({
-      keystone,
-      query: `query getStudent($studentId: ID!){
+const getStudent = async (keystone, studentId) => {
+  const { data } = await graphqlRequest({
+    keystone,
+    query: `query getStudent($studentId: ID!){
   Student(where: { id: $studentId }) {
     id
     teachers { id }
   }
 }`,
-      variables: { studentId },
-    })
-  ).data.Student;
+    variables: { studentId },
+  });
+  return data.Student;
+};
 
 // We can't assume what IDs get assigned, or what order they come back in
 const compareIds = (list, ids) =>

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -20,15 +20,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'uniqueness is enforced over multiple mutations',
         runner(setupKeystone, async ({ keystone }) => {
-          await graphqlRequest({
-            keystone,
-            query: `
-        mutation {
-          createUser(data: { email: "hi@test.com" }) { id }
-        }
-      `,
-          });
-
           const { errors } = await graphqlRequest({
             keystone,
             query: `
@@ -37,9 +28,19 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         }
       `,
           });
+          expect(errors).toBe(undefined);
 
-          expect(errors).toHaveProperty('0.message');
-          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
+          const { errors: errors2 } = await graphqlRequest({
+            keystone,
+            query: `
+        mutation {
+          createUser(data: { email: "hi@test.com" }) { id }
+        }
+      `,
+          });
+
+          expect(errors2).toHaveProperty('0.message');
+          expect(errors2[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
         })
       );
 


### PR DESCRIPTION
When a test does fail it's more useful to know that `errors` was not `undefined` than that the data had the wrong value, as this lets you see the error message in the test report.