### PR TITLE
Change many-relationship graphQL type to [Item!]!

### DIFF
--- a/.changeset/wet-masks-sort.md
+++ b/.changeset/wet-masks-sort.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/fields': major
+---
+
+`many` relationships now have a GraphQL type of `[Item!]!`, rather than `[Item]`.
+
+The old type of `[Item]` implied that the relationship field could return `null`, or that some of the items it returned could be `null`. In practice, neither of these things ever happened. The new type better reflects this reality.
+
+The filter argument `{path}_is_null` has also been removed for `many` relationships, as it does not apply to a non-null array type.

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -60,7 +60,7 @@ export class Relationship extends Implementation {
     if (this.many) {
       const filterArgs = refList.getGraphqlFilterFragment().join('\n');
       return [
-        `${this.path}(${filterArgs}): [${refList.gqlNames.outputTypeName}]`,
+        `${this.path}(${filterArgs}): [${refList.gqlNames.outputTypeName}!]!`,
         this.withMeta ? `_${this.path}Meta(${filterArgs}): _QueryMeta` : '',
       ];
     }
@@ -89,8 +89,6 @@ export class Relationship extends Implementation {
         ${this.path}_some: ${refList.gqlNames.whereInputName}`,
         `""" condition must be false for all nodes """
         ${this.path}_none: ${refList.gqlNames.whereInputName}`,
-        `""" is the relation field null """
-        ${this.path}_is_null: Boolean`,
       ];
     } else {
       return [`${this.path}: ${refList.gqlNames.whereInputName}`, `${this.path}_is_null: Boolean`];

--- a/packages/fields/src/types/Relationship/tests/implementation.test.js
+++ b/packages/fields/src/types/Relationship/tests/implementation.test.js
@@ -296,10 +296,16 @@ describe('Type Generation', () => {
               },
               arguments: mockFilterAST,
               type: {
-                kind: 'ListType',
+                kind: 'NonNullType',
                 type: {
-                  name: {
-                    value: 'Zip',
+                  kind: 'ListType',
+                  type: {
+                    kind: 'NonNullType',
+                    type: {
+                      name: {
+                        value: 'Zip',
+                      },
+                    },
                   },
                 },
               },
@@ -354,10 +360,16 @@ describe('Type Generation', () => {
               },
               arguments: mockFilterAST,
               type: {
-                kind: 'ListType',
+                kind: 'NonNullType',
                 type: {
-                  name: {
-                    value: 'Zip',
+                  kind: 'ListType',
+                  type: {
+                    kind: 'NonNullType',
+                    type: {
+                      name: {
+                        value: 'Zip',
+                      },
+                    },
                   },
                 },
               },


### PR DESCRIPTION
When handling `many` relationships we should always be outputting an array of non-null values. In practice this is what we do. however the current graphQL type of `[Item]` implies that a) the value could be `null` or b) the array could contain `null` values.

This change updates the schema to correctly reflect the intended behaviour with an output type of `[Item!]!`.

~~This change also replaces the `_is_null` where query for an `_is_empty` where query on many relationships, to better reflect that you're asking about an empty array, not a null value. (Side note: We don't appear to have tests for `_is_null` on either one- or many- relationships, and reading the code I suspect we have bugs, so I need to write more tests to exercise this code).~~

~~This is WIP as a I need to ~~a) implement the `_is_empty` where condition and b)~~ add tests for `_is_empty` and `_is_null` (for `one` relationships).~~

EDIT: Implementing `_is_empty` is non-trivial, so I'll defer that to some point in the future.
EDIT: `_is_null` tests now exist