### PR TITLE
Remove left/right relationship test variations

### DIFF
--- a/.changeset/new-moons-travel.md
+++ b/.changeset/new-moons-travel.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': patch
+---
+
+Removed left/right relationship variations as these are now assured by `_consolidateRelationships()`.

--- a/api-tests/relationships/crud-self-ref/many-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many.test.js
@@ -101,22 +101,7 @@ const createReadData = async keystone => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createListsLR = keystone => {
-      keystone.createList('User', {
-        fields: {
-          name: { type: Text },
-          friends: { type: Relationship, ref: 'User.friendOf', many: true },
-          friendOf: { type: Relationship, ref: 'User.friends', many: true },
-        },
-      });
-    };
-    const createListsRL = keystone => {
+    const createLists = keystone => {
       keystone.createList('User', {
         fields: {
           name: { type: Text },
@@ -125,298 +110,294 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         },
       });
     };
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`Many-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`Many-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Read', () => {
-          test(
-            '_some',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 6],
-                  ['B', 5],
-                  ['C', 3],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_some: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_none',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 4],
-                  ['C', 6],
-                  ['D', 9],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_none: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_every',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 3],
-                  ['C', 1],
-                  ['D', 1],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_every: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-        });
+      describe('Read', () => {
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 6],
+                ['B', 5],
+                ['C', 3],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_some: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 4],
+                ['C', 6],
+                ['D', 9],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_none: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 3],
+                ['C', 1],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_every: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+      });
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allUsersMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const friend = users[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const friend = users[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { connect: [{ id: "${friend.id}" }] }
                   }) { id friends { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createUser.friends[0].id.toString()).toEqual(friend.id);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createUser.friends[0].id.toString()).toEqual(friend.id);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                friend.id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              friend.id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
-            })
-          );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${locationName}" }] }
                   }) { id friends { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
-            })
-          );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
+          })
+        );
 
-          test(
-            'With nested connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const user = users[0];
-              const friendName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const user = users[0];
+            const friendName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${friendName}" friendOf: { connect: [{ id: "${user.id}" }] } }] }
                   }) { id friends { id friendOf { id } } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.length).toEqual(2);
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.length).toEqual(2);
 
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friends { id friendOf { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // Both companies should have a location, and the location should have two companies
-              const linkedUsers = allUsers.filter(({ id }) => id === user.id || id === User.id);
-              linkedUsers.forEach(({ friends }) => {
-                expect(friends.map(({ id }) => id)).toEqual([Friend.id.toString()]);
-              });
-              expect(linkedUsers[0].friends[0].friendOf).toEqual([
-                { id: linkedUsers[0].id },
-                { id: linkedUsers[1].id },
-              ]);
-            })
-          );
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friends { id friendOf { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // Both companies should have a location, and the location should have two companies
+            const linkedUsers = allUsers.filter(({ id }) => id === user.id || id === User.id);
+            linkedUsers.forEach(({ friends }) => {
+              expect(friends.map(({ id }) => id)).toEqual([Friend.id.toString()]);
+            });
+            expect(linkedUsers[0].friends[0].friendOf).toEqual([
+              { id: linkedUsers[0].id },
+              { id: linkedUsers[1].id },
+            ]);
+          })
+        );
 
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const friendName = sampleOne(alphanumGenerator);
-              const userName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const friendName = sampleOne(alphanumGenerator);
+            const userName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${friendName}" friendOf: { create: [{ name: "${userName}" }] } }] }
                   }) { id friends { id friendOf { id } } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.length).toEqual(2);
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.length).toEqual(2);
 
-              // Both companies should have a location, and the location should have two companies
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friends { id friendOf { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              allUsers.forEach(({ id, friends }) => {
-                if (id === Friend.id) {
-                  expect(friends.map(({ id }) => id)).toEqual([]);
-                } else {
-                  expect(friends.map(({ id }) => id)).toEqual([Friend.id.toString()]);
-                }
-              });
-              expect(allUsers[0].friends[0].friendOf).toEqual([
-                { id: allUsers[0].id },
-                { id: allUsers[2].id },
-              ]);
-            })
-          );
-        });
+            // Both companies should have a location, and the location should have two companies
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friends { id friendOf { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            allUsers.forEach(({ id, friends }) => {
+              if (id === Friend.id) {
+                expect(friends.map(({ id }) => id)).toEqual([]);
+              } else {
+                expect(friends.map(({ id }) => id)).toEqual([Friend.id.toString()]);
+              }
+            });
+            expect(allUsers[0].friends[0].friendOf).toEqual([
+              { id: allUsers[0].id },
+              { id: allUsers[2].id },
+            ]);
+          })
+        );
+      });
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(user.friends).not.toBe(expect.anything());
-              expect(friend.friendOf).not.toBe(expect.anything());
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(user.friends).not.toBe(expect.anything());
+            expect(friend.friendOf).not.toBe(expect.anything());
 
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
                     data: { friends: { connect: [{ id: "${friend.id}" }] } }
                   ) { id friends { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
-            })
-          );
+            const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              let user = users[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            let user = users[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -424,31 +405,31 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                user.id,
-                data.updateUser.friends[0].id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              user.id,
+              data.updateUser.friends[0].id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
-            })
-          );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.map(({ id }) => id.toString())).toEqual([User.id.toString()]);
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -456,28 +437,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friends).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friends).toEqual([]);
-              expect(result.Friend.friendOf).toEqual([]);
-            })
-          );
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friends).toEqual([]);
+            expect(result.Friend.friendOf).toEqual([]);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -485,41 +466,40 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friends).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friends).toEqual([]);
-              expect(result.Friend.friendOf).toEqual([]);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friends).toEqual([]);
+            expect(result.Friend.friendOf).toEqual([]);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteUser(id: "${user.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteUser.id).toBe(user.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteUser(id: "${user.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteUser.id).toBe(user.id);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User).toBe(null);
-              expect(result.Friend.friendOf).toEqual([]);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User).toBe(null);
+            expect(result.Friend.friendOf).toEqual([]);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud-self-ref/one-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many.test.js
@@ -97,22 +97,7 @@ const createReadData = async keystone => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createListsLR = keystone => {
-      keystone.createList('User', {
-        fields: {
-          name: { type: Text },
-          friends: { type: Relationship, ref: 'User.friendOf', many: true },
-          friendOf: { type: Relationship, ref: 'User.friends' },
-        },
-      });
-    };
-    const createListsRL = keystone => {
+    const createLists = keystone => {
       keystone.createList('User', {
         fields: {
           name: { type: Text },
@@ -122,317 +107,309 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       });
     };
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`One-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`One-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Read', () => {
-          test(
-            'one',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 5],
-                  ['B', 5],
-                  ['C', 4],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friendOf: { name_contains: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_some',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 2],
-                  ['B', 2],
-                  ['C', 2],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_some: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_none',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 2 + 6],
-                  ['B', 2 + 6],
-                  ['C', 2 + 6],
-                  ['D', 4 + 6],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_none: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_every',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 1 + 6],
-                  ['B', 1 + 6],
-                  ['C', 2 + 6],
-                  ['D', 1 + 6],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allUsers(where: { friends_every: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allUsers.length).toEqual(count);
-                })
-              );
-            })
-          );
-        });
+      describe('Read', () => {
+        test(
+          'one',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 5],
+                ['B', 5],
+                ['C', 4],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friendOf: { name_contains: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 2],
+                ['B', 2],
+                ['C', 2],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_some: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 2 + 6],
+                ['B', 2 + 6],
+                ['C', 2 + 6],
+                ['D', 4 + 6],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_none: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 1 + 6],
+                ['B', 1 + 6],
+                ['C', 2 + 6],
+                ['D', 1 + 6],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friends_every: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+      });
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allUsersMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const user = users[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const user = users[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { connect: [{ id: "${user.id}" }] }
                   }) { id friends { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                user.id
-              );
+            const { User, Friend } = await getUserAndFriend(keystone, data.createUser.id, user.id);
 
-              // Everything should now be connected
-              expect(data.createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(data.createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const friendName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const friendName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${friendName}" }] }
                   }) { id friends { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With nested connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const user = users[0];
-              const friendName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const user = users[0];
+            const friendName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${friendName}" friendOf: { connect: { id: "${user.id}" } } }] }
                   }) { id friends { id friendOf { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
+
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friends { id friendOf { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // The nested company should not have a location
+            expect(allUsers.filter(({ id }) => id === User.id)[0].friends[0].friendOf.id).toEqual(
+              User.id
+            );
+            allUsers
+              .filter(({ id }) => id !== User.id)
+              .forEach(user => {
+                expect(user.friends).toEqual([]);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const friendName = sampleOne(alphanumGenerator);
+            const friendOfName = sampleOne(alphanumGenerator);
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friends { id friendOf { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // The nested company should not have a location
-              expect(allUsers.filter(({ id }) => id === User.id)[0].friends[0].friendOf.id).toEqual(
-                User.id
-              );
-              allUsers
-                .filter(({ id }) => id !== User.id)
-                .forEach(user => {
-                  expect(user.friends).toEqual([]);
-                });
-            })
-          );
-
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const friendName = sampleOne(alphanumGenerator);
-              const friendOfName = sampleOne(alphanumGenerator);
-
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friends: { create: [{ name: "${friendName}" friendOf: { create: { name: "${friendOfName}" } } }] }
                   }) { id friends { id friendOf { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friends[0].id
+            );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+
+            // The nested company should not have a location
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friends { id friendOf { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            expect(allUsers.filter(({ id }) => id === User.id)[0].friends[0].friendOf.id).toEqual(
+              User.id
+            );
+            allUsers
+              .filter(({ id }) => id !== User.id)
+              .forEach(user => {
+                expect(user.friends).toEqual([]);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
+      });
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friends[0].id
-              );
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // The nested company should not have a location
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friends { id friendOf { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              expect(allUsers.filter(({ id }) => id === User.id)[0].friends[0].friendOf.id).toEqual(
-                User.id
-              );
-              allUsers
-                .filter(({ id }) => id !== User.id)
-                .forEach(user => {
-                  expect(user.friends).toEqual([]);
-                });
-            })
-          );
-        });
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(user.friends).not.toBe(expect.anything());
+            expect(friend.friendOf).not.toBe(expect.anything());
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
-
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(user.friends).not.toBe(expect.anything());
-              expect(friend.friendOf).not.toBe(expect.anything());
-
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
                     data: { friends: { connect: [{ id: "${friend.id}" }] } }
                   ) { id friends { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              let user = users[0];
-              const friendName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            let user = users[0];
+            const friendName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -440,31 +417,31 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                user.id,
-                data.updateUser.friends[0].id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              user.id,
+              data.updateUser.friends[0].id
+            );
 
-              // Everything should now be connected
-              expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -472,28 +449,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friends).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friends).toEqual([]);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friends).toEqual([]);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -501,41 +478,40 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friends { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friends).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friends).toEqual([]);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friends).toEqual([]);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteUser(id: "${user.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteUser.id).toBe(user.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteUser(id: "${user.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteUser.id).toBe(user.id);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User).toBe(null);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User).toBe(null);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -61,22 +61,7 @@ const getUserAndFriend = async (keystone, userId, friendId) => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createListsLR = keystone => {
-      keystone.createList('User', {
-        fields: {
-          name: { type: Text },
-          friend: { type: Relationship, ref: 'User.friendOf' },
-          friendOf: { type: Relationship, ref: 'User.friend' },
-        },
-      });
-    };
-    const createListsRL = keystone => {
+    const createLists = keystone => {
       keystone.createList('User', {
         fields: {
           name: { type: Text },
@@ -86,298 +71,290 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       });
     };
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`One-to-one relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`One-to-one relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Read', () => {
-          if (adapterName !== 'mongoose') {
-            test(
-              'Where - friend',
-              runner(setupKeystone, async ({ keystone }) => {
-                await createInitialData(keystone);
-                const { user, friend } = await createUserAndFriend(keystone);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `{
-                  allUsers(where: { friend: { name: "${friend.name}"} }) { id }
-                }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data.allUsers.length).toEqual(1);
-                expect(data.allUsers[0].id).toEqual(user.id);
-              })
-            );
-
-            test(
-              'Where - friendOf',
-              runner(setupKeystone, async ({ keystone }) => {
-                await createInitialData(keystone);
-                const { user, friend } = await createUserAndFriend(keystone);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `{
-                  allUsers(where: { friendOf: { name: "${user.name}"} }) { id }
-                }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data.allUsers.length).toEqual(1);
-                expect(data.allUsers[0].id).toEqual(friend.id);
-              })
-            );
-          }
-
+      describe('Read', () => {
+        if (adapterName !== 'mongoose') {
           test(
-            'Count',
+            'Where - friend',
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
+              const { user, friend } = await createUserAndFriend(keystone);
               const { data, errors } = await graphqlRequest({
                 keystone,
-                query: `
+                query: `{
+                  allUsers(where: { friend: { name: "${friend.name}"} }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(1);
+              expect(data.allUsers[0].id).toEqual(user.id);
+            })
+          );
+
+          test(
+            'Where - friendOf',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { user, friend } = await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allUsers(where: { friendOf: { name: "${user.name}"} }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(1);
+              expect(data.allUsers[0].id).toEqual(friend.id);
+            })
+          );
+        }
+
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allUsersMeta { count }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(3);
+          })
+        );
+
+        if (adapterName !== 'mongoose') {
+          test(
+            'Where with count - friend',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              const { friend } = await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  _allUsersMeta(where: { friend: { name: "${friend.name}"} }) { count }
+                }`,
               });
               expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(3);
+              expect(data._allUsersMeta.count).toEqual(1);
             })
           );
 
-          if (adapterName !== 'mongoose') {
-            test(
-              'Where with count - friend',
-              runner(setupKeystone, async ({ keystone }) => {
-                await createInitialData(keystone);
-                const { friend } = await createUserAndFriend(keystone);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `{
-                  _allUsersMeta(where: { friend: { name: "${friend.name}"} }) { count }
-                }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data._allUsersMeta.count).toEqual(1);
-              })
-            );
-
-            test(
-              'Where with count - friendOf',
-              runner(setupKeystone, async ({ keystone }) => {
-                await createInitialData(keystone);
-                const { user } = await createUserAndFriend(keystone);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `{
-                  _allUsersMeta(where: { friendOf: { name: "${user.name}"} }) { count }
-                }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data._allUsersMeta.count).toEqual(1);
-              })
-            );
-          }
-        });
-
-        describe('Create', () => {
           test(
-            'With connect',
+            'Where with count - friendOf',
             runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const user = users[0];
+              await createInitialData(keystone);
+              const { user } = await createUserAndFriend(keystone);
               const { data, errors } = await graphqlRequest({
                 keystone,
-                query: `
+                query: `{
+                  _allUsersMeta(where: { friendOf: { name: "${user.name}"} }) { count }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(1);
+            })
+          );
+        }
+      });
+
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const user = users[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friend: { connect: { id: "${user.id}" } }
                   }) { id friend { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createUser.friend.id.toString()).toEqual(user.id);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createUser.friend.id.toString()).toEqual(user.id);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                user.id
-              );
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            const { User, Friend } = await getUserAndFriend(keystone, data.createUser.id, user.id);
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const friendName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const friendName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friend: { create: { name: "${friendName}" } }
                   }) { id friend { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friend.id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friend.id
+            );
 
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With nested connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              const user = users[0];
-              const friendName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            const user = users[0];
+            const friendName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friend: { create: { name: "${friendName}" friendOf: { connect: { id: "${user.id}" } } } }
                   }) { id friend { id friendOf { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friend.id
+            );
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friend { id friendOf { id }} } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // The nested company should not have a location
+            expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
+              User.id
+            );
+            allUsers
+              .filter(({ id }) => id !== User.id)
+              .forEach(user => {
+                expect(user.friend).toBe(null);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friend.id
-              );
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const friendName = sampleOne(alphanumGenerator);
+            const friendOfName = sampleOne(alphanumGenerator);
 
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friend { id friendOf { id }} } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // The nested company should not have a location
-              expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
-                User.id
-              );
-              allUsers
-                .filter(({ id }) => id !== User.id)
-                .forEach(user => {
-                  expect(user.friend).toBe(null);
-                });
-            })
-          );
-
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const friendName = sampleOne(alphanumGenerator);
-              const friendOfName = sampleOne(alphanumGenerator);
-
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createUser(data: {
                     friend: { create: { name: "${friendName}" friendOf: { create: { name: "${friendOfName}" } } } }
                   }) { id friend { id friendOf { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              data.createUser.id,
+              data.createUser.friend.id
+            );
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+
+            // The nested company should not have a location
+            const {
+              data: { allUsers },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers { id friend { id friendOf { id }} } }`,
+            });
+            expect(errors2).toBe(undefined);
+            expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
+              User.id
+            );
+            allUsers
+              .filter(({ id }) => id !== User.id)
+              .forEach(user => {
+                expect(user.friend).toBe(null);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
+      });
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                data.createUser.id,
-                data.createUser.friend.id
-              );
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // The nested company should not have a location
-              const {
-                data: { allUsers },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allUsers { id friend { id friendOf { id }} } }`,
-              });
-              expect(errors2).toBe(undefined);
-              expect(allUsers.filter(({ id }) => id === User.id)[0].friend.friendOf.id).toEqual(
-                User.id
-              );
-              allUsers
-                .filter(({ id }) => id !== User.id)
-                .forEach(user => {
-                  expect(user.friend).toBe(null);
-                });
-            })
-          );
-        });
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(user.friend).not.toBe(expect.anything());
+            expect(friend.friendOf).not.toBe(expect.anything());
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
-
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(user.friend).not.toBe(expect.anything());
-              expect(friend.friendOf).not.toBe(expect.anything());
-
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
                     data: { friend: { connect: { id: "${friend.id}" } } }
                   ) { id friend { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            const { User, Friend } = await getUserAndFriend(keystone, user.id, friend.id);
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { users } = await createInitialData(keystone);
-              let user = users[0];
-              const friendName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { users } = await createInitialData(keystone);
+            let user = users[0];
+            const friendName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -385,31 +362,31 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friend { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { User, Friend } = await getUserAndFriend(
-                keystone,
-                user.id,
-                data.updateUser.friend.id
-              );
+            const { User, Friend } = await getUserAndFriend(
+              keystone,
+              user.id,
+              data.updateUser.friend.id
+            );
 
-              // Everything should now be connected
-              expect(User.friend.id.toString()).toBe(Friend.id.toString());
-              expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(User.friend.id.toString()).toBe(Friend.id.toString());
+            expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -417,28 +394,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friend { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friend).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friend).toBe(null);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friend).toBe(null);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friend).toBe(null);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateUser(
                     id: "${user.id}",
@@ -446,41 +423,40 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id friend { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateUser.id).toEqual(user.id);
-              expect(data.updateUser.friend).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friend).toBe(null);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User.friend).toBe(null);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User.friend).toBe(null);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { user, friend } = await createUserAndFriend(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteUser(id: "${user.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteUser.id).toBe(user.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteUser(id: "${user.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteUser.id).toBe(user.id);
 
-              // Check the link has been broken
-              const result = await getUserAndFriend(keystone, user.id, friend.id);
-              expect(result.User).toBe(null);
-              expect(result.Friend.friendOf).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getUserAndFriend(keystone, user.id, friend.id);
+            expect(result.User).toBe(null);
+            expect(result.Friend.friendOf).toBe(null);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/many-to-many-one-sided.test.js
@@ -106,238 +106,219 @@ const createReadData = async keystone => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createCompanyList = keystone =>
+    const createLists = keystone => {
       keystone.createList('Company', {
         fields: {
           name: { type: Text },
           locations: { type: Relationship, ref: 'Location', many: true },
         },
       });
-    const createLocationList = keystone =>
       keystone.createList('Location', {
         fields: {
           name: { type: Text },
         },
       });
-
-    const createListsLR = keystone => {
-      createCompanyList(keystone);
-      createLocationList(keystone);
-    };
-    const createListsRL = keystone => {
-      createLocationList(keystone);
-      createCompanyList(keystone);
     };
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`Many-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`Many-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Read', () => {
-          test(
-            '_some',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 6],
-                  ['B', 5],
-                  ['C', 3],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_none',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 4],
-                  ['C', 6],
-                  ['D', 9],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_every',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 3],
-                  ['C', 1],
-                  ['D', 1],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-        });
+      describe('Read', () => {
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 6],
+                ['B', 5],
+                ['C', 3],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 4],
+                ['C', 6],
+                ['D', 9],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 3],
+                ['C', 1],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+      });
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allCompaniesMeta { count }
                   _allLocationsMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { connect: [{ id: "${location.id}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
-                location.id,
-              ]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
+              location.id,
+            ]);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-            })
-          );
-        });
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+          })
+        );
+      });
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.locations).not.toBe(expect.anything());
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.locations).not.toBe(expect.anything());
 
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { locations: { connect: [{ id: "${location.id}" }] } }
                   ) { id locations { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -345,32 +326,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.updateCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -378,27 +359,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -406,39 +387,38 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteCompany.id).toBe(company.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteCompany.id).toBe(company.id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company).toBe(null);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud/many-to-many.test.js
+++ b/api-tests/relationships/crud/many-to-many.test.js
@@ -106,349 +106,330 @@ const createReadData = async keystone => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createCompanyList = keystone =>
+    const createLists = keystone => {
       keystone.createList('Company', {
         fields: {
           name: { type: Text },
           locations: { type: Relationship, ref: 'Location.companies', many: true },
         },
       });
-    const createLocationList = keystone =>
       keystone.createList('Location', {
         fields: {
           name: { type: Text },
           companies: { type: Relationship, ref: 'Company.locations', many: true },
         },
       });
-
-    const createListsLR = keystone => {
-      createCompanyList(keystone);
-      createLocationList(keystone);
-    };
-    const createListsRL = keystone => {
-      createLocationList(keystone);
-      createCompanyList(keystone);
     };
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`Many-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`Many-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Read', () => {
-          test(
-            '_some',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 6],
-                  ['B', 5],
-                  ['C', 3],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_none',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 4],
-                  ['C', 6],
-                  ['D', 9],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_every',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 3],
-                  ['B', 3],
-                  ['C', 1],
-                  ['D', 1],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-        });
+      describe('Read', () => {
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 6],
+                ['B', 5],
+                ['C', 3],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 4],
+                ['C', 6],
+                ['D', 9],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 3],
+                ['C', 1],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+      });
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allCompaniesMeta { count }
                   _allLocationsMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { connect: [{ id: "${location.id}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createCompany.locations[0].id.toString()).toEqual(location.id);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createCompany.locations[0].id.toString()).toEqual(location.id);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.map(({ id }) => id.toString())).toEqual([
-                Company.id.toString(),
-              ]);
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.map(({ id }) => id.toString())).toEqual([
+              Company.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.map(({ id }) => id.toString())).toEqual([
-                Company.id.toString(),
-              ]);
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.map(({ id }) => id.toString())).toEqual([
+              Company.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With nested connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              const company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            const company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" companies: { connect: [{ id: "${company.id}" }] } }] }
                   }) { id locations { id companies { id } } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.length).toEqual(2);
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.length).toEqual(2);
 
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id locations { id companies { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // Both companies should have a location, and the location should have two companies
-              const linkedCompanies = allCompanies.filter(
-                ({ id }) => id === company.id || id === Company.id
-              );
-              linkedCompanies.forEach(({ locations }) => {
-                expect(locations.map(({ id }) => id)).toEqual([Location.id.toString()]);
-              });
-              expect(linkedCompanies[0].locations[0].companies).toEqual([
-                { id: linkedCompanies[0].id },
-                { id: linkedCompanies[1].id },
-              ]);
-            })
-          );
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id locations { id companies { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // Both companies should have a location, and the location should have two companies
+            const linkedCompanies = allCompanies.filter(
+              ({ id }) => id === company.id || id === Company.id
+            );
+            linkedCompanies.forEach(({ locations }) => {
+              expect(locations.map(({ id }) => id)).toEqual([Location.id.toString()]);
+            });
+            expect(linkedCompanies[0].locations[0].companies).toEqual([
+              { id: linkedCompanies[0].id },
+              { id: linkedCompanies[1].id },
+            ]);
+          })
+        );
 
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const companyName = sampleOne(alphanumGenerator);
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const companyName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" companies: { create: [{ name: "${companyName}" }] } }] }
                   }) { id locations { id companies { id } } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.length).toEqual(2);
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.length).toEqual(2);
 
-              // Both companies should have a location, and the location should have two companies
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id locations { id companies { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              allCompanies.forEach(({ locations }) => {
-                expect(locations.map(({ id }) => id)).toEqual([Location.id.toString()]);
-              });
-              expect(allCompanies[0].locations[0].companies).toEqual([
-                { id: allCompanies[0].id },
-                { id: allCompanies[1].id },
-              ]);
-            })
-          );
-        });
+            // Both companies should have a location, and the location should have two companies
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id locations { id companies { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            allCompanies.forEach(({ locations }) => {
+              expect(locations.map(({ id }) => id)).toEqual([Location.id.toString()]);
+            });
+            expect(allCompanies[0].locations[0].companies).toEqual([
+              { id: allCompanies[0].id },
+              { id: allCompanies[1].id },
+            ]);
+          })
+        );
+      });
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.locations).not.toBe(expect.anything());
-              expect(location.companies).not.toBe(expect.anything());
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.locations).not.toBe(expect.anything());
+            expect(location.companies).not.toBe(expect.anything());
 
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { locations: { connect: [{ id: "${location.id}" }] } }
                   ) { id locations { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.map(({ id }) => id.toString())).toEqual([
-                Company.id.toString(),
-              ]);
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.map(({ id }) => id.toString())).toEqual([
+              Company.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -456,35 +437,35 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.updateCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.companies.map(({ id }) => id.toString())).toEqual([
-                Company.id.toString(),
-              ]);
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.companies.map(({ id }) => id.toString())).toEqual([
+              Company.id.toString(),
+            ]);
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -492,28 +473,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-              expect(result.Location.companies).toEqual([]);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+            expect(result.Location.companies).toEqual([]);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -521,41 +502,40 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-              expect(result.Location.companies).toEqual([]);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+            expect(result.Location.companies).toEqual([]);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteCompany.id).toBe(company.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteCompany.id).toBe(company.id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company).toBe(null);
-              expect(result.Location.companies).toEqual([]);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company).toBe(null);
+            expect(result.Location.companies).toEqual([]);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -114,164 +114,145 @@ const getCompanyAndLocation = async (keystone, companyId, locationId) => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createCompanyList = keystone =>
+    const createLists = keystone => {
       keystone.createList('Company', {
         fields: {
           name: { type: Text },
           location: { type: Relationship, ref: 'Location' },
         },
       });
-    const createLocationList = keystone =>
       keystone.createList('Location', {
         fields: {
           name: { type: Text },
         },
       });
-
-    const createListsLR = keystone => {
-      createCompanyList(keystone);
-      createLocationList(keystone);
-    };
-    const createListsRL = keystone => {
-      createLocationList(keystone);
-      createCompanyList(keystone);
     };
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`One-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+    describe(`One-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allCompaniesMeta { count }
                   _allLocationsMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { connect: { id: "${location.id}" } }
                   }) { id location { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createCompany.location.id.toString()).toBe(location.id.toString());
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createCompany.location.id.toString()).toBe(location.id.toString());
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { create: { name: "${locationName}" } }
                   }) { id location { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-            })
-          );
-        });
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+          })
+        );
+      });
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.location).not.toBe(expect.anything());
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.location).not.toBe(expect.anything());
 
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { location: { connect: { id: "${location.id}" } } }
                   ) { id location { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -279,30 +260,30 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.updateCompany.location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -310,27 +291,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.location).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).toBe(null);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -338,167 +319,166 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).toBe(null);
+
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+          })
+        );
+      });
+
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
+
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteCompany.id).toBe(company.id);
+
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company).toBe(null);
+          })
+        );
+
+        ['A', 'B', 'C', 'D', 'E'].forEach(name => {
+          test(
+            `delete company ${name}`,
+            runner(setupKeystone, async ({ keystone }) => {
+              // Setup a complex set of data
+              const { companies } = await createComplexData(keystone);
+
+              // Delete company {name}
+              const id = companies.find(company => company.name === name).id;
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `mutation { deleteCompany(id: "${id}") { id } }`,
               });
               expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.location).toBe(null);
+              expect(data.deleteCompany.id).toBe(id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
+              // Check all the companies look how we expect
+              await (async () => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: '{ allCompanies(sortBy: name_ASC) { id name location { id name } } }',
+                });
+                expect(errors).toBe(undefined);
+
+                const expected = [
+                  ['A', 'A'],
+                  ['B', 'D'],
+                  ['C', 'B'],
+                  ['D', 'B'],
+                  ['E', null],
+                ].filter(([x]) => x !== name);
+
+                expect(data.allCompanies[0].name).toEqual(expected[0][0]);
+                expect(data.allCompanies[0].location.name).toEqual(expected[0][1]);
+                expect(data.allCompanies[1].name).toEqual(expected[1][0]);
+                expect(data.allCompanies[1].location.name).toEqual(expected[1][1]);
+                expect(data.allCompanies[2].name).toEqual(expected[2][0]);
+                expect(data.allCompanies[2].location.name).toEqual(expected[2][1]);
+                expect(data.allCompanies[3].name).toEqual(expected[3][0]);
+                if (expected[3][1] === null) {
+                  expect(data.allCompanies[3].location).toBe(null);
+                } else {
+                  expect(data.allCompanies[2].location.name).toEqual(expected[3][1]);
+                }
+              })();
+
+              // Check all the locations look how we expect
+              await (async () => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: '{ allLocations(sortBy: name_ASC) { id name } }',
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allLocations[0].name).toEqual('A');
+                expect(data.allLocations[1].name).toEqual('B');
+                expect(data.allLocations[2].name).toEqual('C');
+                expect(data.allLocations[3].name).toEqual('D');
+              })();
             })
           );
         });
 
-        describe('Delete', () => {
+        ['A', 'B', 'C', 'D'].forEach(name => {
           test(
-            'delete',
+            `delete location ${name}`,
             runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+              // Setup a complex set of data
+              const { locations } = await createComplexData(keystone);
 
-              // Run the query to disconnect the location from company
+              // Delete location {name}
+              const id = locations.find(location => location.name === name).id;
               const { data, errors } = await graphqlRequest({
                 keystone,
-                query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+                query: `mutation { deleteLocation(id: "${id}") { id } }`,
               });
               expect(errors).toBe(undefined);
-              expect(data.deleteCompany.id).toBe(company.id);
+              expect(data.deleteLocation.id).toBe(id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company).toBe(null);
+              // Check all the companies look how we expect
+              await (async () => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: '{ allCompanies(sortBy: name_ASC) { id name location { id name } } }',
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies[0].name).toEqual('A');
+                if (name === 'A') {
+                  expect(data.allCompanies[0].location).toBe(null);
+                } else {
+                  expect(data.allCompanies[0].location.name).toEqual('A');
+                }
+                expect(data.allCompanies[1].name).toEqual('B');
+                if (name === 'D') {
+                  expect(data.allCompanies[1].location).toBe(null);
+                } else {
+                  expect(data.allCompanies[1].location.name).toEqual('D');
+                }
+                expect(data.allCompanies[2].name).toEqual('C');
+                if (name === 'B') {
+                  expect(data.allCompanies[2].location).toBe(null);
+                } else {
+                  expect(data.allCompanies[2].location.name).toEqual('B');
+                }
+                expect(data.allCompanies[3].name).toEqual('D');
+                if (name === 'B') {
+                  expect(data.allCompanies[3].location).toBe(null);
+                } else {
+                  expect(data.allCompanies[3].location.name).toEqual('B');
+                }
+                expect(data.allCompanies[4].name).toEqual('E');
+                expect(data.allCompanies[4].location).toBe(null);
+              })();
+
+              // Check all the locations look how we expect
+              await (async () => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: '{ allLocations(sortBy: name_ASC) { id name } }',
+                });
+                expect(errors).toBe(undefined);
+                const expected = ['A', 'B', 'C', 'D'].filter(x => x !== name);
+                expect(data.allLocations[0].name).toEqual(expected[0]);
+                expect(data.allLocations[1].name).toEqual(expected[1]);
+                expect(data.allLocations[2].name).toEqual(expected[2]);
+              })();
             })
           );
-
-          ['A', 'B', 'C', 'D', 'E'].forEach(name => {
-            test(
-              `delete company ${name}`,
-              runner(setupKeystone, async ({ keystone }) => {
-                // Setup a complex set of data
-                const { companies } = await createComplexData(keystone);
-
-                // Delete company {name}
-                const id = companies.find(company => company.name === name).id;
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `mutation { deleteCompany(id: "${id}") { id } }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data.deleteCompany.id).toBe(id);
-
-                // Check all the companies look how we expect
-                await (async () => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: '{ allCompanies(sortBy: name_ASC) { id name location { id name } } }',
-                  });
-                  expect(errors).toBe(undefined);
-
-                  const expected = [
-                    ['A', 'A'],
-                    ['B', 'D'],
-                    ['C', 'B'],
-                    ['D', 'B'],
-                    ['E', null],
-                  ].filter(([x]) => x !== name);
-
-                  expect(data.allCompanies[0].name).toEqual(expected[0][0]);
-                  expect(data.allCompanies[0].location.name).toEqual(expected[0][1]);
-                  expect(data.allCompanies[1].name).toEqual(expected[1][0]);
-                  expect(data.allCompanies[1].location.name).toEqual(expected[1][1]);
-                  expect(data.allCompanies[2].name).toEqual(expected[2][0]);
-                  expect(data.allCompanies[2].location.name).toEqual(expected[2][1]);
-                  expect(data.allCompanies[3].name).toEqual(expected[3][0]);
-                  if (expected[3][1] === null) {
-                    expect(data.allCompanies[3].location).toBe(null);
-                  } else {
-                    expect(data.allCompanies[2].location.name).toEqual(expected[3][1]);
-                  }
-                })();
-
-                // Check all the locations look how we expect
-                await (async () => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: '{ allLocations(sortBy: name_ASC) { id name } }',
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allLocations[0].name).toEqual('A');
-                  expect(data.allLocations[1].name).toEqual('B');
-                  expect(data.allLocations[2].name).toEqual('C');
-                  expect(data.allLocations[3].name).toEqual('D');
-                })();
-              })
-            );
-          });
-
-          ['A', 'B', 'C', 'D'].forEach(name => {
-            test(
-              `delete location ${name}`,
-              runner(setupKeystone, async ({ keystone }) => {
-                // Setup a complex set of data
-                const { locations } = await createComplexData(keystone);
-
-                // Delete location {name}
-                const id = locations.find(location => location.name === name).id;
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `mutation { deleteLocation(id: "${id}") { id } }`,
-                });
-                expect(errors).toBe(undefined);
-                expect(data.deleteLocation.id).toBe(id);
-
-                // Check all the companies look how we expect
-                await (async () => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: '{ allCompanies(sortBy: name_ASC) { id name location { id name } } }',
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies[0].name).toEqual('A');
-                  if (name === 'A') {
-                    expect(data.allCompanies[0].location).toBe(null);
-                  } else {
-                    expect(data.allCompanies[0].location.name).toEqual('A');
-                  }
-                  expect(data.allCompanies[1].name).toEqual('B');
-                  if (name === 'D') {
-                    expect(data.allCompanies[1].location).toBe(null);
-                  } else {
-                    expect(data.allCompanies[1].location.name).toEqual('D');
-                  }
-                  expect(data.allCompanies[2].name).toEqual('C');
-                  if (name === 'B') {
-                    expect(data.allCompanies[2].location).toBe(null);
-                  } else {
-                    expect(data.allCompanies[2].location.name).toEqual('B');
-                  }
-                  expect(data.allCompanies[3].name).toEqual('D');
-                  if (name === 'B') {
-                    expect(data.allCompanies[3].location).toBe(null);
-                  } else {
-                    expect(data.allCompanies[3].location.name).toEqual('B');
-                  }
-                  expect(data.allCompanies[4].name).toEqual('E');
-                  expect(data.allCompanies[4].location).toBe(null);
-                })();
-
-                // Check all the locations look how we expect
-                await (async () => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: '{ allLocations(sortBy: name_ASC) { id name } }',
-                  });
-                  expect(errors).toBe(undefined);
-                  const expected = ['A', 'B', 'C', 'D'].filter(x => x !== name);
-                  expect(data.allLocations[0].name).toEqual(expected[0]);
-                  expect(data.allLocations[1].name).toEqual(expected[1]);
-                  expect(data.allLocations[2].name).toEqual(expected[2]);
-                })();
-              })
-            );
-          });
         });
       });
     });

--- a/api-tests/relationships/crud/one-to-many.test.js
+++ b/api-tests/relationships/crud/one-to-many.test.js
@@ -102,361 +102,341 @@ const createReadData = async keystone => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createCompanyList = keystone =>
+    const createLists = keystone => {
       keystone.createList('Company', {
         fields: {
           name: { type: Text },
           locations: { type: Relationship, ref: 'Location.company', many: true },
         },
       });
-    const createLocationList = keystone =>
       keystone.createList('Location', {
         fields: {
           name: { type: Text },
           company: { type: Relationship, ref: 'Company.locations' },
         },
       });
-
-    const createListsLR = keystone => {
-      createCompanyList(keystone);
-      createLocationList(keystone);
     };
-    const createListsRL = keystone => {
-      createLocationList(keystone);
-      createCompanyList(keystone);
-    };
+    describe(`One-to-many relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`One-to-many relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
+      describe('Read', () => {
+        test(
+          'one',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 5],
+                ['B', 5],
+                ['C', 4],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allLocations(where: { company: { name_contains: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allLocations.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 2],
+                ['B', 2],
+                ['C', 2],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 2],
+                ['B', 2],
+                ['C', 2],
+                ['D', 4],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 1],
+                ['B', 1],
+                ['C', 2],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+      });
 
-        describe('Read', () => {
-          test(
-            'one',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 5],
-                  ['B', 5],
-                  ['C', 4],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allLocations(where: { company: { name_contains: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allLocations.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_some',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 2],
-                  ['B', 2],
-                  ['C', 2],
-                  ['D', 0],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_none',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 2],
-                  ['B', 2],
-                  ['C', 2],
-                  ['D', 4],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-          test(
-            '_every',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createReadData(keystone);
-              await Promise.all(
-                [
-                  ['A', 1],
-                  ['B', 1],
-                  ['C', 2],
-                  ['D', 1],
-                ].map(async ([name, count]) => {
-                  const { data, errors } = await graphqlRequest({
-                    keystone,
-                    query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
-                  });
-                  expect(errors).toBe(undefined);
-                  expect(data.allCompanies.length).toEqual(count);
-                })
-              );
-            })
-          );
-        });
-
-        describe('Count', () => {
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Count', () => {
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allCompaniesMeta { count }
                   _allLocationsMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(3);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(3);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { connect: [{ id: "${location.id}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
-                location.id,
-              ]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
+              location.id,
+            ]);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              location.id
+            );
 
-              // Everything should now be connected
-              expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
-                location.id,
-              ]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
+              location.id,
+            ]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" }] }
                   }) { id locations { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With nested connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              const company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            const company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" company: { connect: { id: "${company.id}" } } }] }
                   }) { id locations { id company { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
+
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([Location.id]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id locations { id company { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // The nested company should not have a location
+            expect(
+              allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
+            ).toEqual(Company.id);
+            allCompanies
+              .filter(({ id }) => id !== Company.id)
+              .forEach(company => {
+                expect(company.locations).toEqual([]);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const companyName = sampleOne(alphanumGenerator);
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([Location.id]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id locations { id company { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // The nested company should not have a location
-              expect(
-                allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
-              ).toEqual(Company.id);
-              allCompanies
-                .filter(({ id }) => id !== Company.id)
-                .forEach(company => {
-                  expect(company.locations).toEqual([]);
-                });
-            })
-          );
-
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const companyName = sampleOne(alphanumGenerator);
-
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     locations: { create: [{ name: "${locationName}" company: { create: { name: "${companyName}" } } }] }
                   }) { id locations { id company { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.locations[0].id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([Location.id]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            // The nested company should not have a location
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id locations { id company { id } } } }`,
+            });
+            expect(errors2).toBe(undefined);
+            expect(
+              allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
+            ).toEqual(Company.id);
+            allCompanies
+              .filter(({ id }) => id !== Company.id)
+              .forEach(company => {
+                expect(company.locations).toEqual([]);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
+      });
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.locations[0].id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([Location.id]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
+      describe('Update', () => {
+        test(
+          'With connect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // The nested company should not have a location
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id locations { id company { id } } } }`,
-              });
-              expect(errors2).toBe(undefined);
-              expect(
-                allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
-              ).toEqual(Company.id);
-              allCompanies
-                .filter(({ id }) => id !== Company.id)
-                .forEach(company => {
-                  expect(company.locations).toEqual([]);
-                });
-            })
-          );
-        });
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.location).not.toBe(expect.anything());
+            expect(location.company).not.toBe(expect.anything());
 
-        describe('Update', () => {
-          test(
-            'With connect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
-
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.location).not.toBe(expect.anything());
-              expect(location.company).not.toBe(expect.anything());
-
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { locations: { connect: [{ id: "${location.id}" }] } }
                   ) { id locations { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -464,33 +444,33 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.updateCompany.locations[0].id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.locations[0].id
+            );
 
-              // Everything should now be connected
-              expect(Company.locations.map(({ id }) => id.toString())).toEqual([
-                Location.id.toString(),
-              ]);
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.locations.map(({ id }) => id.toString())).toEqual([
+              Location.id.toString(),
+            ]);
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With disconnect',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnect',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -498,28 +478,28 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-              expect(result.Location.company).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+            expect(result.Location.company).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnectAll',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+        test(
+          'With disconnectAll',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -527,41 +507,40 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id locations { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.locations).toEqual([]);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toEqual([]);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.locations).toEqual([]);
-              expect(result.Location.company).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.locations).toEqual([]);
+            expect(result.Location.company).toBe(null);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Delete', () => {
+        test(
+          'delete',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteCompany.id).toBe(company.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteCompany.id).toBe(company.id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
       });
     });
   })

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -98,474 +98,454 @@ const getCompanyAndLocation = async (keystone, companyId, locationId) => {
 
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    // 1:1 relationships are symmetric in how they behave, but
-    // are (in general) implemented in a non-symmetric way. For example,
-    // in postgres we may decide to store a single foreign key on just
-    // one of the tables involved. As such, we want to ensure that our
-    // tests work correctly no matter which side of the relationship is
-    // defined first.
-    const createCompanyList = keystone =>
+    const createLists = keystone => {
       keystone.createList('Company', {
         fields: {
           name: { type: Text },
           location: { type: Relationship, ref: 'Location.company' },
         },
       });
-    const createLocationList = keystone =>
       keystone.createList('Location', {
         fields: {
           name: { type: Text },
           company: { type: Relationship, ref: 'Company.location' },
         },
       });
-
-    const createListsLR = keystone => {
-      createCompanyList(keystone);
-      createLocationList(keystone);
     };
-    const createListsRL = keystone => {
-      createLocationList(keystone);
-      createCompanyList(keystone);
-    };
+    describe(`One-to-one relationships`, () => {
+      function setupKeystone(adapterName) {
+        return setupServer({ adapterName, createLists });
+      }
 
-    [
-      [createListsLR, 'Left -> Right'],
-      [createListsRL, 'Right -> Left'],
-    ].forEach(([createLists, order]) => {
-      describe(`One-to-one relationships - ${order}`, () => {
-        function setupKeystone(adapterName) {
-          return setupServer({ adapterName, createLists });
-        }
-
-        describe('Read', () => {
-          test(
-            'Where A',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { location, company } = await createCompanyAndLocation(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `{
+      describe('Read', () => {
+        test(
+          'Where A',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { location, company } = await createCompanyAndLocation(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{
                   allLocations(where: { company: { name: "${company.name}"} }) { id }
                   allCompanies(where: { location: { name: "${location.name}"} }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(1);
-              expect(data.allLocations[0].id).toEqual(location.id);
-              expect(data.allCompanies.length).toEqual(1);
-              expect(data.allCompanies[0].id).toEqual(company.id);
-            })
-          );
-          test(
-            'Where B',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { location, company } = await createLocationAndCompany(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(1);
+            expect(data.allLocations[0].id).toEqual(location.id);
+            expect(data.allCompanies.length).toEqual(1);
+            expect(data.allCompanies[0].id).toEqual(company.id);
+          })
+        );
+        test(
+          'Where B',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { location, company } = await createLocationAndCompany(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{
                   allLocations(where: { company: { name: "${company.name}"} }) { id }
                   allCompanies(where: { location: { name: "${location.name}"} }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(1);
-              expect(data.allLocations[0].id).toEqual(location.id);
-              expect(data.allCompanies.length).toEqual(1);
-              expect(data.allCompanies[0].id).toEqual(company.id);
-            })
-          );
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(1);
+            expect(data.allLocations[0].id).toEqual(location.id);
+            expect(data.allCompanies.length).toEqual(1);
+            expect(data.allCompanies[0].id).toEqual(company.id);
+          })
+        );
 
-          test(
-            'Count',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'Count',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 {
                   _allCompaniesMeta { count }
                   _allLocationsMeta { count }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(3);
-            })
-          );
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(3);
+          })
+        );
 
-          test(
-            'Where with count A',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { location, company } = await createCompanyAndLocation(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `{
+        test(
+          'Where with count A',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { location, company } = await createCompanyAndLocation(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(1);
-              expect(data._allLocationsMeta.count).toEqual(1);
-            })
-          );
-          test(
-            'Where with count B',
-            runner(setupKeystone, async ({ keystone }) => {
-              await createInitialData(keystone);
-              const { location, company } = await createLocationAndCompany(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(1);
+            expect(data._allLocationsMeta.count).toEqual(1);
+          })
+        );
+        test(
+          'Where with count B',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createInitialData(keystone);
+            const { location, company } = await createLocationAndCompany(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(1);
-              expect(data._allLocationsMeta.count).toEqual(1);
-            })
-          );
-        });
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(1);
+            expect(data._allLocationsMeta.count).toEqual(1);
+          })
+        );
+      });
 
-        describe('Create', () => {
-          test(
-            'With connect A',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+      describe('Create', () => {
+        test(
+          'With connect A',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { connect: { id: "${location.id}" } }
                   }) { id location { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createCompany.location.id.toString()).toEqual(location.id);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createCompany.location.id.toString()).toEqual(location.id);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With connect B',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              const company = companies[0];
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With connect B',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            const company = companies[0];
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createLocation(data: {
                     company: { connect: { id: "${company.id}" } }
                   }) { id company { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.createLocation.company.id.toString()).toEqual(company.id);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.createLocation.company.id.toString()).toEqual(company.id);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.createLocation.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.createLocation.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With create A',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create A',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { create: { name: "${locationName}" } }
                   }) { id location { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With create B',
-            runner(setupKeystone, async ({ keystone }) => {
-              const companyName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create B',
+          runner(setupKeystone, async ({ keystone }) => {
+            const companyName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createLocation(data: {
                     company: { create: { name: "${companyName}" } }
                   }) { id company { id } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createLocation.company.id,
-                data.createLocation.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createLocation.company.id,
+              data.createLocation.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With nested connect A',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              const company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
+        test(
+          'With nested connect A',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            const company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
 
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { create: { name: "${locationName}" company: { connect: { id: "${company.id}" } } } }
                   }) { id location { id company { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id location { id company { id }} } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // The nested company should not have a location
+            expect(
+              allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
+            ).toEqual(Company.id);
+            allCompanies
+              .filter(({ id }) => id !== Company.id)
+              .forEach(company => {
+                expect(company.location).toBe(null);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
+        test(
+          'With nested connect B',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            const location = locations[0];
+            const companyName = sampleOne(alphanumGenerator);
 
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id location { id company { id }} } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // The nested company should not have a location
-              expect(
-                allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
-              ).toEqual(Company.id);
-              allCompanies
-                .filter(({ id }) => id !== Company.id)
-                .forEach(company => {
-                  expect(company.location).toBe(null);
-                });
-            })
-          );
-
-          test(
-            'With nested connect B',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              const location = locations[0];
-              const companyName = sampleOne(alphanumGenerator);
-
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createLocation(data: {
                     company: { create: { name: "${companyName}" location: { connect: { id: "${location.id}" } } } }
                   }) { id company { id location { id } } }
                 }`,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createLocation.company.id,
+              data.createLocation.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            const {
+              data: { allLocations },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allLocations { id company { id location { id }} } }`,
+            });
+            expect(errors2).toBe(undefined);
+            // The nested company should not have a location
+            expect(
+              allLocations.filter(({ id }) => id === Location.id)[0].company.location.id
+            ).toEqual(Location.id);
+            allLocations
+              .filter(({ id }) => id !== Location.id)
+              .forEach(location => {
+                expect(location.company).toBe(null);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createLocation.company.id,
-                data.createLocation.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
+        test(
+          'With nested create',
+          runner(setupKeystone, async ({ keystone }) => {
+            const locationName = sampleOne(alphanumGenerator);
+            const companyName = sampleOne(alphanumGenerator);
 
-              const {
-                data: { allLocations },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allLocations { id company { id location { id }} } }`,
-              });
-              expect(errors2).toBe(undefined);
-              // The nested company should not have a location
-              expect(
-                allLocations.filter(({ id }) => id === Location.id)[0].company.location.id
-              ).toEqual(Location.id);
-              allLocations
-                .filter(({ id }) => id !== Location.id)
-                .forEach(location => {
-                  expect(location.company).toBe(null);
-                });
-            })
-          );
-
-          test(
-            'With nested create',
-            runner(setupKeystone, async ({ keystone }) => {
-              const locationName = sampleOne(alphanumGenerator);
-              const companyName = sampleOne(alphanumGenerator);
-
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   createCompany(data: {
                     location: { create: { name: "${locationName}" company: { create: { name: "${companyName}" } } } }
                   }) { id location { id company { id } } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.createCompany.id,
+              data.createCompany.location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            // The nested company should not have a location
+            const {
+              data: { allCompanies },
+              errors: errors2,
+            } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies { id location { id company { id }} } }`,
+            });
+            expect(errors2).toBe(undefined);
+            expect(
+              allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
+            ).toEqual(Company.id);
+            allCompanies
+              .filter(({ id }) => id !== Company.id)
+              .forEach(company => {
+                expect(company.location).toBe(null);
               });
-              expect(errors).toBe(undefined);
+          })
+        );
+      });
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.createCompany.id,
-                data.createCompany.location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
+      describe('Update', () => {
+        test(
+          'With connect A',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // The nested company should not have a location
-              const {
-                data: { allCompanies },
-                errors: errors2,
-              } = await graphqlRequest({
-                keystone,
-                query: `{ allCompanies { id location { id company { id }} } }`,
-              });
-              expect(errors2).toBe(undefined);
-              expect(
-                allCompanies.filter(({ id }) => id === Company.id)[0].location.company.id
-              ).toEqual(Company.id);
-              allCompanies
-                .filter(({ id }) => id !== Company.id)
-                .forEach(company => {
-                  expect(company.location).toBe(null);
-                });
-            })
-          );
-        });
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.location).not.toBe(expect.anything());
+            expect(location.company).not.toBe(expect.anything());
 
-        describe('Update', () => {
-          test(
-            'With connect A',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
-
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.location).not.toBe(expect.anything());
-              expect(location.company).not.toBe(expect.anything());
-
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { location: { connect: { id: "${location.id}" } } }
                   ) { id location { id } } }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With connect B',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createLocationAndCompany(keystone);
+        test(
+          'With connect B',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createLocationAndCompany(keystone);
 
-              // Sanity check the links don't yet exist
-              // `...not.toBe(expect.anything())` allows null and undefined values
-              expect(company.location).not.toBe(expect.anything());
-              expect(location.company).not.toBe(expect.anything());
+            // Sanity check the links don't yet exist
+            // `...not.toBe(expect.anything())` allows null and undefined values
+            expect(company.location).not.toBe(expect.anything());
+            expect(location.company).not.toBe(expect.anything());
 
-              const { errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateLocation(
                     id: "${location.id}",
                     data: { company: { connect: { id: "${company.id}" } } }
                   ) { id company { id } } }`,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                location.id
-              );
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
-          test(
-            'With create A',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              location.id
+            );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
+        test(
+          'With create A',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -573,30 +553,30 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                company.id,
-                data.updateCompany.location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With create B',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              let location = locations[0];
-              const companyName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With create B',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            let location = locations[0];
+            const companyName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateLocation(
                     id: "${location.id}",
@@ -604,30 +584,30 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id company { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
-                keystone,
-                data.updateLocation.company.id,
-                location.id
-              );
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.updateLocation.company.id,
+              location.id
+            );
 
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-            })
-          );
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+          })
+        );
 
-          test(
-            'With recreate A',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { companies } = await createInitialData(keystone);
-              let company = companies[0];
-              const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+        test(
+          'With recreate A',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { companies } = await createInitialData(keystone);
+            let company = companies[0];
+            const locationName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -635,25 +615,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
+            });
+            expect(errors).toBe(undefined);
 
-              const { Company, Location } = await getCompanyAndLocation(
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              company.id,
+              data.updateCompany.location.id
+            );
+
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            const originalLocationId = Location.id;
+            await (async () => {
+              const locationName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
                 keystone,
-                company.id,
-                data.updateCompany.location.id
-              );
-
-              // Everything should now be connected
-              expect(Company.location.id.toString()).toBe(Location.id.toString());
-              expect(Location.company.id.toString()).toBe(Company.id.toString());
-
-              const originalLocationId = Location.id;
-              await (async () => {
-                const locationName = sampleOne(alphanumGenerator);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `
+                query: `
                   mutation {
                     updateCompany(
                       id: "${company.id}",
@@ -661,38 +641,38 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     ) { id location { id name } }
                   }
               `,
-                });
-                expect(errors).toBe(undefined);
+              });
+              expect(errors).toBe(undefined);
 
-                const { Company, Location } = await getCompanyAndLocation(
-                  keystone,
-                  company.id,
-                  data.updateCompany.location.id
-                );
-
-                // Everything should now be connected
-                expect(Company.location.id.toString()).toBe(Location.id.toString());
-                expect(Location.company.id.toString()).toBe(Company.id.toString());
-
-                const result = await graphqlRequest({
-                  keystone,
-                  query: `{ Location(where: { id: "${originalLocationId}" }) { id company { id } } }`,
-                });
-                expect(result.errors).toBe(undefined);
-                expect(result.data.Location.company).toBe(null);
-              })();
-            })
-          );
-
-          test(
-            'With recreate B',
-            runner(setupKeystone, async ({ keystone }) => {
-              const { locations } = await createInitialData(keystone);
-              let location = locations[0];
-              const companyName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
+              const { Company, Location } = await getCompanyAndLocation(
                 keystone,
-                query: `
+                company.id,
+                data.updateCompany.location.id
+              );
+
+              // Everything should now be connected
+              expect(Company.location.id.toString()).toBe(Location.id.toString());
+              expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+              const result = await graphqlRequest({
+                keystone,
+                query: `{ Location(where: { id: "${originalLocationId}" }) { id company { id } } }`,
+              });
+              expect(result.errors).toBe(undefined);
+              expect(result.data.Location.company).toBe(null);
+            })();
+          })
+        );
+
+        test(
+          'With recreate B',
+          runner(setupKeystone, async ({ keystone }) => {
+            const { locations } = await createInitialData(keystone);
+            let location = locations[0];
+            const companyName = sampleOne(alphanumGenerator);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateLocation(
                     id: "${location.id}",
@@ -700,6 +680,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id company { id name } }
                 }
             `,
+            });
+            expect(errors).toBe(undefined);
+
+            const { Company, Location } = await getCompanyAndLocation(
+              keystone,
+              data.updateLocation.company.id,
+              location.id
+            );
+
+            // Everything should now be connected
+            expect(Company.location.id.toString()).toBe(Location.id.toString());
+            expect(Location.company.id.toString()).toBe(Company.id.toString());
+
+            const originalCompanyId = Company.id;
+            await (async () => {
+              const companyName = sampleOne(alphanumGenerator);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `
+                  mutation {
+                    updateLocation(
+                      id: "${location.id}",
+                      data: { company: { create: { name: "${companyName}" } } }
+                    ) { id company { id name } }
+                  }
+              `,
               });
               expect(errors).toBe(undefined);
 
@@ -713,52 +719,26 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(Company.location.id.toString()).toBe(Location.id.toString());
               expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-              const originalCompanyId = Company.id;
-              await (async () => {
-                const companyName = sampleOne(alphanumGenerator);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
-                  query: `
-                  mutation {
-                    updateLocation(
-                      id: "${location.id}",
-                      data: { company: { create: { name: "${companyName}" } } }
-                    ) { id company { id name } }
-                  }
-              `,
-                });
-                expect(errors).toBe(undefined);
-
-                const { Company, Location } = await getCompanyAndLocation(
-                  keystone,
-                  data.updateLocation.company.id,
-                  location.id
-                );
-
-                // Everything should now be connected
-                expect(Company.location.id.toString()).toBe(Location.id.toString());
-                expect(Location.company.id.toString()).toBe(Company.id.toString());
-
-                const result = await graphqlRequest({
-                  keystone,
-                  query: `{ Company(where: { id: "${originalCompanyId}" }) { id location { id } } }`,
-                });
-                expect(result.errors).toBe(undefined);
-                expect(result.data.Company.location).toBe(null);
-              })();
-            })
-          );
-
-          test(
-            'With disconnect A',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
-
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
+              const result = await graphqlRequest({
                 keystone,
-                query: `
+                query: `{ Company(where: { id: "${originalCompanyId}" }) { id location { id } } }`,
+              });
+              expect(result.errors).toBe(undefined);
+              expect(result.data.Company.location).toBe(null);
+            })();
+          })
+        );
+
+        test(
+          'With disconnect A',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
+
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
@@ -766,145 +746,144 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   ) { id location { id name } }
                 }
             `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.location).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).toBe(null);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnect B',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createLocationAndCompany(keystone);
+        test(
+          'With disconnect B',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createLocationAndCompany(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateLocation(
                     id: "${location.id}",
                     data: { company: { disconnect: { id: "${company.id}" } } }
                   ) { id company { id name } }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateLocation.id).toEqual(location.id);
-              expect(data.updateLocation.company).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateLocation.id).toEqual(location.id);
+            expect(data.updateLocation.company).toBe(null);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
-          test(
-            'With disconnectAll A',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
+        test(
+          'With disconnectAll A',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateCompany(
                     id: "${company.id}",
                     data: { location: { disconnectAll: true } }
                   ) { id location { id name } }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateCompany.id).toEqual(company.id);
-              expect(data.updateCompany.location).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).toBe(null);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
 
-          test(
-            'With disconnectAll B',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createLocationAndCompany(keystone);
+        test(
+          'With disconnectAll B',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createLocationAndCompany(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `
                 mutation {
                   updateLocation(
                     id: "${location.id}",
                     data: { company: { disconnectAll: true } }
                   ) { id company { id name } }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.updateLocation.id).toEqual(location.id);
-              expect(data.updateLocation.company).toBe(null);
+            });
+            expect(errors).toBe(undefined);
+            expect(data.updateLocation.id).toEqual(location.id);
+            expect(data.updateLocation.company).toBe(null);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
+      });
 
-        describe('Delete', () => {
-          test(
-            'delete A',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createCompanyAndLocation(keystone);
+      describe('Delete', () => {
+        test(
+          'delete A',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteCompany.id).toBe(company.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteCompany.id).toBe(company.id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company).toBe(null);
-              expect(result.Location.company).toBe(null);
-            })
-          );
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company).toBe(null);
+            expect(result.Location.company).toBe(null);
+          })
+        );
 
-          test(
-            'delete B',
-            runner(setupKeystone, async ({ keystone }) => {
-              // Manually setup a connected Company <-> Location
-              const { location, company } = await createLocationAndCompany(keystone);
+        test(
+          'delete B',
+          runner(setupKeystone, async ({ keystone }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createLocationAndCompany(keystone);
 
-              // Run the query to disconnect the location from company
-              const { data, errors } = await graphqlRequest({
-                keystone,
-                query: `mutation { deleteLocation(id: "${location.id}") { id } } `,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.deleteLocation.id).toBe(location.id);
+            // Run the query to disconnect the location from company
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `mutation { deleteLocation(id: "${location.id}") { id } } `,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.deleteLocation.id).toBe(location.id);
 
-              // Check the link has been broken
-              const result = await getCompanyAndLocation(keystone, company.id, location.id);
-              expect(result.Company.location).toBe(null);
-              expect(result.Location).toBe(null);
-            })
-          );
-        });
+            // Check the link has been broken
+            const result = await getCompanyAndLocation(keystone, company.id, location.id);
+            expect(result.Company.location).toBe(null);
+            expect(result.Location).toBe(null);
+          })
+        );
       });
     });
   })


### PR DESCRIPTION
`keystone._consolidateRelationships()` ensures that we have a consistent left/right pattern independent of the order of field definition, so there's no longer the need for relationship tests to be run in both orders.

Hint to reviewer: turn off whitespace changes 🤔 