### PR TITLE
Fix _is_null query on 1:1 relationships

### DIFF
--- a/.changeset/twenty-baboons-rest.md
+++ b/.changeset/twenty-baboons-rest.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/adapter-knex': patch
+---
+
+Fixed bug where `_is_null` queries on relationship fields could generate invalid SQL in `one-to-one` relationships.

--- a/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
@@ -123,6 +123,54 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       function setupKeystone(adapterName) {
         return setupServer({ adapterName, createLists });
       }
+      describe('Read', () => {
+        test(
+          'one',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            await Promise.all(
+              [
+                ['A', 1],
+                ['B', 2],
+                ['C', 0],
+                ['D', 1],
+                ['E', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allUsers(where: { friend: { name_contains: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allUsers.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          'is_null: true',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers(where: { friend_is_null: true }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(5);
+          })
+        );
+        test(
+          'is_null: false',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers(where: { friend_is_null: false }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(4);
+          })
+        );
+      });
 
       describe('Count', () => {
         test(

--- a/api-tests/relationships/crud-self-ref/one-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many.test.js
@@ -68,7 +68,7 @@ const createReadData = async keystone => {
     keystone,
     query: `mutation create($users: [UsersCreateInput]) { createUsers(data: $users) { id name } }`,
     variables: {
-      users: ['A', 'A', 'B', 'B', 'C', 'C'].map(name => ({ data: { name } })),
+      users: ['A', 'A', 'B', 'B', 'C', 'C', 'D'].map(name => ({ data: { name } })),
     },
   });
   expect(errors).toBe(undefined);
@@ -135,6 +135,30 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           })
         );
         test(
+          'is_null: true',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers(where: { friendOf_is_null: true }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(5);
+          })
+        );
+        test(
+          'is_null: false',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allUsers(where: { friendOf_is_null: false }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(6);
+          })
+        );
+        test(
           '_some',
           runner(setupKeystone, async ({ keystone }) => {
             await createReadData(keystone);
@@ -161,10 +185,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             await createReadData(keystone);
             await Promise.all(
               [
-                ['A', 2 + 6],
-                ['B', 2 + 6],
-                ['C', 2 + 6],
-                ['D', 4 + 6],
+                ['A', 2 + 7],
+                ['B', 2 + 7],
+                ['C', 2 + 7],
+                ['D', 4 + 7],
               ].map(async ([name, count]) => {
                 const { data, errors } = await graphqlRequest({
                   keystone,
@@ -182,10 +206,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             await createReadData(keystone);
             await Promise.all(
               [
-                ['A', 1 + 6],
-                ['B', 1 + 6],
-                ['C', 2 + 6],
-                ['D', 1 + 6],
+                ['A', 1 + 7],
+                ['B', 1 + 7],
+                ['C', 2 + 7],
+                ['D', 1 + 7],
               ].map(async ([name, count]) => {
                 const { data, errors } = await graphqlRequest({
                   keystone,

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -10,14 +10,12 @@ const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,
     query: `
-mutation {
-  createUsers(data: [{ data: { name: "${sampleOne(
-    alphanumGenerator
-  )}" } }, { data: { name: "${sampleOne(alphanumGenerator)}" } }, { data: { name: "${sampleOne(
-      alphanumGenerator
-    )}" } }]) { id }
-}
-`,
+      mutation {
+        createUsers(data: [
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } }]) { id }
+      }`,
   });
   expect(errors).toBe(undefined);
   return { users: data.createUsers };
@@ -109,6 +107,66 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(errors).toBe(undefined);
               expect(data.allUsers.length).toEqual(1);
               expect(data.allUsers[0].id).toEqual(friend.id);
+            })
+          );
+          test(
+            'Where friend: is_null: true',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allUsers(where: { friend_is_null: true }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(4);
+            })
+          );
+          test(
+            'Where friendOf: is_null: true',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allUsers(where: { friendOf_is_null: true }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(4);
+            })
+          );
+          test(
+            'Where friend: is_null: false',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allUsers(where: { friend_is_null: false }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(1);
+            })
+          );
+          test(
+            'Where friendOf: is_null: false',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allUsers(where: { friendOf_is_null: false }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allUsers.length).toEqual(1);
             })
           );
         }

--- a/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -133,6 +133,55 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         return setupServer({ adapterName, createLists });
       }
 
+      describe('Read', () => {
+        test(
+          'one',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            await Promise.all(
+              [
+                ['A', 1],
+                ['B', 2],
+                ['C', 0],
+                ['D', 1],
+                ['E', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `{ allCompanies(where: { location: { name_contains: "${name}"}}) { id }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data.allCompanies.length).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          'is_null: true',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies(where: { location_is_null: true }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allCompanies.length).toEqual(1);
+          })
+        );
+        test(
+          'is_null: false',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createComplexData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allCompanies(where: { location_is_null: false }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allCompanies.length).toEqual(4);
+          })
+        );
+      });
+
       describe('Count', () => {
         test(
           'Count',

--- a/api-tests/relationships/crud/one-to-many.test.js
+++ b/api-tests/relationships/crud/one-to-many.test.js
@@ -68,12 +68,12 @@ const getCompanyAndLocation = async (keystone, companyId, locationId) => {
 };
 
 const createReadData = async keystone => {
-  // create locations [A, A, B, B, C, C];
+  // create locations [A, A, B, B, C, C, D];
   const { data, errors } = await graphqlRequest({
     keystone,
     query: `mutation create($locations: [LocationsCreateInput]) { createLocations(data: $locations) { id name } }`,
     variables: {
-      locations: ['A', 'A', 'B', 'B', 'C', 'C'].map(name => ({ data: { name } })),
+      locations: ['A', 'A', 'B', 'B', 'C', 'C', 'D'].map(name => ({ data: { name } })),
     },
   });
   expect(errors).toBe(undefined);
@@ -141,6 +141,30 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 expect(data.allLocations.length).toEqual(count);
               })
             );
+          })
+        );
+        test(
+          'is_null: true',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allLocations(where: { company_is_null: true }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(1);
+          })
+        );
+        test(
+          'is_null: false',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            const { data, errors } = await graphqlRequest({
+              keystone,
+              query: `{ allLocations(where: { company_is_null: false }) { id }}`,
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(6);
           })
         );
         test(

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -10,19 +10,19 @@ const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,
     query: `
-mutation {
-  createCompanies(data: [{ data: { name: "${sampleOne(
-    alphanumGenerator
-  )}" } }, { data: { name: "${sampleOne(alphanumGenerator)}" } }, { data: { name: "${sampleOne(
-      alphanumGenerator
-    )}" } }]) { id }
-  createLocations(data: [{ data: { name: "${sampleOne(
-    alphanumGenerator
-  )}" } }, { data: { name: "${sampleOne(alphanumGenerator)}" } }, { data: { name: "${sampleOne(
-      alphanumGenerator
-    )}" } }]) { id }
-}
-`,
+      mutation {
+        createCompanies(data: [
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } }
+        ]) { id }
+        createLocations(data: [
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } },
+          { data: { name: "${sampleOne(alphanumGenerator)}" } }
+          { data: { name: "${sampleOne(alphanumGenerator)}" } }
+        ]) { id }
+      }`,
   });
   expect(errors).toBe(undefined);
   return { locations: data.createLocations, companies: data.createCompanies };
@@ -156,6 +156,76 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allCompanies[0].id).toEqual(company.id);
           })
         );
+        if (adapterName !== 'mongoose') {
+          test(
+            'Where A: is_null: true',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createCompanyAndLocation(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allLocations(where: { company_is_null: true }) { id }
+                  allCompanies(where: { location_is_null: true }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allLocations.length).toEqual(4);
+              expect(data.allCompanies.length).toEqual(3);
+            })
+          );
+          test(
+            'Where B: is_null: true',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createLocationAndCompany(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allLocations(where: { company_is_null: true }) { id }
+                  allCompanies(where: { location_is_null: true }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allLocations.length).toEqual(4);
+              expect(data.allCompanies.length).toEqual(3);
+            })
+          );
+          test(
+            'Where A: is_null: false',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createCompanyAndLocation(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allLocations(where: { company_is_null: false }) { id }
+                  allCompanies(where: { location_is_null: false }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allLocations.length).toEqual(1);
+              expect(data.allCompanies.length).toEqual(1);
+            })
+          );
+          test(
+            'Where B: is_null: false',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createLocationAndCompany(keystone);
+              const { data, errors } = await graphqlRequest({
+                keystone,
+                query: `{
+                  allLocations(where: { company_is_null: false }) { id }
+                  allCompanies(where: { location_is_null: false }) { id }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data.allLocations.length).toEqual(1);
+              expect(data.allCompanies.length).toEqual(1);
+            })
+          );
+        }
 
         test(
           'Count',
@@ -172,7 +242,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
             expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(3);
-            expect(data._allLocationsMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(4);
           })
         );
 

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -698,7 +698,14 @@ class QueryBuilder {
     const fieldAdapter = listAdapter.fieldAdaptersByPath[dbPath];
     // Can't assume dbPath === fieldAdapter.dbPath (sometimes it isn't)
     return (
-      fieldAdapter && fieldAdapter.getQueryConditions(`${tableAlias}.${fieldAdapter.dbPath}`)[path]
+      fieldAdapter &&
+      fieldAdapter.getQueryConditions(
+        fieldAdapter.isRelationship &&
+          fieldAdapter.rel.cardinality === '1:1' &&
+          fieldAdapter.rel.right === fieldAdapter.field
+          ? `${tableAlias}__${fieldAdapter.path}.id`
+          : `${tableAlias}.${fieldAdapter.dbPath}`
+      )[path]
     );
   }
 


### PR DESCRIPTION
We were generating invalid queries if the query was looking at the right hand side of a one-to-one relationship.