### PR TITLE
Call jest.setTimeout from jest/setup.js

### DIFF
--- a/.changeset/red-pandas-punch.md
+++ b/.changeset/red-pandas-punch.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/build-field-types': patch
+'@keystonejs/mongo-join-builder': patch
+---
+
+Updated tests to consistently use `jest.setTimeout()`.

--- a/api-tests/access-control/authed.test.js
+++ b/api-tests/access-control/authed.test.js
@@ -9,11 +9,6 @@ const {
   nameFn,
   setupKeystone,
 } = require('./utils');
-
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 const expectNoAccess = (data, errors, name) => {
   expect(data[name]).toBe(null);
   expect(errors).toHaveLength(1);

--- a/api-tests/access-control/not-authed.test.js
+++ b/api-tests/access-control/not-authed.test.js
@@ -1,10 +1,6 @@
 const { multiAdapterRunners, authedGraphqlRequest } = require('@keystonejs/test-utils');
 const { FAKE_ID, nameFn, listAccessVariations, setupKeystone } = require('./utils');
 
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 const expectNoAccess = (data, errors, name) => {
   expect(data[name]).toBe(null);
   expect(errors).toHaveLength(1);

--- a/api-tests/access-control/schema.test.js
+++ b/api-tests/access-control/schema.test.js
@@ -10,10 +10,6 @@ const {
   getFieldName,
 } = require('./utils');
 
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 const introspectionQuery = `{
   __schema {
     types {

--- a/api-tests/fields.test.js
+++ b/api-tests/fields.test.js
@@ -2,10 +2,6 @@ const globby = require('globby');
 const path = require('path');
 const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 describe('Fields', () => {
   const testModules = globby.sync(`packages/fields/src/types/**/test-fixtures.js`, {
     absolute: true,

--- a/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud-self-ref/many-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud-self-ref/one-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-many.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud/many-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/many-to-many-one-sided.test.js
@@ -4,23 +4,19 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,
     query: `
 mutation {
-  createCompanies(data: [{ data: { name: "${sampleOne(
-    alphanumGenerator
-  )}" } }, { data: { name: "${sampleOne(alphanumGenerator)}" } }, { data: { name: "${sampleOne(
-      alphanumGenerator
-    )}" } }]) { id }
-  createLocations(data: [{ data: { name: "${sampleOne(
-    alphanumGenerator
-  )}" } }, { data: { name: "${sampleOne(alphanumGenerator)}" } }, { data: { name: "${sampleOne(
-      alphanumGenerator
-    )}" } }]) { id }
+  createCompanies(data: [
+    { data: { name: "${sampleOne(alphanumGenerator)}" } },
+    { data: { name: "${sampleOne(alphanumGenerator)}" } },
+    { data: { name: "${sampleOne(alphanumGenerator)}" } }]) { id }
+  createLocations(data: [
+    { data: { name: "${sampleOne(alphanumGenerator)}" } },
+    { data: { name: "${sampleOne(alphanumGenerator)}" } },
+    { data: { name: "${sampleOne(alphanumGenerator)}" } }]) { id }
 }
 `,
   });

--- a/api-tests/relationships/crud/many-to-many.test.js
+++ b/api-tests/relationships/crud/many-to-many.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud/one-to-many.test.js
+++ b/api-tests/relationships/crud/one-to-many.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 const createInitialData = async keystone => {
   const { data, errors } = await graphqlRequest({
     keystone,

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
@@ -6,10 +6,6 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const toStr = items => items.map(item => item.toString());
 
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 function setupKeystone(adapterName) {
   return setupServer({
     adapterName,

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
@@ -4,8 +4,6 @@ const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonej
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-jest.setTimeout(6000000);
-
 function setupKeystone(adapterName) {
   return setupServer({
     adapterName,

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,3 +1,7 @@
+// `mongodb-memory-server` downloads a binary on first run in CI, which can take
+// a while, so we bump up the timeout here.
+jest.setTimeout(60000); // in milliseconds
+
 // AVA-like test wrapper for known failing tests
 // see: https://github.com/avajs/ava#failing-tests
 test.failing = (title, testFn) => {

--- a/packages/build-field-types/src/__tests__/dev.js
+++ b/packages/build-field-types/src/__tests__/dev.js
@@ -8,8 +8,6 @@ const f = fixturez(__dirname);
 
 jest.mock('../prompt');
 
-jest.setTimeout(10000);
-
 test('dev command works in node', async () => {
   let tmpPath = f.copy('valid-monorepo-that-logs-stuff');
 

--- a/packages/mongo-join-builder/tests/mongo-results.test.js
+++ b/packages/mongo-join-builder/tests/mongo-results.test.js
@@ -30,10 +30,6 @@ let mongoConnection;
 let mongoDb;
 let mongoServer;
 
-// `mongodb-memory-server` downloads a binary on first run in CI, which can take
-// a while, so we bump up the timeout here.
-jest.setTimeout(60000);
-
 beforeAll(async () => {
   mongoServer = new MongoDBMemoryServer();
   const mongoUri = await mongoServer.getConnectionString();


### PR DESCRIPTION
Out package.json contains the following:

```
  "jest": {
    "setupFilesAfterEnv": [
      "./jest/setup.js"
    ],
    ...
  }
```

which means we can use this file to consistently call `jest.setTimeout()` fo all our tests.

https://jestjs.io/docs/en/configuration#setupfilesafterenv-array