### PR TITLE
File-adapters: fix for cloudinary folders bug

### DIFF
--- a/.changeset/breezy-cherries-exercise.md
+++ b/.changeset/breezy-cherries-exercise.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/file-adapters': patch
+---
+
+Fixed a bug in the delete function, due to which it was impossible to delete images in folders.

--- a/packages/file-adapters/lib/cloudinary.js
+++ b/packages/file-adapters/lib/cloudinary.js
@@ -61,7 +61,7 @@ module.exports = class CloudinaryAdapter {
 
     return new Promise((resolve, reject) => {
       if (file) {
-        cloudinary.v2.uploader.destroy(file.id, destroyOptions, (error, result) => {
+        cloudinary.v2.uploader.destroy(file._meta.public_id, destroyOptions, (error, result) => {
           if (error) {
             reject(error);
           } else {


### PR DESCRIPTION
Fix for delete function, due to which it was impossible to delete images in folders.
Cloudinary Destroy method expects a **public id** with the full path instead of a **file id**

https://cloudinary.com/documentation/image_upload_api_reference#syntax-1