### PR TITLE
Admin UI: show ID in label cell

### DIFF
--- a/.changeset/chilled-ants-kiss.md
+++ b/.changeset/chilled-ants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Always show ID in Label cell.

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -253,8 +253,17 @@ const ListRow = ({
         if (path === linkField) {
           return (
             <BodyCellTruncated key={path}>
-              <ItemLink path={list.fullPath} item={item}>
-                {item[linkField]}
+              <ItemLink path={list.fullPath} item={item} css={{ lineHeight: 1.4 }}>
+                <div>{item[linkField]}</div>
+                <div
+                  css={{
+                    fontSize: '0.9em',
+                    fontFamily: 'Monaco, Consolas, monospace',
+                    color: colors.N40,
+                  }}
+                >
+                  ID: {item.id}
+                </div>
               </ItemLink>
             </BodyCellTruncated>
           );


### PR DESCRIPTION
A simple idea that popped into my head. This allows the item ID to be always visible without having to make the ID column visible (still possible). Admittedly, this makes the table take up more vertical space, so I'm a bit on the fence here. Thoughts?

![image](https://user-images.githubusercontent.com/3558659/87969193-6489fe80-cb0d-11ea-8f75-5b98036733b6.png)
