### PR TITLE
Admin UI: stop passing unnecessary props around

### DIFF
--- a/.changeset/chilled-mails-build.md
+++ b/.changeset/chilled-mails-build.md
@@ -2,4 +2,4 @@
 '@keystonejs/app-admin-ui': patch
 ---
 
-Stop passing unnecessary props around through ListLayout, ListTable, ListRow, and SortLink.
+Stopped passing unnecessary props around, especially ones which can be accessed via hooks.

--- a/.changeset/chilled-mails-build.md
+++ b/.changeset/chilled-mails-build.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Stop passing unnecessary props around through ListLayout, ListTable, ListRow, and SortLink.

--- a/packages/app-admin-ui/client/components/DeleteItemModal.js
+++ b/packages/app-admin-ui/client/components/DeleteItemModal.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
+import { useList } from '../../components';
 
-export default function DeleteItemModal({ isOpen, item, list, onClose, onDelete }) {
+export default function DeleteItemModal({ isOpen, item, onClose, onDelete }) {
+  const { list } = useList();
   const [deleteItem, { loading }] = useMutation(list.deleteMutation, {
     refetchQueries: ['getList'],
   });

--- a/packages/app-admin-ui/client/components/DeleteItems.js
+++ b/packages/app-admin-ui/client/components/DeleteItems.js
@@ -32,7 +32,6 @@ const DeleteItems = () => {
       <DeleteManyItemsModal
         isOpen={deleteModalIsVisible}
         itemIds={selectedItems}
-        list={list}
         onClose={() => setDeleteModal(false)}
         onDelete={handleDelete}
       />

--- a/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/DeleteManyItemsModal.js
@@ -2,8 +2,10 @@ import React from 'react';
 import { useMutation } from '@apollo/react-hooks';
 import { Button } from '@arch-ui/button';
 import Confirm from '@arch-ui/confirm';
+import { useList } from '../../components';
 
-export default function DeleteManyModal({ isOpen, itemIds, list, onClose, onDelete }) {
+export default function DeleteManyModal({ isOpen, itemIds, onClose, onDelete }) {
+  const { list } = useList();
   const [deleteItems, { loading }] = useMutation(list.deleteManyMutation, {
     refetchQueries: ['getList'],
   });

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -224,7 +224,6 @@ const ListRow = ({ item, itemErrors = {}, linkField = '_label_', isSelected }) =
         <DeleteItemModal
           isOpen={showDeleteModal}
           item={item}
-          list={list}
           onClose={closeDeleteModal}
           onDelete={handleDelete}
         />
@@ -418,12 +417,7 @@ export default function ListTable({ columnControl, linkField = '_label_' }) {
                 return (
                   <TableContents>
                     <SingleCell columns={columns}>
-                      <NoResults
-                        currentPage={currentPage}
-                        filters={filters}
-                        list={list}
-                        search={search}
-                      />
+                      <NoResults currentPage={currentPage} filters={filters} search={search} />
                     </SingleCell>
                   </TableContents>
                 );

--- a/packages/app-admin-ui/client/components/ListTable.js
+++ b/packages/app-admin-ui/client/components/ListTable.js
@@ -194,7 +194,7 @@ const ListRow = ({ item, itemErrors = {}, linkField = '_label_', isSelected }) =
     setShowDeleteModal(false);
   };
 
-  const handleDelete = result => {
+  const handleDelete = () => {
     if (!mounted.current) return;
     setShowDeleteModal(false);
   };

--- a/packages/app-admin-ui/client/components/NoResults.js
+++ b/packages/app-admin-ui/client/components/NoResults.js
@@ -7,6 +7,7 @@ import { InfoIcon } from '@primer/octicons-react';
 import { colors } from '@arch-ui/theme';
 
 import { useListPagination } from '../pages/List/dataHooks';
+import { useList } from '../../components';
 
 const NoResultsWrapper = ({ children, ...props }) => (
   <div
@@ -27,7 +28,8 @@ const NoResultsWrapper = ({ children, ...props }) => (
   </div>
 );
 
-export const NoResults = ({ currentPage, filters, list, search }) => {
+export const NoResults = ({ currentPage, filters, search }) => {
+  const { list } = useList();
   const { onChange } = useListPagination();
   const onResetPage = () => onChange(1);
 

--- a/packages/app-admin-ui/client/components/UpdateItems.js
+++ b/packages/app-admin-ui/client/components/UpdateItems.js
@@ -33,7 +33,6 @@ const UpdateItems = () => {
       <UpdateManyItemsModal
         isOpen={updateModalIsVisible}
         items={selectedItems}
-        list={list}
         onClose={() => setUpdateModal(false)}
         onUpdate={handleUpdate}
       />

--- a/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
+++ b/packages/app-admin-ui/client/components/UpdateManyItemsModal.js
@@ -13,10 +13,12 @@ import Select from '@arch-ui/select';
 
 import { validateFields, handleCreateUpdateMutationError } from '../util';
 import { ErrorBoundary } from './ErrorBoundary';
+import { useList } from '../../components';
 
 const Render = ({ children }) => children();
 
-const UpdateManyModal = ({ list, items, isOpen, onUpdate, onClose }) => {
+const UpdateManyModal = ({ items, isOpen, onUpdate, onClose }) => {
+  const { list } = useList();
   const { addToast } = useToasts();
   const [updateItem, { loading }] = useMutation(list.updateManyMutation, {
     errorPolicy: 'all',

--- a/packages/app-admin-ui/client/pages/Item/ItemTitle.js
+++ b/packages/app-admin-ui/client/pages/Item/ItemTitle.js
@@ -38,7 +38,7 @@ export const ItemTitle = memo(function ItemTitle({ titleText }) {
           >
             {list.label}
           </IconButton>
-          <Search list={list} />
+          <Search />
         </div>
         {itemHeaderActions ? (
           itemHeaderActions()

--- a/packages/app-admin-ui/client/pages/Item/index.js
+++ b/packages/app-admin-ui/client/pages/Item/index.js
@@ -59,7 +59,8 @@ const getRenderableFields = memoizeOne(list =>
   list.fields.filter(({ isPrimaryKey }) => !isPrimaryKey)
 );
 
-const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
+const ItemDetails = ({ item: initialData, itemErrors, onUpdate }) => {
+  const { list } = useList();
   const [item, setItem] = useState(initialData);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [validationErrors, setValidationErrors] = useState({});
@@ -240,7 +241,7 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
   return (
     <Fragment>
       {itemHasChanged.current && !deleteConfirmed.current && <PreventNavigation />}
-      <ItemTitle id={item.id} list={list} titleText={initialData._label_} />
+      <ItemTitle id={item.id} titleText={initialData._label_} />
       <Card css={{ marginBottom: '3em', paddingBottom: 0 }}>
         <Form>
           <AutocompleteCaptor />
@@ -326,7 +327,6 @@ const ItemDetails = ({ list, item: initialData, itemErrors, onUpdate }) => {
       <DeleteItemModal
         isOpen={showDeleteModal}
         item={initialData}
-        list={list}
         onClose={closeDeleteModal}
         onDelete={onDelete}
       />
@@ -427,7 +427,6 @@ const ItemPage = () => {
             item={item}
             itemErrors={itemErrors}
             key={itemId}
-            list={list}
             onUpdate={async () => {
               const { data } = await refetch();
               return deserializeItem(list, data[list.gqlNames.itemQueryName]);

--- a/packages/app-admin-ui/client/pages/List/Filters/ActiveFilters.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/ActiveFilters.js
@@ -9,6 +9,7 @@ import { gridSize } from '@arch-ui/theme';
 import EditFilterPopout from './EditFilterPopout';
 import AddFilterPopout from './AddFilterPopout';
 import { useListFilter } from '../dataHooks';
+import { useList } from '../../../../components';
 
 export const elementOffsetStyles = {
   marginBottom: gridSize / 2,
@@ -16,7 +17,8 @@ export const elementOffsetStyles = {
   marginRight: gridSize / 2,
 };
 
-export default function ActiveFilters({ list }) {
+export default function ActiveFilters() {
+  const { list } = useList();
   const { filters, onAdd, onRemove, onRemoveAll, onUpdate } = useListFilter();
 
   return (

--- a/packages/app-admin-ui/client/pages/List/Management.js
+++ b/packages/app-admin-ui/client/pages/List/Management.js
@@ -29,21 +29,19 @@ const ListManage = ({ pageSize, totalItems, selectedItems }) => {
   const { listManageActions } = useUIHooks();
 
   return (
-    <Fragment>
-      <FlexGroup align="center">
-        <SelectedCount>
-          {`${selectedItems.length} of ${Math.min(pageSize, totalItems)} Selected`}
-        </SelectedCount>
-        {listManageActions ? (
-          listManageActions()
-        ) : (
-          <Fragment>
-            <UpdateItems />
-            <DeleteItems />
-          </Fragment>
-        )}
-      </FlexGroup>
-    </Fragment>
+    <FlexGroup align="center">
+      <SelectedCount>
+        {`${selectedItems.length} of ${Math.min(pageSize, totalItems)} Selected`}
+      </SelectedCount>
+      {listManageActions ? (
+        listManageActions()
+      ) : (
+        <Fragment>
+          <UpdateItems />
+          <DeleteItems />
+        </Fragment>
+      )}
+    </FlexGroup>
   );
 };
 

--- a/packages/app-admin-ui/client/pages/List/Search.js
+++ b/packages/app-admin-ui/client/pages/List/Search.js
@@ -13,8 +13,10 @@ import { uniformHeight } from '@arch-ui/common';
 
 import { useListSearch } from './dataHooks';
 import { elementOffsetStyles } from './Filters/ActiveFilters';
+import { useList } from '../../../components';
 
-export default function Search({ isLoading, list }) {
+export default function Search({ isLoading }) {
+  const { list } = useList();
   const { searchValue, onChange, onClear, onSubmit } = useListSearch();
   const [value, setValue] = useState(searchValue);
   const inputRef = useRef();

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -27,22 +27,26 @@ import SortPopout from './SortSelect';
 import Pagination, { getPaginationLabel } from './Pagination';
 import Search from './Search';
 import Management, { ManageToolbar } from './Management';
-import { useListFilter, useListSort, useListUrlState } from './dataHooks';
+import { useListSort, useListUrlState } from './dataHooks';
 import { captureSuspensePromises } from '@keystonejs/utils';
 import { useList } from '../../providers/List';
 import { useUIHooks } from '../../providers/Hooks';
 import CreateItem from './CreateItem';
 
 export function ListLayout(props) {
-  const { items, itemCount, queryErrors, query } = props;
+  const { query } = props;
 
-  const { list, selectedItems, setSelectedItems } = useList();
   const {
-    urlState: { currentPage, fields, pageSize, search },
+    list,
+    listData: { items, itemCount },
+    selectedItems,
+  } = useList();
+
+  const {
+    urlState: { currentPage, fields, pageSize },
   } = useListUrlState(list);
 
-  const { filters } = useListFilter();
-  const [sortBy, handleSortChange] = useListSort();
+  const [sortBy] = useListSort();
 
   const { listHeaderActions } = useUIHooks();
 
@@ -107,13 +111,11 @@ export function ListLayout(props) {
                     })}
                     ,
                   </span>
-                  {sortBy ? (
+                  {sortBy && (
                     <Fragment>
                       <span css={{ paddingLeft: '0.5ex' }}>sorted by</span>
                       <SortPopout />
                     </Fragment>
-                  ) : (
-                    ''
                   )}
                   <span css={{ paddingLeft: '0.5ex' }}>with</span>
                   <ColumnPopout
@@ -179,17 +181,6 @@ export function ListLayout(props) {
               )}
             />
           }
-          fields={fields}
-          handleSortChange={handleSortChange}
-          items={items}
-          queryErrors={queryErrors}
-          list={list}
-          onSelectChange={setSelectedItems}
-          selectedItems={selectedItems}
-          sortBy={sortBy}
-          currentPage={currentPage}
-          filters={filters}
-          search={search}
         />
       </Container>
     </main>
@@ -199,7 +190,7 @@ export function ListLayout(props) {
 const ListPage = props => {
   const {
     list,
-    listData: { items, itemCount },
+    listData: { items },
     queryErrorsParsed,
     query,
   } = useList();
@@ -273,13 +264,7 @@ const ListPage = props => {
   return (
     <Fragment>
       <DocTitle title={list.plural} />
-      <ListLayout
-        {...props}
-        items={items}
-        itemCount={itemCount}
-        query={query}
-        queryErrors={queryErrorsParsed}
-      />
+      <ListLayout {...props} query={query} />
     </Fragment>
   );
 };

--- a/packages/app-admin-ui/client/pages/List/index.js
+++ b/packages/app-admin-ui/client/pages/List/index.js
@@ -77,11 +77,11 @@ export function ListLayout(props) {
                       .filter(field => field.path !== '_label_')
                       .map(field => () => field.initCellView())
                   );
-                  return <Search list={list} isLoading={query.loading} />;
+                  return <Search isLoading={query.loading} />;
                 }}
               </Render>
             </Suspense>
-            <ActiveFilters list={list} />
+            <ActiveFilters />
           </div>
 
           <ManageToolbar isVisible css={{ marginLeft: 2 }}>


### PR DESCRIPTION
Removed
- Removed `onDelete` prop from `ListTable` and `ListRow` (was called in `ListRow::handleDelete`, but no callback was ever given)
- Removed unnecessary wrapping `Fragment` from `ListManage`

List view components
- Stop passing `items`, `itemCount`, and `queryError` props to `ListLayout` (now fetched via hooks)
- Stop passing `fields`, `items`, `queryErrors`, `list`, `onSelectChange`, `selectedItems`, `currentPage`, `filters`, and `search` to `ListTable` (now fetched via hooks)
- Stop passing `list`, `fields`, and `onSelectChange` to `ListRow` (now fetched via hooks)
- Stop passing `handleSortChange` to `SortLink` (now fetched via hook)

Also stop passing `list` to the following (now fetched via hook)
- `DeleteItemModal`
- `DeleteManyItemsModal`
- `UpdateManyItemsModal`
- `NoResults`
- `Search`
- `ItemDetails`
- `ItemTitle` (this one was unused)
- `ActiveFilters`
