### PR TITLE
Add cache hints to extended graphql queries

### DIFF
--- a/.changeset/many-laws-compare.md
+++ b/.changeset/many-laws-compare.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/keystone': patch
+---
+
+Added the ability for  static cache hints to be added to custom queries generated using `keystone.extendGraphQLSchema()`

--- a/.changeset/many-laws-compare.md
+++ b/.changeset/many-laws-compare.md
@@ -1,6 +1,6 @@
 ---
 '@keystonejs/api-tests': patch
-'@keystonejs/keystone': patch
+'@keystonejs/keystone': minor
 ---
 
 Added the ability for  static cache hints to be added to custom queries generated using `keystone.extendGraphQLSchema()`

--- a/.changeset/many-laws-compare.md
+++ b/.changeset/many-laws-compare.md
@@ -3,4 +3,4 @@
 '@keystonejs/keystone': minor
 ---
 
-Added the ability for  static cache hints to be added to custom queries generated using `keystone.extendGraphQLSchema()`
+Added the ability for static cache hints to be added to custom queries generated using `keystone.extendGraphQLSchema()`

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -59,6 +59,21 @@ function setupKeystone(adapterName) {
           };
         },
       });
+
+      keystone.extendGraphQLSchema({
+        queries: [
+          {
+            schema: `customQuery: String`,
+            resolver: async () => {
+              return 'Hello World';
+            },
+            cacheHint: {
+              scope: 'PUBLIC',
+              maxAge: 100,
+            },
+          },
+        ],
+      });
     },
   });
 }
@@ -310,6 +325,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('deletePost');
+        })
+      );
+
+      test(
+        'extendedSchema',
+        runner(setupKeystone, async ({ app, create }) => {
+          await addFixtures(create);
+
+          // Basic query
+          let { data, errors, res } = await networkedGraphqlRequest({
+            app,
+            query: `
+              query {
+                customQuery
+              }
+            `,
+          });
+
+          expect(errors).toBe(undefined);
+          expect(data).toHaveProperty('customQuery');
+          expect(res.headers['cache-control']).toBe('max-age=100, public');
         })
       );
     });

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -356,6 +356,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(res.headers['cache-control']).toBe('max-age=100, public');
         })
       );
+
+      test(
+        'extendGraphQLSchemaMutations',
+        runner(setupKeystone, async ({ app, create }) => {
+          await addFixtures(create);
+
+          // Mutation responses shouldn't be cached.
+          // Here's a smoke test to make sure they still work.
+          let { data, errors } = await networkedGraphqlRequest({
+            app,
+            query: `
+              mutation {
+                triple(x: 3)
+              }
+            `,
+          });
+
+          expect(errors).toBe(undefined);
+          expect(data).toHaveProperty('triple');
+        })
+      );
     });
   })
 );

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -362,7 +362,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         runner(setupKeystone, async ({ app, create }) => {
           await addFixtures(create);
 
-          // Basic mutation which shouldn't be cached
+          // Basic mutation
+          // Custom mutations (and subscriptions) can't add cache hints
           let { data, errors, res } = await networkedGraphqlRequest({
             app,
             query: `

--- a/api-tests/queries/cache-hints.test.js
+++ b/api-tests/queries/cache-hints.test.js
@@ -343,7 +343,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             app,
             query: `
               query {
-                double(2) {
+                double(x: 2) {
                   original
                   double
                 }
@@ -354,28 +354,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('double');
           expect(res.headers['cache-control']).toBe('max-age=100, public');
-        })
-      );
-
-      test(
-        'extendGraphQLSchemaMutations',
-        runner(setupKeystone, async ({ app, create }) => {
-          await addFixtures(create);
-
-          // Basic mutation
-          // Custom mutations (and subscriptions) can't add cache hints
-          let { data, errors, res } = await networkedGraphqlRequest({
-            app,
-            query: `
-              mutation {
-                triple(3)
-              }
-            `,
-          });
-
-          expect(errors).toBe(undefined);
-          expect(data).toHaveProperty('triple');
-          expect(res.headers['cache-control']).toBe(undefined);
         })
       );
     });

--- a/docs/api/create-list.md
+++ b/docs/api/create-list.md
@@ -90,69 +90,6 @@ keystone.createList('Todo', {
 });
 ```
 
-### `cacheHint`
-
-HTTP cache hint configuration for list. (See [Apollo docs](https://www.apollographql.com/docs/apollo-server/performance/caching/) and [HTTP spec](https://tools.ietf.org/html/rfc7234#section-5.2.2).)
-
-- `scope`: `'PUBLIC'` or `'PRIVATE'` (corresponds to `public` and `private` `Cache-Control` directives)
-- `maxAge`: maximum age (in seconds) that the result should be cacheable for
-
-Cache headers need to be enabled in the `GraphQLApp` instance:
-
-```javascript
-const app = new GraphQLApp({
-  apollo: {
-    tracing: true,
-    cacheControl: {
-      defaultMaxAge: 3600,
-    },
-  },
-});
-```
-
-See also the [Apollo cache control doc](https://github.com/apollographql/apollo-server/tree/master/packages/apollo-cache-control).
-
-`PRIVATE` is a recommendation that browsers should cache the result, but forbids intermediate caches (like CDNs or corporate proxies) from storing it. It needs to be used whenever the result depends on the logged in user (including secrets and user-specific content like profile information). If the result could be different when a user logs in, `PRIVATE` should still be used even if no user is logged in.
-
-```javascript
-keystone.createList('Post', {
-  fields: {
-    title: { type: Text },
-  },
-  cacheHint: {
-    scope: 'PUBLIC',
-    maxAge: 3600,
-  },
-});
-```
-
-Cache hints can be dynamically returned from a function that takes an object with these members:
-
-- `results`: an array of query results
-- `operationName`: the name of the GraphQL operation that generated the results
-- `meta`: boolean value that's true for a meta (count) query
-
-```javascript
-keystone.createList('Post', {
-  fields: {
-    title: { type: Text },
-  },
-  cacheHint: ({ meta }) => {
-    if (meta) {
-      return {
-        scope: 'PUBLIC',
-        maxAge: 3600,
-      };
-    } else {
-      return {
-        scope: 'PRIVATE',
-        maxAge: 60,
-      };
-    }
-  },
-});
-```
-
 ### `fields`
 
 Defines the fields to use in a list.

--- a/docs/guides/cache-hints.md
+++ b/docs/guides/cache-hints.md
@@ -10,7 +10,7 @@ Automatically set HTTP cache headers and save full responses in a cache. For mor
 
 ### Setting a default `maxAge`
 
-By default, all queries and mutations keystone generates have a `maxAge` of 0 (ie, uncacheable). You can update this behaviour by specifying a default max age when you create your `GraphQLApp`.
+By default, all queries and mutations keystone generates have a `maxAge` of 0 (ie, uncacheable). You can update this behaviour by specifying a default max age when creating the `GraphQLApp`.
 
 ```javascript
 const app = new GraphQLApp({
@@ -24,14 +24,22 @@ const app = new GraphQLApp({
 
 Please see the [Apollo docs](https://www.apollographql.com/docs/apollo-server/performance/caching/#setting-a-default-maxage) for more information.
 
-### Lists
+### Lists / fields
 
-Cache hints can be set on keystone lists like so:
+Cache hints can be set on lists and fields like so:
 
 ```javascript
 keystone.createList('Post', {
   fields: {
-    title: { type: Text },
+    title: {
+      type: Text,
+    },
+    description: {
+      type: Text,
+      cacheHint: {
+        maxAge: 80,
+      },
+    },
   },
   cacheHint: {
     scope: 'PUBLIC',
@@ -40,9 +48,7 @@ keystone.createList('Post', {
 });
 ```
 
-#### Dynamic cache hints
-
-Cache hints can be dynamically returned from a function that takes an object with these members:
+Only static cache hints are supported at the field level, but for lists cache hints can be dynamically returned from a function that takes an object with these members:
 
 - `results`: an array of query results
 - `operationName`: the name of the GraphQL operation that generated the results
@@ -71,7 +77,7 @@ keystone.createList('Post', {
 
 ### Custom queries
 
-Cache hints can be set for custom queries generated from the `keystone.extendGraphQLSchema()` method
+Static cache hints can be set for custom queries generated using the `keystone.extendGraphQLSchema()` method.
 
 ```javascript
 keystone.extendGraphQLSchema({

--- a/docs/guides/cache-hints.md
+++ b/docs/guides/cache-hints.md
@@ -1,0 +1,97 @@
+<!--[meta]
+section: guides
+title: Cache hints
+subSection: advanced
+[meta]-->
+
+# Cache hints
+
+Automatically set HTTP cache headers and save full responses in a cache. For more information please see the [Apollo docs](https://www.apollographql.com/docs/apollo-server/performance/caching/) and the [HTTP spec](https://tools.ietf.org/html/rfc7234#section-5.2.2/).
+
+### Setting a default `maxAge`
+
+By default, all queries and mutations keystone generates have a `maxAge` of 0 (ie, uncacheable). You can update this behaviour by specifying a default max age when you create your `GraphQLApp`.
+
+```javascript
+const app = new GraphQLApp({
+  apollo: {
+    cacheControl: {
+      defaultMaxAge: 3600,
+    },
+  },
+});
+```
+
+Please see the [Apollo docs](https://www.apollographql.com/docs/apollo-server/performance/caching/#setting-a-default-maxage) for more information.
+
+### Lists
+
+Cache hints can be set on keystone lists like so:
+
+```javascript
+keystone.createList('Post', {
+  fields: {
+    title: { type: Text },
+  },
+  cacheHint: {
+    scope: 'PUBLIC',
+    maxAge: 3600,
+  },
+});
+```
+
+#### Dynamic cache hints
+
+Cache hints can be dynamically returned from a function that takes an object with these members:
+
+- `results`: an array of query results
+- `operationName`: the name of the GraphQL operation that generated the results
+- `meta`: boolean value that's true for a meta (count) query
+
+```javascript
+keystone.createList('Post', {
+  fields: {
+    title: { type: Text },
+  },
+  cacheHint: ({ meta }) => {
+    if (meta) {
+      return {
+        scope: 'PUBLIC',
+        maxAge: 3600,
+      };
+    } else {
+      return {
+        scope: 'PRIVATE',
+        maxAge: 60,
+      };
+    }
+  },
+});
+```
+
+### Custom queries
+
+Cache hints can be set for custom queries generated from the `keystone.extendGraphQLSchema()` method
+
+```javascript
+keystone.extendGraphQLSchema({
+  types: [{ type: 'type MyType { original: Int, double: Float }' }],
+  queries: [
+    {
+      schema: 'double(x: Int): MyType',
+      resolver: (_, { x }) => ({ original: x, double: 2.0 * x }),
+      cacheHint: {
+        scope: 'PUBLIC',
+        maxAge: 100,
+      },
+    },
+  ],
+});
+```
+
+### Options
+
+- `scope`: `'PUBLIC'` or `'PRIVATE'` (corresponds to `public` and `private` `Cache-Control` directives)
+- `maxAge`: maximum age (in seconds) that the result should be cacheable for
+
+`PRIVATE` is a recommendation that browsers should cache the result, but forbids intermediate caches (like CDNs or corporate proxies) from storing it. It needs to be used whenever the result depends on the logged in user (including secrets and user-specific content like profile information). If the result could be different when a user logs in, `PRIVATE` should still be used even if no user is logged in.

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -57,7 +57,7 @@ Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/
 
 ## Using reverse proxies
 
-It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](<https://en.wikipedia.org/wiki/Slowloris_(computer_security)>). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
+It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
 
 ```javascript title=index.js
 module.exports = {

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -45,7 +45,7 @@ This option can be set using the [sessionStore](/packages/keystone/README.md#ses
 
 ## Caching
 
-Improve performance and responsiveness by adding cache hints to your [lists](/docs/api/create-list.md#cachehint) and [fields](/packages/fields/README.md#cachehint).
+Improve performance and responsiveness by adding cache hints to your [lists](/docs/api/create-list.md#cachehint), [fields](/packages/fields/README.md#cachehint) and [custom queries](/guides/cache-hints).
 
 ## Access control
 
@@ -57,7 +57,7 @@ Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/
 
 ## Using reverse proxies
 
-It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
+It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](<https://en.wikipedia.org/wiki/Slowloris_(computer_security)>). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
 
 ```javascript title=index.js
 module.exports = {

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -45,7 +45,7 @@ This option can be set using the [sessionStore](/packages/keystone/README.md#ses
 
 ## Caching
 
-Improve performance and responsiveness by adding cache hints to your [lists](/docs/api/create-list.md#cachehint), [fields](/packages/fields/README.md#cachehint) and [custom queries](/guides/cache-hints).
+Improve performance and responsiveness by adding [cache hints](/docs/guides/cache-hints.md) to your lists, fields and custom queries.
 
 ## Access control
 

--- a/packages/keystone/lib/providers/custom.js
+++ b/packages/keystone/lib/providers/custom.js
@@ -116,7 +116,7 @@ class CustomProvider {
           // Allow cache hints to specified on custom queries/mutations/subscriptions
           if (cacheHint) {
             if (typeof cacheHint !== 'object') {
-              throw new Error(`cacheHint must be an object or function`);
+              throw new Error(`cacheHint must be an object`);
             }
             if (info && info.cacheControl) {
               info.cacheControl.setCacheHint(cacheHint);

--- a/packages/keystone/lib/providers/custom.js
+++ b/packages/keystone/lib/providers/custom.js
@@ -113,8 +113,8 @@ class CustomProvider {
 
       const resolve = async (item, args, context, info) => {
         if (resolver) {
-          // Allow cache hints to specified on custom queries/mutations/subscriptions
-          if (cacheHint) {
+          // Allow cache hints to be added to custom queries
+          if (type === 'query' && cacheHint) {
             if (typeof cacheHint !== 'object') {
               throw new Error(`cacheHint must be an object`);
             }


### PR DESCRIPTION
This PR adds the ability to add static cache hints to custom queries generated using `keystone.extendGraphQLSchema()`. Currently only cache hints are supported for lists and fields.

I've also updated the documentation for cache hints. Rather than the docs for cache hints living in `API > Creating lists > cacheHint` they now have their own page under `Guides`. See here: https://deploy-preview-3274--v5keystonejs.netlify.app/guides/cache-hints