### PR TITLE
Remove keystone.registerSchema()

### DIFF
--- a/.changeset/real-zoos-kick.md
+++ b/.changeset/real-zoos-kick.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': major
+---
+
+Removed `keystone.registerSchema()`.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -160,10 +160,9 @@ Please note: We use these internally but provide no support or assurance if used
 
 | Method                | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
-| `dumpSchema`          | Dump schema to a string.                                                       |
+| `dumpSchema`          | Dump schema to a string.                                                     |
 | `getTypeDefs`         | Remove from user documentation?                                              |
 | `getResolvers`        | Remove from user documentation?                                              |
-| `registerSchema`      | Remove from user documentation?                                              |
 | `createItem`          | Remove from user documentation?                                              |
 | `getAdminMeta`        | Remove from user documentation?                                              |
 -->

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -478,7 +478,7 @@ module.exports = class Keystone {
       formatError,
       ...apolloConfig,
     });
-    this.registerSchema(schemaName, server.schema);
+    this._schemas[schemaName] = server.schema;
 
     return server;
   }
@@ -519,13 +519,6 @@ module.exports = class Keystone {
         list => list.views
       ),
     };
-  }
-
-  // It's not Keystone core's responsibility to create an executable schema, but
-  // once one is, Keystone wants to be able to expose the ability to query that
-  // schema, so this function enables other modules to register that function.
-  registerSchema(schemaName, schema) {
-    this._schemas[schemaName] = schema;
   }
 
   getTypeDefs({ schemaName }) {


### PR DESCRIPTION
This was only a public method to allow `createApolloServer` to use it, but now that `createApolloServer` is on the keystone class this method can go away.