### PR TITLE
Use a consistent if (this.many) {} else {} pattern in relationships

### DIFF
--- a/.changeset/wicked-bikes-fry.md
+++ b/.changeset/wicked-bikes-fry.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Refactored relationship internals. No functional changes.

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -63,9 +63,9 @@ export class Relationship extends Implementation {
         `${this.path}(${filterArgs}): [${refList.gqlNames.outputTypeName}!]!`,
         this.withMeta ? `_${this.path}Meta(${filterArgs}): _QueryMeta` : '',
       ];
+    } else {
+      return [`${this.path}: ${refList.gqlNames.outputTypeName}`];
     }
-
-    return [`${this.path}: ${refList.gqlNames.outputTypeName}`];
   }
 
   extendAdminMeta(meta) {
@@ -103,8 +103,27 @@ export class Relationship extends Implementation {
       return [];
     }
 
-    // to-one relationships are much easier to deal with.
-    if (!this.many) {
+    if (this.many) {
+      return {
+        [this.path]: (item, args, context, info) => {
+          return refList.listQuery(args, context, info.fieldName, info, {
+            fromList: this.getListByKey(this.listKey),
+            fromId: item.id,
+            fromField: this.path,
+          });
+        },
+
+        ...(this.withMeta && {
+          [`_${this.path}Meta`]: (item, args, context, info) => {
+            return refList.listQueryMeta(args, context, info.fieldName, info, {
+              fromList: this.getListByKey(this.listKey),
+              fromId: item.id,
+              fromField: this.path,
+            });
+          },
+        }),
+      };
+    } else {
       return {
         [this.path]: (item, _, context, info) => {
           // No ID set, so we return null for the value
@@ -119,26 +138,6 @@ export class Relationship extends Implementation {
         },
       };
     }
-
-    return {
-      [this.path]: (item, args, context, info) => {
-        return refList.listQuery(args, context, info.fieldName, info, {
-          fromList: this.getListByKey(this.listKey),
-          fromId: item.id,
-          fromField: this.path,
-        });
-      },
-
-      ...(this.withMeta && {
-        [`_${this.path}Meta`]: (item, args, context, info) => {
-          return refList.listQueryMeta(args, context, info.fieldName, info, {
-            fromList: this.getListByKey(this.listKey),
-            fromId: item.id,
-            fromField: this.path,
-          });
-        },
-      }),
-    };
   }
 
   /**
@@ -267,33 +266,34 @@ export class Relationship extends Implementation {
         }
       `,
       ];
-    }
-    if (refList.access[schemaName].create) {
-      operations.push(`# Provide data to create a new ${refList.key}.
+    } else {
+      if (refList.access[schemaName].create) {
+        operations.push(`# Provide data to create a new ${refList.key}.
         create: ${refList.gqlNames.createInputName}`);
-    }
-    operations.push(
-      `# Provide a filter to link to an existing ${refList.key}.
+      }
+      operations.push(
+        `# Provide a filter to link to an existing ${refList.key}.
         connect: ${refList.gqlNames.whereUniqueInputName}`,
-      `# Provide a filter to remove to an existing ${refList.key}.
+        `# Provide a filter to remove to an existing ${refList.key}.
         disconnect: ${refList.gqlNames.whereUniqueInputName}`,
-      `# Remove the existing ${refList.key} (if any).
+        `# Remove the existing ${refList.key} (if any).
         disconnectAll: Boolean`
-    );
-    return [
-      `input ${refList.gqlNames.relateToOneInputName} {
+      );
+      return [
+        `input ${refList.gqlNames.relateToOneInputName} {
           ${operations.join('\n')}
         }
       `,
-    ];
+      ];
+    }
   }
   get gqlUpdateInputFields() {
     const { refList } = this.tryResolveRefList();
     if (this.many) {
       return [`${this.path}: ${refList.gqlNames.relateToManyInputName}`];
+    } else {
+      return [`${this.path}: ${refList.gqlNames.relateToOneInputName}`];
     }
-
-    return [`${this.path}: ${refList.gqlNames.relateToOneInputName}`];
   }
   get gqlCreateInputFields() {
     return this.gqlUpdateInputFields;


### PR DESCRIPTION
This change makes it so the relationship code always uses

```
if (this.many) {
...
} else {
...
}
```

This makes it much easier to quickly find the the many-vs-one code when moving around this code.