### PR TITLE
Allow ENABLE_DEV_FEATURES to be false in dev

### DIFF
--- a/.changeset/new-buckets-jog.md
+++ b/.changeset/new-buckets-jog.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Fixed a bug where dev features would show in development even if ENABLE_DEV_FEATURES was explicitly set to false.

--- a/packages/app-admin-ui/server/env.js
+++ b/packages/app-admin-ui/server/env.js
@@ -1,4 +1,8 @@
 exports.mode = process.env.NODE_ENV === 'production' ? 'production' : 'development';
 
 exports.enableDevFeatures =
-  process.env.ENABLE_DEV_FEATURES === 'true' ? true : exports.mode !== 'production';
+  process.env.ENABLE_DEV_FEATURES === 'true'
+    ? true
+    : process.env.ENABLE_DEV_FEATURES === 'false'
+    ? false
+    : exports.mode !== 'production';


### PR DESCRIPTION
Fixed a bug where dev features would show in development even if ENABLE_DEV_FEATURES was explicitly set to false.
