### PR TITLE
Fix isUnique for DateTime on MongooseAdapter

### DIFF
--- a/.changeset/dry-balloons-tell.md
+++ b/.changeset/dry-balloons-tell.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed a bug on `MongooseAdapter` where `DateTime` fields did not respect the `isUnique` flag.

--- a/.changeset/sixty-brooms-work.md
+++ b/.changeset/sixty-brooms-work.md
@@ -1,0 +1,13 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/field-content': patch
+'@keystonejs/fields-authed-relationship': patch
+'@keystonejs/fields-auto-increment': patch
+'@keystonejs/fields-datetime-utc': patch
+'@keystonejs/fields-markdown': patch
+'@keystonejs/fields-mongoid': patch
+'@keystonejs/fields-wysiwyg-tinymce': patch
+'@keystonejs/fields': patch
+---
+
+Added more robust checks for support of the `isUnique` flag config. Added tests for this flag.

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -1,85 +1,132 @@
+const globby = require('globby');
 const { Text } = require('@keystonejs/fields');
 const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
 
-function setupKeystone(adapterName) {
-  return setupServer({
-    adapterName,
-    createLists: keystone => {
-      keystone.createList('User', {
-        fields: {
-          username: { type: Text },
-          email: { type: Text, isUnique: true },
-        },
-      });
-    },
-  });
-}
-multiAdapterRunners().map(({ runner, adapterName }) =>
-  describe(`Adapter: ${adapterName}`, () => {
-    describe('uniqueness', () => {
-      test(
-        'uniqueness is enforced over multiple mutations',
-        runner(setupKeystone, async ({ keystone }) => {
-          const { errors } = await graphqlRequest({
-            keystone,
-            query: `
-        mutation {
-          createUser(data: { email: "hi@test.com" }) { id }
-        }
-      `,
+describe('Test isUnique flag for all field types', () => {
+  const testModules = globby.sync(`packages/**/src/**/test-fixtures.js`, { absolute: true });
+  multiAdapterRunners().map(({ runner, adapterName, after }) =>
+    describe(`Adapter: ${adapterName}`, () => {
+      testModules
+        .map(require)
+        .filter(({ supportsUnique }) => supportsUnique)
+        .forEach(mod => {
+          describe(`Test isUnique flag for module: ${mod.name}`, () => {
+            const keystoneTestWrapper = testFn =>
+              runner(
+                () =>
+                  setupServer({
+                    adapterName,
+                    createLists: keystone => {
+                      keystone.createList('Test', {
+                        fields: {
+                          name: { type: Text },
+                          testField: { type: mod.type, isUnique: true, ...(mod.fieldConfig || {}) },
+                        },
+                      });
+                    },
+                  }),
+                testFn
+              );
+            test(
+              'uniqueness is enforced over multiple mutations',
+              keystoneTestWrapper(async ({ keystone }) => {
+                const { errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  }
+                `,
+                });
+                expect(errors).toBe(undefined);
+
+                const { errors: errors2 } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  }
+                `,
+                });
+
+                expect(errors2).toHaveProperty('0.message');
+                expect(errors2[0].message).toEqual(
+                  expect.stringMatching(/duplicate key|to be unique/)
+                );
+              })
+            );
+
+            test(
+              'uniqueness is enforced over single mutation',
+              keystoneTestWrapper(async ({ keystone }) => {
+                const { errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    foo: createTest(data: { testField: ${mod.exampleValue} }) { id }
+                    bar: createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  }
+                `,
+                });
+
+                expect(errors).toHaveProperty('0.message');
+                expect(errors[0].message).toEqual(
+                  expect.stringMatching(/duplicate key|to be unique/)
+                );
+              })
+            );
+
+            test(
+              'Configuring uniqueness on one field does not affect others',
+              keystoneTestWrapper(async ({ keystone }) => {
+                const { data, errors } = await graphqlRequest({
+                  keystone,
+                  query: `
+                  mutation {
+                    foo: createTest(data: { testField: ${mod.exampleValue}, name: "jess" }) { id }
+                    bar: createTest(data: { testField: ${mod.exampleValue2}, name: "jess" }) { id }
+                  }
+                `,
+                });
+
+                expect(errors).toBe(undefined);
+                expect(data).toHaveProperty('foo.id');
+                expect(data).toHaveProperty('bar.id');
+              })
+            );
           });
-          expect(errors).toBe(undefined);
+        });
 
-          const { errors: errors2 } = await graphqlRequest({
-            keystone,
-            query: `
-        mutation {
-          createUser(data: { email: "hi@test.com" }) { id }
-        }
-      `,
+      testModules
+        .map(require)
+        .filter(({ supportsUnique }) => !supportsUnique)
+        .forEach(mod => {
+          describe(`Test isUnique flag for module: ${mod.name}`, () => {
+            test('Ensure non-supporting fields throw an error', async () => {
+              // Try to create a thing and have it fail
+              let erroredOut = false;
+              try {
+                await setupServer({
+                  adapterName,
+                  createLists: keystone => {
+                    keystone.createList('Test', {
+                      fields: {
+                        name: { type: Text },
+                        testField: { type: mod.type, isUnique: true, ...(mod.fieldConfig || {}) },
+                      },
+                    });
+                  },
+                });
+              } catch (error) {
+                expect(error.message).toMatch('isUnique is not a supported option for field type');
+                erroredOut = true;
+              } finally {
+                after({ disconnect: () => {} });
+              }
+              expect(erroredOut).toEqual(true);
+            });
           });
-
-          expect(errors2).toHaveProperty('0.message');
-          expect(errors2[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
-        })
-      );
-
-      test(
-        'uniqueness is enforced over single mutation',
-        runner(setupKeystone, async ({ keystone }) => {
-          const { errors } = await graphqlRequest({
-            keystone,
-            query: `
-        mutation {
-          foo: createUser(data: { email: "hi@test.com" }) { id }
-          bar: createUser(data: { email: "hi@test.com" }) { id }
-        }
-      `,
-          });
-
-          expect(errors).toHaveProperty('0.message');
-          expect(errors[0].message).toEqual(expect.stringMatching(/duplicate key|to be unique/));
-        })
-      );
-
-      test(
-        'Configuring uniqueness on one field does not affect others',
-        runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
-            query: `
-        mutation {
-          foo: createUser(data: { email: "1", username: "jess" }) { id }
-          bar: createUser(data: { email: "2", username: "jess" }) { id }
-        }
-      `,
-          });
-
-          expect(errors).toBe(undefined);
-          expect(data).toHaveProperty('foo.id');
-          expect(data).toHaveProperty('bar.id');
-        })
-      );
-    });
-  })
-);
+        });
+    })
+  );
+});

--- a/packages/field-content/src/test-fixtures.skip.js
+++ b/packages/field-content/src/test-fixtures.skip.js
@@ -1,0 +1,6 @@
+// We don't currently have uniqueness tests for Relationship field types
+import { Content } from './index';
+
+export const name = 'Content';
+export { Content as type };
+export const supportsUnique = true;

--- a/packages/fields-authed-relationship/src/test-fixtures.skip.js
+++ b/packages/fields-authed-relationship/src/test-fixtures.skip.js
@@ -1,0 +1,6 @@
+// We don't currently have uniqueness tests for Relationship field types
+import { AuthedRelationship } from './index';
+
+export const name = 'AuthedRelationship';
+export { AuthedRelationship as type };
+export const supportsUnique = true;

--- a/packages/fields-auto-increment/src/Implementation.js
+++ b/packages/fields-auto-increment/src/Implementation.js
@@ -23,6 +23,10 @@ export class AutoIncrementImplementation extends Implementation {
     this.gqlType = ['ID', 'Int'].includes(gqlType) ? gqlType : this.isPrimaryKey ? 'ID' : 'Int';
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ${this.gqlType}`];
   }

--- a/packages/fields-auto-increment/src/test-fixtures.skip.js
+++ b/packages/fields-auto-increment/src/test-fixtures.skip.js
@@ -1,0 +1,7 @@
+// The AutoIncrement field type behaves in a way that isn't supported by
+// our current uniqueness tests.
+import { AutoIncrement } from './index';
+
+export const name = 'AutoIncrement';
+export { AutoIncrement as type };
+export const supportsUnique = true;

--- a/packages/fields-datetime-utc/src/Implementation.js
+++ b/packages/fields-datetime-utc/src/Implementation.js
@@ -8,6 +8,11 @@ export class DateTimeUtcImplementation extends Implementation {
     super(...arguments);
     this.isOrderable = true;
   }
+
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: String`];
   }

--- a/packages/fields-datetime-utc/src/test-fixtures.js
+++ b/packages/fields-datetime-utc/src/test-fixtures.js
@@ -1,0 +1,7 @@
+import { DateTimeUtc } from './index';
+
+export const name = 'DateTimeUtc';
+export { DateTimeUtc as type };
+export const exampleValue = '"1990-12-31T12:34:56.789"';
+export const exampleValue2 = '"2000-01-20T00:08:00.000"';
+export const supportsUnique = true;

--- a/packages/fields-markdown/src/test-fixtures.js
+++ b/packages/fields-markdown/src/test-fixtures.js
@@ -1,0 +1,7 @@
+import { Markdown } from './index';
+
+export const name = 'Markdown';
+export { Markdown as type };
+export const exampleValue = '"foo"';
+export const exampleValue2 = '"bar"';
+export const supportsUnique = true;

--- a/packages/fields-mongoid/src/Implementation.js
+++ b/packages/fields-mongoid/src/Implementation.js
@@ -3,6 +3,10 @@ import { MongooseFieldAdapter } from '@keystonejs/adapter-mongoose';
 import { KnexFieldAdapter } from '@keystonejs/adapter-knex';
 
 export class MongoIdImplementation extends Implementation {
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ID`];
   }

--- a/packages/fields-mongoid/src/test-fixtures.js
+++ b/packages/fields-mongoid/src/test-fixtures.js
@@ -1,0 +1,7 @@
+import { MongoId } from './index';
+
+export const name = 'MongoId';
+export { MongoId as type };
+export const exampleValue = '"123456781234567812345678"';
+export const exampleValue2 = '"123456781234567812345679"';
+export const supportsUnique = true;

--- a/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
+++ b/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
@@ -1,0 +1,7 @@
+import { Wysiwyg } from './';
+
+export const name = 'Wysiwyg';
+export { Wysiwyg as type };
+export const exampleValue = '"foo"';
+export const exampleValue2 = '"bar"';
+export const supportsUnique = true;

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -30,6 +30,12 @@ class Field {
     this.getListByKey = getListByKey;
     this.listKey = listKey;
     this.label = label || inflection.humanize(inflection.underscore(path));
+    if (this.config.isUnique && !this._supportsUnique) {
+      throw new Error(
+        `isUnique is not a supported option for field type ${this.constructor.name} (${this.path})`
+      );
+    }
+
     this.adapter = listAdapter.newFieldAdapter(
       fieldAdapterClass,
       this.constructor.name,
@@ -49,6 +55,12 @@ class Field {
       defaultAccess,
       access,
     });
+  }
+
+  // By default we assume that fields do not support unique constraints.
+  // Fields should override this method if they want to support uniqueness.
+  get _supportsUnique() {
+    return false;
   }
 
   parseFieldAccess(args) {

--- a/packages/fields/src/types/CalendarDay/Implementation.js
+++ b/packages/fields/src/types/CalendarDay/Implementation.js
@@ -33,6 +33,10 @@ export class CalendarDay extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: String`];
   }

--- a/packages/fields/src/types/CalendarDay/test-fixtures.js
+++ b/packages/fields/src/types/CalendarDay/test-fixtures.js
@@ -5,6 +5,8 @@ import CalendarDay from './';
 export const name = 'CalendarDay';
 export { CalendarDay as type };
 export const exampleValue = '"1990-12-31"';
+export const exampleValue2 = '"2000-12-31"';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Checkbox/Implementation.js
+++ b/packages/fields/src/types/Checkbox/Implementation.js
@@ -8,6 +8,10 @@ export class Checkbox extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: Boolean`];
   }
@@ -40,7 +44,7 @@ export class KnexCheckboxInterface extends KnexFieldAdapter {
     super(...arguments);
 
     // Error rather than ignoring invalid config
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The Checkbox field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/Checkbox/test-fixtures.js
+++ b/packages/fields/src/types/Checkbox/test-fixtures.js
@@ -5,6 +5,7 @@ import Checkbox from './';
 export const name = 'Checkbox';
 export { Checkbox as type };
 export const exampleValue = 'true';
+export const supportsUnique = false;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/CloudinaryImage/test-fixtures.js
+++ b/packages/fields/src/types/CloudinaryImage/test-fixtures.js
@@ -1,0 +1,6 @@
+import CloudinaryImage from './';
+
+export const name = 'CloudinaryImage';
+export { CloudinaryImage as type };
+export const supportsUnique = false;
+export const skipRequiredTest = true;

--- a/packages/fields/src/types/Color/test-fixtures.js
+++ b/packages/fields/src/types/Color/test-fixtures.js
@@ -1,0 +1,7 @@
+import Color from './';
+
+export const name = 'Color';
+export { Color as type };
+export const exampleValue = '"red"';
+export const exampleValue2 = '"green"';
+export const supportsUnique = true;

--- a/packages/fields/src/types/DateTime/Implementation.js
+++ b/packages/fields/src/types/DateTime/Implementation.js
@@ -15,6 +15,10 @@ class _DateTime extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: DateTime`];
   }
@@ -164,7 +168,7 @@ export class MongoDateTimeInterface extends CommonDateTimeInterface(MongooseFiel
       // attributes to make it through to the pre-hooks.
       [this.path]: { type: String, ...mongooseOptions },
       // These are the actual fields we care about storing in the database.
-      [this.utcPath]: { type: Date, ...mongooseOptions },
+      [this.utcPath]: this.mergeSchemaOptions({ type: Date }, this.config),
       [this.offsetPath]: { type: String, ...mongooseOptions },
     });
   }

--- a/packages/fields/src/types/DateTime/test-fixtures.js
+++ b/packages/fields/src/types/DateTime/test-fixtures.js
@@ -5,6 +5,8 @@ import DateTime from './';
 export const name = 'DateTime';
 export { DateTime as type };
 export const exampleValue = '"1990-12-31T12:34:56.789+01:23"';
+export const exampleValue2 = '"2000-01-20T00:08:00.000+10:00"';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -10,6 +10,10 @@ export class Decimal extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: String`];
   }

--- a/packages/fields/src/types/Decimal/test-fixtures.js
+++ b/packages/fields/src/types/Decimal/test-fixtures.js
@@ -5,6 +5,8 @@ import Decimal from './';
 export const name = 'Decimal';
 export { Decimal as type };
 export const exampleValue = '"6.28"';
+export const exampleValue2 = '"6.283"';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -21,6 +21,9 @@ export class File extends Implementation {
       throw new Error(`No file adapter provided for File field.`);
     }
   }
+  get _supportsUnique() {
+    return false;
+  }
 
   gqlOutputFields() {
     return [`${this.path}: ${this.graphQLOutputType}`];
@@ -151,7 +154,7 @@ export class KnexFileInterface extends CommonFileInterface(KnexFieldAdapter) {
 
     // Error rather than ignoring invalid config
     // We totally can index these values, it's just not trivial. See issue #1297
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The File field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/File/test-fixtures.js
+++ b/packages/fields/src/types/File/test-fixtures.js
@@ -1,0 +1,6 @@
+import File from './';
+
+export const name = 'File';
+export { File as type };
+export const supportsUnique = false;
+export const skipRequiredTest = true;

--- a/packages/fields/src/types/Float/Implementation.js
+++ b/packages/fields/src/types/Float/Implementation.js
@@ -8,6 +8,10 @@ export class Float extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: Float`];
   }

--- a/packages/fields/src/types/Float/test-fixtures.js
+++ b/packages/fields/src/types/Float/test-fixtures.js
@@ -5,6 +5,8 @@ import Float from '.';
 export const name = 'Float';
 export { Float as type };
 export const exampleValue = '6.28';
+export const exampleValue2 = '6.283';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -8,6 +8,10 @@ export class Integer extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: Int`];
   }

--- a/packages/fields/src/types/Integer/test-fixtures.js
+++ b/packages/fields/src/types/Integer/test-fixtures.js
@@ -5,6 +5,8 @@ import Integer from './';
 export const name = 'Integer';
 export { Integer as type };
 export const exampleValue = '37';
+export const exampleValue2 = '38';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Location/Implementation.js
+++ b/packages/fields/src/types/Location/Implementation.js
@@ -27,6 +27,10 @@ export class Location extends Implementation {
     this._googleMapsKey = googleMapsKey;
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   extendAdminMeta(meta) {
     return {
       ...meta,
@@ -151,7 +155,7 @@ export class KnexLocationInterface extends CommonLocationInterface(KnexFieldAdap
 
     // Error rather than ignoring invalid config
     // We totally can index these values, it's just not trivial. See issue #1297
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The Location field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/Location/test-fixtures.js
+++ b/packages/fields/src/types/Location/test-fixtures.js
@@ -1,0 +1,9 @@
+// We need a valid googleMapsKey to be added to CI to make this test runnable
+import Location from './';
+
+export const name = 'Location';
+export { Location as type };
+export const supportsUnique = false;
+export const skipRequiredTest = true;
+export const exampleValue = '"ChIJOza7MD-uEmsRrf4t12uji6Y"';
+export const fieldConfig = { googleMapsKey: 'googleMapsKey' };

--- a/packages/fields/src/types/OEmbed/Implementation.js
+++ b/packages/fields/src/types/OEmbed/Implementation.js
@@ -29,6 +29,10 @@ export class OEmbed extends Implementation {
     this.parameters = parameters;
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ${this.graphQLOutputType}`];
   }
@@ -285,7 +289,7 @@ export class KnexOEmbedInterface extends CommonOEmbedInterface(KnexFieldAdapter)
 
     // Error rather than ignoring invalid config
     // We totally can index these values, it's just not trivial. See issue #1297
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The OEmbed field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/OEmbed/test-fixtures.js
+++ b/packages/fields/src/types/OEmbed/test-fixtures.js
@@ -1,0 +1,6 @@
+import OEmbed from './';
+
+export const name = 'OEmbed';
+export { OEmbed as type };
+export const supportsUnique = false;
+export const skipRequiredTest = true;

--- a/packages/fields/src/types/Password/Implementation.js
+++ b/packages/fields/src/types/Password/Implementation.js
@@ -25,6 +25,10 @@ export class Password extends Implementation {
     }
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     return [`${this.path}_is_set: Boolean`];
   }
@@ -136,7 +140,7 @@ export class KnexPasswordInterface extends CommonPasswordInterface(KnexFieldAdap
     super(...arguments);
 
     // Error rather than ignoring invalid config
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The Password field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/Password/test-fixtures.js
+++ b/packages/fields/src/types/Password/test-fixtures.js
@@ -5,6 +5,7 @@ import Text from '../Text';
 export const name = 'Password';
 export { Password as type };
 export const exampleValue = '"password"';
+export const supportsUnique = false;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -26,6 +26,10 @@ export class Relationship extends Implementation {
     this.withMeta = typeof withMeta !== 'undefined' ? withMeta : true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   tryResolveRefList() {
     const { listKey, path, refListKey, refFieldPath } = this;
     const refList = this.getListByKey(refListKey);

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -70,6 +70,11 @@ export class Select extends Implementation {
     this.dataType = dataType;
     this.isOrderable = true;
   }
+
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ${this.getTypeName()}`];
   }

--- a/packages/fields/src/types/Select/test-fixtures.js
+++ b/packages/fields/src/types/Select/test-fixtures.js
@@ -6,6 +6,14 @@ export const name = 'Select';
 
 export { Select as type };
 export const exampleValue = 'thinkmill';
+export const exampleValue2 = 'atlassian';
+export const supportsUnique = true;
+export const fieldConfig = {
+  options: [
+    { label: 'Thinkmill', value: 'thinkmill' },
+    { label: 'Atlassian', value: 'atlassian' },
+  ],
+};
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Slug/test-fixtures.skip.js
+++ b/packages/fields/src/types/Slug/test-fixtures.skip.js
@@ -1,0 +1,9 @@
+// Slug handles uniqueness in a very different way to most other
+// fields, so the generic uniqueness tests don't make sense for it.
+import Slug from './';
+
+export const name = 'Slug';
+export { Slug as type };
+export const exampleValue = '"foo"';
+export const exampleValue2 = '"bar"';
+export const supportsUnique = true;

--- a/packages/fields/src/types/Text/Implementation.js
+++ b/packages/fields/src/types/Text/Implementation.js
@@ -8,6 +8,11 @@ export class Text extends Implementation {
     this.isMultiline = isMultiline;
     this.isOrderable = true;
   }
+
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: String`];
   }

--- a/packages/fields/src/types/Text/test-fixtures.js
+++ b/packages/fields/src/types/Text/test-fixtures.js
@@ -6,6 +6,8 @@ export { fieldType as name };
 
 export { Text as type };
 export const exampleValue = '"foo"';
+export const exampleValue2 = '"bar"';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Unsplash/Implementation.js
+++ b/packages/fields/src/types/Unsplash/Implementation.js
@@ -64,6 +64,10 @@ export class Unsplash extends Implementation {
     });
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ${this.graphQLOutputType}`];
   }
@@ -281,7 +285,7 @@ export class KnexUnsplashInterface extends CommonUnsplashInterface(KnexFieldAdap
 
     // Error rather than ignoring invalid config
     // We totally can index these values, it's just not trivial. See issue #1297
-    if (this.config.isUnique || this.config.isIndexed) {
+    if (this.config.isIndexed) {
       throw `The Unsplash field type doesn't support indexes on Knex. ` +
         `Check the config for ${this.path} on the ${this.field.listKey} list`;
     }

--- a/packages/fields/src/types/Unsplash/test-fixtures.js
+++ b/packages/fields/src/types/Unsplash/test-fixtures.js
@@ -1,0 +1,10 @@
+import Unsplash from './';
+
+export const name = 'Unsplash';
+export { Unsplash as type };
+export const supportsUnique = false;
+export const skipRequiredTest = true;
+export const fieldConfig = {
+  accessKey: 'accessKey',
+  secretKey: 'secretKey',
+};

--- a/packages/fields/src/types/Url/test-fixtures.js
+++ b/packages/fields/src/types/Url/test-fixtures.js
@@ -1,0 +1,7 @@
+import Url from './';
+
+export const name = 'Url';
+export { Url as type };
+export const exampleValue = '"https://keystonejs.org"';
+export const exampleValue2 = '"https://thinkmill.com.au"';
+export const supportsUnique = true;

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -15,6 +15,10 @@ export class UuidImplementation extends Implementation {
     this.isOrderable = true;
   }
 
+  get _supportsUnique() {
+    return true;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ID`];
   }

--- a/packages/fields/src/types/Uuid/test-fixtures.js
+++ b/packages/fields/src/types/Uuid/test-fixtures.js
@@ -7,6 +7,8 @@ export { fieldType as name };
 
 export { Uuid as type };
 export const exampleValue = '"7b36c9fe-274d-45f1-9f5d-8d4595959734"';
+export const exampleValue2 = '"c0d37cbc-2f01-432c-89e0-405d54fd4cdc"';
+export const supportsUnique = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Virtual/Implementation.js
+++ b/packages/fields/src/types/Virtual/Implementation.js
@@ -22,6 +22,10 @@ export class Virtual extends Implementation {
     this.extendGraphQLTypes = extendGraphQLTypes;
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     const argString = this.args.length
       ? `(${this.args.map(({ name, type }) => `${name}: ${type}`).join('\n')})`


### PR DESCRIPTION
* Correctly apply unique schema config for `DateTime` field on mongoose.
* Provides a higher level flag to indicate whether a field type supports uniqueness or not.
* Adds tests for uniqueness to core fields.
* Update `isRequired` tests to be more similar to `isUnique` tests.