### PR TITLE
Rename default schema from 'testing' to 'public'

### DIFF
--- a/.changeset/chatty-dancers-hunt.md
+++ b/.changeset/chatty-dancers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': major
+---
+
+Changed the default `schemaName` in `setupServer()` from `"testing"` to `"public"`.

--- a/.changeset/young-months-drop.md
+++ b/.changeset/young-months-drop.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/server-side-graphql-client': patch
+'@keystonejs/test-utils': patch
+---
+
+Simplified tests using the updated `test-utils` API.

--- a/api-tests/auth-header.test.js
+++ b/api-tests/auth-header.test.js
@@ -82,8 +82,6 @@ function login(app, email, password) {
   });
 }
 
-const schemaName = 'testing';
-
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     describe('Auth testing', () => {
@@ -91,9 +89,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'Gives access denied when not logged in',
         runner(setupKeystone, async ({ keystone, app }) => {
           // seed the db
-          const context = keystone.createContext({ schemaName, skipAccessControl: true });
           for (const [listKey, items] of Object.entries(initialData)) {
-            await createItems({ keystone, listKey, items, context });
+            await createItems({ keystone, listKey, items });
           }
           const { data, errors } = await networkedGraphqlRequest({
             app,
@@ -108,9 +105,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         test(
           'Allows access with bearer token',
           runner(setupKeystone, async ({ keystone, app }) => {
-            const context = keystone.createContext({ schemaName, skipAccessControl: true });
             for (const [listKey, items] of Object.entries(initialData)) {
-              await createItems({ keystone, listKey, items, context });
+              await createItems({ keystone, listKey, items });
             }
             const { token } = await login(
               app,
@@ -136,9 +132,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         test(
           'Allows access with cookie',
           runner(setupKeystone, async ({ keystone, app }) => {
-            const context = keystone.createContext({ schemaName, skipAccessControl: true });
             for (const [listKey, items] of Object.entries(initialData)) {
-              await createItems({ keystone, listKey, items, context });
+              await createItems({ keystone, listKey, items });
             }
             const { token } = await login(
               app,

--- a/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
+++ b/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
@@ -32,7 +32,7 @@ function setupKeystone(adapterName) {
           {
             schema: 'triple(x: Int): Int',
             resolver: (_, { x }) => 3 * x,
-            access: { testing: true },
+            access: true,
           },
         ],
       });
@@ -46,11 +46,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'Sets up access control properly',
         runner(setupKeystone, async ({ keystone }) => {
           expect(keystone._customProvider._extendedQueries.map(({ access }) => access)).toEqual([
-            { internal: true, testing: true },
-            { internal: true, testing: falseFn },
+            { internal: true, public: true },
+            { internal: true, public: falseFn },
           ]);
           expect(keystone._customProvider._extendedMutations.map(({ access }) => access)).toEqual([
-            { internal: true, testing: true },
+            { internal: true, public: true },
           ]);
         })
       );

--- a/api-tests/fields.test.js
+++ b/api-tests/fields.test.js
@@ -26,12 +26,10 @@ describe('Fields', () => {
             },
             async ({ keystone, ...rest }) => {
               // Populate the database before running the tests
-              const context = keystone.createContext({ schemaName: 'testing' });
               await createItems({
                 keystone,
                 listKey,
                 items: mod.initItems().map(x => ({ data: x })),
-                context,
               });
               return testFn({ keystone, listKey, adapterName, ...rest });
             }

--- a/packages/server-side-graphql-client/tests/index.test.js
+++ b/packages/server-side-graphql-client/tests/index.test.js
@@ -13,15 +13,8 @@ const {
 } = require('../index');
 
 const testData = [{ data: { name: 'test', age: 30 } }, { data: { name: 'test2', age: 40 } }];
-const schemaName = 'testing';
 
-const seedDb = ({ keystone }) =>
-  createItems({
-    keystone,
-    listKey: 'Test',
-    items: testData,
-    context: keystone.createContext({ schemaName }),
-  });
+const seedDb = ({ keystone }) => createItems({ keystone, listKey: 'Test', items: testData });
 
 function setupKeystone(adapterName) {
   return setupServer({
@@ -44,12 +37,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'createItem: Should create and get single item',
         runner(setupKeystone, async ({ keystone }) => {
           // Seed the db
-          const item = await createItem({
-            keystone,
-            listKey: 'Test',
-            item: testData[0].data,
-            context: keystone.createContext({ schemaName }),
-          });
+          const item = await createItem({ keystone, listKey: 'Test', item: testData[0].data });
           expect(typeof item.id).toBe('string');
 
           // Get single item from db
@@ -58,7 +46,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             returnFields: 'name, age',
             itemId: item.id,
-            context: keystone.createContext({ schemaName }),
           });
 
           expect(singleItem).toEqual(testData[0].data);
@@ -68,19 +55,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'createItems: Should create and get multiple items',
         runner(setupKeystone, async ({ keystone }) => {
           // Seed the db
-          await createItems({
-            keystone,
-            listKey: 'Test',
-            items: testData,
-            context: keystone.createContext({ schemaName }),
-          });
+          await createItems({ keystone, listKey: 'Test', items: testData });
           // Get all the items back from db
-          const allItems = await getItems({
-            keystone,
-            listKey: 'Test',
-            returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
-          });
+          const allItems = await getItems({ keystone, listKey: 'Test', returnFields: 'name, age' });
 
           expect(allItems).toEqual(testData.map(x => x.data));
         })
@@ -98,7 +75,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             item: { id: seedItems[0].id, data: { name: 'updateTest' } },
             returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
           });
           expect(item).toEqual({ name: 'updateTest', age: 30 });
         })
@@ -115,7 +91,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             items: seedItems.map((item, i) => ({ id: item.id, data: { name: `update-${i}` } })),
             returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
           });
 
           expect(items).toEqual([
@@ -137,16 +112,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             returnFields: 'name age',
             itemId: items[0].id,
-            context: keystone.createContext({ schemaName }),
           });
 
           // Retrieve items
-          const allItems = await getItems({
-            keystone,
-            listKey: 'Test',
-            returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
-          });
+          const allItems = await getItems({ keystone, listKey: 'Test', returnFields: 'name, age' });
 
           expect(allItems).toEqual([{ name: 'test2', age: 40 }]);
         })
@@ -162,18 +131,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             returnFields: 'name age',
             items: items.map(item => item.id),
-            context: keystone.createContext({ schemaName }),
           });
 
           expect(deletedItems).toEqual(testData.map(d => d.data));
 
           // Get all the items back from db
-          const allItems = await getItems({
-            keystone,
-            listKey: 'Test',
-            returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
-          });
+          const allItems = await getItems({ keystone, listKey: 'Test', returnFields: 'name, age' });
 
           expect(allItems).toEqual([]);
         })
@@ -185,12 +148,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         runner(setupKeystone, async ({ keystone }) => {
           // Seed the db
           await seedDb({ keystone });
-          const allItems = await getItems({
-            keystone,
-            listKey: 'Test',
-            returnFields: 'name, age',
-            context: keystone.createContext({ schemaName }),
-          });
+          const allItems = await getItems({ keystone, listKey: 'Test', returnFields: 'name, age' });
 
           expect(allItems).toEqual(testData.map(x => x.data));
         })
@@ -205,7 +163,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             listKey: 'Test',
             returnFields: 'name',
             where: { name: 'test' },
-            context: keystone.createContext({ schemaName }),
           });
 
           expect(allItems).toEqual([{ name: 'test' }]);

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -9,8 +9,8 @@ const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
 
 async function setupServer({
   adapterName,
-  schemaName = 'testing',
-  schemaNames = ['testing'],
+  schemaName = 'public',
+  schemaNames = ['public'],
   createLists = () => {},
   keystoneOptions,
   graphqlOptions = {},
@@ -63,7 +63,7 @@ async function setupServer({
 
 function graphqlRequest({ keystone, query, variables }) {
   return keystone.executeGraphQL({
-    context: keystone.createContext({ schemaName: 'testing', skipAccessControl: true }),
+    context: keystone.createContext({ skipAccessControl: true }),
     query,
     variables,
   });
@@ -71,15 +71,7 @@ function graphqlRequest({ keystone, query, variables }) {
 
 // This is much like graphqlRequest except we don't skip access control checks!
 function authedGraphqlRequest({ keystone, query, variables }) {
-  return keystone.executeGraphQL({
-    context: keystone.createContext({
-      schemaName: 'testing',
-      authentication: {},
-      skipAccessControl: false,
-    }),
-    query,
-    variables,
-  });
+  return keystone.executeGraphQL({ query, variables });
 }
 
 function networkedGraphqlRequest({


### PR DESCRIPTION
The choice of `schemaName` wasn't particularly important here, but having it be different to the default used by `server-side-graphql-client` means that all users of `test-utils` needed to provide a `context` object when called client functions. This change removes that need, without removing any functionality from `test-utils`.