### PR TITLE
Use authedGraphqlRequest rather than networkedGraphqlRequest

### DIFF
--- a/.changeset/silly-bags-jam.md
+++ b/.changeset/silly-bags-jam.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': patch
+---
+
+Use `authedGraphqlRequest` rather than `networkedGraphqlRequest` where appropriate.

--- a/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
+++ b/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
@@ -3,7 +3,7 @@ const {
   multiAdapterRunners,
   setupServer,
   graphqlRequest,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const falseFn = () => false;
@@ -76,9 +76,9 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       );
       it(
         'Denies access acording to access control',
-        runner(setupKeystone, async ({ app }) => {
-          const { data, errors } = await networkedGraphqlRequest({
-            app,
+        runner(setupKeystone, async ({ keystone }) => {
+          const { data, errors } = await authedGraphqlRequest({
+            keystone,
             query: `
               query {
                 quads(x: 10)

--- a/api-tests/relationships/filtering/access-control.test.js
+++ b/api-tests/relationships/filtering/access-control.test.js
@@ -3,7 +3,7 @@ const { Text, Relationship } = require('@keystonejs/fields');
 const {
   multiAdapterRunners,
   setupServer,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -39,7 +39,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     describe('relationship filtering with access control', () => {
       test(
         'implicitly filters to only the IDs in the database by default',
-        runner(setupKeystone, async ({ app, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           // Create all of the posts with the given IDs & random content
           const posts = await Promise.all(
             postNames.map(name => {
@@ -57,8 +57,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await networkedGraphqlRequest({
-            app,
+          const { data, errors } = await authedGraphqlRequest({
+            keystone,
             query: `
               query {
                 UserToPostLimitedRead(where: { id: "${user.id}" }) {
@@ -85,7 +85,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
       test(
         'explicitly filters when given a `where` clause',
-        runner(setupKeystone, async ({ app, create }) => {
+        runner(setupKeystone, async ({ keystone, create }) => {
           // Create all of the posts with the given IDs & random content
           const posts = await Promise.all(
             postNames.map(name => {
@@ -103,8 +103,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await networkedGraphqlRequest({
-            app,
+          const { data, errors } = await authedGraphqlRequest({
+            keystone,
             query: `
               query {
                 UserToPostLimitedRead(where: { id: "${user.id}" }) {

--- a/api-tests/relationships/nested-mutations/connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/connect-many.test.js
@@ -4,7 +4,7 @@ const {
   multiAdapterRunners,
   setupServer,
   graphqlRequest,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -446,7 +446,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'throws when link nested from within create mutation',
-          runner(setupKeystone, async ({ app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -454,8 +454,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               content: noteContent,
             });
 
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -468,24 +468,19 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               `,
             });
 
-            expect(errors).toMatchObject([
-              {
-                data: {
-                  errors: expect.arrayContaining([
-                    expect.objectContaining({
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                    }),
-                  ]),
-                },
-              },
-            ]);
+            expect(errors).toHaveLength(1);
+            const error = errors[0];
+            expect(error.message).toEqual(
+              'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>'
+            );
+            expect(error.path).toHaveLength(1);
+            expect(error.path[0]).toEqual('createUserToNotesNoRead');
           })
         );
 
         test(
           'throws when link nested from within update mutation',
-          runner(setupKeystone, async ({ app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -497,8 +492,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -514,18 +509,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               `,
             });
 
-            expect(errors).toMatchObject([
-              {
-                data: {
-                  errors: expect.arrayContaining([
-                    expect.objectContaining({
-                      message:
-                        'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>',
-                    }),
-                  ]),
-                },
-              },
-            ]);
+            expect(errors).toHaveLength(1);
+            const error = errors[0];
+            expect(error.message).toEqual(
+              'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>'
+            );
+            expect(error.path).toHaveLength(1);
+            expect(error.path[0]).toEqual('updateUserToNotesNoRead');
           })
         );
       });
@@ -533,7 +523,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('create: false on related list', () => {
         test(
           'does not throw when link nested from within create mutation',
-          runner(setupKeystone, async ({ app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -542,8 +532,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await networkedGraphqlRequest({
-              app,
+            const { data, errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   createUserToNotesNoCreate(data: {
@@ -563,7 +553,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
         test(
           'does not throw when link nested from within update mutation',
-          runner(setupKeystone, async ({ app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -575,8 +565,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { data, errors } = await networkedGraphqlRequest({
-              app,
+            const { data, errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateUserToNotesNoCreate(

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -4,7 +4,7 @@ const {
   setupServer,
   graphqlRequest,
   multiAdapterRunners,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -147,7 +147,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when specifying disconnectAll',
-          runner(setupKeystone, async ({ keystone, app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -160,8 +160,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateUserToNotesNoRead(

--- a/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
@@ -4,7 +4,7 @@ const {
   multiAdapterRunners,
   setupServer,
   graphqlRequest,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -170,7 +170,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when using disconnectAll',
-          runner(setupKeystone, async ({ app, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             const groupName = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -186,8 +186,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateEventToGroupNoRead(

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -4,7 +4,7 @@ const {
   multiAdapterRunners,
   setupServer,
   graphqlRequest,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -247,7 +247,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no impact when disconnecting directly with an id',
-          runner(setupKeystone, async ({ keystone, app, create }) => {
+          runner(setupKeystone, async ({ keystone, create }) => {
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -260,8 +260,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateUserToNotesNoRead(

--- a/api-tests/relationships/nested-mutations/disconnect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-singular.test.js
@@ -4,7 +4,7 @@ const {
   multiAdapterRunners,
   setupServer,
   graphqlRequest,
-  networkedGraphqlRequest,
+  authedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -215,7 +215,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       describe('read: false on related list', () => {
         test(
           'has no effect when disconnecting a specific id',
-          runner(setupKeystone, async ({ app, create, findById }) => {
+          runner(setupKeystone, async ({ keystone, create, findById }) => {
             const groupName = sampleOne(alphanumGenerator);
 
             // Create an item to link against
@@ -231,8 +231,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await networkedGraphqlRequest({
-              app,
+            const { errors } = await authedGraphqlRequest({
+              keystone,
               query: `
                 mutation {
                   updateEventToGroupNoRead(


### PR DESCRIPTION
We should only be using `networkedGraphqlRequest` if we're actually interested in the way the test interacts with the network requests.