### PR TITLE
fix description for afterDelete hook

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -337,7 +337,7 @@ const beforeDelete = ({
 
 ### `afterDelete`
 
-**Used to cause side effects before the delete operation is executed.**
+**Used to cause side effects after the delete operation is executed.**
 
 - Invoked after the delete operation has been executed
 - Available for `delete` operations


### PR DESCRIPTION
Might have been a copy paste error as it points to that of beforeDelete hook. Just a simple fix