### PR TITLE
Alert user before closing the createItemModal form

### DIFF
--- a/.changeset/purple-knives-cough.md
+++ b/.changeset/purple-knives-cough.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/app-admin-ui': patch
+---
+
+Alerted the user before canceling the createItemModal form.

--- a/test-projects/basic/cypress/integration/create-buttons_spec.js
+++ b/test-projects/basic/cypress/integration/create-buttons_spec.js
@@ -75,4 +75,21 @@ describe('Home page', () => {
       cy.contains('div', `Create ${text} Dialog`).should('not.exist');
     });
   });
+
+  it('Ensure Create Modal triggers a confirmation dialog when form data is filled, and user hits cancel button', () => {
+    cy.visit('/admin/users');
+
+    cy.get('#list-page-create-button').click({ force: true });
+    cy.get('#ks-input-name').type('Aman', {
+      force: true,
+    });
+    cy.contains('div', `Create User Dialog`)
+      .contains('button', 'Cancel')
+      .click({ force: true });
+
+    cy.get('div[role="alertdialog"]')
+      .contains('button', 'Cancel')
+      .click({ force: true });
+    cy.contains('div', `Create User Dialog`).should('exist');
+  });
 });


### PR DESCRIPTION
The form data inside the `createItemModal` was getting lost when user
hit the `cancel` button. This could lead to a poor UX.

This fix will identifies if form data has changed from its initial
values before closing the modal. If yes, then it alerts the user for
confirmation. Otherwise, will close the modal.
![admin](https://user-images.githubusercontent.com/11068601/88986642-ea305a00-d316-11ea-9387-bb6657728877.gif)

Closes: #2822