### PR TITLE
Only provide updateAuthed mutation if updates are supported on the list

### DIFF
--- a/.changeset/modern-oranges-sneeze.md
+++ b/.changeset/modern-oranges-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/keystone': patch
+---
+
+Fixed invalid GraphQL schema when using `access: { update: false, auth: true }` on a list configured with an `AuthStrategy`.

--- a/api-tests/access-control/utils.js
+++ b/api-tests/access-control/utils.js
@@ -1,5 +1,6 @@
 const { setupServer } = require('@keystonejs/test-utils');
 const { Text } = require('@keystonejs/fields');
+const { PasswordAuthStrategy } = require('@keystonejs/auth-password');
 const { objMerge } = require('@keystonejs/utils');
 
 const FAKE_ID = { mongoose: '5b3eabd9e9f2e3e4866742ea', knex: 137 };
@@ -112,6 +113,13 @@ function setupKeystone(adapterName) {
           },
           access,
         });
+        if (access.auth) {
+          keystone.createAuthStrategy({
+            type: PasswordAuthStrategy,
+            list: getStaticListName(access),
+            config: {},
+          });
+        }
         keystone.createList(getImperativeListName(access), {
           fields: {
             name: { type: Text },

--- a/docs/discussions/database-schema.md
+++ b/docs/discussions/database-schema.md
@@ -69,6 +69,7 @@ One column holds a reference to `Posts` and the other holds a reference to `User
 In PostgreSQL this is implemented as a table where the contents of each column is a [foreign key](https://www.postgresql.org/docs/12/ddl-constraints.html#DDL-CONSTRAINTS-FK) referencing the respective table.
 
 In MongoDB this is implemented as a collection where the contents of each field is an `ObjectID` referencing the respective [document](https://docs.mongodb.com/manual/core/document/). The above many-to-many example would result in a collection named `post_authors_manies` with a joining document of this format:
+
 ```javascript
 {
   "_id": ObjectID,
@@ -76,6 +77,7 @@ In MongoDB this is implemented as a collection where the contents of each field 
   "User_right_id": ObjectID,
 }
 ```
+
 The two-sided cases is handled using the same pattern, however the generated table/collection and column/fields names will be different.
 
 ## One-to-one


### PR DESCRIPTION
If you have a schema with `access: { update: false, auth: true }` and added an auth strategy the auth strategy would attempt to create a mutation using `updateInputName`, which is not defined for this access configuration.