### PR TITLE
Replace calls to graphqlRequest with keystone.executeGraphQL

### DIFF
--- a/.changeset/fresh-eagles-sniff.md
+++ b/.changeset/fresh-eagles-sniff.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/api-tests': patch
+---
+
+Replaced calls to `graphqlRequest` with calls to `keystone.executeGraphQL`.

--- a/api-tests/CalendarDay.test.js
+++ b/api-tests/CalendarDay.test.js
@@ -1,4 +1,4 @@
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const { CalendarDay } = require('@keystonejs/fields');
 
@@ -21,8 +21,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'Valid date passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `mutation { createUser(data: { birthday: "2001-01-01" }) { birthday } }`,
           });
           expect(errors).toBe(undefined);
@@ -33,8 +32,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'date === dateTo passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `mutation { createUser(data: { birthday: "2020-01-01" }) { birthday } }`,
           });
           expect(errors).toBe(undefined);
@@ -45,8 +43,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'date === dateFrom passes validation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `mutation { createUser(data: { birthday: "2020-01-01" }) { birthday } }`,
           });
           expect(errors).toBe(undefined);
@@ -57,8 +54,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'Invalid date failsvalidation',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `mutation { createUser(data: { birthday: "3000-01-01" }) { birthday } }`,
           });
           expect(errors).toHaveLength(1);

--- a/api-tests/DateTime.test.js
+++ b/api-tests/DateTime.test.js
@@ -1,4 +1,4 @@
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { Text, DateTime } = require('@keystonejs/fields');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
@@ -25,8 +25,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { __schema },
             errors,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         query {
           __schema {
@@ -81,8 +80,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await createItem({ keystone, listKey: 'Post', item: { postedAt } });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           Post(where: { id: "${createPost.id}" }) {
@@ -102,8 +100,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const postedAt = '2018-08-31T06:49:07.000Z';
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createPost(data: { postedAt: "${postedAt}" }) {
@@ -127,8 +124,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await createItem({ keystone, listKey: 'Post', item: { postedAt } });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { postedAt: "${updatedPostedAt}" }) {
@@ -150,8 +146,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createPost = await createItem({ keystone, listKey: 'Post', item: { postedAt } });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { postedAt: null }) {
@@ -169,8 +164,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'allows initialising to null',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createPost(data: { postedAt: null }) {
@@ -197,8 +191,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updatePost(id: "${createPost.id}", data: { title: "Something else" }) {

--- a/api-tests/Virtual.test.js
+++ b/api-tests/Virtual.test.js
@@ -1,4 +1,4 @@
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { Integer, Virtual } = require('@keystonejs/fields');
 
 function makeSetupKeystone(fields) {
@@ -27,8 +27,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             foo: { type: Virtual, resolver: () => 'Hello world!' },
           }),
           async ({ keystone }) => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
@@ -47,8 +46,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             foo: { type: Virtual, graphQLReturnType: 'Int', resolver: () => 42 },
           }),
           async ({ keystone }) => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
@@ -75,8 +73,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             },
           }),
           async ({ keystone }) => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo(x: 10, y: 20) }
               }`,
@@ -103,8 +100,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             },
           }),
           async ({ keystone }) => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
@@ -128,8 +124,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             },
           }),
           async ({ keystone }) => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo { title rating } }
               }`,

--- a/api-tests/access-control/schema.test.js
+++ b/api-tests/access-control/schema.test.js
@@ -1,4 +1,4 @@
-const { multiAdapterRunners, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners } = require('@keystonejs/test-utils');
 const { arrayToObject } = require('@keystonejs/utils');
 const {
   setupKeystone,
@@ -49,8 +49,7 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
       const _before = await before(setupKeystone);
       keystone = _before.keystone;
 
-      const { data, errors } = await graphqlRequest({
-        keystone,
+      const { data, errors } = await keystone.executeGraphQL({
         query: introspectionQuery,
       });
       expect(errors).toBe(undefined);

--- a/api-tests/default-value/defaults.test.js
+++ b/api-tests/default-value/defaults.test.js
@@ -1,4 +1,4 @@
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { Text } = require('@keystonejs/fields');
 
 const setupList = (adapterName, fields) =>
@@ -19,15 +19,16 @@ describe('defaultValue field config', () => {
               name: { type: Text },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: null,
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: null,
+                });
+              })
         )();
       });
 
@@ -38,15 +39,16 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue: undefined },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: null,
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: null,
+                });
+              })
         )();
       });
 
@@ -57,15 +59,16 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue: null },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: null,
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: null,
+                });
+              })
         )();
       });
 
@@ -76,15 +79,16 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue: 'hello' },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: 'hello',
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: 'hello',
+                });
+              })
         )();
       });
 
@@ -95,15 +99,16 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue: () => 'foobar' },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: 'foobar',
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: 'foobar',
+                });
+              })
         )();
       });
 
@@ -114,15 +119,16 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue: () => Promise.resolve('zippity') },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data.createUser).toMatchObject({
-                name: 'zippity',
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(data.createUser).toMatchObject({
+                  name: 'zippity',
+                });
+              })
         )();
       });
 
@@ -134,19 +140,20 @@ describe('defaultValue field config', () => {
               name: { type: Text, defaultValue },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: {} ) { name } }`,
-            }).then(({ errors }) => {
-              expect(errors).toBe(undefined);
-              expect(defaultValue).toHaveBeenCalledTimes(1);
-              expect(defaultValue).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  context: expect.any(Object),
-                  originalInput: expect.any(Object),
-                })
-              );
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: {} ) { name } }`,
+              })
+              .then(({ errors }) => {
+                expect(errors).toBe(undefined);
+                expect(defaultValue).toHaveBeenCalledTimes(1);
+                expect(defaultValue).toHaveBeenCalledWith(
+                  expect.objectContaining({
+                    context: expect.any(Object),
+                    originalInput: expect.any(Object),
+                  })
+                );
+              })
         )();
       });
 
@@ -159,24 +166,25 @@ describe('defaultValue field config', () => {
               salutation: { type: Text },
             }),
           ({ keystone }) =>
-            graphqlRequest({
-              keystone,
-              query: `mutation { createUser(data: { salutation: "Doctor" } ) { name } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(defaultValue).toHaveBeenCalledTimes(1);
-              expect(defaultValue).toHaveBeenCalledWith(
-                expect.objectContaining({
-                  context: expect.any(Object),
-                  originalInput: {
-                    salutation: 'Doctor',
-                  },
-                })
-              );
-              expect(data.createUser).toMatchObject({
-                name: 'Doctor X',
-              });
-            })
+            keystone
+              .executeGraphQL({
+                query: `mutation { createUser(data: { salutation: "Doctor" } ) { name } }`,
+              })
+              .then(({ data, errors }) => {
+                expect(errors).toBe(undefined);
+                expect(defaultValue).toHaveBeenCalledTimes(1);
+                expect(defaultValue).toHaveBeenCalledWith(
+                  expect.objectContaining({
+                    context: expect.any(Object),
+                    originalInput: {
+                      salutation: 'Doctor',
+                    },
+                  })
+                );
+                expect(data.createUser).toMatchObject({
+                  name: 'Doctor X',
+                });
+              })
         )();
       });
     })

--- a/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
+++ b/api-tests/extend-graphql-schema/extend-graphql-schema.test.js
@@ -1,5 +1,5 @@
 const { Text } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const falseFn = () => false;
 
@@ -53,8 +53,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'Executes custom queries correctly',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
               query {
                 double(x: 10)
@@ -87,8 +86,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'Executes custom mutations correctly',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
               mutation {
                 triple(x: 10)

--- a/api-tests/hooks/list-hooks.test.js
+++ b/api-tests/hooks/list-hooks.test.js
@@ -1,5 +1,5 @@
 const { Text } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 function setupKeystone(adapterName) {
   return setupServer({
@@ -33,8 +33,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'resolves fields first, then passes them to the list',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
               mutation {
                 createUser(data: { name: "jess" }) { name }

--- a/api-tests/queries-access-control/meta.test.js
+++ b/api-tests/queries-access-control/meta.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 function setupKeystone(adapterName) {
   return setupServer({
@@ -43,8 +43,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _CompaniesMeta {
@@ -75,8 +74,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _CompaniesMeta {
@@ -122,8 +120,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _ksListsMeta {
@@ -170,8 +167,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all visible lists',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _ksListsMeta {

--- a/api-tests/queries/limits.test.js
+++ b/api-tests/queries/limits.test.js
@@ -2,7 +2,6 @@ const { Integer, Text, Relationship } = require('@keystonejs/fields');
 const {
   multiAdapterRunners,
   setupServer,
-  graphqlRequest,
   networkedGraphqlRequest,
 } = require('@keystonejs/test-utils');
 const {
@@ -63,8 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // 2 results is okay
-            let { data, errors } = await graphqlRequest({
-              keystone,
+            let { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(
@@ -82,8 +80,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allUsers).toEqual([{ name: 'Jess' }, { name: 'Johanna' }]);
 
             // No results is okay
-            ({ data, errors } = await graphqlRequest({
-              keystone,
+            ({ data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(
@@ -100,8 +97,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allUsers.length).toEqual(0);
 
             // Count is still correct
-            ({ data, errors } = await graphqlRequest({
-              keystone,
+            ({ data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             meta: _allUsersMeta {
@@ -116,8 +112,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.meta.count).toBe(users.length);
 
             // This query is only okay because of the "first" parameter
-            ({ data, errors } = await graphqlRequest({
-              keystone,
+            ({ data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(first: 1) {
@@ -132,8 +127,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allUsers.length).toEqual(1);
 
             // This query returns too many results
-            ({ errors } = await graphqlRequest({
-              keystone,
+            ({ errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers {
@@ -146,8 +140,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
 
             // The query results don't break the limits, but the "first" parameter does
-            ({ errors } = await graphqlRequest({
-              keystone,
+            ({ errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(
@@ -202,8 +195,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // A basic query that should work
-            let { data, errors } = await graphqlRequest({
-              keystone,
+            let { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(
@@ -228,8 +220,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // Each subquery is within the limit (even though the total isn't)
-            ({ data, errors } = await graphqlRequest({
-              keystone,
+            ({ data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(
@@ -264,8 +255,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
 
             // This post has too many authors
-            ({ errors } = await graphqlRequest({
-              keystone,
+            ({ errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(
@@ -283,8 +273,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
 
             // Requesting the too-many-authors post is okay as long as the authors aren't returned
-            ({ data, errors } = await graphqlRequest({
-              keystone,
+            ({ data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(
@@ -301,8 +290,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allPosts).toEqual([{ title: 'Three authors' }]);
 
             // Some posts are okay, but one breaks the limit
-            ({ errors } = await graphqlRequest({
-              keystone,
+            ({ errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts {
@@ -318,8 +306,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(errors).toMatchObject([{ message: 'Your request exceeded server limits' }]);
 
             // All subqueries are within limits, but the total isn't
-            ({ errors } = await graphqlRequest({
-              keystone,
+            ({ errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(where: { title: "Two authors" }) {

--- a/api-tests/queries/meta.test.js
+++ b/api-tests/queries/meta.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 function setupKeystone(adapterName) {
   return setupServer({
@@ -34,8 +34,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _CompaniesMeta {
@@ -78,8 +77,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema.relatedFields' returns empty array when none exist`,
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _PostsMeta {
@@ -119,8 +117,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all lists',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _ksListsMeta {
@@ -254,8 +251,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for one list',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _ksListsMeta(where: { key: "User" }) {
@@ -328,8 +324,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for one list and one type of field',
         runner(setupKeystone, async ({ keystone }) => {
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             _ksListsMeta(where: { key: "Company" }) {

--- a/api-tests/queries/relationships.test.js
+++ b/api-tests/queries/relationships.test.js
@@ -1,7 +1,7 @@
 const { gen, sampleOne } = require('testcheck');
 
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, createItems } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -76,8 +76,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(where: {
@@ -124,8 +123,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allPosts(where: {
@@ -184,8 +182,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -216,8 +213,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -254,8 +250,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -310,8 +305,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -340,8 +334,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -375,8 +368,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -425,8 +417,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -460,8 +451,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {
@@ -490,8 +480,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           query {
             allUsers(where: {

--- a/api-tests/queries/search.test.js
+++ b/api-tests/queries/search.test.js
@@ -1,5 +1,5 @@
 const { Text, Integer } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -33,8 +33,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await graphqlRequest({
-          keystone,
+        const { data, errors } = await keystone.executeGraphQL({
           query: `
           query {
             allTests(
@@ -62,8 +61,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await graphqlRequest({
-          keystone,
+        const { data, errors } = await keystone.executeGraphQL({
           query: `
           query {
             allTests(
@@ -92,8 +90,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await graphqlRequest({
-          keystone,
+        const { data, errors } = await keystone.executeGraphQL({
           query: `
           query {
             allTests(
@@ -121,8 +118,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await graphqlRequest({
-          keystone,
+        const { data, errors } = await keystone.executeGraphQL({
           query: `
           query {
             allNumbers(

--- a/api-tests/relationships/crud-self-ref/many-to-many.test.js
+++ b/api-tests/relationships/crud-self-ref/many-to-many.test.js
@@ -1,12 +1,11 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async keystone => {
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `
       mutation {
         createUsers(data: [
@@ -24,8 +23,7 @@ const createUserAndFriend = async keystone => {
   const {
     data: { createUser },
     errors,
-  } = await graphqlRequest({
-    keystone,
+  } = await keystone.executeGraphQL({
     query: `
       mutation {
         createUser(data: {
@@ -48,8 +46,7 @@ const createUserAndFriend = async keystone => {
 };
 
 const getUserAndFriend = async (keystone, userId, friendId) => {
-  const { data } = await graphqlRequest({
-    keystone,
+  const { data } = await keystone.executeGraphQL({
     query: `
       {
         User(where: { id: "${userId}"} ) { id friends { id } }
@@ -61,8 +58,7 @@ const getUserAndFriend = async (keystone, userId, friendId) => {
 
 const createReadData = async keystone => {
   // create locations [A, A, B, B, C, C];
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `mutation create($users: [UsersCreateInput]) { createUsers(data: $users) { id name } }`,
     variables: {
       users: ['A', 'A', 'B', 'B', 'C', 'C', 'D', 'D', 'E'].map(name => ({ data: { name } })),
@@ -83,8 +79,7 @@ const createReadData = async keystone => {
       [], //  -> []
     ].map(async (locationIdxs, j) => {
       const ids = locationIdxs.map(i => ({ id: createUsers[i].id }));
-      const { data, errors } = await graphqlRequest({
-        keystone,
+      const { data, errors } = await keystone.executeGraphQL({
         query: `mutation update($friends: [UserWhereUniqueInput], $user: ID!) { updateUser(id: $user data: {
     friends: { connect: $friends }
   }) { id friends { name }}}`,
@@ -125,8 +120,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 3],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allUsers(where: { friends_some: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -146,8 +140,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 6],
                 ['D', 9],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allUsers(where: { friends_none: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -167,8 +160,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 1],
                 ['D', 1],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allUsers(where: { friends_every: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -184,8 +176,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'Count',
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 {
                   _allUsersMeta { count }
@@ -204,8 +195,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const { users } = await createInitialData(keystone);
             const friend = users[0];
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -233,8 +223,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'With create',
           runner(setupKeystone, async ({ keystone }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -264,8 +253,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const user = users[0];
             const friendName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -288,8 +276,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allUsers },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allUsers { id friends { id friendOf { id } } } }`,
             });
             expect(errors2).toBe(undefined);
@@ -310,8 +297,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const friendName = sampleOne(alphanumGenerator);
             const userName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -336,8 +322,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allUsers },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allUsers { id friends { id friendOf { id } } } }`,
             });
             expect(errors2).toBe(undefined);
@@ -368,8 +353,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(user.friends).not.toBe(expect.anything());
             expect(friend.friendOf).not.toBe(expect.anything());
 
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -393,8 +377,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await createInitialData(keystone);
             let user = users[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -425,8 +408,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -454,8 +436,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -485,8 +466,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation { deleteUser(id: "${user.id}") { id } } `,
             });
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -1,12 +1,11 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async keystone => {
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `
       mutation {
         createUsers(data: [
@@ -24,8 +23,7 @@ const createUserAndFriend = async keystone => {
   const {
     data: { createUser },
     errors,
-  } = await graphqlRequest({
-    keystone,
+  } = await keystone.executeGraphQL({
     query: `
       mutation {
         createUser(data: {
@@ -45,8 +43,7 @@ const createUserAndFriend = async keystone => {
 };
 
 const getUserAndFriend = async (keystone, userId, friendId) => {
-  const { data } = await graphqlRequest({
-    keystone,
+  const { data } = await keystone.executeGraphQL({
     query: `
       {
         User(where: { id: "${userId}"} ) { id friend { id } }
@@ -80,8 +77,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               const { user, friend } = await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friend: { name: "${friend.name}"} }) { id }
                 }`,
@@ -97,8 +93,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               const { user, friend } = await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friendOf: { name: "${user.name}"} }) { id }
                 }`,
@@ -113,8 +108,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friend_is_null: true }) { id }
                 }`,
@@ -128,8 +122,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friendOf_is_null: true }) { id }
                 }`,
@@ -143,8 +136,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friend_is_null: false }) { id }
                 }`,
@@ -158,8 +150,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allUsers(where: { friendOf_is_null: false }) { id }
                 }`,
@@ -174,8 +165,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'Count',
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 {
                   _allUsersMeta { count }
@@ -193,8 +183,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               const { friend } = await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   _allUsersMeta(where: { friend: { name: "${friend.name}"} }) { count }
                 }`,
@@ -209,8 +198,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               const { user } = await createUserAndFriend(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   _allUsersMeta(where: { friendOf: { name: "${user.name}"} }) { count }
                 }`,
@@ -228,8 +216,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const { users } = await createInitialData(keystone);
             const user = users[0];
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -252,8 +239,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'With create',
           runner(setupKeystone, async ({ keystone }) => {
             const friendName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -283,8 +269,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const user = users[0];
             const friendName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -307,8 +292,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allUsers },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allUsers { id friend { id friendOf { id }} } }`,
             });
             expect(errors2).toBe(undefined);
@@ -330,8 +314,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const friendName = sampleOne(alphanumGenerator);
             const friendOfName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createUser(data: {
@@ -355,8 +338,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allUsers },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allUsers { id friend { id friendOf { id }} } }`,
             });
             expect(errors2).toBe(undefined);
@@ -384,8 +366,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(user.friend).not.toBe(expect.anything());
             expect(friend.friendOf).not.toBe(expect.anything());
 
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -409,8 +390,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await createInitialData(keystone);
             let user = users[0];
             const friendName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -441,8 +421,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -470,8 +449,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateUser(
@@ -501,8 +479,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { user, friend } = await createUserAndFriend(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation { deleteUser(id: "${user.id}") { id } } `,
             });
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/crud/many-to-many.test.js
+++ b/api-tests/relationships/crud/many-to-many.test.js
@@ -1,12 +1,11 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async keystone => {
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `
       mutation {
         createCompanies(data: [
@@ -29,8 +28,7 @@ const createCompanyAndLocation = async keystone => {
   const {
     data: { createCompany },
     errors,
-  } = await graphqlRequest({
-    keystone,
+  } = await keystone.executeGraphQL({
     query: `
       mutation {
         createCompany(data: {
@@ -53,8 +51,7 @@ const createCompanyAndLocation = async keystone => {
 };
 
 const getCompanyAndLocation = async (keystone, companyId, locationId) => {
-  const { data } = await graphqlRequest({
-    keystone,
+  const { data } = await keystone.executeGraphQL({
     query: `
       {
         Company(where: { id: "${companyId}"} ) { id locations { id } }
@@ -66,8 +63,7 @@ const getCompanyAndLocation = async (keystone, companyId, locationId) => {
 
 const createReadData = async keystone => {
   // create locations [A, A, B, B, C, C];
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `mutation create($locations: [LocationsCreateInput]) { createLocations(data: $locations) { id name } }`,
     variables: {
       locations: ['A', 'A', 'B', 'B', 'C', 'C'].map(name => ({ data: { name } })),
@@ -88,8 +84,7 @@ const createReadData = async keystone => {
       [], //  -> []
     ].map(async locationIdxs => {
       const ids = locationIdxs.map(i => ({ id: createLocations[i].id }));
-      const { data, errors } = await graphqlRequest({
-        keystone,
+      const { data, errors } = await keystone.executeGraphQL({
         query: `mutation create($locations: [LocationWhereUniqueInput]) { createCompany(data: {
     locations: { connect: $locations }
   }) { id locations { name }}}`,
@@ -135,8 +130,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 3],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -156,8 +150,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 6],
                 ['D', 9],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -177,8 +170,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ['C', 1],
                 ['D', 1],
               ].map(async ([name, count]) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
                 });
                 expect(errors).toBe(undefined);
@@ -194,8 +186,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'Count',
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 {
                   _allCompaniesMeta { count }
@@ -216,8 +207,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const { locations } = await createInitialData(keystone);
             const location = locations[0];
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -249,8 +239,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'With create',
           runner(setupKeystone, async ({ keystone }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -284,8 +273,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -310,8 +298,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allCompanies },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allCompanies { id locations { id companies { id } } } }`,
             });
             expect(errors2).toBe(undefined);
@@ -334,8 +321,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const locationName = sampleOne(alphanumGenerator);
             const companyName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -362,8 +348,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allCompanies },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allCompanies { id locations { id companies { id } } } }`,
             });
             expect(errors2).toBe(undefined);
@@ -389,8 +374,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(company.locations).not.toBe(expect.anything());
             expect(location.companies).not.toBe(expect.anything());
 
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -422,8 +406,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { companies } = await createInitialData(keystone);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -458,8 +441,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -487,8 +469,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -518,8 +499,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
             });
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/crud/one-to-one.test.js
+++ b/api-tests/relationships/crud/one-to-one.test.js
@@ -1,12 +1,11 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async keystone => {
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `
       mutation {
         createCompanies(data: [
@@ -30,8 +29,7 @@ const createCompanyAndLocation = async keystone => {
   const {
     data: { createCompany },
     errors,
-  } = await graphqlRequest({
-    keystone,
+  } = await keystone.executeGraphQL({
     query: `
       mutation {
         createCompany(data: {
@@ -58,8 +56,7 @@ const createLocationAndCompany = async keystone => {
   const {
     data: { createLocation },
     errors,
-  } = await graphqlRequest({
-    keystone,
+  } = await keystone.executeGraphQL({
     query: `
       mutation {
         createLocation(data: {
@@ -83,8 +80,7 @@ const createLocationAndCompany = async keystone => {
 };
 
 const getCompanyAndLocation = async (keystone, companyId, locationId) => {
-  const { data } = await graphqlRequest({
-    keystone,
+  const { data } = await keystone.executeGraphQL({
     query: `
   {
     Company(where: { id: "${companyId}"} ) { id location { id } }
@@ -122,8 +118,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
             const { location, company } = await createCompanyAndLocation(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `{
                   allLocations(where: { company: { name: "${company.name}"} }) { id }
                   allCompanies(where: { location: { name: "${location.name}"} }) { id }
@@ -141,8 +136,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
             const { location, company } = await createLocationAndCompany(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `{
                   allLocations(where: { company: { name: "${company.name}"} }) { id }
                   allCompanies(where: { location: { name: "${location.name}"} }) { id }
@@ -161,8 +155,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createCompanyAndLocation(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
@@ -178,8 +171,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createLocationAndCompany(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
@@ -195,8 +187,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createCompanyAndLocation(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
@@ -212,8 +203,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             runner(setupKeystone, async ({ keystone }) => {
               await createInitialData(keystone);
               await createLocationAndCompany(keystone);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
@@ -230,8 +220,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'Count',
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 {
                   _allCompaniesMeta { count }
@@ -250,8 +239,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
             const { location, company } = await createCompanyAndLocation(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
@@ -267,8 +255,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             await createInitialData(keystone);
             const { location, company } = await createLocationAndCompany(keystone);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
@@ -287,8 +274,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const { locations } = await createInitialData(keystone);
             const location = locations[0];
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -316,8 +302,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           runner(setupKeystone, async ({ keystone }) => {
             const { companies } = await createInitialData(keystone);
             const company = companies[0];
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createLocation(data: {
@@ -344,8 +329,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'With create A',
           runner(setupKeystone, async ({ keystone }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -372,8 +356,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           'With create B',
           runner(setupKeystone, async ({ keystone }) => {
             const companyName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createLocation(data: {
@@ -403,8 +386,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -427,8 +409,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allCompanies },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allCompanies { id location { id company { id }} } }`,
             });
             expect(errors2).toBe(undefined);
@@ -451,8 +432,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const location = locations[0];
             const companyName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createLocation(data: {
@@ -474,8 +454,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allLocations },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allLocations { id company { id location { id }} } }`,
             });
             expect(errors2).toBe(undefined);
@@ -497,8 +476,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const locationName = sampleOne(alphanumGenerator);
             const companyName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   createCompany(data: {
@@ -522,8 +500,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allCompanies },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `{ allCompanies { id location { id company { id }} } }`,
             });
             expect(errors2).toBe(undefined);
@@ -551,8 +528,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(company.location).not.toBe(expect.anything());
             expect(location.company).not.toBe(expect.anything());
 
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -585,8 +561,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(company.location).not.toBe(expect.anything());
             expect(location.company).not.toBe(expect.anything());
 
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateLocation(
@@ -612,8 +587,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { companies } = await createInitialData(keystone);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -643,8 +617,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { locations } = await createInitialData(keystone);
             let location = locations[0];
             const companyName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateLocation(
@@ -674,8 +647,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { companies } = await createInitialData(keystone);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -700,8 +672,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const originalLocationId = Location.id;
             await (async () => {
               const locationName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `
                   mutation {
                     updateCompany(
@@ -723,8 +694,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(Company.location.id.toString()).toBe(Location.id.toString());
               expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-              const result = await graphqlRequest({
-                keystone,
+              const result = await keystone.executeGraphQL({
                 query: `{ Location(where: { id: "${originalLocationId}" }) { id company { id } } }`,
               });
               expect(result.errors).toBe(undefined);
@@ -739,8 +709,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { locations } = await createInitialData(keystone);
             let location = locations[0];
             const companyName = sampleOne(alphanumGenerator);
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateLocation(
@@ -765,8 +734,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const originalCompanyId = Company.id;
             await (async () => {
               const companyName = sampleOne(alphanumGenerator);
-              const { data, errors } = await graphqlRequest({
-                keystone,
+              const { data, errors } = await keystone.executeGraphQL({
                 query: `
                   mutation {
                     updateLocation(
@@ -788,8 +756,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(Company.location.id.toString()).toBe(Location.id.toString());
               expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-              const result = await graphqlRequest({
-                keystone,
+              const result = await keystone.executeGraphQL({
                 query: `{ Company(where: { id: "${originalCompanyId}" }) { id location { id } } }`,
               });
               expect(result.errors).toBe(undefined);
@@ -805,8 +772,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -834,8 +800,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createLocationAndCompany(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateLocation(
@@ -861,8 +826,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateCompany(
@@ -889,8 +853,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createLocationAndCompany(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
                 mutation {
                   updateLocation(
@@ -919,8 +882,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createCompanyAndLocation(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
             });
             expect(errors).toBe(undefined);
@@ -940,8 +902,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { location, company } = await createLocationAndCompany(keystone);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `mutation { deleteLocation(id: "${location.id}") { id } } `,
             });
             expect(errors).toBe(undefined);

--- a/api-tests/relationships/filtering/filtering.test.js
+++ b/api-tests/relationships/filtering/filtering.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -55,8 +55,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             item: { company: { connect: { id: otherCompany.id } } },
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers(where: {
@@ -116,8 +115,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             item: { company: { connect: { id: otherCompany.id } } },
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             allUsers(where: {
@@ -176,8 +174,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await createItem({ keystone, listKey: 'User', item: {} });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers(where: {
@@ -229,8 +226,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Create a dummy user to make sure we're actually filtering it out
           await createItem({ keystone, listKey: 'User', item: {} });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           query {
             allUsers(where: {
@@ -331,8 +327,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           // adsCompany users whose every post is spam
           // NB: this includes users who have no posts at all
-          let { data, errors } = await graphqlRequest({
-            keystone,
+          let { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers(where: {
@@ -362,8 +357,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // adsCompany users with no spam
-          ({ data, errors } = await graphqlRequest({
-            keystone,
+          ({ data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers(where: {
@@ -395,8 +389,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           ]);
 
           // adsCompany users with some spam
-          ({ data, errors } = await graphqlRequest({
-            keystone,
+          ({ data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers(where: {

--- a/api-tests/relationships/filtering/nested.test.js
+++ b/api-tests/relationships/filtering/nested.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, createItems } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -52,8 +52,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -104,8 +103,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -147,8 +145,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -195,8 +192,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -233,8 +229,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         runner(setupKeystone, async ({ keystone }) => {
           await createItem({ keystone, listKey: 'User', item: {} });
 
-          const result = await graphqlRequest({
-            keystone,
+          const result = await keystone.executeGraphQL({
             query: `
               query {
                 allUsers(where: { posts_some: { content_contains: "foo" } }) {
@@ -274,8 +269,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -318,8 +312,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -364,8 +357,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -408,8 +400,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {
@@ -457,8 +448,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ],
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         query {
           allUsers {

--- a/api-tests/relationships/nested-mutations/connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/connect-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -72,8 +72,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -96,8 +95,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { createUser },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -117,8 +115,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Test an empty list of related notes
-          const result = await graphqlRequest({
-            keystone,
+          const result = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -158,8 +155,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUsers(data: [
@@ -205,8 +201,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -243,8 +238,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { updateUser },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -308,8 +302,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -381,8 +374,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             item: { username: 'user2' },
           });
 
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUsers(data: [
@@ -431,8 +423,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
 
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -463,8 +454,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await createItem({ keystone, listKey: 'User', item: {} });
 
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(

--- a/api-tests/relationships/nested-mutations/connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/connect-singular.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, getItem } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -118,8 +118,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           mutation {
             createEvent(data: {
@@ -153,15 +152,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { createEvent },
             errors,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: 'mutation { createEvent(data: { title: "A thing", }) { id } }',
           });
           expect(errors).toBe(undefined);
 
           // Update the item and link the relationship field
-          const { data, errors: errors2 } = await graphqlRequest({
-            keystone,
+          const { data, errors: errors2 } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(
@@ -201,8 +198,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
 
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createEvent(data: {
@@ -233,8 +229,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await createItem({ keystone, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(

--- a/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -73,8 +73,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -109,8 +108,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { allNotes },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         query {
           allNotes(where: { id_in: [${data.createUser.notes
@@ -148,8 +146,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -193,8 +190,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { allNotes },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         query {
           allNotes(where: { id_in: [${data.updateUser.notes
@@ -217,8 +213,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'when neither id or create data passed',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: { notes: {} }) {

--- a/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-and-connect-singular.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 function setupKeystone(adapterName) {
   return setupServer({
@@ -27,8 +27,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'when neither id or create data passed',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createEvent(data: { group: {} }) {
@@ -48,8 +47,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'when both id and create data passed',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createEvent(data: { group: {

--- a/api-tests/relationships/nested-mutations/create-many.test.js
+++ b/api-tests/relationships/nested-mutations/create-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -67,8 +67,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const noteContent3 = `c${sampleOne(alphanumGenerator)}`;
 
           // Create an item that does the nested create
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -102,8 +101,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { createUser },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -140,8 +138,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { allNotes },
             errors: errors3,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         query {
           allNotes(where: { id_in: [${createUser.notes.map(({ id }) => `"${id}"`).join(',')}] }) {
@@ -155,8 +152,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(allNotes).toHaveLength(createUser.notes.length);
 
           // Test an empty list of related notes
-          const result = await graphqlRequest({
-            keystone,
+          const result = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -192,8 +188,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update an item that does the nested create
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -228,8 +223,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { updateUser },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -277,8 +271,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { allNotes },
             errors: errors3,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
         query {
           allNotes(where: { id_in: [${updateUser.notes.map(({ id }) => `"${id}"`).join(',')}] }) {
@@ -418,8 +411,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allNoteNoCreates, allUserToNotesNoCreates },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `
           query {
             allNoteNoCreates(where: { content: "${noteContent}" }) {
@@ -481,8 +473,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const {
               data: { allNoteNoCreates },
               errors: errors2,
-            } = await graphqlRequest({
-              keystone,
+            } = await keystone.executeGraphQL({
               query: `
           query {
             allNoteNoCreates(where: { content: "${noteContent}" }) {

--- a/api-tests/relationships/nested-mutations/create-singular.test.js
+++ b/api-tests/relationships/nested-mutations/create-singular.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, getItem } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -111,8 +111,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
           // Create an item that does the nested create
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
               mutation {
                 createEvent(data: {
@@ -143,8 +142,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { Group },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
               query {
                 Group(where: { id: "${data.createEvent.group.id}" }) {
@@ -175,8 +173,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update an item that does the nested create
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
               mutation {
                 updateEvent(
@@ -210,8 +207,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const {
             data: { Group },
             errors: errors2,
-          } = await graphqlRequest({
-            keystone,
+          } = await keystone.executeGraphQL({
             query: `
               query {
                 Group(where: { id: "${data.updateEvent.group.id}" }) {
@@ -364,8 +360,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   expect(error.path[0]).toEqual(`createEventTo${group.name}`);
                 }
                 // Confirm it didn't insert either of the records anyway
-                const result = await graphqlRequest({
-                  keystone,
+                const result = await keystone.executeGraphQL({
                   query: `
                     query {
                       all${group.name}s(where: { name: "${groupName}" }) {
@@ -379,8 +374,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 expect(result.data[`all${group.name}s`]).toMatchObject([]);
 
                 // Confirm it didn't insert either of the records anyway
-                const result2 = await graphqlRequest({
-                  keystone,
+                const result2 = await keystone.executeGraphQL({
                   query: `
                     query {
                       allEventTo${group.name}s(where: { title: "${eventName}" }) {
@@ -441,8 +435,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
 
                 // Confirm it didn't insert the record anyway
-                const result = await graphqlRequest({
-                  keystone,
+                const result = await keystone.executeGraphQL({
                   query: `
                     query {
                       all${group.name}s(where: { name: "${groupName}" }) {

--- a/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { setupServer, graphqlRequest, multiAdapterRunners } = require('@keystonejs/test-utils');
+const { setupServer, multiAdapterRunners } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -89,8 +89,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           mutation {
             updateUser(
@@ -124,8 +123,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
           mutation {
             createUser(data: {
@@ -194,8 +192,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
             expect(errors).toBe(undefined);
 
-            const result = await graphqlRequest({
-              keystone,
+            const result = await keystone.executeGraphQL({
               query: `
                 query getUserNodes($userId: ID!){
                   UserToNotesNoRead(where: { id: $userId }) {
@@ -205,6 +202,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
             `,
               variables: { userId: createUser.id },
+              context: keystone.createContext({ skipAccessControl: true }),
             });
             expect(result.errors).toBe(undefined);
             expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);

--- a/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-all-singular.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, getItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -70,8 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(
@@ -113,8 +112,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ keystone }) => {
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createEvent(data: {
@@ -146,8 +144,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await createItem({ keystone, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(

--- a/api-tests/relationships/nested-mutations/disconnect-many.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -89,8 +89,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -131,8 +130,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createUser(data: {
@@ -168,8 +166,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await createItem({ keystone, listKey: 'User', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -227,8 +224,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateUser(
@@ -306,8 +302,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
             expect(errors).toBe(undefined);
 
-            const result = await graphqlRequest({
-              keystone,
+            const result = await keystone.executeGraphQL({
               query: `
                 query getUserNodes($userId: ID!){
                   UserToNotesNoRead(where: { id: $userId }) {
@@ -317,6 +312,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
             `,
               variables: { userId: createUser.id },
+              context: keystone.createContext({ skipAccessControl: true }),
             });
             expect(result.errors).toBe(undefined);
             expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);

--- a/api-tests/relationships/nested-mutations/disconnect-singular.test.js
+++ b/api-tests/relationships/nested-mutations/disconnect-singular.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem, getItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -70,8 +70,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(
@@ -115,8 +114,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createEvent(data: {
@@ -151,8 +149,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await createItem({ keystone, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(
@@ -199,8 +196,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateEvent(

--- a/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.js
+++ b/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.js
@@ -1,5 +1,5 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItems } = require('@keystonejs/server-side-graphql-client');
 
 function setupKeystone(adapterName) {
@@ -42,8 +42,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Create some users that does the linking
-          const { data: alice, errors } = await graphqlRequest({
-            keystone,
+          const { data: alice, errors } = await keystone.executeGraphQL({
             query: `
               mutation {
                 createUser(data: {
@@ -57,8 +56,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           `,
           });
           expect(errors).toBe(undefined);
-          const { data: bob, errors: errors2 } = await graphqlRequest({
-            keystone,
+          const { data: bob, errors: errors2 } = await keystone.executeGraphQL({
             query: `
               mutation {
                 createUser(data: {
@@ -80,8 +78,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           // Set Bob as the author of note B
           await (async () => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
               mutation {
                 updateUser(id: "${bob.createUser.id}" data: {
@@ -100,8 +97,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           // B should see Bob as its author
           await (async () => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
             {
               Note(where: { id: "${noteB.id}"}) {
@@ -120,8 +116,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           // Alice should no longer see `B` in her notes
           await (async () => {
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
             {
               User(where: { id: "${alice.createUser.id}"}) {

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { createItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -29,8 +29,7 @@ function setupKeystone(adapterName) {
 }
 
 const getTeacher = async (keystone, teacherId) => {
-  const { data, errors } = await graphqlRequest({
-    keystone,
+  const { data, errors } = await keystone.executeGraphQL({
     query: `query getTeacher($teacherId: ID!){
   Teacher(where: { id: $teacherId }) {
     id
@@ -44,8 +43,7 @@ const getTeacher = async (keystone, teacherId) => {
 };
 
 const getStudent = async (keystone, studentId) => {
-  const { data } = await graphqlRequest({
-    keystone,
+  const { data } = await keystone.executeGraphQL({
     query: `query getStudent($studentId: ID!){
   Student(where: { id: $studentId }) {
     id
@@ -88,8 +86,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           mutation {
             createStudent(
@@ -146,8 +143,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(toStr(teacher2.students)).toHaveLength(0);
 
             // Run the query to disconnect the teacher from student
-            const { errors } = await graphqlRequest({
-              keystone,
+            const { errors } = await keystone.executeGraphQL({
               query: `
           mutation {
             updateStudent(
@@ -190,8 +186,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           mutation {
             createStudent(
@@ -232,8 +227,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const teacherName2 = sampleOne(alphanumGenerator);
 
             // Run the query to disconnect the teacher from student
-            const { data, errors } = await graphqlRequest({
-              keystone,
+            const { data, errors } = await keystone.executeGraphQL({
               query: `
           mutation {
             updateStudent(
@@ -299,8 +293,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           compareIds(teacher2.students, [student1, student2]);
 
           // Run the query to disconnect the teacher from student
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateStudent(
@@ -366,8 +359,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           compareIds(teacher2.students, [student1, student2]);
 
           // Run the query to disconnect the teacher from student
-          const { errors } = await graphqlRequest({
-            keystone,
+          const { errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           updateStudent(
@@ -434,8 +426,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         compareIds(teacher2.students, [student1, student2]);
 
         // Run the query to delete the student
-        const { errors } = await graphqlRequest({
-          keystone,
+        const { errors } = await keystone.executeGraphQL({
           query: `
       mutation {
         deleteStudent(id: "${student1.id}") {

--- a/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
+++ b/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.js
@@ -1,6 +1,6 @@
 const { gen, sampleOne } = require('testcheck');
 const { Text, Relationship } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { getItem } = require('@keystonejs/server-side-graphql-client');
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
@@ -32,8 +32,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'nested create',
         runner(setupKeystone, async ({ keystone }) => {
           const locationName = sampleOne(alphanumGenerator);
-          const { data, errors } = await graphqlRequest({
-            keystone,
+          const { data, errors } = await keystone.executeGraphQL({
             query: `
         mutation {
           createCompany(data: {

--- a/api-tests/required.test.js
+++ b/api-tests/required.test.js
@@ -1,5 +1,5 @@
 const globby = require('globby');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { Text } = require('@keystonejs/fields');
 
 describe('Test isRequired flag for all field types', () => {
@@ -34,8 +34,7 @@ describe('Test isRequired flag for all field types', () => {
             test(
               'Create an object without the required field',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     createTest(data: { name: "test entry" } ) { id }
@@ -52,16 +51,14 @@ describe('Test isRequired flag for all field types', () => {
             test(
               'Update an object with the required field having a null value',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { data: data0, errors: errors0 } = await graphqlRequest({
-                  keystone,
+                const { data: data0, errors: errors0 } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     createTest(data: { name: "test entry", testField: ${mod.exampleValue} } ) { id }
                   }`,
                 });
                 expect(errors0).toBe(undefined);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     updateTest(id: "${data0.createTest.id}" data: { name: "updated test entry", testField: null } ) { id }
@@ -78,16 +75,14 @@ describe('Test isRequired flag for all field types', () => {
             test(
               'Update an object without the required field',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { data: data0, errors: errors0 } = await graphqlRequest({
-                  keystone,
+                const { data: data0, errors: errors0 } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     createTest(data: { name: "test entry", testField: ${mod.exampleValue} } ) { id }
                   }`,
                 });
                 expect(errors0).toBe(undefined);
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     updateTest(id: "${data0.createTest.id}" data: { name: "updated test entry" } ) { id }

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -1,6 +1,6 @@
 const globby = require('globby');
 const { Text } = require('@keystonejs/fields');
-const { multiAdapterRunners, setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 
 describe('Test isUnique flag for all field types', () => {
   const testModules = globby.sync(`packages/**/src/**/test-fixtures.js`, { absolute: true });
@@ -30,8 +30,7 @@ describe('Test isUnique flag for all field types', () => {
             test(
               'uniqueness is enforced over multiple mutations',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { errors } = await graphqlRequest({
-                  keystone,
+                const { errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     createTest(data: { testField: ${mod.exampleValue} }) { id }
@@ -40,8 +39,7 @@ describe('Test isUnique flag for all field types', () => {
                 });
                 expect(errors).toBe(undefined);
 
-                const { errors: errors2 } = await graphqlRequest({
-                  keystone,
+                const { errors: errors2 } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     createTest(data: { testField: ${mod.exampleValue} }) { id }
@@ -59,8 +57,7 @@ describe('Test isUnique flag for all field types', () => {
             test(
               'uniqueness is enforced over single mutation',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { errors } = await graphqlRequest({
-                  keystone,
+                const { errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     foo: createTest(data: { testField: ${mod.exampleValue} }) { id }
@@ -79,8 +76,7 @@ describe('Test isUnique flag for all field types', () => {
             test(
               'Configuring uniqueness on one field does not affect others',
               keystoneTestWrapper(async ({ keystone }) => {
-                const { data, errors } = await graphqlRequest({
-                  keystone,
+                const { data, errors } = await keystone.executeGraphQL({
                   query: `
                   mutation {
                     foo: createTest(data: { testField: ${mod.exampleValue}, name: "jess" }) { id }


### PR DESCRIPTION
`graphqlRequest` skips access control, which we generally don't want to do, except in very specific circumstances. This change uses regular old `keystone.executeGraphQL`, which has access control tuned on by default. This means if we want to skip access control we need to explicitly call it out.