### PR TITLE
Made "default value" column of config table of Field API pages wrap

### DIFF
--- a/website/src/components/markdown/Table.js
+++ b/website/src/components/markdown/Table.js
@@ -92,7 +92,7 @@ export const Table = props => {
                 paddingRight: gridSize,
               },
 
-              '&:last-of-type': {
+              '&:last-of-type, &:nth-last-of-type(2)': {
                 whiteSpace: 'normal',
               },
 


### PR DESCRIPTION
This is because config tables on some field API pages aren't laying out correctly due to relatively long "default value" column content, eg. https://www.keystonejs.com/keystonejs/fields/src/types/slug/#config

Before the change:
![image](https://user-images.githubusercontent.com/10912424/89186980-e3b31400-d59c-11ea-9231-c9af60314143.png)

After:
![image](https://user-images.githubusercontent.com/10912424/89187087-0a714a80-d59d-11ea-9243-632fe8d56db1.png)

Note: I didn't check how this change affects other tables, so that's something you'd have to verify on your own. But arguably even if it does impact other tables aesthetics negatively, it makes otherwise completely unreadable tables now readable.
