### PR TITLE
Run preconstruct build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ x-simple-tests: &simple-tests
         environment:
           JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
     - run: yarn build
-
     - store_test_results:
         path: reports/junit
     - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ x-simple-tests: &simple-tests
     # causing the other job to fail with a "Missing Cypress" error.
     - run: CYPRESS_CACHE_FOLDER=$CIRCLE_WORKING_DIRECTORY/node_modules/cypress/.cache/ yarn
     - save_cache: *save-cache
+    - run: yarn build
     - run: yarn lint:eslint --format junit -o reports/junit/js-lint-results.xml
     - run: yarn lint:prettier
     - run: yarn lint:markdown

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,6 @@ x-simple-tests: &simple-tests
     # causing the other job to fail with a "Missing Cypress" error.
     - run: CYPRESS_CACHE_FOLDER=$CIRCLE_WORKING_DIRECTORY/node_modules/cypress/.cache/ yarn
     - save_cache: *save-cache
-    - run: yarn build
     - run: yarn lint:eslint --format junit -o reports/junit/js-lint-results.xml
     - run: yarn lint:prettier
     - run: yarn lint:markdown
@@ -88,6 +87,8 @@ x-simple-tests: &simple-tests
         command: yarn jest --ci --reporters=default --reporters=jest-junit --maxWorkers=1
         environment:
           JEST_JUNIT_OUTPUT: 'reports/junit/js-test-results.xml'
+    - run: yarn build
+
     - store_test_results:
         path: reports/junit
     - store_artifacts:


### PR DESCRIPTION
There are some errors that are only surfaced when doing a build and currently the only time a build happens is when building before publishing.