### PR TITLE
Update README.md

### DIFF
--- a/packages/file-adapters/README.md
+++ b/packages/file-adapters/README.md
@@ -118,7 +118,7 @@ const fileAdapter = new S3Adapter({
   },
   uploadParams: ({ filename, id, mimetype, encoding }) => ({
     Metadata: {
-      keystone_id: id,
+      keystone_id: `${id}`,
     },
   }),
 });


### PR DESCRIPTION
After a little debugging in file-adapters/s3.js I found that s3 was complaining about keystone_id not being a string. I'm not entirely sure where that is set, ie. if that is my local setting somewhere and this doesn't apply to others, but in either case, since there is no console debugging to notify users I would suggest either doing a id.toString() or `${id}` to ensure it's not kicking up a stink without saying.

```
    uploadParams: ({ filename, id, mimetype, encoding }) => ({
       Metadata: {
       keystone_id: `${id}`,
       },
    }),
```