### PR TITLE
Make keystone optional for ssgc functions

### DIFF
--- a/.changeset/famous-ties-type.md
+++ b/.changeset/famous-ties-type.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/server-side-graphql-client': minor
+'@keystonejs/keystone': patch
+---
+
+- Added a function `gqlNames(listKey)` to the `context` object created by `keystone.createContext`  This allows extracting graphQL query and mutation names from the `context` object.
+- Made the `keystone` argument optional when a `context` value is provided in any of the utility functions in `server-side-graphql-client` package.

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -213,6 +213,7 @@ module.exports = class Keystone {
     }) => this.createContext({ schemaName, authentication, skipAccessControl });
     context.executeGraphQL = ({ context = defaults.context, query, variables }) =>
       this.executeGraphQL({ context, query, variables });
+    context.gqlNames = listKey => this.lists[listKey].gqlNames;
     return context;
   }
 

--- a/packages/server-side-graphql-client/README.md
+++ b/packages/server-side-graphql-client/README.md
@@ -107,6 +107,8 @@ The following config options are common to all server-side graphQL functions.
 | `returnFields` | `String`   | `id`       | A graphQL fragment of fields to return. Must match the graphQL return type.                                                                                                                                         |
 | `context`      | `Object`   | N/A        | An Apollo [`context` object](https://www.apollographql.com/docs/apollo-server/data/resolvers/#the-context-argument). See the [server side graphQL docs](/docs/discussions/server-side-graphql.md) for more details. |
 
+> NOTE: If `context` argument is provided then the `keystone` argument is not required.
+
 ### `createItem`
 
 Create a single item.

--- a/packages/server-side-graphql-client/tests/index.test.js
+++ b/packages/server-side-graphql-client/tests/index.test.js
@@ -37,8 +37,18 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'createItem: Should create and get single item',
         runner(setupKeystone, async ({ keystone }) => {
+          const testContext = keystone.createContext({
+            schemaName: 'public',
+            authentication: {},
+            skipAccessControl: true,
+          });
           // Seed the db
-          const item = await createItem({ keystone, listKey: 'Test', item: testData[0].data });
+          const item = await createItem({
+            keystone,
+            context: testContext,
+            listKey: 'Test',
+            item: testData[0].data,
+          });
           expect(typeof item.id).toBe('string');
 
           // Get single item from db
@@ -255,6 +265,35 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const itemsASC = await getSortItems('age_ASC');
           expect(itemsASC.length).toEqual(4);
           expect(itemsASC[0]).toEqual({ name: 'User-4', age: 4 });
+        })
+      );
+    });
+    describe('context', () => {
+      test(
+        'Should make keystone optional when context is present',
+        runner(setupKeystone, async ({ keystone }) => {
+          const testContext = keystone.createContext({
+            schemaName: 'public',
+            authentication: {},
+            skipAccessControl: true,
+          });
+          // Seed the db
+          const item = await createItem({
+            context: testContext,
+            listKey: 'Test',
+            item: testData[0].data,
+          });
+          expect(typeof item.id).toBe('string');
+
+          // Get single item from db
+          const singleItem = await getItem({
+            context: testContext,
+            listKey: 'Test',
+            returnFields: 'name, age',
+            itemId: item.id,
+          });
+
+          expect(singleItem).toEqual(testData[0].data);
         })
       );
     });


### PR DESCRIPTION
- `context` object created via `keystone.createContext` now has `gqlNames(listKey)` function. This allows extracting graphql query and mutation names via context object.
- Made keystone optional when context is provided in any of the utility functions in `server-side-graphql-client` package.