### PR TITLE
Fix fields-cloudinary-image views not being compiled

### DIFF
--- a/.changeset/violet-pandas-burn.md
+++ b/.changeset/violet-pandas-burn.md
@@ -2,4 +2,4 @@
 '@keystonejs/fields-cloudinary-image': patch
 ---
 
-Fix field type views not being compiled
+Fixed ` fields-cloudinary-image` views not being compiled.

--- a/.changeset/violet-pandas-burn.md
+++ b/.changeset/violet-pandas-burn.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields-cloudinary-image': patch
+---
+
+Fix field type views not being compiled

--- a/packages/fields-cloudinary-image/package.json
+++ b/packages/fields-cloudinary-image/package.json
@@ -36,5 +36,8 @@
     "slate-react": "^0.22.4"
   },
   "main": "dist/fields-cloudinary-image.cjs.js",
-  "module": "dist/fields-cloudinary-image.esm.js"
+  "module": "dist/fields-cloudinary-image.esm.js",
+  "preconstruct": {
+    "entrypoints": ["index.js", "views/*.js", "views/blocks/single-image.js"]
+  }
 }

--- a/packages/fields-cloudinary-image/package.json
+++ b/packages/fields-cloudinary-image/package.json
@@ -21,7 +21,6 @@
     "@iframely/embed.js": "^1.1.1",
     "@keystonejs/adapter-knex": "^11.0.0",
     "@keystonejs/adapter-mongoose": "^9.0.0",
-    "@keystonejs/build-field-types": "^5.2.10",
     "@keystonejs/fields": "^16.0.0",
     "@keystonejs/fields-content": "^8.0.0",
     "@primer/octicons-react": "^10.0.0",

--- a/packages/fields-cloudinary-image/src/ImageBlock.js
+++ b/packages/fields-cloudinary-image/src/ImageBlock.js
@@ -1,5 +1,5 @@
 import pluralize from 'pluralize';
-import { importView } from '@keystonejs/build-field-types';
+import { resolveView } from './resolve-view';
 
 import { Block } from '@keystonejs/fields-content/Block';
 import { imageContainer, caption } from '@keystonejs/fields-content/blocks';
@@ -72,7 +72,7 @@ export class ImageBlock extends Block {
 
   getAdminViews() {
     return [
-      importView('./views/blocks/single-image'),
+      resolveView('views/blocks/single-image'),
       ...new imageContainer().getAdminViews(),
       ...new caption().getAdminViews(),
     ];

--- a/packages/fields-cloudinary-image/src/index.js
+++ b/packages/fields-cloudinary-image/src/index.js
@@ -1,4 +1,4 @@
-import { importView } from '@keystonejs/build-field-types';
+import { resolveView } from './resolve-view';
 
 import {
   CloudinaryImage as Implementation,
@@ -11,9 +11,9 @@ export const CloudinaryImage = {
   type: 'CloudinaryImage',
   implementation: Implementation,
   views: {
-    Controller: importView('./views/Controller'),
-    Field: importView('./views/Field'),
-    Cell: importView('./views/Cell'),
+    Controller: resolveView('views/Controller'),
+    Field: resolveView('views/Field'),
+    Cell: resolveView('views/Cell'),
   },
   adapters: {
     mongoose: MongoCloudinaryImageInterface,

--- a/packages/fields-cloudinary-image/src/resolve-view.js
+++ b/packages/fields-cloudinary-image/src/resolve-view.js
@@ -1,0 +1,5 @@
+import path from 'path';
+
+const pkgDir = path.dirname(require.resolve('@keystonejs/fields-cloudinary-image/package.json'));
+
+export const resolveView = pathname => path.join(pkgDir, pathname);

--- a/packages/fields-cloudinary-image/views/Cell/package.json
+++ b/packages/fields-cloudinary-image/views/Cell/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/fields-cloudinary-image.cjs.js",
+  "module": "dist/fields-cloudinary-image.esm.js"
+}

--- a/packages/fields-cloudinary-image/views/Controller/package.json
+++ b/packages/fields-cloudinary-image/views/Controller/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/fields-cloudinary-image.cjs.js",
+  "module": "dist/fields-cloudinary-image.esm.js"
+}

--- a/packages/fields-cloudinary-image/views/Field/package.json
+++ b/packages/fields-cloudinary-image/views/Field/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/fields-cloudinary-image.cjs.js",
+  "module": "dist/fields-cloudinary-image.esm.js"
+}

--- a/packages/fields-cloudinary-image/views/blocks/single-image/package.json
+++ b/packages/fields-cloudinary-image/views/blocks/single-image/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/fields-cloudinary-image.cjs.js",
+  "module": "dist/fields-cloudinary-image.esm.js"
+}


### PR DESCRIPTION
Found this while I was completely removing build-field-types, looks like I missed changing to entrypoints from build-field-types' importView even though I changed it to be built with Preconstruct instead of build-field-types.

Note that this currently means that fields-cloudinary-image is broken on npm right now so this should probably be released quickly