### PR TITLE
Fetch commits to find the last release from the default branch in create-keystone-app

### DIFF
--- a/.changeset/great-rockets-study.md
+++ b/.changeset/great-rockets-study.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-app': patch
+---
+
+Fetch commits to find the last release from the default branch rather than  `create-keystone-app-from-github`

--- a/packages/create-keystone-app/lib/github-api.js
+++ b/packages/create-keystone-app/lib/github-api.js
@@ -11,9 +11,7 @@ let cachedLatestVersionCommit;
 const getLatestVersionCommit = async () => {
   if (cachedLatestVersionCommit === undefined) {
     let commits = await got
-      .get(
-        'https://api.github.com/repos/keystonejs/keystone/commits?path=.github/release-count&sha=create-keystone-app-from-github'
-      )
+      .get('https://api.github.com/repos/keystonejs/keystone/commits?path=.github/release-count')
       .json();
     if (!commits.length) {
       throw new Error(


### PR DESCRIPTION
Closes #3368

I also restored the `create-keystone-app-from-github` branch so that the previous release isn't broken with an unexpected error right now.

Once this is merged and released, I'll push a change to `create-keystone-app-from-github` so that create-keystone-app will prompt users to update create-keystone-app.