### PR TITLE
Fix the `CloudinaryImage` field import

### DIFF
--- a/.changeset/clever-phones-dress.md
+++ b/.changeset/clever-phones-dress.md
@@ -1,0 +1,9 @@
+---
+'@keystonejs/demo-project-meetup': patch
+---
+
+**Fixed the `CloudinaryImage` field import in meetup demo**
+
+The `CloudinaryImage` was wrongly imported from `@keystonejs/fields` package causing an invalid type error. 
+
+This change imports it correctly from `@keystonejs/fields-cloudinary-image`.

--- a/demo-projects/meetup/package.json
+++ b/demo-projects/meetup/package.json
@@ -23,6 +23,7 @@
     "@keystonejs/auth-password": "^5.1.13",
     "@keystonejs/email": "^5.1.5",
     "@keystonejs/fields": "^16.0.0",
+    "@keystonejs/fields-cloudinary-image": "^1.0.1",
     "@keystonejs/fields-wysiwyg-tinymce": "^5.3.5",
     "@keystonejs/file-adapters": "^7.0.2",
     "@keystonejs/keystone": "^13.1.0",

--- a/demo-projects/meetup/schema.js
+++ b/demo-projects/meetup/schema.js
@@ -3,7 +3,6 @@ const { v4: uuid } = require('uuid');
 const { sendEmail } = require('./emails');
 
 const {
-  CloudinaryImage,
   Checkbox,
   DateTime,
   Integer,
@@ -13,6 +12,7 @@ const {
   Text,
 } = require('@keystonejs/fields');
 const { CloudinaryAdapter } = require('@keystonejs/file-adapters');
+const { CloudinaryImage } = require('@keystonejs/fields-cloudinary-image');
 const { Wysiwyg } = require('@keystonejs/fields-wysiwyg-tinymce');
 
 const cloudinaryAdapter = new CloudinaryAdapter({


### PR DESCRIPTION
The `CloudinaryImage` field was incorrectly imported from `@keystonejs/fields` inside meetup demo. 
This fix will import it correctly from `@keystonejs/fields-cloudinary-image`. 