### PR TITLE
Remove global variables

### DIFF
--- a/.changeset/yellow-ways-mix.md
+++ b/.changeset/yellow-ways-mix.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields-location-google': patch
+'@keystonejs/fields': patch
+---
+
+Removed internal global variables.

--- a/packages/fields-location-google/src/Implementation.js
+++ b/packages/fields-location-google/src/Implementation.js
@@ -9,10 +9,6 @@ import fetch from 'node-fetch';
 // https://github.com/Automattic/mongoose/blob/master/migrating_to_5.md#checking-if-a-path-is-populated
 mongoose.set('objectIdGetter', false);
 
-const {
-  Types: { ObjectId },
-} = mongoose;
-
 export class LocationGoogleImplementation extends Implementation {
   constructor(_, { googleMapsKey }) {
     super(...arguments);
@@ -103,7 +99,7 @@ export class LocationGoogleImplementation extends Implementation {
       const { place_id, formatted_address } = response.results[0];
       const { lat, lng } = response.results[0].geometry.location;
       return {
-        id: new ObjectId(),
+        id: new mongoose.Types.ObjectId(),
         googlePlaceID: place_id,
         formattedAddress: formatted_address,
         lat: lat,
@@ -138,7 +134,7 @@ export class MongoLocationGoogleInterface extends CommonLocationInterface(Mongoo
   addToMongooseSchema(schema) {
     const schemaOptions = {
       type: {
-        id: ObjectId,
+        id: mongoose.Types.ObjectId,
         googlePlaceID: String,
         formattedAddress: String,
         lat: Number,

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -7,10 +7,6 @@ import mongoose from 'mongoose';
 // https://mongoosejs.com/docs/migrating_to_5.html#id-getter
 mongoose.set('objectIdGetter', false);
 
-const {
-  Types: { ObjectId },
-} = mongoose;
-
 export class File extends Implementation {
   constructor(path, { adapter }) {
     super(...arguments);
@@ -99,7 +95,7 @@ export class File extends Implementation {
       return previousData;
     }
 
-    const newId = new ObjectId();
+    const newId = new mongoose.Types.ObjectId();
 
     const { id, filename, _meta } = await this.fileAdapter.save({
       stream,
@@ -135,7 +131,7 @@ export class MongoFileInterface extends CommonFileInterface(MongooseFieldAdapter
   addToMongooseSchema(schema) {
     const schemaOptions = {
       type: {
-        id: ObjectId,
+        id: mongoose.Types.ObjectId,
         path: String,
         filename: String,
         originalFilename: String,

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -2,12 +2,6 @@ import mongoose from 'mongoose';
 import { MongooseFieldAdapter } from '@keystonejs/adapter-mongoose';
 import { KnexFieldAdapter } from '@keystonejs/adapter-knex';
 
-const {
-  Schema: {
-    Types: { ObjectId },
-  },
-} = mongoose;
-
 import { Implementation } from '../../Implementation';
 import { resolveNested } from './nested-mutations';
 
@@ -315,7 +309,7 @@ export class MongoRelationshipInterface extends MongooseFieldAdapter {
     this.isRelationship = true;
   }
 
-  addToMongooseSchema(schema, mongoose, rels) {
+  addToMongooseSchema(schema, _mongoose, rels) {
     // If we're relating to 'many' things, we don't store ids in this table
     if (!this.field.many) {
       // If we're the right hand side of a 1:1 relationship, do nothing.
@@ -327,13 +321,9 @@ export class MongoRelationshipInterface extends MongooseFieldAdapter {
       }
 
       // Otherwise, we're are hosting a foreign key
-      const {
-        refListKey: ref,
-        config: { many },
-      } = this;
-      const type = many ? [ObjectId] : ObjectId; // FIXME: redundant?
-      const schemaOptions = { type, ref };
-      schema.add({ [this.path]: this.mergeSchemaOptions(schemaOptions, this.config) });
+      const { refListKey, config } = this;
+      const type = mongoose.Types.ObjectId;
+      schema.add({ [this.path]: this.mergeSchemaOptions({ type, ref: refListKey }, config) });
     }
   }
 


### PR DESCRIPTION
I bumped into these globals while investigating #3275. Removing these doesn't solve that issue, but it cleans up the heap a little bit to help trying to find the memory leak.

This also cleans up a code path that was never taken (and had been flagged with a FIXME).