### PR TITLE
Clean up Slug unique value generation

### DIFF
--- a/.changeset/cool-flies-bake.md
+++ b/.changeset/cool-flies-bake.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Cleaned up the implementation of generating unique `Slug` values.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -36,6 +36,7 @@
     "@keystonejs/adapter-knex": "^11.0.1",
     "@keystonejs/adapter-mongoose": "^9.0.1",
     "@keystonejs/app-admin-ui": "^7.3.0",
+    "@keystonejs/server-side-graphql-client": "^1.1.0",
     "@keystonejs/utils": "^5.4.2",
     "@primer/octicons-react": "^10.0.0",
     "@sindresorhus/slugify": "^0.11.0",


### PR DESCRIPTION
Replaces a somewhat confusing `do...while` loop with a more standard `for` loop, and makes use of `server-side-graphql-client` to simplify executing a query inside the hook.