### PR TITLE
Refactor the slug type tests

### DIFF
--- a/.changeset/wise-zoos-tickle.md
+++ b/.changeset/wise-zoos-tickle.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Updated tests for the `Slug` field type.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -36,6 +36,7 @@
     "@keystonejs/adapter-knex": "^11.0.1",
     "@keystonejs/adapter-mongoose": "^9.0.1",
     "@keystonejs/app-admin-ui": "^7.3.0",
+    "@keystonejs/server-side-graphql-client": "1.1.0",
     "@keystonejs/utils": "^5.4.2",
     "@primer/octicons-react": "^10.0.0",
     "@sindresorhus/slugify": "^0.11.0",

--- a/packages/fields/src/types/Slug/Implementation.test.js
+++ b/packages/fields/src/types/Slug/Implementation.test.js
@@ -1,4 +1,5 @@
-import { multiAdapterRunners, setupServer, graphqlRequest } from '@keystonejs/test-utils';
+import { createItem, deleteItem, updateItem } from '@keystonejs/server-side-graphql-client';
+import { multiAdapterRunners, setupServer } from '@keystonejs/test-utils';
 
 import cuid from 'cuid';
 import Text from '../Text';
@@ -19,7 +20,7 @@ const generateListName = () =>
   // Ensure plurality isn't a problem
   'foo';
 
-const setupList = (adapterName, fields) =>
+const setupList = (adapterName, fields) => () =>
   setupServer({
     adapterName,
     createLists: keystone => {
@@ -30,356 +31,260 @@ const setupList = (adapterName, fields) =>
 describe('Slug#implementation', () => {
   multiAdapterRunners().map(({ runner, adapterName }) =>
     describe(`Adapter: ${adapterName}`, () => {
-      it('Instantiates correctly if from is a string', () => {
+      test('Instantiates correctly if from is a string', () => {
         expect(() => {
           runner(
-            () => setupList(adapterName, { url: { type: Slug, from: 'foo' } }),
+            setupList(adapterName, { url: { type: Slug, from: 'foo' } }),
             // Empty test, we just want to assert the setup works
             () => {}
           )();
         }).not.toThrow();
       });
 
-      it("By default, generates a slug from the 'name' field", () => {
+      test(
+        "By default, generates a slug from the 'name' field",
+        runner(
+          setupList(adapterName, {
+            name: { type: Text },
+            title: { type: Text },
+            url: { type: Slug },
+          }),
+          async ({ keystone }) => {
+            const { key: listKey } = keystone.listsArray[0];
+            const item = { name: 'Test Entry!', title: 'A title' };
+            const returnFields = 'url';
+            const result = await createItem({ keystone, listKey, item, returnFields });
+            expect(result).toMatchObject({ url: 'test-entry' });
+          }
+        )
+      );
+
+      test(
+        "By default, generates a slug from the 'title' field if no 'name' field exists",
+        runner(
+          setupList(adapterName, {
+            title: { type: Text },
+            url: { type: Slug },
+          }),
+          async ({ keystone }) => {
+            const { key: listKey } = keystone.listsArray[0];
+            const item = { title: 'Something funny?' };
+            const returnFields = 'url';
+            const result = await createItem({ keystone, listKey, item, returnFields });
+            expect(result).toMatchObject({ url: 'something-funny' });
+          }
+        )
+      );
+
+      test(
+        "Generates a slug using the 'from' field specified",
+        runner(
+          setupList(adapterName, {
+            username: { type: Text },
+            url: { type: Slug, from: 'username' },
+          }),
+          async ({ keystone }) => {
+            const { key: listKey } = keystone.listsArray[0];
+            const item = { username: 'Test Entry!' };
+            const returnFields = 'url';
+            const result = await createItem({ keystone, listKey, item, returnFields });
+            expect(result).toMatchObject({ url: 'test-entry' });
+          }
+        )
+      );
+
+      test(`Should handle an async 'generate' function`, () => {
+        const generate = () => new Promise(resolve => setTimeout(() => resolve('foobar'), 4));
         return runner(
-          () =>
-            setupList(adapterName, {
-              name: { type: Text },
-              title: { type: Text },
-              url: { type: Slug },
-            }),
-          ({ keystone }) => {
-            const {
-              gqlNames: { createMutationName },
-            } = keystone.listsArray[0];
-            return graphqlRequest({
-              keystone,
-              query: `mutation { ${createMutationName}(data: { name: "Test Entry!", title: "A title" } ) { id name url } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data[createMutationName]).toMatchObject({
-                url: 'test-entry',
-              });
-            });
+          setupList(adapterName, {
+            name: { type: Text },
+            url: { type: Slug, generate },
+          }),
+          async ({ keystone }) => {
+            const { key: listKey } = keystone.listsArray[0];
+            const item = { name: 'Awesome Sauce' };
+            const returnFields = 'url';
+            const result = await createItem({ keystone, listKey, item, returnFields });
+            expect(result).toMatchObject({ url: 'foobar' });
           }
         )();
       });
 
-      it("By default, generates a slug from the 'title' field if no 'name' field exists", () => {
-        return runner(
-          () =>
-            setupList(adapterName, {
-              title: { type: Text },
-              url: { type: Slug },
-            }),
-          ({ keystone }) => {
-            const {
-              gqlNames: { createMutationName },
-            } = keystone.listsArray[0];
-            return graphqlRequest({
-              keystone,
-              query: `mutation { ${createMutationName}(data: { title: "Something funny?" } ) { id title url } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data[createMutationName]).toMatchObject({
-                url: 'something-funny',
-              });
-            });
+      test(
+        `Should handle an async 'makeUnique' function`,
+        runner(
+          setupList(adapterName, {
+            name: { type: Text },
+            url: {
+              type: Slug,
+              from: 'name',
+              makeUnique: () => new Promise(resolve => setTimeout(() => resolve('foobar'), 4)),
+            },
+          }),
+          async ({ keystone }) => {
+            const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+            const { key: listKey } = keystone.listsArray[0];
+            await createItem({ keystone, listKey, item });
+            const result = await createItem({ keystone, listKey, item, returnFields: 'url' });
+            expect(result).toMatchObject({ url: 'foobar' });
           }
-        )();
-      });
+        )
+      );
 
-      it("Generates a slug using the 'from' field specified", () => {
-        return runner(
-          () =>
+      describe('create mutation', () => {
+        test(
+          "Doesn't generate when a value is set in mutation",
+          runner(
             setupList(adapterName, {
               username: { type: Text },
               url: { type: Slug, from: 'username' },
             }),
-          ({ keystone }) => {
-            const {
-              gqlNames: { createMutationName },
-            } = keystone.listsArray[0];
-            return graphqlRequest({
-              keystone,
-              query: `mutation { ${createMutationName}(data: { username: "Test Entry!" } ) { id username url } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data[createMutationName]).toMatchObject({
-                url: 'test-entry',
-              });
-            });
-          }
-        )();
-      });
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { username: 'Test Entry!', url: 'foo' };
+              const returnFields = 'url';
+              const result = await createItem({ keystone, listKey, item, returnFields });
+              expect(result).toMatchObject({ url: 'foo' });
+            }
+          )
+        );
 
-      it(`Should handle an async 'generate' function`, () => {
-        const generate = () => new Promise(resolve => setTimeout(() => resolve('foobar'), 4));
-        return runner(
-          () =>
+        test('Calls generate with `{ resolvedData, existingData }`', () => {
+          const generate = jest.fn(() => 'foobar');
+          return runner(
             setupList(adapterName, {
               name: { type: Text },
               url: { type: Slug, generate },
             }),
-          async ({ keystone }) => {
-            const {
-              gqlNames: { createMutationName },
-            } = keystone.listsArray[0];
-            return graphqlRequest({
-              keystone,
-              query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce" } ) { id name url } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data[createMutationName]).toMatchObject({
-                url: 'foobar',
-              });
-            });
-          }
-        )();
-      });
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce' };
+              await createItem({ keystone, listKey, item });
+              expect(generate).toHaveBeenCalledTimes(1);
+              expect(generate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  resolvedData: expect.any(Object),
+                  existingItem: undefined,
+                })
+              );
+            }
+          )();
+        });
 
-      it(`Should handle an async 'makeUnique' function`, () => {
-        const makeUnique = () => new Promise(resolve => setTimeout(() => resolve('foobar'), 4));
-        return runner(
-          () =>
+        test(
+          'Generates a unique slug when a collision occurs',
+          runner(
             setupList(adapterName, {
               name: { type: Text },
-              url: { type: Slug, from: 'name', makeUnique },
+              url: { type: Slug, from: 'name' },
             }),
-          async ({ keystone, create }) => {
-            const {
-              key,
-              gqlNames: { createMutationName },
-            } = keystone.listsArray[0];
-            await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-            return graphqlRequest({
-              keystone,
-              query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-            }).then(({ data, errors }) => {
-              expect(errors).toBe(undefined);
-              expect(data[createMutationName]).toMatchObject({
-                url: 'foobar',
-              });
-            });
-          }
-        )();
-      });
-
-      describe('create mutation', () => {
-        it("Doesn't generate when a value is set in mutation", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                username: { type: Text },
-                url: { type: Slug, from: 'username' },
-              }),
-            ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { username: "Test Entry!", url: "foo" } ) { id username url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: 'foo',
-                });
-              });
-            }
-          )();
-        });
-
-        it('Calls generate with `{ resolvedData, existingData }`', () => {
-          const generate = jest.fn(() => 'foobar');
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, generate },
-              }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce" } ) { id name url } }`,
-              }).then(({ errors }) => {
-                expect(errors).toBe(undefined);
-                expect(generate).toHaveBeenCalledTimes(1);
-                expect(generate).toHaveBeenCalledWith(
-                  expect.objectContaining({
-                    resolvedData: expect.any(Object),
-                    existingItem: undefined,
-                  })
-                );
-              });
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const returnFields = 'url';
+              await createItem({ keystone, listKey, item });
+              const { url } = await createItem({ keystone, listKey, item, returnFields });
+              expect(url).toMatch(/^awesome-sauce-[a-zA-Z0-9]+$/);
             }
-          )();
-        });
+          )
+        );
 
-        it('Generates a unique slug when a collision occurs', () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: expect.stringMatching(/^awesome-sauce-[a-zA-Z0-9]+$/),
-                });
-              });
+        test(
+          "Calls 'makeUnique' when a collision occurs",
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, from: 'name', makeUnique: ({ slug }) => reverse(slug) },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const returnFields = 'url';
+              await createItem({ keystone, listKey, item });
+              const result = await createItem({ keystone, listKey, item, returnFields });
+              expect(result).toMatchObject({ url: reverse('awesome-sauce') });
             }
-          )();
-        });
+          )
+        );
 
-        it("Calls 'makeUnique' when a collision occurs", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, from: 'name', makeUnique: ({ slug }) => reverse(slug) },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: reverse('awesome-sauce'),
-                });
-              });
-            }
-          )();
-        });
-
-        it("Doesn't call 'makeUnique' when isUnique: false & a collision occurs", () => {
+        test("Doesn't call 'makeUnique' when isUnique: false & a collision occurs", () => {
           const makeUnique = jest.fn();
           return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, from: 'name', makeUnique, isUnique: false },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: 'awesome-sauce',
-                });
-                expect(makeUnique).not.toHaveBeenCalled();
-              });
-            }
-          )();
-        });
-
-        it('Generates a unique slug when alwaysMakeUnique: true', () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, from: 'name', alwaysMakeUnique: true },
-              }),
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, from: 'name', makeUnique, isUnique: false },
+            }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Wicked Sauce", url: "wicked-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: expect.stringMatching(/^wicked-sauce-[a-zA-Z0-9]+$/),
-                });
-              });
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const returnFields = 'url';
+              await createItem({ keystone, listKey, item, returnFields });
+              const result = await createItem({ keystone, listKey, item, returnFields });
+              expect(result).toMatchObject({ url: 'awesome-sauce' });
+              expect(makeUnique).not.toHaveBeenCalled();
             }
           )();
         });
 
-        it("Calls 'makeUnique' when alwaysMakeUnique is true", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: {
-                  type: Slug,
-                  from: 'name',
-                  alwaysMakeUnique: true,
-                  makeUnique: ({ slug }) => reverse(slug),
-                },
-              }),
+        test(
+          'Generates a unique slug when alwaysMakeUnique: true',
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, from: 'name', alwaysMakeUnique: true },
+            }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: reverse('awesome-sauce'),
-                });
-              });
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Wicked Sauce', url: 'wicked-sauce' };
+              const returnFields = 'url';
+              const { url } = await createItem({ keystone, listKey, item, returnFields });
+              expect(url).toMatch(/^wicked-sauce-[a-zA-Z0-9]+$/);
             }
-          )();
-        });
+          )
+        );
 
-        it("Still calls 'makeUnique' when isUnique: false & alwaysMakeUnique: true", () => {
+        test(
+          "Calls 'makeUnique' when alwaysMakeUnique is true",
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: {
+                type: Slug,
+                from: 'name',
+                alwaysMakeUnique: true,
+                makeUnique: ({ slug }) => reverse(slug),
+              },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const returnFields = 'url';
+              const result = await createItem({ keystone, listKey, item, returnFields });
+              expect(result).toMatchObject({ url: reverse('awesome-sauce') });
+            }
+          )
+        );
+
+        test("Still calls 'makeUnique' when isUnique: false & alwaysMakeUnique: true", () => {
           const makeUnique = jest.fn(({ slug }) => reverse(slug));
           return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: {
-                  type: Slug,
-                  from: 'name',
-                  alwaysMakeUnique: true,
-                  makeUnique,
-                  isUnique: false,
-                },
-              }),
+            setupList(adapterName, {
+              name: { type: Text },
+              url: {
+                type: Slug,
+                from: 'name',
+                alwaysMakeUnique: true,
+                makeUnique,
+                isUnique: false,
+              },
+            }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Awesome Sauce", url: "awesome-sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).toMatchObject({
-                  url: reverse('awesome-sauce'),
-                });
-                expect(makeUnique).toHaveBeenCalled();
-              });
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const returnFields = 'url';
+              const result = await createItem({ keystone, listKey, item, returnFields });
+              expect(result).toMatchObject({ url: reverse('awesome-sauce') });
+              expect(makeUnique).toHaveBeenCalled();
             }
           )();
         });
@@ -389,344 +294,265 @@ describe('Slug#implementation', () => {
         it('Calls generate with `{ resolvedData, existingData }` on update', () => {
           const generate = jest.fn(() => 'foobar');
           return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, generate },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { updateMutationName },
-              } = keystone.listsArray[0];
-              const { id } = await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, generate },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const { id } = await createItem({ keystone, listKey, item });
+
+              await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { name: "Something Else" } ) { id name url } }`,
-              }).then(({ errors }) => {
-                expect(errors).toBe(undefined);
-                expect(generate).toHaveBeenCalledWith(
-                  expect.objectContaining({
-                    resolvedData: expect.any(Object),
-                    existingItem: expect.any(Object),
-                  })
-                );
+                listKey,
+                item: { id, data: { name: 'Something Else' } },
               });
+
+              expect(generate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  resolvedData: expect.any(Object),
+                  existingItem: expect.any(Object),
+                })
+              );
             }
           )();
         });
 
-        it('Has a stable unique ID across regenerations', () => {
+        test(
+          'Has a stable unique ID across regenerations',
           // 1. Create { name: "Hi Ho" } (slug: 'hi-ho')
           // 2. { id } = Create { name: "Hi Ho" } (slug: 'hi-ho-dsbwerlk')
           // 3. Update { id, author: "Sam" } (slug: 'hi-ho-dsbwerlk')
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                author: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName, updateMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Hi Ho', url: 'hi-ho' });
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              author: { type: Text },
+              url: { type: Slug, from: 'name' },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Hi Ho', url: 'hi-ho' };
+              const returnFields = 'id url';
+              await createItem({ keystone, listKey, item });
 
-              const creationResult = await graphqlRequest({
+              const { id, url } = await createItem({
                 keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Hi Ho" } ) { id url } }`,
+                listKey,
+                item: { name: 'Hi Ho' },
+                returnFields,
               });
-
-              expect(creationResult.errors).toBe(undefined);
-
-              const { id, url } = creationResult.data[createMutationName];
 
               // The slug has been uniquified
               expect(url).toMatch(/hi-ho-[a-zA-Z0-9]+/);
 
-              const updateResult = await graphqlRequest({
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { author: "Sam" } ) { id url } }`,
+                listKey,
+                item: { id, data: { author: 'Sam' } },
+                returnFields,
               });
-
-              expect(updateResult.errors).toBe(undefined);
 
               // The url should not have changed across updates, even though we
               // have regenerateOnUpdate: true
-              expect(updateResult.data[updateMutationName]).toMatchObject({
-                url,
-              });
+              expect(result).toMatchObject({ url });
             }
-          )();
-        });
+          )
+        );
 
         // NOTE: This documents current behaviour, but it would be great if in
         // the future this test were to be modified so the slug _is_ stable.
-        it('Does not have a stable unique ID across regenerations when a slug is supplied', () => {
+        test(
+          'Does not have a stable unique ID across regenerations when a slug is supplied',
           // 1. Create { name: "Hi Ho" } (slug: 'hi-ho')
           // 2. { id } = Create { name: "Hi Ho", slug: "hi-ho" } (slug: 'hi-ho-dsbwerlk')
           // 3. Update { id, author: "Sam", slug: "hi-ho" } (slug: 'hi-ho-dsbwerlk')
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                author: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName, updateMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Hi Ho', url: 'hi-ho' });
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              author: { type: Text },
+              url: { type: Slug, from: 'name' },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Hi Ho', url: 'hi-ho' };
+              const returnFields = 'id url';
+              await createItem({ keystone, listKey, item });
 
-              const creationResult = await graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Hi Ho", url: "hi-ho" } ) { id url } }`,
-              });
-
-              expect(creationResult.errors).toBe(undefined);
-
-              const { id, url } = creationResult.data[createMutationName];
+              const { id, url } = await createItem({ keystone, listKey, item, returnFields });
 
               // The slug has been uniquified
               expect(url).toMatch(/hi-ho-[a-zA-Z0-9]+/);
 
-              const updateResult = await graphqlRequest({
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { author: "Sam", url: "hi-ho" } ) { id url } }`,
+                listKey,
+                item: { id, data: { author: 'Sam', url: 'hi-ho' } },
+                returnFields,
               });
-
-              expect(updateResult.errors).toBe(undefined);
 
               // The url should not have changed across updates, even though we
               // have regenerateOnUpdate: true
-              expect(updateResult.data[updateMutationName]).not.toMatchObject({
-                url,
-              });
+              expect(result).not.toMatchObject({ url });
             }
-          )();
-        });
+          )
+        );
 
-        it('Has a stable unique ID across regenerations when original conflict is gone', () => {
+        test(
+          'Has a stable unique ID across regenerations when original conflict is gone',
           // 1. { id } = Create { name: "Hi Ho" } (slug: 'hi-ho')
           // 2. { id: newId } = Create { name: "Hi Ho" } (slug: 'hi-ho-dsbwerlk')
           // 3. Delete { id }
           // 4. Update { id: newId, author: "Sam" } (slug: 'hi-ho-dsbwerlk')
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                author: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create, delete: deleteFn }) => {
-              const {
-                key,
-                gqlNames: { createMutationName, updateMutationName },
-              } = keystone.listsArray[0];
-              const originalItem = await create(key, { name: 'Hi Ho', url: 'hi-ho' });
-
-              const creationResult = await graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Hi Ho" } ) { id url } }`,
-              });
-
-              expect(creationResult.errors).toBe(undefined);
-
-              const { id, url } = creationResult.data[createMutationName];
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              author: { type: Text },
+              url: { type: Slug, from: 'name' },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Hi Ho', url: 'hi-ho' };
+              const returnFields = 'id url';
+              const originalItem = await createItem({ keystone, listKey, item });
+              const { id, url } = await createItem({ keystone, listKey, item, returnFields });
 
               // The slug has been uniquified
               expect(url).toMatch(/hi-ho-[a-zA-Z0-9]+/);
 
               // delete the original created item
-              await deleteFn(key, originalItem.id);
+              await deleteItem({ keystone, listKey, itemId: originalItem.id });
 
-              const updateResult = await graphqlRequest({
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { author: "Sam" } ) { id url } }`,
+                listKey,
+                item: { id, data: { author: 'Sam' } },
+                returnFields,
               });
-
-              expect(updateResult.errors).toBe(undefined);
 
               // The url should not have changed across updates, even though we
               // have regenerateOnUpdate: true
-              expect(updateResult.data[updateMutationName]).toMatchObject({
-                url,
-              });
+              expect(result).toMatchObject({ url });
             }
-          )();
-        });
+          )
+        );
 
-        it('Does not have a stable unique ID across regenerations when original conflict is gone, when a slug is supplied', () => {
+        test(
+          'Does not have a stable unique ID across regenerations when original conflict is gone, when a slug is supplied',
           // 1. { id } = Create { name: "Hi Ho" } (slug: 'hi-ho')
           // 2. { id: newId } = Create { name: "Hi Ho", slug: "hi-ho" } (slug: 'hi-ho-dsbwerlk')
           // 3. Delete { id }
           // 4. Update { id: newId, author: "Sam", slug: "hi-ho" } (slug: 'hi-ho-dsbwerlk')
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                author: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create, delete: deleteFn }) => {
-              const {
-                key,
-                gqlNames: { createMutationName, updateMutationName },
-              } = keystone.listsArray[0];
-              const originalItem = await create(key, { name: 'Hi Ho', url: 'hi-ho' });
-
-              const creationResult = await graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Hi Ho", url: "hi-ho" } ) { id url } }`,
-              });
-
-              expect(creationResult.errors).toBe(undefined);
-
-              const { id, url } = creationResult.data[createMutationName];
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              author: { type: Text },
+              url: { type: Slug, from: 'name' },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Hi Ho', url: 'hi-ho' };
+              const returnFields = 'id url';
+              const originalItem = await createItem({ keystone, listKey, item });
+              const { id, url } = await createItem({ keystone, listKey, item, returnFields });
 
               // The slug has been uniquified
               expect(url).toMatch(/hi-ho-[a-zA-Z0-9]+/);
 
               // delete the original created item
-              await deleteFn(key, originalItem.id);
+              await deleteItem({ keystone, listKey, itemId: originalItem.id });
 
-              const updateResult = await graphqlRequest({
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { author: "Sam", url: "hi-ho" } ) { id url } }`,
+                listKey,
+                item: { id, data: { author: 'Sam', url: 'hi-ho' } },
+                returnFields,
               });
-
-              expect(updateResult.errors).toBe(undefined);
 
               // The url should not have changed across updates, even though we
               // have regenerateOnUpdate: true
-              expect(updateResult.data[updateMutationName]).not.toMatchObject({
-                url,
-              });
+              expect(result).not.toMatchObject({ url });
             }
-          )();
-        });
+          )
+        );
 
-        it('Uses supplied slug even when regenerateOnUpdate: false', () => {
+        test('Uses supplied slug even when regenerateOnUpdate: false', () => {
           const generate = jest.fn();
           return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, generate, regenerateOnUpdate: false },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { updateMutationName },
-              } = keystone.listsArray[0];
-              const { id } = await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, generate, regenerateOnUpdate: false },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const { id } = await createItem({ keystone, listKey, item });
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { name: "Something Else", url: "something-something" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[updateMutationName]).toMatchObject({
-                  url: 'something-something',
-                });
-                expect(generate).not.toHaveBeenCalled();
+                listKey,
+                item: { id, data: { name: 'Something Else', url: 'something-something' } },
+                returnFields: 'url',
               });
+              expect(result).toMatchObject({ url: 'something-something' });
+              expect(generate).not.toHaveBeenCalled();
             }
           )();
         });
 
-        it('Has a stable slug when regenerateOnUpdate: false', () => {
+        test('Has a stable slug when regenerateOnUpdate: false', () => {
           const generate = jest.fn();
           return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, generate, regenerateOnUpdate: false },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { updateMutationName },
-              } = keystone.listsArray[0];
-              const { id } = await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              return graphqlRequest({
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, generate, regenerateOnUpdate: false },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const { id } = await createItem({ keystone, listKey, item });
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { name: "Something Else" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[updateMutationName]).toMatchObject({
-                  url: 'awesome-sauce',
-                });
-                expect(generate).not.toHaveBeenCalled();
+                listKey,
+                item: { id, data: { name: 'Something Else' } },
+                returnFields: 'url',
               });
+              expect(result).toMatchObject({ url: 'awesome-sauce' });
+              expect(generate).not.toHaveBeenCalled();
             }
           )();
         });
 
-        it('Does not generate a new slug when regenerateOnUpdate: false and no previous slug exists', () => {
-          const generate = jest.fn();
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, generate, regenerateOnUpdate: false },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { updateMutationName },
-              } = keystone.listsArray[0];
-              const { id } = await create(key, { name: 'Awesome Sauce' });
-              return graphqlRequest({
+        test(
+          'Regenerates & Uniquifies by default',
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, from: 'name' },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item1 = { name: 'Awesome Sauce', url: 'awesome-sauce' };
+              const item2 = { name: 'This Post', url: 'this-post' };
+              await createItem({ keystone, listKey, item: item1 });
+              const { id } = await createItem({ keystone, listKey, item: item2 });
+              const result = await updateItem({
                 keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { name: "Something Else" } ) { id url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[updateMutationName]).toMatchObject({
-                  url: null,
-                });
-                expect(generate).not.toHaveBeenCalled();
+                listKey,
+                item: { id, data: { name: item1.name } },
+                returnFields: 'url',
+              });
+              expect(result).toMatchObject({
+                url: expect.stringMatching(/awesome-sauce-[a-zA-Z0-9]+/),
               });
             }
-          )();
-        });
-
-        it('Regenerates & Uniquifies by default', () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, from: 'name' },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { updateMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Awesome Sauce', url: 'awesome-sauce' });
-              const { id } = await create(key, { name: 'This Post', url: 'this-post' });
-
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${updateMutationName}(id: "${id}", data: { name: "Awesome Sauce" } ) { id name url } }`,
-              }).then(({ data, errors }) => {
-                expect(errors).toBe(undefined);
-                expect(data[updateMutationName]).toMatchObject({
-                  url: expect.stringMatching(/awesome-sauce-[a-zA-Z0-9]+/),
-                });
-              });
-            }
-          )();
-        });
+          )
+        );
       });
 
       describe('error handling', () => {
-        it("throws if 'regenerateOnUpdate' is not a bool", () => {
+        test("throws if 'regenerateOnUpdate' is not a bool", () => {
           return expect(
-            runner(() =>
+            runner(
               setupList(adapterName, {
                 url: { type: Slug, from: 'foo', regenerateOnUpdate: 13 },
               })
@@ -734,9 +560,9 @@ describe('Slug#implementation', () => {
           ).rejects.toThrow(/The 'regenerateOnUpdate' option on .*\.url must be true\/false/);
         });
 
-        it("throws if 'alwaysMakeUnique' is not a bool", () => {
+        test("throws if 'alwaysMakeUnique' is not a bool", () => {
           return expect(
-            runner(() =>
+            runner(
               setupList(adapterName, {
                 url: { type: Slug, from: 'foo', alwaysMakeUnique: 13 },
               })
@@ -744,133 +570,120 @@ describe('Slug#implementation', () => {
           ).rejects.toThrow(/The 'alwaysMakeUnique' option on .*\.url must be true\/false/);
         });
 
-        it("throws if both 'from' and 'generate' specified", () => {
+        test("throws if both 'from' and 'generate' specified", () => {
           return expect(
-            runner(() =>
+            runner(
               setupList(adapterName, { url: { type: Slug, from: 'foo', generate: () => {} } })
             )()
           ).rejects.toThrow("Only one of 'from' or 'generate' can be supplied");
         });
 
-        it("throws if 'from' is not a string", () => {
+        test("throws if 'from' is not a string", () => {
           return expect(
-            runner(() => setupList(adapterName, { url: { type: Slug, from: 12 } }))()
+            runner(setupList(adapterName, { url: { type: Slug, from: 12 } }))()
           ).rejects.toThrow(/The 'from' option on .* must be a string/);
         });
 
-        it("throws if 'from' is a function", () => {
+        test("throws if 'from' is a function", () => {
           return expect(
-            runner(() => setupList(adapterName, { url: { type: Slug, from: () => {} } }))()
+            runner(setupList(adapterName, { url: { type: Slug, from: () => {} } }))()
           ).rejects.toThrow(/A function was specified for the 'from' option/);
         });
 
-        it("throws when 'makeUnique' isn't a function", () => {
+        test("throws when 'makeUnique' isn't a function", () => {
           return expect(
-            runner(() => setupList(adapterName, { url: { type: Slug, makeUnique: 'foo' } }))()
+            runner(setupList(adapterName, { url: { type: Slug, makeUnique: 'foo' } }))()
           ).rejects.toThrow(
             /The 'makeUnique' option on .* must be a function, but received string/
           );
         });
 
-        it("throws when 'from' field doesn't exist", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                url: { type: Slug, from: 'name' },
-              }),
+        test(
+          "throws when 'from' field doesn't exist",
+          runner(
+            setupList(adapterName, {
+              url: { type: Slug, from: 'name' },
+            }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: {}) { id url } }`,
-              }).then(({ errors }) => {
-                expect(errors).not.toBe(undefined);
-                expect(errors.length).toEqual(1);
-                expect(errors[0].message).toMatch(
+              const { key: listKey } = keystone.listsArray[0];
+              try {
+                await createItem({ keystone, listKey, item: {} });
+                expect(true).toEqual(false);
+              } catch (error) {
+                expect(error).not.toBe(undefined);
+                expect(error.message).toMatch(
                   /The field 'name' does not exist on the list '.*' as specified in the 'from' option of '.*\.url'/
                 );
-              });
+              }
             }
-          )();
-        });
+          )
+        );
 
-        it("throws when 'generate' returns a non-string", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                url: { type: Slug, generate: () => 12 },
-              }),
+        test("throws when 'generate' returns a non-string", () => {
+          runner(
+            setupList(adapterName, {
+              url: { type: Slug, generate: () => 12 },
+            }),
             async ({ keystone }) => {
-              const {
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: {}) { id url } }`,
-              }).then(({ errors }) => {
-                expect(errors).not.toBe(undefined);
-                expect(errors.length).toEqual(1);
-                expect(errors[0].message).toMatch(
+              const { key: listKey } = keystone.listsArray[0];
+              try {
+                await createItem({ keystone, listKey, item: {} });
+                expect(true).toEqual(false);
+              } catch (error) {
+                expect(error).not.toBe(undefined);
+                expect(error.message).toMatch(
                   /.*\.url's 'generate' option resolved with a number, but expected a string./
                 );
-              });
+              }
             }
-          )();
+          );
         });
 
-        it("throws when 'makeUnique' returns a non-string", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, makeUnique: () => 12 },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Make Unique', url: 'make-unique' });
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Make Unique" }) { id url } }`,
-              }).then(({ errors }) => {
-                expect(errors).not.toBe(undefined);
-                expect(errors.length).toEqual(1);
-                expect(errors[0].message).toMatch(
+        test(
+          "throws when 'makeUnique' returns a non-string",
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, makeUnique: () => 12 },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Make Unique', url: 'make-unique' };
+              await createItem({ keystone, listKey, item });
+              try {
+                await createItem({ keystone, listKey, item });
+                expect(true).toEqual(false);
+              } catch (error) {
+                expect(error).not.toBe(undefined);
+                expect(error.message).toMatch(
                   /.*\.url's 'makeUnique' option resolved with a number, but expected a string./
                 );
-              });
+              }
             }
-          )();
-        });
+          )
+        );
 
-        it("throws when 'makeUnique' can't generate a unique value", () => {
-          return runner(
-            () =>
-              setupList(adapterName, {
-                name: { type: Text },
-                url: { type: Slug, makeUnique: ({ slug }) => slug },
-              }),
-            async ({ keystone, create }) => {
-              const {
-                key,
-                gqlNames: { createMutationName },
-              } = keystone.listsArray[0];
-              await create(key, { name: 'Make Unique', url: 'make-unique' });
-              return graphqlRequest({
-                keystone,
-                query: `mutation { ${createMutationName}(data: { name: "Make Unique" }) { id url } }`,
-              }).then(({ errors }) => {
-                expect(errors).not.toBe(undefined);
-                expect(errors.length).toEqual(1);
-                expect(errors[0].message).toMatch(/failed after too many attempts/);
-              });
+        test(
+          "throws when 'makeUnique' can't generate a unique value",
+          runner(
+            setupList(adapterName, {
+              name: { type: Text },
+              url: { type: Slug, makeUnique: ({ slug }) => slug },
+            }),
+            async ({ keystone }) => {
+              const { key: listKey } = keystone.listsArray[0];
+              const item = { name: 'Make Unique', url: 'make-unique' };
+              await createItem({ keystone, listKey, item });
+              try {
+                await createItem({ keystone, listKey, item });
+                expect(true).toEqual(false);
+              } catch (error) {
+                expect(error).not.toBe(undefined);
+                expect(error.message).toMatch(/failed after too many attempts/);
+              }
             }
-          )();
-        });
+          )
+        );
       });
     })
   );


### PR DESCRIPTION
The main differences are:
 * Remove `.then()` pattern
 * Use `server-side-graphql-client` functions
