### PR TITLE
Update the ssgc tests to have stable ordering

### DIFF
--- a/.changeset/many-eagles-tickle.md
+++ b/.changeset/many-eagles-tickle.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/server-side-graphql-client': patch
+---
+
+Updated the `server-side-graphql-client` tests to have stable ordering

--- a/packages/server-side-graphql-client/tests/index.test.js
+++ b/packages/server-side-graphql-client/tests/index.test.js
@@ -217,6 +217,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               returnFields: 'name, age',
               pageSize,
               first,
+              sortBy: 'age_ASC',
             });
           expect((await getFirstItems(9, 5)).length).toEqual(9);
           expect((await getFirstItems(5, 9)).length).toEqual(5);


### PR DESCRIPTION
Calling `getItems` with `first` can return a result in a different order. This was causing a test failure. 

Closes: #3381 