### PR TITLE
Replace usage of `graphqlRequest` with ssgc functions

### DIFF
--- a/.changeset/tiny-emus-rush.md
+++ b/.changeset/tiny-emus-rush.md
@@ -1,0 +1,7 @@
+---
+'@keystonejs/benchmarks': patch
+'@keystonejs/fields': patch
+'@keystonejs/test-utils': patch
+---
+
+Refactored internals to use `server-side-graphql-client`.

--- a/benchmarks/fixtures/query.js
+++ b/benchmarks/fixtures/query.js
@@ -1,5 +1,6 @@
 const { Text, Relationship } = require('@keystonejs/fields');
-const { setupServer, graphqlRequest } = require('@keystonejs/test-utils');
+const { createItem, createItems } = require('@keystonejs/server-side-graphql-client');
+const { setupServer } = require('@keystonejs/test-utils');
 const { FixtureGroup, timeQuery, populate, range } = require('../lib/utils');
 
 function setupKeystone(adapterName) {
@@ -25,15 +26,10 @@ const group = new FixtureGroup(setupKeystone);
 
 group.add({
   fn: async ({ keystone, adapterName }) => {
-    const { data } = await graphqlRequest({
+    const { id: userId } = await createItem({
       keystone,
-      query: `
-    mutation {
-      createUser(data: { name: "test", posts: { create: [] } }) { id }
-    }`,
+      item: { name: 'test', posts: { create: [] } },
     });
-    const userId = data.createUser.id;
-
     const query = `query getPost($userId: ID!) { User(where: { id: $userId }) { id } }`;
     const { time, success } = await timeQuery({ keystone, query, variables: { userId } });
     console.log({ adapterName, time, success, name: 'Cold read with relationship, N=1' });
@@ -42,15 +38,10 @@ group.add({
 
 group.add({
   fn: async ({ keystone, adapterName }) => {
-    const { data } = await graphqlRequest({
+    const { id: userId } = await createItem({
       keystone,
-      query: `
-    mutation {
-      createUser(data: { name: "test", posts: { create: [] } }) { id }
-    }`,
+      item: { name: 'test', posts: { create: [] } },
     });
-    const userId = data.createUser.id;
-
     const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id } }`;
     const { time, success } = await timeQuery({
       keystone,
@@ -68,17 +59,11 @@ range(14).forEach(i => {
   group.add({
     fn: async ({ keystone, adapterName }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const variables = { users: populate(N, i => ({ data: { name: `test${i}`, posts } })) };
-      const { data } = await graphqlRequest({
+      const users = await createItems({
         keystone,
-        query: `
-      mutation createMany($users: [UsersCreateInput]){
-        createUsers(data: $users) { id }
-      }`,
-        variables,
+        item: populate(N, i => ({ data: { name: `test${i}`, posts } })),
       });
-
-      const userId = data.createUsers[0].id;
+      const userId = users[0].id;
       const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id } }`;
       const { time, success } = await timeQuery({
         keystone,
@@ -103,18 +88,11 @@ range(k).forEach(i => {
   group.add({
     fn: async ({ keystone, adapterName }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const variables = { users: populate(N, i => ({ data: { name: `test${i}`, posts } })) };
-
-      const { data } = await graphqlRequest({
+      const users = await createItems({
         keystone,
-        query: `
-      mutation createMany($users: [UsersCreateInput]){
-        createUsers(data: $users) { id }
-      }`,
-        variables,
+        item: populate(N, i => ({ data: { name: `test${i}`, posts } })),
       });
-
-      const userId = data.createUsers[0].id;
+      const userId = users[0].id;
       const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id } }`;
       const { time, success } = await timeQuery({
         keystone,
@@ -138,17 +116,11 @@ range(14).forEach(i => {
   group.add({
     fn: async ({ keystone, adapterName }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const variables = { users: populate(N, i => ({ data: { name: `test${i}`, posts } })) };
-      const { data } = await graphqlRequest({
+      const users = await createItems({
         keystone,
-        query: `
-      mutation createMany($users: [UsersCreateInput]){
-        createUsers(data: $users) { id }
-      }`,
-        variables,
+        item: populate(N, i => ({ data: { name: `test${i}`, posts } })),
       });
-
-      const userId = data.createUsers[0].id;
+      const userId = users[0].id;
       const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id posts { id } } }`;
       const { time, success } = await timeQuery({
         keystone,
@@ -172,18 +144,11 @@ range(k).forEach(i => {
   group.add({
     fn: async ({ keystone, adapterName }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const variables = { users: populate(N, i => ({ data: { name: `test${i}`, posts } })) };
-
-      const { data } = await graphqlRequest({
+      const users = await createItems({
         keystone,
-        query: `
-      mutation createMany($users: [UsersCreateInput]){
-        createUsers(data: $users) { id }
-      }`,
-        variables,
+        item: populate(N, i => ({ data: { name: `test${i}`, posts } })),
       });
-
-      const userId = data.createUsers[0].id;
+      const userId = users[0].id;
       const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id posts { id } } }`;
       const { time, success } = await timeQuery({
         keystone,

--- a/benchmarks/lib/utils.js
+++ b/benchmarks/lib/utils.js
@@ -1,11 +1,15 @@
-const { multiAdapterRunners, graphqlRequest } = require('@keystonejs/test-utils');
+const { multiAdapterRunners } = require('@keystonejs/test-utils');
+const { runCustomQuery } = require('@keystonejs/server-side-graphql-client');
 
 const timeQuery = async ({ keystone, query, variables, repeat = 1 }) => {
   const t0_us = process.hrtime.bigint();
   const allErrors = [];
   for (let i = 0; i < repeat; i++) {
-    const { errors } = await graphqlRequest({ keystone, query, variables });
-    if (errors) allErrors.push(errors);
+    try {
+      await runCustomQuery({ keystone, query, variables });
+    } catch (error) {
+      allErrors.push(error);
+    }
   }
   const t1_us = process.hrtime.bigint();
   if (allErrors.length) {

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -19,6 +19,7 @@
     "@keystonejs/app-graphql": "^6.1.0",
     "@keystonejs/fields": "^16.0.0",
     "@keystonejs/keystone": "^13.1.0",
+    "@keystonejs/server-side-graphql-client": "^1.1.0",
     "@keystonejs/session": "^8.1.0",
     "@keystonejs/test-utils": "^7.1.1",
     "body-parser": "^1.18.2",

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -6,6 +6,7 @@ const { Keystone } = require('@keystonejs/keystone');
 const { GraphQLApp } = require('@keystonejs/app-graphql');
 const { KnexAdapter } = require('@keystonejs/adapter-knex');
 const { MongooseAdapter } = require('@keystonejs/adapter-mongoose');
+const { runCustomQuery } = require('@keystonejs/server-side-graphql-client');
 
 async function setupServer({
   adapterName,
@@ -241,17 +242,16 @@ const sorted = (arr, keyFn) => {
   return arr;
 };
 
-const matchFilter = ({ keystone, queryArgs, fieldSelection, expected, sortKey }) => {
-  return graphqlRequest({
+const matchFilter = async ({ keystone, queryArgs, fieldSelection, expected, sortKey }) => {
+  const data = await runCustomQuery({
     keystone,
     query: `query {
       allTests${queryArgs ? `(${queryArgs})` : ''} { ${fieldSelection} }
     }`,
-  }).then(({ data, errors }) => {
-    expect(errors).toBe(undefined);
-    const value = sortKey ? sorted(data.allTests || [], i => i[sortKey]) : data.allTests;
-    expect(value).toEqual(expected);
   });
+
+  const value = sortKey ? sorted(data.allTests || [], i => i[sortKey]) : data.allTests;
+  expect(value).toEqual(expected);
 };
 
 class MockFieldImplementation {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -12,6 +12,7 @@
     "@keystonejs/adapter-mongoose": "^9.0.1",
     "@keystonejs/app-graphql": "^6.1.0",
     "@keystonejs/keystone": "^13.0.0",
+    "@keystonejs/server-side-graphql-client": "^1.1.0",
     "express": "^4.17.1",
     "mongodb-memory-server-core": "^6.5.2",
     "supertest-light": "^1.0.3"


### PR DESCRIPTION
`@keystonejs/benchmark`
- [timeQuery](https://github.com/keystonejs/keystone/blob/585d21f5b9f7aab819e1596e5197514e523e01c5/benchmarks/lib/utils.js#L3) function now uses `runCustomQuery` from `server-side-graphql-client`.
- replaced `graphqlRequest` with corresponding `server-side-graphql-client` functions.

`@keystonejs/test-utils`
- [matchFilter](https://github.com/keystonejs/keystone/blob/585d21f5b9f7aab819e1596e5197514e523e01c5/packages/test-utils/lib/test-utils.js#L244) now uses [runCustomQuery](https://github.com/keystonejs/keystone/blob/585d21f5b9f7aab819e1596e5197514e523e01c5/packages/server-side-graphql-client/lib/server-side-graphql-client.js#L8) instead of `graphqlRequest`.

`@keystonejs/fields`
- replaced uses of `graphqlReqest` with the corresponding functions from `server-side-graphql-client`. 