### PR TITLE
Cleanup test-utils module

### DIFF
--- a/.changeset/serious-falcons-divide.md
+++ b/.changeset/serious-falcons-divide.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/test-utils': patch
+---
+
+Removed redundant test helper functions from `_keystoneRunner`.

--- a/packages/test-utils/lib/test-utils.js
+++ b/packages/test-utils/lib/test-utils.js
@@ -138,26 +138,6 @@ function teardownMongoMemoryServer() {
   return stopping;
 }
 
-function getCreate(keystone) {
-  return (list, item) => keystone.getListByKey(list).adapter.create(item);
-}
-
-function getFindById(keystone) {
-  return (list, item) => keystone.getListByKey(list).adapter.findById(item);
-}
-
-function getFindOne(keystone) {
-  return (list, item) => keystone.getListByKey(list).adapter.findOne(item);
-}
-
-function getUpdate(keystone) {
-  return (list, id, data) => keystone.getListByKey(list).adapter.update(id, data);
-}
-
-function getDelete(keystone) {
-  return (list, id) => keystone.getListByKey(list).adapter.delete(id);
-}
-
 function _keystoneRunner(adapterName, tearDownFunction) {
   return function(setupKeystoneFn, testFn) {
     return async function() {
@@ -180,11 +160,6 @@ function _keystoneRunner(adapterName, tearDownFunction) {
       try {
         await testFn({
           ...setup,
-          create: getCreate(keystone),
-          findById: getFindById(keystone),
-          findOne: getFindOne(keystone),
-          update: getUpdate(keystone),
-          delete: getDelete(keystone),
         });
       } finally {
         await keystone.disconnect();


### PR DESCRIPTION
We were using some crud helper functions, for example `findById`, `findOne`,
and `update`, inside `_keystoneRunner` function. But now with the addition
of ssgc package we don't need them anymore.