### PR TITLE
Update matchFilter to use getItems

### DIFF
--- a/.changeset/small-cups-protect.md
+++ b/.changeset/small-cups-protect.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Updated `match` function in tests to use `getItems` function from `server-side-graphql-client`.

--- a/packages/fields/src/types/CalendarDay/test-fixtures.js
+++ b/packages/fields/src/types/CalendarDay/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import CalendarDay from './';
 
@@ -26,14 +26,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name birthday',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name birthday',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -51,7 +53,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -64,16 +66,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday: "2000-01-20" }', [
-        { name: 'person2', birthday: '2000-01-20' },
-      ])
+      match(keystone, { birthday: '2000-01-20' }, [{ name: 'person2', birthday: '2000-01-20' }])
     )
   );
 
   test(
     'Filter: birthday_not',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_not: "2000-01-20" }', [
+      match(keystone, { birthday_not: '2000-01-20' }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
@@ -85,7 +85,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_not null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_not: null }', [
+      match(keystone, { birthday_not: null }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -97,16 +97,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_lt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_lt: "1950-10-01" }', [
-        { name: 'person4', birthday: '1666-04-12' },
-      ])
+      match(keystone, { birthday_lt: '1950-10-01' }, [{ name: 'person4', birthday: '1666-04-12' }])
     )
   );
 
   test(
     'Filter: birthday_lte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_lte: "1950-10-01" }', [
+      match(keystone, { birthday_lte: '1950-10-01' }, [
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
       ])
@@ -116,7 +114,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_gt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_gt: "1950-10-01" }', [
+      match(keystone, { birthday_gt: '1950-10-01' }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
       ])
@@ -126,7 +124,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_gte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_gte: "1950-10-01" }', [
+      match(keystone, { birthday_gte: '1950-10-01' }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -136,13 +134,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: birthday_in (empty list)',
-    withKeystone(({ keystone }) => match(keystone, 'where: { birthday_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, { birthday_in: [] }, []))
   );
 
   test(
     'Filter: birthday_not_in (empty list)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_not_in: [] }', [
+      match(keystone, { birthday_not_in: [] }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -155,7 +153,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
+      match(keystone, { birthday_in: ['1990-12-31', '2000-01-20', '1950-10-01'] }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },
@@ -166,7 +164,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_not_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_not_in: ["1990-12-31", "2000-01-20", "1950-10-01"] }', [
+      match(keystone, { birthday_not_in: ['1990-12-31', '2000-01-20', '1950-10-01'] }, [
         { name: 'person4', birthday: '1666-04-12' },
         { name: 'person5', birthday: null },
       ])
@@ -176,14 +174,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: birthday_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_in: [null] }', [{ name: 'person5', birthday: null }])
+      match(keystone, { birthday_in: [null] }, [{ name: 'person5', birthday: null }])
     )
   );
 
   test(
     'Filter: birthday_not_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { birthday_not_in: [null] }', [
+      match(keystone, { birthday_not_in: [null] }, [
         { name: 'person1', birthday: '1990-12-31' },
         { name: 'person2', birthday: '2000-01-20' },
         { name: 'person3', birthday: '1950-10-01' },

--- a/packages/fields/src/types/Checkbox/test-fixtures.js
+++ b/packages/fields/src/types/Checkbox/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Checkbox from './';
 
@@ -24,14 +24,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name enabled',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name enabled',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -48,7 +50,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'person1', enabled: true },
         { name: 'person2', enabled: false },
         { name: 'person3', enabled: null },
@@ -60,7 +62,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: enabled true',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { enabled: true }', [
+      match(keystone, { enabled: true }, [
         { name: 'person1', enabled: true },
         { name: 'person4', enabled: true },
       ])
@@ -70,14 +72,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: enabled false',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { enabled: false }', [{ name: 'person2', enabled: false }])
+      match(keystone, { enabled: false }, [{ name: 'person2', enabled: false }])
     )
   );
 
   test(
     'Filter: enabled_not true',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { enabled_not: true }', [
+      match(keystone, { enabled_not: true }, [
         { name: 'person2', enabled: false },
         { name: 'person3', enabled: null },
       ])
@@ -87,7 +89,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: enabled_not false',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { enabled_not: false }', [
+      match(keystone, { enabled_not: false }, [
         { name: 'person1', enabled: true },
         { name: 'person3', enabled: null },
         { name: 'person4', enabled: true },

--- a/packages/fields/src/types/DateTimeUtc/test-fixtures.js
+++ b/packages/fields/src/types/DateTimeUtc/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import DateTimeUtc from './';
 
@@ -26,14 +26,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected, forceSortBy = 'name') =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name lastOnline',
-      expected,
-      sortKey: forceSortBy,
-    });
+  const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name lastOnline',
+        sortBy,
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -51,7 +53,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
@@ -64,7 +66,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline: "2000-01-20T00:08:00.000Z" }', [
+      match(keystone, { lastOnline: '2000-01-20T00:08:00.000Z' }, [
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
       ])
     )
@@ -73,7 +75,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_not',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_not: "2000-01-20T00:08:00.000Z" }', [
+      match(keystone, { lastOnline_not: '2000-01-20T00:08:00.000Z' }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000Z' },
@@ -85,7 +87,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_not null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_not: null }', [
+      match(keystone, { lastOnline_not: null }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
@@ -97,7 +99,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_lt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_lt: "1950-10-01T23:59:59.999Z" }', [
+      match(keystone, { lastOnline_lt: '1950-10-01T23:59:59.999Z' }, [
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000Z' },
       ])
     )
@@ -106,7 +108,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_lte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_lte: "1950-10-01T23:59:59.999Z" }', [
+      match(keystone, { lastOnline_lte: '1950-10-01T23:59:59.999Z' }, [
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
         { name: 'person4', lastOnline: '1666-04-12T00:08:00.000Z' },
       ])
@@ -116,7 +118,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_gt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_gt: "1950-10-01T23:59:59.999Z" }', [
+      match(keystone, { lastOnline_gt: '1950-10-01T23:59:59.999Z' }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
       ])
@@ -126,7 +128,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_gte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_gte: "1950-10-01T23:59:59.999Z" }', [
+      match(keystone, { lastOnline_gte: '1950-10-01T23:59:59.999Z' }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
@@ -136,13 +138,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: lastOnline_in (empty list)',
-    withKeystone(({ keystone }) => match(keystone, 'where: { lastOnline_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, { lastOnline_in: [] }, []))
   );
 
   test(
     'Filter: lastOnline_not_in (empty list)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_not_in: [] }', [
+      match(keystone, { lastOnline_not_in: [] }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
@@ -157,7 +159,13 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { lastOnline_in: ["1990-12-31T12:34:56.789Z", "2000-01-20T00:08:00.000Z", "1950-10-01T23:59:59.999Z"] }',
+        {
+          lastOnline_in: [
+            '1990-12-31T12:34:56.789Z',
+            '2000-01-20T00:08:00.000Z',
+            '1950-10-01T23:59:59.999Z',
+          ],
+        },
         [
           { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
           { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
@@ -172,7 +180,13 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { lastOnline_not_in: ["1990-12-31T12:34:56.789Z", "2000-01-20T00:08:00.000Z", "1950-10-01T23:59:59.999Z"] }',
+        {
+          lastOnline_not_in: [
+            '1990-12-31T12:34:56.789Z',
+            '2000-01-20T00:08:00.000Z',
+            '1950-10-01T23:59:59.999Z',
+          ],
+        },
         [
           { name: 'person4', lastOnline: '1666-04-12T00:08:00.000Z' },
           { name: 'person5', lastOnline: null },
@@ -184,14 +198,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: lastOnline_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_in: [null] }', [{ name: 'person5', lastOnline: null }])
+      match(keystone, { lastOnline_in: [null] }, [{ name: 'person5', lastOnline: null }])
     )
   );
 
   test(
     'Filter: lastOnline_not_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { lastOnline_not_in: [null] }', [
+      match(keystone, { lastOnline_not_in: [null] }, [
         { name: 'person1', lastOnline: '1990-12-31T12:34:56.789Z' },
         { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
         { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
@@ -205,7 +219,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone, adapterName }) =>
       match(
         keystone,
-        'sortBy: lastOnline_ASC',
+        undefined,
         adapterName === 'mongoose'
           ? [
               { name: 'person5', lastOnline: null },
@@ -221,7 +235,7 @@ export const filterTests = withKeystone => {
               { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
               { name: 'person5', lastOnline: null },
             ],
-        null
+        'lastOnline_ASC'
       )
     )
   );
@@ -231,7 +245,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone, adapterName }) =>
       match(
         keystone,
-        'sortBy: lastOnline_DESC',
+        undefined,
         adapterName === 'mongoose'
           ? [
               { name: 'person2', lastOnline: '2000-01-20T00:08:00.000Z' },
@@ -247,7 +261,7 @@ export const filterTests = withKeystone => {
               { name: 'person3', lastOnline: '1950-10-01T23:59:59.999Z' },
               { name: 'person4', lastOnline: '1666-04-12T00:08:00.000Z' },
             ],
-        null
+        'lastOnline_DESC'
       )
     )
   );

--- a/packages/fields/src/types/Decimal/test-fixtures.js
+++ b/packages/fields/src/types/Decimal/test-fixtures.js
@@ -1,5 +1,4 @@
 import { createItem, getItems, getItem, updateItem } from '@keystonejs/server-side-graphql-client';
-import { matchFilter } from '@keystonejs/test-utils';
 import Text from '../Text';
 import Decimal from './';
 
@@ -27,14 +26,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name price',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name price',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -52,7 +53,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'price1', price: '50.00' },
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
@@ -65,14 +66,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: price',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price: "50.00" }', [{ name: 'price1', price: '50.00' }])
+      match(keystone, { price: '50.00' }, [{ name: 'price1', price: '50.00' }])
     )
   );
 
   test(
     'Filter: price_not',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price_not: "50.00" }', [
+      match(keystone, { price_not: '50.00' }, [
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
         { name: 'price4', price: '40000.00' },
@@ -84,14 +85,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: price_lt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price_lt: "50.00" }', [{ name: 'price2', price: '0.01' }])
+      match(keystone, { price_lt: '50.00' }, [{ name: 'price2', price: '0.01' }])
     )
   );
 
   test(
     'Filter: price_lte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price_lte: "2000.00" }', [
+      match(keystone, { price_lte: '2000.00' }, [
         { name: 'price1', price: '50.00' },
         { name: 'price2', price: '0.01' },
         { name: 'price3', price: '2000.00' },
@@ -102,14 +103,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: price_gt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price_gt: "2000.00" }', [{ name: 'price4', price: '40000.00' }])
+      match(keystone, { price_gt: '2000.00' }, [{ name: 'price4', price: '40000.00' }])
     )
   );
 
   test(
     'Filter: price_gte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { price_gte: "2000.00" }', [
+      match(keystone, { price_gte: '2000.00' }, [
         { name: 'price3', price: '2000.00' },
         { name: 'price4', price: '40000.00' },
       ])

--- a/packages/fields/src/types/Float/test-fixtures.js
+++ b/packages/fields/src/types/Float/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Float from '.';
 
@@ -30,14 +30,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name stars',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name stars',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -55,7 +57,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },
@@ -67,15 +69,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: stars',
-    withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars: 1.2 }', [{ name: 'post2', stars: 1.2 }])
-    )
+    withKeystone(({ keystone }) => match(keystone, { stars: 1.2 }, [{ name: 'post2', stars: 1.2 }]))
   );
 
   test(
     'Filter: stars_not',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_not: 1.2 }', [
+      match(keystone, { stars_not: 1.2 }, [
         { name: 'post1', stars: 0 },
         { name: 'post3', stars: 2.3 },
         { name: 'post4', stars: 3 },
@@ -87,7 +87,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_not null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_not: null }', [
+      match(keystone, { stars_not: null }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },
@@ -99,7 +99,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_lt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_lt: 2.30 }', [
+      match(keystone, { stars_lt: 2.3 }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
       ])
@@ -109,7 +109,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_lte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_lte: 2.30 }', [
+      match(keystone, { stars_lte: 2.3 }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },
@@ -120,14 +120,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_gt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_gt: 2.30 }', [{ name: 'post4', stars: 3 }])
+      match(keystone, { stars_gt: 2.3 }, [{ name: 'post4', stars: 3 }])
     )
   );
 
   test(
     'Filter: stars_gte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_gte: 2.30 }', [
+      match(keystone, { stars_gte: 2.3 }, [
         { name: 'post3', stars: 2.3 },
         { name: 'post4', stars: 3 },
       ])
@@ -136,13 +136,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: stars_in (empty list)',
-    withKeystone(({ keystone }) => match(keystone, 'where: { stars_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, { stars_in: [] }, []))
   );
 
   test(
     'Filter: stars_not_in (empty list)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_not_in: [] }', [
+      match(keystone, { stars_not_in: [] }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },
@@ -155,7 +155,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_in: [0, 1.2, 2.30] }', [
+      match(keystone, { stars_in: [0, 1.2, 2.3] }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },
@@ -166,7 +166,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_not_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_not_in: [0, 1.2, 2.30] }', [
+      match(keystone, { stars_not_in: [0, 1.2, 2.3] }, [
         { name: 'post4', stars: 3 },
         { name: 'post5', stars: null },
       ])
@@ -176,14 +176,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: stars_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_in: [null] }', [{ name: 'post5', stars: null }])
+      match(keystone, { stars_in: [null] }, [{ name: 'post5', stars: null }])
     )
   );
 
   test(
     'Filter: stars_not_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { stars_not_in: [null] }', [
+      match(keystone, { stars_not_in: [null] }, [
         { name: 'post1', stars: 0 },
         { name: 'post2', stars: 1.2 },
         { name: 'post3', stars: 2.3 },

--- a/packages/fields/src/types/Integer/test-fixtures.js
+++ b/packages/fields/src/types/Integer/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Integer from './';
 
@@ -26,14 +26,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name count',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name count',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -51,7 +53,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -63,15 +65,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count',
-    withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count: 1 }', [{ name: 'person2', count: 1 }])
-    )
+    withKeystone(({ keystone }) => match(keystone, { count: 1 }, [{ name: 'person2', count: 1 }]))
   );
 
   test(
     'Filter: count_not',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_not: 1 }', [
+      match(keystone, { count_not: 1 }, [
         { name: 'person1', count: 0 },
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
@@ -83,7 +83,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_not null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_not: null }', [
+      match(keystone, { count_not: null }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -95,7 +95,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_lt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_lt: 2 }', [
+      match(keystone, { count_lt: 2 }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
       ])
@@ -105,7 +105,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_lte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_lte: 2 }', [
+      match(keystone, { count_lte: 2 }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -116,14 +116,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_gt',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_gt: 2 }', [{ name: 'person4', count: 3 }])
+      match(keystone, { count_gt: 2 }, [{ name: 'person4', count: 3 }])
     )
   );
 
   test(
     'Filter: count_gte',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_gte: 2 }', [
+      match(keystone, { count_gte: 2 }, [
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
       ])
@@ -132,13 +132,13 @@ export const filterTests = withKeystone => {
 
   test(
     'Filter: count_in (empty list)',
-    withKeystone(({ keystone }) => match(keystone, 'where: { count_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, { count_in: [] }, []))
   );
 
   test(
     'Filter: count_not_in (empty list)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_not_in: [] }', [
+      match(keystone, { count_not_in: [] }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -151,7 +151,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_in: [0, 1, 2] }', [
+      match(keystone, { count_in: [0, 1, 2] }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },
@@ -162,7 +162,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_not_in',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_not_in: [0, 1, 2] }', [
+      match(keystone, { count_not_in: [0, 1, 2] }, [
         { name: 'person4', count: 3 },
         { name: 'person5', count: null },
       ])
@@ -172,14 +172,14 @@ export const filterTests = withKeystone => {
   test(
     'Filter: count_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_in: [null] }', [{ name: 'person5', count: null }])
+      match(keystone, { count_in: [null] }, [{ name: 'person5', count: null }])
     )
   );
 
   test(
     'Filter: count_not_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { count_not_in: [null] }', [
+      match(keystone, { count_not_in: [null] }, [
         { name: 'person1', count: 0 },
         { name: 'person2', count: 1 },
         { name: 'person3', count: 2 },

--- a/packages/fields/src/types/Password/test-fixtures.js
+++ b/packages/fields/src/types/Password/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Password from './';
 import Text from '../Text';
 
@@ -23,14 +23,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'name password_is_set',
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'name password_is_set',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter',
@@ -46,7 +48,7 @@ export const filterTests = withKeystone => {
   test(
     'Empty filter',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { }', [
+      match(keystone, {}, [
         { name: 'person1', password_is_set: true },
         { name: 'person2', password_is_set: false },
         { name: 'person3', password_is_set: true },
@@ -57,7 +59,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: is_set - true',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { password_is_set: true }', [
+      match(keystone, { password_is_set: true }, [
         { name: 'person1', password_is_set: true },
         { name: 'person3', password_is_set: true },
       ])
@@ -67,9 +69,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: is_set - false',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { password_is_set: false }', [
-        { name: 'person2', password_is_set: false },
-      ])
+      match(keystone, { password_is_set: false }, [{ name: 'person2', password_is_set: false }])
     )
   );
 };

--- a/packages/fields/src/types/Select/test-fixtures.js
+++ b/packages/fields/src/types/Select/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Select from './';
 import Text from '../Text';
 
@@ -59,14 +59,16 @@ export const initItems = () => {
 };
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected, fieldSelection = 'name company') =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection,
-      expected,
-      sortKey: 'name',
-    });
+  const match = async (keystone, where, expected, returnFields = 'name company') =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields,
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     'No filter (dataType: enum)',
@@ -117,7 +119,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: company (dataType: enum)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { company: thinkmill }', [{ company: 'thinkmill', name: 'a' }])
+      match(keystone, { company: 'thinkmill' }, [{ company: 'thinkmill', name: 'a' }])
     )
   );
 
@@ -126,7 +128,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { selectString: "a string" }',
+        { selectString: 'a string' },
         [
           { selectString: 'a string', name: 'a' },
           { selectString: 'a string', name: 'c' },
@@ -141,7 +143,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { selectNumber: 1 }',
+        { selectNumber: 1 },
         [
           { name: 'a', selectNumber: 1 },
           { name: 'd', selectNumber: 1 },
@@ -154,7 +156,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: company_not (dataType: enum)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { company_not: thinkmill }', [
+      match(keystone, { company_not: 'thinkmill' }, [
         { company: 'atlassian', name: 'b' },
         { company: 'gelato', name: 'c' },
         { company: 'cete', name: 'd' },
@@ -167,7 +169,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { selectString_not: "a string" }',
+        { selectString_not: 'a string' },
         [
           { name: 'b', selectString: '@¯\\_(ツ)_/¯' },
           { name: 'd', selectString: '1number' },
@@ -182,7 +184,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        'where: { selectNumber_not: 1 }',
+        { selectNumber_not: 1 },
         [
           { name: 'b', selectNumber: 2 },
           { name: 'c', selectNumber: 3 },
@@ -195,7 +197,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: company_in (dataType: enum)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { company_in: [ atlassian, gelato ] }', [
+      match(keystone, { company_in: ['atlassian', 'gelato'] }, [
         { company: 'atlassian', name: 'b' },
         { company: 'gelato', name: 'c' },
       ])
@@ -207,7 +209,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        `where: { selectString_in: [ ${JSON.stringify(`@¯\\_(ツ)_/¯`)}, "1number" ] }`,
+        { selectString_in: [`@¯\\_(ツ)_/¯`, '1number'] },
         [
           { name: 'b', selectString: `@¯\\_(ツ)_/¯` },
           { name: 'd', selectString: '1number' },
@@ -222,7 +224,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        `where: { selectNumber_in: [ 2, 3] }`,
+        { selectNumber_in: [2, 3] },
         [
           { name: 'b', selectNumber: 2 },
           { name: 'c', selectNumber: 3 },
@@ -235,7 +237,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: company_not_in (dataType: enum)',
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { company_not_in: [ atlassian, gelato ] }', [
+      match(keystone, { company_not_in: ['atlassian', 'gelato'] }, [
         { company: 'thinkmill', name: 'a' },
         { company: 'cete', name: 'd' },
       ])
@@ -247,7 +249,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        `where: { selectString_not_in: [ ${JSON.stringify(`@¯\\_(ツ)_/¯`)}, "1number" ] }`,
+        { selectString_not_in: [`@¯\\_(ツ)_/¯`, '1number'] },
         [
           { selectString: 'a string', name: 'a' },
           { selectString: 'a string', name: 'c' },
@@ -262,7 +264,7 @@ export const filterTests = withKeystone => {
     withKeystone(({ keystone }) =>
       match(
         keystone,
-        `where: { selectNumber_not_in: [ 2, 3 ] }`,
+        { selectNumber_not_in: [2, 3] },
         [
           { name: 'a', selectNumber: 1 },
           { name: 'd', selectNumber: 1 },

--- a/packages/fields/src/types/Text/test-fixtures.js
+++ b/packages/fields/src/types/Text/test-fixtures.js
@@ -1,4 +1,4 @@
-import { matchFilter } from '@keystonejs/test-utils';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from './';
 
 const fieldType = 'Text';
@@ -32,19 +32,21 @@ export const initItems = () => {
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {
-  const match = (keystone, queryArgs, expected) =>
-    matchFilter({
-      keystone,
-      queryArgs,
-      fieldSelection: 'order name',
-      expected,
-      sortKey: 'order',
-    });
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'test',
+        where,
+        returnFields: 'order name',
+        sortBy: 'order_ASC',
+      })
+    ).toEqual(expected);
 
   test(
     `No 'where' argument`,
     withKeystone(({ keystone }) =>
-      match(keystone, '', [
+      match(keystone, undefined, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -58,7 +60,7 @@ export const filterTests = withKeystone => {
   test(
     `Empty 'where' argument'`,
     withKeystone(({ keystone }) =>
-      match(keystone, '', [
+      match(keystone, {}, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -73,13 +75,13 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key} (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name: "fooBAR" }', [{ order: 'd', name: 'fooBAR' }])
+      match(keystone, { name: 'fooBAR' }, [{ order: 'd', name: 'fooBAR' }])
     )
   );
   test(
     `Filter: {key}_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_i: "fooBAR" }', [
+      match(keystone, { name_i: 'fooBAR' }, [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -90,7 +92,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not: "fooBAR" }', [
+      match(keystone, { name_not: 'fooBAR' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -103,7 +105,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_i: "fooBAR" }', [
+      match(keystone, { name_not_i: 'fooBAR' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -115,7 +117,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_contains: "oo" }', [
+      match(keystone, { name_contains: 'oo' }, [
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
       ])
@@ -124,7 +126,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_contains_i: "oo" }', [
+      match(keystone, { name_contains_i: 'oo' }, [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -135,7 +137,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_contains: "oo" }', [
+      match(keystone, { name_not_contains: 'oo' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -147,7 +149,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_contains_i: "oo" }', [
+      match(keystone, { name_not_contains_i: 'oo' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -159,7 +161,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_starts_with: "foo" }', [
+      match(keystone, { name_starts_with: 'foo' }, [
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
       ])
@@ -168,7 +170,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_starts_with_i: "foo" }', [
+      match(keystone, { name_starts_with_i: 'foo' }, [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -179,7 +181,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_starts_with: "foo" }', [
+      match(keystone, { name_not_starts_with: 'foo' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -191,7 +193,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_starts_with_i: "foo" }', [
+      match(keystone, { name_not_starts_with_i: 'foo' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -203,7 +205,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_ends_with: "BAR" }', [
+      match(keystone, { name_ends_with: 'BAR' }, [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
       ])
@@ -212,7 +214,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_ends_with_i: "BAR" }', [
+      match(keystone, { name_ends_with_i: 'BAR' }, [
         { order: 'c', name: 'FOOBAR' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },
@@ -223,7 +225,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_ends_with: "BAR" }', [
+      match(keystone, { name_not_ends_with: 'BAR' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'e', name: 'foobar' },
@@ -235,7 +237,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_ends_with_i: "BAR" }', [
+      match(keystone, { name_not_ends_with_i: 'BAR' }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'f', name: null },
@@ -246,12 +248,12 @@ export const filterTests = withKeystone => {
 
   test(
     `Filter: {key}_in (case-sensitive, empty list)`,
-    withKeystone(({ keystone }) => match(keystone, 'where: { name_in: [] }', []))
+    withKeystone(({ keystone }) => match(keystone, { name_in: [] }, []))
   );
   test(
     `Filter: {key}_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_in: ["", "FOOBAR"] }', [
+      match(keystone, { name_in: ['', 'FOOBAR'] }, [
         { order: 'a', name: '' },
         { order: 'c', name: 'FOOBAR' },
       ])
@@ -261,7 +263,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_in (case-sensitive, empty list)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_in: [] }', [
+      match(keystone, { name_not_in: [] }, [
         { order: 'a', name: '' },
         { order: 'b', name: 'other' },
         { order: 'c', name: 'FOOBAR' },
@@ -275,7 +277,7 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, 'where: { name_not_in: ["", "FOOBAR"] }', [
+      match(keystone, { name_not_in: ['', 'FOOBAR'] }, [
         { order: 'b', name: 'other' },
         { order: 'd', name: 'fooBAR' },
         { order: 'e', name: 'foobar' },


### PR DESCRIPTION
This PR removes `matchFilter` and instead uses direct calls to `getItems` from `server-side-graphql-client`. It removes the need to do client side sorting and removes an unnecessary level of abstraction which makes these `test-fixtures` harder to understand.