### PR TITLE
fix s3 path on windows, removed unnecessary path.join

### DIFF
--- a/.changeset/quick-parents-stare.md
+++ b/.changeset/quick-parents-stare.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/file-adapters': patch
+---
+
+Fixed S3 adapter issue on windows where the wrong path character was being used due to `path.join`

--- a/packages/file-adapters/lib/s3.js
+++ b/packages/file-adapters/lib/s3.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const AWS = require('aws-sdk');
 const urlJoin = require('url-join');
 
@@ -37,7 +36,7 @@ module.exports = class S3Adapter {
           Body: stream,
           ContentType: mimetype,
           Bucket: this.bucket,
-          Key: path.join(this.folder, fileData.filename),
+          Key: `${this.folder}/${fileData.filename}`,
           ...uploadParams,
         },
         (error, data) => {
@@ -64,7 +63,7 @@ module.exports = class S3Adapter {
       return this.s3
         .deleteObject({
           Bucket: this.bucket,
-          Key: path.join(this.folder, file.filename),
+          Key: `${this.folder}/${file.filename}`,
           ...options,
         })
         .promise();


### PR DESCRIPTION
I found that on windows (with DigitalOcean) it was using `\` instead of `/` when saving file to folder. I believe this would also be an issue with S3. 

fixed it by replacing `path.join` (which uses os specific separator) with template string.