### PR TITLE
lock mongoose dependency to 5.9.11

### DIFF
--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -14,7 +14,7 @@
     "@keystonejs/mongo-join-builder": "^7.1.2",
     "@keystonejs/utils": "^5.4.1",
     "@sindresorhus/slugify": "^0.11.0",
-    "mongoose": "^5.9.11",
+    "mongoose": "5.9.11",
     "p-settle": "^3.1.0",
     "pluralize": "^7.0.0"
   },


### PR DESCRIPTION
Locking mongoose dependency to 5.9.11 until compatibility with mongoose 5.10.0 can be achieved.

fixes #3397 

Something in mongoose 5.10.0 broke adapter-mongoose.  This change locks the version to 5.9.11, until a long-term fix can make adapter-mongoose compatible with mongoose 5.10.0.