### PR TITLE
Update to mongodb 3.6.0 and mongoose 5.10.0

### DIFF
--- a/.changeset/unlucky-crabs-attack.md
+++ b/.changeset/unlucky-crabs-attack.md
@@ -1,0 +1,8 @@
+---
+'@keystonejs/adapter-mongoose': patch
+'@keystonejs/fields': patch
+'@keystonejs/fields-location-google': patch
+'@keystonejs/mongo-join-builder': patch
+---
+
+Updated Mongodb driver to 3.6.0 and Mongoose to 5.10.0. This enables support for MongoDB 4.4.

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "mocha": "^7.1.2",
     "mocha-junit-reporter": "^1.23.3",
     "moment": "^2.24.0",
-    "mongodb": "^3.5.7",
+    "mongodb": "^3.6.0",
     "p-is-promise": "^3.0.0",
     "pino-colada": "^1.6.1",
     "prettier": "^1.19.1",

--- a/packages/adapter-mongoose/package.json
+++ b/packages/adapter-mongoose/package.json
@@ -14,7 +14,7 @@
     "@keystonejs/mongo-join-builder": "^7.1.2",
     "@keystonejs/utils": "^5.4.1",
     "@sindresorhus/slugify": "^0.11.0",
-    "mongoose": "^5.9.11",
+    "mongoose": "^5.10.0",
     "p-settle": "^3.1.0",
     "pluralize": "^7.0.0"
   },

--- a/packages/fields-location-google/package.json
+++ b/packages/fields-location-google/package.json
@@ -18,7 +18,7 @@
     "@keystonejs/adapter-mongoose": "^9.0.0",
     "@keystonejs/fields": "^16.0.0",
     "google-maps-react": "^2.0.6",
-    "mongoose": "^5.9.11",
+    "mongoose": "^5.10.0",
     "node-fetch": "^2.3.0",
     "react": "^16.13.1",
     "react-toast-notifications": "^2.4.0"

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -52,7 +52,7 @@
     "lodash.groupby": "^4.6.0",
     "lodash.isequal": "^4.5.0",
     "luxon": "^1.11.4",
-    "mongoose": "^5.9.11",
+    "mongoose": "^5.10.0",
     "node-fetch": "^2.3.0",
     "p-settle": "^3.1.0",
     "pluralize": "^7.0.0",

--- a/packages/mongo-join-builder/package.json
+++ b/packages/mongo-join-builder/package.json
@@ -12,7 +12,7 @@
     "cuid": "^2.1.8"
   },
   "devDependencies": {
-    "mongodb": "^3.5.7",
+    "mongodb": "^3.6.0",
     "mongodb-memory-server-core": "^6.5.2"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/packages/mongo-join-builder"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17285,10 +17285,10 @@ mongodb-memory-server-core@^6.5.2:
   optionalDependencies:
     mongodb "^3.5.4"
 
-mongodb@3.5.7, mongodb@^3.5.7:
-  version "3.5.7"
-  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.5.7.tgz#6dcfff3bdbf67a53263dcca1647c265eea1d065d"
-  integrity sha512-lMtleRT+vIgY/JhhTn1nyGwnSMmJkJELp+4ZbrjctrnBxuLbj6rmLuJFz8W2xUzUqWmqoyVxJLYuC58ZKpcTYQ==
+mongodb@3.6.0, mongodb@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.6.0.tgz#babd7172ec717e2ed3f85e079b3f1aa29dce4724"
+  integrity sha512-/XWWub1mHZVoqEsUppE0GV7u9kanLvHxho6EvBxQbShXTKYF9trhZC2NzbulRGeG7xMJHD8IOWRcdKx5LPjAjQ==
   dependencies:
     bl "^2.2.0"
     bson "^1.1.4"
@@ -17316,20 +17316,20 @@ mongoose-legacy-pluralize@1.0.2:
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
-mongoose@^5.9.11:
-  version "5.9.11"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.9.11.tgz#12464f557019ab1fe5d0fdcc342cab0e52adb172"
-  integrity sha512-xsPquUEBfJQ/ufT7SI4+qWHml1+HTNra5jQS0RsgCXIMMltCWxn3jeugLiPbyFkKZokMZ+tPy5yEDtLZu5gHeg==
+mongoose@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.10.0.tgz#05a35f5a3d8485613c9988aeb9548285a97083f7"
+  integrity sha512-5itAvBMVDG4+zTDtuLg/IyoTxEMgvpOSHnigQ9Cyh8LR4BEgMAChJj7JSaGkg+tr1AjCSY9DgSdU8bHqCOoxXg==
   dependencies:
     bson "^1.1.4"
     kareem "2.3.1"
-    mongodb "3.5.7"
+    mongodb "3.6.0"
     mongoose-legacy-pluralize "1.0.2"
     mpath "0.7.0"
     mquery "3.2.2"
     ms "2.1.2"
     regexp-clone "1.0.0"
-    safe-buffer "5.1.2"
+    safe-buffer "5.2.1"
     sift "7.0.1"
     sliced "1.0.1"
 
@@ -22275,6 +22275,11 @@ safe-buffer@5.2.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+
+safe-buffer@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Enables support for MongoDB 4.4. Possibly closes #3397 

https://github.com/mongodb/node-mongodb-native/releases/tag/v3.6.0
https://github.com/Automattic/mongoose/blob/master/History.md#5100--2020-08-14