### PR TITLE
Add filter and CRUD tests for AutoIncrement field

### DIFF
--- a/.changeset/few-icons-ring.md
+++ b/.changeset/few-icons-ring.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/fields-auto-increment': patch
+---
+
+Added filter and CRUD tests for `AutoIncrement` field type.

--- a/api-tests/fields/crud.test.js
+++ b/api-tests/fields/crud.test.js
@@ -19,7 +19,10 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`${adapterName} adapter`, () => {
     testModules
       .map(require)
-      .filter(({ skipCrudTest }) => !skipCrudTest)
+      .filter(
+        ({ skipCrudTest, unSupportedAdapterList = [] }) =>
+          !skipCrudTest && !unSupportedAdapterList.includes(adapterName)
+      )
       .forEach(mod => {
         const listKey = 'Test';
         const keystoneTestWrapper = (testFn = () => {}) =>

--- a/api-tests/fields/required.test.js
+++ b/api-tests/fields/required.test.js
@@ -2,12 +2,17 @@ const globby = require('globby');
 const { multiAdapterRunners, setupServer } = require('@keystonejs/test-utils');
 const { Text } = require('@keystonejs/fields');
 
-const testModules = globby.sync(`packages/**/src/**/test-fixtures.js`, { absolute: true });
+const testModules = globby.sync(`packages/**/src/**/test-fixtures.js`, {
+  absolute: true,
+});
 multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     testModules
       .map(require)
-      .filter(({ skipRequiredTest }) => !skipRequiredTest)
+      .filter(
+        ({ skipCrudTest, unSupportedAdapterList = [] }) =>
+          !skipCrudTest && !unSupportedAdapterList.includes(adapterName)
+      )
       .forEach(mod => {
         describe(`${mod.name} - isRequired`, () => {
           const keystoneTestWrapper = testFn =>

--- a/api-tests/fields/unique.test.js
+++ b/api-tests/fields/unique.test.js
@@ -7,7 +7,10 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
   describe(`Adapter: ${adapterName}`, () => {
     testModules
       .map(require)
-      .filter(({ supportsUnique }) => supportsUnique)
+      .filter(
+        ({ supportsUnique, unSupportedAdapterList = [] }) =>
+          supportsUnique && !unSupportedAdapterList.includes(adapterName)
+      )
       .forEach(mod => {
         describe(`${mod.name} - isUnique`, () => {
           const keystoneTestWrapper = testFn =>

--- a/packages/fields-auto-increment/package.json
+++ b/packages/fields-auto-increment/package.json
@@ -14,6 +14,9 @@
     "@keystonejs/adapter-knex": "^11.0.2",
     "@keystonejs/fields": "^17.0.0"
   },
+  "devDependencies": {
+    "@keystonejs/server-side-graphql-client": "*"
+  },
   "main": "dist/fields-auto-increment.cjs.js",
   "module": "dist/fields-auto-increment.esm.js"
 }

--- a/packages/fields-auto-increment/src/test-fixtures.js
+++ b/packages/fields-auto-increment/src/test-fixtures.js
@@ -1,0 +1,206 @@
+import { getItems } from '@keystonejs/server-side-graphql-client';
+import { Text } from '@keystonejs/fields';
+import { AutoIncrement } from './index';
+
+export const name = 'AutoIncrement';
+export { AutoIncrement as type };
+export const exampleValue = 35;
+export const exampleValue2 = 36;
+export const supportsUnique = true;
+export const fieldName = 'orderNumber';
+export const skipCreateTest = true;
+export const skipUpdateTest = true;
+
+// `AutoIncrement` field type is not supported by `mongoose`. So, we need to filter it out while performing `API` tests.
+export const unSupportedAdapterList = ['mongoose'];
+
+// Be default, `AutoIncrement` are read-only. But for `isRequired` test purpose, we need to bypass these restrictions.
+export const fieldConfig = { access: { create: true, update: true } };
+
+export const getTestFields = () => {
+  return {
+    name: { type: Text },
+    orderNumber: {
+      type: AutoIncrement,
+      gqlType: 'Int',
+    },
+  };
+};
+
+export const initItems = () => {
+  return [
+    { name: 'product1' },
+    { name: 'product2' },
+    { name: 'product3' },
+    { name: 'product4' },
+    { name: 'product5' },
+  ];
+};
+
+export const filterTests = withKeystone => {
+  const match = async (keystone, where, expected) =>
+    expect(
+      await getItems({
+        keystone,
+        listKey: 'Test',
+        where,
+        returnFields: 'name orderNumber',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected);
+
+  test(
+    'No filter',
+    withKeystone(({ keystone }) =>
+      match(keystone, undefined, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Empty filter',
+    withKeystone(({ keystone }) =>
+      match(keystone, {}, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber: 1 }, [{ name: 'product1', orderNumber: 1 }])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_not: 1 }, [
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not null',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_not: null }, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_lt',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_lt: 2 }, [{ name: 'product1', orderNumber: 1 }])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_lte',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_lte: 2 }, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_gt',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_gt: 2 }, [
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_gte',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_gte: 2 }, [
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in (empty list)',
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_in: [] }, []))
+  );
+
+  test(
+    'Filter: orderNumber_not_in (empty list)',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_not_in: [] }, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_in: [1, 2, 3] }, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not_in',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_not_in: [1, 2, 3] }, [
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in null',
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_in: [null] }, []))
+  );
+
+  test(
+    'Filter: orderNumber_not_in null',
+    withKeystone(({ keystone }) =>
+      match(keystone, { orderNumber_not_in: [null] }, [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+      ])
+    )
+  );
+};

--- a/packages/fields-auto-increment/src/test-fixtures.skip.js
+++ b/packages/fields-auto-increment/src/test-fixtures.skip.js
@@ -1,7 +1,0 @@
-// The AutoIncrement field type behaves in a way that isn't supported by
-// our current uniqueness tests.
-import { AutoIncrement } from './index';
-
-export const name = 'AutoIncrement';
-export { AutoIncrement as type };
-export const supportsUnique = true;


### PR DESCRIPTION
- Add a filter to accommodate `adapter` specific field API tests.
- Update `fields.test.js` to insert items in an order as in array returned by `initItems()` function of the module. 