### PR TITLE
Remove .md files from the prettier checks, as remark lints these files

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -161,6 +161,7 @@ The result is passed to [the next function in the execution order](/docs/guides/
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const resolveInput = ({
   operation,
@@ -198,6 +199,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const validateInput = ({
   operation,
@@ -235,6 +237,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeChange = ({
   operation,
@@ -275,6 +278,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterChange = ({
   operation,
@@ -309,6 +313,7 @@ Should throw or register errors with `addFieldValidationError(<String>)` if the 
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const validateDelete = ({
   operation,
@@ -342,6 +347,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeDelete = ({
   operation,
@@ -376,6 +382,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterDelete = ({
   operation,
@@ -409,6 +416,7 @@ The result is passed to [the next function in the execution order](/docs/guides/
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const resolveAuthInput = ({
   operation,
@@ -444,6 +452,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const validateAuthInput = ({
   operation,
@@ -479,6 +488,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeAuth = ({
   operation,
@@ -519,6 +529,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterAuth = ({
   operation,
@@ -555,6 +566,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const beforeUnauth = ({
   operation,
@@ -590,6 +602,7 @@ Return values are ignored.
 #### Usage
 
 <!-- prettier-ignore -->
+
 ```js
 const afterAuth = ({
   operation,

--- a/docs/guides/production.md
+++ b/docs/guides/production.md
@@ -57,7 +57,7 @@ Add [query limits](/docs/api/create-list.md#querylimits) and [validation](/docs/
 
 ## Using reverse proxies
 
-It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](<https://en.wikipedia.org/wiki/Slowloris_(computer_security)>). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
+It's recommended to run production Javascript servers behind a reverse proxy such as [Nginx](https://nginx.org/), [HAProxy](https://www.haproxy.org/), a CDN or a cloud-based application (layer 7) load balancer. Doing that can improve performance and protect against [Slowloris Dos attacks](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). The express application variable [`trust proxy`](https://expressjs.com/en/guide/behind-proxies.html) must be set to support reverse proxying:
 
 ```javascript title=index.js
 module.exports = {

--- a/docs/guides/relationship-migration.md
+++ b/docs/guides/relationship-migration.md
@@ -130,7 +130,7 @@ keystone upgrade-relationships --migration
 > **Note:** Always be careful when running auto-generated migration code.
 > Be sure to manually verify that the changes are doing what you want, as incorrect migrations can lead to data loss.
 
-#
+# 
 
 > **Important:** While we have taken every effort to ensure the auto-generated migration code is correct, we cannot account for every possible scenario.
 > Again; please verify the changes work as expected to avoid data loss.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "fresh": "yarn clean && yarn",
     "clean": "rimraf \"**/cypress/{screenshots,videos,reports}\" \"**/node_modules\" \"**/yarn-error.log\" \"**/out.log\" \"**/.DS_Store\" \"**/website/.cache\" \"**/dist\"",
     "lint:eslint": "eslint . --ext ts,tsx,js",
-    "lint:prettier": "prettier --list-different \"**/*.{js,json,ts,tsx,md}\"",
+    "lint:prettier": "prettier --list-different \"**/*.{js,json,ts,tsx}\"",
     "lint:markdown": "remark . --frail --quiet",
     "lint:types": "tsc",
     "lint": "yarn lint:prettier && yarn lint:eslint && yarn lint:markdown && yarn lint:types",

--- a/packages/arch/packages/alert/README.md
+++ b/packages/arch/packages/alert/README.md
@@ -145,6 +145,9 @@ An alert that is full width; removes border and border radius.
 MIT © [Thinkmill](https://www.thinkmill.com.au/)
 
 [source]: https://github.com/keystonejs/keystone/tree/master/packages/arch
+
 [npm]: https://www.npmjs.com/package/@arch-ui/alert
+
 [install-npm]: https://docs.npmjs.com/getting-started/installing-node
+
 [theme]: http://npmjs.com/package/@arch-ui/theme

--- a/packages/fields/src/types/Relationship/README.md
+++ b/packages/fields/src/types/Relationship/README.md
@@ -75,6 +75,7 @@ Use the `create` nested mutation to create and append an item to a to-many
 relationship:
 
 <!-- prettier-ignore -->
+
 ```graphql
 # Replace all posts of a given User
 mutation replaceAllPosts {
@@ -100,6 +101,7 @@ Use the `connect` nested mutation to append an existing item to a to-many
 relationship:
 
 <!-- prettier-ignore -->
+
 ```graphql
 # Replace the company of a given User
 mutation replaceAllPosts {
@@ -126,6 +128,7 @@ the value of a to-single relationship (it's not necessary to use `disconnectAll`
 as is the case for [to-many relationships](#overriding-a-to-many-relationship)):
 
 <!-- prettier-ignore -->
+
 ```graphql
 # Replace the company of a given User
 mutation replaceAllPosts {
@@ -152,6 +155,7 @@ To completely replace the related items in a to-many list, you can perform a
 mutation (thanks to the [order of execution](#order-of-execution)):
 
 <!-- prettier-ignore -->
+
 ```graphql
 # Replace all posts related to a given User
 mutation replaceAllPosts {


### PR DESCRIPTION
We format markdown files with `remark`, which disagrees with `prettier` on the formatting rules to apply.

This PR allows `yarn format` to generate code which passes `yarn lint:prettier`.