### PR TITLE
Update required test for Field API

### DIFF
--- a/.changeset/seven-parents-play.md
+++ b/.changeset/seven-parents-play.md
@@ -1,0 +1,10 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/fields-color': patch
+'@keystonejs/fields-markdown': patch
+'@keystonejs/fields-mongoid': patch
+'@keystonejs/fields-wysiwyg-tinymce': patch
+'@keystonejs/fields': patch
+---
+
+Updated `required` and `uniqueness` tests for field API.

--- a/api-tests/required.test.js
+++ b/api-tests/required.test.js
@@ -53,9 +53,15 @@ describe('Test isRequired flag for all field types', () => {
               keystoneTestWrapper(async ({ keystone }) => {
                 const { data: data0, errors: errors0 } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    createTest(data: { name: "test entry", testField: ${mod.exampleValue} } ) { id }
+                  mutation($data: TestCreateInput) {
+                    createTest(data: $data ) { id }
                   }`,
+                  variables: {
+                    data: {
+                      name: 'test entry',
+                      testField: mod.exampleValue,
+                    },
+                  },
                 });
                 expect(errors0).toBe(undefined);
                 const { data, errors } = await keystone.executeGraphQL({
@@ -77,9 +83,15 @@ describe('Test isRequired flag for all field types', () => {
               keystoneTestWrapper(async ({ keystone }) => {
                 const { data: data0, errors: errors0 } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    createTest(data: { name: "test entry", testField: ${mod.exampleValue} } ) { id }
+                  mutation($data: TestCreateInput) {
+                    createTest(data: $data ) { id }
                   }`,
+                  variables: {
+                    data: {
+                      name: 'test entry',
+                      testField: mod.exampleValue,
+                    },
+                  },
                 });
                 expect(errors0).toBe(undefined);
                 const { data, errors } = await keystone.executeGraphQL({

--- a/api-tests/uniqueness/unique.test.js
+++ b/api-tests/uniqueness/unique.test.js
@@ -32,19 +32,29 @@ describe('Test isUnique flag for all field types', () => {
               keystoneTestWrapper(async ({ keystone }) => {
                 const { errors } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  mutation($data: TestCreateInput) {
+                    createTest(data: $data) { id }
                   }
                 `,
+                  variables: {
+                    data: {
+                      testField: mod.exampleValue,
+                    },
+                  },
                 });
                 expect(errors).toBe(undefined);
 
                 const { errors: errors2 } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  mutation($data: TestCreateInput) {
+                    createTest(data: $data) { id }
                   }
                 `,
+                  variables: {
+                    data: {
+                      testField: mod.exampleValue,
+                    },
+                  },
                 });
 
                 expect(errors2).toHaveProperty('0.message');
@@ -59,11 +69,19 @@ describe('Test isUnique flag for all field types', () => {
               keystoneTestWrapper(async ({ keystone }) => {
                 const { errors } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    foo: createTest(data: { testField: ${mod.exampleValue} }) { id }
-                    bar: createTest(data: { testField: ${mod.exampleValue} }) { id }
+                  mutation($fooData: TestCreateInput, $barData: TestCreateInput) {
+                    foo: createTest(data: $fooData) { id }
+                    bar: createTest(data: $barData) { id }
                   }
                 `,
+                  variables: {
+                    fooData: {
+                      testField: mod.exampleValue,
+                    },
+                    barData: {
+                      testField: mod.exampleValue,
+                    },
+                  },
                 });
 
                 expect(errors).toHaveProperty('0.message');
@@ -78,11 +96,21 @@ describe('Test isUnique flag for all field types', () => {
               keystoneTestWrapper(async ({ keystone }) => {
                 const { data, errors } = await keystone.executeGraphQL({
                   query: `
-                  mutation {
-                    foo: createTest(data: { testField: ${mod.exampleValue}, name: "jess" }) { id }
-                    bar: createTest(data: { testField: ${mod.exampleValue2}, name: "jess" }) { id }
+                  mutation($fooData: TestCreateInput, $barData: TestCreateInput) {
+                    foo: createTest(data: $fooData) { id }
+                    bar: createTest(data: $barData) { id }
                   }
                 `,
+                  variables: {
+                    fooData: {
+                      testField: mod.exampleValue,
+                      name: 'jess',
+                    },
+                    barData: {
+                      testField: mod.exampleValue2,
+                      name: 'jess',
+                    },
+                  },
                 });
 
                 expect(errors).toBe(undefined);

--- a/packages/fields-color/src/test-fixtures.js
+++ b/packages/fields-color/src/test-fixtures.js
@@ -4,8 +4,8 @@ import { Text } from '@keystonejs/fields';
 
 export const name = 'Color';
 export { Color as type };
-export const exampleValue = '"red"';
-export const exampleValue2 = '"green"';
+export const exampleValue = 'red';
+export const exampleValue2 = 'green';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields-markdown/src/test-fixtures.js
+++ b/packages/fields-markdown/src/test-fixtures.js
@@ -5,8 +5,8 @@ import { Markdown } from './index';
 
 export const name = 'Markdown';
 export { Markdown as type };
-export const exampleValue = '"foo"';
-export const exampleValue2 = '"bar"';
+export const exampleValue = 'foo';
+export const exampleValue2 = 'bar';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields-mongoid/src/test-fixtures.js
+++ b/packages/fields-mongoid/src/test-fixtures.js
@@ -2,6 +2,6 @@ import { MongoId } from './index';
 
 export const name = 'MongoId';
 export { MongoId as type };
-export const exampleValue = '"123456781234567812345678"';
-export const exampleValue2 = '"123456781234567812345679"';
+export const exampleValue = '123456781234567812345678';
+export const exampleValue2 = '123456781234567812345679';
 export const supportsUnique = true;

--- a/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
+++ b/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
@@ -5,8 +5,8 @@ import { Wysiwyg } from './';
 
 export const name = 'Wysiwyg';
 export { Wysiwyg as type };
-export const exampleValue = '"foo"';
-export const exampleValue2 = '"<p><strong>This is BOLD</strong></p>"';
+export const exampleValue = 'foo';
+export const exampleValue2 = '<p><strong>This is BOLD</strong></p>';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/CalendarDay/test-fixtures.js
+++ b/packages/fields/src/types/CalendarDay/test-fixtures.js
@@ -4,8 +4,8 @@ import CalendarDay from './';
 
 export const name = 'CalendarDay';
 export { CalendarDay as type };
-export const exampleValue = '"1990-12-31"';
-export const exampleValue2 = '"2000-12-31"';
+export const exampleValue = '1990-12-31';
+export const exampleValue2 = '2000-12-31';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Checkbox/test-fixtures.js
+++ b/packages/fields/src/types/Checkbox/test-fixtures.js
@@ -4,7 +4,7 @@ import Checkbox from './';
 
 export const name = 'Checkbox';
 export { Checkbox as type };
-export const exampleValue = 'true';
+export const exampleValue = true;
 export const supportsUnique = false;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/DateTime/test-fixtures.js
+++ b/packages/fields/src/types/DateTime/test-fixtures.js
@@ -4,8 +4,8 @@ import DateTime from './';
 
 export const name = 'DateTime';
 export { DateTime as type };
-export const exampleValue = '"1990-12-31T12:34:56.789+01:23"';
-export const exampleValue2 = '"2000-01-20T00:08:00.000+10:00"';
+export const exampleValue = '1990-12-31T12:34:56.789+01:23';
+export const exampleValue2 = '2000-01-20T00:08:00.000+10:00';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/DateTimeUtc/test-fixtures.js
+++ b/packages/fields/src/types/DateTimeUtc/test-fixtures.js
@@ -4,8 +4,8 @@ import DateTimeUtc from './';
 
 export const name = 'DateTimeUtc';
 export { DateTimeUtc as type };
-export const exampleValue = '"1990-12-31T12:34:56.789Z"';
-export const exampleValue2 = '"2000-01-20T00:08:00.000Z"';
+export const exampleValue = '1990-12-31T12:34:56.789Z';
+export const exampleValue2 = '2000-01-20T00:08:00.000Z';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Decimal/test-fixtures.js
+++ b/packages/fields/src/types/Decimal/test-fixtures.js
@@ -4,8 +4,8 @@ import Decimal from './';
 
 export const name = 'Decimal';
 export { Decimal as type };
-export const exampleValue = '"6.28"';
-export const exampleValue2 = '"6.283"';
+export const exampleValue = '6.28';
+export const exampleValue2 = '6.283';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Float/test-fixtures.js
+++ b/packages/fields/src/types/Float/test-fixtures.js
@@ -4,8 +4,8 @@ import Float from '.';
 
 export const name = 'Float';
 export { Float as type };
-export const exampleValue = '6.28';
-export const exampleValue2 = '6.283';
+export const exampleValue = 6.28;
+export const exampleValue2 = 6.283;
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Integer/test-fixtures.js
+++ b/packages/fields/src/types/Integer/test-fixtures.js
@@ -4,8 +4,8 @@ import Integer from './';
 
 export const name = 'Integer';
 export { Integer as type };
-export const exampleValue = '37';
-export const exampleValue2 = '38';
+export const exampleValue = 37;
+export const exampleValue2 = 38;
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Password/test-fixtures.js
+++ b/packages/fields/src/types/Password/test-fixtures.js
@@ -4,7 +4,7 @@ import Text from '../Text';
 
 export const name = 'Password';
 export { Password as type };
-export const exampleValue = '"password"';
+export const exampleValue = 'password';
 export const supportsUnique = false;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Text/test-fixtures.js
+++ b/packages/fields/src/types/Text/test-fixtures.js
@@ -5,8 +5,8 @@ const fieldType = 'Text';
 export { fieldType as name };
 
 export { Text as type };
-export const exampleValue = '"foo"';
-export const exampleValue2 = '"bar"';
+export const exampleValue = 'foo';
+export const exampleValue2 = 'bar';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Url/test-fixtures.js
+++ b/packages/fields/src/types/Url/test-fixtures.js
@@ -4,8 +4,8 @@ import Url from './';
 
 export const name = 'Url';
 export { Url as type };
-export const exampleValue = '"https://keystonejs.org"';
-export const exampleValue2 = '"https://thinkmill.com.au"';
+export const exampleValue = 'https://keystonejs.org';
+export const exampleValue2 = 'https://thinkmill.com.au';
 export const supportsUnique = true;
 
 export const getTestFields = () => {

--- a/packages/fields/src/types/Uuid/test-fixtures.js
+++ b/packages/fields/src/types/Uuid/test-fixtures.js
@@ -6,8 +6,8 @@ const fieldType = 'Uuid';
 export { fieldType as name };
 
 export { Uuid as type };
-export const exampleValue = '"7b36c9fe-274d-45f1-9f5d-8d4595959734"';
-export const exampleValue2 = '"c0d37cbc-2f01-432c-89e0-405d54fd4cdc"';
+export const exampleValue = '7b36c9fe-274d-45f1-9f5d-8d4595959734';
+export const exampleValue2 = 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc';
 export const supportsUnique = true;
 
 export const getTestFields = () => {


### PR DESCRIPTION
Referring to this issue [here](https://github.com/keystonejs/keystone/pull/3433#issue-471428574) here, `create` mutation now uses data argument as query variables. 
For this reason, we need to update all the example values in the `test-fixtures.js` files. 