### PR TITLE
Add missing delete API tests

### DIFF
--- a/.changeset/weak-bags-suffer.md
+++ b/.changeset/weak-bags-suffer.md
@@ -1,0 +1,8 @@
+---
+'@keystonejs/fields': patch
+'@keystonejs/fields-color': patch
+'@keystonejs/fields-markdown': patch
+'@keystonejs/fields-wysiwyg-tinymce': patch
+---
+
+Added `Delete` API tests for `Decimal`, `Markdown`, `Color` and `Wysiwyg` field type.

--- a/packages/fields-color/src/test-fixtures.js
+++ b/packages/fields-color/src/test-fixtures.js
@@ -1,4 +1,10 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import { Color } from '.';
 import { Text } from '@keystonejs/fields';
 
@@ -297,7 +303,7 @@ export const crudTests = withKeystone => {
       const items = await getItems({
         keystone,
         listKey,
-        returnFields: 'id hexColor',
+        returnFields: 'id name hexColor',
       });
       return wrappedFn({ keystone, listKey, items });
     };
@@ -394,4 +400,27 @@ export const crudTests = withKeystone => {
       )
     );
   });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name hexColor',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.hexColor).toBe(items[0].hexColor);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name hexColor',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
+    )
+  );
 };

--- a/packages/fields-markdown/src/test-fixtures.js
+++ b/packages/fields-markdown/src/test-fixtures.js
@@ -1,4 +1,10 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import { Text } from '@keystonejs/fields';
 
 import { Markdown } from './index';
@@ -310,7 +316,7 @@ export const crudTests = withKeystone => {
       const items = await getItems({
         keystone,
         listKey,
-        returnFields: 'id content',
+        returnFields: 'id name content',
       });
       return wrappedFn({ keystone, listKey, items });
     };
@@ -407,4 +413,28 @@ export const crudTests = withKeystone => {
       )
     );
   });
+
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name content',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.content).toBe(items[0].content);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name content',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
+    )
+  );
 };

--- a/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
+++ b/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
@@ -1,4 +1,10 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import { Text } from '@keystonejs/fields';
 
 import { Wysiwyg } from './';
@@ -391,7 +397,7 @@ export const crudTests = withKeystone => {
         keystone,
         listKey,
         sortBy: 'name_ASC',
-        returnFields: 'id content',
+        returnFields: 'id name content',
       });
       return wrappedFn({ keystone, listKey, items });
     };
@@ -488,4 +494,28 @@ export const crudTests = withKeystone => {
       )
     );
   });
+
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name content',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.content).toBe(items[0].content);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name content',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
+    )
+  );
 };

--- a/packages/fields/src/types/Decimal/test-fixtures.js
+++ b/packages/fields/src/types/Decimal/test-fixtures.js
@@ -1,4 +1,10 @@
-import { createItem, getItems, getItem, updateItem } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItems,
+  getItem,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Decimal from './';
 
@@ -124,7 +130,7 @@ export const crudTests = withKeystone => {
       const items = await getItems({
         keystone,
         listKey,
-        returnFields: 'id price',
+        returnFields: 'id name price',
       });
       return wrappedFn({ keystone, listKey, items });
     };
@@ -221,4 +227,27 @@ export const crudTests = withKeystone => {
       )
     );
   });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name price',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.price).toBe(items[0].price);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name price',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
+    )
+  );
 };


### PR DESCRIPTION
Add `delete` API tests for: 
- Color
- Wyswig
- Markdown
- Decimal