### PR TITLE
Add CRUD tests for core field types

### DIFF
--- a/.changeset/gold-comics-notice.md
+++ b/.changeset/gold-comics-notice.md
@@ -1,5 +1,0 @@
----
-'@keystonejs/fields': patch
----
-
-Added CRUD API tests for core field types.

--- a/.changeset/gold-comics-notice.md
+++ b/.changeset/gold-comics-notice.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Added CRUD API tests for core field types.

--- a/.changeset/rotten-ladybugs-visit.md
+++ b/.changeset/rotten-ladybugs-visit.md
@@ -1,0 +1,14 @@
+---
+'@keystonejs/api-tests': patch
+'@keystonejs/fields': patch
+'@keystonejs/fields-cloudinary-image': patch
+'@keystonejs/fields-color': patch
+'@keystonejs/fields-location-google': patch
+'@keystonejs/fields-markdown': patch
+'@keystonejs/fields-mongoid': patch
+'@keystonejs/fields-oembed': patch
+'@keystonejs/fields-unsplash': patch
+'@keystonejs/fields-wysiwyg-tinymce': patch
+---
+
+Updated CRUD API tests for field types.

--- a/packages/fields-cloudinary-image/src/test-fixtures.js
+++ b/packages/fields-cloudinary-image/src/test-fixtures.js
@@ -4,3 +4,4 @@ export const name = 'CloudinaryImage';
 export { CloudinaryImage as type };
 export const supportsUnique = false;
 export const skipRequiredTest = true;
+export const skipCrudTest = true;

--- a/packages/fields-color/src/test-fixtures.js
+++ b/packages/fields-color/src/test-fixtures.js
@@ -1,4 +1,4 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import { Color } from '.';
 import { Text } from '@keystonejs/fields';
 
@@ -7,6 +7,7 @@ export { Color as type };
 export const exampleValue = 'red';
 export const exampleValue2 = 'green';
 export const supportsUnique = true;
+export const fieldName = 'hexColor';
 
 export const getTestFields = () => {
   return {
@@ -289,109 +290,4 @@ export const filterTests = withKeystone => {
       ])
     )
   );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id hexColor',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'purple', hexColor: 'rgba(154, 18, 179, 1)' },
-          returnFields: 'hexColor',
-        });
-        expect(data).not.toBe(null);
-        expect(data.hexColor).toBe('rgba(154, 18, 179, 1)');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'hexColor',
-        });
-        expect(data).not.toBe(null);
-        expect(data.hexColor).toBe(items[0].hexColor);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { hexColor: 'rgba(145, 61, 136, 1)' },
-            },
-            returnFields: 'hexColor',
-          });
-          expect(data).not.toBe(null);
-          expect(data.hexColor).toBe('rgba(145, 61, 136, 1)');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { hexColor: null },
-            },
-            returnFields: 'hexColor',
-          });
-          expect(data).not.toBe(null);
-          expect(data.hexColor).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Plum' },
-            },
-            returnFields: 'name hexColor',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Plum');
-          expect(data.hexColor).toBe(items[0].hexColor);
-        })
-      )
-    );
-  });
 };

--- a/packages/fields-location-google/src/test-fixtures.js
+++ b/packages/fields-location-google/src/test-fixtures.js
@@ -5,5 +5,6 @@ export const name = 'Location';
 export { LocationGoogle as type };
 export const supportsUnique = false;
 export const skipRequiredTest = true;
+export const skipCrudTest = true;
 export const exampleValue = '"ChIJOza7MD-uEmsRrf4t12uji6Y"';
 export const fieldConfig = { googleMapsKey: 'googleMapsKey' };

--- a/packages/fields-markdown/src/test-fixtures.js
+++ b/packages/fields-markdown/src/test-fixtures.js
@@ -1,4 +1,4 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import { Text } from '@keystonejs/fields';
 
 import { Markdown } from './index';
@@ -8,6 +8,7 @@ export { Markdown as type };
 export const exampleValue = 'foo';
 export const exampleValue2 = 'bar';
 export const supportsUnique = true;
+export const fieldName = 'content';
 
 export const getTestFields = () => {
   return {
@@ -302,109 +303,4 @@ export const filterTests = withKeystone => {
       ])
     )
   );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id content',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'Getting Started', content: '**This is getting started guide**.' },
-          returnFields: 'content',
-        });
-        expect(data).not.toBe(null);
-        expect(data.content).toBe('**This is getting started guide**.');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'content',
-        });
-        expect(data).not.toBe(null);
-        expect(data.content).toBe(items[0].content);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { content: '~~This is getting started guide~~.' },
-            },
-            returnFields: 'content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.content).toBe('~~This is getting started guide~~.');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { content: null },
-            },
-            returnFields: 'content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.content).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Keystone User Guide' },
-            },
-            returnFields: 'name content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Keystone User Guide');
-          expect(data.content).toBe(items[0].content);
-        })
-      )
-    );
-  });
 };

--- a/packages/fields-mongoid/src/test-fixtures.js
+++ b/packages/fields-mongoid/src/test-fixtures.js
@@ -5,3 +5,4 @@ export { MongoId as type };
 export const exampleValue = '123456781234567812345678';
 export const exampleValue2 = '123456781234567812345679';
 export const supportsUnique = true;
+export const skipCrudTest = true;

--- a/packages/fields-oembed/src/test-fixtures.js
+++ b/packages/fields-oembed/src/test-fixtures.js
@@ -4,3 +4,4 @@ export const name = 'OEmbed';
 export { OEmbed as type };
 export const supportsUnique = false;
 export const skipRequiredTest = true;
+export const skipCrudTest = true;

--- a/packages/fields-unsplash/src/test-fixtures.js
+++ b/packages/fields-unsplash/src/test-fixtures.js
@@ -4,6 +4,7 @@ export const name = 'Unsplash';
 export { Unsplash as type };
 export const supportsUnique = false;
 export const skipRequiredTest = true;
+export const skipCrudTest = true;
 export const fieldConfig = {
   accessKey: 'accessKey',
   secretKey: 'secretKey',

--- a/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
+++ b/packages/fields-wysiwyg-tinymce/src/test-fixtures.js
@@ -1,4 +1,4 @@
-import { createItem, getItem, getItems, updateItem } from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import { Text } from '@keystonejs/fields';
 
 import { Wysiwyg } from './';
@@ -8,6 +8,7 @@ export { Wysiwyg as type };
 export const exampleValue = 'foo';
 export const exampleValue2 = '<p><strong>This is BOLD</strong></p>';
 export const supportsUnique = true;
+export const fieldName = 'content';
 
 export const getTestFields = () => {
   return {
@@ -382,110 +383,4 @@ export const filterTests = withKeystone => {
       ])
     )
   );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        sortBy: 'name_ASC',
-        returnFields: 'id content',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'Getting Started', content: '<p><strong>I am bold</strong></p>' },
-          returnFields: 'content',
-        });
-        expect(data).not.toBe(null);
-        expect(data.content).toBe('<p><strong>I am bold</strong></p>');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'content',
-        });
-        expect(data).not.toBe(null);
-        expect(data.content).toBe(items[0].content);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { content: '<p>This is <a href="www.test.com">link</a></p>' },
-            },
-            returnFields: 'content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.content).toBe('<p>This is <a href="www.test.com">link</a></p>');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { content: null },
-            },
-            returnFields: 'content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.content).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Keystone User Guide' },
-            },
-            returnFields: 'name content',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Keystone User Guide');
-          expect(data.content).toBe(items[0].content);
-        })
-      )
-    );
-  });
 };

--- a/packages/fields/src/types/CalendarDay/test-fixtures.js
+++ b/packages/fields/src/types/CalendarDay/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItem,
-  getItems,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import CalendarDay from './';
 
@@ -13,6 +7,7 @@ export { CalendarDay as type };
 export const exampleValue = '1990-12-31';
 export const exampleValue2 = '2000-12-31';
 export const supportsUnique = true;
+export const fieldName = 'birthday';
 
 export const getTestFields = () => {
   return {
@@ -193,134 +188,6 @@ export const filterTests = withKeystone => {
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name birthday',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'person5', birthday: '2000-02-20' },
-          returnFields: 'birthday',
-        });
-        expect(data).not.toBe(null);
-        expect(data.birthday).toBe('2000-02-20');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'birthday',
-        });
-        expect(data).not.toBe(null);
-        expect(data.birthday).toBe(items[0].birthday);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { birthday: '2018-12-14' },
-            },
-            returnFields: 'birthday',
-          });
-          expect(data).not.toBe(null);
-          expect(data.birthday).toBe('2018-12-14');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { birthday: null },
-            },
-            returnFields: 'birthday',
-          });
-          expect(data).not.toBe(null);
-          expect(data.birthday).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Plum' },
-            },
-            returnFields: 'name birthday',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Plum');
-          expect(data.birthday).toBe(items[0].birthday);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name birthday',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.birthday).toBe(items[0].birthday);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name birthday',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/CalendarDay/test-fixtures.js
+++ b/packages/fields/src/types/CalendarDay/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import CalendarDay from './';
 
@@ -187,6 +193,134 @@ export const filterTests = withKeystone => {
         { name: 'person3', birthday: '1950-10-01' },
         { name: 'person4', birthday: '1666-04-12' },
       ])
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name birthday',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'person5', birthday: '2000-02-20' },
+          returnFields: 'birthday',
+        });
+        expect(data).not.toBe(null);
+        expect(data.birthday).toBe('2000-02-20');
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'birthday',
+        });
+        expect(data).not.toBe(null);
+        expect(data.birthday).toBe(items[0].birthday);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { birthday: '2018-12-14' },
+            },
+            returnFields: 'birthday',
+          });
+          expect(data).not.toBe(null);
+          expect(data.birthday).toBe('2018-12-14');
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { birthday: null },
+            },
+            returnFields: 'birthday',
+          });
+          expect(data).not.toBe(null);
+          expect(data.birthday).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'Plum' },
+            },
+            returnFields: 'name birthday',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('Plum');
+          expect(data.birthday).toBe(items[0].birthday);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name birthday',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.birthday).toBe(items[0].birthday);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name birthday',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/Checkbox/test-fixtures.js
+++ b/packages/fields/src/types/Checkbox/test-fixtures.js
@@ -1,17 +1,13 @@
-import {
-  createItem,
-  deleteItem,
-  getItem,
-  getItems,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Checkbox from './';
 
 export const name = 'Checkbox';
 export { Checkbox as type };
 export const exampleValue = true;
+export const exampleValue2 = false;
 export const supportsUnique = false;
+export const fieldName = 'enabled';
 
 export const getTestFields = () => {
   return {
@@ -100,134 +96,6 @@ export const filterTests = withKeystone => {
         { name: 'person3', enabled: null },
         { name: 'person4', enabled: true },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name enabled',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'person5', enabled: false },
-          returnFields: 'enabled',
-        });
-        expect(data).not.toBe(null);
-        expect(data.enabled).toBe(false);
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'enabled',
-        });
-        expect(data).not.toBe(null);
-        expect(data.enabled).toBe(items[0].enabled);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { enabled: true },
-            },
-            returnFields: 'enabled',
-          });
-          expect(data).not.toBe(null);
-          expect(data.enabled).toBe(true);
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { enabled: null },
-            },
-            returnFields: 'enabled',
-          });
-          expect(data).not.toBe(null);
-          expect(data.enabled).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Plum' },
-            },
-            returnFields: 'name enabled',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Plum');
-          expect(data.enabled).toBe(items[0].enabled);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name enabled',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.enabled).toBe(items[0].enabled);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name enabled',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/DateTime/test-fixtures.js
+++ b/packages/fields/src/types/DateTime/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import DateTime from './';
 
@@ -263,6 +269,135 @@ export const filterTests = withKeystone => {
             ],
         'lastOnline_DESC'
       )
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name lastOnline',
+        sortBy: 'name_ASC',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'person5', lastOnline: '1950-11-01T23:59:59.999-10:00' },
+          returnFields: 'lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.lastOnline).toBe('1950-11-01T23:59:59.999-10:00');
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.lastOnline).toBe(items[0].lastOnline);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { lastOnline: '2018-11-01T23:59:59.999-10:00' },
+            },
+            returnFields: 'lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.lastOnline).toBe('2018-11-01T23:59:59.999-10:00');
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { lastOnline: null },
+            },
+            returnFields: 'lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.lastOnline).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'Plum' },
+            },
+            returnFields: 'name lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('Plum');
+          expect(data.lastOnline).toBe(items[0].lastOnline);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.lastOnline).toBe(items[0].lastOnline);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name lastOnline',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/DateTime/test-fixtures.js
+++ b/packages/fields/src/types/DateTime/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItem,
-  getItems,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import DateTime from './';
 
@@ -13,6 +7,7 @@ export { DateTime as type };
 export const exampleValue = '1990-12-31T12:34:56.789+01:23';
 export const exampleValue2 = '2000-01-20T00:08:00.000+10:00';
 export const supportsUnique = true;
+export const fieldName = 'lastOnline';
 
 export const getTestFields = () => {
   return {
@@ -269,135 +264,6 @@ export const filterTests = withKeystone => {
             ],
         'lastOnline_DESC'
       )
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name lastOnline',
-        sortBy: 'name_ASC',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'person5', lastOnline: '1950-11-01T23:59:59.999-10:00' },
-          returnFields: 'lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.lastOnline).toBe('1950-11-01T23:59:59.999-10:00');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.lastOnline).toBe(items[0].lastOnline);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { lastOnline: '2018-11-01T23:59:59.999-10:00' },
-            },
-            returnFields: 'lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.lastOnline).toBe('2018-11-01T23:59:59.999-10:00');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { lastOnline: null },
-            },
-            returnFields: 'lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.lastOnline).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Plum' },
-            },
-            returnFields: 'name lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Plum');
-          expect(data.lastOnline).toBe(items[0].lastOnline);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.lastOnline).toBe(items[0].lastOnline);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name lastOnline',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/DateTimeUtc/test-fixtures.js
+++ b/packages/fields/src/types/DateTimeUtc/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItem,
-  getItems,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import DateTimeUtc from './';
 
@@ -13,6 +7,7 @@ export { DateTimeUtc as type };
 export const exampleValue = '1990-12-31T12:34:56.789Z';
 export const exampleValue2 = '2000-01-20T00:08:00.000Z';
 export const supportsUnique = true;
+export const fieldName = 'lastOnline';
 
 export const getTestFields = () => {
   return {
@@ -269,135 +264,6 @@ export const filterTests = withKeystone => {
             ],
         'lastOnline_DESC'
       )
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name lastOnline',
-        sortBy: 'name_ASC',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'person5', lastOnline: '2019-12-01T23:59:59.999Z' },
-          returnFields: 'lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.lastOnline).toBe('2019-12-01T23:59:59.999Z');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.lastOnline).toBe(items[0].lastOnline);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { lastOnline: '2018-11-01T23:59:59.999Z' },
-            },
-            returnFields: 'lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.lastOnline).toBe('2018-11-01T23:59:59.999Z');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { lastOnline: null },
-            },
-            returnFields: 'lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.lastOnline).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Plum' },
-            },
-            returnFields: 'name lastOnline',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Plum');
-          expect(data.lastOnline).toBe(items[0].lastOnline);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name lastOnline',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.lastOnline).toBe(items[0].lastOnline);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name lastOnline',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/DateTimeUtc/test-fixtures.js
+++ b/packages/fields/src/types/DateTimeUtc/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItem,
+  getItems,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import DateTimeUtc from './';
 
@@ -263,6 +269,135 @@ export const filterTests = withKeystone => {
             ],
         'lastOnline_DESC'
       )
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name lastOnline',
+        sortBy: 'name_ASC',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'person5', lastOnline: '2019-12-01T23:59:59.999Z' },
+          returnFields: 'lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.lastOnline).toBe('2019-12-01T23:59:59.999Z');
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.lastOnline).toBe(items[0].lastOnline);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { lastOnline: '2018-11-01T23:59:59.999Z' },
+            },
+            returnFields: 'lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.lastOnline).toBe('2018-11-01T23:59:59.999Z');
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { lastOnline: null },
+            },
+            returnFields: 'lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.lastOnline).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'Plum' },
+            },
+            returnFields: 'name lastOnline',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('Plum');
+          expect(data.lastOnline).toBe(items[0].lastOnline);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name lastOnline',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.lastOnline).toBe(items[0].lastOnline);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name lastOnline',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/Decimal/test-fixtures.js
+++ b/packages/fields/src/types/Decimal/test-fixtures.js
@@ -1,12 +1,13 @@
-import { createItem, getItems, getItem, updateItem } from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Decimal from './';
 
 export const name = 'Decimal';
 export { Decimal as type };
 export const exampleValue = '6.28';
-export const exampleValue2 = '6.283';
+export const exampleValue2 = '6.45';
 export const supportsUnique = true;
+export const fieldName = 'price';
 
 export const getTestFields = () => {
   return {
@@ -116,109 +117,4 @@ export const filterTests = withKeystone => {
       ])
     )
   );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id price',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'test entry', price: '17.56' },
-          returnFields: 'price',
-        });
-        expect(data).not.toBe(null);
-        expect(data.price).toBe('17.56');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'price',
-        });
-        expect(data).not.toBe(null);
-        expect(data.price).toBe(items[0].price);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { price: '879.46' },
-            },
-            returnFields: 'price',
-          });
-          expect(data).not.toBe(null);
-          expect(data.price).toBe('879.46');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { price: null },
-            },
-            returnFields: 'price',
-          });
-          expect(data).not.toBe(null);
-          expect(data.price).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'foobarbaz' },
-            },
-            returnFields: 'name price',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('foobarbaz');
-          expect(data.price).toBe(items[0].price);
-        })
-      )
-    );
-  });
 };

--- a/packages/fields/src/types/File/test-fixtures.js
+++ b/packages/fields/src/types/File/test-fixtures.js
@@ -4,3 +4,4 @@ export const name = 'File';
 export { File as type };
 export const supportsUnique = false;
 export const skipRequiredTest = true;
+export const skipCrudTest = true;

--- a/packages/fields/src/types/Float/test-fixtures.js
+++ b/packages/fields/src/types/Float/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItems,
-  getItem,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Float from '.';
 
@@ -13,6 +7,7 @@ export { Float as type };
 export const exampleValue = 6.28;
 export const exampleValue2 = 6.283;
 export const supportsUnique = true;
+export const fieldName = 'stars';
 
 export const getTestFields = () => {
   return {
@@ -195,134 +190,6 @@ export const filterTests = withKeystone => {
         { name: 'post3', stars: 2.3 },
         { name: 'post4', stars: 3 },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name stars',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'Keysontejs loves GraphQL', stars: 4.5 },
-          returnFields: 'stars',
-        });
-        expect(data).not.toBe(null);
-        expect(data.stars).toBe(4.5);
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'stars',
-        });
-        expect(data).not.toBe(null);
-        expect(data.stars).toBe(items[0].stars);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { stars: 3.5 },
-            },
-            returnFields: 'stars',
-          });
-          expect(data).not.toBe(null);
-          expect(data.stars).toBe(3.5);
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { stars: null },
-            },
-            returnFields: 'stars',
-          });
-          expect(data).not.toBe(null);
-          expect(data.stars).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'foobarbaz' },
-            },
-            returnFields: 'name stars',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('foobarbaz');
-          expect(data.stars).toBe(items[0].stars);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name stars',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.stars).toBe(items[0].stars);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name stars',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/Float/test-fixtures.js
+++ b/packages/fields/src/types/Float/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItems,
+  getItem,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Float from '.';
 
@@ -189,6 +195,134 @@ export const filterTests = withKeystone => {
         { name: 'post3', stars: 2.3 },
         { name: 'post4', stars: 3 },
       ])
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name stars',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'Keysontejs loves GraphQL', stars: 4.5 },
+          returnFields: 'stars',
+        });
+        expect(data).not.toBe(null);
+        expect(data.stars).toBe(4.5);
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'stars',
+        });
+        expect(data).not.toBe(null);
+        expect(data.stars).toBe(items[0].stars);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { stars: 3.5 },
+            },
+            returnFields: 'stars',
+          });
+          expect(data).not.toBe(null);
+          expect(data.stars).toBe(3.5);
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { stars: null },
+            },
+            returnFields: 'stars',
+          });
+          expect(data).not.toBe(null);
+          expect(data.stars).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'foobarbaz' },
+            },
+            returnFields: 'name stars',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('foobarbaz');
+          expect(data.stars).toBe(items[0].stars);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name stars',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.stars).toBe(items[0].stars);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name stars',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/Integer/test-fixtures.js
+++ b/packages/fields/src/types/Integer/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItems,
-  getItem,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Integer from './';
 
@@ -13,6 +7,7 @@ export { Integer as type };
 export const exampleValue = 37;
 export const exampleValue2 = 38;
 export const supportsUnique = true;
+export const fieldName = 'count';
 
 export const getTestFields = () => {
   return {
@@ -191,134 +186,6 @@ export const filterTests = withKeystone => {
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name count',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'Keystone', count: 4 },
-          returnFields: 'count',
-        });
-        expect(data).not.toBe(null);
-        expect(data.count).toBe(4);
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'count',
-        });
-        expect(data).not.toBe(null);
-        expect(data.count).toBe(items[0].count);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { count: 6 },
-            },
-            returnFields: 'count',
-          });
-          expect(data).not.toBe(null);
-          expect(data.count).toBe(6);
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { count: null },
-            },
-            returnFields: 'count',
-          });
-          expect(data).not.toBe(null);
-          expect(data.count).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'foobarbaz' },
-            },
-            returnFields: 'name count',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('foobarbaz');
-          expect(data.count).toBe(items[0].count);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name count',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-        expect(data.count).toBe(items[0].count);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name count',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/Integer/test-fixtures.js
+++ b/packages/fields/src/types/Integer/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItems,
+  getItem,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Integer from './';
 
@@ -185,6 +191,134 @@ export const filterTests = withKeystone => {
         { name: 'person3', count: 2 },
         { name: 'person4', count: 3 },
       ])
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name count',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'Keystone', count: 4 },
+          returnFields: 'count',
+        });
+        expect(data).not.toBe(null);
+        expect(data.count).toBe(4);
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'count',
+        });
+        expect(data).not.toBe(null);
+        expect(data.count).toBe(items[0].count);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { count: 6 },
+            },
+            returnFields: 'count',
+          });
+          expect(data).not.toBe(null);
+          expect(data.count).toBe(6);
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { count: null },
+            },
+            returnFields: 'count',
+          });
+          expect(data).not.toBe(null);
+          expect(data.count).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'foobarbaz' },
+            },
+            returnFields: 'name count',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('foobarbaz');
+          expect(data.count).toBe(items[0].count);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name count',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+        expect(data.count).toBe(items[0].count);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name count',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/Password/test-fixtures.js
+++ b/packages/fields/src/types/Password/test-fixtures.js
@@ -5,7 +5,11 @@ import Text from '../Text';
 export const name = 'Password';
 export { Password as type };
 export const exampleValue = 'password';
+export const exampleValue2 = 'password2';
 export const supportsUnique = false;
+export const fieldName = 'password';
+export const skipCreateTest = true;
+export const skipUpdateTest = true;
 
 export const getTestFields = () => {
   return {

--- a/packages/fields/src/types/Select/test-fixtures.js
+++ b/packages/fields/src/types/Select/test-fixtures.js
@@ -15,6 +15,8 @@ export const fieldConfig = {
   ],
 };
 
+export const fieldName = 'company';
+
 export const getTestFields = () => {
   return {
     name: { type: Text }, // Provide a field to sort on

--- a/packages/fields/src/types/Text/test-fixtures.js
+++ b/packages/fields/src/types/Text/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItems,
-  getItem,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from './';
 
 const fieldType = 'Text';
@@ -14,38 +8,39 @@ export { Text as type };
 export const exampleValue = 'foo';
 export const exampleValue2 = 'bar';
 export const supportsUnique = true;
+export const fieldName = 'text';
 
 export const getTestFields = () => {
   return {
-    order: { type: Text },
     name: { type: Text },
+    text: { type: Text },
   };
 };
 
 export const initItems = () => {
   return [
-    { order: 'a', name: '' },
-    { order: 'b', name: 'other' },
-    { order: 'c', name: 'FOOBAR' },
-    { order: 'd', name: 'fooBAR' },
-    { order: 'e', name: 'foobar' },
-    { order: 'f', name: null },
-    { order: 'g' },
+    { name: 'a', text: '' },
+    { name: 'b', text: 'other' },
+    { name: 'c', text: 'FOOBAR' },
+    { name: 'd', text: 'fooBAR' },
+    { name: 'e', text: 'foobar' },
+    { name: 'f', text: null },
+    { name: 'g' },
   ];
 };
 
-// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and ordering)
+// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and nameing)
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {
-  const match = async (keystone, where, expected) =>
+  const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
     expect(
       await getItems({
         keystone,
         listKey: 'test',
         where,
-        returnFields: 'order name',
-        sortBy: 'order_ASC',
+        returnFields: 'name text',
+        sortBy,
       })
     ).toEqual(expected);
 
@@ -53,13 +48,13 @@ export const filterTests = withKeystone => {
     `No 'where' argument`,
     withKeystone(({ keystone }) =>
       match(keystone, undefined, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
@@ -67,13 +62,13 @@ export const filterTests = withKeystone => {
     `Empty 'where' argument'`,
     withKeystone(({ keystone }) =>
       match(keystone, {}, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
@@ -81,16 +76,16 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key} (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name: 'fooBAR' }, [{ order: 'd', name: 'fooBAR' }])
+      match(keystone, { text: 'fooBAR' }, [{ name: 'd', text: 'fooBAR' }])
     )
   );
   test(
     `Filter: {key}_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_i: 'fooBAR' }, [
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_i: 'fooBAR' }, [
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
@@ -98,24 +93,24 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not: 'fooBAR' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not: 'fooBAR' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_i: 'fooBAR' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_i: 'fooBAR' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
@@ -123,19 +118,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_contains: 'oo' }, [
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_contains: 'oo' }, [
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
   test(
     `Filter: {key}_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_contains_i: 'oo' }, [
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_contains_i: 'oo' }, [
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
@@ -143,23 +138,23 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_contains: 'oo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_contains: 'oo' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_contains_i: 'oo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_contains_i: 'oo' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
@@ -167,19 +162,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_starts_with: 'foo' }, [
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_starts_with: 'foo' }, [
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
   test(
     `Filter: {key}_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_starts_with_i: 'foo' }, [
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_starts_with_i: 'foo' }, [
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
@@ -187,23 +182,23 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_starts_with: 'foo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_starts_with: 'foo' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_starts_with_i: 'foo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_starts_with_i: 'foo' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
@@ -211,19 +206,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_ends_with: 'BAR' }, [
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
+      match(keystone, { text_ends_with: 'BAR' }, [
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
       ])
     )
   );
   test(
     `Filter: {key}_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_ends_with_i: 'BAR' }, [
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
+      match(keystone, { text_ends_with_i: 'BAR' }, [
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
       ])
     )
   );
@@ -231,37 +226,37 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_ends_with: 'BAR' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_ends_with: 'BAR' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_ends_with_i: 'BAR' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_ends_with_i: 'BAR' }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
 
   test(
     `Filter: {key}_in (case-sensitive, empty list)`,
-    withKeystone(({ keystone }) => match(keystone, { name_in: [] }, []))
+    withKeystone(({ keystone }) => match(keystone, { text_in: [] }, []))
   );
   test(
     `Filter: {key}_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_in: ['', 'FOOBAR'] }, [
-        { order: 'a', name: '' },
-        { order: 'c', name: 'FOOBAR' },
+      match(keystone, { text_in: ['', 'FOOBAR'] }, [
+        { name: 'a', text: '' },
+        { name: 'c', text: 'FOOBAR' },
       ])
     )
   );
@@ -269,155 +264,27 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_in (case-sensitive, empty list)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_in: [] }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'other' },
-        { order: 'c', name: 'FOOBAR' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_in: [] }, [
+        { name: 'a', text: '' },
+        { name: 'b', text: 'other' },
+        { name: 'c', text: 'FOOBAR' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_in: ['', 'FOOBAR'] }, [
-        { order: 'b', name: 'other' },
-        { order: 'd', name: 'fooBAR' },
-        { order: 'e', name: 'foobar' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { text_not_in: ['', 'FOOBAR'] }, [
+        { name: 'b', text: 'other' },
+        { name: 'd', text: 'fooBAR' },
+        { name: 'e', text: 'foobar' },
+        { name: 'f', text: null },
+        { name: 'g', text: null },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name ',
-        sortBy: 'order_ASC',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'Keystone', order: 'h' },
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe('Keystone');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'Sachin' },
-            },
-            returnFields: 'name',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('Sachin');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: null },
-            },
-            returnFields: 'name',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { order: 'i' },
-            },
-            returnFields: 'name order',
-          });
-          expect(data).not.toBe(null);
-          expect(data.order).toBe('i');
-          expect(data.name).toBe(items[0].name);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/Url/test-fixtures.js
+++ b/packages/fields/src/types/Url/test-fixtures.js
@@ -28,7 +28,7 @@ export const initItems = () => {
   ];
 };
 
-// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and nameing)
+// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and ordering)
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {

--- a/packages/fields/src/types/Url/test-fixtures.js
+++ b/packages/fields/src/types/Url/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItems,
-  getItem,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from './';
 import Url from './';
 
@@ -13,27 +7,28 @@ export { Url as type };
 export const exampleValue = 'https://keystonejs.org';
 export const exampleValue2 = 'https://thinkmill.com.au';
 export const supportsUnique = true;
+export const fieldName = 'url';
 
 export const getTestFields = () => {
   return {
-    order: { type: Text },
-    name: { type: Url },
+    name: { type: Text },
+    url: { type: Url },
   };
 };
 
 export const initItems = () => {
   return [
-    { order: 'a', name: '' },
-    { order: 'b', name: 'https://other.com' },
-    { order: 'c', name: 'https://FOOBAR.com' },
-    { order: 'd', name: 'https://fooBAR.com' },
-    { order: 'e', name: 'https://foobar.com' },
-    { order: 'f', name: null },
-    { order: 'g' },
+    { name: 'a', url: '' },
+    { name: 'b', url: 'https://other.com' },
+    { name: 'c', url: 'https://FOOBAR.com' },
+    { name: 'd', url: 'https://fooBAR.com' },
+    { name: 'e', url: 'https://foobar.com' },
+    { name: 'f', url: null },
+    { name: 'g' },
   ];
 };
 
-// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and ordering)
+// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and nameing)
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {
@@ -43,8 +38,8 @@ export const filterTests = withKeystone => {
         keystone,
         listKey: 'test',
         where,
-        returnFields: 'order name',
-        sortBy: 'order_ASC',
+        returnFields: 'name url',
+        sortBy: 'name_ASC',
       })
     ).toEqual(expected);
 
@@ -52,13 +47,13 @@ export const filterTests = withKeystone => {
     `No 'where' argument`,
     withKeystone(({ keystone }) =>
       match(keystone, undefined, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -66,13 +61,13 @@ export const filterTests = withKeystone => {
     `Empty 'where' argument'`,
     withKeystone(({ keystone }) =>
       match(keystone, {}, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -80,16 +75,16 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key} (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name: 'https://fooBAR.com' }, [{ order: 'd', name: 'https://fooBAR.com' }])
+      match(keystone, { url: 'https://fooBAR.com' }, [{ name: 'd', url: 'https://fooBAR.com' }])
     )
   );
   test(
     `Filter: {key}_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_i: 'https://fooBAR.com' }, [
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_i: 'https://fooBAR.com' }, [
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
@@ -97,24 +92,24 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not: 'https://fooBAR.com' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not: 'https://fooBAR.com' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_i: 'https://fooBAR.com' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_i: 'https://fooBAR.com' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -122,19 +117,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_contains: 'oo' }, [
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_contains: 'oo' }, [
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
   test(
     `Filter: {key}_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_contains_i: 'oo' }, [
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_contains_i: 'oo' }, [
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
@@ -142,23 +137,23 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_contains (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_contains: 'oo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_contains: 'oo' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_contains_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_contains_i: 'oo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_contains_i: 'oo' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -166,19 +161,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_starts_with: 'https://foo' }, [
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_starts_with: 'https://foo' }, [
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
   test(
     `Filter: {key}_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_starts_with_i: 'https://foo' }, [
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_starts_with_i: 'https://foo' }, [
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
@@ -186,12 +181,12 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_starts_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_starts_with: 'https://foo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_starts_with: 'https://foo' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -199,11 +194,11 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_starts_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_starts_with_i: 'https://foo' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_starts_with_i: 'https://foo' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
@@ -211,19 +206,19 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_ends_with: 'BAR.com' }, [
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
+      match(keystone, { url_ends_with: 'BAR.com' }, [
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
       ])
     )
   );
   test(
     `Filter: {key}_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_ends_with_i: 'BAR.com' }, [
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
+      match(keystone, { url_ends_with_i: 'BAR.com' }, [
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
       ])
     )
   );
@@ -231,37 +226,37 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_ends_with (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_ends_with: 'BAR.com' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_ends_with: 'BAR.com' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_ends_with_i (case-insensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_ends_with_i: 'BAR.com' }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_ends_with_i: 'BAR.com' }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
 
   test(
     `Filter: {key}_in (case-sensitive, empty list)`,
-    withKeystone(({ keystone }) => match(keystone, { name_in: [] }, []))
+    withKeystone(({ keystone }) => match(keystone, { url_in: [] }, []))
   );
   test(
     `Filter: {key}_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_in: ['', 'https://FOOBAR.com'] }, [
-        { order: 'a', name: '' },
-        { order: 'c', name: 'https://FOOBAR.com' },
+      match(keystone, { url_in: ['', 'https://FOOBAR.com'] }, [
+        { name: 'a', url: '' },
+        { name: 'c', url: 'https://FOOBAR.com' },
       ])
     )
   );
@@ -269,155 +264,27 @@ export const filterTests = withKeystone => {
   test(
     `Filter: {key}_not_in (case-sensitive, empty list)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_in: [] }, [
-        { order: 'a', name: '' },
-        { order: 'b', name: 'https://other.com' },
-        { order: 'c', name: 'https://FOOBAR.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_in: [] }, [
+        { name: 'a', url: '' },
+        { name: 'b', url: 'https://other.com' },
+        { name: 'c', url: 'https://FOOBAR.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
     )
   );
   test(
     `Filter: {key}_not_in (case-sensitive)`,
     withKeystone(({ keystone }) =>
-      match(keystone, { name_not_in: ['', 'https://FOOBAR.com'] }, [
-        { order: 'b', name: 'https://other.com' },
-        { order: 'd', name: 'https://fooBAR.com' },
-        { order: 'e', name: 'https://foobar.com' },
-        { order: 'f', name: null },
-        { order: 'g', name: null },
+      match(keystone, { url_not_in: ['', 'https://FOOBAR.com'] }, [
+        { name: 'b', url: 'https://other.com' },
+        { name: 'd', url: 'https://fooBAR.com' },
+        { name: 'e', url: 'https://foobar.com' },
+        { name: 'f', url: null },
+        { name: 'g', url: null },
       ])
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id name ',
-        sortBy: 'order_ASC',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { name: 'https://keystonejs.com', order: 'h' },
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe('https://keystonejs.com');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: 'https://jestjs.io' },
-            },
-            returnFields: 'name',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe('https://jestjs.io');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { name: null },
-            },
-            returnFields: 'name',
-          });
-          expect(data).not.toBe(null);
-          expect(data.name).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { order: 'i' },
-            },
-            returnFields: 'name order',
-          });
-          expect(data).not.toBe(null);
-          expect(data.order).toBe('i');
-          expect(data.name).toBe(items[0].name);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'name',
-        });
-        expect(data).not.toBe(null);
-        expect(data.name).toBe(items[0].name);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'name',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/src/types/Url/test-fixtures.js
+++ b/packages/fields/src/types/Url/test-fixtures.js
@@ -1,4 +1,10 @@
-import { getItems } from '@keystonejs/server-side-graphql-client';
+import {
+  createItem,
+  deleteItem,
+  getItems,
+  getItem,
+  updateItem,
+} from '@keystonejs/server-side-graphql-client';
 import Text from './';
 import Url from './';
 
@@ -284,6 +290,134 @@ export const filterTests = withKeystone => {
         { order: 'f', name: null },
         { order: 'g', name: null },
       ])
+    )
+  );
+};
+
+export const crudTests = withKeystone => {
+  const withHelpers = wrappedFn => {
+    return async ({ keystone, listKey }) => {
+      const items = await getItems({
+        keystone,
+        listKey,
+        returnFields: 'id name ',
+        sortBy: 'order_ASC',
+      });
+      return wrappedFn({ keystone, listKey, items });
+    };
+  };
+
+  test(
+    'Create',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey }) => {
+        const data = await createItem({
+          keystone,
+          listKey,
+          item: { name: 'https://keystonejs.com', order: 'h' },
+          returnFields: 'name',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe('https://keystonejs.com');
+      })
+    )
+  );
+
+  test(
+    'Read',
+    withKeystone(
+      withHelpers(async ({ keystone, listKey, items }) => {
+        const data = await getItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+      })
+    )
+  );
+
+  describe('Update', () => {
+    test(
+      'Updating the value',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: 'https://jestjs.io' },
+            },
+            returnFields: 'name',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe('https://jestjs.io');
+        })
+      )
+    );
+
+    test(
+      'Updating the value to null',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { name: null },
+            },
+            returnFields: 'name',
+          });
+          expect(data).not.toBe(null);
+          expect(data.name).toBe(null);
+        })
+      )
+    );
+
+    test(
+      'Updating without this field',
+      withKeystone(
+        withHelpers(async ({ keystone, items, listKey }) => {
+          const data = await updateItem({
+            keystone,
+            listKey,
+            item: {
+              id: items[0].id,
+              data: { order: 'i' },
+            },
+            returnFields: 'name order',
+          });
+          expect(data).not.toBe(null);
+          expect(data.order).toBe('i');
+          expect(data.name).toBe(items[0].name);
+        })
+      )
+    );
+  });
+  test(
+    'Delete',
+    withKeystone(
+      withHelpers(async ({ keystone, items, listKey }) => {
+        const data = await deleteItem({
+          keystone,
+          listKey,
+          itemId: items[0].id,
+          returnFields: 'name',
+        });
+        expect(data).not.toBe(null);
+        expect(data.name).toBe(items[0].name);
+
+        const allItems = await getItems({
+          keystone,
+          listKey,
+          returnFields: 'name',
+        });
+        expect(allItems).toEqual(expect.not.arrayContaining([data]));
+      })
     )
   );
 };

--- a/packages/fields/src/types/Uuid/test-fixtures.js
+++ b/packages/fields/src/types/Uuid/test-fixtures.js
@@ -27,7 +27,7 @@ export const initItems = () => {
   ];
 };
 
-// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and nameing)
+// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and ordering)
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {

--- a/packages/fields/src/types/Uuid/test-fixtures.js
+++ b/packages/fields/src/types/Uuid/test-fixtures.js
@@ -1,10 +1,4 @@
-import {
-  createItem,
-  deleteItem,
-  getItems,
-  getItem,
-  updateItem,
-} from '@keystonejs/server-side-graphql-client';
+import { getItems } from '@keystonejs/server-side-graphql-client';
 import Text from '../Text';
 import Uuid from './';
 
@@ -15,24 +9,25 @@ export { Uuid as type };
 export const exampleValue = '7b36c9fe-274d-45f1-9f5d-8d4595959734';
 export const exampleValue2 = 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc';
 export const supportsUnique = true;
+export const fieldName = 'otherId';
 
 export const getTestFields = () => {
   return {
-    order: { type: Text },
+    name: { type: Text },
     otherId: { type: Uuid },
   };
 };
 
 export const initItems = () => {
   return [
-    { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-    { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-    { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-    { order: 'd', otherId: null },
+    { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+    { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+    { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+    { name: 'd', otherId: null },
   ];
 };
 
-// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and ordering)
+// JM: These tests are Mongo/Mongoose specific due to null handling (filtering and nameing)
 // See https://github.com/keystonejs/keystone/issues/391
 
 export const filterTests = withKeystone => {
@@ -42,8 +37,8 @@ export const filterTests = withKeystone => {
         keystone,
         listKey: 'test',
         where,
-        returnFields: 'order otherId',
-        sortBy: 'order_ASC',
+        returnFields: 'name otherId',
+        sortBy: 'name_ASC',
       })
     ).toEqual(expected);
 
@@ -51,10 +46,10 @@ export const filterTests = withKeystone => {
     `No argument`,
     withKeystone(({ keystone }) =>
       match(keystone, undefined, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-        { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-        { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-        { order: 'd', otherId: null },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+        { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+        { name: 'd', otherId: null },
       ])
     )
   );
@@ -62,10 +57,10 @@ export const filterTests = withKeystone => {
     `Empty argument`,
     withKeystone(({ keystone }) =>
       match(keystone, {}, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-        { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-        { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-        { order: 'd', otherId: null },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+        { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+        { name: 'd', otherId: null },
       ])
     )
   );
@@ -74,7 +69,7 @@ export const filterTests = withKeystone => {
     `Filter: {key}`,
     withKeystone(({ keystone }) =>
       match(keystone, { otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' }, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
       ])
     )
   );
@@ -82,7 +77,7 @@ export const filterTests = withKeystone => {
     `Filter: {key} (implicit case-insensitivity)`,
     withKeystone(({ keystone }) =>
       match(keystone, { otherId: 'C0D37CBC-2F01-432C-89E0-405D54FD4CDC' }, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
       ])
     )
   );
@@ -91,9 +86,9 @@ export const filterTests = withKeystone => {
     `Filter: {key}_not`,
     withKeystone(({ keystone }) =>
       match(keystone, { otherId_not: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' }, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-        { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-        { order: 'd', otherId: null },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+        { name: 'd', otherId: null },
       ])
     )
   );
@@ -101,9 +96,9 @@ export const filterTests = withKeystone => {
     `Filter: {key}_not (implicit case-insensitivity)`,
     withKeystone(({ keystone }) =>
       match(keystone, { otherId_not: '8452DE22-4DFD-4E2A-A6AC-C20CEEF0ADE4' }, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-        { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-        { order: 'd', otherId: null },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+        { name: 'd', otherId: null },
       ])
     )
   );
@@ -124,8 +119,8 @@ export const filterTests = withKeystone => {
           ],
         },
         [
-          { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-          { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+          { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+          { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
         ]
       )
     )
@@ -142,8 +137,8 @@ export const filterTests = withKeystone => {
           ],
         },
         [
-          { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-          { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+          { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+          { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
         ]
       )
     )
@@ -153,10 +148,10 @@ export const filterTests = withKeystone => {
     `Filter: {key}_not_in (empty list)`,
     withKeystone(({ keystone }) =>
       match(keystone, { otherId_not_in: [] }, [
-        { order: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
-        { order: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
-        { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-        { order: 'd', otherId: null },
+        { name: 'a', otherId: 'c0d37cbc-2f01-432c-89e0-405d54fd4cdc' },
+        { name: 'b', otherId: '01d20b3c-c0fe-4198-beb6-1a013c041805' },
+        { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+        { name: 'd', otherId: null },
       ])
     )
   );
@@ -172,8 +167,8 @@ export const filterTests = withKeystone => {
           ],
         },
         [
-          { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-          { order: 'd', otherId: null },
+          { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+          { name: 'd', otherId: null },
         ]
       )
     )
@@ -190,138 +185,10 @@ export const filterTests = withKeystone => {
           ],
         },
         [
-          { order: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
-          { order: 'd', otherId: null },
+          { name: 'c', otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade4' },
+          { name: 'd', otherId: null },
         ]
       )
-    )
-  );
-};
-
-export const crudTests = withKeystone => {
-  const withHelpers = wrappedFn => {
-    return async ({ keystone, listKey }) => {
-      const items = await getItems({
-        keystone,
-        listKey,
-        returnFields: 'id otherId ',
-        sortBy: 'order_ASC',
-      });
-      return wrappedFn({ keystone, listKey, items });
-    };
-  };
-
-  test(
-    'Create',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey }) => {
-        const data = await createItem({
-          keystone,
-          listKey,
-          item: { otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0ade5', order: 'h' },
-          returnFields: 'otherId',
-        });
-        expect(data).not.toBe(null);
-        expect(data.otherId).toBe('8452de22-4dfd-4e2a-a6ac-c20ceef0ade5');
-      })
-    )
-  );
-
-  test(
-    'Read',
-    withKeystone(
-      withHelpers(async ({ keystone, listKey, items }) => {
-        const data = await getItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'otherId',
-        });
-        expect(data).not.toBe(null);
-        expect(data.otherId).toBe(items[0].otherId);
-      })
-    )
-  );
-
-  describe('Update', () => {
-    test(
-      'Updating the value',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { otherId: '8452de22-4dfd-4e2a-a6ac-c20ceef0adf5' },
-            },
-            returnFields: 'otherId',
-          });
-          expect(data).not.toBe(null);
-          expect(data.otherId).toBe('8452de22-4dfd-4e2a-a6ac-c20ceef0adf5');
-        })
-      )
-    );
-
-    test(
-      'Updating the value to null',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { otherId: null },
-            },
-            returnFields: 'otherId',
-          });
-          expect(data).not.toBe(null);
-          expect(data.otherId).toBe(null);
-        })
-      )
-    );
-
-    test(
-      'Updating without this field',
-      withKeystone(
-        withHelpers(async ({ keystone, items, listKey }) => {
-          const data = await updateItem({
-            keystone,
-            listKey,
-            item: {
-              id: items[0].id,
-              data: { order: 'i' },
-            },
-            returnFields: 'otherId order',
-          });
-          expect(data).not.toBe(null);
-          expect(data.order).toBe('i');
-          expect(data.otherId).toBe(items[0].otherId);
-        })
-      )
-    );
-  });
-  test(
-    'Delete',
-    withKeystone(
-      withHelpers(async ({ keystone, items, listKey }) => {
-        const data = await deleteItem({
-          keystone,
-          listKey,
-          itemId: items[0].id,
-          returnFields: 'otherId',
-        });
-        expect(data).not.toBe(null);
-        expect(data.otherId).toBe(items[0].otherId);
-
-        const allItems = await getItems({
-          keystone,
-          listKey,
-          returnFields: 'otherId',
-        });
-        expect(allItems).toEqual(expect.not.arrayContaining([data]));
-      })
     )
   );
 };

--- a/packages/fields/tests/test-fixtures.js
+++ b/packages/fields/tests/test-fixtures.js
@@ -4,6 +4,7 @@ import Text from '../src/types/Text';
 export const name = 'ID';
 export { Text as type };
 export const exampleValue = '"foo"';
+export const skipCrudTest = true;
 
 export const getTestFields = () => {
   return {


### PR DESCRIPTION
Add missing `CRUD` types using config approach. 
Also, added a configuration check for: 
- Individual CRUD constraints (e.g Password doesn't support read and update operations) via `mod.skipReadTest` etc. 
- Skip all CRUD tests for the ones who have WIP (e.g OEmbed, File, etc) via `mod.skipCrudTest`