### PR TITLE
Removed unsupported filter options for field types

### DIFF
--- a/.changeset/sharp-donkeys-dance.md
+++ b/.changeset/sharp-donkeys-dance.md
@@ -1,0 +1,8 @@
+---
+'@keystonejs/fields': minor
+'@keystonejs/fields-location-google': minor
+'@keystonejs/fields-oembed': minor
+'@keystonejs/fields-unsplash': minor
+---
+
+Removed unsupported filters for `File`, `CloudinaryImage`, `LocationGoogle`, `Unsplash`, and `OEmbed` field types.

--- a/packages/fields-location-google/src/Implementation.js
+++ b/packages/fields-location-google/src/Implementation.js
@@ -39,11 +39,7 @@ export class LocationGoogleImplementation extends Implementation {
   }
 
   gqlQueryInputFields() {
-    return [
-      ...this.equalityInputFields('String'),
-      ...this.stringInputFields('String'),
-      ...this.inInputFields('String'),
-    ];
+    return [...this.equalityInputFields('String'), ...this.inInputFields('String')];
   }
 
   getGqlAuxTypes() {
@@ -124,7 +120,6 @@ const CommonLocationInterface = superclass =>
     getQueryConditions(dbPath) {
       return {
         ...this.equalityConditions(dbPath),
-        ...this.stringConditions(dbPath),
         ...this.inConditions(dbPath),
       };
     }

--- a/packages/fields-oembed/src/Implementation.js
+++ b/packages/fields-oembed/src/Implementation.js
@@ -38,11 +38,7 @@ export class OEmbed extends Implementation {
   }
 
   gqlQueryInputFields() {
-    return [
-      ...this.equalityInputFields('String'),
-      ...this.stringInputFields('String'),
-      ...this.inInputFields('String'),
-    ];
+    return [...this.equalityInputFields('String'), ...this.inInputFields('String')];
   }
 
   getGqlAuxTypes() {
@@ -270,7 +266,6 @@ const CommonOEmbedInterface = superclass =>
     getQueryConditions(dbPath) {
       return {
         ...this.equalityConditions(dbPath),
-        ...this.stringConditions(dbPath),
         ...this.inConditions(dbPath),
       };
     }

--- a/packages/fields-unsplash/src/Implementation.js
+++ b/packages/fields-unsplash/src/Implementation.js
@@ -74,11 +74,7 @@ export class Unsplash extends Implementation {
 
   // Filter based on Unsplash Image IDs
   gqlQueryInputFields() {
-    return [
-      ...this.equalityInputFields('String'),
-      ...this.stringInputFields('String'),
-      ...this.inInputFields('String'),
-    ];
+    return [...this.equalityInputFields('String'), ...this.inInputFields('String')];
   }
 
   getGqlAuxTypes() {
@@ -266,7 +262,6 @@ const CommonUnsplashInterface = superclass =>
     getQueryConditions(dbPath) {
       return {
         ...this.equalityConditions(dbPath, ({ unsplashId }) => unsplashId),
-        ...this.stringConditions(dbPath, ({ unsplashId }) => unsplashId),
         ...this.inConditions(dbPath, ({ unsplashId }) => unsplashId),
       };
     }

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -25,11 +25,7 @@ export class File extends Implementation {
     return [`${this.path}: ${this.graphQLOutputType}`];
   }
   gqlQueryInputFields() {
-    return [
-      ...this.equalityInputFields('String'),
-      ...this.stringInputFields('String'),
-      ...this.inInputFields('String'),
-    ];
+    return [...this.equalityInputFields('String'), ...this.inInputFields('String')];
   }
   getFileUploadType() {
     return 'Upload';
@@ -121,7 +117,6 @@ const CommonFileInterface = superclass =>
     getQueryConditions(dbPath) {
       return {
         ...this.equalityConditions(dbPath),
-        ...this.stringConditions(dbPath),
         ...this.inConditions(dbPath),
       };
     }


### PR DESCRIPTION
The following filter options are not supported for `File`, `Cloudinary`, `LocationGoogle`, `Unsplash`, and  `OEmbed` field type at the moment: 

- {this.path}_contains: ${type}
- {this.path}_not_contains: ${type}
- {this.path}_starts_with: ${type}
- this.path}_not_starts_with: ${type}
- {this.path}_ends_with: ${type}
- {this.path}_not_ends_with: ${type}
