### PR TITLE
Fix bug with count null queries on 1:1 rels

### DIFF
--- a/.changeset/nasty-rules-call.md
+++ b/.changeset/nasty-rules-call.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/adapter-knex': patch
+'@keystonejs/api-tests': patch
+---
+
+Fixed a query generation bug when performing `count` operations on `1:1` relationships with a filter.

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -580,15 +580,12 @@ class QueryBuilder {
       console.log('Knex adapter does not currently support search!');
     }
 
-    if (meta) {
-      // SELECT count from <tableName> as t0
-      this._query.count();
-    } else {
+    if (!meta) {
       // SELECT t0.* from <tableName> as t0
       this._query.column(`${baseTableAlias}.*`);
     }
 
-    this._addJoins(this._query, listAdapter, where, baseTableAlias, meta);
+    this._addJoins(this._query, listAdapter, where, baseTableAlias);
 
     // Joins/where to effectively translate us onto a different list
     if (Object.keys(from).length) {
@@ -620,7 +617,7 @@ class QueryBuilder {
       this._query.whereRaw('true');
     }
 
-    this._addWheres(w => this._query.andWhere(w), listAdapter, where, baseTableAlias, meta);
+    this._addWheres(w => this._query.andWhere(w), listAdapter, where, baseTableAlias);
 
     // TODO: Implement configurable search fields for lists
     const searchField = listAdapter.fieldAdaptersByPath['name'];
@@ -634,7 +631,9 @@ class QueryBuilder {
     }
 
     // Add query modifiers as required
-    if (!meta) {
+    if (meta) {
+      this._query = listAdapter.parentAdapter.knex.count('*').from(this._query.as('unused_alias'));
+    } else {
       if (first !== undefined) {
         // SELECT ... LIMIT <first>
         this._query.limit(first);
@@ -699,7 +698,7 @@ class QueryBuilder {
   // Recursively traverse the `where` query to identify required joins and add them to the query
   // We perform joins on non-many relationship fields which are mentioned in the where query.
   // Joins are performed as left outer joins on fromTable.fromCol to toTable.id
-  _addJoins(query, listAdapter, where, tableAlias, meta) {
+  _addJoins(query, listAdapter, where, tableAlias) {
     // Insert joins to handle 1:1 relationships where the FK is stored on the other table.
     // We join against the other table and select its ID as the path name, so that it appears
     // as if it existed on the primary table all along!
@@ -714,7 +713,7 @@ class QueryBuilder {
       .forEach(({ path, rel }) => {
         const { tableName, columnName } = rel;
         const otherTableAlias = `${tableAlias}__${path}`;
-        if (!this._tableAliases[otherTableAlias] && (!meta || joinPaths.includes(path))) {
+        if (!this._tableAliases[otherTableAlias]) {
           this._tableAliases[otherTableAlias] = true;
           // LEFT OUTERJOIN on ... table>.<id> = <otherTable>.<columnName> SELECT <othertable>.<id> as <path>
           query.leftOuterJoin(
@@ -722,9 +721,7 @@ class QueryBuilder {
             `${otherTableAlias}.${columnName}`,
             `${tableAlias}.id`
           );
-          if (!meta) {
-            query.select(`${otherTableAlias}.id as ${path}`);
-          }
+          query.select(`${otherTableAlias}.id as ${path}`);
           joinedPaths.push(path);
         }
       });
@@ -732,7 +729,7 @@ class QueryBuilder {
     for (let path of joinPaths) {
       if (path === 'AND' || path === 'OR') {
         // AND/OR we need to traverse their children
-        where[path].forEach(x => this._addJoins(query, listAdapter, x, tableAlias, meta));
+        where[path].forEach(x => this._addJoins(query, listAdapter, x, tableAlias));
       } else {
         const otherAdapter = listAdapter.fieldAdaptersByPath[path];
         // If no adapter is found, it must be a query of the form `foo_some`, `foo_every`, etc.
@@ -754,7 +751,7 @@ class QueryBuilder {
               `${tableAlias}.${path}`
             );
           }
-          this._addJoins(query, otherListAdapter, where[path], otherTableAlias, meta);
+          this._addJoins(query, otherListAdapter, where[path], otherTableAlias);
         }
       }
     }
@@ -762,7 +759,7 @@ class QueryBuilder {
 
   // Recursively traverses the `where` query and pushes knex query functions to whereJoiner,
   // which will normally do something like pass it to q.andWhere() to add to a query
-  _addWheres(whereJoiner, listAdapter, where, tableAlias, meta) {
+  _addWheres(whereJoiner, listAdapter, where, tableAlias) {
     for (let path of Object.keys(where)) {
       const condition = this._getQueryConditionByPath(listAdapter, path, tableAlias);
       if (condition) {
@@ -779,7 +776,7 @@ class QueryBuilder {
             subJoiner = w => q.orWhere(w);
           }
           where[path].forEach(subWhere =>
-            this._addWheres(subJoiner, listAdapter, subWhere, tableAlias, meta)
+            this._addWheres(subJoiner, listAdapter, subWhere, tableAlias)
           );
         });
       } else {
@@ -788,13 +785,7 @@ class QueryBuilder {
         if (fieldAdapter) {
           // Non-many relationship. Traverse the sub-query, using the referenced list as a root.
           const otherListAdapter = listAdapter.getListAdapterByKey(fieldAdapter.refListKey);
-          this._addWheres(
-            whereJoiner,
-            otherListAdapter,
-            where[path],
-            `${tableAlias}__${path}`,
-            meta
-          );
+          this._addWheres(whereJoiner, otherListAdapter, where[path], `${tableAlias}__${path}`);
         } else {
           // Many relationship
           const [p, constraintType] = path.split('_');
@@ -829,7 +820,7 @@ class QueryBuilder {
               `${subBaseTableAlias}.${far}`
             );
           }
-          this._addJoins(subQuery, otherListAdapter, where[path], otherTableAlias, meta);
+          this._addJoins(subQuery, otherListAdapter, where[path], otherTableAlias);
 
           // some: the ID is in the examples found
           // none: the ID is not in the examples found
@@ -840,13 +831,7 @@ class QueryBuilder {
           if (constraintType === 'every') {
             subQuery.whereNot(q => {
               q.whereRaw('true');
-              this._addWheres(
-                w => q.andWhere(w),
-                otherListAdapter,
-                where[path],
-                otherTableAlias,
-                meta
-              );
+              this._addWheres(w => q.andWhere(w), otherListAdapter, where[path], otherTableAlias);
             });
           } else {
             subQuery.whereRaw('true');
@@ -854,16 +839,15 @@ class QueryBuilder {
               w => subQuery.andWhere(w),
               otherListAdapter,
               where[path],
-              otherTableAlias,
-              meta
+              otherTableAlias
             );
           }
 
           // Ensure there therwhereIn/whereNotIn query is run against
           // a table with exactly one column.
-          const subSubQuery = listAdapter.parentAdapter.knex.raw(
-            `SELECT "${selectCol}" FROM (${subQuery}) AS unused_alias`
-          );
+          const subSubQuery = listAdapter.parentAdapter.knex
+            .select(selectCol)
+            .from(subQuery.as('unused_alias'));
           if (constraintType === 'some') {
             whereJoiner(q => q.whereIn(`${tableAlias}.id`, subSubQuery));
           } else {

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -207,6 +207,35 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               expect(data._allUsersMeta.count).toEqual(1);
             })
           );
+          test(
+            'Where null with count - friend',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await keystone.executeGraphQL({
+                query: `{
+                  _allUsersMeta(where: { friend_is_null: true }) { count }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(4);
+            })
+          );
+
+          test(
+            'Where null with count - friendOf',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createUserAndFriend(keystone);
+              const { data, errors } = await keystone.executeGraphQL({
+                query: `{
+                  _allUsersMeta(where: { friendOf_is_null: true }) { count }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allUsersMeta.count).toEqual(4);
+            })
+          );
         }
       });
 

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.js
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.js
@@ -198,6 +198,67 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data._allLocationsMeta.count).toEqual(3);
           })
         );
+
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 6],
+                ['B', 5],
+                ['C', 3],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_some: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 4],
+                ['C', 6],
+                ['D', 9],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_none: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 3],
+                ['C', 1],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_every: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
       });
 
       describe('Create', () => {

--- a/tests/api-tests/relationships/crud/many-to-many.test.js
+++ b/tests/api-tests/relationships/crud/many-to-many.test.js
@@ -199,6 +199,66 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data._allLocationsMeta.count).toEqual(3);
           })
         );
+        test(
+          '_some',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 6],
+                ['B', 5],
+                ['C', 3],
+                ['D', 0],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_some: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_none',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 4],
+                ['C', 6],
+                ['D', 9],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_none: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
+        test(
+          '_every',
+          runner(setupKeystone, async ({ keystone }) => {
+            await createReadData(keystone);
+            await Promise.all(
+              [
+                ['A', 3],
+                ['B', 3],
+                ['C', 1],
+                ['D', 1],
+              ].map(async ([name, count]) => {
+                const { data, errors } = await keystone.executeGraphQL({
+                  query: `{ _allCompaniesMeta(where: { locations_every: { name: "${name}"}}) { count }}`,
+                });
+                expect(errors).toBe(undefined);
+                expect(data._allCompaniesMeta.count).toEqual(count);
+              })
+            );
+          })
+        );
       });
 
       describe('Create', () => {

--- a/tests/api-tests/relationships/crud/one-to-one.test.js
+++ b/tests/api-tests/relationships/crud/one-to-one.test.js
@@ -110,7 +110,7 @@ const setupKeystone = adapterName =>
     },
   });
 
-multiAdapterRunners('knex').map(({ runner, adapterName }) =>
+multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     describe(`One-to-one relationships`, () => {
       describe('Read', () => {
@@ -267,6 +267,40 @@ multiAdapterRunners('knex').map(({ runner, adapterName }) =>
             expect(data._allLocationsMeta.count).toEqual(1);
           })
         );
+        if (adapterName !== 'mongoose') {
+          test(
+            'Where null with count A',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createCompanyAndLocation(keystone);
+              const { data, errors } = await keystone.executeGraphQL({
+                query: `{
+                  _allLocationsMeta(where: { company_is_null: true }) { count }
+                  _allCompaniesMeta(where: { location_is_null: true }) { count }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(4);
+            })
+          );
+          test(
+            'Where null with count B',
+            runner(setupKeystone, async ({ keystone }) => {
+              await createInitialData(keystone);
+              await createLocationAndCompany(keystone);
+              const { data, errors } = await keystone.executeGraphQL({
+                query: `{
+                  _allLocationsMeta(where: { company_is_null: true }) { count }
+                  _allCompaniesMeta(where: { location_is_null: true }) { count }
+                }`,
+              });
+              expect(errors).toBe(undefined);
+              expect(data._allCompaniesMeta.count).toEqual(3);
+              expect(data._allLocationsMeta.count).toEqual(4);
+            })
+          );
+        }
       });
 
       describe('Create', () => {

--- a/tests/api-tests/relationships/filtering/nested.test.js
+++ b/tests/api-tests/relationships/filtering/nested.test.js
@@ -451,20 +451,20 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
           const { data, errors } = await keystone.executeGraphQL({
             query: `
-        query {
-          allUsers {
-            id
-            _postsMeta (where: {
-              OR: [
-                { content_contains: "i w" },
-                { content_contains: "? O" },
-              ]
-            }){
-              count
-            }
-          }
-        }
-      `,
+              query {
+                allUsers {
+                  id
+                  _postsMeta (where: {
+                    OR: [
+                      { content_contains: "i w" },
+                      { content_contains: "? O" },
+                    ]
+                  }){
+                    count
+                  }
+                }
+              }
+            `,
           });
 
           expect(errors).toBe(undefined);


### PR DESCRIPTION
Adds tests for, and fixes a bug with, queries of the form `_allFooMeta(where: { bar_is_null: true }) { count }`. The result is a nicer general pattern for performing `count` queries, which simplifies `_addWheres` and `_addJoins` by not needing to worry about the `meta` flag any more.