### PR TITLE
Update ID field API test

### DIFF
--- a/.changeset/empty-impalas-serve.md
+++ b/.changeset/empty-impalas-serve.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': patch
+'@keystonejs/api-tests': patch
+---
+
+Updated ID field tests.

--- a/packages/fields/tests/test-fixtures.js
+++ b/packages/fields/tests/test-fixtures.js
@@ -4,7 +4,6 @@ import Text from '../src/types/Text';
 export const name = 'ID';
 export { Text as type };
 export const exampleValue = () => '"foo"';
-export const skipCrudTest = true;
 
 export const getTestFields = () => {
   return {
@@ -16,11 +15,12 @@ export const initItems = () => {
   return [{ name: 'person1' }, { name: 'person2' }, { name: 'person3' }, { name: 'person4' }];
 };
 
-export const supportedFilters = ['null_equality', 'equality', 'in_empty_null', 'in_value'];
+export const skipCrudTest = true;
+export const skipCommonFilterTest = true;
 
 const getIDs = async keystone => {
   const IDs = {};
-  await keystone.lists['test'].adapter.findAll().then(data => {
+  await keystone.lists['Test'].adapter.findAll().then(data => {
     data.forEach(entry => {
       IDs[entry.name] = entry.id.toString();
     });

--- a/tests/api-tests/fields/filter.test.js
+++ b/tests/api-tests/fields/filter.test.js
@@ -53,277 +53,282 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               mod.filterTests(withKeystone);
             });
           }
-          describe(`${mod.name} - ${matrixValue} - Common Filtering`, () => {
-            beforeAll(() => {
-              if (mod.beforeAll) {
-                mod.beforeAll();
+
+          if (!mod.skipCommonFilterTest) {
+            describe(`${mod.name} - ${matrixValue} - Common Filtering`, () => {
+              beforeAll(() => {
+                if (mod.beforeAll) {
+                  mod.beforeAll();
+                }
+              });
+              afterAll(async () => {
+                if (mod.afterAll) {
+                  await mod.afterAll();
+                }
+              });
+              const { readFieldName, fieldName, subfieldName, storedValues: _storedValues } = mod;
+              const storedValues = _storedValues(matrixValue);
+              const returnFields = readFieldName
+                ? `name ${readFieldName}`
+                : subfieldName
+                ? `name ${fieldName} { ${subfieldName} }`
+                : `name ${fieldName}`;
+
+              const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
+                expect(await getItems({ keystone, listKey, where, returnFields, sortBy })).toEqual(
+                  expected.map(i => storedValues[i])
+                );
+
+              test(
+                `No Filter`,
+                withKeystone(({ keystone }) => match(keystone, undefined, [0, 1, 2, 3, 4, 5, 6]))
+              );
+
+              test(
+                `Empty Filter`,
+                withKeystone(({ keystone }) => match(keystone, {}, [0, 1, 2, 3, 4, 5, 6]))
+              );
+              if (mod.supportedFilters.includes('null_equality')) {
+                test(
+                  'Equals null',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}`]: null }, [5, 6])
+                  )
+                );
+                test(
+                  'Not Equals null',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not`]: null }, [0, 1, 2, 3, 4])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('equality')) {
+                test(
+                  'Equals',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}`]: storedValues[3][fieldName] }, [3])
+                  )
+                );
+                test(
+                  'Not Equals',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not`]: storedValues[3][fieldName] }, [
+                      0,
+                      1,
+                      2,
+                      4,
+                      5,
+                      6,
+                    ])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('equality_case_insensitive')) {
+                test(
+                  `Equals - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_i`]: storedValues[3][fieldName] }, [2, 3, 4])
+                  )
+                );
+
+                test(
+                  `Not Equals - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_i`]: storedValues[3][fieldName] }, [
+                      0,
+                      1,
+                      5,
+                      6,
+                    ])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('string')) {
+                test(
+                  `Contains`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_contains`]: 'oo' }, [3, 4])
+                  )
+                );
+                test(
+                  `Not Contains`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_contains`]: 'oo' }, [0, 1, 2, 5, 6])
+                  )
+                );
+                test(
+                  `Starts With`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_starts_with`]: 'foo' }, [3, 4])
+                  )
+                );
+                test(
+                  `Not Starts With`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_starts_with`]: 'foo' }, [0, 1, 2, 5, 6])
+                  )
+                );
+                test(
+                  `Ends With`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_ends_with`]: 'BAR' }, [2, 3])
+                  )
+                );
+                test(
+                  `Not Ends With`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_ends_with`]: 'BAR' }, [0, 1, 4, 5, 6])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('string_case_insensitive')) {
+                test(
+                  `Contains - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_contains_i`]: 'oo' }, [2, 3, 4])
+                  )
+                );
+
+                test(
+                  `Not Contains - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_contains_i`]: 'oo' }, [0, 1, 5, 6])
+                  )
+                );
+
+                test(
+                  `Starts With - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_starts_with_i`]: 'foo' }, [2, 3, 4])
+                  )
+                );
+
+                test(
+                  `Not Starts With - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_starts_with_i`]: 'foo' }, [0, 1, 5, 6])
+                  )
+                );
+
+                test(
+                  `Ends With - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_ends_with_i`]: 'BAR' }, [2, 3, 4])
+                  )
+                );
+
+                test(
+                  `Not Ends With - Case Insensitive`,
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_ends_with_i`]: 'BAR' }, [0, 1, 5, 6])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('ordering')) {
+                test(
+                  'Less than',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_lt`]: storedValues[2][fieldName] }, [0, 1])
+                  )
+                );
+                test(
+                  'Less than or equal',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_lte`]: storedValues[2][fieldName] }, [0, 1, 2])
+                  )
+                );
+                test(
+                  'Greater than',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_gt`]: storedValues[2][fieldName] }, [3, 4])
+                  )
+                );
+                test(
+                  'Greater than or equal',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_gte`]: storedValues[2][fieldName] }, [2, 3, 4])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('in_empty_null')) {
+                test(
+                  'In - Empty List',
+                  withKeystone(({ keystone }) => match(keystone, { [`${fieldName}_in`]: [] }, []))
+                );
+
+                test(
+                  'Not In - Empty List',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_in`]: [] }, [0, 1, 2, 3, 4, 5, 6])
+                  )
+                );
+
+                test(
+                  'In - null',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_in`]: [null] }, [5, 6])
+                  )
+                );
+
+                test(
+                  'Not In - null',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_not_in`]: [null] }, [0, 1, 2, 3, 4])
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('in_equal')) {
+                test(
+                  'In - values',
+                  withKeystone(({ keystone }) =>
+                    match(
+                      keystone,
+                      {
+                        [`${fieldName}_in`]: [
+                          storedValues[0][fieldName],
+                          storedValues[2][fieldName],
+                          storedValues[4][fieldName],
+                        ],
+                      },
+                      [0, 2, 4]
+                    )
+                  )
+                );
+
+                test(
+                  'Not In - values',
+                  withKeystone(({ keystone }) =>
+                    match(
+                      keystone,
+                      {
+                        [`${fieldName}_not_in`]: [
+                          storedValues[0][fieldName],
+                          storedValues[2][fieldName],
+                          storedValues[4][fieldName],
+                        ],
+                      },
+                      [1, 3, 5, 6]
+                    )
+                  )
+                );
+              }
+              if (mod.supportedFilters.includes('is_set')) {
+                test(
+                  'Is Set - true',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_is_set`]: true }, [0, 2, 3, 4])
+                  )
+                );
+
+                test(
+                  'Is Set - false',
+                  withKeystone(({ keystone }) =>
+                    match(keystone, { [`${fieldName}_is_set`]: false }, [1, 5, 6])
+                  )
+                );
               }
             });
-            afterAll(async () => {
-              if (mod.afterAll) {
-                await mod.afterAll();
-              }
-            });
-            const { readFieldName, fieldName, subfieldName, storedValues: _storedValues } = mod;
-            const storedValues = _storedValues(matrixValue);
-            const returnFields = readFieldName
-              ? `name ${readFieldName}`
-              : subfieldName
-              ? `name ${fieldName} { ${subfieldName} }`
-              : `name ${fieldName}`;
-
-            const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
-              expect(await getItems({ keystone, listKey, where, returnFields, sortBy })).toEqual(
-                expected.map(i => storedValues[i])
-              );
-
-            test(
-              `No Filter`,
-              withKeystone(({ keystone }) => match(keystone, undefined, [0, 1, 2, 3, 4, 5, 6]))
-            );
-
-            test(
-              `Empty Filter`,
-              withKeystone(({ keystone }) => match(keystone, {}, [0, 1, 2, 3, 4, 5, 6]))
-            );
-            if (mod.supportedFilters.includes('null_equality')) {
-              test(
-                'Equals null',
-                withKeystone(({ keystone }) => match(keystone, { [`${fieldName}`]: null }, [5, 6]))
-              );
-              test(
-                'Not Equals null',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not`]: null }, [0, 1, 2, 3, 4])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('equality')) {
-              test(
-                'Equals',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}`]: storedValues[3][fieldName] }, [3])
-                )
-              );
-              test(
-                'Not Equals',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not`]: storedValues[3][fieldName] }, [
-                    0,
-                    1,
-                    2,
-                    4,
-                    5,
-                    6,
-                  ])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('equality_case_insensitive')) {
-              test(
-                `Equals - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_i`]: storedValues[3][fieldName] }, [2, 3, 4])
-                )
-              );
-
-              test(
-                `Not Equals - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_i`]: storedValues[3][fieldName] }, [
-                    0,
-                    1,
-                    5,
-                    6,
-                  ])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('string')) {
-              test(
-                `Contains`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_contains`]: 'oo' }, [3, 4])
-                )
-              );
-              test(
-                `Not Contains`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_contains`]: 'oo' }, [0, 1, 2, 5, 6])
-                )
-              );
-              test(
-                `Starts With`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_starts_with`]: 'foo' }, [3, 4])
-                )
-              );
-              test(
-                `Not Starts With`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_starts_with`]: 'foo' }, [0, 1, 2, 5, 6])
-                )
-              );
-              test(
-                `Ends With`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_ends_with`]: 'BAR' }, [2, 3])
-                )
-              );
-              test(
-                `Not Ends With`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_ends_with`]: 'BAR' }, [0, 1, 4, 5, 6])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('string_case_insensitive')) {
-              test(
-                `Contains - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_contains_i`]: 'oo' }, [2, 3, 4])
-                )
-              );
-
-              test(
-                `Not Contains - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_contains_i`]: 'oo' }, [0, 1, 5, 6])
-                )
-              );
-
-              test(
-                `Starts With - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_starts_with_i`]: 'foo' }, [2, 3, 4])
-                )
-              );
-
-              test(
-                `Not Starts With - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_starts_with_i`]: 'foo' }, [0, 1, 5, 6])
-                )
-              );
-
-              test(
-                `Ends With - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_ends_with_i`]: 'BAR' }, [2, 3, 4])
-                )
-              );
-
-              test(
-                `Not Ends With - Case Insensitive`,
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_ends_with_i`]: 'BAR' }, [0, 1, 5, 6])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('ordering')) {
-              test(
-                'Less than',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_lt`]: storedValues[2][fieldName] }, [0, 1])
-                )
-              );
-              test(
-                'Less than or equal',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_lte`]: storedValues[2][fieldName] }, [0, 1, 2])
-                )
-              );
-              test(
-                'Greater than',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_gt`]: storedValues[2][fieldName] }, [3, 4])
-                )
-              );
-              test(
-                'Greater than or equal',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_gte`]: storedValues[2][fieldName] }, [2, 3, 4])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('in_empty_null')) {
-              test(
-                'In - Empty List',
-                withKeystone(({ keystone }) => match(keystone, { [`${fieldName}_in`]: [] }, []))
-              );
-
-              test(
-                'Not In - Empty List',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_in`]: [] }, [0, 1, 2, 3, 4, 5, 6])
-                )
-              );
-
-              test(
-                'In - null',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_in`]: [null] }, [5, 6])
-                )
-              );
-
-              test(
-                'Not In - null',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_not_in`]: [null] }, [0, 1, 2, 3, 4])
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('in_equal')) {
-              test(
-                'In - values',
-                withKeystone(({ keystone }) =>
-                  match(
-                    keystone,
-                    {
-                      [`${fieldName}_in`]: [
-                        storedValues[0][fieldName],
-                        storedValues[2][fieldName],
-                        storedValues[4][fieldName],
-                      ],
-                    },
-                    [0, 2, 4]
-                  )
-                )
-              );
-
-              test(
-                'Not In - values',
-                withKeystone(({ keystone }) =>
-                  match(
-                    keystone,
-                    {
-                      [`${fieldName}_not_in`]: [
-                        storedValues[0][fieldName],
-                        storedValues[2][fieldName],
-                        storedValues[4][fieldName],
-                      ],
-                    },
-                    [1, 3, 5, 6]
-                  )
-                )
-              );
-            }
-            if (mod.supportedFilters.includes('is_set')) {
-              test(
-                'Is Set - true',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_is_set`]: true }, [0, 2, 3, 4])
-                )
-              );
-
-              test(
-                'Is Set - false',
-                withKeystone(({ keystone }) =>
-                  match(keystone, { [`${fieldName}_is_set`]: false }, [1, 5, 6])
-                )
-              );
-            }
-          });
+          }
         });
       });
   })

--- a/tests/api-tests/fields/required.test.js
+++ b/tests/api-tests/fields/required.test.js
@@ -10,8 +10,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
     testModules
       .map(require)
       .filter(
-        ({ skipCrudTest, unSupportedAdapterList = [] }) =>
-          !skipCrudTest && !unSupportedAdapterList.includes(adapterName)
+        ({ skipRequiredTest, unSupportedAdapterList = [] }) =>
+          !skipRequiredTest && !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
         (mod.testMatrix || ['default']).forEach(matrixValue => {


### PR DESCRIPTION
**ID** field is a scalar type (unique identifier) and requires id to be
re-fetched from the server to perform filtering tests.

For this reason, this commit when applied will:
- Add `skipCommonFilterTest` flag to stop running the `common` filter
  tests for ID field
- Remove the `skipCrudTest` flag from **filter** tests, which was filtering it out before running tests.