### PR TITLE
Remove native type mapping

### DIFF
--- a/.changeset/giant-brooms-drop.md
+++ b/.changeset/giant-brooms-drop.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': major
+---
+
+Removed the automatic mapping of native types to keystone field types when defining fields. Keystone will no longer convert `{ type: String }` to `{ type: Text }`, `{ type: Number }` to `{ type: Float }`, or `{ type: Boolean }` to `{ type: Checkbox }`.

--- a/packages/fields-authed-relationship/README.md
+++ b/packages/fields-authed-relationship/README.md
@@ -17,10 +17,11 @@ Great for setting fields like `Post.author` or `Product.owner`, etc.
 
 ```js
 const { AuthedRelationship } = require('@keystonejs/fields-authed-relationship');
+const { Text } = require('@keystonejs/fields');
 
 keystone.createList('User', {
   fields: {
-    name: { type: String },
+    name: { type: Text },
   },
 });
 
@@ -41,11 +42,11 @@ This example allows "admins" to overwrite the value
 
 ```js
 const { AuthedRelationship } = require('@keystonejs/fields-authed-relationship');
-const { Checkbox } = require('@keystonejs/fields');
+const { Checkbox, Text } = require('@keystonejs/fields');
 
 keystone.createList('User', {
   fields: {
-    name: { type: String },
+    name: { type: Text },
     isAdmin: { type: Checkbox, default: false },
   },
 });

--- a/packages/fields-authed-relationship/src/tests/index.test.js
+++ b/packages/fields-authed-relationship/src/tests/index.test.js
@@ -27,7 +27,7 @@ function setupKeystone(adapterName) {
       });
       keystone.createList('Post', {
         fields: {
-          title: { type: String },
+          title: { type: Text },
           // Automatically set to the currently logged in user on create
           author: {
             type: AuthedRelationship,

--- a/packages/fields-location-google/src/test-fixtures.skip.js
+++ b/packages/fields-location-google/src/test-fixtures.skip.js
@@ -1,6 +1,6 @@
 const path = require('path');
 require('dotenv').config({ path: path.resolve(__dirname, '../.env') });
-
+import { Text } from '@keystonejs/fields';
 import { LocationGoogle } from './';
 
 export const name = 'LocationGoogle';
@@ -13,7 +13,7 @@ export const subfieldName = 'googlePlaceID';
 export const fieldConfig = () => ({ googleMapsKey: process.env.GOOGLE_API_KEY });
 
 export const getTestFields = () => ({
-  name: { type: String },
+  name: { type: Text },
   venue: { type, googleMapsKey: process.env.GOOGLE_API_KEY },
 });
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -158,25 +158,3 @@ _Note_: Field level access control does not accept graphQL where clauses.
 [HTTP cache hint](https://keystonejs.com/api/create-list#cacheHint) for field.
 
 Only static hints are supported for fields.
-
-## Native type aliases
-
-Keystone allows the use of a few native JavaScript types for fields. They are converted to their Keystone field equivalents at runtime.
-
-| Native type | Field type equivalent |
-| ----------- | --------------------- |
-| `Boolean`   | `Checkbox`            |
-| `Number`    | `Float`               |
-| `String`    | `Text`                |
-
-### Usage
-
-```javascript
-keystone.createList('Post', {
-  fields: {
-    title: {
-      type: String,
-    }
-  }
-}
-```

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -20,7 +20,6 @@ const {
   labelToPath,
   labelToClass,
   opToType,
-  mapNativeTypeToKeystoneType,
   getDefaultLabelResolver,
   mapToFields,
 } = require('./utils');
@@ -165,10 +164,7 @@ module.exports = class List {
     if (this.fieldsInitialised) return;
     this.fieldsInitialised = true;
 
-    let sanitisedFieldsConfig = mapKeys(this._fields, (fieldConfig, path) => ({
-      ...fieldConfig,
-      type: mapNativeTypeToKeystoneType(fieldConfig.type, this.key, path),
-    }));
+    let sanitisedFieldsConfig = this._fields;
 
     // Add an 'id' field if none supplied
     if (!sanitisedFieldsConfig.id) {

--- a/packages/keystone/lib/ListTypes/utils.js
+++ b/packages/keystone/lib/ListTypes/utils.js
@@ -1,7 +1,4 @@
 const { upcase, resolveAllKeys, arrayToObject } = require('@keystonejs/utils');
-const { logger } = require('@keystonejs/logger');
-
-const keystoneLogger = logger('keystone');
 
 const preventInvalidUnderscorePrefix = str => str.replace(/^__/, '_');
 
@@ -31,47 +28,6 @@ const opToType = {
   delete: 'mutation',
 };
 
-const mapNativeTypeToKeystoneType = (type, listKey, fieldPath) => {
-  const { Text, Checkbox, Float } = require('@keystonejs/fields');
-
-  const nativeTypeMap = new Map([
-    [
-      Boolean,
-      {
-        name: 'Boolean',
-        keystoneType: Checkbox,
-      },
-    ],
-    [
-      String,
-      {
-        name: 'String',
-        keystoneType: Text,
-      },
-    ],
-    [
-      Number,
-      {
-        name: 'Number',
-        keystoneType: Float,
-      },
-    ],
-  ]);
-
-  if (!nativeTypeMap.has(type)) {
-    return type;
-  }
-
-  const { name, keystoneType } = nativeTypeMap.get(type);
-
-  keystoneLogger.warn(
-    { nativeType: type, keystoneType, listKey, fieldPath },
-    `Mapped field ${listKey}.${fieldPath} from native JavaScript type '${name}', to '${keystoneType.type.type}' from the @keystonejs/fields package.`
-  );
-
-  return keystoneType;
-};
-
 const getDefaultLabelResolver = labelField => item => {
   const value = item[labelField || 'name'];
   if (typeof value === 'number') {
@@ -96,7 +52,6 @@ module.exports = {
   labelToPath,
   labelToClass,
   opToType,
-  mapNativeTypeToKeystoneType,
   getDefaultLabelResolver,
   mapToFields,
 };

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -9,7 +9,6 @@ jest.doMock('@keystonejs/logger', () => ({
 const { List } = require('../lib/ListTypes');
 const { AccessDeniedError } = require('../lib/ListTypes/graphqlErrors');
 const { Text, Checkbox, Float, Relationship, Integer } = require('@keystonejs/fields');
-const { getType } = require('@keystonejs/utils');
 const path = require('path');
 
 let fieldsPackagePath = path.dirname(require.resolve('@keystonejs/fields/package.json'));
@@ -1320,40 +1319,6 @@ describe('List Hooks', () => {
       Object.keys(hooks).forEach(hook => {
         expect(hooks[hook]).toHaveBeenCalledWith(expect.objectContaining({}));
       });
-    });
-  });
-});
-
-describe('Maps from Native JS types to Keystone types', () => {
-  const adapter = new MockAdapter();
-
-  [
-    {
-      nativeType: Boolean,
-      keystoneType: Checkbox,
-    },
-    {
-      nativeType: String,
-      keystoneType: Text,
-    },
-    {
-      nativeType: Number,
-      keystoneType: Float,
-    },
-  ].forEach(({ nativeType, keystoneType }) => {
-    test(`${getType(nativeType.prototype)} -> ${keystoneType.type}`, () => {
-      const list = new List(
-        'Test',
-        { fields: { foo: { type: nativeType } } },
-        {
-          adapter,
-          defaultAccess: { list: true, field: true },
-          registerType: () => {},
-          schemaNames: ['public'],
-        }
-      );
-      list.initFields();
-      expect(list.fieldsByPath.foo).toBeInstanceOf(keystoneType.implementation);
     });
   });
 });

--- a/packages/server-side-graphql-client/README.md
+++ b/packages/server-side-graphql-client/README.md
@@ -121,7 +121,7 @@ const { createItem } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -160,7 +160,7 @@ const { createItems } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -202,7 +202,7 @@ const { getItem } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -238,7 +238,7 @@ const { getItems } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -280,7 +280,7 @@ const { updateItem } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -316,7 +316,7 @@ const { updateItems } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -358,7 +358,7 @@ const { deleteItem } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 
@@ -389,7 +389,7 @@ const { deleteItems } = require('@keystonejs/server-side-graphql-client');
 keystone.createList('User', {
   fields: {
     name: { type: Text },
-    email: { type: String },
+    email: { type: Text },
   },
 });
 


### PR DESCRIPTION
This functionality allowed devs to writing fields like `name: { type: String }` and have this automagically map from `String` to `Text`. This gives us an API with two different ways to spell the same thing, with no real usage benefits. This PR removes the mapping, and forces devs to explicitly name the field type they want. This will remove ambiguity and increase consistency in schema definition. This is a `major` change, but shouldn't impact too many users, and the fix is a trivial replacement.