### PR TITLE
Utilized Octicons size prop (fixes minor icon size issues)

### DIFF
--- a/.changeset/tame-pets-learn.md
+++ b/.changeset/tame-pets-learn.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/app-admin-ui': patch
+'@arch-ui/button': patch
+---
+
+Utilized Octicons size prop.

--- a/packages/app-admin-ui/client/components/Nav.js
+++ b/packages/app-admin-ui/client/components/Nav.js
@@ -353,7 +353,7 @@ const UserInfo = ({ authListPath }) => {
   return (
     <UserInfoContainer>
       <UserIcon>
-        <PersonIcon width={20} height={20} />
+        <PersonIcon size={24} />
       </UserIcon>
       <div css={{ overflow: 'hidden' }}>
         <Truncate css={{ fontSize: '0.7em' }}>Logged in as</Truncate>

--- a/packages/app-admin-ui/client/components/NoResults.js
+++ b/packages/app-admin-ui/client/components/NoResults.js
@@ -22,7 +22,7 @@ const NoResultsWrapper = ({ children, ...props }) => (
     }}
     {...props}
   >
-    <InfoIcon css={{ height: 48, width: 48, marginBottom: '0.5em' }} />
+    <InfoIcon size={48} css={{ marginBottom: '0.5em' }} />
     {children}
   </div>
 );

--- a/packages/app-admin-ui/client/components/PageError.js
+++ b/packages/app-admin-ui/client/components/PageError.js
@@ -17,7 +17,7 @@ export default function PageError({ children, icon: Icon = StopIcon, ...props })
         }}
         {...props}
       >
-        <Icon css={{ height: 48, width: 48 }} />
+        <Icon size={48} />
         {children}
       </div>
     </Container>

--- a/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
+++ b/packages/app-admin-ui/client/pages/List/Filters/AddFilterPopout.js
@@ -289,9 +289,8 @@ export default class AddFilterPopout extends Component {
               <div ref={ref} style={style}>
                 <Alert appearance="warning" variant="bold">
                   <AlertIcon
+                    size={24}
                     css={{
-                      height: 24,
-                      width: 24,
                       marginLeft: -8,
                       marginRight: 12,
                     }}

--- a/packages/app-admin-ui/client/pages/Signout.js
+++ b/packages/app-admin-ui/client/pages/Signout.js
@@ -74,7 +74,7 @@ const SignedOutPage = () => {
       ) : (
         <Fragment>
           <Animation name="pulse" duration="500ms">
-            <CheckIcon css={{ color: colors.primary, height: '3em', width: '3em' }} />
+            <CheckIcon size={48} css={{ color: colors.primary }} />
           </Animation>
           <Caption>You have been signed out.</Caption>
           <FlexBox>

--- a/packages/arch/packages/button/src/icon.js
+++ b/packages/arch/packages/button/src/icon.js
@@ -6,7 +6,7 @@ import { Button } from './primitives';
 export const IconButton = forwardRef(({ children, icon: Icon, iconSize = 16, ...props }, ref) => (
   <Button ref={ref} {...props}>
     <span css={{ display: 'flex', alignItems: 'center' }}>
-      <Icon css={children ? { height: iconSize, width: iconSize, marginRight: '0.5em' } : null} />
+      <Icon size={iconSize} css={children ? { marginRight: '0.5em' } : null} />
       {children}
     </span>
   </Button>


### PR DESCRIPTION
This fixes a few minor visual issues, notable the user icon being too small and the info using the smaller, thicker icon rather than the thinner, larger one:

Before:
![image](https://user-images.githubusercontent.com/3558659/93181330-121f3400-f784-11ea-9be1-3f099859a19b.png)

After:
![image](https://user-images.githubusercontent.com/3558659/93181354-19464200-f784-11ea-8762-50822e762137.png)
