### PR TITLE
Allow touch-scrolling the body of dialogs and drawers

### DIFF
--- a/.changeset/kind-pugs-arrive.md
+++ b/.changeset/kind-pugs-arrive.md
@@ -1,0 +1,6 @@
+---
+"@arch-ui/dialog": patch
+"@arch-ui/drawer": patch
+---
+
+Allow touch-scrolling the body of dialogs and drawers

--- a/.changeset/kind-pugs-arrive.md
+++ b/.changeset/kind-pugs-arrive.md
@@ -3,4 +3,4 @@
 "@arch-ui/drawer": patch
 ---
 
-Allow touch-scrolling the body of dialogs and drawers
+Fixed touch-scrolling behaviour of `Dialog` and `Drawer` components.

--- a/packages/arch/packages/dialog/src/Dialog.js
+++ b/packages/arch/packages/dialog/src/Dialog.js
@@ -60,12 +60,13 @@ const ModalDialog = memo(
                   <Title>{heading}</Title>
                 </Header>
               ) : null}
-              <Body>{children}</Body>
+              <ScrollLock>
+                <Body>{children}</Body>
+              </ScrollLock>
               {footer ? <Footer>{footer}</Footer> : null}
             </Dialog>
           </FocusTrap>
         </Positioner>
-        <ScrollLock />
       </Fragment>,
       attachTo
     );

--- a/packages/arch/packages/drawer/src/index.js
+++ b/packages/arch/packages/drawer/src/index.js
@@ -173,12 +173,13 @@ function ModalDialogComponent({
                 <Title>{heading}</Title>
               </Header>
             ) : null}
-            <Body>{children}</Body>
+            <ScrollLock>
+              <Body>{children}</Body>
+            </ScrollLock>
             {footer ? <Footer>{footer}</Footer> : null}
           </Dialog>
         </FocusTrap>
       </Positioner>
-      <ScrollLock />
     </Fragment>,
     attachTo
   );


### PR DESCRIPTION
This fixes #3688

The `<ScrollLock>` component needed to be wrapped around the body -- events inside the children are allowed.