### PR TITLE
Auto approve PRs from base repo that only change new interfaces

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,24 @@
+name: Auto Approve
+
+on:
+  pull_request:
+
+jobs:
+  approve:
+    name: Auto Approve
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == 'keystonejs/keystone' }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            shouldRequireApprovalFromPerson:
+              - '!{packages-next,examples-next,design-system}/**'
+      - uses: Thinkmill/auto-approve-action@v1
+        with:
+          approve: ${{ steps.filter.outputs.shouldRequireApprovalFromPerson == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since the new interfaces code is quite early, we don't want to have PR reviews for it just yet so we're going to use an action to automatically approve them

Some notes:
- This will only happen for PRs from the base repo (i.e. not for PRs from forks)
- If a PR is opened which only changes things in the new interfaces but then changes things outside of the new interfaces, the approval will be dismissed(and if the changes outside of the new interfaces are removed, it'll be approved again)

Demo of it where changes to `test.md` are automatically approved and anything else is not: https://github.com/Thinkmill/auto-approve-action/pull/1