### PR TITLE
Test AutoIncrement as both an ID and Int graphQL type

### DIFF
--- a/packages/fields-auto-increment/src/test-fixtures.js
+++ b/packages/fields-auto-increment/src/test-fixtures.js
@@ -4,8 +4,9 @@ import { AutoIncrement } from './index';
 
 export const name = 'AutoIncrement';
 export const type = AutoIncrement;
-export const exampleValue = () => 35;
-export const exampleValue2 = () => 36;
+export const testMatrix = ['ID', 'Int'];
+export const exampleValue = matrixValue => (matrixValue === 'ID' ? '35' : 35);
+export const exampleValue2 = matrixValue => (matrixValue === 'ID' ? '36' : 36);
 export const supportsUnique = true;
 export const fieldName = 'orderNumber';
 export const skipCreateTest = true;
@@ -15,11 +16,14 @@ export const skipUpdateTest = true;
 export const unSupportedAdapterList = ['mongoose'];
 
 // Be default, `AutoIncrement` are read-only. But for `isRequired` test purpose, we need to bypass these restrictions.
-export const fieldConfig = () => ({ access: { create: true, update: true } });
+export const fieldConfig = matrixValue => ({
+  gqlType: matrixValue,
+  access: { create: true, update: true },
+});
 
-export const getTestFields = () => ({
+export const getTestFields = matrixValue => ({
   name: { type: Text },
-  orderNumber: { type, gqlType: 'Int' },
+  orderNumber: { type, gqlType: matrixValue },
 });
 
 export const initItems = () => {
@@ -34,19 +38,32 @@ export const initItems = () => {
   ];
 };
 
-export const storedValues = () => [
-  { name: 'product1', orderNumber: 1 },
-  { name: 'product2', orderNumber: 2 },
-  { name: 'product3', orderNumber: 3 },
-  { name: 'product4', orderNumber: 4 },
-  { name: 'product5', orderNumber: 5 },
-  { name: 'product6', orderNumber: 6 },
-  { name: 'product7', orderNumber: 7 },
-];
+export const storedValues = matrixValue =>
+  matrixValue === 'ID'
+    ? [
+        { name: 'product1', orderNumber: '1' },
+        { name: 'product2', orderNumber: '2' },
+        { name: 'product3', orderNumber: '3' },
+        { name: 'product4', orderNumber: '4' },
+        { name: 'product5', orderNumber: '5' },
+        { name: 'product6', orderNumber: '6' },
+        { name: 'product7', orderNumber: '7' },
+      ]
+    : [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+        { name: 'product6', orderNumber: 6 },
+        { name: 'product7', orderNumber: 7 },
+      ];
 
 export const supportedFilters = [];
 
-export const filterTests = withKeystone => {
+export const filterTests = (withKeystone, matrixValue) => {
+  const _storedValues = storedValues(matrixValue);
+  const _f = matrixValue === 'ID' ? x => x.toString() : x => x;
   const match = async (keystone, where, expected) =>
     expect(
       await getItems({
@@ -56,86 +73,43 @@ export const filterTests = withKeystone => {
         returnFields: 'name orderNumber',
         sortBy: 'name_ASC',
       })
-    ).toEqual(expected);
+    ).toEqual(expected.map(i => _storedValues[i]));
 
   test(
     'Filter: orderNumber',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber: 1 }, [{ name: 'product1', orderNumber: 1 }])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber: _f(1) }, [0]))
   );
 
   test(
     'Filter: orderNumber_not',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_not: 1 }, [
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_not: _f(1) }, [1, 2, 3, 4, 5, 6]))
   );
 
   test(
     'Filter: orderNumber_not null',
     withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_not: null }, [
-        { name: 'product1', orderNumber: 1 },
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
+      match(keystone, { orderNumber_not: null }, [0, 1, 2, 3, 4, 5, 6])
     )
   );
 
   test(
     'Filter: orderNumber_lt',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_lt: 2 }, [{ name: 'product1', orderNumber: 1 }])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_lt: _f(2) }, [0]))
   );
 
   test(
     'Filter: orderNumber_lte',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_lte: 2 }, [
-        { name: 'product1', orderNumber: 1 },
-        { name: 'product2', orderNumber: 2 },
-      ])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_lte: _f(2) }, [0, 1]))
   );
 
   test(
     'Filter: orderNumber_gt',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_gt: 2 }, [
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_gt: _f(2) }, [2, 3, 4, 5, 6]))
   );
 
   test(
     'Filter: orderNumber_gte',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_gte: 2 }, [
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
-    )
+    withKeystone(({ keystone }) => match(keystone, { orderNumber_gte: _f(2) }, [1, 2, 3, 4, 5, 6]))
   );
 
   test(
@@ -146,38 +120,21 @@ export const filterTests = withKeystone => {
   test(
     'Filter: orderNumber_not_in (empty list)',
     withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_not_in: [] }, [
-        { name: 'product1', orderNumber: 1 },
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
+      match(keystone, { orderNumber_not_in: [] }, [0, 1, 2, 3, 4, 5, 6])
     )
   );
 
   test(
     'Filter: orderNumber_in',
     withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_in: [1, 2, 3] }, [
-        { name: 'product1', orderNumber: 1 },
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-      ])
+      match(keystone, { orderNumber_in: [1, 2, 3].map(_f) }, [0, 1, 2])
     )
   );
 
   test(
     'Filter: orderNumber_not_in',
     withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_not_in: [1, 2, 3] }, [
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
+      match(keystone, { orderNumber_not_in: [1, 2, 3].map(_f) }, [3, 4, 5, 6])
     )
   );
 
@@ -189,15 +146,7 @@ export const filterTests = withKeystone => {
   test(
     'Filter: orderNumber_not_in null',
     withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_not_in: [null] }, [
-        { name: 'product1', orderNumber: 1 },
-        { name: 'product2', orderNumber: 2 },
-        { name: 'product3', orderNumber: 3 },
-        { name: 'product4', orderNumber: 4 },
-        { name: 'product5', orderNumber: 5 },
-        { name: 'product6', orderNumber: 6 },
-        { name: 'product7', orderNumber: 7 },
-      ])
+      match(keystone, { orderNumber_not_in: [null] }, [0, 1, 2, 3, 4, 5, 6])
     )
   );
 };

--- a/tests/api-tests/fields/filter.test.js
+++ b/tests/api-tests/fields/filter.test.js
@@ -50,7 +50,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   await mod.afterAll();
                 }
               });
-              mod.filterTests(withKeystone);
+              mod.filterTests(withKeystone, matrixValue);
             });
           }
 


### PR DESCRIPTION
We need to make sure that this field behaves correctly when used as both an `ID` and `Int` field in graphQL.