### PR TITLE
Make GraphQL _QueryMeta non-nullable on output types

### DIFF
--- a/.changeset/mighty-spoons-worry.md
+++ b/.changeset/mighty-spoons-worry.md
@@ -1,6 +1,4 @@
 ---
-'@keystonejs/adapter-knex': major
-'@keystonejs/adapter-mongoose': major
 '@keystonejs/fields': major
 '@keystonejs/keystone': major
 ---

--- a/.changeset/mighty-spoons-worry.md
+++ b/.changeset/mighty-spoons-worry.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': major
+'@keystonejs/keystone': major
+---
+
+Updated the GraphQL output types for meta queries so they are non-nullable 

--- a/.changeset/mighty-spoons-worry.md
+++ b/.changeset/mighty-spoons-worry.md
@@ -1,6 +1,8 @@
 ---
+'@keystonejs/adapter-knex': major
+'@keystonejs/adapter-mongoose': major
 '@keystonejs/fields': major
 '@keystonejs/keystone': major
 ---
 
-Updated the GraphQL output types for meta queries so they are non-nullable 
+Updated the GraphQL output types for meta queries so they are non-nullable.

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -59,7 +59,7 @@ export class Relationship extends Implementation {
       const filterArgs = refList.getGraphqlFilterFragment().join('\n');
       return [
         `${this.path}(${filterArgs}): [${refList.gqlNames.outputTypeName}!]!`,
-        this.withMeta ? `_${this.path}Meta(${filterArgs}): _QueryMeta` : '',
+        this.withMeta ? `_${this.path}Meta(${filterArgs}): _QueryMeta!` : '',
       ];
     } else {
       return [`${this.path}: ${refList.gqlNames.outputTypeName}`];

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -1071,7 +1071,7 @@ module.exports = class List {
         } items which match the where clause. """
         ${this.gqlNames.listQueryMetaName}(
           ${this.getGraphqlFilterFragment().join('\n')}
-        ): _QueryMeta`,
+        ): _QueryMeta!`,
 
         `
         """ Retrieve the meta-data for the ${this.gqlNames.itemQueryName} list. """

--- a/packages/keystone/lib/providers/listCRUDTypes.js
+++ b/packages/keystone/lib/providers/listCRUDTypes.js
@@ -181,7 +181,7 @@ const getListCRUDTypes = ({ listsMetaInput }) => [
   `,
   `
     type _QueryMeta {
-      count: Int
+      count: Int!
     }
   `,
   `


### PR DESCRIPTION
Related to #3684

In [this method](https://github.com/keystonejs/keystone/blob/master/packages/keystone/lib/providers/listCRUD.js#L45) it looks like Keystone always returns an object with a `count` field, so we should be specifying `_QueryMeta` as non-nullable.

It also looks like [looks like](https://github.com/keystonejs/keystone/blob/06be15471406ed09b0ed79b353500b37d019dc02/packages/keystone/lib/ListTypes/list.js#L500)  that the `count` field always returns an `Int`, so we can also set this field as as non-nullable.