### PR TITLE
Initial stub-like timestamp implementation

### DIFF
--- a/examples-next/basic/schema.ts
+++ b/examples-next/basic/schema.ts
@@ -1,5 +1,5 @@
 import { createSchema, list, graphQLSchemaExtension, gql } from '@keystone-spike/keystone/schema';
-import { text, relationship, checkbox, password } from '@keystone-spike/fields';
+import { text, relationship, checkbox, password, timestamp } from '@keystone-spike/fields';
 
 const randomNumber = () => Math.round(Math.random() * 10);
 
@@ -88,7 +88,7 @@ export const lists = createSchema({
       }),
       content: text({}),
       published: checkbox({ defaultValue: false }),
-      publishDate: text({}),
+      publishDate: timestamp({}),
       author: relationship({ ref: 'User.posts' }),
     },
   }),

--- a/packages-next/fields/src/index.ts
+++ b/packages-next/fields/src/index.ts
@@ -6,3 +6,5 @@ export { text } from './types/text';
 export type { TextFieldConfig } from './types/text';
 export { password } from './types/password';
 // export type { PasswordFieldConfig } from './types/password';
+export { timestamp } from './types/timestamp';
+export type { TimestampFieldConfig } from './types/timestamp';

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -1,0 +1,30 @@
+import { DateTimeUtc } from '@keystonejs/fields';
+
+import type { FieldConfig } from '../../interfaces';
+import type { FieldType } from '@keystone-spike/types';
+import type { BaseGeneratedListTypes } from '@keystone-spike/types';
+
+export type TimestampFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
+  TGeneratedListTypes
+> & {
+  defaultValue?: string;
+  isRequired?: boolean;
+  isIndexed?: boolean;
+  isUnique?: boolean;
+};
+
+export const timestamp = <TGeneratedListTypes extends BaseGeneratedListTypes>(
+  config: TimestampFieldConfig<TGeneratedListTypes>
+): FieldType<TGeneratedListTypes> => ({
+  type: DateTimeUtc,
+  config,
+  views: '@keystone-spike/fields/src/types/timestamp/views',
+  getBackingType(path: string) {
+    return {
+      [path]: {
+        optional: true,
+        type: 'Date | null',
+      },
+    };
+  },
+});

--- a/packages-next/fields/src/types/timestamp/views/index.tsx
+++ b/packages-next/fields/src/types/timestamp/views/index.tsx
@@ -1,0 +1,45 @@
+/* @jsx jsx */
+import { jsx } from '@keystone-ui/core';
+import { FieldContainer, FieldLabel, TextInput } from '@keystone-ui/fields';
+
+import {
+  CellComponent,
+  FieldControllerConfig,
+  FieldProps,
+  makeController,
+} from '@keystone-spike/types';
+import { Link } from '@keystone-spike/admin-ui/router';
+import { Fragment } from 'react';
+
+// TODO: Bring across the datetime/datetimeUtc interfaces, date picker, etc.
+
+export const Field = ({ field, value, onChange }: FieldProps<typeof controller>) => (
+  <FieldContainer>
+    <FieldLabel>{field.label}</FieldLabel>
+    <TextInput
+      onChange={event => {
+        onChange(event.target.value);
+      }}
+      value={value}
+    />
+  </FieldContainer>
+);
+
+export const Cell: CellComponent = ({ item, path, linkTo }) => {
+  let value = item[path];
+  return linkTo ? <Link {...linkTo}>{value}</Link> : <Fragment>{value}</Fragment>;
+};
+Cell.supportsLinkTo = true;
+
+type Config = FieldControllerConfig<{}>;
+
+export const controller = makeController((config: Config) => {
+  return {
+    path: config.path,
+    label: config.label,
+    graphqlSelection: config.path,
+    defaultValue: '',
+    deserialize: data => data[config.path],
+    serialize: value => ({ [config.path]: value }),
+  };
+});

--- a/packages-next/fields/src/types/timestamp/views/index.tsx
+++ b/packages-next/fields/src/types/timestamp/views/index.tsx
@@ -31,11 +31,7 @@ export const Cell: CellComponent = ({ item, path, linkTo }) => {
 };
 Cell.supportsLinkTo = true;
 
-type Config = FieldControllerConfig<{}>;
-
-export const controller = (
-  config: Config
-): FieldController<string, string> => {
+export const controller = (config: FieldControllerConfig): FieldController<string, string> => {
   return {
     path: config.path,
     label: config.label,

--- a/packages-next/fields/src/types/timestamp/views/index.tsx
+++ b/packages-next/fields/src/types/timestamp/views/index.tsx
@@ -4,9 +4,9 @@ import { FieldContainer, FieldLabel, TextInput } from '@keystone-ui/fields';
 
 import {
   CellComponent,
+  FieldController,
   FieldControllerConfig,
   FieldProps,
-  makeController,
 } from '@keystone-spike/types';
 import { Link } from '@keystone-spike/admin-ui/router';
 import { Fragment } from 'react';
@@ -33,7 +33,9 @@ Cell.supportsLinkTo = true;
 
 type Config = FieldControllerConfig<{}>;
 
-export const controller = makeController((config: Config) => {
+export const controller = (
+  config: Config
+): FieldController<string, string> => {
   return {
     path: config.path,
     label: config.label,
@@ -42,4 +44,4 @@ export const controller = makeController((config: Config) => {
     deserialize: data => data[config.path],
     serialize: value => ({ [config.path]: value }),
   };
-});
+};


### PR DESCRIPTION
Pretty basic, just wraps `DateTimeUtc`, but in line with [current planning for the date/time types](https://github.com/keystonejs/keystone/blob/master/packages-next/fields/TODO.md#date--time-types-reboot).