### PR TITLE
Added a no-Cypress install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "contributors:generate": "all-contributors generate",
     "heroku-postbuild": "yarn build && yarn workspace @keystonejs/demo-project-blog build",
     "npm-tag": "manypkg npm-tag",
-    "update": "manypkg upgrade"
+    "update": "manypkg upgrade",
+    "no-cypress-install": "cross-env CYPRESS_INSTALL_BINARY=0 && yarn"
   },
   "dependencies": {
     "@babel/cli": "^7.11.6",


### PR DESCRIPTION
Minor thing, but I had *significant* issues installing Cypress (the download kept aborting for some reason. I still haven't gotten it to work). It's much easier to install the deps sans Cypress, especially since I don't run unit tests locally.