### PR TITLE
Add support for small and large checkboxes and radio buttons

### DIFF
--- a/design-system/packages/core/src/themes/default.ts
+++ b/design-system/packages/core/src/themes/default.ts
@@ -430,6 +430,16 @@ const radii = {
   full: 9999,
 };
 
+const sizing = {
+  xxsmall: 16,
+  xsmall: 20,
+  small: 24,
+  medium: 32,
+  large: 38,
+  xlarge: 42,
+  xxlarge: 48,
+};
+
 const spacing = {
   none: 0,
   xsmall: 4,
@@ -471,16 +481,6 @@ const opacity = {
   full: 1,
   none: 0,
   disabled: 0.65,
-};
-
-// TODO: Jed's not sure we need this, Dom thinks it should be a function
-const sizing = {
-  xsmall: 24,
-  small: 32,
-  base: 38,
-  medium: 48,
-  large: 56,
-  xlarge: 72,
 };
 
 /**
@@ -542,6 +542,7 @@ type ControlSize = {
   height: number;
   gap: number;
   fontSize: number | string;
+  indicatorBoxSize: number | string;
   indicatorFontSize: number | string;
 };
 
@@ -552,9 +553,10 @@ const controlSizes: { [key: string]: ControlSize } = {
     gutter: spacing.xsmall,
     paddingX: spacing.medium,
     paddingY: spacing.xsmall,
-    height: sizing.small,
+    height: sizing.medium,
     gap: spacing.small,
     fontSize: typography.fontSize.small,
+    indicatorBoxSize: sizing.xsmall,
     indicatorFontSize: typography.fontSize.xxxsmall,
   },
   medium: {
@@ -563,9 +565,10 @@ const controlSizes: { [key: string]: ControlSize } = {
     gutter: spacing.xsmall,
     paddingX: spacing.medium,
     paddingY: spacing.xsmall,
-    height: sizing.base,
+    height: sizing.large,
     gap: spacing.medium,
     fontSize: typography.fontSize.medium,
+    indicatorBoxSize: sizing.small,
     indicatorFontSize: typography.fontSize.xxsmall,
   },
   large: {
@@ -574,9 +577,10 @@ const controlSizes: { [key: string]: ControlSize } = {
     gutter: spacing.small,
     paddingX: spacing.large,
     paddingY: spacing.small,
-    height: sizing.medium,
+    height: sizing.xxlarge,
     gap: spacing.medium,
     fontSize: typography.fontSize.large,
+    indicatorBoxSize: sizing.medium,
     indicatorFontSize: typography.fontSize.small,
   },
 };
@@ -817,8 +821,8 @@ export const theme = {
   breakpoints,
   elevation,
   radii,
-  spacing,
   sizing,
+  spacing,
   shadow,
   animation,
   opacity,

--- a/design-system/packages/fields/src/Checkbox.tsx
+++ b/design-system/packages/fields/src/Checkbox.tsx
@@ -6,6 +6,7 @@ import { jsx, VisuallyHidden } from '@keystone-ui/core';
 import { ControlLabel } from './components/ControlLabel';
 import { CheckIcon } from './components/Icons';
 import { useIndicatorStyles, useIndicatorTokens } from './hooks/indicators';
+import type { SizeType } from './types';
 
 type CheckboxProps = {
   /** The checkbox label content. */
@@ -27,21 +28,25 @@ type CheckboxControlProps = {
   checked?: boolean;
   /** When true, the checkbox will be disabled. */
   disabled?: boolean;
+  /** The size of the Checkbox */
+  size?: SizeType;
   /** The value of the Checkbox. */
   value?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const CheckboxControl = forwardRef<HTMLInputElement, CheckboxControlProps>((props, ref) => (
-  <Fragment>
-    <VisuallyHidden ref={ref} as="input" type="checkbox" {...props} />
-    <Indicator>
-      <CheckIcon />
-    </Indicator>
-  </Fragment>
-));
+export const CheckboxControl = forwardRef<HTMLInputElement, CheckboxControlProps>(
+  ({ size, ...props }, ref) => (
+    <Fragment>
+      <VisuallyHidden ref={ref} as="input" type="checkbox" {...props} />
+      <Indicator size={size}>
+        <CheckIcon size={size} />
+      </Indicator>
+    </Fragment>
+  )
+);
 
-const Indicator = (props: { children?: ReactNode }) => {
-  const tokens = useIndicatorTokens({ type: 'checkbox' });
+const Indicator = ({ size, ...props }: { size?: SizeType; children?: ReactNode }) => {
+  const tokens = useIndicatorTokens({ type: 'checkbox', size: size || 'medium' });
   const styles = useIndicatorStyles({ tokens });
   return <div css={styles} {...props} />;
 };

--- a/design-system/packages/fields/src/Checkbox.tsx
+++ b/design-system/packages/fields/src/Checkbox.tsx
@@ -36,7 +36,7 @@ type CheckboxControlProps = {
   size?: SizeType;
   /** The value of the Checkbox. */
   value?: string;
-} & InputHTMLAttributes<HTMLInputElement>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const CheckboxControl = forwardRef<HTMLInputElement, CheckboxControlProps>(
   ({ size, ...props }, ref) => (

--- a/design-system/packages/fields/src/Checkbox.tsx
+++ b/design-system/packages/fields/src/Checkbox.tsx
@@ -14,9 +14,13 @@ type CheckboxProps = {
 } & CheckboxControlProps;
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, size, ...props }, ref) => {
     return (
-      <ControlLabel className={className} control={<CheckboxControl ref={ref} {...props} />}>
+      <ControlLabel
+        className={className}
+        size={size}
+        control={<CheckboxControl ref={ref} size={size} {...props} />}
+      >
         {children}
       </ControlLabel>
     );

--- a/design-system/packages/fields/src/Radio.tsx
+++ b/design-system/packages/fields/src/Radio.tsx
@@ -14,9 +14,13 @@ type RadioProps = {
 } & RadioControlProps;
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(
-  ({ children, className, ...props }, ref) => {
+  ({ children, className, size, ...props }, ref) => {
     return (
-      <ControlLabel className={className} control={<RadioControl ref={ref} {...props} />}>
+      <ControlLabel
+        className={className}
+        size={size}
+        control={<RadioControl ref={ref} size={size} {...props} />}
+      >
         {children}
       </ControlLabel>
     );

--- a/design-system/packages/fields/src/Radio.tsx
+++ b/design-system/packages/fields/src/Radio.tsx
@@ -36,7 +36,7 @@ type RadioControlProps = {
   size?: SizeType;
   /** The value of the Radio. */
   value?: string;
-} & InputHTMLAttributes<HTMLInputElement>;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const RadioControl = forwardRef<HTMLInputElement, RadioControlProps>(
   ({ size, ...props }, ref) => (

--- a/design-system/packages/fields/src/Radio.tsx
+++ b/design-system/packages/fields/src/Radio.tsx
@@ -6,6 +6,7 @@ import { jsx, VisuallyHidden } from '@keystone-ui/core';
 import { ControlLabel } from './components/ControlLabel';
 import { DotIcon } from './components/Icons';
 import { useIndicatorStyles, useIndicatorTokens } from './hooks/indicators';
+import type { SizeType } from './types';
 
 type RadioProps = {
   /** The radio label content. */
@@ -27,21 +28,25 @@ type RadioControlProps = {
   checked?: boolean;
   /** When true, the radio will be disabled. */
   disabled?: boolean;
+  /** The size of the Radio */
+  size?: SizeType;
   /** The value of the Radio. */
   value?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const RadioControl = forwardRef<HTMLInputElement, RadioControlProps>((props, ref) => (
-  <Fragment>
-    <VisuallyHidden ref={ref} as="input" type="radio" {...props} />
-    <Indicator>
-      <DotIcon />
-    </Indicator>
-  </Fragment>
-));
+export const RadioControl = forwardRef<HTMLInputElement, RadioControlProps>(
+  ({ size, ...props }, ref) => (
+    <Fragment>
+      <VisuallyHidden ref={ref} as="input" type="radio" {...props} />
+      <Indicator size={size}>
+        <DotIcon size={size} />
+      </Indicator>
+    </Fragment>
+  )
+);
 
-const Indicator = (props: { children?: ReactNode }) => {
-  const tokens = useIndicatorTokens({ type: 'radio' });
+const Indicator = ({ size, ...props }: { size?: SizeType; children?: ReactNode }) => {
+  const tokens = useIndicatorTokens({ type: 'radio', size: size || 'medium' });
   const styles = useIndicatorStyles({ tokens });
   return <div css={styles} {...props} />;
 };

--- a/design-system/packages/fields/src/components/ControlLabel.tsx
+++ b/design-system/packages/fields/src/components/ControlLabel.tsx
@@ -3,6 +3,8 @@
 import { ReactNode, ReactElement } from 'react';
 import { jsx, useTheme } from '@keystone-ui/core';
 
+import type { SizeType } from '../types';
+
 /**
  * TODO
  *
@@ -13,10 +15,18 @@ type ControlLabelProps = {
   className?: string;
   control: ReactElement;
   children?: ReactNode;
+  size?: SizeType;
 };
 
-export const ControlLabel = ({ children, className, control }: ControlLabelProps) => {
-  const { spacing, typography } = useTheme();
+export const ControlLabel = ({
+  children,
+  className,
+  control,
+  size: sizeKey = 'medium',
+}: ControlLabelProps) => {
+  const { controlSizes, spacing, typography } = useTheme();
+
+  const size = controlSizes[sizeKey];
 
   return (
     <label className={className} css={{ alignItems: 'flex-start', display: 'inline-flex' }}>
@@ -24,7 +34,7 @@ export const ControlLabel = ({ children, className, control }: ControlLabelProps
       {children && (
         <div
           css={{
-            fontSize: typography.fontSize.medium,
+            fontSize: size.fontSize,
             lineHeight: typography.leading.tight,
             marginLeft: spacing.small,
             paddingTop: spacing.xsmall,

--- a/design-system/packages/fields/src/components/Icons.tsx
+++ b/design-system/packages/fields/src/components/Icons.tsx
@@ -26,17 +26,27 @@ const Svg = ({ children, size, stroke = 'none', fill = 'none' }: SvgProps) => (
   </svg>
 );
 
-export const CheckIcon = () => {
+const checkSizeMap = {
+  small: 14,
+  medium: 18,
+  large: 24,
+};
+export const CheckIcon = ({ size = 'medium' }: { size?: keyof typeof checkSizeMap }) => {
   return (
-    <Svg size="18" stroke="currentColor">
+    <Svg size={checkSizeMap[size]} stroke="currentColor">
       <polyline points="20 6 10 18 4 12" />
     </Svg>
   );
 };
 
-export const DotIcon = () => {
+const dotSizeMap = {
+  small: 12,
+  medium: 16,
+  large: 20,
+};
+export const DotIcon = ({ size = 'medium' }: { size?: keyof typeof dotSizeMap }) => {
   return (
-    <Svg size="16" fill="currentColor">
+    <Svg size={dotSizeMap[size]} fill="currentColor">
       <circle cx="12" cy="12" r="8" />
     </Svg>
   );

--- a/design-system/packages/fields/src/hooks/indicators.ts
+++ b/design-system/packages/fields/src/hooks/indicators.ts
@@ -1,10 +1,12 @@
 import { useTheme } from '@keystone-ui/core';
 
+import type { SizeType } from '../types';
+
 export type IndicatorTokensProps = {
-  // size: SizeType;
+  /** The size of the indicator */
+  size: SizeType;
+  /** Controls whether the indicator looks like a checkbox or radio button */
   type: 'checkbox' | 'radio';
-  /* Causes the indicator to invert background and foreground when selected */
-  invertOnSelect?: boolean;
 };
 
 type IndicatorStateTokens = {
@@ -25,14 +27,20 @@ export type IndicatorTokens = {
   disabled: IndicatorStateTokens;
 } & IndicatorStateTokens;
 
-export const useIndicatorTokens = ({ type }: IndicatorTokensProps): IndicatorTokens => {
-  const { animation, sizing, fields } = useTheme();
+export const useIndicatorTokens = ({
+  size: sizeKey,
+  type,
+}: IndicatorTokensProps): IndicatorTokens => {
+  const { animation, controlSizes, fields } = useTheme();
+
+  const size = controlSizes[sizeKey];
+
   return {
     background: fields.controlBackground,
     borderColor: fields.controlBorderColor,
     borderRadius: type === 'checkbox' ? fields.controlBorderRadius : '50%',
     borderWidth: fields.controlBorderWidth,
-    boxSize: sizing.xsmall,
+    boxSize: size.indicatorBoxSize,
     foreground: fields.controlBackground, // visually hide the icon unless the control is checked
     transition: `
       background-color ${animation.duration100},
@@ -71,8 +79,9 @@ export const useIndicatorTokens = ({ type }: IndicatorTokensProps): IndicatorTok
 
 export type IndicatorStylesProps = { tokens: IndicatorTokens };
 
-export const useIndicatorStyles = ({ tokens }: IndicatorStylesProps) =>
-  ({
+export const useIndicatorStyles = ({ tokens }: IndicatorStylesProps) => {
+  console.log(tokens.boxSize);
+  return {
     alignItems: 'center',
     backgroundColor: tokens.background,
     borderColor: tokens.borderColor,
@@ -117,4 +126,5 @@ export const useIndicatorStyles = ({ tokens }: IndicatorStylesProps) =>
     'input:checked:disabled + &': {
       color: tokens.disabled.foreground,
     },
-  } as const);
+  } as const;
+};

--- a/design-system/website/pages/components/fields.tsx
+++ b/design-system/website/pages/components/fields.tsx
@@ -71,6 +71,18 @@ export default function FieldsPage() {
           Checked + Disabled
         </Checkbox>
       </FieldWrapper>
+      <h3>Sizes</h3>
+      <FieldWrapper>
+        <Checkbox css={{ marginRight: spacing.medium }} size="small">
+          Small
+        </Checkbox>
+        <Checkbox css={{ marginRight: spacing.medium }} size="medium">
+          Medium
+        </Checkbox>
+        <Checkbox css={{ marginRight: spacing.medium }} size="large">
+          Large
+        </Checkbox>
+      </FieldWrapper>
       <h2>Radio Buttons</h2>
       <FieldWrapper>
         <Radio name="radio-set" css={{ marginRight: spacing.medium }}>
@@ -87,6 +99,18 @@ export default function FieldsPage() {
         </Radio>
         <Radio css={{ marginRight: spacing.medium }} disabled checked readOnly>
           Checked + Disabled
+        </Radio>
+      </FieldWrapper>
+      <h3>Sizes</h3>
+      <FieldWrapper>
+        <Radio name="radio-size-set" css={{ marginRight: spacing.medium }} size="small">
+          Small
+        </Radio>
+        <Radio name="radio-size-set" css={{ marginRight: spacing.medium }} size="medium">
+          Medium
+        </Radio>
+        <Radio name="radio-size-set" css={{ marginRight: spacing.medium }} size="large">
+          Large
         </Radio>
       </FieldWrapper>
       <h2>Switches</h2>

--- a/packages-next/admin-ui/src/pages/ListPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ListPage/index.tsx
@@ -273,6 +273,7 @@ function ListTable({
           <TableHeaderCell css={{ paddingLeft: 0 }}>
             <label>
               <CheckboxControl
+                size="small"
                 checked={selectedItemsCount === items.length}
                 onChange={() => {
                   const selectedItems: Record<string, true> = {};
@@ -323,6 +324,7 @@ function ListTable({
                 <TableBodyCell>
                   <label>
                     <CheckboxControl
+                      size="small"
                       checked={selectedItems[item.id] !== undefined}
                       onChange={() => {
                         const newSelectedItems = { ...selectedItems };


### PR DESCRIPTION
This fixes the jumbo checkboxes on the list screen.

@mitchellhamilton something I don't understand going on here with the types: when actually setting the `size` prop on either the `Checkbox` or `Radio` components it says:

```
Type 'string' is not assignable to type 'never'.ts(2322)
Checkbox.tsx(36, 3): The expected type comes from property 'size' which is declared here on type 'IntrinsicAttributes & { children: ReactNode; } & { checked?: boolean; disabled?: boolean; size?: SizeType; value?: string; } & InputHTMLAttributes<HTMLInputElement> & RefAttributes<...>'
```

I can't see what's going on that would make it think the type is `never`. Would you mind taking a look?