### PR TITLE
Fix error on signin to Admin UI

### DIFF
--- a/packages-next/admin-ui/src/index.tsx
+++ b/packages-next/admin-ui/src/index.tsx
@@ -2,4 +2,10 @@ export { HomePage } from './pages/HomePage';
 export { ItemPage } from './pages/ItemPage';
 export { ListPage } from './pages/ListPage';
 export { NoAccessPage } from './pages/NoAccessPage';
-export { KeystoneProvider, useKeystone, useList, useRawKeystone } from './context';
+export {
+  KeystoneProvider,
+  useKeystone,
+  useList,
+  useRawKeystone,
+  useReinitContext,
+} from './context';

--- a/packages-next/admin-ui/src/utils/useAdminMeta.tsx
+++ b/packages-next/admin-ui/src/utils/useAdminMeta.tsx
@@ -37,7 +37,7 @@ export function useAdminMeta(
     if (typeof window === 'undefined') {
       return;
     }
-    let item = localStorage.getItem(adminMetaLocalStorageKey);
+    const item = localStorage.getItem(adminMetaLocalStorageKey);
     if (item === null) {
       return;
     }
@@ -50,6 +50,7 @@ export function useAdminMeta(
       return;
     }
   }, []);
+
   const { data, error, refetch } = useQuery(staticAdminMetaQuery, {
     client,
     skip: adminMetaFromLocalStorage !== undefined,
@@ -114,7 +115,9 @@ export function useAdminMeta(
     }
     return runtimeAdminMeta;
   }, [data, error, adminMetaFromLocalStorage]);
-  let mustRenderServerResult = useMustRenderServerResult();
+
+  const mustRenderServerResult = useMustRenderServerResult();
+
   if (mustRenderServerResult) {
     return {
       state: 'loading' as const,

--- a/packages-next/admin-ui/src/utils/useAuthenticatedItem.tsx
+++ b/packages-next/admin-ui/src/utils/useAuthenticatedItem.tsx
@@ -3,7 +3,7 @@ import { ApolloError, DocumentNode, useQuery, ApolloClient } from '../apollo';
 export type AuthenticatedItem =
   | { state: 'unauthenticated'; refetch: () => void }
   | { state: 'authenticated'; label: string; id: string; listKey: string; refetch: () => void }
-  | { state: 'loading' }
+  | { state: 'loading'; refetch: () => void }
   | { state: 'error'; error: ApolloError; refetch: () => void };
 
 export function useAuthenticatedItem(
@@ -47,5 +47,6 @@ export function useAuthenticatedItem(
 
   return {
     state: 'loading',
+    refetch,
   };
 }

--- a/packages-next/auth/TODO.md
+++ b/packages-next/auth/TODO.md
@@ -8,20 +8,20 @@
   - [x] Implement no access UI
   - [x] Make no access UI look nice @jed
 - [x] Put generating Auth Admin UI Pages in the package, add them with `getAdditionalFiles` @mitchell
-- [ ] Load Admin Meta from an API route @mitchell
+- [x] Load Admin Meta from an API route @mitchell
   - [ ] With good HTTP caching headers
-  - [ ] Protect it with the `secureFn`
-  - [ ] Make it synchronously available on all pages
+  - [x] Protect it with the `secureFn`
+  - [x] Make it synchronously available on all pages
 - [x] Write `withItemData` wrapper for sessions @noviny
   - [x] Session functions will need enough API to execute a query
 - [x] Pass session in context as `session` @mitchell
   - [ ] Remove `authentication` property from context and the usages of it
   - [ ] Pass this as an arg on access control? -- yes
-- [ ] Implement signout @jed
+- [x] Implement signout @jed
   - [x] Only generate the endSession mutation if session.end exists
   - [ ] Create UI for the signout page
   - [ ] Only generate the signout page if the config is enabled
-  - [ ] Add a signout button to the Admin UI when the config is enabled
+  - [x] Add a signout button to the Admin UI when the config is enabled
 - [ ] Implement forgotten password & magic links @molomby
   - [ ] Define the list
   - [ ] Add the mutations

--- a/packages-next/auth/src/pages/InitPage.tsx
+++ b/packages-next/auth/src/pages/InitPage.tsx
@@ -11,6 +11,7 @@ import { SigninContainer } from '../components/SigninContainer';
 import { DocumentNode } from 'graphql';
 import { Notice } from '@keystone-ui/notice';
 import { useMutation } from '@keystone-spike/admin-ui/apollo';
+import { useReinitContext } from '@keystone-spike/admin-ui/context';
 import { useRouter } from '@keystone-spike/admin-ui/router';
 
 export const InitPage = ({
@@ -50,15 +51,13 @@ export const InitPage = ({
   });
 
   const [createFirstItem, { loading, error }] = useMutation(mutation);
-
+  const reinitContext = useReinitContext();
   const router = useRouter();
 
   const nameInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     nameInputRef.current?.focus();
   }, []);
-
-  console.log({ fields, serializedFields });
 
   return (
     <SigninContainer>
@@ -77,8 +76,8 @@ export const InitPage = ({
               ),
             },
           });
+          reinitContext();
           await router.push('/');
-          window.location.reload();
         }}
       >
         {error && <Notice>{error.message}</Notice>}

--- a/packages-next/auth/src/pages/SigninPage.tsx
+++ b/packages-next/auth/src/pages/SigninPage.tsx
@@ -9,6 +9,7 @@ import { Notice } from '@keystone-ui/notice';
 
 import { SigninContainer } from '../components/SigninContainer';
 import { useMutation, DocumentNode } from '@keystone-spike/admin-ui/apollo';
+import { useReinitContext } from '@keystone-spike/admin-ui/context';
 import { useRouter } from '@keystone-spike/admin-ui/router';
 
 export const SigninPage = ({ mutation }: { mutation: DocumentNode }) => {
@@ -21,13 +22,15 @@ export const SigninPage = ({ mutation }: { mutation: DocumentNode }) => {
 
   const [mode, setMode] = useState<'signin' | 'forgot password'>('signin');
   const [state, setState] = useState({ identity: '', secret: '' });
-  const router = useRouter();
+
   const identityFieldRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     identityFieldRef.current?.focus();
   }, [mode]);
 
   const [mutate, { error, loading }] = useMutation(mutation);
+  const reinitContext = useReinitContext();
+  const router = useRouter();
 
   return (
     <SigninContainer>
@@ -49,8 +52,8 @@ export const SigninPage = ({ mutation }: { mutation: DocumentNode }) => {
             } catch (err) {
               return;
             }
+            reinitContext();
             await router.push('/');
-            window.location.reload();
           }
         }}
       >


### PR DESCRIPTION
At the moment, signing into the Admin UI flashes an error while the page reloads.

This PR adds a function to context which refetches the admin meta and authenticated user, allowing us to do a proper client-side redirect.

Still need to follow up with a fix for when you sign in successfully, but don't have access to the Admin UI

FYI @mitchellhamilton - there's a lot of stuff going on inside the keystone context, there may be some edge cases this doesn't handle yet and you might want to take a look at it but given the work yet to come on fetching dynamic admin meta and since this is a UX improvement, I figure this is good enough for now and we can review it all a bit later.