### PR TITLE
Make unit tests more parallel to increase throughput

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -85,7 +85,7 @@ jobs:
           CLOUDINARY_CLOUD_NAME: keystone-cloudinary
           CLOUDINARY_KEY: 758252673115372
           CLOUDINARY_SECRET: ${{ secrets.CLOUDINARY_SECRET }}
-          CI_NODE_TOTAL: 10
+          CI_NODE_TOTAL: 9
           CI_NODE_INDEX: ${{ matrix.index }}
           IFRAMELY_API_KEY: ${{ secrets.IFRAMELY_API_KEY }}
           UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
           CLOUDINARY_CLOUD_NAME: keystone-cloudinary
           CLOUDINARY_KEY: 758252673115372
           CLOUDINARY_SECRET: ${{ secrets.CLOUDINARY_SECRET }}
-          CI_NODE_TOTAL: 5
+          CI_NODE_TOTAL: 10
           CI_NODE_INDEX: ${{ matrix.index }}
           IFRAMELY_API_KEY: ${{ secrets.IFRAMELY_API_KEY }}
           UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        index: [0, 1, 2, 3, 4]
+        index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
A lot of our test time is tied up in a couple of long running tests. This change appears to make things a little bit better. A longer term solution will be to break up/speed up the long running tests (there's definitely a lot of scope for optimisation, but it's also a lot of work). Let's try out this config and see if it a) makes things faster and b) reduces false positives due to memory issues.