### PR TITLE
Upping max session age in the basic demo

### DIFF
--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -10,6 +10,7 @@ import { createAuth } from '@keystone-spike/auth';
 
 let sessionSecret =
   'a very very good secreta very very good secreta very very good secreta very very good secret';
+let sessionMaxAge = 60 * 60 * 24 * 30; // 30 days
 
 const auth = createAuth({
   listKey: 'User',
@@ -54,6 +55,7 @@ export default auth.withAuth(
     extendGraphqlSchema,
     session: withItemData(
       statelessSessions({
+        maxAge: sessionMaxAge,
         secret: sessionSecret,
       }),
       { User: 'name isAdmin' }


### PR DESCRIPTION
This keeps catching me with the signout. While 8 hours is probably a safe default for sessions (making them longer would be an explicit choice for the developer) I think it's fine for our demo to have a much more generous timeout.