### PR TITLE
Enable tests in Json based field types for prisma

### DIFF
--- a/packages/fields-cloudinary-image/src/test-fixtures.skip.js
+++ b/packages/fields-cloudinary-image/src/test-fixtures.skip.js
@@ -41,7 +41,6 @@ export const type = CloudinaryImage;
 export const supportsUnique = false;
 export const fieldName = 'image';
 export const subfieldName = 'originalFilename';
-export const unSupportedAdapterList = ['prisma_postgresql'];
 
 // This function will run after all the tests are completed.
 // We use it to cleanup the resources (e.g Cloudinary images) which are no longer required.
@@ -77,4 +76,7 @@ export const storedValues = () => [
   { image: null, name: 'file6' },
 ];
 
-export const supportedFilters = () => ['null_equality', 'in_empty_null'];
+export const supportedFilters = adapterName => [
+  'null_equality',
+  adapterName !== 'prisma_postgresql' && 'in_empty_null',
+];

--- a/packages/fields-oembed/src/test-fixtures.js
+++ b/packages/fields-oembed/src/test-fixtures.js
@@ -11,7 +11,6 @@ export const exampleValue2 = () => 'https://codesandbox.io';
 export const supportsUnique = false;
 export const fieldName = 'portfolio';
 export const subfieldName = 'originalUrl';
-export const unSupportedAdapterList = ['prisma_postgresql'];
 
 const iframelyAdapter = new IframelyOEmbedAdapter({
   apiKey: process.env.IFRAMELY_API_KEY || 'iframely_api_key',
@@ -46,4 +45,7 @@ export const storedValues = () => [
   { name: 'g', portfolio: null },
 ];
 
-export const supportedFilters = () => ['null_equality', 'in_empty_null'];
+export const supportedFilters = adapterName => [
+  'null_equality',
+  adapterName !== 'prisma_postgresql' && 'in_empty_null',
+];

--- a/packages/fields-unsplash/src/test-fixtures.skip.js
+++ b/packages/fields-unsplash/src/test-fixtures.skip.js
@@ -11,7 +11,6 @@ export const exampleValue = () => 'U0tBTn8UR8I';
 export const exampleValue2 = () => 'xrVDYZRGdw4';
 export const fieldName = 'heroImage';
 export const subfieldName = 'unsplashId';
-export const unSupportedAdapterList = ['prisma_postgresql'];
 export const fieldConfig = () => ({
   accessKey: process.env.UNSPLASH_KEY || 'unsplash_key',
   secretKey: process.env.UNSPLASH_SECRET || 'unplash_secret',
@@ -48,4 +47,7 @@ export const storedValues = () => [
   { name: 'g', heroImage: null },
 ];
 
-export const supportedFilters = () => ['null_equality', 'in_empty_null'];
+export const supportedFilters = adapterName => [
+  'null_equality',
+  adapterName !== 'prisma_postgresql' && 'in_empty_null',
+];

--- a/packages/fields/src/types/File/test-fixtures.js
+++ b/packages/fields/src/types/File/test-fixtures.js
@@ -11,7 +11,6 @@ export const type = File;
 export const supportsUnique = false;
 export const fieldName = 'image';
 export const subfieldName = 'originalFilename';
-export const unSupportedAdapterList = ['prisma_postgresql'];
 
 // Grab all the image files from the directory
 const directory = './files';
@@ -88,4 +87,7 @@ export const afterAll = () => {
   });
 };
 
-export const supportedFilters = () => ['null_equality', 'in_empty_null'];
+export const supportedFilters = adapterName => [
+  'null_equality',
+  adapterName !== 'prisma_postgresql' && 'in_empty_null',
+];


### PR DESCRIPTION
The Prisma Json field type supports equality checking, but not `in` operations, so this PR selectively enables the tests we expect to pass, while leaving the `in` operations alone.