### PR TITLE
Ignore yarn.lock in shouldRunTests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           filters: |
             shouldRunTests:
-              - '!{{website,docs,examples,packages-next,examples-next,design-system}/**,**/*.md}'
+              - '!{{website,docs,examples,packages-next,examples-next,design-system}/**,**/*.md,yarn.lock}'
       - run: echo "::set-env name=SHOULD_RUN_TESTS::$SHOULD_RUN"
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
This ignores changes to yarn.lock in the shouldRunTests check, which should speed up CI for package bumps that only change the new packages

(e.g #3921)