### PR TITLE
Use Emotion 11 in new interfaces

### DIFF
--- a/design-system/packages/button/package.json
+++ b/design-system/packages/button/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-ui/core": "*",
     "@keystone-ui/icons": "*",
     "@keystone-ui/loading": "*",

--- a/design-system/packages/core/package.json
+++ b/design-system/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
+    "@emotion/react": "11.0.0-rc.0",
     "facepaint": "^1.2.1"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/design-system/packages/core"

--- a/design-system/packages/core/src/components/Box.tsx
+++ b/design-system/packages/core/src/components/Box.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { useTheme } from '../theme';
 import { useMediaQuery } from '../hooks/useMediaQuery';

--- a/design-system/packages/core/src/components/Center.tsx
+++ b/design-system/packages/core/src/components/Center.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { Box, BoxProps } from './Box';
 import { forwardRefWithAs } from '../utils';

--- a/design-system/packages/core/src/components/Core.tsx
+++ b/design-system/packages/core/src/components/Core.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx, Global } from '@emotion/core';
+import { jsx, Global } from '../emotion';
 import { Fragment, ReactNode, memo } from 'react';
 
 import { normalize } from '../normalize';

--- a/design-system/packages/core/src/components/Divider.tsx
+++ b/design-system/packages/core/src/components/Divider.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { Box, MarginProps } from './Box';
 import { useTheme } from '../theme';

--- a/design-system/packages/core/src/components/Divider.tsx
+++ b/design-system/packages/core/src/components/Divider.tsx
@@ -17,6 +17,7 @@ type DividerProps = {
   children?: never;
   color?: ColorType;
   orientation?: keyof typeof orientationMap;
+  className?: string;
 } & MarginProps;
 
 export const Divider = ({ orientation = 'vertical', color, ...props }: DividerProps) => {

--- a/design-system/packages/core/src/components/Heading.tsx
+++ b/design-system/packages/core/src/components/Heading.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { Box, BoxProps } from './Box';
 import { forwardRefWithAs } from '../utils';

--- a/design-system/packages/core/src/components/Inline.tsx
+++ b/design-system/packages/core/src/components/Inline.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { Children, ReactNode } from 'react';
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { Box, BoxProps } from './Box';
 import { forwardRefWithAs } from '../utils';

--- a/design-system/packages/core/src/components/Link.tsx
+++ b/design-system/packages/core/src/components/Link.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 import { useTheme } from '../theme';
 import { forwardRefWithAs } from '../utils';
 

--- a/design-system/packages/core/src/components/Stack.tsx
+++ b/design-system/packages/core/src/components/Stack.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { Children, Fragment, HTMLAttributes, isValidElement, ReactNode } from 'react';
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 import { Box, BoxProps } from './Box';
 import { forwardRefWithAs, mapResponsiveProp } from '../utils';
 import { Theme } from '../types';

--- a/design-system/packages/core/src/components/Text.tsx
+++ b/design-system/packages/core/src/components/Text.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '../emotion';
 
 import { Box, BoxProps } from './Box';
 import { Theme } from '../types';

--- a/design-system/packages/core/src/emotion.ts
+++ b/design-system/packages/core/src/emotion.ts
@@ -1,1 +1,1 @@
-export { css, jsx, keyframes, Global, ClassNames } from '@emotion/core'; // ensure the same version of emotion
+export { css, jsx, keyframes, Global, ClassNames } from '@emotion/react'; // ensure the same version of emotion

--- a/design-system/packages/core/src/emotion.ts
+++ b/design-system/packages/core/src/emotion.ts
@@ -1,0 +1,1 @@
+export { css, jsx, keyframes, Global, ClassNames } from '@emotion/core'; // ensure the same version of emotion

--- a/design-system/packages/core/src/index.ts
+++ b/design-system/packages/core/src/index.ts
@@ -1,5 +1,4 @@
-export { css, jsx, keyframes, Global, ClassNames } from '@emotion/core'; // ensure the same version of emotion
-
+export * from './emotion';
 export { VisuallyHidden } from './a11y/VisuallyHidden';
 export { Box } from './components/Box';
 export type { BoxProps, ColorProps, RadiiProps, MarginProps, PaddingProps } from './components/Box';

--- a/design-system/packages/core/src/normalize.ts
+++ b/design-system/packages/core/src/normalize.ts
@@ -1,4 +1,4 @@
-import { css } from '@emotion/core';
+import { css } from './emotion';
 
 export const normalize = css`
   /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */

--- a/design-system/packages/fields/package.json
+++ b/design-system/packages/fields/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-ui/core": "*",
     "@keystone-ui/icons": "*",
     "react": "^16.13.1"

--- a/design-system/packages/loading/package.json
+++ b/design-system/packages/loading/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-ui/core": "*",
     "react": "^16.13.1"
   },

--- a/design-system/packages/notice/src/Notice.tsx
+++ b/design-system/packages/notice/src/Notice.tsx
@@ -34,6 +34,7 @@ type NoticeProps = {
   children: ReactNode;
   tone?: ToneKey;
   title?: string;
+  className?: string;
 } /* TODO: & MarginProps */;
 
 export const Notice = ({

--- a/design-system/packages/segmented-control/package.json
+++ b/design-system/packages/segmented-control/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-ui/core": "*"
   },
   "peerDependencies": {

--- a/design-system/website/components/Code.tsx
+++ b/design-system/website/components/Code.tsx
@@ -1,8 +1,7 @@
 /* @jsx jsx */
 
 import { ReactNode } from 'react';
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 
 export const Code = ({ children }: { children: ReactNode }) => {
   const { palette, spacing, radii } = useTheme();

--- a/design-system/website/components/Navigation.tsx
+++ b/design-system/website/components/Navigation.tsx
@@ -1,8 +1,7 @@
 /* @jsx jsx */
 
 import { Fragment, ReactNode } from 'react';
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 

--- a/design-system/website/components/Page.tsx
+++ b/design-system/website/components/Page.tsx
@@ -1,8 +1,7 @@
 /* @jsx jsx */
 
 import type { HTMLAttributes, ReactNode } from 'react';
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 
 import { Navigation } from './Navigation';
 

--- a/design-system/website/components/ReadableColor.tsx
+++ b/design-system/website/components/ReadableColor.tsx
@@ -1,7 +1,7 @@
 /* @jsx jsx */
 
 import type { ReactNode } from 'react';
-import { jsx } from '@emotion/core';
+import { jsx } from '@keystone-ui/core';
 import tinycolor from 'tinycolor2';
 
 const BLACK = '#000';

--- a/design-system/website/package.json
+++ b/design-system/website/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-ui/button": "*",
     "@keystone-ui/core": "*",
     "@keystone-ui/fields": "*",

--- a/design-system/website/pages/components/button.tsx
+++ b/design-system/website/pages/components/button.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { Stack } from '@keystone-ui/core';
+import { jsx, Stack } from '@keystone-ui/core';
 import { Button, buttonToneValues, ToneKey, buttonWeightValues } from '@keystone-ui/button';
 
 import { Page } from '../../components/Page';

--- a/design-system/website/pages/components/fields.tsx
+++ b/design-system/website/pages/components/fields.tsx
@@ -1,8 +1,7 @@
 /* @jsx jsx */
 
 import { ReactNode, useState } from 'react';
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 import { Checkbox, Radio, TextArea, TextInput, Switch, SelectInput } from '@keystone-ui/fields';
 import { SegmentedControl } from '@keystone-ui/segmented-control';
 

--- a/design-system/website/pages/components/fields.tsx
+++ b/design-system/website/pages/components/fields.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { ReactNode, useState } from 'react';
+import { ComponentProps, ReactNode, useState } from 'react';
 import { jsx, useTheme } from '@keystone-ui/core';
 import { Checkbox, Radio, TextArea, TextInput, Switch, SelectInput } from '@keystone-ui/fields';
 import { SegmentedControl } from '@keystone-ui/segmented-control';
@@ -21,7 +21,7 @@ const FieldWrapper = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const StatefulSwitch = ({ children, ...props }: { children: ReactNode }) => {
+const StatefulSwitch = ({ children, ...props }: ComponentProps<typeof Switch>) => {
   const [checked, setChecked] = useState(false);
   return (
     <Switch checked={checked} onClick={() => setChecked(!checked)} {...props}>

--- a/design-system/website/pages/components/notice.tsx
+++ b/design-system/website/pages/components/notice.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '@keystone-ui/core';
 import { Notice, noticeToneValues } from '@keystone-ui/notice';
 
 import { Page } from '../../components/Page';

--- a/design-system/website/pages/core/alias-tokens.tsx
+++ b/design-system/website/pages/core/alias-tokens.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { useTheme, Inline } from '@keystone-ui/core';
+import { jsx, useTheme, Inline } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 import { ReadableColor } from '../../components/ReadableColor';

--- a/design-system/website/pages/core/global-tokens.tsx
+++ b/design-system/website/pages/core/global-tokens.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 import { ReadableColor } from '../../components/ReadableColor';

--- a/design-system/website/pages/core/theme.tsx
+++ b/design-system/website/pages/core/theme.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 

--- a/design-system/website/pages/index.tsx
+++ b/design-system/website/pages/index.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '@keystone-ui/core';
 
 import { Page } from '../components/Page';
 

--- a/design-system/website/pages/layout/box.tsx
+++ b/design-system/website/pages/layout/box.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { Box, useTheme } from '@keystone-ui/core';
+import { jsx, Box, useTheme } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 import { Code } from '../../components/Code';

--- a/design-system/website/pages/layout/center.tsx
+++ b/design-system/website/pages/layout/center.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { Box, useTheme, Center } from '@keystone-ui/core';
+import { jsx, Box, useTheme, Center } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 import { Code } from '../../components/Code';

--- a/design-system/website/pages/layout/stack.tsx
+++ b/design-system/website/pages/layout/stack.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { Text, Stack } from '@keystone-ui/core';
+import { jsx, Text, Stack } from '@keystone-ui/core';
 
 import { Page } from '../../components/Page';
 import { Code } from '../../components/Code';

--- a/examples-next/basic/admin/fieldViews/Content.tsx
+++ b/examples-next/basic/admin/fieldViews/Content.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
 
 type FieldProps = {

--- a/packages-next/admin-ui/package.json
+++ b/packages-next/admin-ui/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@apollo/client": "^3.2.3",
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@emotion/hash": "^0.8.0",
     "@emotion/weak-memoize": "^0.2.5",
     "@graphql-tools/merge": "^6.2.4",

--- a/packages-next/admin-ui/src/components/Logo.tsx
+++ b/packages-next/admin-ui/src/components/Logo.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { useTheme, H2 } from '@keystone-ui/core';
+import { jsx, useTheme, H2 } from '@keystone-ui/core';
 import Link from 'next/link';
 
 import { useKeystone } from '../context';

--- a/packages-next/admin-ui/src/components/Navigation.tsx
+++ b/packages-next/admin-ui/src/components/Navigation.tsx
@@ -1,8 +1,7 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
 import { Button } from '@keystone-ui/button';
-import { Box, Stack, Inline, useTheme } from '@keystone-ui/core';
+import { jsx, Box, Stack, Inline, useTheme } from '@keystone-ui/core';
 import { GithubIcon } from '@keystone-ui/icons/icons/GithubIcon';
 import { DatabaseIcon } from '@keystone-ui/icons/icons/DatabaseIcon';
 import { useRouter } from 'next/router';

--- a/packages-next/admin-ui/src/components/PageContainer.tsx
+++ b/packages-next/admin-ui/src/components/PageContainer.tsx
@@ -1,7 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
-import { useTheme } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 import type { HTMLAttributes, ReactNode } from 'react';
 
 import { Navigation } from './Navigation';

--- a/packages-next/admin-ui/src/components/SignoutButton.tsx
+++ b/packages-next/admin-ui/src/components/SignoutButton.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { jsx } from '@keystone-ui/core';
 import { Button } from '@keystone-ui/button';
 import { ReactNode, useEffect } from 'react';
 

--- a/packages-next/auth/package.json
+++ b/packages-next/auth/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-spike/fields": "*",
     "@keystone-spike/types": "*",
     "@keystone-ui/button": "*",

--- a/packages-next/auth/src/components/SigninContainer.tsx
+++ b/packages-next/auth/src/components/SigninContainer.tsx
@@ -1,9 +1,8 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
 import { ReactNode } from 'react';
 
-import { Box, Center, useTheme } from '@keystone-ui/core';
+import { jsx, Box, Center, useTheme } from '@keystone-ui/core';
 
 type SigninContainerProps = {
   children: ReactNode;

--- a/packages-next/fields/package.json
+++ b/packages-next/fields/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",
-    "@emotion/core": "^10.0.35",
     "@keystone-spike/admin-ui": "*",
     "@keystone-spike/types": "*",
     "@keystone-ui/core": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2679,6 +2679,17 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
+"@emotion/cache@^11.0.0-rc.0":
+  version "11.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.0.0-rc.0.tgz#27e800eaa67813e3af736062609ae5111382b441"
+  integrity sha512-2LMa4ZAgoIFV5yiGYGalqBilhrTAvDryBdvQQ4LEmC2PibueHeKgl451czeLzzhZ9JFt371Bb9ykaZxnMG9UIA==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0-rc.0"
+    "@emotion/utils" "^1.0.0-rc.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
 "@emotion/core@^10.0.14", "@emotion/core@^10.0.9":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
@@ -2741,10 +2752,23 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
   integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
 
-"@emotion/memoize@0.7.4":
+"@emotion/memoize@0.7.4", "@emotion/memoize@^0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/react@11.0.0-rc.0":
+  version "11.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.0.0-rc.0.tgz#3f2aa6a86e1e0f606d9bd6627880c5e660901c25"
+  integrity sha512-XN1ZV5LG2fP6qBc/ebFch4pXxrGJUPaJ66X+2FBphOrFgWaUTIRbdbtW1MR5nu3xEW4g9/FsE0+n+c9+G7DZcw==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.0.0-rc.0"
+    "@emotion/serialize" "^1.0.0-rc.0"
+    "@emotion/sheet" "^1.0.0-rc.0"
+    "@emotion/utils" "^1.0.0-rc.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
 
 "@emotion/serialize@^0.11.15":
   version "0.11.15"
@@ -2768,10 +2792,26 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
+"@emotion/serialize@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.0-rc.0.tgz#db7e3c4d35f9a1d71d9e62eab0b545dbe03595b7"
+  integrity sha512-dulhplA/piZ56Uj/mxiPp/G+bEOaFMt4aQ98DtjL7Nh/XObhjWoN8L/RRfV6A8lzIWhr6yM+/8bFfW55+KQo3w==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0-rc.0"
+    csstype "^3.0.2"
+
 "@emotion/sheet@0.9.4":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.0-rc.0.tgz#6f24f7de059138e16c0fc12e32ec19f3342d1fe2"
+  integrity sha512-wZBWjoF1ie4PQbIGO2fTSLd5TUhDR9p1vT5nfUDYA9qyRtAwag5NO/s1vhru5MHsLgxNWSsgtqFRt6qhNlvBrg==
 
 "@emotion/styled-base@^10.0.27":
   version "10.0.27"
@@ -2796,7 +2836,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.0":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.0", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -2805,6 +2845,11 @@
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
+
+"@emotion/utils@^1.0.0-rc.0":
+  version "1.0.0-rc.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0-rc.0.tgz#ab9d21e71887158f8c1899c063072a1e82eacb90"
+  integrity sha512-W9YjlRRq8ImIARa3iHlmDnJIBcuUoVciML767eAO42bZnWkrYLSBssbjTVWiAUJ9AQn1WZR+L3TFlPYXI7NWmA==
 
 "@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
@@ -14614,7 +14659,7 @@ hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   dependencies:
     react-is "^16.7.0"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -25969,6 +26014,11 @@ stylis@3.5.4, stylis@^3.5.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
   integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
+stylis@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.3.tgz#0d714765f3f694a685550f0c45411ebf90a9bded"
+  integrity sha512-iAxdFyR9cHKp4H5M2dJlDnvcb/3TvPprzlKjvYVbH7Sh+y8hjY/mUu/ssdcvVz6Z4lKI3vsoS0jAkMYmX7ozfA==
 
 subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16, subscriptions-transport-ws@^0.9.5:
   version "0.9.16"


### PR DESCRIPTION
This is mostly because I want to test Emotion 11(it's already v reliable, don't worry), there's lots of stuff but the big that matters here is improved type defs, it changes the way the css prop is typed from "some prop that you can use on any component" to "you can use it if the component has a className prop AND you've setup the jsx pragma" which is v nice. (the requiring a className prop on the component before allowing the css prop bit found some missing className props on things 🎉 )