### PR TITLE
Prepare create-keystone-app for more than two adapters

### DIFF
--- a/.changeset/nine-deers-hide.md
+++ b/.changeset/nine-deers-hide.md
@@ -1,0 +1,5 @@
+---
+'create-keystone-app': patch
+---
+
+Updated internals to better support more than two database adapter options.

--- a/packages/create-keystone-app/lib/generate-code.js
+++ b/packages/create-keystone-app/lib/generate-code.js
@@ -6,14 +6,15 @@ const generateCode = async () => {
   const projectName = await getProjectName();
 
   const adapterChoice = await getAdapterChoice();
-  const adapterConfig =
-    adapterChoice.name === 'MongoDB'
-      ? `{ mongoUri: '${await getAdapterConfig()}' }`
-      : `{ knexOptions: { connection: '${await getAdapterConfig()}' } }`;
-  const adapterRequire =
-    adapterChoice.name === 'MongoDB'
-      ? `const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');`
-      : `const { KnexAdapter: Adapter } = require('@keystonejs/adapter-knex');`;
+  const adapterConfig = {
+    MongoDB: `{ mongoUri: '${await getAdapterConfig()}' }`,
+    PostgreSQL: `{ knexOptions: { connection: '${await getAdapterConfig()}' } }`,
+  }[adapterChoice.key];
+
+  const adapterRequire = {
+    MongoDB: `const { MongooseAdapter: Adapter } = require('@keystonejs/adapter-mongoose');`,
+    PostgreSQL: `const { KnexAdapter: Adapter } = require('@keystonejs/adapter-knex');`,
+  }[adapterChoice.key];
 
   return `${adapterRequire}
 const PROJECT_NAME = '${projectName}';

--- a/packages/create-keystone-app/lib/get-adapter-choice.js
+++ b/packages/create-keystone-app/lib/get-adapter-choice.js
@@ -14,16 +14,16 @@ const adapters = {
     name: 'PostgreSQL',
     file: 'adapter-knex.js',
     dependencies: ['@keystonejs/adapter-knex'],
-    description: 'Connect to a PostgreSQL database.',
+    description: 'Connect to a PostgreSQL database with knex.',
     removeDependencies: ['@keystonejs/adapter-mongoose'],
     defaultConfig: name => `postgres://localhost/${slugify(name, { separator: '_' })}`,
   },
 };
 
-const choices = Object.keys(adapters).map(key => ({
-  value: adapters[key],
-  title: key,
-  description: adapters[key].description,
+const choices = Object.entries(adapters).map(([key, value]) => ({
+  value: { ...value, key },
+  title: value.name,
+  description: value.description,
 }));
 
 let ADAPTER_CHOICE;

--- a/packages/create-keystone-app/lib/get-adapter-config.js
+++ b/packages/create-keystone-app/lib/get-adapter-config.js
@@ -16,14 +16,14 @@ const getAdapterConfig = async () => {
       return CONNECTION_STRING;
     }
 
-    const adapter = await getAdapterChoice();
+    const adapterChoice = await getAdapterChoice();
     const projectName = await getProjectName();
     const response = await prompts(
       {
         type: 'text',
         name: 'value',
         message: 'Where is your database located?',
-        initial: adapter.defaultConfig(projectName),
+        initial: adapterChoice.defaultConfig(projectName),
         onCancel: () => {
           return true;
         },

--- a/packages/create-keystone-app/lib/show-success-message.js
+++ b/packages/create-keystone-app/lib/show-success-message.js
@@ -6,9 +6,9 @@ const { getAdapterChoice } = require('./get-adapter-choice');
 
 const showSuccessMessage = async () => {
   const projectDir = await getProjectDirectory();
-  const adapterConfig = await getAdapterChoice();
+  const adapterChoice = await getAdapterChoice();
   let knexMessage = '';
-  if (adapterConfig.name === 'PostgreSQL') {
+  if (adapterChoice.key === 'PostgreSQL') {
     knexMessage = `
 ${c.bold('  Before you run Keystone you will need to initialise the tables in your database:')}
 

--- a/packages/create-keystone-app/lib/test-adapter-connection.js
+++ b/packages/create-keystone-app/lib/test-adapter-connection.js
@@ -45,23 +45,23 @@ const testAdapterConnection = async () => {
     const adapterChoice = await getAdapterChoice();
     const config = await getAdapterConfig();
 
-    const Adapter = adapterChoice.name === 'MongoDB' ? MongooseAdapter : KnexAdapter;
-    const adapterConfig =
-      adapterChoice.name === 'MongoDB'
-        ? { mongoUri: config }
-        : { knexOptions: { connection: config } };
+    const Adapter = { MongoDB: MongooseAdapter, PostgreSQL: KnexAdapter }[adapterChoice.key];
+    const adapterConfig = {
+      MongoDB: { mongoUri: config },
+      PostgreSQL: { knexOptions: { connection: config } },
+    }[adapterChoice.key];
     const adapter = new Adapter(adapterConfig);
     try {
       await adapter._connect();
       adapter.disconnect();
       tick(`Successfully connected to ${config}`);
     } catch (err) {
-      error(`Failed to connect to ${adapterChoice.name} at: ${config}`);
+      error(`Failed to connect to ${adapterChoice.key} at: ${config}`);
       console.log(
         'Please check that you can connect directly to your database with the following command:'
       );
       console.log('');
-      console.log(`$ ${adapterChoice.name === 'MongoDB' ? 'mongo' : 'psql'} ${config}`);
+      console.log(`$ ${adapterChoice.key === 'MongoDB' ? 'mongo' : 'psql'} ${config}`);
       console.log('');
       console.log(
         `Please see the database ${terminalLink(


### PR DESCRIPTION
 - Replace ternary operations with object lookups
 - Add a `.key` property to `adapterChoice`, distinct from the `.name` property (even though they happen to be identical for the existing adapters, this won't be the case for the prisma adapter)