### PR TITLE
Fixing keystone case in label resolver blog example

### DIFF
--- a/docs/blog/better-ux-with-custom-labels.md
+++ b/docs/blog/better-ux-with-custom-labels.md
@@ -138,7 +138,7 @@ const Post = {
     // and the rest of the fields too
   },
   labelResolver: async item => {
-    const { data } = await Keystone.executeGraphQL({
+    const { data } = await keystone.executeGraphQL({
       query: `query {
           User(where: {id: "${item.author}" }) {
             name


### PR DESCRIPTION
My bad, caught `keystone.executeGraphQL` in the search-replace for proper casing "Keystone"