### PR TITLE
Exit the dev process when an error is thrown

### DIFF
--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -45,6 +45,10 @@ export const dev = async () => {
     console.log(`⭐️ Dev Server Ready on http://localhost:${PORT}`);
     // Don't start initialising Keystone until the dev server is ready,
     // otherwise it slows down the first response significantly
-    initKeystone();
+    initKeystone().catch(err => {
+      console.error(`🚨 There was an error initialising Keystone`);
+      console.error(err);
+      process.exit(1);
+    });
   });
 };

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -197,6 +197,7 @@ export function storedSessions({
   };
 }
 
+// TODO: We gotta find a better name for this...
 export function sessionStuff(sessionStrategy: SessionStrategy<unknown>) {
   let isConnected = false;
   let connect = async () => {

--- a/packages-next/keystone/src/static/dev-loading.html
+++ b/packages-next/keystone/src/static/dev-loading.html
@@ -119,10 +119,12 @@
       const INTERVAL = 250;
       const statusEl = document.querySelector('#status');
       const messageEl = document.querySelector('#message');
+      const loadingEl = document.querySelector('.loading-spinner');
 
       function onError(err) {
         statusEl.innerHTML = 'Error';
         messageEl.innerHTML = 'Please check your console.';
+        loadingEl.remove();
         throw err;
       }
       function onReady() {


### PR DESCRIPTION
As it is now, errors that are thrown will be logged in the dev process but not exit the process which doesn't help draw your attention back to the terminal. This fixes that.