### PR TITLE
Fix unnecessarily refetching static admin meta in new interfaces

### DIFF
--- a/packages-next/admin-ui/src/context.tsx
+++ b/packages-next/admin-ui/src/context.tsx
@@ -35,28 +35,17 @@ type KeystoneProviderProps = {
   lazyMetadataQuery: DocumentNode;
 };
 
-export const KeystoneProvider = ({
+function InternalKeystoneProvider({
   adminConfig,
   fieldViews,
   adminMetaHash,
   children,
   lazyMetadataQuery,
-}: KeystoneProviderProps) => {
-  const apolloClient = useMemo(
-    () =>
-      new ApolloClient({
-        cache: new InMemoryCache(),
-        uri: '/api/graphql',
-      }),
-    []
-  );
-
-  const adminMeta = useAdminMeta(apolloClient, adminMetaHash, fieldViews);
+}: KeystoneProviderProps) {
+  const adminMeta = useAdminMeta(adminMetaHash, fieldViews);
   const { authenticatedItem, visibleLists, createViewFieldModes, refetch } = useLazyMetadata(
-    lazyMetadataQuery,
-    apolloClient
+    lazyMetadataQuery
   );
-
   const reinitContext = () => {
     adminMeta?.refetch?.();
     refetch();
@@ -83,10 +72,28 @@ export const KeystoneProvider = ({
             createViewFieldModes,
           }}
         >
-          <ApolloProvider client={apolloClient}>{children}</ApolloProvider>
+          {children}
         </KeystoneContext.Provider>
       </DrawerProvider>
     </ToastProvider>
+  );
+}
+
+export const KeystoneProvider = (props: KeystoneProviderProps) => {
+  const apolloClient = useMemo(
+    () =>
+      new ApolloClient({
+        cache: new InMemoryCache(),
+        uri: '/api/graphql',
+      }),
+    []
+  );
+
+  return (
+    <ApolloProvider client={apolloClient}>
+      <script src="http://localhost:8097" />
+      <InternalKeystoneProvider {...props} />
+    </ApolloProvider>
   );
 };
 

--- a/packages-next/admin-ui/src/utils/useAdminMeta.tsx
+++ b/packages-next/admin-ui/src/utils/useAdminMeta.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ApolloClient, useQuery } from '../apollo';
+import { useLazyQuery } from '../apollo';
 import hashString from '@emotion/hash';
 import { SerializedAdminMeta, AdminMeta, FieldViews, getGqlNames } from '@keystone-spike/types';
 import { StaticAdminMetaQuery, staticAdminMetaQuery } from '../admin-meta-graphql';
@@ -28,11 +28,7 @@ function useMustRenderServerResult() {
   return _mustRenderServerResult;
 }
 
-export function useAdminMeta(
-  client: ApolloClient<any>,
-  adminMetaHash: string,
-  fieldViews: FieldViews
-) {
+export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
   const adminMetaFromLocalStorage = useMemo(() => {
     if (typeof window === 'undefined') {
       return;
@@ -51,11 +47,11 @@ export function useAdminMeta(
     }
   }, []);
 
-  const { data, error, refetch } = useQuery(staticAdminMetaQuery, {
-    client,
-    skip: adminMetaFromLocalStorage !== undefined,
-  });
-
+  // it seems like Apollo doesn't skip the first fetch when using skip: true so we're using useLazyQuery instead
+  const [fetchStaticAdminMeta, { data, error, called }] = useLazyQuery(staticAdminMetaQuery);
+  if (typeof window !== 'undefined' && adminMetaFromLocalStorage === undefined && !called) {
+    fetchStaticAdminMeta();
+  }
   const runtimeAdminMeta = useMemo(() => {
     if ((!data || error) && !adminMetaFromLocalStorage) {
       return undefined;
@@ -134,7 +130,7 @@ export function useAdminMeta(
       state: 'error' as const,
       error,
       refetch: () => {
-        refetch();
+        fetchStaticAdminMeta();
       },
     };
   }

--- a/packages-next/admin-ui/src/utils/useAuthenticatedItem.tsx
+++ b/packages-next/admin-ui/src/utils/useAuthenticatedItem.tsx
@@ -1,13 +1,6 @@
 import { GraphQLError } from 'graphql';
 import { useMemo } from 'react';
-import {
-  DocumentNode,
-  useQuery,
-  ApolloClient,
-  QueryResult,
-  ServerError,
-  ServerParseError,
-} from '../apollo';
+import { DocumentNode, useQuery, QueryResult, ServerError, ServerParseError } from '../apollo';
 import { DeepNullable, makeDataGetter } from './dataGetter';
 
 export type AuthenticatedItem =
@@ -27,16 +20,14 @@ export type CreateViewFieldModes =
   | { state: 'error'; error: Error | readonly [GraphQLError, ...GraphQLError[]] };
 
 export function useLazyMetadata(
-  query: DocumentNode,
-  client: ApolloClient<any>
+  query: DocumentNode
 ): {
   authenticatedItem: AuthenticatedItem;
   refetch: () => void;
   visibleLists: VisibleLists;
   createViewFieldModes: CreateViewFieldModes;
 } {
-  let result = useQuery(query, { client, errorPolicy: 'all' });
-
+  let result = useQuery(query, { errorPolicy: 'all' });
   return useMemo(() => {
     let refetch = () => {
       result.refetch();


### PR DESCRIPTION
@JedWatson this doesn't actually fix the Safari issue, I just found that we were always refetching while I was looking into it