### PR TITLE
fix(knex-adapter): prepend relation tables with schema name in dropDatabase method

### DIFF
--- a/.changeset/silver-dryers-mate.md
+++ b/.changeset/silver-dryers-mate.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-knex': patch
+---
+
+prepend relation tables with schema in dropDatabase method

--- a/.changeset/silver-dryers-mate.md
+++ b/.changeset/silver-dryers-mate.md
@@ -2,4 +2,4 @@
 '@keystonejs/adapter-knex': patch
 ---
 
-prepend relation tables with schema in dropDatabase method
+Fixed bug in `.dropDatabase()`, relationship join tables are now correctly dropped when using a non-default `schemaName`.

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -222,7 +222,7 @@ class KnexAdapter extends BaseKeystoneAdapter {
       ),
       ...this.rels
         .filter(({ cardinality }) => cardinality === 'N:N')
-        .map(({ tableName }) => tableName),
+        .map(({ tableName }) => `"${this.schemaName}"."${tableName}"`),
     ].join(',');
     return this.knex.raw(`DROP TABLE IF EXISTS ${tables} CASCADE`);
   }


### PR DESCRIPTION
The `dropDatabase` method doesn't delete relation tables because schema name is not defined.
This P.R simply prepends the schema name to relation tables.