### PR TITLE
Ui tweaks new interface - segmented control wrap and width

### DIFF
--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -155,6 +155,8 @@ const Root = forwardRef<HTMLDivElement, RootProps>(({ fill, size, ...props }, re
         // -- TODO
         background: fields.inputBackground,
         display: fill ? 'flex' : 'inline-flex',
+        flexWrap: 'wrap',
+        justifyContent: 'space-between',
         lineHeight: 1,
         position: 'relative',
       }}

--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -33,7 +33,7 @@ import {
   VisuallyHidden,
 } from '@keystone-ui/core';
 
-import { SizeKey, useControlTokens } from './hooks/segmentedControl';
+import { SizeKey, WidthKey, useControlTokens } from './hooks/segmentedControl';
 
 type Index = number;
 
@@ -45,7 +45,7 @@ type SegmentedControlProps = {
   animate?: boolean;
   /** Whether the controls should take up the full width of their container. */
   fill?: boolean;
-  /** Provide an inital index for an uncontrolled segmented control. */
+  /** Provide an initial index for an uncontrolled segmented control. */
   initialIndex?: Index;
   /** Function to be called when one of the segments is selected. */
   onChange?: ManagedChangeHandler<Index>;
@@ -55,6 +55,8 @@ type SegmentedControlProps = {
   selectedIndex?: Index;
   /** The size of the controls. */
   size?: SizeKey;
+  /** The width of the controls. */
+  width?: WidthKey;
 } & BoxProps;
 
 export const SegmentedControl = ({
@@ -64,6 +66,7 @@ export const SegmentedControl = ({
   onChange: onChangeProp,
   segments,
   size = 'medium',
+  width = 'large',
   selectedIndex: selectedIndexProp,
   ...props
 }: SegmentedControlProps) => {
@@ -105,7 +108,7 @@ export const SegmentedControl = ({
 
   return (
     <Box {...props}>
-      <Root fill={fill} size={size} ref={rootRef}>
+      <Root fill={fill} size={size} ref={rootRef} width={width}>
         {segments.map((label, idx) => {
           const isSelected = selectedIndex === idx;
 
@@ -136,11 +139,12 @@ export const SegmentedControl = ({
 type RootProps = {
   fill: boolean;
   size: SizeKey;
+  width: WidthKey;
 } & HTMLAttributes<HTMLDivElement>;
 
-const Root = forwardRef<HTMLDivElement, RootProps>(({ fill, size, ...props }, ref) => {
+const Root = forwardRef<HTMLDivElement, RootProps>(({ fill, size, width, ...props }, ref) => {
   const { fields } = useTheme();
-  const tokens = useControlTokens({ size });
+  const tokens = useControlTokens({ size, width });
 
   return (
     <div
@@ -156,6 +160,7 @@ const Root = forwardRef<HTMLDivElement, RootProps>(({ fill, size, ...props }, re
         background: fields.inputBackground,
         display: fill ? 'flex' : 'inline-flex',
         flexWrap: 'wrap',
+        maxWidth: tokens.width,
         justifyContent: 'space-between',
         lineHeight: 1,
         position: 'relative',

--- a/design-system/packages/segmented-control/src/hooks/segmentedControl.ts
+++ b/design-system/packages/segmented-control/src/hooks/segmentedControl.ts
@@ -2,24 +2,40 @@ import { useTheme } from '@keystone-ui/core';
 
 export const segmentedControlSizeValues = ['large', 'medium', 'small'] as const;
 
+// TODO: Move to theme.
+export const widthMap = {
+  small: 128,
+  medium: 256,
+  large: 512,
+  full: '100%',
+};
+
 export type SizeKey = typeof segmentedControlSizeValues[number];
+export type WidthKey = 'small' | 'medium' | 'large' | 'full';
 
 export type ControlTokensProps = {
   size: SizeKey;
+  width: WidthKey;
 };
 export type ControlTokens = {
   borderRadius: number | string;
   paddingX: number | string;
   paddingY: number | string;
+  width: number | string;
 };
 
-export const useControlTokens = ({ size: sizeKey }: ControlTokensProps): ControlTokens => {
+export const useControlTokens = ({
+  size: sizeKey,
+  width: widthKey,
+}: ControlTokensProps): ControlTokens => {
   const { controlSizes } = useTheme();
   const size = controlSizes[sizeKey];
+  const width = widthMap[widthKey];
   return {
     borderRadius: size.borderRadius,
     paddingX: size.gutter,
     paddingY: size.gutter,
+    width,
   };
 };
 


### PR DESCRIPTION
ref #4005 

was able to fix the width as well as wrap on this but not able to fix the relationship field. 

![image](https://user-images.githubusercontent.com/5769869/97057454-d9efea00-15a8-11eb-9a9a-27302c32a0b9.png)

tried using token system. (still TODO for theme based width - not my expertise yet)