### PR TITLE
Pin package version to allow yarn.lock clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     ]
   },
   "resolutions": {
+    "babel-plugin-remove-graphql-queries": "2.7.2",
     "graphql-upload": "^11.0.0",
     "gatsby-cli": "2.7.15",
     "gatsby-link": "2.2.2",


### PR DESCRIPTION
This should allow the yarn.lock cleaning PR from renovate bot to go through 🤞 