### PR TITLE
Rename session.item to session.data

### DIFF
--- a/examples-next/auth/schema.ts
+++ b/examples-next/auth/schema.ts
@@ -5,11 +5,11 @@ export const lists = createSchema({
   User: list({
     access: {
       // Only allow admins to delete users
-      delete: ({ session }) => session?.item?.isAdmin,
+      delete: ({ session }) => session?.data?.isAdmin,
     },
     admin: {
       // Since you can't delete users unless you're an admin, we hide the UI for it
-      hideDelete: ({ session }) => !session?.item?.isAdmin,
+      hideDelete: ({ session }) => !session?.data?.isAdmin,
       listView: {
         // These are the default columns that will be displayed in the list view
         initialColumns: ['name', 'email', 'isAdmin'],
@@ -29,17 +29,17 @@ export const lists = createSchema({
           // Passwords can always be set when creating items
           // Users can change their own passwords, and Admins can change anyone's password
           update: ({ session, item }) =>
-            session && (session.item.isAdmin || session.itemId === item.id),
+            session && (session.data.isAdmin || session.itemId === item.id),
         },
         admin: {
           // Based on the same logic as update access, the password field is editable.
           // The password field is hidden from non-Admin users (except for themselves)
           // createView: {
-          //   fieldMode: ({ session }) => (session?.item?.isAdmin ? 'edit' : 'hidden'),
+          //   fieldMode: ({ session }) => (session?.data?.isAdmin ? 'edit' : 'hidden'),
           // },
           itemView: {
             fieldMode: ({ session, item }) =>
-              session && (session.item.isAdmin || session.itemId === item.id) ? 'edit' : 'hidden',
+              session && (session.data.isAdmin || session.itemId === item.id) ? 'edit' : 'hidden',
           },
           listView: {
             fieldMode: ({ session }) => (session?.item?.isAdmin ? 'read' : 'hidden'),
@@ -50,16 +50,16 @@ export const lists = createSchema({
       isAdmin: checkbox({
         access: {
           // Only Admins can set the isAdmin flag for any users
-          // create: ({ session }) => session?.item.isAdmin,
-          update: ({ session }) => session?.item.isAdmin,
+          // create: ({ session }) => session?.data.isAdmin,
+          update: ({ session }) => session?.data.isAdmin,
         },
         admin: {
           // All users can see the isAdmin status, only admins can change it
           // createView: {
-          //   fieldMode: ({ session }) => (session?.item.isAdmin ? 'edit' : 'hidden'),
+          //   fieldMode: ({ session }) => (session?.data.isAdmin ? 'edit' : 'hidden'),
           // },
           itemView: {
-            fieldMode: ({ session }) => (session?.item.isAdmin ? 'edit' : 'read'),
+            fieldMode: ({ session }) => (session?.data.isAdmin ? 'edit' : 'read'),
           },
         },
       }),
@@ -68,13 +68,13 @@ export const lists = createSchema({
       isEnabled: checkbox({
         access: {
           // Only Admins can change the isEnabled flag for any users
-          // create: ({ session }) => session?.item.isAdmin,
-          update: ({ session }) => session?.item.isAdmin,
+          // create: ({ session }) => session?.data.isAdmin,
+          update: ({ session }) => session?.data.isAdmin,
         },
         admin: {
           // All users can see the isEnabled status, only admins can change it
           itemView: {
-            fieldMode: ({ session }) => (session?.item.isAdmin ? 'edit' : 'read'),
+            fieldMode: ({ session }) => (session?.data.isAdmin ? 'edit' : 'read'),
           },
         },
       }),

--- a/packages-next/keystone/src/classes/Keystone.ts
+++ b/packages-next/keystone/src/classes/Keystone.ts
@@ -9,7 +9,7 @@ import type {
   SessionContext,
   FieldType,
 } from '@keystone-next/types';
-import { sessionStuff } from '../session';
+import { implementSession } from '../session';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { mergeSchemas } from '@graphql-tools/merge';
 import { gql } from '../schema';
@@ -113,7 +113,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
     schemaName: 'public',
     dev: process.env.NODE_ENV === 'development',
   });
-  let sessionThing = sessionStrategy ? sessionStuff(sessionStrategy) : undefined;
+  let sessionImplementation = sessionStrategy ? implementSession(sessionStrategy) : undefined;
   const schemaFromApolloServer: GraphQLSchema = server.schema;
   const schema = mapSchema(schemaFromApolloServer, {
     'MapperKind.OBJECT_TYPE'(type) {
@@ -160,7 +160,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
     adminMeta,
     graphQLSchema,
     isAccessAllowed:
-      sessionThing === undefined
+      sessionImplementation === undefined
         ? undefined
         : config.admin?.isAccessAllowed ?? (({ session }) => session !== undefined),
     config,
@@ -189,7 +189,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
     crud[listKey] = crudForList((keystone as any).lists[listKey], graphQLSchema, createContext);
   }
 
-  const createSessionContext = sessionThing?.createContext;
+  const createSessionContext = sessionImplementation?.createContext;
   let keystoneThing = {
     keystone,
     adminMeta,
@@ -202,7 +202,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
       : undefined,
     createContext,
     async createContextFromRequest(req: IncomingMessage, res: ServerResponse) {
-      let sessionContext = await sessionThing?.createContext(req, res, keystoneThing);
+      let sessionContext = await sessionImplementation?.createContext(req, res, keystoneThing);
 
       return createContext({ sessionContext });
     },

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -75,9 +75,9 @@ type CreateSession = ReturnType<typeof statelessSessions>;
 
 export function withItemData(createSession: CreateSession, fieldSelections: FieldSelections) {
   return (): SessionStrategy<any> => {
-    const { get, ...sessionThing } = createSession();
+    const { get, ...sessionStrategy } = createSession();
     return {
-      ...sessionThing,
+      ...sessionStrategy,
       get: async ({ req, keystone }) => {
         const session = await get({ req, keystone });
         if (!session) return;
@@ -101,7 +101,7 @@ export function withItemData(createSession: CreateSession, fieldSelections: Fiel
         if (!result?.data?.item) {
           return;
         }
-        return { ...session, item: result.data.item };
+        return { ...session, data: result.data.item };
       },
     };
   };
@@ -200,8 +200,10 @@ export function storedSessions({
   };
 }
 
-// TODO: We gotta find a better name for this...
-export function sessionStuff(sessionStrategy: SessionStrategy<unknown>) {
+/**
+ * This is the function createKeystone uses to implement the session strategy provided
+ */
+export function implementSession(sessionStrategy: SessionStrategy<unknown>) {
   let isConnected = false;
   let connect = async () => {
     await sessionStrategy.connect?.();


### PR DESCRIPTION
Follow up to #4074

I'm renaming the property `withItemData(sessionStrategy)` adds to the session from `session.item` to `session.data`

This importantly distinguishes it from the `item` argument.

Basically, we need to start being clearer about when what you're working with is an item **backing type** (i.e the raw result of loading the item data from the database through the adapter; equivalent to `select * from {list.table} where id = {itemId}`) as opposed to **item data** that's been transformed by the field resolvers (i.e what you'd retrieve through a GraphQL query)

In access control (and similar) functions, the provided `item` gives you the backing type for the item in question. This means you get all the data for the item stored in the database, which may include private information like password hashes and won't include any dynamic properties like virtual fields.

Since `withItemData` takes a field selection set and loads those fields from the GraphQL resolvers, I think we should call it `data` instead because what you're getting will be very different from the `item` argument (i.e you only get the requested fields, which cannot include private information from the database, and may include dynamic properties).

Because you can request dynamic properties, you can add things like virtual fields or deeply nested relationship data to the session as well -- which is great! but importantly is **not** the "item" that the session represents.

It's subtle, but important, and I think helps make the new session implementation (where you get the **item data** in the new `session` argument) more clearly differentiated from the previous session implementation (where you got the **item backing type** in the `authentication` argument)

cc/ @timleslie @molomby @mitchellhamilton @jesstelford 