### PR TITLE
Make field config optional where possible

### DIFF
--- a/packages-next/fields/src/types/autoIncrement/index.ts
+++ b/packages-next/fields/src/types/autoIncrement/index.ts
@@ -12,7 +12,7 @@ export type AutoIncrementFieldConfig<
 const views = resolveView('integer/views');
 
 export const autoIncrement = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: AutoIncrementFieldConfig<TGeneratedListTypes>
+  config: AutoIncrementFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: AutoIncrement,
   config: config,

--- a/packages-next/fields/src/types/checkbox/index.ts
+++ b/packages-next/fields/src/types/checkbox/index.ts
@@ -13,7 +13,7 @@ export type CheckboxFieldConfig<TGeneratedListTypes extends BaseGeneratedListTyp
 const views = resolveView('checkbox/views');
 
 export const checkbox = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: CheckboxFieldConfig<TGeneratedListTypes>
+  config: CheckboxFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: Checkbox,
   config: config,

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -11,7 +11,7 @@ export type IntegerFieldConfig<TGeneratedListTypes extends BaseGeneratedListType
 const views = resolveView('integer/views');
 
 export const integer = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: IntegerFieldConfig<TGeneratedListTypes>
+  config: IntegerFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: Integer,
   config: config,

--- a/packages-next/fields/src/types/password/index.ts
+++ b/packages-next/fields/src/types/password/index.ts
@@ -16,7 +16,7 @@ type PasswordFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = F
 };
 
 export const password = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: PasswordFieldConfig<TGeneratedListTypes>
+  config: PasswordFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: Password,
   config,

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -19,7 +19,7 @@ export type TextFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> 
 const views = resolveView('text/views');
 
 export const text = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: TextFieldConfig<TGeneratedListTypes>
+  config: TextFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: Text,
   config,

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -17,7 +17,7 @@ export type TimestampFieldConfig<TGeneratedListTypes extends BaseGeneratedListTy
 const views = resolveView('timestamp/views');
 
 export const timestamp = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: TimestampFieldConfig<TGeneratedListTypes>
+  config: TimestampFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: DateTimeUtc,
   config,


### PR DESCRIPTION
This just simplifies schema definition so you don't need to pass an empty config object when all the config fields are optional

before:

```js
fields: {
  name: text({})
}
```

after:

```js
fields: {
  name: text()
}
```