### PR TITLE
Move createKeystone to lib

### DIFF
--- a/packages-next/TODO.md
+++ b/packages-next/TODO.md
@@ -24,4 +24,6 @@
 
 ## Next steps after alpha release
 
+- [ ] Review how we're returning errors from the GraphQL API
+- [ ] Review how the search field (and query input) works
 - [ ] Revisit design system and theming

--- a/packages-next/keystone/src/index.ts
+++ b/packages-next/keystone/src/index.ts
@@ -1,1 +1,1 @@
-export { createKeystone } from './classes/Keystone';
+export { createKeystone } from './lib/createKeystone';

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -15,9 +15,9 @@ import { mergeSchemas } from '@graphql-tools/merge';
 import { gql } from '../schema';
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 import { mapSchema } from '@graphql-tools/utils';
-import { crudForList } from '../lib/crud-api';
+import { crudForList } from './crud-api';
 import { adminMetaSchemaExtension } from '@keystone-next/admin-ui/templates';
-import { accessControlContext, skipAccessControlContext } from '../lib/createAccessControlContext';
+import { accessControlContext, skipAccessControlContext } from './createAccessControlContext';
 import { autoIncrement, mongoId } from '@keystone-next/fields';
 
 export function createKeystone(config: KeystoneConfig): Keystone {

--- a/packages-next/keystone/src/lib/initKeystoneFromConfig.ts
+++ b/packages-next/keystone/src/lib/initKeystoneFromConfig.ts
@@ -1,5 +1,5 @@
 import type { KeystoneConfig } from '@keystone-next/types';
-import { createKeystone } from '../classes/Keystone';
+import { createKeystone } from './createKeystone';
 import { requireProjectFile } from './requireSource';
 
 export const initKeystoneFromConfig = () => {


### PR DESCRIPTION
The `createKeystone` function was left in `classes` when we refactored it from a class to a function. This just moves it into the `lib` folder with the rest of the main keystone functions, which I think makes more sense for people new to the codebase.

(also added a couple of TODOs, not worth an additional PR)