### PR TITLE
Update resolveInput hook documentation

### DIFF
--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -176,6 +176,11 @@ const resolveInput = ({
 }) => {
   // Input resolution logic. Object returned is used in place of `resolvedData`.
   return resolvedData;
+  // This will not work.
+  return { ...resolvedData, listField: <value> };
+  // Do this instead.
+  resolvedData.listField = <value>
+  return resolvedData;
 };
 ```
 


### PR DESCRIPTION
specific thing which does not work.

```js
const resolveInput = ({
  operation,
  existingItem,
  originalInput,
  resolvedData,
  context,
  listKey,
  fieldPath, // exists only for field hooks
}) => {
  // Input resolution logic. Object returned is used in place of `resolvedData`.
  return resolvedData;
  // This will not work.
  return { ...resolvedData, listField: <value> }; // this did eat some of my time which I may have saved.
  // Do this instead.
  resolvedData.listField = <value>
  return resolvedData;
};
```