### PR TITLE
Rename admin config key to ui

### DIFF
--- a/examples-next/auth/keystone.ts
+++ b/examples-next/auth/keystone.ts
@@ -62,7 +62,7 @@ export default withAuth(
       url: 'mongodb://localhost/keystone-examples-next-auth',
     },
     lists,
-    admin: {},
+    ui: {},
     session: withItemData(
       // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie
       statelessSessions({

--- a/examples-next/auth/schema.ts
+++ b/examples-next/auth/schema.ts
@@ -7,7 +7,7 @@ export const lists = createSchema({
       // Only allow admins to delete users
       delete: ({ session }) => session?.data?.isAdmin,
     },
-    admin: {
+    ui: {
       // Since you can't delete users unless you're an admin, we hide the UI for it
       hideDelete: ({ session }) => !session?.data?.isAdmin,
       listView: {
@@ -31,7 +31,7 @@ export const lists = createSchema({
           update: ({ session, item }) =>
             session && (session.data.isAdmin || session.itemId === item.id),
         },
-        admin: {
+        ui: {
           // Based on the same logic as update access, the password field is editable.
           // The password field is hidden from non-Admin users (except for themselves)
           // createView: {
@@ -53,7 +53,7 @@ export const lists = createSchema({
           // create: ({ session }) => session?.data.isAdmin,
           update: ({ session }) => session?.data.isAdmin,
         },
-        admin: {
+        ui: {
           // All users can see the isAdmin status, only admins can change it
           // createView: {
           //   fieldMode: ({ session }) => (session?.data.isAdmin ? 'edit' : 'hidden'),
@@ -71,7 +71,7 @@ export const lists = createSchema({
           // create: ({ session }) => session?.data.isAdmin,
           update: ({ session }) => session?.data.isAdmin,
         },
-        admin: {
+        ui: {
           // All users can see the isEnabled status, only admins can change it
           itemView: {
             fieldMode: ({ session }) => (session?.data.isAdmin ? 'edit' : 'read'),

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -33,20 +33,10 @@ export default auth.withAuth(
       // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
       path: '/api/graphql',
     },
-    admin: {
+    ui: {
       // NOTE -- this is not implemented, keystone currently always provides an admin ui at /
       path: '/admin',
       // isAccessAllowed,
-      /* TODO -- Create a separate example for custom pages in the Admin UI */
-      getAdditionalFiles: [
-        () => [
-          {
-            mode: 'write',
-            outputPath: 'pages/custom.js',
-            src: 'export default function Something() { return "This is a custom page." }',
-          },
-        ],
-      ],
     },
     lists,
     extendGraphqlSchema,

--- a/examples-next/basic/schema.ts
+++ b/examples-next/basic/schema.ts
@@ -31,7 +31,7 @@ const randomNumber = () => Math.round(Math.random() * 10);
 
 export const lists = createSchema({
   User: list({
-    admin: {
+    ui: {
       listView: {
         initialColumns: ['name', 'posts'],
       },
@@ -46,7 +46,7 @@ export const lists = createSchema({
           read: access.isAdmin,
           update: access.isAdmin,
         },
-        admin: {
+        ui: {
           createView: {
             fieldMode: args => (access.isAdmin(args) ? 'edit' : 'hidden'),
           },
@@ -65,7 +65,7 @@ export const lists = createSchema({
     },
   }),
   Post: list({
-    admin: {
+    ui: {
       labelField: 'title',
     },
     fields: {
@@ -75,12 +75,12 @@ export const lists = createSchema({
           { label: 'Published', value: 'published' },
           { label: 'Draft', value: 'draft' },
         ],
-        admin: {
+        ui: {
           displayMode: 'segmented-control',
         },
       }),
       content: text({
-        admin: {
+        ui: {
           views: require.resolve('./admin/fieldViews/Content.tsx'),
         },
       }),

--- a/packages-next/TODO.md
+++ b/packages-next/TODO.md
@@ -3,7 +3,7 @@
 - [x] Make it work for JS
 - [ ] Test package installs with local registry (use pnpm first to find missing deps)
 - [ ] Make sure we have the right peerDeps
-- [ ] Rename `admin` to `ui` in config
+- [x] Rename `admin` to `ui` in config
 - [ ] Publish the packages to a preview scope (`@keystone-next`)
 - [ ] Clean up stable set of features
   - [ ] Custom views @mitchell

--- a/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
+++ b/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
@@ -160,15 +160,15 @@ export function adminMetaSchemaExtension({
       },
       KeystoneAdminUIListMeta: {
         isHidden(rootVal: ListMetaRootVal, args: any, { session }: any) {
-          return runMaybeFunction(config.lists[rootVal.key].admin?.isHidden, false, { session });
+          return runMaybeFunction(config.lists[rootVal.key].ui?.isHidden, false, { session });
         },
         hideDelete(rootVal: ListMetaRootVal, args: any, { session }: any) {
-          return runMaybeFunction(config.lists[rootVal.key].admin?.hideDelete, false, {
+          return runMaybeFunction(config.lists[rootVal.key].ui?.hideDelete, false, {
             session,
           });
         },
         hideCreate(rootVal: ListMetaRootVal, args: any, { session }: any) {
-          return runMaybeFunction(config.lists[rootVal.key].admin?.hideCreate, false, {
+          return runMaybeFunction(config.lists[rootVal.key].ui?.hideCreate, false, {
             session,
           });
         },
@@ -200,8 +200,8 @@ export function adminMetaSchemaExtension({
       KeystoneAdminUIFieldMetaCreateView: {
         fieldMode(rootVal: FieldIdentifier, args: any, { session }: any) {
           return runMaybeFunction(
-            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.admin?.createView
-              ?.fieldMode ?? config.lists[rootVal.listKey].admin?.createView?.defaultFieldMode,
+            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.ui?.createView
+              ?.fieldMode ?? config.lists[rootVal.listKey].ui?.createView?.defaultFieldMode,
             'edit',
             { session }
           );
@@ -210,8 +210,8 @@ export function adminMetaSchemaExtension({
       KeystoneAdminUIFieldMetaListView: {
         fieldMode(rootVal: FieldIdentifier, args: any, { session }: any) {
           return runMaybeFunction(
-            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.admin?.listView
-              ?.fieldMode ?? config.lists[rootVal.listKey].admin?.listView?.defaultFieldMode,
+            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.ui?.listView
+              ?.fieldMode ?? config.lists[rootVal.listKey].ui?.listView?.defaultFieldMode,
             'read',
             { session }
           );
@@ -226,8 +226,8 @@ export function adminMetaSchemaExtension({
           const item = await crud[rootVal.listKey].findOne({ where: { id: rootVal.itemId } });
 
           return runMaybeFunction(
-            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.admin?.itemView
-              ?.fieldMode ?? config.lists[rootVal.listKey].admin?.itemView?.defaultFieldMode,
+            config.lists[rootVal.listKey].fields[rootVal.fieldPath].config.ui?.itemView
+              ?.fieldMode ?? config.lists[rootVal.listKey].ui?.itemView?.defaultFieldMode,
             'edit',
             { session, item }
           );

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -61,7 +61,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   // updated to use our crud API, we can set these to static false values.
   const fieldConfig = {
     access: () => false,
-    admin: {
+    ui: {
       createView: { fieldMode: 'hidden' },
       itemView: { fieldMode: 'hidden' },
       listView: { fieldMode: 'hidden' },
@@ -80,14 +80,14 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   /**
    * adminPageMiddleware
    *
-   * Should be added to the admin.pageMiddleware stack.
+   * Should be added to the ui.pageMiddleware stack.
    *
    * Redirects:
    *  - from the signin or init pages to the index when a valid session is present
    *  - to the init page when initFirstItem is configured, and there are no user in the database
    *  - to the signin page when no valid session is present
    */
-  const adminPageMiddleware: Auth['admin']['pageMiddleware'] = async ({
+  const adminPageMiddleware: Auth['ui']['pageMiddleware'] = async ({
     req,
     isValidSession,
     keystone,
@@ -135,11 +135,11 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    * additionalFiles
    *
    * This function adds files to be generated into the Admin UI build. Must be added to the
-   * admin.additionalFiles config.
+   * ui.additionalFiles config.
    *
    * The signin page is always included, and the init page is included when initFirstItem is set
    */
-  const additionalFiles: Auth['admin']['getAdditionalFiles'] = keystone => {
+  const additionalFiles: Auth['ui']['getAdditionalFiles'] = keystone => {
     let filesToWrite: AdminFileToWrite[] = [
       {
         mode: 'write',
@@ -164,11 +164,11 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   };
 
   /**
-   * adminPublicPages
+   * uiPublicPages
    *
-   * Must be added to the admin.publicPages config
+   * Must be added to the ui.publicPages config
    */
-  const adminPublicPages = ['/signin', '/init'];
+  const uiPublicPages = ['/signin', '/init'];
 
   /**
    * extendGraphqlSchema
@@ -320,18 +320,18 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    * the way auth is set up with custom functionality.
    *
    * It validates the auth config against the provided keystone config, and preserves existing
-   * config by composing existing extendGraphqlSchema functions and admin config.
+   * config by composing existing extendGraphqlSchema functions and ui config.
    */
   const withAuth = (keystoneConfig: KeystoneConfig): KeystoneConfig => {
     validateConfig(keystoneConfig);
-    let admin = keystoneConfig.admin;
-    if (keystoneConfig.admin) {
-      admin = {
-        ...keystoneConfig.admin,
-        publicPages: [...(keystoneConfig.admin.publicPages || []), ...adminPublicPages],
-        getAdditionalFiles: [...(keystoneConfig.admin.getAdditionalFiles || []), additionalFiles],
+    let ui = keystoneConfig.ui;
+    if (ui) {
+      ui = {
+        ...ui,
+        publicPages: [...(ui.publicPages || []), ...uiPublicPages],
+        getAdditionalFiles: [...(ui.getAdditionalFiles || []), additionalFiles],
         pageMiddleware: async args => {
-          return (await adminPageMiddleware(args)) ?? keystoneConfig.admin?.pageMiddleware?.(args);
+          return (await adminPageMiddleware(args)) ?? ui?.pageMiddleware?.(args);
         },
         enableSessionItem: true,
       };
@@ -340,7 +340,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
 
     return {
       ...keystoneConfig,
-      admin,
+      ui,
       // Add the additional fields to the references lists fields object
       // TODO: The additionalListFields we're adding here shouldn't naively replace existing fields with the same key
       // Leaving existing fields in place would allow solution devs to customise these field defs (eg. access control,
@@ -368,10 +368,10 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    * your keystone config by hand.
    */
   return {
-    admin: {
+    ui: {
       enableSessionItem: true,
       pageMiddleware: adminPageMiddleware,
-      publicPages: adminPublicPages,
+      publicPages: uiPublicPages,
       getAdditionalFiles: additionalFiles,
     },
     fields: additionalListFields,

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -164,11 +164,11 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   };
 
   /**
-   * uiPublicPages
+   * publicAuthPages
    *
    * Must be added to the ui.publicPages config
    */
-  const uiPublicPages = ['/signin', '/init'];
+  const publicAuthPages = ['/signin', '/init'];
 
   /**
    * extendGraphqlSchema
@@ -325,11 +325,11 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   const withAuth = (keystoneConfig: KeystoneConfig): KeystoneConfig => {
     validateConfig(keystoneConfig);
     let ui = keystoneConfig.ui;
-    if (ui) {
+    if (keystoneConfig.ui) {
       ui = {
-        ...ui,
-        publicPages: [...(ui.publicPages || []), ...uiPublicPages],
-        getAdditionalFiles: [...(ui.getAdditionalFiles || []), additionalFiles],
+        ...keystoneConfig.ui,
+        publicPages: [...(keystoneConfig.ui.publicPages || []), ...publicAuthPages],
+        getAdditionalFiles: [...(keystoneConfig.ui.getAdditionalFiles || []), additionalFiles],
         pageMiddleware: async args => {
           return (await adminPageMiddleware(args)) ?? ui?.pageMiddleware?.(args);
         },
@@ -371,7 +371,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     ui: {
       enableSessionItem: true,
       pageMiddleware: adminPageMiddleware,
-      publicPages: uiPublicPages,
+      publicPages: publicAuthPages,
       getAdditionalFiles: additionalFiles,
     },
     fields: additionalListFields,

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -331,7 +331,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
         publicPages: [...(keystoneConfig.ui.publicPages || []), ...publicAuthPages],
         getAdditionalFiles: [...(keystoneConfig.ui.getAdditionalFiles || []), additionalFiles],
         pageMiddleware: async args => {
-          return (await adminPageMiddleware(args)) ?? ui?.pageMiddleware?.(args);
+          return (await adminPageMiddleware(args)) ?? keystoneConfig?.ui?.pageMiddleware?.(args);
         },
         enableSessionItem: true,
       };

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -1,4 +1,8 @@
-import { BaseGeneratedListTypes, KeystoneAdminConfig, KeystoneConfig } from '@keystone-next/types';
+import {
+  BaseGeneratedListTypes,
+  KeystoneAdminUIConfig,
+  KeystoneConfig,
+} from '@keystone-next/types';
 
 export type AuthGqlNames = {
   CreateInitialInput: string;
@@ -61,11 +65,11 @@ export type AuthConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {
 };
 
 export type Auth = {
-  admin: {
-    enableSessionItem: NonNullable<KeystoneAdminConfig['enableSessionItem']>;
-    publicPages: NonNullable<KeystoneAdminConfig['publicPages']>;
-    pageMiddleware: NonNullable<KeystoneAdminConfig['pageMiddleware']>;
-    getAdditionalFiles: NonNullable<KeystoneAdminConfig['getAdditionalFiles']>[number];
+  ui: {
+    enableSessionItem: NonNullable<KeystoneAdminUIConfig['enableSessionItem']>;
+    publicPages: NonNullable<KeystoneAdminUIConfig['publicPages']>;
+    pageMiddleware: NonNullable<KeystoneAdminUIConfig['pageMiddleware']>;
+    getAdditionalFiles: NonNullable<KeystoneAdminUIConfig['getAdditionalFiles']>[number];
   };
   extendGraphqlSchema: NonNullable<KeystoneConfig['extendGraphqlSchema']>;
   fields: { [prop: string]: any };

--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -10,7 +10,7 @@ export type RelationshipFieldConfig<
 > = FieldConfig<TGeneratedListTypes> & {
   many?: boolean;
   ref: string;
-  admin?: {
+  ui?: {
     hideCreate?: boolean;
   };
 };
@@ -29,7 +29,7 @@ export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>
       refListKey,
       refLabelField: adminMeta.lists[refListKey].labelField,
       many: config.many ?? false,
-      hideCreate: config.admin?.hideCreate ?? false,
+      hideCreate: config.ui?.hideCreate ?? false,
     };
   },
   getBackingType(path) {

--- a/packages-next/fields/src/types/select/index.ts
+++ b/packages-next/fields/src/types/select/index.ts
@@ -18,7 +18,7 @@ export type SelectFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes
         dataType: 'integer';
       }
   ) & {
-    admin?: {
+    ui?: {
       displayMode?: 'select' | 'segmented-control';
     };
   };
@@ -33,7 +33,7 @@ export const select = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   getAdminMeta: () => ({
     options: config.options,
     dataType: config.dataType ?? 'string',
-    displayMode: config.admin?.displayMode ?? 'select',
+    displayMode: config.ui?.displayMode ?? 'select',
   }),
   views,
   getBackingType(path: string) {

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -11,7 +11,7 @@ export type TextFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> 
   defaultValue?: string;
   isRequired?: boolean;
   isUnique?: boolean;
-  admin?: {
+  ui?: {
     displayMode?: 'input' | 'textarea';
   };
 };
@@ -24,7 +24,7 @@ export const text = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   type: Text,
   config,
   getAdminMeta: () => ({
-    displayMode: config.admin?.displayMode ?? 'input',
+    displayMode: config.ui?.displayMode ?? 'input',
   }),
   views,
   getBackingType(path: string) {

--- a/packages-next/keystone/src/lib/createAdminUIServer.ts
+++ b/packages-next/keystone/src/lib/createAdminUIServer.ts
@@ -33,7 +33,7 @@ export const createAdminUIServer = async (keystone: Keystone) => {
   });
   apolloServer.applyMiddleware({ app: server, path: '/api/graphql' });
 
-  const publicPages = keystone.config.admin?.publicPages ?? [];
+  const publicPages = keystone.config.ui?.publicPages ?? [];
 
   server.use(async (req, res) => {
     const { pathname } = url.parse(req.url);
@@ -42,10 +42,10 @@ export const createAdminUIServer = async (keystone: Keystone) => {
       return;
     }
     const session = (await keystone.createSessionContext?.(req, res))?.session;
-    const isValidSession = keystone.config.admin?.isAccessAllowed
-      ? await keystone.config.admin.isAccessAllowed({ session })
+    const isValidSession = keystone.config.ui?.isAccessAllowed
+      ? await keystone.config.ui.isAccessAllowed({ session })
       : session !== undefined;
-    const maybeRedirect = await keystone.config.admin?.pageMiddleware?.({
+    const maybeRedirect = await keystone.config.ui?.pageMiddleware?.({
       req,
       session,
       isValidSession,

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -21,7 +21,7 @@ import { accessControlContext, skipAccessControlContext } from './createAccessCo
 import { autoIncrement, mongoId } from '@keystone-next/fields';
 
 export function createKeystone(config: KeystoneConfig): Keystone {
-  config = validateConfig(config);
+  config = applyIdFieldDefaults(config);
 
   let keystone = new BaseKeystone({
     name: config.name,
@@ -210,9 +210,8 @@ export function createKeystone(config: KeystoneConfig): Keystone {
   return keystoneThing;
 }
 
-/** Validates and defaults the Keystone Config */
-function validateConfig(config: KeystoneConfig): KeystoneConfig {
-  /* Validate lists config and default the id field */
+/* Validate lists config and default the id field */
+function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig {
   const lists: KeystoneConfig['lists'] = {};
   Object.keys(config.lists).forEach(key => {
     const listConfig = config.lists[key];

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -21,7 +21,7 @@ import { accessControlContext, skipAccessControlContext } from './createAccessCo
 import { autoIncrement, mongoId } from '@keystone-next/fields';
 
 export function createKeystone(config: KeystoneConfig): Keystone {
-  config = applyIdFieldDefaults(config);
+  config = validateConfig(config);
 
   let keystone = new BaseKeystone({
     name: config.name,
@@ -36,7 +36,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
   const sessionStrategy = config.session?.();
 
   const adminMeta: SerializedAdminMeta = {
-    enableSessionItem: config.admin?.enableSessionItem || false,
+    enableSessionItem: config.ui?.enableSessionItem || false,
     enableSignout: sessionStrategy?.end !== undefined,
     lists: {},
   };
@@ -69,22 +69,21 @@ export function createKeystone(config: KeystoneConfig): Keystone {
       hooks: listConfig.hooks,
     } as any) as any;
     const labelField =
-      (listConfig.admin?.labelField as string | undefined) ??
-      (listConfig.fields.name ? 'name' : 'id');
+      (listConfig.ui?.labelField as string | undefined) ?? (listConfig.fields.name ? 'name' : 'id');
     adminMeta.lists[key] = {
       key,
       labelField,
-      description: listConfig.admin?.description ?? listConfig.description ?? null,
+      description: listConfig.ui?.description ?? listConfig.description ?? null,
       label: list.adminUILabels.label,
       singular: list.adminUILabels.singular,
       plural: list.adminUILabels.plural,
       path: list.adminUILabels.path,
       fields: {},
-      pageSize: listConfig.admin?.listView?.pageSize ?? 50,
+      pageSize: listConfig.ui?.listView?.pageSize ?? 50,
       gqlNames: list.gqlNames,
-      initialColumns: (listConfig.admin?.listView?.initialColumns as string[]) ?? [labelField],
+      initialColumns: (listConfig.ui?.listView?.initialColumns as string[]) ?? [labelField],
       initialSort:
-        (listConfig.admin?.listView?.initialSort as
+        (listConfig.ui?.listView?.initialSort as
           | {
               field: string;
               direction: 'ASC' | 'DESC';
@@ -101,8 +100,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
       adminMeta.lists[key].fields[fieldKey] = {
         label: list.fieldsByPath[fieldKey].label,
         views: getViewId(field.views),
-        customViews:
-          field.config.admin?.views === undefined ? null : getViewId(field.config.admin.views),
+        customViews: field.config.ui?.views === undefined ? null : getViewId(field.config.ui.views),
         fieldMeta: field.getAdminMeta?.(key, fieldKey, adminMeta) ?? null,
         isOrderable: list.fieldsByPath[fieldKey].isOrderable || fieldKey === 'id',
       };
@@ -163,7 +161,7 @@ export function createKeystone(config: KeystoneConfig): Keystone {
     isAccessAllowed:
       sessionImplementation === undefined
         ? undefined
-        : config.admin?.isAccessAllowed ?? (({ session }) => session !== undefined),
+        : config.ui?.isAccessAllowed ?? (({ session }) => session !== undefined),
     config,
   });
 
@@ -212,8 +210,10 @@ export function createKeystone(config: KeystoneConfig): Keystone {
   return keystoneThing;
 }
 
-function applyIdFieldDefaults(config: KeystoneConfig) {
-  const newLists: KeystoneConfig['lists'] = {};
+/** Validates and defaults the Keystone Config */
+function validateConfig(config: KeystoneConfig): KeystoneConfig {
+  /* Validate lists config and default the id field */
+  const lists: KeystoneConfig['lists'] = {};
   Object.keys(config.lists).forEach(key => {
     const listConfig = config.lists[key];
     if (listConfig.fields.id) {
@@ -229,23 +229,23 @@ function applyIdFieldDefaults(config: KeystoneConfig) {
     idField = {
       ...idField,
       config: {
-        admin: {
+        ui: {
           createView: {
             fieldMode: 'hidden',
-            ...idField.config.admin?.createView,
+            ...idField.config.ui?.createView,
           },
           itemView: {
             fieldMode: 'hidden',
-            ...idField.config.admin?.itemView,
+            ...idField.config.ui?.itemView,
           },
-          ...idField.config.admin,
+          ...idField.config.ui,
         },
         ...idField.config,
       },
     };
 
     const fields = { id: idField, ...listConfig.fields };
-    newLists[key] = {
+    lists[key] = {
       ...listConfig,
       fields,
     };
@@ -253,6 +253,6 @@ function applyIdFieldDefaults(config: KeystoneConfig) {
 
   return {
     ...config,
-    lists: newLists,
+    lists,
   };
 }

--- a/packages-next/keystone/src/lib/generateAdminUI.ts
+++ b/packages-next/keystone/src/lib/generateAdminUI.ts
@@ -75,7 +75,7 @@ export const generateAdminUI = async (keystone: Keystone, cwd: string) => {
   const filesWritten = new Set(
     [
       ...(await writeAdminFilesToDisk(
-        keystone.config.admin?.getAdditionalFiles?.map(x => x(keystone)) ?? [],
+        keystone.config.ui?.getAdditionalFiles?.map(x => x(keystone)) ?? [],
         projectAdminPath
       )),
     ].map(x => Path.normalize(x))

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -25,7 +25,7 @@ export type AdminFileToWrite =
       outputPath: string;
     };
 
-export type KeystoneAdminConfig = {
+export type KeystoneAdminUIConfig = {
   /** Enables certain functionality in the Admin UI that expects the session to be an item */
   enableSessionItem?: boolean;
   /** A function that can be run to validate that the current session should have access to the Admin UI */
@@ -56,7 +56,7 @@ export type KeystoneConfig = {
     };
   };
   session?: () => SessionStrategy<any>;
-  admin?: KeystoneAdminConfig;
+  ui?: KeystoneAdminUIConfig;
 } & SchemaConfig;
 
 export type MaybeItemFunction<T> =
@@ -72,7 +72,7 @@ export type MaybeSessionFunction<T extends string | boolean> =
 export type FieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = {
   hooks?: ListHooks<TGeneratedListTypes>;
   access?: FieldAccessControl<TGeneratedListTypes>;
-  admin?: {
+  ui?: {
     views?: string;
     description?: string;
     createView?: {

--- a/packages-next/types/src/schema/index.ts
+++ b/packages-next/types/src/schema/index.ts
@@ -56,7 +56,7 @@ export type ListConfig<
   access?: ListAccessControl<TGeneratedListTypes> | boolean;
   idField?: FieldType<TGeneratedListTypes>;
   /** Config for how this list should act in the Admin UI */
-  admin?: {
+  ui?: {
     /**
      * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.
      * @default 'name' if it exists, otherwise 'id'


### PR DESCRIPTION
The word `admin` is getting confusing in the new Keystone and List config, so after discussion with @timleslie and @mitchellhamilton I'm renaming it to `ui`

Specifically, you're often configuring the field behaviour in the context of permissions, and `admin` reads like a permission, not a feature. In those cases `ui` is a lot clearer, and I think also a better key for most other cases as well.