### PR TITLE
Rename inlineLink to inlineConnect in relationship field config

### DIFF
--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -33,7 +33,7 @@ type CardsDisplayConfig = {
     /** Configures inline edit mode for cards */
     inlineEdit?: { fields: string[] };
     /** Configures whether a select to add existing items should be shown or not */
-    inlineLink?: boolean;
+    inlineConnect?: boolean;
   };
 };
 
@@ -77,7 +77,7 @@ export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>
             removeMode: config.ui.removeMode ?? 'disconnect',
             inlineCreate: config.ui.inlineCreate ?? null,
             inlineEdit: config.ui.inlineEdit ?? null,
-            inlineLink: config.ui.inlineLink ?? false,
+            inlineConnect: config.ui.inlineConnect ?? false,
           }
         : {
             displayMode: 'select',

--- a/packages-next/fields/src/types/relationship/views/index.tsx
+++ b/packages-next/fields/src/types/relationship/views/index.tsx
@@ -262,7 +262,7 @@ type RelationshipController = FieldController<
         removeMode: 'disconnect' | 'none';
         inlineCreate: { fields: string[] } | null;
         inlineEdit: { fields: string[] } | null;
-        inlineLink: boolean;
+        inlineConnect: boolean;
       };
   listKey: string;
   refListKey: string;
@@ -288,7 +288,7 @@ export const controller = (
           removeMode: 'disconnect' | 'none';
           inlineCreate: { fields: string[] } | null;
           inlineEdit: { fields: string[] } | null;
-          inlineLink: boolean;
+          inlineConnect: boolean;
         }
     )
   >
@@ -307,7 +307,7 @@ export const controller = (
             inlineEdit: config.fieldMeta.inlineCreate,
             linkToItem: config.fieldMeta.linkToItem,
             removeMode: config.fieldMeta.removeMode,
-            inlineLink: config.fieldMeta.inlineLink,
+            inlineConnect: config.fieldMeta.inlineConnect,
           }
         : {
             mode: 'select',


### PR DESCRIPTION
Calling the config option `inlineLink` is confusing when next to `linkToItem`, so we're going with the more correct "connect" terminology