### PR TITLE
UX improvements to relationship cards

### DIFF
--- a/.changeset/proud-buses-wait.md
+++ b/.changeset/proud-buses-wait.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/fields": patch
+---
+
+UX improvements to relationship cards

--- a/packages-next/fields/src/types/relationship/views/RelationshipSelect.tsx
+++ b/packages-next/fields/src/types/relationship/views/RelationshipSelect.tsx
@@ -22,17 +22,19 @@ const subsequentItemsToLoad = 50;
 
 export const RelationshipSelect = ({
   autoFocus,
-  list,
-  isDisabled,
-  state,
   controlShouldRenderValue,
+  isDisabled,
   isLoading,
+  list,
+  placeholder,
+  state,
 }: {
-  list: ListMeta;
   autoFocus?: boolean;
-  isDisabled: boolean;
   controlShouldRenderValue: boolean;
+  isDisabled: boolean;
   isLoading?: boolean;
+  list: ListMeta;
+  placeholder?: string;
   state:
     | {
         kind: 'many';
@@ -154,6 +156,7 @@ export const RelationshipSelect = ({
               : null
           );
         }}
+        placeholder={placeholder}
         controlShouldRenderValue={controlShouldRenderValue}
         isClearable={controlShouldRenderValue}
         isDisabled={isDisabled}
@@ -173,6 +176,7 @@ export const RelationshipSelect = ({
       onChange={value => {
         state.onChange(value.map(x => ({ id: x.value, label: x.label })));
       }}
+      placeholder={placeholder}
       controlShouldRenderValue={controlShouldRenderValue}
       isClearable={controlShouldRenderValue}
       isDisabled={isDisabled}


### PR DESCRIPTION
Tweaked a lot of the UI for managing relationship cards, including losing the drop shadow in favour of a color border indicating mode (view / edit / create) and made the layout more consistent between modes.

Quick preview:

![image](https://user-images.githubusercontent.com/872310/98467398-22eea200-2229-11eb-92cc-4798be6b6b5a.png)
