### PR TITLE
Always load the session item in withItemData

### DIFF
--- a/.changeset/beige-elephants-deny.md
+++ b/.changeset/beige-elephants-deny.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": minor
+---
+
+Always load the session item in withItemData. The second argument to `withItemData` is now optional.


### PR DESCRIPTION
I have a use case where I want to check that the item stored in session is valid, but don't need to load any additional data for it.

So this changes the logic in the `withItemData` function so that the second argument `fieldSelections` is not required, and it falls back to just loading the ID for the current item.

Previously, we skipped loading the item data altogether for lists that weren't specified in the `fieldSelections` map, but that means we can't validate session items without specifying additional fields to query.