### PR TITLE
Fixed field defaultValue types for new fields package

### DIFF
--- a/packages-next/fields/TODO.md
+++ b/packages-next/fields/TODO.md
@@ -1,14 +1,21 @@
-# Password
+# General
+
+- [ ] Review types for defaultValue across all fields
+- [ ] Review types for hooks, specifically including GraphQLInput
+
+# Field Types
+
+## Password
 
 - [x] Add Password Field
 
-# Select
+## Select
 
 - [x] Add Select Field
 - [x] Current UI with a Select
 - [x] New UI Mode with a SegmentedControl
 
-# Relationship
+## Relationship
 
 - [x] Make a functional Relationship Field UI as per the current Relationship field (i.e just a select)
 

--- a/packages-next/fields/src/types/autoIncrement/index.ts
+++ b/packages-next/fields/src/types/autoIncrement/index.ts
@@ -2,7 +2,7 @@
 import { AutoIncrement } from '@keystonejs/fields-auto-increment';
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type AutoIncrementFieldConfig<
@@ -11,7 +11,7 @@ export type AutoIncrementFieldConfig<
   isRequired?: boolean;
   isIndexed?: boolean;
   isUnique?: boolean;
-  defaultValue?: number;
+  defaultValue?: FieldDefaultValue<number>;
 };
 
 const views = resolveView('integer/views');

--- a/packages-next/fields/src/types/checkbox/index.ts
+++ b/packages-next/fields/src/types/checkbox/index.ts
@@ -1,13 +1,13 @@
 import { Checkbox } from '@keystonejs/fields';
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type CheckboxFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
   TGeneratedListTypes
 > & {
-  defaultValue?: boolean;
+  defaultValue?: FieldDefaultValue<boolean>;
   isRequired?: boolean;
 };
 

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -1,7 +1,7 @@
 import { Integer } from '@keystonejs/fields';
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type IntegerFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
@@ -10,7 +10,7 @@ export type IntegerFieldConfig<TGeneratedListTypes extends BaseGeneratedListType
   isRequired?: boolean;
   isIndexed?: boolean;
   isUnique?: boolean;
-  defaultValue?: number;
+  defaultValue?: FieldDefaultValue<number>;
 };
 
 const views = resolveView('integer/views');

--- a/packages-next/fields/src/types/mongoId/index.ts
+++ b/packages-next/fields/src/types/mongoId/index.ts
@@ -2,7 +2,7 @@
 import { MongoId } from '@keystonejs/fields-mongoid';
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type MongoIdFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
@@ -11,7 +11,7 @@ export type MongoIdFieldConfig<TGeneratedListTypes extends BaseGeneratedListType
   isRequired?: boolean;
   isIndexed?: boolean;
   isUnique?: boolean;
-  defaultValue?: string;
+  defaultValue?: FieldDefaultValue<string>;
 };
 
 const views = resolveView('mongoId/views');

--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -2,7 +2,7 @@ import { Relationship } from '@keystonejs/fields';
 
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 // This is the default display mode for Relationships
@@ -45,6 +45,7 @@ export type RelationshipFieldConfig<
   ui?: {
     hideCreate?: boolean;
   };
+  defaultValue?: FieldDefaultValue<Record<string, unknown>>;
   isIndexed?: boolean;
   isUnique?: boolean;
 } & (SelectDisplayConfig | CardsDisplayConfig);

--- a/packages-next/fields/src/types/select/index.ts
+++ b/packages-next/fields/src/types/select/index.ts
@@ -2,7 +2,7 @@ import { Text } from '@keystonejs/fields';
 
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type SelectFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
@@ -12,12 +12,12 @@ export type SelectFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes
     | {
         options: { label: string; value: string }[];
         dataType?: 'string' | 'enum';
-        defaultValue?: string;
+        defaultValue?: FieldDefaultValue<string>;
       }
     | {
         options: { label: string; value: number }[];
         dataType: 'integer';
-        defaultValue?: number;
+        defaultValue?: FieldDefaultValue<number>;
       }
   ) & {
     ui?: {

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -2,13 +2,13 @@ import { Text } from '@keystonejs/fields';
 
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type TextFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
   TGeneratedListTypes
 > & {
-  defaultValue?: string;
+  defaultValue?: FieldDefaultValue<string>;
   isRequired?: boolean;
   isUnique?: boolean;
   isIndexed?: boolean;

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -2,13 +2,13 @@ import { DateTimeUtc } from '@keystonejs/fields';
 
 import type { FieldConfig } from '../../interfaces';
 import type { FieldType } from '@keystone-next/types';
-import type { BaseGeneratedListTypes } from '@keystone-next/types';
+import type { BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
 export type TimestampFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> = FieldConfig<
   TGeneratedListTypes
 > & {
-  defaultValue?: string;
+  defaultValue?: FieldDefaultValue<string>;
   isRequired?: boolean;
   isIndexed?: boolean;
   isUnique?: boolean;

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -1,5 +1,11 @@
 import type { FieldAccessControl } from './schema/access-control';
-import type { BaseGeneratedListTypes, JSONValue, GqlNames, MaybePromise } from './utils';
+import type {
+  BaseGeneratedListTypes,
+  JSONValue,
+  GqlNames,
+  GraphQLContext,
+  MaybePromise,
+} from './utils';
 import type { ListHooks } from './schema/hooks';
 import { SessionStrategy } from './session';
 import { SchemaConfig } from './schema';
@@ -119,6 +125,13 @@ export type FieldType<TGeneratedListTypes extends BaseGeneratedListTypes> = {
     }
   >;
 };
+
+/* TODO: Review these types */
+type FieldDefaultValueArgs<T> = { context: GraphQLContext; originalInput?: T };
+export type FieldDefaultValue<T> =
+  | T
+  | null
+  | MaybePromise<(args: FieldDefaultValueArgs<T>) => T | null | undefined>;
 
 export type Keystone = {
   keystone: any;

--- a/packages-next/types/src/schema/hooks.ts
+++ b/packages-next/types/src/schema/hooks.ts
@@ -77,7 +77,14 @@ type ResolveInputHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
 ) =>
   | Promise<TGeneratedListTypes['inputs']['create'] | TGeneratedListTypes['inputs']['update']>
   | TGeneratedListTypes['inputs']['create']
-  | TGeneratedListTypes['inputs']['update'];
+  | TGeneratedListTypes['inputs']['update']
+  // TODO: I'm pretty sure this is wrong, but without these additional types you can't define a
+  // resolveInput hook for a field that returns a simple value (e.g timestamp)
+  | Record<string, any>
+  | string
+  | number
+  | boolean
+  | null;
 
 type ValidateInputHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
   args: ArgsForCreateOrUpdateOperation<TGeneratedListTypes> & ValidationArgs

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -14,7 +14,7 @@ export type BaseGeneratedListTypes = {
 
 type BackingTypeForItem = any;
 
-type GraphQLInput = Record<string, any> | string | number | boolean | null;
+type GraphQLInput = Record<string, any>;
 
 export type GraphQLContext = Record<string, any>;
 

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -14,7 +14,7 @@ export type BaseGeneratedListTypes = {
 
 type BackingTypeForItem = any;
 
-type GraphQLInput = Record<string, any>;
+type GraphQLInput = Record<string, any> | string | number | boolean | null;
 
 export type GraphQLContext = Record<string, any>;
 


### PR DESCRIPTION
These types were wrong, noticed when I was working on the new tracking fields example.

@mitchellhamilton really want you to take a look at what I've done here (after merge, none of it should be problematic 🤞)

Specifically, the big thing I'm fixing here is that the `defaultValue` config for fields can be a plain value (of a type specific to the field type) or a function that returns that type.