### PR TITLE
Add new todo example (WIP)

### DIFF
--- a/examples-next/TODO.md
+++ b/examples-next/TODO.md
@@ -5,8 +5,8 @@
 
 # New example projects
 
-- [ ] Simple TODO list (JavaScript)
-- [ ] Simple TODO list (TypeScript)
+- [x] Simple TODO list
+- [ ] Tracking fields (created / updated at / by)
 - [ ] Content example (blog-like)
 - [ ] Relationships
 - [ ] All field types

--- a/examples-next/todo/keystone.ts
+++ b/examples-next/todo/keystone.ts
@@ -1,0 +1,35 @@
+import { config } from '@keystone-next/keystone/schema';
+import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { lists } from './schema';
+import { createAuth } from '@keystone-next/auth';
+
+const sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
+const sessionMaxAge = 60 * 60 * 24 * 30; // 30 days
+const sessionConfig = {
+  maxAge: sessionMaxAge,
+  secret: sessionSecret,
+};
+
+const { withAuth } = createAuth({
+  listKey: 'User',
+  identityField: 'email',
+  secretField: 'password',
+  initFirstItem: {
+    fields: ['name', 'email', 'password'],
+  },
+});
+
+export default withAuth(
+  config({
+    name: 'KeystoneJS Tracking Fields Example',
+    db: {
+      adapter: 'mongoose',
+      url: 'mongodb://localhost/keystone-examples-todo',
+    },
+    lists,
+    ui: {
+      isAccessAllowed: ({ session }) => !!session,
+    },
+    session: withItemData(statelessSessions(sessionConfig)),
+  })
+);

--- a/examples-next/todo/package.json
+++ b/examples-next/todo/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@keystone-next/example-todo",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "dev": "keystone-next"
+  },
+  "dependencies": {
+    "@keystone-next/admin-ui": "^2.0.0",
+    "@keystone-next/auth": "^2.0.0",
+    "@keystone-next/fields": "^2.0.0",
+    "@keystone-next/keystone": "^2.0.0",
+    "next": "^9.5.5",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.5"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/master/examples-next/todo"
+}

--- a/examples-next/todo/schema.ts
+++ b/examples-next/todo/schema.ts
@@ -1,0 +1,81 @@
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { checkbox, password, relationship, text, timestamp } from '@keystone-next/fields';
+
+const trackingFields = {
+  createdAt: timestamp({
+    access: { create: false, read: true, update: false },
+    defaultValue: () => new Date().toISOString(),
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+  }),
+  createdBy: relationship({
+    ref: 'User',
+    access: { create: false, read: true, update: false },
+    defaultValue: ({ context: { session } }) =>
+      session ? { connect: { id: session.itemId } } : null,
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+  }),
+  updatedAt: timestamp({
+    access: { create: false, read: true, update: false },
+    hooks: {
+      resolveInput: () => new Date().toISOString(),
+    },
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+  }),
+  updatedBy: relationship({
+    ref: 'User',
+    access: { create: false, read: true, update: false },
+    hooks: {
+      resolveInput: ({ context: { session } }) => (session ? session.itemId : null),
+    },
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+  }),
+};
+
+export const lists = createSchema({
+  Todo: list({
+    ui: {
+      labelField: 'label',
+      listView: {
+        initialColumns: ['label', 'createdAt', 'createdBy', 'updatedAt', 'updatedBy'],
+      },
+    },
+    fields: {
+      label: text({ isRequired: true }),
+      isComplete: checkbox(),
+      assignedTo: relationship({ ref: 'User.tasks' }),
+      ...trackingFields,
+    },
+  }),
+  User: list({
+    ui: {
+      listView: {
+        initialColumns: ['name' /* , 'createdAt', 'createdBy', 'updatedAt', 'updatedBy' */],
+      },
+    },
+    fields: {
+      name: text({ isRequired: true }),
+      email: text(),
+      password: password(),
+      tasks: relationship({
+        ref: 'Todo.assignedTo',
+        many: true,
+        ui: {
+          itemView: { fieldMode: 'read' },
+        },
+      }),
+      ...trackingFields,
+    },
+  }),
+});


### PR DESCRIPTION
This adds a new example project, with a todo list that can be assigned to users.

It's slightly more complex than most todo examples, but I think there's a bunch of useful stuff we can do here including different relationship views, tacking fields, and hooks.

I'd like to add more features to it and use it as a separate use case for testing, and the tracking fields need to be pulled out into their own package, but it's a good start.