### PR TITLE
Fix Select menu cropping in create item drawer

### DIFF
--- a/.changeset/gold-poets-fetch.md
+++ b/.changeset/gold-poets-fetch.md
@@ -1,0 +1,6 @@
+---
+"@keystonejs/fields": patch
+"@keystone-ui/fields": patch
+---
+
+Fix Select menu cropping in create item drawer

--- a/design-system/packages/fields/src/Select.tsx
+++ b/design-system/packages/fields/src/Select.tsx
@@ -84,6 +84,7 @@ const useStyles = ({
       boxShadow: '0 4px 11px hsla(0, 0%, 0%, 0.1)',
       borderRadius: tokens.borderRadius,
     }),
+    menuPortal: (provided: any) => ({ ...provided, zIndex: 9999 }),
     multiValue: (provided: any) => ({
       ...provided,
       backgroundColor: palette.neutral300,
@@ -121,6 +122,8 @@ export function Select({
   const tokens = useInputTokens({ width: widthKey });
   const styles = useStyles({ tokens });
 
+  const portalTarget = typeof document !== 'undefined' ? document.body : undefined;
+
   return (
     <ReactSelect
       value={value}
@@ -135,6 +138,7 @@ export function Select({
       }}
       {...props}
       isMulti={false}
+      menuPortalTarget={portalTarget}
     />
   );
 }


### PR DESCRIPTION
The Select menu was being cropped by the overflow in the `Drawer` component. This sets it to portal the menu to the document body, which fixes the problem.

![image](https://user-images.githubusercontent.com/872310/98802132-ead4a280-2466-11eb-948f-f3c74a1aa38d.png)
