### PR TITLE
Fixing menu cropping in Drawers for multi select

### DIFF
--- a/design-system/packages/fields/src/Select.tsx
+++ b/design-system/packages/fields/src/Select.tsx
@@ -110,6 +110,8 @@ const useStyles = ({
   };
 };
 
+const portalTarget = typeof document !== 'undefined' ? document.body : undefined;
+
 export function Select({
   onChange,
   value,
@@ -121,8 +123,6 @@ export function Select({
 }) {
   const tokens = useInputTokens({ width: widthKey });
   const styles = useStyles({ tokens });
-
-  const portalTarget = typeof document !== 'undefined' ? document.body : undefined;
 
   return (
     <ReactSelect
@@ -171,6 +171,7 @@ export function MultiSelect({
       }}
       {...props}
       isMulti
+      menuPortalTarget={portalTarget}
     />
   );
 }


### PR DESCRIPTION
Same fix as #4204, I missed the `MultiSelect` variant