### PR TITLE
Fix the default textarea width

### DIFF
--- a/design-system/packages/fields/src/TextArea.tsx
+++ b/design-system/packages/fields/src/TextArea.tsx
@@ -16,7 +16,7 @@ export type TextAreaProps = {
 } & Omit<InputProps, 'onChange' | 'size' | 'value'>;
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ invalid = false, size = 'medium' as const, width = 'medium' as const, ...props }, ref) => {
+  ({ invalid = false, size = 'medium' as const, width = 'large' as const, ...props }, ref) => {
     const tokens = useInputTokens({ size, width, shape: 'square', fixHeight: false });
     const styles = useInputStyles({ invalid, tokens });
 


### PR DESCRIPTION
The `Textarea` component had the wrong default width:

![image](https://user-images.githubusercontent.com/872310/98816778-46118f80-247d-11eb-8ff1-5af300564bc9.png)

It now defaults to the same size as the `TextInput`