### PR TITLE
Improve error message when relationships have an invalid ref listKey

### DIFF
--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -66,6 +66,9 @@ export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>
     typeof import('@keystone-next/fields/types/relationship/views').controller
   >[0]['fieldMeta'] {
     const refListKey = config.ref.split('.')[0];
+    if (!adminMeta.lists[refListKey]) {
+      throw new Error(`The ref [${config.ref}] on relationship [${listKey}.${path}] is invalid`);
+    }
     return {
       refListKey,
       many: config.many ?? false,


### PR DESCRIPTION
When you set an invalid listKey as the ref for a relationship field, the new interfaces would throw creating the adminMeta before the current validation has a chance to run.

This adds a simple validation to the first part of the ref.

cc/ @mitchellhamilton because it's not great that we're doubling up on validation, but can't think of a better compromise right now