### PR TITLE
Rename KeystoneItemAPI to KeystoneListsAPI

### DIFF
--- a/.changeset/chilly-hounds-smell.md
+++ b/.changeset/chilly-hounds-smell.md
@@ -1,0 +1,7 @@
+---
+"@keystone-next/app-basic": patch
+"@keystone-next/keystone": patch
+"@keystone-next/types": patch
+---
+
+Rename KeystoneItemAPI to KeystoneListsAPI

--- a/examples-next/basic/schema.ts
+++ b/examples-next/basic/schema.ts
@@ -9,7 +9,7 @@ import {
   virtual,
 } from '@keystone-next/fields';
 // import { cloudinaryImage } from '@keystone-next/cloudinary';
-import { KeystoneItemAPI } from '@keystone-next/types';
+import { KeystoneListsAPI } from '@keystone-next/types';
 import { KeystoneListsTypeInfo } from './.keystone/schema-types';
 
 // TODO: Can we generate this type based on withItemData in the main config?
@@ -179,7 +179,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
       createRandomPosts(root: any, args: any, ctx: any) {
         // TODO: add a way to verify access control here, e.g
         // await ctx.verifyAccessControl(userIsAdmin);
-        const lists: KeystoneItemAPI<KeystoneListsTypeInfo> = ctx.lists;
+        const lists: KeystoneListsAPI<KeystoneListsTypeInfo> = ctx.lists;
         const data = Array.from({ length: 238 }).map((x, i) => ({ data: { title: `Post ${i}` } }));
         return lists.Post.createMany({ data });
       },

--- a/packages-next/keystone/src/lib/itemAPI.ts
+++ b/packages-next/keystone/src/lib/itemAPI.ts
@@ -2,7 +2,7 @@ import {
   BaseGeneratedListTypes,
   BaseKeystoneList,
   Keystone,
-  KeystoneItemAPI,
+  KeystoneListsAPI,
 } from '@keystone-next/types';
 import { GraphQLSchema } from 'graphql';
 import { getCoerceAndValidateArgumentsFnForGraphQLField } from './getCoerceAndValidateArgumentsFnForGraphQLField';
@@ -11,7 +11,7 @@ export function itemAPIForList(
   list: BaseKeystoneList,
   schema: GraphQLSchema,
   createContext: Keystone['createContext']
-): KeystoneItemAPI<Record<string, BaseGeneratedListTypes>>[string] {
+): KeystoneListsAPI<Record<string, BaseGeneratedListTypes>>[string] {
   const queryFields = schema.getQueryType()!.getFields();
   const mutationFields = schema.getMutationType()!.getFields();
 

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -252,7 +252,7 @@ export type KeystoneGraphQLAPI<
   raw: (args: GraphQLExecutionArguments) => Promise<ExecutionResult>;
 };
 
-export type KeystoneItemAPI<
+export type KeystoneListsAPI<
   KeystoneListsTypeInfo extends Record<string, BaseGeneratedListTypes>
 > = {
   [Key in keyof KeystoneListsTypeInfo]: {


### PR DESCRIPTION
The type name KeystoneItemAPI name felt weird when I was using it in the example projects, I think given we named it `lists` this is clearer.

cc/ @mitchellhamilton 