### PR TITLE
Fix dropdown in nav in Firefox

### DIFF
--- a/packages-next/admin-ui/src/components/Navigation.tsx
+++ b/packages-next/admin-ui/src/components/Navigation.tsx
@@ -82,7 +82,7 @@ const AuthenticatedItem = ({ item }: { item: { id: string; label: string } }) =>
           </Button>
         )}
       >
-        <Stack width={220} height={80} gap="medium" padding="large" dividers="between">
+        <Stack gap="medium" padding="large" dividers="between">
           <PopoverLink target="_blank" href="/api/graphql">
             API Explorer
           </PopoverLink>


### PR DESCRIPTION
Not sure why the width and height were there, it looks like Safari and Chrome ignore the height so it looks normal there but Firefox respects it so it squashes all the content