### PR TITLE
Add Cross-Origin Resource Support to the dev server

### DIFF
--- a/.changeset/short-needles-cry.md
+++ b/.changeset/short-needles-cry.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": minor
+---
+
+Add Cross-Origin Resource Support to the dev server

--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -34,6 +34,7 @@
     "@types/uid-safe": "^2.1.2",
     "apollo-server-express": "^2.19.0",
     "cookie": "^0.4.1",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.1",

--- a/packages-next/keystone/src/lib/createAdminUIServer.ts
+++ b/packages-next/keystone/src/lib/createAdminUIServer.ts
@@ -1,3 +1,4 @@
+import cors from 'cors';
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 // @ts-ignore
@@ -11,6 +12,9 @@ const dev = process.env.NODE_ENV !== 'production';
 
 export const createAdminUIServer = async (keystone: Keystone) => {
   const server = express();
+
+  // TODO: allow cors to be configured
+  server.use(cors({ origin: true, credentials: true }));
 
   console.log('✨ Preparing Next.js app');
   const app = next({ dev, dir: Path.join(process.cwd(), '.keystone', 'admin') });


### PR DESCRIPTION
This adds `core` middleware to the new dev server, with the same defalults keystone had previously.

We should make this configurable, but for now it will unblock development against the API.

cc/ @wesbos