### PR TITLE
Fixed the session permissions loading in the eCommerce example

### DIFF
--- a/examples-next/ecommerce/keystone.ts
+++ b/examples-next/ecommerce/keystone.ts
@@ -41,7 +41,7 @@ export default withAuth(
       isAccessAllowed: ({ session }) => !!session,
     },
     session: withItemData(statelessSessions(sessionConfig), {
-      User: 'name roles { canCreateProducts canCreateUsers }',
+      User: 'name permissions',
     }),
   })
 );


### PR DESCRIPTION
Just realised that I was spiking a roles-based access approach here, and left the wrong fields being loaded for the session in the eCommerce example. This fixes it so that permissions in the Admin UI work again.