### PR TITLE
Add getBackingTypes() to Implementation

### DIFF
--- a/.changeset/healthy-chefs-smash.md
+++ b/.changeset/healthy-chefs-smash.md
@@ -1,0 +1,11 @@
+---
+'@keystonejs/fields': minor
+'@keystonejs/fields-auto-increment': minor
+'@keystonejs/fields-cloudinary-image': minor
+'@keystonejs/fields-location-google': minor
+'@keystonejs/fields-mongoid': minor
+'@keystonejs/fields-oembed': minor
+'@keystonejs/fields-unsplash': minor
+---
+
+Added a `.getBackingTypes()` method to all `Field` implementations, which returns `{ path: { optional, type } }`. This method will be used to generate typescript types in our upcoming [new interfaces](https://www.keystonejs.com/blog/roadmap-update).

--- a/.changeset/hip-humans-jam.md
+++ b/.changeset/hip-humans-jam.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/cloudinary': major
+'@keystone-next/fields': major
+'@keystone-next/types': major
+---
+
+Removed `getBackingType` from `FieldType` as this functionality is now provided by `field.getBackingTypes()` in the core field classes.

--- a/.changeset/thick-monkeys-camp.md
+++ b/.changeset/thick-monkeys-camp.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Uses the new `field.getBackingTypes()` method on core field objects to generate types.

--- a/.changeset/thick-monkeys-camp.md
+++ b/.changeset/thick-monkeys-camp.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-next/keystone': patch
+'@keystone-next/keystone': major
 ---
 
 Uses the new `field.getBackingTypes()` method on core field objects to generate types.

--- a/packages-next/cloudinary/src/index.ts
+++ b/packages-next/cloudinary/src/index.ts
@@ -34,12 +34,4 @@ export const cloudinaryImage = <TGeneratedListTypes extends BaseGeneratedListTyp
     adapter: new CloudinaryAdapter(cloudinary),
   },
   views,
-  getBackingType(path) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'any',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/autoIncrement/index.ts
+++ b/packages-next/fields/src/types/autoIncrement/index.ts
@@ -22,20 +22,4 @@ export const autoIncrement = <TGeneratedListTypes extends BaseGeneratedListTypes
   type: AutoIncrement,
   config: config,
   views,
-  getBackingType(path) {
-    if (path === 'id') {
-      return {
-        [path]: {
-          optional: false,
-          type: 'number',
-        },
-      };
-    }
-    return {
-      [path]: {
-        optional: true,
-        type: 'number | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/checkbox/index.ts
+++ b/packages-next/fields/src/types/checkbox/index.ts
@@ -19,12 +19,4 @@ export const checkbox = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   type: Checkbox,
   config: config,
   views,
-  getBackingType(path) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'boolean | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -21,12 +21,4 @@ export const integer = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   type: Integer,
   config: config,
   views,
-  getBackingType(path) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'number | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/mongoId/index.ts
+++ b/packages-next/fields/src/types/mongoId/index.ts
@@ -22,20 +22,4 @@ export const mongoId = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   type: MongoId,
   config: config,
   views,
-  getBackingType(path) {
-    if (path === 'id') {
-      return {
-        [path]: {
-          optional: false,
-          type: 'string',
-        },
-      };
-    }
-    return {
-      [path]: {
-        optional: true,
-        type: 'string | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/password/index.ts
+++ b/packages-next/fields/src/types/password/index.ts
@@ -26,12 +26,4 @@ export const password = <TGeneratedListTypes extends BaseGeneratedListTypes>(
       minLength: config.minLength !== undefined ? config.minLength : 8,
     };
   },
-  getBackingType(path) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'string | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -89,12 +89,4 @@ export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>
           }),
     };
   },
-  getBackingType(path) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'string | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/select/index.ts
+++ b/packages-next/fields/src/types/select/index.ts
@@ -41,12 +41,4 @@ export const select = <TGeneratedListTypes extends BaseGeneratedListTypes>(
     displayMode: config.ui?.displayMode ?? 'select',
   }),
   views,
-  getBackingType(path: string) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'string | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -28,12 +28,4 @@ export const text = <TGeneratedListTypes extends BaseGeneratedListTypes>(
     displayMode: config.ui?.displayMode ?? 'input',
   }),
   views,
-  getBackingType(path: string) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'string | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -22,12 +22,4 @@ export const timestamp = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   type: DateTimeUtc,
   config,
   views,
-  getBackingType(path: string) {
-    return {
-      [path]: {
-        optional: true,
-        type: 'Date | null',
-      },
-    };
-  },
 });

--- a/packages-next/fields/src/types/virtual/index.ts
+++ b/packages-next/fields/src/types/virtual/index.ts
@@ -28,7 +28,4 @@ export const virtual = <TGeneratedListTypes extends BaseGeneratedListTypes>(
       graphQLReturnFragment: config.graphQLReturnFragment ?? '',
     };
   },
-  getBackingType() {
-    return {};
-  },
 });

--- a/packages-next/keystone/src/scripts/schema-type-printer.tsx
+++ b/packages-next/keystone/src/scripts/schema-type-printer.tsx
@@ -120,13 +120,9 @@ export function printGeneratedTypes(printedSchema: string, keystone: Keystone) {
   for (const listKey in keystone.adminMeta.lists) {
     const list = keystone.adminMeta.lists[listKey];
     let backingTypes = '{\n';
-    for (const fieldKey in keystone.config.lists[list.key].fields) {
-      const fieldThing = keystone.config.lists[list.key].fields[fieldKey];
-      let backingType = fieldThing.getBackingType(fieldKey);
-      for (const key in backingType) {
-        backingTypes += `readonly ${JSON.stringify(key)}${backingType[key].optional ? '?' : ''}: ${
-          backingType[key].type
-        };\n`;
+    for (const field of keystone.keystone.lists[list.key].fields) {
+      for (const [key, { optional, type }] of Object.entries(field.getBackingTypes()) as any) {
+        backingTypes += `readonly ${JSON.stringify(key)}${optional ? '?' : ''}: ${type};\n`;
       }
     }
     backingTypes += '}';

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -116,15 +116,6 @@ export type FieldType<TGeneratedListTypes extends BaseGeneratedListTypes> = {
       lists: Record<string, BaseListMeta>;
     }
   ) => JSONValue;
-  getBackingType: (
-    path: string
-  ) => Record<
-    string,
-    {
-      optional: boolean;
-      type: string;
-    }
-  >;
 };
 
 /* TODO: Review these types */

--- a/packages/fields-auto-increment/src/Implementation.js
+++ b/packages/fields-auto-increment/src/Implementation.js
@@ -50,7 +50,7 @@ export class AutoIncrementImplementation extends Implementation {
 
   getBackingTypes() {
     if (this.path === 'id') {
-      return { [this.path]: { optional: false, type: 'number' } };
+      return { [this.path]: { optional: false, type: 'string' } };
     }
     return { [this.path]: { optional: true, type: 'number | null' } };
   }

--- a/packages/fields-auto-increment/src/Implementation.js
+++ b/packages/fields-auto-increment/src/Implementation.js
@@ -47,6 +47,13 @@ export class AutoIncrementImplementation extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: ${this.gqlType}`];
   }
+
+  getBackingTypes() {
+    if (this.path === 'id') {
+      return { [this.path]: { optional: false, type: 'number' } };
+    }
+    return { [this.path]: { optional: true, type: 'number | null' } };
+  }
 }
 
 export class KnexAutoIncrementInterface extends KnexFieldAdapter {

--- a/packages/fields-cloudinary-image/src/Implementation.js
+++ b/packages/fields-cloudinary-image/src/Implementation.js
@@ -89,6 +89,10 @@ class CloudinaryImage extends File.implementation {
       },
     };
   }
+
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'any' } };
+  }
 }
 
 const MongoCloudinaryImageInterface = File.adapters.mongoose;

--- a/packages/fields-location-google/src/Implementation.js
+++ b/packages/fields-location-google/src/Implementation.js
@@ -114,6 +114,17 @@ export class LocationGoogleImplementation extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: String`];
   }
+  getBackingTypes() {
+    const type = `null | {
+      id: string;
+      googlePlaceID: string;
+      formattedAddress: string;
+      lat: number;
+      lng: number;
+      }
+    `;
+    return { [this.path]: { optional: true, type } };
+  }
 }
 
 const CommonLocationInterface = superclass =>

--- a/packages/fields-mongoid/src/Implementation.js
+++ b/packages/fields-mongoid/src/Implementation.js
@@ -23,6 +23,12 @@ export class MongoIdImplementation extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: ID`];
   }
+  getBackingTypes() {
+    if (this.path === 'id') {
+      return { [this.path]: { optional: false, type: 'string' } };
+    }
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const validator = a => (a ? /^[0-9a-fA-F]{24}$/.test(a.toString()) : true);

--- a/packages/fields-oembed/src/Implementation.js
+++ b/packages/fields-oembed/src/Implementation.js
@@ -260,6 +260,9 @@ export class OEmbed extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: String`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'Record<string, any> | null' } };
+  }
 }
 
 const CommonOEmbedInterface = superclass =>

--- a/packages/fields-unsplash/src/Implementation.js
+++ b/packages/fields-unsplash/src/Implementation.js
@@ -256,6 +256,9 @@ export class Unsplash extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: String`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'Record<string, any> | null' } };
+  }
 }
 
 const CommonUnsplashInterface = superclass =>

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -221,6 +221,13 @@ class Field {
     // By default, the default value is undefined
     return undefined;
   }
+
+  getBackingTypes() {
+    // Return the typescript types of the backing item for this field type.
+    // This method can be helpful if you want to auto-generate typescript types.
+    // Future releases of Keystone will provide full typescript support
+    return { [this.path]: { optional: true, type: 'any' } };
+  }
 }
 
 export { Field as Implementation };

--- a/packages/fields/src/types/CalendarDay/Implementation.js
+++ b/packages/fields/src/types/CalendarDay/Implementation.js
@@ -94,6 +94,10 @@ export class CalendarDay extends Implementation {
       }
     }
   }
+
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const CommonCalendarInterface = superclass =>

--- a/packages/fields/src/types/Checkbox/Implementation.js
+++ b/packages/fields/src/types/Checkbox/Implementation.js
@@ -29,6 +29,9 @@ export class Checkbox extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: Boolean`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'boolean | null' } };
+  }
 }
 
 export class MongoCheckboxInterface extends MongooseFieldAdapter {

--- a/packages/fields/src/types/DateTime/Implementation.js
+++ b/packages/fields/src/types/DateTime/Implementation.js
@@ -68,6 +68,9 @@ class _DateTime extends Implementation {
       }),
     };
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const toDate = s => s && DateTime.fromISO(s, { zone: 'utc' }).toJSDate();

--- a/packages/fields/src/types/DateTimeUtc/Implementation.js
+++ b/packages/fields/src/types/DateTimeUtc/Implementation.js
@@ -41,6 +41,9 @@ export class DateTimeUtcImplementation extends Implementation {
   extendAdminMeta(meta) {
     return { ...meta, format: this.format };
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'Date | null' } };
+  }
 }
 
 // All values must have an offset

--- a/packages/fields/src/types/Decimal/Implementation.js
+++ b/packages/fields/src/types/Decimal/Implementation.js
@@ -40,6 +40,9 @@ export class Decimal extends Implementation {
       symbol: this.symbol,
     };
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 export class MongoDecimalInterface extends MongooseFieldAdapter {

--- a/packages/fields/src/types/File/Implementation.js
+++ b/packages/fields/src/types/File/Implementation.js
@@ -111,6 +111,19 @@ export class File extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: ${this.getFileUploadType()}`];
   }
+  getBackingTypes() {
+    const type = `null | {
+      id: string;
+      path: string;
+      filename: string;
+      originalFilename: string;
+      mimetype: string;
+      encoding: string;
+      _meta: Record<string, any>
+     }
+    `;
+    return { [this.path]: { optional: true, type } };
+  }
 }
 
 const CommonFileInterface = superclass =>

--- a/packages/fields/src/types/Float/Implementation.js
+++ b/packages/fields/src/types/Float/Implementation.js
@@ -33,6 +33,9 @@ export class Float extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: Float`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'number | null' } };
+  }
 }
 
 const CommonFloatInterface = superclass =>

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -33,6 +33,9 @@ export class Integer extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: Int`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'number | null' } };
+  }
 }
 
 const CommonIntegerInterface = superclass =>

--- a/packages/fields/src/types/Password/Implementation.js
+++ b/packages/fields/src/types/Password/Implementation.js
@@ -89,6 +89,10 @@ export class Password extends Implementation {
       );
     }
   }
+
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const CommonPasswordInterface = superclass =>

--- a/packages/fields/src/types/Relationship/Implementation.js
+++ b/packages/fields/src/types/Relationship/Implementation.js
@@ -322,6 +322,9 @@ export class Relationship extends Implementation {
   gqlCreateInputFields({ schemaName }) {
     return this.gqlUpdateInputFields({ schemaName });
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 export class MongoRelationshipInterface extends MongooseFieldAdapter {

--- a/packages/fields/src/types/Select/Implementation.js
+++ b/packages/fields/src/types/Select/Implementation.js
@@ -121,6 +121,10 @@ export class Select extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: ${this.getTypeName()}`];
   }
+
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const CommonSelectInterface = superclass =>

--- a/packages/fields/src/types/Text/Implementation.js
+++ b/packages/fields/src/types/Text/Implementation.js
@@ -39,6 +39,9 @@ export class Text extends Implementation {
     const { isMultiline } = this;
     return { isMultiline, ...meta };
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const CommonTextInterface = superclass =>

--- a/packages/fields/src/types/Uuid/Implementation.js
+++ b/packages/fields/src/types/Uuid/Implementation.js
@@ -35,6 +35,9 @@ export class UuidImplementation extends Implementation {
   gqlCreateInputFields() {
     return [`${this.path}: ID`];
   }
+  getBackingTypes() {
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
 }
 
 const validator = a =>

--- a/packages/fields/src/types/Virtual/Implementation.js
+++ b/packages/fields/src/types/Virtual/Implementation.js
@@ -58,6 +58,10 @@ export class Virtual extends Implementation {
       return prev;
     }, {});
   }
+
+  getBackingTypes() {
+    return {};
+  }
 }
 
 const CommonTextInterface = superclass =>


### PR DESCRIPTION
This PR adds support for backing type generation to all field types as a core method. This allows us to co-locate the type info close to where it is used and thins out the functionality required to be embedded in the field wrapper functions for new interfaces.