### PR TITLE
Remove name field from KeystoneConfig

### DIFF
--- a/.changeset/tall-jars-sparkle.md
+++ b/.changeset/tall-jars-sparkle.md
@@ -1,0 +1,10 @@
+---
+'@keystone-next/types': major
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-ecommerce': patch
+'@keystone-next/example-todo': patch
+'@keystone-next/keystone': patch
+---
+
+Removed `name` field from `KeystoneConfig` type, as it doesn't actually do anything.

--- a/examples-next/auth/keystone.ts
+++ b/examples-next/auth/keystone.ts
@@ -56,7 +56,6 @@ const { withAuth } = createAuth({
 // withAuth applies the signin functionality to the keystone config
 export default withAuth(
   config({
-    name: 'KeystoneJS Auth Example',
     db: {
       adapter: 'mongoose',
       url: 'mongodb://localhost/keystone-examples-next-auth',

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -24,7 +24,6 @@ const auth = createAuth({
 
 export default auth.withAuth(
   config({
-    name: 'Keystone 2020 Spike',
     db: {
       adapter: 'mongoose',
       url: 'mongodb://localhost/keystone-examples-next-basic',

--- a/examples-next/ecommerce/keystone.ts
+++ b/examples-next/ecommerce/keystone.ts
@@ -31,7 +31,6 @@ const { withAuth } = createAuth({
 
 export default withAuth(
   config({
-    name: 'KeystoneJS eCommerce Example',
     db: {
       adapter: 'mongoose',
       url: databaseUrl,

--- a/examples-next/todo/keystone.ts
+++ b/examples-next/todo/keystone.ts
@@ -21,7 +21,6 @@ const { withAuth } = createAuth({
 
 export default withAuth(
   config({
-    name: 'KeystoneJS Tracking Fields Example',
     db: {
       adapter: 'mongoose',
       url: 'mongodb://localhost/keystone-examples-todo',

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -24,8 +24,8 @@ import { accessControlContext, skipAccessControlContext } from './createAccessCo
 export function createKeystone(config: KeystoneConfig): Keystone {
   config = applyIdFieldDefaults(config);
 
+  // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
   let keystone = new BaseKeystone({
-    name: config.name,
     adapter:
       // FIXME: prisma support
       config.db.adapter === 'knex'

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -50,7 +50,6 @@ export type KeystoneAdminUIConfig = {
 };
 
 export type KeystoneConfig = {
-  name: string;
   db: {
     adapter: 'mongoose' | 'knex';
     url: string;


### PR DESCRIPTION
This value doesn't actually do anything, so let's get rid of it.