### PR TITLE
Add product status field to the ecommerce example

### DIFF
--- a/examples-next/ecommerce/schema.ts
+++ b/examples-next/ecommerce/schema.ts
@@ -106,6 +106,17 @@ export const lists = createSchema({
     },
     fields: {
       name: text({ isRequired: true }),
+      permissions: select({
+        options: [
+          { label: 'Draft', value: 'DRAFT' },
+          { label: 'Available', value: 'AVAILABLE' },
+          { label: 'Unavailable', value: 'UNAVAILABLE' },
+        ],
+        defaultValue: 'DRAFT',
+        ui: {
+          displayMode: 'segmented-control',
+        },
+      }),
       description: text({ ui: { displayMode: 'textarea' } }),
       price: integer(),
       image: relationship({

--- a/examples-next/ecommerce/schema.ts
+++ b/examples-next/ecommerce/schema.ts
@@ -115,6 +115,7 @@ export const lists = createSchema({
         defaultValue: 'DRAFT',
         ui: {
           displayMode: 'segmented-control',
+          createView: { fieldMode: 'hidden' },
         },
       }),
       description: text({ ui: { displayMode: 'textarea' } }),


### PR DESCRIPTION
@wesbos this is for you to make a call on, I think it's worth adding a `status` field to Products in the eCommerce example.

Means that the front-end would query for "Available" products, and you could draft a new product without sending it live, as well as remove products for sale without deleting them.