### PR TITLE
fix label in item page

### DIFF
--- a/.changeset/violet-mayflies-sell.md
+++ b/.changeset/violet-mayflies-sell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/fields': patch
+---
+
+Fixed FieldLabel to default to label instead of button

--- a/design-system/packages/fields/src/FieldLabel.tsx
+++ b/design-system/packages/fields/src/FieldLabel.tsx
@@ -8,7 +8,7 @@ type FieldLabelProps = {
 };
 
 export const FieldLabel = forwardRefWithAs<'label', FieldLabelProps>(
-  ({ as: Tag = 'button', children, ...props }, ref) => {
+  ({ as: Tag = 'label', children, ...props }, ref) => {
     const { typography, fields, spacing } = useTheme();
     return (
       <Tag


### PR DESCRIPTION
fixed label which was recently updated and defaulted to button instead of label

before
![image](https://user-images.githubusercontent.com/5769869/99144726-47fe6d00-268e-11eb-9fc8-f87b2959acc7.png)

after
![image](https://user-images.githubusercontent.com/5769869/99144738-65cbd200-268e-11eb-88eb-b68b894f1135.png)
