### PR TITLE
Factor out _createKeystone

### DIFF
--- a/.changeset/shaggy-pens-bow.md
+++ b/.changeset/shaggy-pens-bow.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Factored out a `_createKeystone` function to allow for backwards compatibility.


### PR DESCRIPTION
This refactor disentangles the `Keystone` object creation from the `adminMeta` and also provides a possible public API function for backwards compatibility support.