### PR TITLE
Rename KeystoneSystem objects to system

### DIFF
--- a/.changeset/soft-adults-call.md
+++ b/.changeset/soft-adults-call.md
@@ -1,7 +1,7 @@
 ---
 '@keystone-next/types': major
-'@keystone-next/auth': patch
-'@keystone-next/keystone': patch
+'@keystone-next/auth': major
+'@keystone-next/keystone': major
 ---
 
 Renamed `keystone` argument of `KeystoneAdminUIConfig.getAdditionalFiles()` and `KeystoneAdminUIConfig.pageMiddleware()` to `system`.

--- a/.changeset/soft-adults-call.md
+++ b/.changeset/soft-adults-call.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/types': major
+'@keystone-next/auth': patch
+'@keystone-next/keystone': patch
+---
+
+Renamed `keystone` argument of `KeystoneAdminUIConfig.getAdditionalFiles()` and `KeystoneAdminUIConfig.pageMiddleware()` to `system`.
+Renamed `keystone` argument of `SessionStrategy.start`, `SessionStrategy.end` and `SessionStrategy.get` to `system`.

--- a/.changeset/tough-hounds-punch.md
+++ b/.changeset/tough-hounds-punch.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/keystone': patch
+---
+
+Renamed `keystone` argument of `writeAdminFiles()` to `system`.

--- a/packages-next/admin-ui/src/templates/app.ts
+++ b/packages-next/admin-ui/src/templates/app.ts
@@ -20,14 +20,14 @@ type AppTemplateOptions = {
 };
 
 export const appTemplate = (
-  keystone: KeystoneSystem,
+  system: KeystoneSystem,
   { configFile, projectAdminPath }: AppTemplateOptions
 ) => {
-  const lazyMetadataQuery = getLazyMetadataQuery(keystone.graphQLSchema, keystone.adminMeta);
+  const lazyMetadataQuery = getLazyMetadataQuery(system.graphQLSchema, system.adminMeta);
 
   const result = executeSync({
     document: staticAdminMetaQuery,
-    schema: keystone.graphQLSchema,
+    schema: system.graphQLSchema,
     contextValue: {
       isAdminUIBuildProcess: true,
     },
@@ -44,7 +44,7 @@ import { KeystoneProvider } from '@keystone-next/admin-ui/context';
 import { ErrorBoundary } from '@keystone-next/admin-ui/components';
 import { Core } from '@keystone-ui/core';
 
-${keystone.views
+${system.views
   .map(
     (view, i) =>
       `import * as view${i} from ${JSON.stringify(
@@ -55,7 +55,7 @@ ${keystone.views
 
 ${configFile ? `import * as adminConfig from "../../../admin/config";` : 'const adminConfig = {};'}
 
-const fieldViews = [${keystone.views.map((x, i) => `view${i}`)}];
+const fieldViews = [${system.views.map((x, i) => `view${i}`)}];
 
 const lazyMetadataQuery = ${JSON.stringify(lazyMetadataQuery)};
 

--- a/packages-next/admin-ui/src/templates/home.ts
+++ b/packages-next/admin-ui/src/templates/home.ts
@@ -1,6 +1,6 @@
 import type { KeystoneSystem } from '@keystone-next/types';
 
-export const homeTemplate = (keystone: KeystoneSystem) => {
+export const homeTemplate = (system: KeystoneSystem) => {
   let query = `query {
     keystone {
       adminMeta {
@@ -16,8 +16,8 @@ export const homeTemplate = (keystone: KeystoneSystem) => {
       }
     }
 `;
-  for (const listKey in keystone.adminMeta.lists) {
-    query += `${listKey}: ${keystone.adminMeta.lists[listKey].gqlNames.listQueryMetaName} { count }\n`;
+  for (const listKey in system.adminMeta.lists) {
+    query += `${listKey}: ${system.adminMeta.lists[listKey].gqlNames.listQueryMetaName} { count }\n`;
   }
   query += '}';
   // -- TEMPLATE START

--- a/packages-next/admin-ui/src/templates/index.ts
+++ b/packages-next/admin-ui/src/templates/index.ts
@@ -13,7 +13,7 @@ const pkgDir = Path.dirname(require.resolve('@keystone-next/admin-ui/package.jso
 export { adminMetaSchemaExtension } from './adminMetaSchemaExtension';
 
 export const writeAdminFiles = (
-  keystone: KeystoneSystem,
+  system: KeystoneSystem,
   configFile: boolean,
   projectAdminPath: string
 ): AdminFileToWrite[] => {
@@ -31,30 +31,30 @@ export const writeAdminFiles = (
     {
       mode: 'write',
       outputPath: 'pages/no-access.js',
-      src: noAccessTemplate(keystone),
+      src: noAccessTemplate(system),
     },
     {
       mode: 'write',
       outputPath: 'pages/_app.js',
-      src: appTemplate(keystone, { configFile, projectAdminPath }),
+      src: appTemplate(system, { configFile, projectAdminPath }),
     },
     {
       mode: 'write',
-      src: homeTemplate(keystone),
+      src: homeTemplate(system),
       outputPath: 'pages/index.js',
     },
-    ...Object.values(keystone.adminMeta.lists)
+    ...Object.values(system.adminMeta.lists)
       .map(list => {
         const { path } = list;
         return [
           {
             mode: 'write',
-            src: listTemplate(keystone, { list }),
+            src: listTemplate(system, { list }),
             outputPath: `pages/${path}/index.js`,
           },
           {
             mode: 'write',
-            src: itemTemplate(keystone, { list }),
+            src: itemTemplate(system, { list }),
             outputPath: `pages/${path}/[id].js`,
           },
         ] as const;

--- a/packages-next/admin-ui/src/templates/item.tsx
+++ b/packages-next/admin-ui/src/templates/item.tsx
@@ -4,7 +4,7 @@ type ItemPageTemplateOptions = {
   list: KeystoneSystem['adminMeta']['lists'][string];
 };
 
-export const itemTemplate = (keystone: KeystoneSystem, { list }: ItemPageTemplateOptions) => {
+export const itemTemplate = (system: KeystoneSystem, { list }: ItemPageTemplateOptions) => {
   // -- TEMPLATE START
   return `
 import React from 'react';

--- a/packages-next/admin-ui/src/templates/list.tsx
+++ b/packages-next/admin-ui/src/templates/list.tsx
@@ -4,7 +4,7 @@ type ListPageTemplateOptions = {
   list: KeystoneSystem['adminMeta']['lists'][string];
 };
 
-export const listTemplate = (keystone: KeystoneSystem, { list }: ListPageTemplateOptions) => {
+export const listTemplate = (system: KeystoneSystem, { list }: ListPageTemplateOptions) => {
   // -- TEMPLATE START
   return `
 import React from 'react';

--- a/packages-next/admin-ui/src/templates/no-access.ts
+++ b/packages-next/admin-ui/src/templates/no-access.ts
@@ -1,6 +1,6 @@
 import type { KeystoneSystem } from '@keystone-next/types';
 
-export const noAccessTemplate = (keystone: KeystoneSystem) => {
+export const noAccessTemplate = (system: KeystoneSystem) => {
   // -- TEMPLATE START
   return `
 import React from 'react';
@@ -8,7 +8,7 @@ import React from 'react';
 import { NoAccessPage } from '@keystone-next/admin-ui/pages/NoAccessPage';
 
 export default function Home() {
-  return <NoAccessPage sessionsEnabled={${!!keystone.config.session}} />;
+  return <NoAccessPage sessionsEnabled={${!!system.config.session}} />;
 }
   `;
   // -- TEMPLATE END

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -90,7 +90,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   const adminPageMiddleware: Auth['ui']['pageMiddleware'] = async ({
     req,
     isValidSession,
-    keystone,
+    system,
     session,
   }) => {
     const pathname = url.parse(req.url!).pathname!;
@@ -106,7 +106,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
 
     if (!session && initFirstItem) {
-      const { count } = await keystone.keystone.lists[listKey].adapter.itemsQuery(
+      const { count } = await system.keystone.lists[listKey].adapter.itemsQuery(
         {},
         {
           meta: true,
@@ -139,7 +139,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    *
    * The signin page is always included, and the init page is included when initFirstItem is set
    */
-  const additionalFiles: Auth['ui']['getAdditionalFiles'] = keystone => {
+  const additionalFiles: Auth['ui']['getAdditionalFiles'] = system => {
     let filesToWrite: AdminFileToWrite[] = [
       {
         mode: 'write',
@@ -150,7 +150,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     if (initFirstItem) {
       const fields: Record<string, SerializedFieldMeta> = {};
       for (const fieldPath of initFirstItem.fields) {
-        fields[fieldPath] = keystone.adminMeta.lists[listKey].fields[fieldPath];
+        fields[fieldPath] = system.adminMeta.lists[listKey].fields[fieldPath];
       }
 
       filesToWrite.push({

--- a/packages-next/keystone/src/lib/generateAdminUI.ts
+++ b/packages-next/keystone/src/lib/generateAdminUI.ts
@@ -66,7 +66,7 @@ async function writeAdminFilesToDisk(
   ).flat();
 }
 
-export const generateAdminUI = async (keystone: KeystoneSystem, cwd: string) => {
+export const generateAdminUI = async (system: KeystoneSystem, cwd: string) => {
   const projectAdminPath = Path.resolve(cwd, './.keystone/admin');
 
   await fs.remove(projectAdminPath);
@@ -75,12 +75,12 @@ export const generateAdminUI = async (keystone: KeystoneSystem, cwd: string) => 
   const filesWritten = new Set(
     [
       ...(await writeAdminFilesToDisk(
-        keystone.config.ui?.getAdditionalFiles?.map(x => x(keystone)) ?? [],
+        system.config.ui?.getAdditionalFiles?.map(x => x(system)) ?? [],
         projectAdminPath
       )),
     ].map(x => Path.normalize(x))
   );
-  const baseFiles = writeAdminFiles(keystone, configFile, projectAdminPath).filter(x => {
+  const baseFiles = writeAdminFiles(system, configFile, projectAdminPath).filter(x => {
     if (filesWritten.has(Path.normalize(x.outputPath))) {
       return false;
     }

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -27,19 +27,19 @@ export const dev = async () => {
   let adminUIServer: null | ReturnType<typeof express> = null;
 
   const initKeystone = async () => {
-    const keystone = createKeystone(requireSource(path.join(process.cwd(), 'keystone')).default);
-    let printedSchema = printSchema(keystone.graphQLSchema);
+    const system = createKeystone(requireSource(path.join(process.cwd(), 'keystone')).default);
+    let printedSchema = printSchema(system.graphQLSchema);
     console.log('✨ Generating Schema');
     await fs.outputFile('./.keystone/schema.graphql', printedSchema);
     await fs.outputFile(
       './.keystone/schema-types.ts',
-      formatSource(printGeneratedTypes(printedSchema, keystone), 'babel-ts')
+      formatSource(printGeneratedTypes(printedSchema, system), 'babel-ts')
     );
 
     console.log('✨ Generating Admin UI');
-    await generateAdminUI(keystone, process.cwd());
+    await generateAdminUI(system, process.cwd());
 
-    adminUIServer = await createAdminUIServer(keystone);
+    adminUIServer = await createAdminUIServer(system);
     console.log(`👋 Admin UI Ready`);
   };
 

--- a/packages-next/keystone/src/scripts/schema-type-printer.tsx
+++ b/packages-next/keystone/src/scripts/schema-type-printer.tsx
@@ -70,7 +70,7 @@ function printInputTypesFromSchema(
   return { printedTypes: typeString + '\n', ast, printTypeNode };
 }
 
-export function printGeneratedTypes(printedSchema: string, keystone: KeystoneSystem) {
+export function printGeneratedTypes(printedSchema: string, system: KeystoneSystem) {
   let scalars = {
     ID: 'string',
     Boolean: 'boolean',
@@ -82,7 +82,7 @@ export function printGeneratedTypes(printedSchema: string, keystone: KeystoneSys
 
   let { printedTypes, ast, printTypeNode } = printInputTypesFromSchema(
     printedSchema,
-    keystone.graphQLSchema,
+    system.graphQLSchema,
     scalars
   );
 
@@ -90,7 +90,7 @@ export function printGeneratedTypes(printedSchema: string, keystone: KeystoneSys
 
   let allListsStr = '\nexport type KeystoneListsTypeInfo = {';
 
-  let queryTypeName = keystone.graphQLSchema.getQueryType()!.name;
+  let queryTypeName = system.graphQLSchema.getQueryType()!.name;
 
   let queryNode = ast.definitions.find((node): node is ObjectTypeDefinitionNode => {
     return node.kind === 'ObjectTypeDefinition' && node.name.value === queryTypeName;
@@ -117,10 +117,10 @@ export function printGeneratedTypes(printedSchema: string, keystone: KeystoneSys
     return types + '}';
   };
 
-  for (const listKey in keystone.adminMeta.lists) {
-    const list = keystone.adminMeta.lists[listKey];
+  for (const listKey in system.adminMeta.lists) {
+    const list = system.adminMeta.lists[listKey];
     let backingTypes = '{\n';
-    for (const field of keystone.keystone.lists[list.key].fields) {
+    for (const field of system.keystone.lists[list.key].fields) {
       for (const [key, { optional, type }] of Object.entries(field.getBackingTypes()) as any) {
         backingTypes += `readonly ${JSON.stringify(key)}${optional ? '?' : ''}: ${type};\n`;
       }
@@ -131,7 +131,7 @@ export function printGeneratedTypes(printedSchema: string, keystone: KeystoneSys
     printedTypes += `
 export type ${listTypeInfoName} = {
   key: ${JSON.stringify(listKey)};
-  fields: ${Object.keys(keystone.adminMeta.lists[list.key].fields)
+  fields: ${Object.keys(system.adminMeta.lists[list.key].fields)
     .map(x => JSON.stringify(x))
     .join('|')}
   backing: ${backingTypes};

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -78,11 +78,11 @@ export function withItemData(createSession: CreateSession, fieldSelections: Fiel
     const { get, ...sessionStrategy } = createSession();
     return {
       ...sessionStrategy,
-      get: async ({ req, keystone }) => {
-        const session = await get({ req, keystone });
+      get: async ({ req, system }) => {
+        const session = await get({ req, system });
         if (!session) return;
-        const context = keystone.createContext({ skipAccessControl: true });
-        const { gqlNames } = keystone.adminMeta.lists[session.listKey];
+        const context = system.createContext({ skipAccessControl: true });
+        const { gqlNames } = system.adminMeta.lists[session.listKey];
         // If no field selection is specified, just load the id. We still load the item,
         // because doing so validates that it exists in the database
         const fields = fieldSelections[session.listKey] || 'id';
@@ -92,7 +92,7 @@ export function withItemData(createSession: CreateSession, fieldSelections: Fiel
           }
         }`);
         const args = { id: session.itemId };
-        const result = await execute(keystone.graphQLSchema, query, null, context, args);
+        const result = await execute(system.graphQLSchema, query, null, context, args);
         // TODO: This causes "not found" errors to throw, which is not what we want
         // TODO: Also, why is this coming back as an access denied error instead of "not found" with an invalid session?
         // if (result.errors?.length) {
@@ -124,7 +124,7 @@ export function statelessSessions({
     }
     return sessionStrategy({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      async get({ req, keystone }) {
+      async get({ req, system }) {
         if (!req.headers.cookie) return;
         let cookies = cookie.parse(req.headers.cookie);
         if (!cookies[TOKEN_NAME]) return;
@@ -179,23 +179,23 @@ export function storedSessions({
     return {
       connect: store.connect,
       disconnect: store.disconnect,
-      async get({ req, keystone }) {
-        let sessionId = await get({ req, keystone });
+      async get({ req, system }) {
+        let sessionId = await get({ req, system });
         if (typeof sessionId === 'string') {
           return store.get(sessionId);
         }
       },
-      async start({ res, data, keystone }) {
+      async start({ res, data, system }) {
         let sessionId = generateSessionId();
         await store.set(sessionId, data);
-        return start({ res, data: { sessionId }, keystone });
+        return start({ res, data: { sessionId }, system });
       },
-      async end({ req, res, keystone }) {
-        let sessionId = await get({ req, keystone });
+      async end({ req, res, system }) {
+        let sessionId = await get({ req, system });
         if (typeof sessionId === 'string') {
           await store.delete(sessionId);
         }
-        await end({ req, res, keystone });
+        await end({ req, res, system });
       },
     };
   };
@@ -220,20 +220,20 @@ export function implementSession(sessionStrategy: SessionStrategy<unknown>) {
     async createContext(
       req: IncomingMessage,
       res: ServerResponse,
-      keystone: KeystoneSystem
+      system: KeystoneSystem
     ): Promise<SessionContext> {
       if (!isConnected) {
         await connect();
       }
-      const session = await sessionStrategy.get({ req, keystone });
+      const session = await sessionStrategy.get({ req, system });
       const startSession = sessionStrategy.start;
       const endSession = sessionStrategy.end;
       return {
         session,
         startSession: startSession
-          ? (data: unknown) => startSession({ res, data, keystone })
+          ? (data: unknown) => startSession({ res, data, system })
           : undefined,
-        endSession: endSession ? () => endSession({ req, res, keystone }) : undefined,
+        endSession: endSession ? () => endSession({ req, res, system }) : undefined,
       };
     },
   };

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -40,12 +40,12 @@ export type KeystoneAdminUIConfig = {
   publicPages?: string[];
   /** The basePath for the Admin UI App */
   path?: string;
-  getAdditionalFiles?: ((keystone: KeystoneSystem) => MaybePromise<AdminFileToWrite[]>)[];
+  getAdditionalFiles?: ((system: KeystoneSystem) => MaybePromise<AdminFileToWrite[]>)[];
   pageMiddleware?: (args: {
     req: IncomingMessage;
     session: any;
     isValidSession: boolean;
-    keystone: KeystoneSystem;
+    system: KeystoneSystem;
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 

--- a/packages-next/types/src/session.ts
+++ b/packages-next/types/src/session.ts
@@ -10,19 +10,19 @@ export type SessionStrategy<StoredSessionData, StartSessionData = never> = {
   start?: (args: {
     res: ServerResponse;
     data: StoredSessionData | StartSessionData;
-    keystone: KeystoneSystem;
+    system: KeystoneSystem;
   }) => Promise<string>;
   // resets the cookie via res
   end?: (args: {
     req: IncomingMessage;
     res: ServerResponse;
-    keystone: KeystoneSystem;
+    system: KeystoneSystem;
   }) => Promise<void>;
   // -- this one is invoked at the start of every request
   // reads the token, gets the data, returns it
   get: (args: {
     req: IncomingMessage;
-    keystone: KeystoneSystem;
+    system: KeystoneSystem;
   }) => Promise<StoredSessionData | undefined>;
 };
 


### PR DESCRIPTION
Now we know that a variable called `keystone` is indeed a core `Keystone` object.