### PR TITLE
Simplify auth graphQL generation

### DIFF
--- a/.changeset/happy-pigs-suffer.md
+++ b/.changeset/happy-pigs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Simplified the code used to generate graphQL extensions.

--- a/packages-next/auth/package.json
+++ b/packages-next/auth/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
+    "@graphql-tools/merge": "^6.2.5",
     "@keystone-next/fields": "^3.0.0",
     "@keystone-next/types": "^3.0.0",
     "@keystone-ui/button": "^2.0.1",

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -1,4 +1,3 @@
-import { graphQLSchemaExtension } from '@keystone-next/keystone/schema';
 import { AuthGqlNames } from '../types';
 
 import { attemptAuthentication } from '../lib/attemptAuthentication';
@@ -17,7 +16,7 @@ export function getBaseAuthSchema({
   protectIdentities: boolean;
   gqlNames: AuthGqlNames;
 }) {
-  return graphQLSchemaExtension({
+  return {
     typeDefs: `
       # Auth
       union AuthenticatedItem = ${listKey}
@@ -104,5 +103,5 @@ export function getBaseAuthSchema({
         },
       },
     },
-  });
+  };
 }

--- a/packages-next/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages-next/auth/src/gql/getInitFirstItemSchema.ts
@@ -1,5 +1,3 @@
-import { GraphQLSchema } from 'graphql';
-import { graphQLSchemaExtension } from '@keystone-next/keystone/schema';
 import { AuthGqlNames } from '../types';
 
 export function getInitFirstItemSchema({
@@ -7,62 +5,51 @@ export function getInitFirstItemSchema({
   fields,
   itemData,
   gqlNames,
+  keystone,
 }: {
   listKey: string;
   fields: string[];
   itemData: Record<string, any> | undefined;
   gqlNames: AuthGqlNames;
+  keystone: any;
 }) {
-  return (schema: GraphQLSchema, keystoneClassInstance: any) => {
-    const list = keystoneClassInstance.lists[listKey];
+  const list = keystone.lists[listKey];
 
-    const newSchema = graphQLSchemaExtension({
-      typeDefs: `
+  return {
+    typeDefs: `
         input ${gqlNames.CreateInitialInput} {
           ${Array.prototype
             .concat(
               ...fields.map(fieldPath =>
-                list.fieldsByPath[fieldPath].gqlCreateInputFields({
-                  schemaName: 'public',
-                })
+                list.fieldsByPath[fieldPath].gqlCreateInputFields({ schemaName: 'public' })
               )
             )
             .join('\n')}
         }
         type Mutation {
           ${gqlNames.createInitialItem}(data: ${gqlNames.CreateInitialInput}!): ${
-        gqlNames.ItemAuthenticationWithPasswordResult
-      }!
+      gqlNames.ItemAuthenticationWithPasswordResult
+    }!
         }
       `,
-      resolvers: {
-        Mutation: {
-          async [`createInitial${listKey}`](rootVal: any, { data }: any, context: any) {
-            const { count } = await list.adapter.itemsQuery(
-              {},
-              {
-                meta: true,
-              }
-            );
-            if (count !== 0) {
-              throw new Error('Initial items can only be created when no items exist in that list');
-            }
-            const contextThatSkipsAccessControl = await context.createContext({
-              skipAccessControl: true,
-            });
-            const item = await list.createMutation(
-              { ...data, ...itemData },
-              contextThatSkipsAccessControl
-            );
-            const token = await context.startSession({ listKey, itemId: item.id });
-            return {
-              item,
-              token,
-            };
-          },
+    resolvers: {
+      Mutation: {
+        async [`createInitial${listKey}`](rootVal: any, { data }: any, context: any) {
+          const { count } = await list.adapter.itemsQuery({}, { meta: true });
+          if (count !== 0) {
+            throw new Error('Initial items can only be created when no items exist in that list');
+          }
+          const contextThatSkipsAccessControl = await context.createContext({
+            skipAccessControl: true,
+          });
+          const item = await list.createMutation(
+            { ...data, ...itemData },
+            contextThatSkipsAccessControl
+          );
+          const token = await context.startSession({ listKey, itemId: item.id });
+          return { item, token };
         },
       },
-    })(schema, keystoneClassInstance);
-    return newSchema;
+    },
   };
 }

--- a/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -1,4 +1,3 @@
-import { graphQLSchemaExtension } from '@keystone-next/keystone/schema';
 import { AuthGqlNames, AuthTokenTypeConfig } from '../types';
 
 import { updateAuthToken } from '../lib/updateAuthToken';
@@ -19,7 +18,7 @@ export function getMagicAuthLinkSchema({
   gqlNames: AuthGqlNames;
   magicAuthLink: AuthTokenTypeConfig;
 }) {
-  return graphQLSchemaExtension({
+  return {
     typeDefs: `
       # Magic links
       type Mutation {
@@ -125,5 +124,5 @@ export function getMagicAuthLinkSchema({
         },
       },
     },
-  });
+  };
 }

--- a/packages-next/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages-next/auth/src/gql/getPasswordResetSchema.ts
@@ -1,4 +1,3 @@
-import { graphQLSchemaExtension } from '@keystone-next/keystone/schema';
 import { AuthGqlNames, AuthTokenTypeConfig } from '../types';
 
 import { updateAuthToken } from '../lib/updateAuthToken';
@@ -22,7 +21,7 @@ export function getPasswordResetSchema({
   gqlNames: AuthGqlNames;
   passwordResetLink: AuthTokenTypeConfig;
 }) {
-  return graphQLSchemaExtension({
+  return {
     typeDefs: `
       # Reset password
       type Mutation {
@@ -145,5 +144,5 @@ export function getPasswordResetSchema({
         },
       },
     },
-  });
+  };
 }


### PR DESCRIPTION
This PR changes things up so that the helper functions just have to worry about returning `{ typeDefs, resolvers }`, and all the schema merging is handled in a single step.