### PR TITLE
New docs site for the new interfaces

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           filters: |
             shouldRequireApprovalFromPerson:
-              - '!{packages-next,examples-next,design-system}/**'
+              - '!{design-system,docs-next,examples-next,packages-next}/**'
       - uses: Thinkmill/auto-approve-action@v1
         with:
           approve: ${{ steps.filter.outputs.shouldRequireApprovalFromPerson == 'false' }}

--- a/docs-next/website/components/Code.tsx
+++ b/docs-next/website/components/Code.tsx
@@ -1,0 +1,20 @@
+/* @jsx jsx */
+
+import { ReactNode } from 'react';
+import { jsx, useTheme } from '@keystone-ui/core';
+
+export const Code = ({ children }: { children: ReactNode }) => {
+  const { palette, spacing, radii } = useTheme();
+  return (
+    <code
+      css={{
+        color: palette.neutral700,
+        background: palette.neutral100,
+        padding: spacing.xsmall,
+        borderRadius: radii.small,
+      }}
+    >
+      {children}
+    </code>
+  );
+};

--- a/docs-next/website/components/Navigation.tsx
+++ b/docs-next/website/components/Navigation.tsx
@@ -1,0 +1,81 @@
+/* @jsx jsx */
+
+import { Fragment, ReactNode } from 'react';
+import { jsx, useTheme } from '@keystone-ui/core';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+const Brand = () => {
+  const { palette } = useTheme();
+  return (
+    <h2>
+      <Link href="/" passHref>
+        <a
+          css={{
+            color: palette.neutral700,
+            textDecoration: 'none',
+            display: 'block',
+          }}
+        >
+          Keystone Next
+        </a>
+      </Link>
+    </h2>
+  );
+};
+
+type SectionProps = { label: string; children: ReactNode };
+const Section = ({ label, children }: SectionProps) => {
+  return (
+    <Fragment>
+      <h3>{label}</h3>
+      <ul css={{ margin: 0, padding: 0 }}>{children}</ul>
+    </Fragment>
+  );
+};
+
+type NavItemProps = { href: string; children: ReactNode };
+const NavItem = ({ href, children }: NavItemProps) => {
+  const { palette, radii, spacing } = useTheme();
+  const router = useRouter();
+  const isSelected = router.pathname === href;
+  return (
+    <li
+      css={{
+        listStyle: 'none',
+        marginLeft: 0,
+        paddingLeft: 0,
+      }}
+    >
+      <Link href={href} passHref>
+        <a
+          css={{
+            color: isSelected ? palette.neutral800 : palette.neutral700,
+            backgroundColor: isSelected ? palette.white : undefined,
+            borderRadius: radii.medium,
+            padding: spacing.small,
+            display: 'block',
+            textDecoration: 'none',
+            ':hover': {
+              color: isSelected ? undefined : palette.blue500,
+              backgroundColor: isSelected ? undefined : palette.white,
+            },
+          }}
+        >
+          {children}
+        </a>
+      </Link>
+    </li>
+  );
+};
+
+export const Navigation = () => {
+  return (
+    <Fragment>
+      <Brand />
+      <Section label="Guides">
+        <NavItem href="/guides/getting-started">Getting Started</NavItem>
+      </Section>
+    </Fragment>
+  );
+};

--- a/docs-next/website/components/Page.tsx
+++ b/docs-next/website/components/Page.tsx
@@ -1,0 +1,68 @@
+/* @jsx jsx */
+
+import type { HTMLAttributes, ReactNode } from 'react';
+import { jsx, useTheme } from '@keystone-ui/core';
+
+import { Navigation } from './Navigation';
+
+const SIDEBAR_WIDTH = 320;
+
+const PageWrapper = (props: HTMLAttributes<HTMLElement>) => (
+  <div css={{ display: 'flex' }} {...props} />
+);
+
+const Sidebar = (props: HTMLAttributes<HTMLElement>) => {
+  const { palette, spacing } = useTheme();
+
+  return (
+    <aside
+      css={{
+        backgroundColor: palette.neutral100,
+        borderRight: `1px solid ${palette.neutral400}`,
+        boxSizing: 'border-box',
+        flexShrink: 0,
+        height: '100vh',
+        minWidth: 0,
+        paddingLeft: spacing.xlarge,
+        paddingRight: spacing.xlarge,
+        overflowY: 'auto',
+        position: 'sticky',
+        top: 0,
+        width: SIDEBAR_WIDTH,
+        WebkitOverflowScrolling: 'touch',
+      }}
+      {...props}
+    />
+  );
+};
+
+const Content = (props: HTMLAttributes<HTMLElement>) => {
+  const { colors, spacing } = useTheme();
+
+  return (
+    <div
+      css={{
+        backgroundColor: colors.background,
+        boxSizing: 'border-box',
+        flex: 1,
+        minHeight: '100vh',
+        minWidth: 1, // resolves collapsing issues in children
+        paddingLeft: spacing.xlarge,
+        paddingRight: spacing.xlarge,
+        paddingBottom: spacing.xlarge,
+      }}
+      {...props}
+    />
+  );
+};
+
+export const Page = ({ children }: { children: ReactNode }) => {
+  return (
+    <PageWrapper>
+      <Sidebar>
+        <Navigation />
+      </Sidebar>
+      <Content>{children}</Content>
+    </PageWrapper>
+  );
+};

--- a/docs-next/website/next-env.d.ts
+++ b/docs-next/website/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/docs-next/website/next.config.js
+++ b/docs-next/website/next.config.js
@@ -1,0 +1,3 @@
+const withPreconstruct = require('@preconstruct/next');
+
+module.exports = withPreconstruct();

--- a/docs-next/website/package.json
+++ b/docs-next/website/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@keystone-next/website",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "dev": "next -p 8000"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.12.5",
+    "@keystone-ui/button": "^2.0.1",
+    "@keystone-ui/core": "^1.0.2",
+    "@keystone-ui/fields": "^1.0.1",
+    "@keystone-ui/notice": "^1.0.1",
+    "@keystone-ui/tooltip": "^1.0.2",
+    "@preconstruct/next": "^2.0.0",
+    "@types/react": "^16.9.56",
+    "@types/react-dom": "^16.9.9",
+    "@types/webpack": "^4.41.25",
+    "next": "^9.5.5",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.5"
+  },
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/master/docs-next/website"
+}

--- a/docs-next/website/pages/_app.tsx
+++ b/docs-next/website/pages/_app.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Core } from '@keystone-ui/core';
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <Core>
+      <Component {...pageProps} />
+    </Core>
+  );
+}

--- a/docs-next/website/pages/guides/getting-started.tsx
+++ b/docs-next/website/pages/guides/getting-started.tsx
@@ -1,0 +1,14 @@
+/* @jsx jsx */
+
+import { jsx } from '@keystone-ui/core';
+
+import { Page } from '../../components/Page';
+
+export default function IndexPage() {
+  return (
+    <Page>
+      <h1>Getting Started</h1>
+      <p>(coming soon)</p>
+    </Page>
+  );
+}

--- a/docs-next/website/pages/index.tsx
+++ b/docs-next/website/pages/index.tsx
@@ -1,0 +1,14 @@
+/* @jsx jsx */
+
+import { jsx } from '@keystone-ui/core';
+
+import { Page } from '../components/Page';
+
+export default function IndexPage() {
+  return (
+    <Page>
+      <h1>Welcome</h1>
+      <p>These are the docs for the next version of KeystoneJS.</p>
+    </Page>
+  );
+}

--- a/docs-next/website/tsconfig.json
+++ b/docs-next/website/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
       "examples-next/*",
       "packages-next/*",
       "design-system/packages/*",
-      "design-system/website"
+      "design-system/website",
+      "docs-next/website"
     ],
     "nohoist": [
       "**/cypress-multi-reporters"


### PR DESCRIPTION
We really need somewhere to start documenting the new interfaces, so this PR adds a super basic docs website to the `docs-next` directory (based on the also super basic design system docs website)

I've got a few plans for this including experimenting with a different IA to the current site, using Next.js over Gatsby for simplicity, not using the same source for package docs and README.md, and also I don't want to have any of the new docs show up in the current site yet. So this may turn out to be an interim measure of sorts, but docs are pretty portable anyway so whatever we write here can be factored in elsewhere once we decide what the longer term strategy is 🙂