### PR TITLE
Ensure session listKey and itemId are valid in withItemData

### DIFF
--- a/.changeset/cuddly-ladybugs-bathe.md
+++ b/.changeset/cuddly-ladybugs-bathe.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Fixed behaviour in withItemData when session listKey and itemId aren't valid

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -80,7 +80,14 @@ export function withItemData(createSession: CreateSession, fieldSelections: Fiel
       ...sessionStrategy,
       get: async ({ req, system }) => {
         const session = await get({ req, system });
-        if (!session) return;
+        if (
+          !session ||
+          !session.listKey ||
+          !session.itemId ||
+          !system.adminMeta.lists[session.listKey]
+        ) {
+          return;
+        }
         const context = system.createContext({ skipAccessControl: true });
         const { gqlNames } = system.adminMeta.lists[session.listKey];
         // If no field selection is specified, just load the id. We still load the item,


### PR DESCRIPTION
This fixes a bug where if you had an invalid session cookie (e.g were signed into a project on localhost, and switched to another one that uses a different `listKey` for sessions) it would throw an error in `withItemData` instead of failing gracefully.

Now, it will just pretend the session is invalid, which is the same as having an `itemId` that can't be found in the database