### PR TITLE
Fixed auth when you're using a listKey other than User

### DIFF
--- a/.changeset/new-lies-reflect.md
+++ b/.changeset/new-lies-reflect.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/auth": patch
+---
+
+Fixed auth when you're using a listKey other than User

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -67,7 +67,7 @@ export function getBaseAuthSchema({
             return { code: result.code, message };
           }
 
-          const sessionToken = await ctx.startSession({ listKey: 'User', itemId: result.item.id });
+          const sessionToken = await ctx.startSession({ listKey, itemId: result.item.id });
           return { token: sessionToken, item: result.item };
         },
       },


### PR DESCRIPTION
😅 well this was a pretty big miss...

The `listKey` in the auth data was hardcoded to `User`. Fixed now.