### PR TITLE
Fixed hard errors on the item screen when you can't load the item

### DIFF
--- a/.changeset/four-starfishes-greet.md
+++ b/.changeset/four-starfishes-greet.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/admin-ui": patch
+---
+
+Fixed hard errors on the item screen when you can't load the item

--- a/packages-next/admin-ui/src/pages/ItemPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ItemPage/index.tsx
@@ -12,6 +12,7 @@ import { LoadingDots } from '@keystone-ui/loading';
 import { ClipboardIcon } from '@keystone-ui/icons/icons/ClipboardIcon';
 import { ChevronRightIcon } from '@keystone-ui/icons/icons/ChevronRightIcon';
 import { AlertDialog, DrawerController } from '@keystone-ui/modals';
+import { Notice } from '@keystone-ui/notice';
 import { useToasts } from '@keystone-ui/toast';
 import { Tooltip } from '@keystone-ui/tooltip';
 import { FieldLabel, TextInput } from '@keystone-ui/fields';
@@ -180,7 +181,7 @@ function ItemForm({
                 });
               }}
             >
-              Reset
+              Reset changes
             </Button>
           ) : (
             <Text weight="medium" paddingX="large" color="neutral600">
@@ -342,7 +343,7 @@ export const ItemPage = ({ listKey }: ItemPageProps) => {
     return itemViewFieldModesByField;
   }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
 
-  const errorsFromMetaQuery = dataGetter.get('keystone').errors;
+  const metaQueryErrors = dataGetter.get('keystone').errors;
 
   // NOTE: The create button is always hidden on this page for now, while we work on the
   // placment of the save and delete buttons.
@@ -393,7 +394,9 @@ export const ItemPage = ({ listKey }: ItemPageProps) => {
                 whiteSpace: 'nowrap',
               }}
             >
-              {data && data.item && (data.item[list.labelField] || data.item.id)}
+              {loading
+                ? 'Loading...'
+                : (data && data.item && (data.item[list.labelField] || data.item.id)) || id}
             </Heading>
           </div>
           {!hideCreate && <CreateButton listKey={listKey} id={data.item.id} />}
@@ -404,8 +407,10 @@ export const ItemPage = ({ listKey }: ItemPageProps) => {
         <Center css={{ height: `calc(100vh - ${HEADER_HEIGHT}px)` }}>
           <LoadingDots label="Loading item data" size="large" tone="passive" />
         </Center>
-      ) : errorsFromMetaQuery ? (
-        <div css={{ color: 'red' }}>{errorsFromMetaQuery[0].message}</div>
+      ) : metaQueryErrors ? (
+        <Box marginY="xlarge">
+          <Notice tone="negative">{metaQueryErrors[0].message}</Notice>
+        </Box>
       ) : (
         <Fragment>
           <ColumnLayout>


### PR DESCRIPTION
In dev I found cases where the item screen would hard crash when you didn't have access to an item (or it didn't exist)

This PR fixes them, and also cleans up the loading and error states a bit (including using the Notice component)

![image](https://user-images.githubusercontent.com/872310/99397824-ab5ef800-2937-11eb-98de-ab7fcc1f360b.png)
