### PR TITLE
[RFC] Add support for system level plugins

### DIFF
--- a/examples-next/auth/keystone.ts
+++ b/examples-next/auth/keystone.ts
@@ -54,25 +54,23 @@ const { withAuth } = createAuth({
   */
 });
 
-// withAuth applies the signin functionality to the keystone config
-export default withAuth(
-  config({
-    db: {
-      adapter: 'mongoose',
-      url: 'mongodb://localhost/keystone-examples-next-auth',
-    },
-    lists,
-    ui: {},
-    session: withItemData(
-      // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie
-      statelessSessions({
-        // The maxAge option controls how long session cookies are valid for before they expire
-        maxAge: sessionMaxAge,
-        // The session secret is used to encrypt cookie data (should be an environment variable)
-        secret: sessionSecret,
-      }),
-      // withItemData will fetch these fields for signed-in User items to populate session.data
-      { User: 'name isAdmin' }
-    ),
-  })
-);
+export default config({
+  db: {
+    adapter: 'mongoose',
+    url: 'mongodb://localhost/keystone-examples-next-auth',
+  },
+  lists,
+  ui: {},
+  session: withItemData(
+    // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie
+    statelessSessions({
+      // The maxAge option controls how long session cookies are valid for before they expire
+      maxAge: sessionMaxAge,
+      // The session secret is used to encrypt cookie data (should be an environment variable)
+      secret: sessionSecret,
+    }),
+    // withItemData will fetch these fields for signed-in User items to populate session.data
+    { User: 'name isAdmin' }
+  ),
+  plugins: [withAuth],
+});

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -22,35 +22,34 @@ const auth = createAuth({
 // TODO -- Create a separate example for access control in the Admin UI
 // const isAccessAllowed = ({ session }: { session: any }) => !!session?.item?.isAdmin;
 
-export default auth.withAuth(
-  config({
-    db: {
-      adapter: 'mongoose',
-      url: 'mongodb://localhost/keystone-examples-next-basic',
-    },
-    graphql: {
-      // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
-      path: '/api/graphql',
-    },
-    ui: {
-      // NOTE -- this is not implemented, keystone currently always provides an admin ui at /
-      path: '/admin',
-      // isAccessAllowed,
-    },
-    lists,
-    extendGraphqlSchema,
-    session: withItemData(
-      statelessSessions({
-        maxAge: sessionMaxAge,
-        secret: sessionSecret,
-      }),
-      { User: 'name isAdmin' }
-    ),
-    // TODO -- Create a separate example for stored/redis sessions
-    // session: storedSessions({
-    //   store: new Map(),
-    //   // store: redisSessionStore({ client: redis.createClient() }),
-    //   secret: sessionSecret,
-    // }),
-  })
-);
+export default config({
+  db: {
+    adapter: 'mongoose',
+    url: 'mongodb://localhost/keystone-examples-next-basic',
+  },
+  graphql: {
+    // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
+    path: '/api/graphql',
+  },
+  ui: {
+    // NOTE -- this is not implemented, keystone currently always provides an admin ui at /
+    path: '/admin',
+    // isAccessAllowed,
+  },
+  lists,
+  extendGraphqlSchema,
+  session: withItemData(
+    statelessSessions({
+      maxAge: sessionMaxAge,
+      secret: sessionSecret,
+    }),
+    { User: 'name isAdmin' }
+  ),
+  plugins: [auth.withAuth],
+  // TODO -- Create a separate example for stored/redis sessions
+  // session: storedSessions({
+  //   store: new Map(),
+  //   // store: redisSessionStore({ client: redis.createClient() }),
+  //   secret: sessionSecret,
+  // }),
+});

--- a/examples-next/roles/keystone.ts
+++ b/examples-next/roles/keystone.ts
@@ -38,20 +38,19 @@ const { withAuth } = createAuth({
   },
 });
 
-export default withAuth(
-  config({
-    db: {
-      adapter: 'mongoose',
-      url: 'mongodb://localhost/keystone-examples-roles',
-    },
-    lists,
-    ui: {
-      /* Everyone who is signed in can access the Admin UI */
-      isAccessAllowed: isSignedIn,
-    },
-    session: withItemData(statelessSessions(sessionConfig), {
-      /* This loads the related role for the current user, including all permissions */
-      Person: `name role {
+export default config({
+  db: {
+    adapter: 'mongoose',
+    url: 'mongodb://localhost/keystone-examples-roles',
+  },
+  lists,
+  ui: {
+    /* Everyone who is signed in can access the Admin UI */
+    isAccessAllowed: isSignedIn,
+  },
+  session: withItemData(statelessSessions(sessionConfig), {
+    /* This loads the related role for the current user, including all permissions */
+    Person: `name role {
         id
         name
         canCreateTodos
@@ -61,6 +60,6 @@ export default withAuth(
         canManagePeople
         canManageRoles
       }`,
-    }),
-  })
-);
+  }),
+  plugins: [withAuth],
+});

--- a/examples-next/todo/keystone.ts
+++ b/examples-next/todo/keystone.ts
@@ -10,25 +10,24 @@ const sessionConfig = {
   secret: sessionSecret,
 };
 
-const { withAuth } = createAuth({
-  listKey: 'User',
-  identityField: 'email',
-  secretField: 'password',
-  initFirstItem: {
-    fields: ['name', 'email', 'password'],
+export default config({
+  db: {
+    adapter: 'mongoose',
+    url: 'mongodb://localhost/keystone-examples-todo',
   },
+  lists,
+  ui: {
+    isAccessAllowed: ({ session }) => !!session,
+  },
+  session: withItemData(statelessSessions(sessionConfig)),
+  plugins: [
+    createAuth({
+      listKey: 'User',
+      identityField: 'email',
+      secretField: 'password',
+      initFirstItem: {
+        fields: ['name', 'email', 'password'],
+      },
+    }).withAuth,
+  ],
 });
-
-export default withAuth(
-  config({
-    db: {
-      adapter: 'mongoose',
-      url: 'mongodb://localhost/keystone-examples-todo',
-    },
-    lists,
-    ui: {
-      isAccessAllowed: ({ session }) => !!session,
-    },
-    session: withItemData(statelessSessions(sessionConfig)),
-  })
-);

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import express from 'express';
 import { printSchema } from 'graphql';
 import * as fs from 'fs-extra';
+import type { KeystoneConfig } from '@keystone-next/types';
 import { createSystem } from '../lib/createSystem';
 import { requireSource } from '../lib/requireSource';
 import { formatSource, generateAdminUI } from '../lib/generateAdminUI';
@@ -20,6 +21,14 @@ const devLoadingHTMLFilepath = path.join(
   'dev-loading.html'
 );
 
+const applyPlugins = (config: KeystoneConfig): KeystoneConfig => {
+  const { plugins = [] } = config;
+  for (const plugin of plugins) {
+    config = plugin(config);
+  }
+  return config;
+};
+
 export const dev = async () => {
   console.log('🤞 Starting Keystone');
 
@@ -27,7 +36,7 @@ export const dev = async () => {
   let adminUIServer: null | ReturnType<typeof express> = null;
 
   const initKeystone = async () => {
-    const config = requireSource(path.join(process.cwd(), 'keystone')).default;
+    const config = applyPlugins(requireSource(path.join(process.cwd(), 'keystone')).default);
     const system = createSystem(config);
     let printedSchema = printSchema(system.graphQLSchema);
     console.log('✨ Generating Schema');

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -67,6 +67,7 @@ export type KeystoneConfig = {
     /** Configuration options for the cors middleware. Set to true to core Keystone defaults */
     cors?: any;
   };
+  plugins?: [(config: KeystoneConfig) => KeystoneConfig];
 } & SchemaConfig;
 
 export type MaybeItemFunction<T> =


### PR DESCRIPTION
This PR adds a `plugins` field to the `KeystoneConfig` type. Plugins are simply functions which take a `KeystoneConfig` object and return a new/modified `KeystoneConfig` object. They can be used to package up functionality which cuts across multiple levels of the system. 

The following code:

```js
export default config({
  ...,
  plugins: [plugin1, plugin2]
});
```

is functionally equivalent to

```js
export default plugin2(plugin1(config({
  ...
})));
```

The reason for adding this syntactic-sugar feature is to allow plugins to be applied in a declarative manner, which is consistent with the rest of the system configuration.

The pre-existing use case is the `withAuth` function in the auth package. This PR updates the examples to use the `plugins` feature to demonstrate how this pattern would look. There are a few different ways of spelling it across the different examples. One thing to note is that is that if we move to this pattern then we would probably want to rename `withAuth` to something like `plugin`, so the code would look like:

```js
export default config({
  ...,
  plugins: [createAuth({...}).plugin]
});
```