### PR TITLE
Fix sessionToken return value of auth mutation

### DIFF
--- a/.changeset/cuddly-bugs-argue.md
+++ b/.changeset/cuddly-bugs-argue.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Fixed return values of authentication mutations.

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -68,7 +68,7 @@ export function getBaseAuthSchema({
           }
 
           const sessionToken = await ctx.startSession({ listKey, itemId: result.item.id });
-          return { token: sessionToken, item: result.item };
+          return { sessionToken, item: result.item };
         },
       },
       Query: {
@@ -97,7 +97,7 @@ export function getBaseAuthSchema({
       // TODO: Is this the preferred approach for this?
       [gqlNames.ItemAuthenticationWithPasswordResult]: {
         __resolveType(rootVal: any) {
-          return rootVal.token
+          return rootVal.sessionToken
             ? gqlNames.ItemAuthenticationWithPasswordSuccess
             : gqlNames.ItemAuthenticationWithPasswordFailure;
         },


### PR DESCRIPTION
No `sessionToken` value was being returned, which also had the side effect of returning the data as the wrong graphQL type.