### PR TITLE
Use itemAPI in authenticatedItem mutation

### DIFF
--- a/.changeset/ten-pens-nail.md
+++ b/.changeset/ten-pens-nail.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Updated `authenticatedItem` to use the items API rather than direct adapter access.

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -72,26 +72,17 @@ export function getBaseAuthSchema({
         },
       },
       Query: {
-        async authenticatedItem(root: any, args: any, ctx: any) {
-          if (typeof ctx.session?.itemId === 'string' && typeof ctx.session.listKey === 'string') {
-            const item = (
-              await ctx.keystone.lists[ctx.session.listKey].adapter.find({
-                id: ctx.session.itemId,
-              })
-            )[0];
-            if (!item) return null;
-            return {
-              ...item,
-              // TODO: Is there a better way of doing this?
-              __typename: ctx.session.listKey,
-            };
+        async authenticatedItem(root: any, args: any, { session, lists }: any) {
+          if (typeof session?.itemId === 'string' && typeof session.listKey === 'string') {
+            const item = await lists[session.listKey].findOne({ where: { id: session.itemId } });
+            return item || null;
           }
           return null;
         },
       },
       AuthenticatedItem: {
-        __resolveType(rootVal: any) {
-          return rootVal.__typename;
+        __resolveType(rootVal: any, { session }: any) {
+          return session?.listKey;
         },
       },
       // TODO: Is this the preferred approach for this?


### PR DESCRIPTION
This PR also cleans up the type resolver for `AuthenticatedItem`, which simplifies the resolver code.