### PR TITLE
Lighter and faster color picker: replace react-color with react-colorful

### DIFF
--- a/.changeset/plenty-dancers-allow.md
+++ b/.changeset/plenty-dancers-allow.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields-color': minor
+---
+
+New color picker component: replaced react-color with react-colorful

--- a/packages/fields-color/package.json
+++ b/packages/fields-color/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystonejs/fields-color",
   "description": "KeystoneJS Color Field Type",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "author": "The KeystoneJS Development Team",
   "license": "MIT",
   "engines": {
@@ -14,7 +14,8 @@
     "@babel/runtime": "^7.12.5",
     "@emotion/core": "^10.1.1",
     "@keystonejs/fields": "^20.1.1",
-    "react-color": "^2.19.3"
+    "react-colorful": "^4.4.2",
+    "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
     "react": "^16.14.0"

--- a/packages/fields-color/src/views/Field.js
+++ b/packages/fields-color/src/views/Field.js
@@ -16,7 +16,7 @@ const ColorField = ({ field, value, errors, onChange, isDisabled }) => {
     // it is now stored as an rgba string
     if (value && value.indexOf('rgba') !== 0) return convert(value).toRgbString();
     // the color that picker shows if no value passed
-    return 'rgba(0, 0, 0, 1)';
+    return value || 'rgba(0, 0, 0, 1)';
   }, [value]);
 
   const target = props => (

--- a/packages/fields-color/src/views/Field.js
+++ b/packages/fields-color/src/views/Field.js
@@ -4,22 +4,19 @@ import { Fragment, useMemo } from 'react';
 import { FieldContainer, FieldLabel, FieldDescription, FieldInput } from '@arch-ui/fields';
 import Popout from '@arch-ui/popout';
 import { Button } from '@arch-ui/button';
-import SketchPicker from 'react-color/lib/Sketch';
+import convert from 'tinycolor2';
+import { RgbaStringColorPicker } from 'react-colorful';
+import 'react-colorful/dist/index.css';
 
-const ColorField = ({ field, value = '', errors, onChange, isDisabled }) => {
+const ColorField = ({ field, value, errors, onChange, isDisabled }) => {
   const htmlID = `ks-input-${field.path}`;
 
   const colorPickerValue = useMemo(() => {
     // keystone previously stored values as a hex string and this should still be supported
     // it is now stored as an rgba string
-    if (value) {
-      if (value.indexOf('rgba', 0) === 0) {
-        const rgbaValues = value.replace(/^rgba\(|\s+|\)$/g, '').split(',');
-        return { r: rgbaValues[0], g: rgbaValues[1], b: rgbaValues[2], a: rgbaValues[3] };
-      }
-      return value;
-    }
-    return '';
+    if (value && value.indexOf('rgba') !== 0) return convert(value).toRgbString();
+    // the color that picker shows if no value passed
+    return 'rgba(0, 0, 0, 1)';
   }, [value]);
 
   const target = props => (
@@ -62,18 +59,13 @@ const ColorField = ({ field, value = '', errors, onChange, isDisabled }) => {
       <FieldLabel htmlFor={htmlID} field={field} errors={errors} />
       <FieldDescription text={field.adminDoc} />
       <FieldInput>
-        <Popout width={220} target={target}>
-          <SketchPicker
+        <Popout width="auto" target={target}>
+          <RgbaStringColorPicker
             css={{
-              // using !important because react-color uses inline styles and applies a box shadow
-              // but Popout already applies a box shadow
-              boxShadow: 'none !important',
+              padding: 12,
             }}
-            presetColors={[]}
             color={colorPickerValue}
-            onChange={({ rgb: { r, g, b, a } }) => {
-              onChange(`rgba(${r}, ${g}, ${b}, ${a})`);
-            }}
+            onChange={onChange}
           />
         </Popout>
       </FieldInput>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2111,11 +2111,6 @@
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
-"@icons/material@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"
-  integrity sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==
-
 "@iframely/embed.js@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@iframely/embed.js/-/embed.js-1.3.1.tgz#b37c19604ff28bc22b3200e4ffa9151f44d0319c"
@@ -15908,11 +15903,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
@@ -16130,7 +16120,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@^4.0.1, lodash@^4.1.1, lodash@^4.11.1, lodash@^4.11.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.1.1, lodash@^4.11.1, lodash@^4.11.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -16453,11 +16443,6 @@ marked@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
   integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
-
-material-colors@^1.2.1:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
-  integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
 md5-file@^3.1.1:
   version "3.2.3"
@@ -20997,18 +20982,10 @@ react-codemirror@^1.0.0:
     lodash.isequal "^4.5.0"
     prop-types "^15.5.4"
 
-react-color@^2.19.3:
-  version "2.19.3"
-  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.19.3.tgz#ec6c6b4568312a3c6a18420ab0472e146aa5683d"
-  integrity sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==
-  dependencies:
-    "@icons/material" "^0.2.4"
-    lodash "^4.17.15"
-    lodash-es "^4.17.15"
-    material-colors "^1.2.1"
-    prop-types "^15.5.10"
-    reactcss "^1.2.0"
-    tinycolor2 "^1.4.1"
+react-colorful@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-4.4.2.tgz#b32c4458e3ae6447049cb1a8f17a2a5f6b0f5b1f"
+  integrity sha512-oQ4gG7RSpJt+C9ozmvObiZIh4E6MIgjkzjNXA1xx/Bel01Q2P6JalLODe1YlU8U44WaoCXrVXVv7d1sMWR7gvw==
 
 react-copy-to-clipboard@^5.0.1:
   version "5.0.2"
@@ -21426,13 +21403,6 @@ react@^16.14.0, react@^16.3.2, react@^16.8.4:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-reactcss@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.3.tgz#c00013875e557b1cf0dfd9a368a1c3dab3b548dd"
-  integrity sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==
-  dependencies:
-    lodash "^4.0.1"
 
 read-cache@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hi! 👋 My name is Vlad and I love to make packages/projects lighter and faster.

I noticed that you're using `react-color` which is [143 KB](https://bundlephobia.com/result?p=react-color@2.19.3) (far larger than the entirety of `react-dom`), is not tree-shakeable, is not accessible, [pulls a lot of dependencies](http://npm.anvaka.com/#/view/2d/react-color), and is not as fast as it could be.

Ryan Christian, Alex Taktarov, and I had been working hard since June and several months ago we released [`react-colorful`](https://omgovich.github.io/react-colorful/) — a tiny fast alternative to `react-color` that aligned with modern requirements.

I would be glad if you consider using our component in your project.

**`react-colorful` features**
- **Small**: Just 1,9 KB gzipped (17 times lighter than **react-color**).
- **Tree-shakeable**: Only the parts you use will be imported into your app's bundle.
- **Fast**: Built with hooks and functional components only.
- **Bulletproof**: Written in strict TypeScript and covered by 40+ tests (100% code coverage).
- **Simple**: The interface is straight forward and easy to use.
- **Mobile-friendly**: Works well on mobile devices and touch screens.
- **Accessible**: Follows the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) guidelines to support users of assistive technologies. Supports keyboard navigation.
- **No dependencies**

**Demo:** 
- https://omgovich.github.io/react-colorful

**Repo/docs:**
- https://github.com/omgovich/react-colorful

**Benchmark:**
- https://github.com/omgovich/react-colorful#why-react-colorful

**Articles about `react-colorful`:**
- https://dev.to/omgovich/react-colorful-1-8-kb-color-picker-for-react-fast-dependency-free-customizable-and-accessible-8le
- https://medium.com/@nathansebhastian/8d408e1b9ebb

## PR results

- Minified bundle size reduced by ~130 KB
- –4 dependencies
- Color selection UI is times faster now
- New fresh look (fits better to your design):

![image](https://user-images.githubusercontent.com/206567/99555942-f4638a80-29d1-11eb-8a63-5a61ec937cdc.png)