### PR TITLE
Improved cors support

### DIFF
--- a/.changeset/quick-wombats-accept.md
+++ b/.changeset/quick-wombats-accept.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': minor
+'@keystone-next/types': minor
+---
+
+Added a `config.server.cors` option to allow configuration of the cors middleware. Updated the Apollo server middleware to not override cors options.

--- a/packages-next/keystone/src/lib/createAdminUIServer.ts
+++ b/packages-next/keystone/src/lib/createAdminUIServer.ts
@@ -45,7 +45,7 @@ export const createAdminUIServer = async (config: KeystoneConfig, system: Keysto
   if (config.server?.cors) {
     // Setting config.server.cors = true will provide backwards compatible defaults
     // Otherwise, the user can provide their own config object to use
-    let corsConfig =
+    const corsConfig =
       typeof config.server.cors === 'boolean'
         ? { origin: true, credentials: true }
         : config.server.cors;

--- a/packages-next/keystone/src/lib/createAdminUIServer.ts
+++ b/packages-next/keystone/src/lib/createAdminUIServer.ts
@@ -6,7 +6,7 @@ import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 // @ts-ignore
 import { formatError } from '@keystonejs/keystone/lib/Keystone/format-error';
-import type { KeystoneSystem } from '@keystone-next/types';
+import type { KeystoneSystem, KeystoneConfig } from '@keystone-next/types';
 
 const dev = process.env.NODE_ENV !== 'production';
 
@@ -36,14 +36,14 @@ const addApolloServer = ({ server, system }: { server: any; system: KeystoneSyst
   });
   // FIXME: Support custom API path via config.graphql.path.
   // Note: Core keystone uses '/admin/api' as the default.
-  apolloServer.applyMiddleware({ app: server, path: '/api/graphql' });
+  apolloServer.applyMiddleware({ app: server, path: '/api/graphql', cors: false });
 };
 
-export const createAdminUIServer = async (system: KeystoneSystem) => {
+export const createAdminUIServer = async (config: KeystoneConfig, system: KeystoneSystem) => {
   const server = express();
 
   // TODO: allow cors to be configured
-  server.use(cors({ origin: true, credentials: true }));
+  server.use(cors({ origin: true, credentials: true, ...(config.server?.cors || {}) }));
 
   console.log('✨ Preparing Next.js app');
   const app = next({ dev, dir: Path.join(process.cwd(), '.keystone', 'admin') });

--- a/packages-next/keystone/src/lib/createAdminUIServer.ts
+++ b/packages-next/keystone/src/lib/createAdminUIServer.ts
@@ -42,8 +42,15 @@ const addApolloServer = ({ server, system }: { server: any; system: KeystoneSyst
 export const createAdminUIServer = async (config: KeystoneConfig, system: KeystoneSystem) => {
   const server = express();
 
-  // TODO: allow cors to be configured
-  server.use(cors({ origin: true, credentials: true, ...(config.server?.cors || {}) }));
+  if (config.server?.cors) {
+    // Setting config.server.cors = true will provide backwards compatible defaults
+    // Otherwise, the user can provide their own config object to use
+    let corsConfig =
+      typeof config.server.cors === 'boolean'
+        ? { origin: true, credentials: true }
+        : config.server.cors;
+    server.use(cors(corsConfig));
+  }
 
   console.log('✨ Preparing Next.js app');
   const app = next({ dev, dir: Path.join(process.cwd(), '.keystone', 'admin') });

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -27,7 +27,8 @@ export const dev = async () => {
   let adminUIServer: null | ReturnType<typeof express> = null;
 
   const initKeystone = async () => {
-    const system = createSystem(requireSource(path.join(process.cwd(), 'keystone')).default);
+    const config = requireSource(path.join(process.cwd(), 'keystone')).default;
+    const system = createSystem(config);
     let printedSchema = printSchema(system.graphQLSchema);
     console.log('✨ Generating Schema');
     await fs.outputFile('./.keystone/schema.graphql', printedSchema);
@@ -39,7 +40,7 @@ export const dev = async () => {
     console.log('✨ Generating Admin UI');
     await generateAdminUI(system, process.cwd());
 
-    adminUIServer = await createAdminUIServer(system);
+    adminUIServer = await createAdminUIServer(config, system);
     console.log(`👋 Admin UI Ready`);
   };
 

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -63,6 +63,10 @@ export type KeystoneConfig = {
   };
   session?: () => SessionStrategy<any>;
   ui?: KeystoneAdminUIConfig;
+  server?: {
+    /** Configuration options for the cors middleware */
+    cors?: any;
+  };
 } & SchemaConfig;
 
 export type MaybeItemFunction<T> =

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -64,7 +64,7 @@ export type KeystoneConfig = {
   session?: () => SessionStrategy<any>;
   ui?: KeystoneAdminUIConfig;
   server?: {
-    /** Configuration options for the cors middleware */
+    /** Configuration options for the cors middleware. Set to true to core Keystone defaults */
     cors?: any;
   };
 } & SchemaConfig;


### PR DESCRIPTION
This PR adds support for configuring the `cors` middleware in line with what's currently available in core Keystone. The developer can now specify `server.cors` in their config object. Also, the apollo server no longer hijacks the cors config.