### PR TITLE
Update renovate config to be less busy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,16 @@
 {
   "extends": ["config:base"],
   "ignorePaths": ["packages/build-field-tyes/__fixtures__/**/*"],
-  "rangeStrategy": "bump",
+  "ignoreDeps": ["gatsby", "remark"],
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
-      "packagePatterns": ["gatsby", "remark"],
-      "enabled": false
+      "updateTypes": ["patch"],
+      "groupName": "Dependencies (patch)"
     }
-  ]
+  ],
+  "rangeStrategy": "bump",
+  "schedule": ["before 7am on Tuesday"],
+  "timezone": "Australia/Sydney",
+  "updateNotScheduled": false
 }


### PR DESCRIPTION
Runs all updates before we come in on Tuesday, which is the day after our regular Monday release, giving us the week to hopefully deal with all the bumps. Also groups all `patch` level changes into a single PR as we can almost always ship these changes without worry about CI failing.

This change also disables PR updates outside of the Tuesday morning window, which should take the load off CI. Once a PR has been approved the process becomes (if out of date) Update -> CI -> merge, which is consistent with our workflow for regular PRs, and hopefully won't be that much of a burden.