### PR TITLE
Pass through itemAPI rather than full context in auth lib

### DIFF
--- a/.changeset/green-hornets-hammer.md
+++ b/.changeset/green-hornets-hammer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Updated library code to no longer require a full `context` object.

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -48,14 +48,14 @@ export function getBaseAuthSchema({
       Mutation: {
         async [gqlNames.authenticateItemWithPassword](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const result = await attemptAuthentication(
             list,
-            listKey,
             identityField,
             secretField,
             protectIdentities,
             args,
-            ctx
+            itemAPI
           );
 
           if (!result.success) {

--- a/packages-next/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages-next/auth/src/gql/getInitFirstItemSchema.ts
@@ -35,11 +35,12 @@ export function getInitFirstItemSchema({
     resolvers: {
       Mutation: {
         async [gqlNames.createInitialItem](rootVal: any, { data }: any, context: any) {
-          const count = await context.lists[listKey].count({});
+          const itemAPI = context.lists[listKey];
+          const count = await itemAPI.count({});
           if (count !== 0) {
             throw new Error('Initial items can only be created when no items exist in that list');
           }
-          const item = await context.lists[listKey].createOne({ data: { ...data, ...itemData } });
+          const item = await itemAPI.createOne({ data: { ...data, ...itemData } });
           const sessionToken = await context.startSession({ listKey, itemId: item.id });
           return { item, sessionToken };
         },

--- a/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -58,14 +58,14 @@ export function getMagicAuthLinkSchema({
       Mutation: {
         async [gqlNames.sendItemMagicAuthLink](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const identity = args[identityField];
           const result = await updateAuthToken(
             'magicAuth',
-            listKey,
             identityField,
             protectIdentities,
             identity,
-            ctx
+            itemAPI
           );
 
           // Note: `success` can be false with no code
@@ -85,15 +85,15 @@ export function getMagicAuthLinkSchema({
         },
         async [gqlNames.redeemItemMagicAuthToken](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const result = await redeemAuthToken(
             'magicAuth',
             list,
-            listKey,
             identityField,
             protectIdentities,
             magicAuthLink.tokensValidForMins,
             args,
-            ctx
+            itemAPI
           );
 
           if (!result.success) {

--- a/packages-next/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages-next/auth/src/gql/getPasswordResetSchema.ts
@@ -62,14 +62,14 @@ export function getPasswordResetSchema({
       Mutation: {
         async [gqlNames.sendItemPasswordResetLink](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const identity = args[identityField];
           const result = await updateAuthToken(
             'passwordReset',
-            listKey,
             identityField,
             protectIdentities,
             identity,
-            ctx
+            itemAPI
           );
 
           // Note: `success` can be false with no code
@@ -93,15 +93,15 @@ export function getPasswordResetSchema({
         },
         async [gqlNames.redeemItemPasswordResetToken](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const result = await redeemAuthToken(
             'passwordReset',
             list,
-            listKey,
             identityField,
             protectIdentities,
             passwordResetLink.tokensValidForMins,
             args,
-            ctx
+            itemAPI
           );
 
           if (!result.success) {
@@ -115,7 +115,7 @@ export function getPasswordResetSchema({
           }
 
           // Save the provided secret
-          await ctx.lists[listKey].updateOne({
+          await itemAPI.updateOne({
             id: result.item.id,
             data: { [secretField]: args[secretField] },
           });
@@ -126,15 +126,15 @@ export function getPasswordResetSchema({
       Query: {
         async [gqlNames.validateItemPasswordResetToken](root: any, args: any, ctx: any) {
           const list = ctx.keystone.lists[listKey];
+          const itemAPI = ctx.lists[listKey];
           const result = await validateAuthToken(
             'passwordReset',
             list,
-            listKey,
             identityField,
             protectIdentities,
             passwordResetLink.tokensValidForMins,
             args,
-            ctx
+            itemAPI
           );
 
           if (!result.success && result.code) {

--- a/packages-next/auth/src/lib/attemptAuthentication.ts
+++ b/packages-next/auth/src/lib/attemptAuthentication.ts
@@ -2,12 +2,11 @@ import { PasswordAuthErrorCode } from '../types';
 
 export async function attemptAuthentication(
   list: any,
-  listKey: string,
   identityField: string,
   secretField: string,
   protectIdentities: boolean,
   args: Record<string, string>,
-  context: any
+  itemAPI: any
 ): Promise<
   | { success: false; code: PasswordAuthErrorCode }
   | { success: true; item: { id: any; [prop: string]: any } }
@@ -17,7 +16,7 @@ export async function attemptAuthentication(
   const secretFieldInstance = list.fieldsByPath[secretField];
 
   // TODO: Allow additional filters to be suppled in config? eg. `validUserConditions: { isEnable: true, isVerified: true, ... }`
-  const items = await context.lists[listKey].findMany({ where: { [identityField]: identity } });
+  const items = await itemAPI.findMany({ where: { [identityField]: identity } });
 
   // Identity failures with helpful errors
   let specificCode: PasswordAuthErrorCode | undefined;

--- a/packages-next/auth/src/lib/redeemAuthToken.ts
+++ b/packages-next/auth/src/lib/redeemAuthToken.ts
@@ -4,12 +4,11 @@ import { validateAuthToken } from './validateAuthToken';
 export async function redeemAuthToken(
   tokenType: 'passwordReset' | 'magicAuth',
   list: any,
-  listKey: string,
   identityField: string,
   protectIdentities: boolean,
   tokenValidMins: number | undefined,
   args: Record<string, string>,
-  context: any
+  itemAPI: any
 ): Promise<
   | { success: false; code: AuthTokenRedemptionErrorCode }
   | { success: true; item: { id: any; [prop: string]: any } }
@@ -18,19 +17,18 @@ export async function redeemAuthToken(
   const validationResult = await validateAuthToken(
     tokenType,
     list,
-    listKey,
     identityField,
     protectIdentities,
     tokenValidMins,
     args,
-    context
+    itemAPI
   );
   if (!validationResult.success) {
     return validationResult;
   }
 
   // Save the token and related info back to the item
-  await context.lists[listKey].updateOne({
+  await itemAPI.updateOne({
     id: validationResult.item.id,
     data: { [`${tokenType}RedeemedAt`]: new Date().toISOString() },
   });

--- a/packages-next/auth/src/lib/updateAuthToken.ts
+++ b/packages-next/auth/src/lib/updateAuthToken.ts
@@ -5,16 +5,15 @@ import { generateToken } from './generateToken';
 // We don't (currently) make any effort to mitigate the time taken to record the new token or sent the email when successful
 export async function updateAuthToken(
   tokenType: 'passwordReset' | 'magicAuth',
-  listKey: string,
   identityField: string,
   protectIdentities: boolean,
   identity: string,
-  context: any
+  itemAPI: any
 ): Promise<
   | { success: false; code?: AuthTokenRequestErrorCode }
   | { success: true; itemId: string | number; token: string }
 > {
-  const items = await context.lists[listKey].findMany({ where: { [identityField]: identity } });
+  const items = await itemAPI.findMany({ where: { [identityField]: identity } });
 
   // Identity failures with helpful errors (unless it would violate our protectIdentities config)
   let specificCode: AuthTokenRequestErrorCode | undefined;
@@ -31,7 +30,7 @@ export async function updateAuthToken(
   const itemId = items[0].id;
   const token = generateToken(20);
   // Save the token and related info back to the item
-  await context.lists[listKey].updateOne({
+  await itemAPI.updateOne({
     id: itemId,
     data: {
       [`${tokenType}Token`]: token,

--- a/packages-next/auth/src/lib/validateAuthToken.ts
+++ b/packages-next/auth/src/lib/validateAuthToken.ts
@@ -10,12 +10,11 @@ function sanitiseValidForMinsConfig(input: any): number {
 export async function validateAuthToken(
   tokenType: 'passwordReset' | 'magicAuth',
   list: any,
-  listKey: string,
   identityField: string,
   protectIdentities: boolean,
   tokenValidMins: number | undefined,
   args: Record<string, string>,
-  context: any
+  itemAPI: any
 ): Promise<
   | { success: false; code: AuthTokenRedemptionErrorCode }
   | { success: true; item: { id: any; [prop: string]: any } }
@@ -30,7 +29,7 @@ export async function validateAuthToken(
   const canidatePlaintext = args.token;
 
   // TODO: Allow additional filters to be suppled in config? eg. `validUserConditions: { isEnable: true, isVerified: true, ... }`
-  const items = await context.lists[listKey].findMany({ where: { [identityField]: identity } });
+  const items = await itemAPI.findMany({ where: { [identityField]: identity } });
 
   // Check the for identity-related failures first
   let specificCode: AuthTokenRedemptionErrorCode | undefined;


### PR DESCRIPTION
Greatly reduces the API surface area available to our auth lib functions, making them easier to reason about.