### PR TITLE
Rename attemptAuthentication to validateSecret

### DIFF
--- a/.changeset/moody-wolves-obey.md
+++ b/.changeset/moody-wolves-obey.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Renamed `attemptAuthentication` to `validateSecret`.

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -1,6 +1,6 @@
 import { AuthGqlNames } from '../types';
 
-import { attemptAuthentication } from '../lib/attemptAuthentication';
+import { validateSecret } from '../lib/validateSecret';
 import { getPasswordAuthError } from '../lib/getErrorMessage';
 
 export function getBaseAuthSchema({
@@ -49,7 +49,7 @@ export function getBaseAuthSchema({
         async [gqlNames.authenticateItemWithPassword](root: any, args: any, context: any) {
           const list = context.keystone.lists[listKey];
           const itemAPI = context.lists[listKey];
-          const result = await attemptAuthentication(
+          const result = await validateSecret(
             list,
             identityField,
             secretField,

--- a/packages-next/auth/src/lib/validateSecret.ts
+++ b/packages-next/auth/src/lib/validateSecret.ts
@@ -1,6 +1,6 @@
 import { PasswordAuthErrorCode } from '../types';
 
-export async function attemptAuthentication(
+export async function validateSecret(
   list: any,
   identityField: string,
   secretField: string,


### PR DESCRIPTION
This is a slightly more specific name, and will make more sense when we go to re-use this code inside `validateAuthToken`.