### PR TITLE
Show list label instead of "item" when linking to related items

### DIFF
--- a/.changeset/wise-wolves-camp.md
+++ b/.changeset/wise-wolves-camp.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/fields": patch
+---
+
+Show list label instead of "item" when linking to related items

--- a/packages-next/fields/src/types/relationship/views/cards/index.tsx
+++ b/packages-next/fields/src/types/relationship/views/cards/index.tsx
@@ -228,7 +228,7 @@ export function Cards({
                   as={Link}
                   href={`/${foreignList.path}/${id}`}
                 >
-                  View item details
+                  View {foreignList.singular} details
                 </Button>
               )}
             </Stack>

--- a/packages-next/fields/src/types/relationship/views/index.tsx
+++ b/packages-next/fields/src/types/relationship/views/index.tsx
@@ -47,14 +47,14 @@ function LinkToRelatedItems({
           .map(({ id }) => id)
           .join(',')}"`}
       >
-        View related items
+        View related {list.plural}
       </Button>
     );
   }
 
   return (
     <Button {...commonProps} as={Link} href={`/${list.path}/${value.value?.id}`}>
-      View item details
+      View {list.singular} details
     </Button>
   );
 }


### PR DESCRIPTION
This changes the "Show item details" button to actually use the related list's name in the Admin UI, which I think fits more naturally with the rest of the buttons and improves usability:

(see where it says **View Role details** below now)

![image](https://user-images.githubusercontent.com/872310/100355649-3f227980-3046-11eb-9892-edd8be45571f.png)
