### PR TITLE
Fix Slug field with maxResults set

### DIFF
--- a/.changeset/silver-bees-act.md
+++ b/.changeset/silver-bees-act.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Fixed [issue](https://github.com/keystonejs/keystone/issues/4310) with creating `Slug` fields when `{ queryLimits: { maxResults } }` is set.

--- a/packages/fields/src/types/Slug/Implementation.js
+++ b/packages/fields/src/types/Slug/Implementation.js
@@ -218,6 +218,7 @@ export class SlugImplementation extends Text {
           // we miss a match and try to insert anyway.
           context: context.createContext({ skipAccessControl: true }),
           listKey: this.listKey,
+          first: 1,
           where: {
             [this.path]: uniqueSlug,
             // Ensure we ignore the current item when doing an update


### PR DESCRIPTION
By default the `server-side-graphql-client` library will use a `pageSize` of `500`, which causes the error to trigger. Explicitly setting `first: 1` in the `getItems` query solves this.

Fixes #4310.