### PR TITLE
Refactor other methods out of createSystem

### DIFF
--- a/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
+++ b/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
@@ -1,0 +1,36 @@
+import type { KeystoneConfig } from '@keystone-next/types';
+import { autoIncrement, mongoId } from '@keystone-next/fields';
+
+/* Validate lists config and default the id field */
+export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig {
+  const lists: KeystoneConfig['lists'] = {};
+  Object.keys(config.lists).forEach(key => {
+    const listConfig = config.lists[key];
+    if (listConfig.fields.id) {
+      throw new Error(
+        `A field with the \`id\` path is defined in the fields object on the ${JSON.stringify(
+          key
+        )} list. This is not allowed, use the idField option instead.`
+      );
+    }
+    let idField =
+      config.lists[key].idField ??
+      { mongoose: mongoId({}), knex: autoIncrement({}) }[config.db.adapter];
+    idField = {
+      ...idField,
+      config: {
+        ui: {
+          createView: { fieldMode: 'hidden', ...idField.config.ui?.createView },
+          itemView: { fieldMode: 'hidden', ...idField.config.ui?.itemView },
+          ...idField.config.ui,
+        },
+        ...idField.config,
+      },
+    };
+
+    const fields = { id: idField, ...listConfig.fields };
+    lists[key] = { ...listConfig, fields };
+  });
+
+  return { ...config, lists };
+}

--- a/packages-next/keystone/src/lib/createAdminMeta.ts
+++ b/packages-next/keystone/src/lib/createAdminMeta.ts
@@ -1,0 +1,77 @@
+import type {
+  SerializedAdminMeta,
+  KeystoneConfig,
+  FieldType,
+  SessionStrategy,
+} from '@keystone-next/types';
+
+export function createAdminMeta(
+  config: KeystoneConfig,
+  keystone: any,
+  sessionStrategy?: SessionStrategy<unknown>
+) {
+  const { ui, lists } = config;
+  const adminMeta: SerializedAdminMeta = {
+    enableSessionItem: ui?.enableSessionItem || false,
+    enableSignout: sessionStrategy?.end !== undefined,
+    lists: {},
+  };
+  let uniqueViewCount = -1;
+  const stringViewsToIndex: Record<string, number> = {};
+  const views: string[] = [];
+  function getViewId(view: string) {
+    if (stringViewsToIndex[view] === undefined) {
+      uniqueViewCount++;
+      stringViewsToIndex[view] = uniqueViewCount;
+      views.push(view);
+    }
+    return stringViewsToIndex[view];
+  }
+  Object.keys(lists).forEach(key => {
+    const listConfig = lists[key];
+    const list = keystone.lists[key];
+    // Default the labelField to `name`, `label`, or `title` if they exist; otherwise fall back to `id`
+    const labelField =
+      (listConfig.ui?.labelField as string | undefined) ??
+      (listConfig.fields.label
+        ? 'label'
+        : listConfig.fields.name
+        ? 'name'
+        : listConfig.fields.title
+        ? 'title'
+        : 'id');
+    adminMeta.lists[key] = {
+      key,
+      labelField,
+      description: listConfig.ui?.description ?? listConfig.description ?? null,
+      label: list.adminUILabels.label,
+      singular: list.adminUILabels.singular,
+      plural: list.adminUILabels.plural,
+      path: list.adminUILabels.path,
+      fields: {},
+      pageSize: listConfig.ui?.listView?.pageSize ?? 50,
+      gqlNames: list.gqlNames,
+      initialColumns: (listConfig.ui?.listView?.initialColumns as string[]) ?? [labelField],
+      initialSort:
+        (listConfig.ui?.listView?.initialSort as
+          | { field: string; direction: 'ASC' | 'DESC' }
+          | undefined) ?? null,
+    };
+  });
+  Object.keys(adminMeta.lists).forEach(key => {
+    const listConfig = lists[key];
+    const list = (keystone as any).lists[key];
+    for (const fieldKey of Object.keys(listConfig.fields)) {
+      const field: FieldType<any> = listConfig.fields[fieldKey];
+      adminMeta.lists[key].fields[fieldKey] = {
+        label: list.fieldsByPath[fieldKey].label,
+        views: getViewId(field.views),
+        customViews: field.config.ui?.views === undefined ? null : getViewId(field.config.ui.views),
+        fieldMeta: field.getAdminMeta?.(key, fieldKey, adminMeta) ?? null,
+        isOrderable: list.fieldsByPath[fieldKey].isOrderable || fieldKey === 'id',
+      };
+    }
+  });
+
+  return { adminMeta, views };
+}

--- a/packages-next/keystone/src/lib/createGraphQLSchema.ts
+++ b/packages-next/keystone/src/lib/createGraphQLSchema.ts
@@ -1,0 +1,70 @@
+import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+import { mergeSchemas } from '@graphql-tools/merge';
+import { mapSchema } from '@graphql-tools/utils';
+import type { KeystoneConfig, SessionStrategy } from '@keystone-next/types';
+import { adminMetaSchemaExtension } from '@keystone-next/admin-ui/templates';
+
+import { gql } from '../schema';
+
+export function createGraphQLSchema(
+  config: KeystoneConfig,
+  keystone: any,
+  adminMeta: any,
+  sessionStrategy?: SessionStrategy<unknown>,
+  sessionImplementation?: any
+) {
+  // @ts-ignore
+  const server = keystone.createApolloServer({
+    schemaName: 'public',
+    dev: process.env.NODE_ENV === 'development',
+  });
+  const schemaFromApolloServer: GraphQLSchema = server.schema;
+  const schema = mapSchema(schemaFromApolloServer, {
+    'MapperKind.OBJECT_TYPE'(type) {
+      if (
+        config.lists[type.name] !== undefined &&
+        config.lists[type.name].fields._label_ === undefined
+      ) {
+        let {
+          fields: { _label_, ...fields },
+          ...objectTypeConfig
+        } = type.toConfig();
+        return new GraphQLObjectType({ fields, ...objectTypeConfig });
+      }
+
+      return type;
+    },
+  });
+
+  // TODO: find a way to not pass keystone in here, if we can - it's too broad and makes
+  // everything in the keystone instance public API
+  let graphQLSchema = config.extendGraphqlSchema?.(schema, keystone) || schema;
+  if (sessionStrategy?.end) {
+    graphQLSchema = mergeSchemas({
+      schemas: [graphQLSchema],
+      typeDefs: gql`
+        type Mutation {
+          endSession: Boolean!
+        }
+      `,
+      resolvers: {
+        Mutation: {
+          async endSession(rootVal, args, context) {
+            await context.endSession();
+            return true;
+          },
+        },
+      },
+    });
+  }
+  graphQLSchema = adminMetaSchemaExtension({
+    adminMeta,
+    graphQLSchema,
+    isAccessAllowed:
+      sessionImplementation === undefined
+        ? undefined
+        : config.ui?.isAccessAllowed ?? (({ session }) => session !== undefined),
+    config,
+  });
+  return graphQLSchema;
+}

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,22 +1,15 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import { GraphQLSchema, GraphQLObjectType } from 'graphql';
-import { mergeSchemas } from '@graphql-tools/merge';
-import { mapSchema } from '@graphql-tools/utils';
 import { Keystone } from '@keystonejs/keystone';
 import { MongooseAdapter } from '@keystonejs/adapter-mongoose';
 import { KnexAdapter } from '@keystonejs/adapter-knex';
-import type {
-  SerializedAdminMeta,
-  KeystoneConfig,
-  KeystoneSystem,
-  FieldType,
-  SessionStrategy,
-} from '@keystone-next/types';
-import { adminMetaSchemaExtension } from '@keystone-next/admin-ui/templates';
-import { autoIncrement, mongoId } from '@keystone-next/fields';
+import type { KeystoneConfig, KeystoneSystem } from '@keystone-next/types';
+
+import { applyIdFieldDefaults } from './applyIdFieldDefaults';
+import { createAdminMeta } from './createAdminMeta';
+import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './createContext';
+
 import { implementSession } from '../session';
-import { gql } from '../schema';
 
 export function createKeystone(config: KeystoneConfig): any {
   // Note: For backwards compatibility we may want to expose
@@ -82,140 +75,6 @@ export function createKeystone(config: KeystoneConfig): any {
   return keystone;
 }
 
-function createAdminMeta(
-  config: KeystoneConfig,
-  keystone: any,
-  sessionStrategy?: SessionStrategy<unknown>
-) {
-  const { ui, lists } = config;
-  const adminMeta: SerializedAdminMeta = {
-    enableSessionItem: ui?.enableSessionItem || false,
-    enableSignout: sessionStrategy?.end !== undefined,
-    lists: {},
-  };
-  let uniqueViewCount = -1;
-  const stringViewsToIndex: Record<string, number> = {};
-  const views: string[] = [];
-  function getViewId(view: string) {
-    if (stringViewsToIndex[view] === undefined) {
-      uniqueViewCount++;
-      stringViewsToIndex[view] = uniqueViewCount;
-      views.push(view);
-    }
-    return stringViewsToIndex[view];
-  }
-  Object.keys(lists).forEach(key => {
-    const listConfig = lists[key];
-    const list = keystone.lists[key];
-    // Default the labelField to `name`, `label`, or `title` if they exist; otherwise fall back to `id`
-    const labelField =
-      (listConfig.ui?.labelField as string | undefined) ??
-      (listConfig.fields.label
-        ? 'label'
-        : listConfig.fields.name
-        ? 'name'
-        : listConfig.fields.title
-        ? 'title'
-        : 'id');
-    adminMeta.lists[key] = {
-      key,
-      labelField,
-      description: listConfig.ui?.description ?? listConfig.description ?? null,
-      label: list.adminUILabels.label,
-      singular: list.adminUILabels.singular,
-      plural: list.adminUILabels.plural,
-      path: list.adminUILabels.path,
-      fields: {},
-      pageSize: listConfig.ui?.listView?.pageSize ?? 50,
-      gqlNames: list.gqlNames,
-      initialColumns: (listConfig.ui?.listView?.initialColumns as string[]) ?? [labelField],
-      initialSort:
-        (listConfig.ui?.listView?.initialSort as
-          | { field: string; direction: 'ASC' | 'DESC' }
-          | undefined) ?? null,
-    };
-  });
-  Object.keys(adminMeta.lists).forEach(key => {
-    const listConfig = lists[key];
-    const list = (keystone as any).lists[key];
-    for (const fieldKey of Object.keys(listConfig.fields)) {
-      const field: FieldType<any> = listConfig.fields[fieldKey];
-      adminMeta.lists[key].fields[fieldKey] = {
-        label: list.fieldsByPath[fieldKey].label,
-        views: getViewId(field.views),
-        customViews: field.config.ui?.views === undefined ? null : getViewId(field.config.ui.views),
-        fieldMeta: field.getAdminMeta?.(key, fieldKey, adminMeta) ?? null,
-        isOrderable: list.fieldsByPath[fieldKey].isOrderable || fieldKey === 'id',
-      };
-    }
-  });
-
-  return { adminMeta, views };
-}
-
-function createGraphQLSchema(
-  config: KeystoneConfig,
-  keystone: any,
-  adminMeta: any,
-  sessionStrategy?: SessionStrategy<unknown>,
-  sessionImplementation?: any
-) {
-  // @ts-ignore
-  const server = keystone.createApolloServer({
-    schemaName: 'public',
-    dev: process.env.NODE_ENV === 'development',
-  });
-  const schemaFromApolloServer: GraphQLSchema = server.schema;
-  const schema = mapSchema(schemaFromApolloServer, {
-    'MapperKind.OBJECT_TYPE'(type) {
-      if (
-        config.lists[type.name] !== undefined &&
-        config.lists[type.name].fields._label_ === undefined
-      ) {
-        let {
-          fields: { _label_, ...fields },
-          ...objectTypeConfig
-        } = type.toConfig();
-        return new GraphQLObjectType({ fields, ...objectTypeConfig });
-      }
-
-      return type;
-    },
-  });
-
-  // TODO: find a way to not pass keystone in here, if we can - it's too broad and makes
-  // everything in the keystone instance public API
-  let graphQLSchema = config.extendGraphqlSchema?.(schema, keystone) || schema;
-  if (sessionStrategy?.end) {
-    graphQLSchema = mergeSchemas({
-      schemas: [graphQLSchema],
-      typeDefs: gql`
-        type Mutation {
-          endSession: Boolean!
-        }
-      `,
-      resolvers: {
-        Mutation: {
-          async endSession(rootVal, args, context) {
-            await context.endSession();
-            return true;
-          },
-        },
-      },
-    });
-  }
-  graphQLSchema = adminMetaSchemaExtension({
-    adminMeta,
-    graphQLSchema,
-    isAccessAllowed:
-      sessionImplementation === undefined
-        ? undefined
-        : config.ui?.isAccessAllowed ?? (({ session }) => session !== undefined),
-    config,
-  });
-  return graphQLSchema;
-}
-
 export function createSystem(config: KeystoneConfig): KeystoneSystem {
   config = applyIdFieldDefaults(config);
 
@@ -256,38 +115,4 @@ export function createSystem(config: KeystoneConfig): KeystoneSystem {
   };
 
   return system;
-}
-
-/* Validate lists config and default the id field */
-function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig {
-  const lists: KeystoneConfig['lists'] = {};
-  Object.keys(config.lists).forEach(key => {
-    const listConfig = config.lists[key];
-    if (listConfig.fields.id) {
-      throw new Error(
-        `A field with the \`id\` path is defined in the fields object on the ${JSON.stringify(
-          key
-        )} list. This is not allowed, use the idField option instead.`
-      );
-    }
-    let idField =
-      config.lists[key].idField ??
-      { mongoose: mongoId({}), knex: autoIncrement({}) }[config.db.adapter];
-    idField = {
-      ...idField,
-      config: {
-        ui: {
-          createView: { fieldMode: 'hidden', ...idField.config.ui?.createView },
-          itemView: { fieldMode: 'hidden', ...idField.config.ui?.itemView },
-          ...idField.config.ui,
-        },
-        ...idField.config,
-      },
-    };
-
-    const fields = { id: idField, ...listConfig.fields };
-    lists[key] = { ...listConfig, fields };
-  });
-
-  return { ...config, lists };
 }


### PR DESCRIPTION
Following on from #4406 this simply moves the other functions out of `createSystem` into their own files.