### PR TITLE
Updated InitPage to fix the error with the new field value shape

### DIFF
--- a/.changeset/nasty-dingos-punch.md
+++ b/.changeset/nasty-dingos-punch.md
@@ -1,7 +1,7 @@
 ---
 '@keystone-next/auth': patch
 '@keystone-next/keystone': patch
-'@keystone-next/types': major
+'@keystone-next/types': minor
 ---
 
 Added a `BaseKeystone` type to replace usage of `any` in all instances.

--- a/.changeset/tame-ducks-promise.md
+++ b/.changeset/tame-ducks-promise.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/auth": patch
+---
+
+Updated InitPage to fix the error with the new field value shape

--- a/packages-next/auth/src/pages/InitPage.tsx
+++ b/packages-next/auth/src/pages/InitPage.tsx
@@ -66,7 +66,7 @@ export const InitPage = ({
   const [value, setValue] = useState(() => {
     let state: Record<string, any> = {};
     Object.keys(fields).forEach(fieldPath => {
-      state[fieldPath] = fields[fieldPath].controller.defaultValue;
+      state[fieldPath] = { kind: 'value', value: fields[fieldPath].controller.defaultValue };
     });
     return state;
   });


### PR DESCRIPTION
This fixes the error you see when opening keystone for the first time with an empty database