### PR TITLE
Maintain session info on new contexts

### DIFF
--- a/.changeset/blue-spies-mix.md
+++ b/.changeset/blue-spies-mix.md
@@ -1,0 +1,13 @@
+---
+'@keystone-next/keystone': major
+---
+
+`context.createContext()` now inherits the argument values for `sessionContext` and `skipAccessControl` from `context` as defaults.
+
+This means, for example, that
+
+```js
+context.createContext({ skipAccessControl: true })
+```
+
+will create a new context with the same `sessionContext` that the original `context` object had.

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -44,6 +44,8 @@ export function makeCreateContext({
       return result.data as Record<string, any>;
     };
     const itemAPI: Record<string, ReturnType<typeof itemAPIForList>> = {};
+    const _sessionContext = sessionContext;
+    const _skipAccessControl = skipAccessControl;
     const contextToReturn: KeystoneContext = {
       schemaName: 'public',
       ...(skipAccessControl ? skipAccessControlContext : accessControlContext),
@@ -62,7 +64,10 @@ export function makeCreateContext({
         schema: graphQLSchema,
       } as KeystoneGraphQLAPI<any>,
       maxTotalResults: (keystone as any).queryLimits.maxTotalResults,
-      createContext,
+      createContext: ({
+        sessionContext = _sessionContext,
+        skipAccessControl = _skipAccessControl,
+      } = {}) => createContext({ sessionContext, skipAccessControl }),
       ...sessionContext,
       // Note: These two fields let us use the server-side-graphql-client library.
       // We may want to remove them once the updated itemAPI w/ resolveFields is available.


### PR DESCRIPTION
This PR changes the behaviour of `context.createContext` in a fairly fundamental way: It now carries forwards the parameters that were used to create the original `context` object. This matches the behaviour we currently have implemented in the core `createContext()` function. This results in what is arguably the "expected" behaviour, if you do:

```js
newContext = context.createContext({ skipAccessControl: true })
```

you will get a new context object which has the same session information as the original context. In the much less common case of this not being what you want you can always do:

```js
newContext = context.createContext({ sessionContext: {}, skipAccessControl: true })
```

I think changing the behaviour of `createContext` is a nicer solution that the `cloneContext` function proposed in #4425.
