### PR TITLE
Decouple keystone.connect() from admin UI setup

### DIFF
--- a/.changeset/famous-walls-laugh.md
+++ b/.changeset/famous-walls-laugh.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Decoupled DB connection from Admin UI server setup.

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -59,7 +59,7 @@ export const createExpressServer = async (config: KeystoneConfig, system: Keysto
   console.log('✨ Preparing Next.js app');
   const app = next({ dev, dir: Path.join(process.cwd(), '.keystone', 'admin') });
   const handle = app.getRequestHandler();
-  await Promise.all([app.prepare(), system.keystone.connect()]);
+  await app.prepare();
 
   console.log('✨ Preparing GraphQL Server');
   addApolloServer({ server, system });

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -37,6 +37,9 @@ export const dev = async () => {
       formatSource(printGeneratedTypes(printedSchema, system), 'babel-ts')
     );
 
+    console.log('✨ Connecting to DB');
+    await system.keystone.connect();
+
     console.log('✨ Generating Admin UI');
     await generateAdminUI(config, system, process.cwd());
 

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -37,7 +37,7 @@ export const dev = async () => {
       formatSource(printGeneratedTypes(printedSchema, system), 'babel-ts')
     );
 
-    console.log('✨ Connecting to DB');
+    console.log('✨ Connecting to the Database');
     await system.keystone.connect();
 
     console.log('✨ Generating Admin UI');


### PR DESCRIPTION
First in a series of PRs to isolate the individual steps used in the `dev` script to make the new interfaces testable.