### PR TITLE
Rename createAdminUIServer to createExpressServer

### DIFF
--- a/.changeset/little-pumpkins-repeat.md
+++ b/.changeset/little-pumpkins-repeat.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Renamed `createAdminUIServer` to `createExpressServer` to better capture what this module is doing.

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -39,7 +39,7 @@ const addApolloServer = ({ server, system }: { server: any; system: KeystoneSyst
   apolloServer.applyMiddleware({ app: server, path: '/api/graphql', cors: false });
 };
 
-export const createAdminUIServer = async (config: KeystoneConfig, system: KeystoneSystem) => {
+export const createExpressServer = async (config: KeystoneConfig, system: KeystoneSystem) => {
   const server = express();
 
   if (config.server?.cors) {

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs-extra';
 import { createSystem } from '../lib/createSystem';
 import { requireSource } from '../lib/requireSource';
 import { formatSource, generateAdminUI } from '../lib/generateAdminUI';
-import { createAdminUIServer } from '../lib/createAdminUIServer';
+import { createExpressServer } from '../lib/createExpressServer';
 import { printGeneratedTypes } from './schema-type-printer';
 
 // TODO: Read port from config or process args
@@ -24,7 +24,7 @@ export const dev = async () => {
   console.log('🤞 Starting Keystone');
 
   const server = express();
-  let adminUIServer: null | ReturnType<typeof express> = null;
+  let expressServer: null | ReturnType<typeof express> = null;
 
   const initKeystone = async () => {
     const config = requireSource(path.join(process.cwd(), 'keystone')).default;
@@ -40,15 +40,15 @@ export const dev = async () => {
     console.log('✨ Generating Admin UI');
     await generateAdminUI(system, process.cwd());
 
-    adminUIServer = await createAdminUIServer(config, system);
+    expressServer = await createExpressServer(config, system);
     console.log(`👋 Admin UI Ready`);
   };
 
   server.use('/__keystone_dev_status', (req, res) => {
-    res.json({ ready: adminUIServer ? true : false });
+    res.json({ ready: expressServer ? true : false });
   });
   server.use((req, res, next) => {
-    if (adminUIServer) return adminUIServer(req, res, next);
+    if (expressServer) return expressServer(req, res, next);
     res.sendFile(devLoadingHTMLFilepath);
   });
   server.listen(PORT, (err?: any) => {


### PR DESCRIPTION
Subsequent PRs will isolate the part of the code which is actually doing `createAdminUIServer`. This is part of the work to make the new interfaces testable.