### PR TITLE
Use original config object, not system.config

### DIFF
--- a/.changeset/chilled-onions-type.md
+++ b/.changeset/chilled-onions-type.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/admin-ui': patch
+'@keystone-next/keystone': patch
+---
+
+Refactored code to use the original `config` object, rather than `system.config`.

--- a/packages-next/admin-ui/src/templates/index.ts
+++ b/packages-next/admin-ui/src/templates/index.ts
@@ -4,7 +4,7 @@ import { listTemplate } from './list';
 import { itemTemplate } from './item';
 import { noAccessTemplate } from './no-access';
 
-import type { KeystoneSystem } from '@keystone-next/types';
+import type { KeystoneSystem, KeystoneConfig } from '@keystone-next/types';
 import { AdminFileToWrite } from '@keystone-next/types';
 import * as Path from 'path';
 
@@ -13,12 +13,12 @@ const pkgDir = Path.dirname(require.resolve('@keystone-next/admin-ui/package.jso
 export { adminMetaSchemaExtension } from './adminMetaSchemaExtension';
 
 export const writeAdminFiles = (
+  session: KeystoneConfig['session'],
   system: KeystoneSystem,
   configFile: boolean,
   projectAdminPath: string
 ): AdminFileToWrite[] => {
   const { adminMeta } = system;
-  const { session } = system.config;
   return [
     {
       mode: 'copy',

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -64,7 +64,7 @@ export const createExpressServer = async (config: KeystoneConfig, system: Keysto
   console.log('✨ Preparing GraphQL Server');
   addApolloServer({ server, system });
 
-  const publicPages = system.config.ui?.publicPages ?? [];
+  const publicPages = config.ui?.publicPages ?? [];
 
   server.use(async (req, res) => {
     const { pathname } = url.parse(req.url);
@@ -74,10 +74,10 @@ export const createExpressServer = async (config: KeystoneConfig, system: Keysto
     }
     const session = (await system.sessionImplementation?.createContext?.(req, res, system))
       ?.session;
-    const isValidSession = system.config.ui?.isAccessAllowed
-      ? await system.config.ui.isAccessAllowed({ session })
+    const isValidSession = config.ui?.isAccessAllowed
+      ? await config.ui.isAccessAllowed({ session })
       : session !== undefined;
-    const maybeRedirect = await system.config.ui?.pageMiddleware?.({
+    const maybeRedirect = await config.ui?.pageMiddleware?.({
       req,
       session,
       isValidSession,

--- a/packages-next/keystone/src/lib/generateAdminUI.ts
+++ b/packages-next/keystone/src/lib/generateAdminUI.ts
@@ -4,7 +4,7 @@ import Path from 'path';
 import fastGlob from 'fast-glob';
 import prettier from 'prettier';
 import resolve from 'resolve';
-import type { KeystoneSystem } from '@keystone-next/types';
+import type { KeystoneConfig, KeystoneSystem } from '@keystone-next/types';
 import { writeAdminFiles } from '@keystone-next/admin-ui/templates';
 import { AdminFileToWrite, MaybePromise } from '@keystone-next/types';
 
@@ -66,7 +66,11 @@ async function writeAdminFilesToDisk(
   ).flat();
 }
 
-export const generateAdminUI = async (system: KeystoneSystem, cwd: string) => {
+export const generateAdminUI = async (
+  config: KeystoneConfig,
+  system: KeystoneSystem,
+  cwd: string
+) => {
   const projectAdminPath = Path.resolve(cwd, './.keystone/admin');
 
   await fs.remove(projectAdminPath);
@@ -75,17 +79,19 @@ export const generateAdminUI = async (system: KeystoneSystem, cwd: string) => {
   const filesWritten = new Set(
     [
       ...(await writeAdminFilesToDisk(
-        system.config.ui?.getAdditionalFiles?.map(x => x(system)) ?? [],
+        config.ui?.getAdditionalFiles?.map(x => x(system)) ?? [],
         projectAdminPath
       )),
     ].map(x => Path.normalize(x))
   );
-  const baseFiles = writeAdminFiles(system, configFile, projectAdminPath).filter(x => {
-    if (filesWritten.has(Path.normalize(x.outputPath))) {
-      return false;
+  const baseFiles = writeAdminFiles(config.session, system, configFile, projectAdminPath).filter(
+    x => {
+      if (filesWritten.has(Path.normalize(x.outputPath))) {
+        return false;
+      }
+      return true;
     }
-    return true;
-  });
+  );
 
   await writeAdminFilesToDisk([baseFiles], projectAdminPath);
   const userPagesDir = Path.join(cwd, 'admin', 'pages');

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -38,7 +38,7 @@ export const dev = async () => {
     );
 
     console.log('✨ Generating Admin UI');
-    await generateAdminUI(system, process.cwd());
+    await generateAdminUI(config, system, process.cwd());
 
     expressServer = await createExpressServer(config, system);
     console.log(`👋 Admin UI Ready`);


### PR DESCRIPTION
Moving towards not carrying the `config` property on the `system`. We should be explicitly consuming the original `config` object where required.