### PR TITLE
Put sessionImplementation on the system object

### DIFF
--- a/.changeset/pink-years-return.md
+++ b/.changeset/pink-years-return.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Removed `createContextFromRequest` and `createSessionContext` from `KeystoneSystem` and replaced them with `sessionImplementation`, which provides the same core functionality.

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,4 +1,3 @@
-import type { IncomingMessage, ServerResponse } from 'http';
 import { Keystone } from '@keystonejs/keystone';
 import { MongooseAdapter } from '@keystonejs/adapter-mongoose';
 import { KnexAdapter } from '@keystonejs/adapter-knex';
@@ -99,7 +98,6 @@ export function createSystem(config: KeystoneConfig): KeystoneSystem {
     sessionImplementation
   );
 
-  const createSessionContext = sessionImplementation?.createContext;
   const createContext = makeCreateContext({ keystone, graphQLSchema });
 
   let system = {
@@ -107,15 +105,8 @@ export function createSystem(config: KeystoneConfig): KeystoneSystem {
     adminMeta,
     graphQLSchema,
     views,
-    createSessionContext: createSessionContext
-      ? (req: IncomingMessage, res: ServerResponse) => createSessionContext(req, res, system)
-      : undefined,
+    sessionImplementation,
     createContext,
-    async createContextFromRequest(req: IncomingMessage, res: ServerResponse) {
-      return createContext({
-        sessionContext: await sessionImplementation?.createContext(req, res, system),
-      });
-    },
     config,
   };
 

--- a/packages-next/types/src/index.ts
+++ b/packages-next/types/src/index.ts
@@ -144,10 +144,13 @@ export type KeystoneSystem = {
     sessionContext?: SessionContext;
     skipAccessControl?: boolean;
   }) => KeystoneContext;
-  createContextFromRequest: (req: IncomingMessage, res: ServerResponse) => Promise<KeystoneContext>;
-  createSessionContext:
-    | ((req: IncomingMessage, res: ServerResponse) => Promise<SessionContext>)
-    | undefined;
+  sessionImplementation?: {
+    createContext(
+      req: IncomingMessage,
+      res: ServerResponse,
+      system: KeystoneSystem
+    ): Promise<SessionContext>;
+  };
   views: string[];
 };
 


### PR DESCRIPTION
This removes some unnecessary layers of abstraction and makes it more obvious exactly where the `sessionContext` is being generated. A subsequent refactor may possibly be able to remove the `sessionImplementation` from the `system` object entirely, but we'll cross that bridge when we get to it.