### PR TITLE
Apply applyIdFieldDefaults before createSystem

### DIFF
--- a/.changeset/plenty-donkeys-live.md
+++ b/.changeset/plenty-donkeys-live.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Refactored dev script to apply `applyIdFieldDefaults` before sending `config` object to `createSystem`.

--- a/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
+++ b/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
@@ -2,7 +2,7 @@ import type { KeystoneConfig } from '@keystone-next/types';
 import { autoIncrement, mongoId } from '@keystone-next/fields';
 
 /* Validate lists config and default the id field */
-export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig {
+export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
   const lists: KeystoneConfig['lists'] = {};
   Object.keys(config.lists).forEach(key => {
     const listConfig = config.lists[key];
@@ -31,6 +31,5 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig {
     const fields = { id: idField, ...listConfig.fields };
     lists[key] = { ...listConfig, fields };
   });
-
-  return { ...config, lists };
+  return lists;
 }

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -3,7 +3,6 @@ import { MongooseAdapter } from '@keystonejs/adapter-mongoose';
 import { KnexAdapter } from '@keystonejs/adapter-knex';
 import type { KeystoneConfig, KeystoneSystem, BaseKeystone } from '@keystone-next/types';
 
-import { applyIdFieldDefaults } from './applyIdFieldDefaults';
 import { createAdminMeta } from './createAdminMeta';
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './createContext';
@@ -80,8 +79,6 @@ export function createKeystone(
 }
 
 export function createSystem(config: KeystoneConfig): KeystoneSystem {
-  config = applyIdFieldDefaults(config);
-
   const keystone = createKeystone(config, () => createContext);
 
   const sessionStrategy = config.session?.();

--- a/packages-next/keystone/src/lib/initConfig.ts
+++ b/packages-next/keystone/src/lib/initConfig.ts
@@ -1,0 +1,13 @@
+import { KeystoneConfig } from '@keystone-next/types';
+
+import { applyIdFieldDefaults } from '../lib/applyIdFieldDefaults';
+
+/*
+  This function executes the validation and other initialisation logic that
+  needs to be run on Keystone Config before it can be used.
+*/
+
+export function initConfig(config: KeystoneConfig) {
+  config.lists = applyIdFieldDefaults(config);
+  return config;
+}

--- a/packages-next/keystone/src/scripts/dev.ts
+++ b/packages-next/keystone/src/scripts/dev.ts
@@ -3,16 +3,19 @@ import express from 'express';
 import { printSchema } from 'graphql';
 import * as fs from 'fs-extra';
 import { createSystem } from '../lib/createSystem';
+import { initConfig } from '../lib/initConfig';
 import { requireSource } from '../lib/requireSource';
 import { formatSource, generateAdminUI } from '../lib/generateAdminUI';
 import { createExpressServer } from '../lib/createExpressServer';
 import { printGeneratedTypes } from './schema-type-printer';
 
+// TODO: Read config path from process args
+const CONFIG_PATH = path.join(process.cwd(), 'keystone');
+
 // TODO: Read port from config or process args
 const PORT = process.env.PORT || 3000;
 
 // TODO: Don't generate or start an Admin UI if it isn't configured!!
-
 const devLoadingHTMLFilepath = path.join(
   path.dirname(require.resolve('@keystone-next/keystone/package.json')),
   'src',
@@ -27,7 +30,8 @@ export const dev = async () => {
   let expressServer: null | ReturnType<typeof express> = null;
 
   const initKeystone = async () => {
-    const config = requireSource(path.join(process.cwd(), 'keystone')).default;
+    const config = initConfig(requireSource(CONFIG_PATH).default);
+
     const system = createSystem(config);
     let printedSchema = printSchema(system.graphQLSchema);
     console.log('✨ Generating Schema');


### PR DESCRIPTION
Having `createSystem` modify the `config` object is somewhat unexpected. This makes it more clear that we're modifying the config object immediately after loading it.

I suspect as we continue factoring the code for testability these couple of lines in `dev.ts` will evolve further, but this is a useful first step.