### PR TITLE
Rename sessionStrategy to asSessionStrategy

### DIFF
--- a/.changeset/eight-numbers-remember.md
+++ b/.changeset/eight-numbers-remember.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Renamed helper function `sessionStrategy` to `asSessionStrategy` to avoid naming clashes.

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -17,7 +17,7 @@ function generateSessionId() {
   return uid(24);
 }
 
-function sessionStrategy<TSessionStrategy extends SessionStrategy<any>>(
+function asSessionStrategy<TSessionStrategy extends SessionStrategy<any>>(
   sessionStrategy: TSessionStrategy
 ): TSessionStrategy {
   return sessionStrategy;
@@ -129,7 +129,7 @@ export function statelessSessions({
     if (secret.length < 32) {
       throw new Error('The session secret must be at least 32 characters long');
     }
-    return sessionStrategy({
+    return asSessionStrategy({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async get({ req, system }) {
         if (!req.headers.cookie) return;


### PR DESCRIPTION
The namespace clash with various variables also called `sessionStrategy` was confusing me 🤷‍♂️ 