### PR TITLE
[RFC] Make SessionStrategy.start and SessionStrategy.end required

### DIFF
--- a/.changeset/eight-taxis-lick.md
+++ b/.changeset/eight-taxis-lick.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': major
+---
+
+Updated `SessionStrategy.start` and `SessionStrategy.end` to be required attributes.

--- a/packages-next/types/src/session.ts
+++ b/packages-next/types/src/session.ts
@@ -7,13 +7,13 @@ export type SessionStrategy<StoredSessionData, StartSessionData = never> = {
   disconnect?: () => Promise<void>;
   // -- these two are invoked from mutations
   // creates token from data, sets the cookie with token via res, returns token
-  start?: (args: {
+  start: (args: {
     res: ServerResponse;
     data: StoredSessionData | StartSessionData;
     system: KeystoneSystem;
   }) => Promise<string>;
   // resets the cookie via res
-  end?: (args: {
+  end: (args: {
     req: IncomingMessage;
     res: ServerResponse;
     system: KeystoneSystem;


### PR DESCRIPTION
Having these methods being optional leads to some slightly awkward arrangements in our code. For example the `enableSignout` property of `adminMeta` is conditional on the `.end` property existing. This has implications all the way through how we setup out `system` object.

We could greatly simplify our internal code by making these methods required on the type. If a strategy doesn't have anything to do then they can always provide a no-op function.

If there something that I'm missing here? For example is there a world in which we want to have a session implemented but explicitly don't want the user to ever be able to signout?

If we decide to go ahead with this change I'll follow up with PRs to simplify the code that follows from this.

