### PR TITLE
Remove unneeded calls to JSON.stringify

### DIFF
--- a/.changeset/brave-flies-crash.md
+++ b/.changeset/brave-flies-crash.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Removed unncessary calls to `JSON.stringify` in error messages and generated code.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -253,9 +253,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     const specifiedListConfig = keystoneConfig.lists[listKey];
     if (keystoneConfig.lists[listKey] === undefined) {
       throw new Error(
-        `A createAuth() invocation specifies the list ${JSON.stringify(
-          listKey
-        )} but no list with that key has been defined.`
+        `A createAuth() invocation specifies the list "${listKey}" but no list with that key has been defined.`
       );
     }
 
@@ -263,9 +261,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     const identityFieldConfig = specifiedListConfig.fields[identityField];
     if (identityFieldConfig === undefined) {
       throw new Error(
-        `A createAuth() invocation for the ${JSON.stringify(
-          listKey
-        )} list specifies ${JSON.stringify(
+        `A createAuth() invocation for the "${listKey}" list specifies ${JSON.stringify(
           identityField
         )} as its identityField but no field with that key exists on the list.`
       );
@@ -275,9 +271,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     const secretFieldConfig = specifiedListConfig.fields[secretField];
     if (secretFieldConfig === undefined) {
       throw new Error(
-        `A createAuth() invocation for the ${JSON.stringify(
-          listKey
-        )} list specifies ${JSON.stringify(
+        `A createAuth() invocation for the "${listKey}" list specifies ${JSON.stringify(
           secretField
         )} as its secretField but no field with that key exists on the list.`
       );
@@ -289,9 +283,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     const secretTypename = secretFieldConfig.type && secretFieldConfig.type.type;
     if (typeof secretPrototype.compare !== 'function' || secretPrototype.compare.length < 2) {
       throw new Error(
-        `A createAuth() invocation for the ${JSON.stringify(
-          listKey
-        )} list specifies ${JSON.stringify(
+        `A createAuth() invocation for the "${listKey}" list specifies ${JSON.stringify(
           secretField
         )} as its secretField, which uses the field type ${JSON.stringify(
           secretTypename
@@ -305,9 +297,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
     if (typeof secretPrototype.generateHash !== 'function') {
       throw new Error(
-        `A createAuth() invocation for the ${JSON.stringify(
-          listKey
-        )} list specifies ${JSON.stringify(
+        `A createAuth() invocation for the "${listKey}" list specifies ${JSON.stringify(
           secretField
         )} as its secretField, which uses the field type ${JSON.stringify(
           secretTypename
@@ -324,9 +314,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     for (const field of initFirstItem?.fields || []) {
       if (specifiedListConfig.fields[field] === undefined) {
         throw new Error(
-          `A createAuth() invocation for the ${JSON.stringify(
-            listKey
-          )} list specifies the field ${JSON.stringify(
+          `A createAuth() invocation for the "${listKey}" list specifies the field ${JSON.stringify(
             field
           )} in initFirstItem.fields array but no field with that key exist on the list.`
         );

--- a/packages-next/auth/src/templates/init.ts
+++ b/packages-next/auth/src/templates/init.ts
@@ -16,9 +16,7 @@ export const initTemplate = ({ listKey, initFirstItem, fields }: InitTemplateArg
   const fieldsMeta = ${JSON.stringify(fields)}
 
   export default function Init() {
-    return <InitPage listKey=${JSON.stringify(
-      listKey
-    )} fields={fieldsMeta} showKeystoneSignup={${JSON.stringify(
+    return <InitPage listKey="${listKey}" fields={fieldsMeta} showKeystoneSignup={${JSON.stringify(
     !initFirstItem.skipKeystoneSignup
   )}} />
   }

--- a/packages-next/auth/src/templates/signin.ts
+++ b/packages-next/auth/src/templates/signin.ts
@@ -17,11 +17,11 @@ import { SigninPage } from '@keystone-next/auth/pages/SigninPage'
 
 export default function Signin() {
   return <SigninPage
-           identityField=${JSON.stringify(identityField)}
-           secretField=${JSON.stringify(secretField)}
-           mutationName=${JSON.stringify(gqlNames.authenticateItemWithPassword)}
-           successTypename=${JSON.stringify(gqlNames.ItemAuthenticationWithPasswordSuccess)}
-           failureTypename=${JSON.stringify(gqlNames.ItemAuthenticationWithPasswordFailure)}
+           identityField="${identityField}"
+           secretField="${secretField}"
+           mutationName="${gqlNames.authenticateItemWithPassword}"
+           successTypename="${gqlNames.ItemAuthenticationWithPasswordSuccess}"
+           failureTypename="${gqlNames.ItemAuthenticationWithPasswordFailure}"
          />
 }
   `;


### PR DESCRIPTION
Direct formatting of `string` typed values is easier to grok and avoids horrific line break formatting.