### PR TITLE
Remove config from system

### DIFF
--- a/.changeset/four-ducks-taste.md
+++ b/.changeset/four-ducks-taste.md
@@ -1,0 +1,9 @@
+---
+'@keystone-next/admin-ui': patch
+'@keystone-next/auth': patch
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Removed `config` from type `KeystoneSystem`. The config object is now explicitly passed around where needed to make it clear which code is consuming it.
+Type `KeystoneAdminUIConfig.getAdditionalFiles` now takes a `config` parameter. 

--- a/packages-next/admin-ui/src/system/generateAdminUI.ts
+++ b/packages-next/admin-ui/src/system/generateAdminUI.ts
@@ -83,7 +83,7 @@ export const generateAdminUI = async (
   const filesWritten = new Set(
     [
       ...(await writeAdminFilesToDisk(
-        config.ui?.getAdditionalFiles?.map(x => x(system)) ?? [],
+        config.ui?.getAdditionalFiles?.map(x => x(config, system)) ?? [],
         projectAdminPath
       )),
     ].map(x => Path.normalize(x))

--- a/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
+++ b/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
@@ -2,7 +2,7 @@ import { mergeSchemas } from '@graphql-tools/merge';
 import { GraphQLSchema } from 'graphql';
 import { gql } from '../apollo';
 import { StaticAdminMetaQueryWithoutTypeNames } from '../admin-meta-graphql';
-import { KeystoneSystem, KeystoneContext } from '@keystone-next/types';
+import { KeystoneSystem, KeystoneContext, KeystoneConfig } from '@keystone-next/types';
 
 let typeDefs = gql`
   type Query {
@@ -90,7 +90,7 @@ export function adminMetaSchemaExtension({
   config,
 }: {
   adminMeta: KeystoneSystem['adminMeta'];
-  config: KeystoneSystem['config'];
+  config: KeystoneConfig;
   graphQLSchema: GraphQLSchema;
 }) {
   type AdminMeta = StaticAdminMetaQueryWithoutTypeNames['keystone']['adminMeta'];

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -197,7 +197,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    *
    * The signin page is always included, and the init page is included when initFirstItem is set
    */
-  const additionalFiles: Auth['ui']['getAdditionalFiles'] = system => {
+  const additionalFiles: Auth['ui']['getAdditionalFiles'] = (config, system) => {
     let filesToWrite: AdminFileToWrite[] = [
       {
         mode: 'write',

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -62,7 +62,7 @@ export const createExpressServer = async (config: KeystoneConfig, system: Keysto
   addApolloServer({ server, system });
 
   console.log('✨ Preparing Next.js app');
-  server.use(await createAdminUIServer(system));
+  server.use(await createAdminUIServer(config.ui, system));
 
   return server;
 };

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -31,7 +31,10 @@ export type KeystoneAdminUIConfig = {
   publicPages?: string[];
   /** The basePath for the Admin UI App */
   path?: string;
-  getAdditionalFiles?: ((system: KeystoneSystem) => MaybePromise<AdminFileToWrite[]>)[];
+  getAdditionalFiles?: ((
+    config: KeystoneConfig,
+    system: KeystoneSystem
+  ) => MaybePromise<AdminFileToWrite[]>)[];
   pageMiddleware?: (args: {
     req: IncomingMessage;
     session: any;
@@ -131,7 +134,6 @@ export type CreateContext = (args: {
 
 export type KeystoneSystem = {
   keystone: BaseKeystone;
-  config: KeystoneConfig;
   adminMeta: SerializedAdminMeta;
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;


### PR DESCRIPTION
This makes it more explicit exactly where and how the config object is being consumed, vs where ones its derivations (the `system` object) is used.