### PR TITLE
Disabled the debug output by default in the Document field

### DIFF
--- a/packages-next/fields-document/src/DocumentEditor/index.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/index.tsx
@@ -315,10 +315,9 @@ export function DocumentEditor({
                 renderLeaf={renderLeaf}
               />
             </Slate>
-
             {
               // for debugging
-              true && <pre>{JSON.stringify(value, null, 2)}</pre>
+              false && <pre>{JSON.stringify(value, null, 2)}</pre>
             }
           </ComponentBlockProvider>
         </ColumnOptionsProvider>


### PR DESCRIPTION
This snuck in with a recent commit, shouldn't be turned on by default.

Might be nice to add an option for it that's accessible without changing code, but that can happen later, just turn it off for now.