### PR TITLE
Updating auth extensions to skip access control after the context API changes

### DIFF
--- a/.changeset/few-pillows-lie.md
+++ b/.changeset/few-pillows-lie.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/auth": patch
+---
+
+Updating auth extensions to skip access control after the context API changes

--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -54,7 +54,8 @@ export function getBaseAuthSchema({
           }
 
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const result = await validateSecret(
             list,
             identityField,

--- a/packages-next/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages-next/auth/src/gql/getInitFirstItemSchema.ts
@@ -41,7 +41,8 @@ export function getInitFirstItemSchema({
             throw new Error('No session implementation available on context');
           }
 
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const count = await itemAPI.count({});
           if (count !== 0) {
             throw new Error('Initial items can only be created when no items exist in that list');

--- a/packages-next/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages-next/auth/src/gql/getInitFirstItemSchema.ts
@@ -49,7 +49,10 @@ export function getInitFirstItemSchema({
           }
 
           // Update system state
-          const item = await itemAPI.createOne({ data: { ...data, ...itemData } });
+          const item = await itemAPI.createOne({
+            data: { ...data, ...itemData },
+            resolveFields: false,
+          });
           const sessionToken = await context.startSession({ listKey, itemId: item.id });
           return { item, sessionToken };
         },

--- a/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -60,7 +60,8 @@ export function getMagicAuthLinkSchema({
       Mutation: {
         async [gqlNames.sendItemMagicAuthLink](root, args, context) {
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const tokenType = 'magicAuth';
           const identity = args[identityField];
 
@@ -100,7 +101,8 @@ export function getMagicAuthLinkSchema({
           }
 
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const tokenType = 'magicAuth';
           const result = await validateAuthToken(
             tokenType,

--- a/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -89,6 +89,7 @@ export function getMagicAuthLinkSchema({
                 [`${tokenType}IssuedAt`]: new Date().toISOString(),
                 [`${tokenType}RedeemedAt`]: null,
               },
+              resolveFields: false,
             });
 
             await magicAuthLink.sendToken({ itemId, identity, token });
@@ -130,6 +131,7 @@ export function getMagicAuthLinkSchema({
           await itemAPI.updateOne({
             id: result.item.id,
             data: { [`${tokenType}RedeemedAt`]: new Date().toISOString() },
+            resolveFields: false,
           });
 
           const sessionToken = await context.startSession({ listKey, itemId: result.item.id });

--- a/packages-next/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages-next/auth/src/gql/getPasswordResetSchema.ts
@@ -90,6 +90,7 @@ export function getPasswordResetSchema({
                 [`${tokenType}IssuedAt`]: new Date().toISOString(),
                 [`${tokenType}RedeemedAt`]: null,
               },
+              resolveFields: false,
             });
 
             await passwordResetLink.sendToken({ itemId, identity, token });
@@ -128,12 +129,17 @@ export function getPasswordResetSchema({
           await itemAPI.updateOne({
             id: itemId,
             data: { [`${tokenType}RedeemedAt`]: new Date().toISOString() },
+            resolveFields: false,
           });
 
           // Save the provided secret. Do this as a separate step as password validation
           // may fail, in which case we still want to mark the token as redeemed
           // (NB: Is this *really* what we want? -TL)
-          await itemAPI.updateOne({ id: itemId, data: { [secretField]: args[secretField] } });
+          await itemAPI.updateOne({
+            id: itemId,
+            data: { [secretField]: args[secretField] },
+            resolveFields: false,
+          });
 
           return null;
         },

--- a/packages-next/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages-next/auth/src/gql/getPasswordResetSchema.ts
@@ -63,7 +63,8 @@ export function getPasswordResetSchema({
       Mutation: {
         async [gqlNames.sendItemPasswordResetLink](root, args, context) {
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const tokenType = 'passwordReset';
           const identity = args[identityField];
           const result = await updateAuthToken(identityField, protectIdentities, identity, itemAPI);
@@ -97,7 +98,8 @@ export function getPasswordResetSchema({
         },
         async [gqlNames.redeemItemPasswordResetToken](root, args, context) {
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const tokenType = 'passwordReset';
           const result = await validateAuthToken(
             tokenType,
@@ -139,7 +141,8 @@ export function getPasswordResetSchema({
       Query: {
         async [gqlNames.validateItemPasswordResetToken](root, args, context) {
           const list = context.keystone.lists[listKey];
-          const itemAPI = context.lists[listKey];
+          const sudoContext = context.createContext({ skipAccessControl: true });
+          const itemAPI = sudoContext.lists[listKey];
           const tokenType = 'passwordReset';
           const result = await validateAuthToken(
             tokenType,

--- a/packages-next/auth/src/lib/findMatchingIdentity.ts
+++ b/packages-next/auth/src/lib/findMatchingIdentity.ts
@@ -10,7 +10,10 @@ export async function findMatchingIdentity(
   | { success: false; code: AuthTokenRequestErrorCode }
   | { success: true; item: { id: any; [prop: string]: any } }
 > {
-  const items = await itemAPI.findMany({ where: { [identityField]: identity } });
+  const items = await itemAPI.findMany({
+    where: { [identityField]: identity },
+    resolveFields: false,
+  });
 
   // Identity failures with helpful errors
   let code: AuthTokenRequestErrorCode | undefined;


### PR DESCRIPTION
Having changed the itemAPI to use the current context by default, we need to update our internal use of it to create a new context that skips access control.