### PR TITLE
Pass createContext rather than system to session functions

### DIFF
--- a/.changeset/smooth-snails-mate.md
+++ b/.changeset/smooth-snails-mate.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+'@keystone-next/admin-ui': patch
+---
+
+Replaced the `system` argument on `SessionStrategy.start`, '.end`, and`.get`with`createContext`.

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -18,8 +18,9 @@ export const createAdminUIServer = async (system: KeystoneSystem) => {
       handle(req, res);
       return;
     }
-    const session = (await system.sessionImplementation?.createContext?.(req, res, system))
-      ?.session;
+    const session = (
+      await system.sessionImplementation?.createContext?.(req, res, system.createContext)
+    )?.session;
     const isValidSession = system.config.ui?.isAccessAllowed
       ? await system.config.ui.isAccessAllowed({ session })
       : session !== undefined;

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -25,7 +25,7 @@ const addApolloServer = ({
     formatError, // TODO: this needs to be discussed
     context: async ({ req, res }: { req: IncomingMessage; res: ServerResponse }) =>
       createContext({
-        sessionContext: await sessionImplementation?.createContext(req, res, system),
+        sessionContext: await sessionImplementation?.createContext(req, res, createContext),
       }),
     // FIXME: support for apollo studio tracing
     // ...(process.env.ENGINE_API_KEY || process.env.APOLLO_KEY

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -1,13 +1,12 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import * as cookie from 'cookie';
 import Iron from '@hapi/iron';
-import { execute, parse } from 'graphql';
 import {
   SessionStrategy,
   JSONValue,
   SessionStoreFunction,
   SessionContext,
-  KeystoneSystem,
+  CreateContext,
 } from '@keystone-next/types';
 
 // uid-safe is what express-session uses so let's just use it
@@ -78,38 +77,28 @@ export function withItemData(createSession: CreateSession, fieldSelections: Fiel
     const { get, ...sessionStrategy } = createSession();
     return {
       ...sessionStrategy,
-      get: async ({ req, system }) => {
-        const session = await get({ req, system });
+      get: async ({ req, createContext }) => {
+        const session = await get({ req, createContext });
+        const sudoContext = createContext({ skipAccessControl: true });
         if (
           !session ||
           !session.listKey ||
           !session.itemId ||
-          !system.adminMeta.lists[session.listKey]
+          !sudoContext.lists[session.listKey]
         ) {
           return;
         }
-        const context = system.createContext({ skipAccessControl: true });
-        const { gqlNames } = system.adminMeta.lists[session.listKey];
         // If no field selection is specified, just load the id. We still load the item,
         // because doing so validates that it exists in the database
-        const fields = fieldSelections[session.listKey] || 'id';
-        const query = parse(`query($id: ID!) {
-          item: ${gqlNames.itemQueryName}(where: { id: $id }) {
-            ${fields}
-          }
-        }`);
-        const args = { id: session.itemId };
-        const result = await execute(system.graphQLSchema, query, null, context, args);
-        // TODO: This causes "not found" errors to throw, which is not what we want
-        // TODO: Also, why is this coming back as an access denied error instead of "not found" with an invalid session?
-        // if (result.errors?.length) {
-        //   throw result.errors[0];
-        // }
+        const item = await sudoContext.lists[session.listKey].findOne({
+          where: { id: session.itemId },
+          resolveFields: fieldSelections[session.listKey] || 'id',
+        });
         // If there is no matching item found, return no session
-        if (!result?.data?.item) {
+        if (!item) {
           return;
         }
-        return { ...session, data: result.data.item };
+        return { ...session, data: item };
       },
     };
   };
@@ -131,7 +120,7 @@ export function statelessSessions({
     }
     return asSessionStrategy({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      async get({ req, system }) {
+      async get({ req, createContext }) {
         if (!req.headers.cookie) return;
         let cookies = cookie.parse(req.headers.cookie);
         if (!cookies[TOKEN_NAME]) return;
@@ -186,23 +175,23 @@ export function storedSessions({
     return {
       connect: store.connect,
       disconnect: store.disconnect,
-      async get({ req, system }) {
-        let sessionId = await get({ req, system });
+      async get({ req, createContext }) {
+        let sessionId = await get({ req, createContext });
         if (typeof sessionId === 'string') {
           return store.get(sessionId);
         }
       },
-      async start({ res, data, system }) {
+      async start({ res, data, createContext }) {
         let sessionId = generateSessionId();
         await store.set(sessionId, data);
-        return start?.({ res, data: { sessionId }, system }) || '';
+        return start?.({ res, data: { sessionId }, createContext }) || '';
       },
-      async end({ req, res, system }) {
-        let sessionId = await get({ req, system });
+      async end({ req, res, createContext }) {
+        let sessionId = await get({ req, createContext });
         if (typeof sessionId === 'string') {
           await store.delete(sessionId);
         }
-        await end?.({ req, res, system });
+        await end?.({ req, res, createContext });
       },
     };
   };
@@ -217,16 +206,16 @@ export function implementSession<T>(sessionStrategy: SessionStrategy<T>) {
     async createContext(
       req: IncomingMessage,
       res: ServerResponse,
-      system: KeystoneSystem
+      createContext: CreateContext
     ): Promise<SessionContext<T>> {
       if (!isConnected) {
         await sessionStrategy.connect?.();
         isConnected = true;
       }
       return {
-        session: await sessionStrategy.get({ req, system }),
-        startSession: (data: T) => sessionStrategy.start({ res, data, system }),
-        endSession: () => sessionStrategy.end({ req, res, system }),
+        session: await sessionStrategy.get({ req, createContext }),
+        startSession: (data: T) => sessionStrategy.start({ res, data, createContext }),
+        endSession: () => sessionStrategy.end({ req, res, createContext }),
       };
     },
   };

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -124,20 +124,22 @@ export type FieldDefaultValue<T> =
   | null
   | MaybePromise<(args: FieldDefaultValueArgs<T>) => T | null | undefined>;
 
+export type CreateContext = (args: {
+  sessionContext?: SessionContext<any>;
+  skipAccessControl?: boolean;
+}) => KeystoneContext;
+
 export type KeystoneSystem = {
   keystone: BaseKeystone;
   config: KeystoneConfig;
   adminMeta: SerializedAdminMeta;
   graphQLSchema: GraphQLSchema;
-  createContext: (args: {
-    sessionContext?: SessionContext<any>;
-    skipAccessControl?: boolean;
-  }) => KeystoneContext;
+  createContext: CreateContext;
   sessionImplementation?: {
     createContext(
       req: IncomingMessage,
       res: ServerResponse,
-      system: KeystoneSystem
+      createContext: CreateContext
     ): Promise<SessionContext<any>>;
   };
   views: string[];

--- a/packages-next/types/src/session.ts
+++ b/packages-next/types/src/session.ts
@@ -1,6 +1,6 @@
 import type { JSONValue } from './utils';
 import type { ServerResponse, IncomingMessage } from 'http';
-import { KeystoneSystem } from '.';
+import { CreateContext } from '.';
 
 export type SessionStrategy<StoredSessionData, StartSessionData = never> = {
   connect?: () => Promise<void>;
@@ -10,19 +10,19 @@ export type SessionStrategy<StoredSessionData, StartSessionData = never> = {
   start: (args: {
     res: ServerResponse;
     data: StoredSessionData | StartSessionData;
-    system: KeystoneSystem;
+    createContext: CreateContext;
   }) => Promise<string>;
   // resets the cookie via res
   end: (args: {
     req: IncomingMessage;
     res: ServerResponse;
-    system: KeystoneSystem;
+    createContext: CreateContext;
   }) => Promise<void>;
   // -- this one is invoked at the start of every request
   // reads the token, gets the data, returns it
   get: (args: {
     req: IncomingMessage;
-    system: KeystoneSystem;
+    createContext: CreateContext;
   }) => Promise<StoredSessionData | undefined>;
 };
 


### PR DESCRIPTION
Narrows down the API surface area that we're exposing in this corner of the system to just what we need.