### PR TITLE
Rename KeystoneSystem.views to KeystoneSystem.allViews

### DIFF
--- a/.changeset/chatty-tips-taste.md
+++ b/.changeset/chatty-tips-taste.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/admin-ui': patch
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Renamed `KeystoneSystem.views` to `KeystoneSystem.allViews`.

--- a/packages-next/admin-ui/src/templates/app.ts
+++ b/packages-next/admin-ui/src/templates/app.ts
@@ -23,7 +23,7 @@ export const appTemplate = (
   system: KeystoneSystem,
   { configFile, projectAdminPath }: AppTemplateOptions
 ) => {
-  const { graphQLSchema, adminMeta, views } = system;
+  const { graphQLSchema, adminMeta, allViews } = system;
   const lazyMetadataQuery = getLazyMetadataQuery(graphQLSchema, adminMeta);
 
   const result = executeSync({
@@ -45,18 +45,18 @@ import { KeystoneProvider } from '@keystone-next/admin-ui/context';
 import { ErrorBoundary } from '@keystone-next/admin-ui/components';
 import { Core } from '@keystone-ui/core';
 
-${views
+${allViews
   .map(
-    (view, i) =>
+    (views, i) =>
       `import * as view${i} from ${JSON.stringify(
-        Path.isAbsolute(view) ? Path.relative(Path.join(projectAdminPath, 'pages'), view) : view
+        Path.isAbsolute(views) ? Path.relative(Path.join(projectAdminPath, 'pages'), views) : views
       )}`
   )
   .join('\n')}
 
 ${configFile ? `import * as adminConfig from "../../../admin/config";` : 'const adminConfig = {};'}
 
-const fieldViews = [${views.map((x, i) => `view${i}`)}];
+const fieldViews = [${allViews.map((x, i) => `view${i}`)}];
 
 const lazyMetadataQuery = ${JSON.stringify(lazyMetadataQuery)};
 

--- a/packages-next/keystone/src/lib/createAdminMeta.ts
+++ b/packages-next/keystone/src/lib/createAdminMeta.ts
@@ -14,14 +14,14 @@ export function createAdminMeta(config: KeystoneConfig, keystone: BaseKeystone) 
   };
   let uniqueViewCount = -1;
   const stringViewsToIndex: Record<string, number> = {};
-  const views: string[] = [];
-  function getViewId(view: string) {
-    if (stringViewsToIndex[view] === undefined) {
+  const allViews: string[] = [];
+  function getViewsId(views: string) {
+    if (stringViewsToIndex[views] === undefined) {
       uniqueViewCount++;
-      stringViewsToIndex[view] = uniqueViewCount;
-      views.push(view);
+      stringViewsToIndex[views] = uniqueViewCount;
+      allViews.push(views);
     }
-    return stringViewsToIndex[view];
+    return stringViewsToIndex[views];
   }
   Object.keys(lists).forEach(key => {
     const listConfig = lists[key];
@@ -61,13 +61,14 @@ export function createAdminMeta(config: KeystoneConfig, keystone: BaseKeystone) 
       const field: FieldType<any> = listConfig.fields[fieldKey];
       adminMeta.lists[key].fields[fieldKey] = {
         label: list.fieldsByPath[fieldKey].label,
-        views: getViewId(field.views),
-        customViews: field.config.ui?.views === undefined ? null : getViewId(field.config.ui.views),
+        views: getViewsId(field.views),
+        customViews:
+          field.config.ui?.views === undefined ? null : getViewsId(field.config.ui.views),
         fieldMeta: field.getAdminMeta?.(key, fieldKey, adminMeta) ?? null,
         isOrderable: list.fieldsByPath[fieldKey].isOrderable || fieldKey === 'id',
       };
     }
   });
 
-  return { adminMeta, views };
+  return { adminMeta, allViews };
 }

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -81,7 +81,7 @@ export function createKeystone(
 export function createSystem(config: KeystoneConfig): KeystoneSystem {
   const keystone = createKeystone(config, () => createContext);
 
-  const { adminMeta, views } = createAdminMeta(config, keystone);
+  const { adminMeta, allViews } = createAdminMeta(config, keystone);
 
   const graphQLSchema = createGraphQLSchema(config, keystone, adminMeta);
 
@@ -91,7 +91,7 @@ export function createSystem(config: KeystoneConfig): KeystoneSystem {
     keystone,
     adminMeta,
     graphQLSchema,
-    views,
+    allViews,
     sessionImplementation: config.session ? implementSession(config.session()) : undefined,
     createContext,
     config,

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -142,7 +142,7 @@ export type KeystoneSystem = {
       createContext: CreateContext
     ): Promise<SessionContext<any>>;
   };
-  views: string[];
+  allViews: string[];
 };
 
 export type AccessControlContext = {


### PR DESCRIPTION
More name-clash avoidance.