### PR TITLE
Remove schema merge from adminMetaSchemaExtension

### DIFF
--- a/.changeset/clean-pants-judge.md
+++ b/.changeset/clean-pants-judge.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/keystone': patch
+---
+
+Updated and renamed `adminMetaSchemaExtension` to no longer perform the schema merge operation. It now simply returns `{ typeDefs, resolvers }` and allows the calling function to merge them as required, and is renamed to `getAdminMetaSchema`.

--- a/packages-next/admin-ui/package.json
+++ b/packages-next/admin-ui/package.json
@@ -7,7 +7,6 @@
     "@babel/runtime": "^7.12.5",
     "@emotion/hash": "^0.8.0",
     "@emotion/weak-memoize": "^0.2.5",
-    "@graphql-tools/merge": "^6.2.6",
     "@keystone-next/admin-ui-utils": "^2.0.1",
     "@keystone-next/keystone": "^5.0.0",
     "@keystone-next/types": "^5.0.0",

--- a/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
+++ b/packages-next/admin-ui/src/templates/adminMetaSchemaExtension.ts
@@ -1,5 +1,3 @@
-import { mergeSchemas } from '@graphql-tools/merge';
-import { GraphQLSchema } from 'graphql';
 import { gql } from '../apollo';
 import { StaticAdminMetaQueryWithoutTypeNames } from '../admin-meta-graphql';
 import { KeystoneSystem, KeystoneContext, KeystoneConfig } from '@keystone-next/types';
@@ -84,14 +82,12 @@ let typeDefs = gql`
   }
 `;
 
-export function adminMetaSchemaExtension({
+export function getAdminMetaSchema({
   adminMeta,
-  graphQLSchema,
   config,
 }: {
   adminMeta: KeystoneSystem['adminMeta'];
   config: KeystoneConfig;
-  graphQLSchema: GraphQLSchema;
 }) {
   type AdminMeta = StaticAdminMetaQueryWithoutTypeNames['keystone']['adminMeta'];
   type ListMetaRootVal = AdminMeta['lists'][number];
@@ -129,8 +125,7 @@ export function adminMetaSchemaExtension({
       ? undefined
       : config.ui?.isAccessAllowed ?? (({ session }) => session !== undefined);
 
-  return mergeSchemas({
-    schemas: [graphQLSchema],
+  return {
     typeDefs,
     resolvers: {
       Query: {
@@ -238,7 +233,7 @@ export function adminMetaSchemaExtension({
         },
       },
     },
-  });
+  };
 }
 
 type FieldIdentifier = { listKey: string; fieldPath: string };

--- a/packages-next/admin-ui/src/templates/index.ts
+++ b/packages-next/admin-ui/src/templates/index.ts
@@ -10,7 +10,7 @@ import * as Path from 'path';
 
 const pkgDir = Path.dirname(require.resolve('@keystone-next/admin-ui/package.json'));
 
-export { adminMetaSchemaExtension } from './adminMetaSchemaExtension';
+export { getAdminMetaSchema } from './adminMetaSchemaExtension';
 
 export const writeAdminFiles = (
   session: KeystoneConfig['session'],

--- a/packages-next/keystone/src/lib/createGraphQLSchema.ts
+++ b/packages-next/keystone/src/lib/createGraphQLSchema.ts
@@ -7,7 +7,7 @@ import type {
   BaseKeystone,
   SerializedAdminMeta,
 } from '@keystone-next/types';
-import { adminMetaSchemaExtension } from '@keystone-next/admin-ui/templates';
+import { getAdminMetaSchema } from '@keystone-next/admin-ui/templates';
 
 import { gql } from '../schema';
 
@@ -65,7 +65,10 @@ export function createGraphQLSchema(
     });
   }
 
-  graphQLSchema = adminMetaSchemaExtension({ adminMeta, graphQLSchema, config });
+  graphQLSchema = mergeSchemas({
+    schemas: [graphQLSchema],
+    ...getAdminMetaSchema({ adminMeta, config }),
+  });
 
   return graphQLSchema;
 }


### PR DESCRIPTION
This consolidates all the schema merging in one place, which makes it easier to follow.