### PR TITLE
Remove sessionImplementation from KeystoneSystem

### DIFF
--- a/.changeset/chatty-roses-joke.md
+++ b/.changeset/chatty-roses-joke.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Removed `sessionImplementation` from `KeystoneSystem` and instead pass it explicitly where needed.

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -2,11 +2,15 @@ import Path from 'path';
 import url from 'url';
 import next from 'next';
 import express from 'express';
-import type { KeystoneSystem, KeystoneConfig } from '@keystone-next/types';
+import type { KeystoneSystem, KeystoneConfig, SessionImplementation } from '@keystone-next/types';
 
 const dev = process.env.NODE_ENV !== 'production';
 
-export const createAdminUIServer = async (ui: KeystoneConfig['ui'], system: KeystoneSystem) => {
+export const createAdminUIServer = async (
+  ui: KeystoneConfig['ui'],
+  system: KeystoneSystem,
+  sessionImplementation?: SessionImplementation
+) => {
   const app = next({ dev, dir: Path.join(process.cwd(), '.keystone', 'admin') });
   const handle = app.getRequestHandler();
   await app.prepare();
@@ -18,9 +22,8 @@ export const createAdminUIServer = async (ui: KeystoneConfig['ui'], system: Keys
       handle(req, res);
       return;
     }
-    const session = (
-      await system.sessionImplementation?.createContext?.(req, res, system.createContext)
-    )?.session;
+    const session = (await sessionImplementation?.createContext?.(req, res, system.createContext))
+      ?.session;
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed({ session })
       : session !== undefined;

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -7,8 +7,6 @@ import { createAdminMeta } from './createAdminMeta';
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './createContext';
 
-import { implementSession } from '../session';
-
 export function createKeystone(
   config: KeystoneConfig,
   createContextFactory: () => ReturnType<typeof makeCreateContext>
@@ -87,15 +85,5 @@ export function createSystem(config: KeystoneConfig): KeystoneSystem {
 
   const createContext = makeCreateContext({ keystone, graphQLSchema });
 
-  let system = {
-    keystone,
-    adminMeta,
-    graphQLSchema,
-    allViews,
-    sessionImplementation: config.session ? implementSession(config.session()) : undefined,
-    createContext,
-    config,
-  };
-
-  return system;
+  return { keystone, adminMeta, graphQLSchema, allViews, createContext };
 }

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -132,18 +132,19 @@ export type CreateContext = (args: {
   skipAccessControl?: boolean;
 }) => KeystoneContext;
 
+export type SessionImplementation = {
+  createContext(
+    req: IncomingMessage,
+    res: ServerResponse,
+    createContext: CreateContext
+  ): Promise<SessionContext<any>>;
+};
+
 export type KeystoneSystem = {
   keystone: BaseKeystone;
   adminMeta: SerializedAdminMeta;
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;
-  sessionImplementation?: {
-    createContext(
-      req: IncomingMessage,
-      res: ServerResponse,
-      createContext: CreateContext
-    ): Promise<SessionContext<any>>;
-  };
   allViews: string[];
 };
 


### PR DESCRIPTION
The `sessionImplementation` only needs to be instantiated when we're setting up the server. Passing it through only where needed makes it easier to reason about that being part of the `system` object.