### PR TITLE
Fixed key missed in #4493, rename views to viewsIndex

### DIFF
--- a/packages-next/admin-ui/src/admin-meta-graphql.ts
+++ b/packages-next/admin-ui/src/admin-meta-graphql.ts
@@ -33,7 +33,7 @@ export const staticAdminMetaQuery = gql`
             label
             isOrderable
             fieldMeta
-            views
+            viewsIndex
             customViews
           }
         }


### PR DESCRIPTION
This key was missed in #4493 when `views` was renamed to `viewsIndex`, fixes it so the Admin UI loads again 😅 