### PR TITLE
Added resolveFields: false to the authenticatedItem query

### DIFF
--- a/packages-next/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages-next/auth/src/gql/getBaseAuthSchema.ts
@@ -85,7 +85,10 @@ export function getBaseAuthSchema({
       Query: {
         async authenticatedItem(root, args, { session, lists }) {
           if (typeof session?.itemId === 'string' && typeof session.listKey === 'string') {
-            const item = await lists[session.listKey].findOne({ where: { id: session.itemId } });
+            const item = await lists[session.listKey].findOne({
+              where: { id: session.itemId },
+              resolveFields: false,
+            });
             return item || null;
           }
           return null;


### PR DESCRIPTION
Add a missing `resolveFields` argument in the `authenticatedItem` query so that the fields resolve properly again.

Fixes this bug in the Admin UI:

![image](https://user-images.githubusercontent.com/872310/101138115-dcdc0100-3663-11eb-816f-4db0bf048daf.png)
