### PR TITLE
Fixed an issue where invalid items would crash session initialisation

### DIFF
--- a/.changeset/odd-shoes-chew.md
+++ b/.changeset/odd-shoes-chew.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Fixed an issue where invalid items would crash session initialisation


### PR DESCRIPTION
This has brought up some deeper issues I think we need to address, but for now, implements an urgent fix to prevent session initialisation hanging when you have an invalid itemId in the session cookie.