### PR TITLE
Force the Admin UI to use consistent versions of react, react-dom and @keystone-next/admin-ui

### DIFF
--- a/.changeset/giant-zebras-collect.md
+++ b/.changeset/giant-zebras-collect.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/admin-ui': patch
+---
+
+Forced the Admin UI to use consistent versions of react, react-dom and @keystone-next/admin-ui

--- a/packages-next/admin-ui/next-config/package.json
+++ b/packages-next/admin-ui/next-config/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/admin-ui.cjs.js",
+  "module": "dist/admin-ui.esm.js"
+}

--- a/packages-next/admin-ui/package.json
+++ b/packages-next/admin-ui/package.json
@@ -50,7 +50,8 @@
       "pages/*/index.tsx",
       "apollo.tsx",
       "context.tsx",
-      "router.tsx"
+      "router.tsx",
+      "next-config.ts"
     ]
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/packages-next/admin-ui"

--- a/packages-next/admin-ui/src/next-config.ts
+++ b/packages-next/admin-ui/src/next-config.ts
@@ -1,0 +1,17 @@
+// @ts-ignore
+import withPreconstruct from '@preconstruct/next';
+import Path from 'path';
+
+export const config = withPreconstruct({
+  webpack(config: any) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      react: Path.dirname(require.resolve('react/package.json')),
+      'react-dom': Path.dirname(require.resolve('react-dom/package.json')),
+      '@keystone-next/admin-ui': Path.dirname(
+        require.resolve('@keystone-next/admin-ui/package.json')
+      ),
+    };
+    return config;
+  },
+});

--- a/packages-next/admin-ui/static/next.config.js
+++ b/packages-next/admin-ui/static/next.config.js
@@ -1,1 +1,3 @@
+// this file is copied somewhere else so this lint rule is incorrect
+// eslint-disable-next-line import/no-extraneous-dependencies
 module.exports = require('@keystone-next/admin-ui/next-config').config;

--- a/packages-next/admin-ui/static/next.config.js
+++ b/packages-next/admin-ui/static/next.config.js
@@ -1,3 +1,1 @@
-const withPreconstruct = require('@preconstruct/next');
-
-module.exports = withPreconstruct();
+module.exports = require('@keystone-next/admin-ui/next-config').config;


### PR DESCRIPTION
This is basically the same as we do in the current Admin UI