### PR TITLE
Fixed typo in initial-data.md

### DIFF
--- a/docs/tutorials/initial-data.md
+++ b/docs/tutorials/initial-data.md
@@ -276,7 +276,7 @@ const keystone = new Keystone({
             password: 'dolphins',
             posts: {
               // Filtering list of items where title contains the word `React`
-              connect: post.filter(p => /\bReact\b/i.test(p.title)).map(i => ({ id: i.id })),
+              connect: posts.filter(p => /\bReact\b/i.test(p.title)).map(i => ({ id: i.id })),
             },
           },
         },


### PR DESCRIPTION
In the many to one relationship part, there is a typo missing an s that will cause the code error.