### PR TITLE
Copy rather than mutate in initConfig

### DIFF
--- a/.changeset/long-rocks-study.md
+++ b/.changeset/long-rocks-study.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Updated `initConfig` to return a copy of the `config` object, rather than modifying the object.

--- a/packages-next/keystone/src/lib/initConfig.ts
+++ b/packages-next/keystone/src/lib/initConfig.ts
@@ -8,6 +8,5 @@ import { applyIdFieldDefaults } from '../lib/applyIdFieldDefaults';
 */
 
 export function initConfig(config: KeystoneConfig) {
-  config.lists = applyIdFieldDefaults(config);
-  return config;
+  return { ...config, lists: applyIdFieldDefaults(config) };
 }


### PR DESCRIPTION
This is needed if we want to use the same config object multiple times, which is the case when running tests.