### PR TITLE
Update docs on graphql-upload workaround

### DIFF
--- a/.changeset/popular-comics-roll.md
+++ b/.changeset/popular-comics-roll.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/fields': patch
+'@keystonejs/fields-cloudinary-image': patch
+---
+
+Updated the README docs with more info on how to work around issues with `graphql-upload`.

--- a/packages/fields-cloudinary-image/README.md
+++ b/packages/fields-cloudinary-image/README.md
@@ -8,6 +8,19 @@ title: CloudinaryImage
 
 The `CloudinaryImage` field extends the [`File`](/packages/fields/src/types/File/README.md) field and allows uploading images to Cloudinary. It also exposes additional GraphQL functionality for querying your uploaded images.
 
+> **Important:** As of this writing (December 2020), an upstream [issue](https://github.com/apollographql/apollo-server/issues/3508)
+> with `apollo-server`'s dependencies can cause a server crash when using this field (regardless of adapter) with **Node 13 or above**.
+> To work around this, use Node 12 or below _or_ add the following to your `package.json`:
+>
+> ```js title=package.json
+> "preinstall": "npx npm-force-resolutions",  // NPM users only
+> "resolutions": {
+>   "graphql-upload": "^11.0.0"
+> }
+> ```
+>
+> You can track this issue [here](https://github.com/keystonejs/keystone/issues/2101).
+
 ## Usage
 
 This field must be used with the [`CoundinaryAdapter`](/packages/file-adapters/README.md#cloudinaryfileadapter) file adapter:

--- a/packages/fields/src/types/File/README.md
+++ b/packages/fields/src/types/File/README.md
@@ -8,11 +8,12 @@ title: File
 
 Support files hosted in a range of different contexts, e.g. in the local filesystem, or on a cloud based file server.
 
-> **Important:** As of this writing (April 2020), an upstream [issue](https://github.com/apollographql/apollo-server/issues/3508)
-> with `apollo-server`'s dependencies can cause a server crash when using this field (regardless of adapter) with **Node 13 only**.
+> **Important:** As of this writing (December 2020), an upstream [issue](https://github.com/apollographql/apollo-server/issues/3508)
+> with `apollo-server`'s dependencies can cause a server crash when using this field with **Node 13 or above**.
 > To work around this, use Node 12 or below _or_ add the following to your `package.json`:
 >
 > ```js title=package.json
+> "preinstall": "npx npm-force-resolutions",  // NPM users only
 > "resolutions": {
 >   "graphql-upload": "^11.0.0"
 > }


### PR DESCRIPTION
I've spent some time looking into this and I don't see a better workaround than simply informing people on how to get the correct `graphql-upload` package installed. All the options for manually installing the upload middleware make things much more complex, and would potentially cause more confusion than they alleviate.

See https://github.com/keystonejs/keystone/issues/2101