### PR TITLE
Remove script element from debugging

### DIFF
--- a/.changeset/clean-peas-agree.md
+++ b/.changeset/clean-peas-agree.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/admin-ui": patch
+---
+
+Removed script element from debugging

--- a/packages-next/admin-ui/src/context.tsx
+++ b/packages-next/admin-ui/src/context.tsx
@@ -93,7 +93,6 @@ export const KeystoneProvider = (props: KeystoneProviderProps) => {
 
   return (
     <ApolloProvider client={apolloClient}>
-      <script src="http://localhost:8097" />
       <InternalKeystoneProvider {...props} />
     </ApolloProvider>
   );


### PR DESCRIPTION
I was using this a while ago for some debugging and probably forgot to remove it.