### PR TITLE
Remove adminMeta from KeystoneSystem

### DIFF
--- a/.changeset/light-chairs-destroy.md
+++ b/.changeset/light-chairs-destroy.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+'@keystone-next/admin-ui': major
+---
+
+Removed `adminMeta` from `KeystoneSystem`. `getAdminMetaSchema` now takes a `BaseKeystone` argument `keystone` rather than `adminMeta`.

--- a/packages-next/admin-ui/src/system/getAdminMetaSchema.ts
+++ b/packages-next/admin-ui/src/system/getAdminMetaSchema.ts
@@ -1,6 +1,7 @@
 import { gql } from '../apollo';
 import { StaticAdminMetaQueryWithoutTypeNames } from '../admin-meta-graphql';
-import { KeystoneSystem, KeystoneContext, KeystoneConfig } from '@keystone-next/types';
+import { KeystoneContext, KeystoneConfig, BaseKeystone } from '@keystone-next/types';
+import { createAdminMeta } from './createAdminMeta';
 
 let typeDefs = gql`
   type Query {
@@ -83,12 +84,14 @@ let typeDefs = gql`
 `;
 
 export function getAdminMetaSchema({
-  adminMeta,
+  keystone,
   config,
 }: {
-  adminMeta: KeystoneSystem['adminMeta'];
+  keystone: BaseKeystone;
   config: KeystoneConfig;
 }) {
+  const { adminMeta } = createAdminMeta(config, keystone);
+
   type AdminMeta = StaticAdminMetaQueryWithoutTypeNames['keystone']['adminMeta'];
   type ListMetaRootVal = AdminMeta['lists'][number];
   type FieldMetaRootVal = AdminMeta['lists'][number]['fields'][number];

--- a/packages-next/admin-ui/src/templates/home.ts
+++ b/packages-next/admin-ui/src/templates/home.ts
@@ -1,6 +1,6 @@
-import type { KeystoneSystem } from '@keystone-next/types';
+import type { BaseKeystone } from '@keystone-next/types';
 
-export const homeTemplate = (lists: KeystoneSystem['adminMeta']['lists']) =>
+export const homeTemplate = (lists: BaseKeystone['lists']) =>
   `
 import React from 'react';
 

--- a/packages-next/admin-ui/src/templates/index.ts
+++ b/packages-next/admin-ui/src/templates/index.ts
@@ -26,13 +26,13 @@ export const writeAdminFiles = (
     outputPath: 'pages/_app.js',
     src: appTemplate(config, system, { configFileExists, projectAdminPath }),
   },
-  { mode: 'write', src: homeTemplate(system.adminMeta.lists), outputPath: 'pages/index.js' },
-  ...Object.values(system.adminMeta.lists).map(
-    ({ path, key }) =>
+  { mode: 'write', src: homeTemplate(system.keystone.lists), outputPath: 'pages/index.js' },
+  ...Object.values(system.keystone.lists).map(
+    ({ adminUILabels: { path }, key }) =>
       ({ mode: 'write', src: listTemplate(key), outputPath: `pages/${path}/index.js` } as const)
   ),
-  ...Object.values(system.adminMeta.lists).map(
-    ({ path, key }) =>
+  ...Object.values(system.keystone.lists).map(
+    ({ adminUILabels: { path }, key }) =>
       ({ mode: 'write', src: itemTemplate(key), outputPath: `pages/${path}/[id].js` } as const)
   ),
 ];

--- a/packages-next/keystone/src/lib/createGraphQLSchema.ts
+++ b/packages-next/keystone/src/lib/createGraphQLSchema.ts
@@ -2,21 +2,12 @@ import { GraphQLObjectType } from 'graphql';
 import { mergeSchemas } from '@graphql-tools/merge';
 import { mapSchema } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import type {
-  KeystoneConfig,
-  KeystoneContext,
-  BaseKeystone,
-  SerializedAdminMeta,
-} from '@keystone-next/types';
+import type { KeystoneConfig, KeystoneContext, BaseKeystone } from '@keystone-next/types';
 import { getAdminMetaSchema } from '@keystone-next/admin-ui/system';
 
 import { gql } from '../schema';
 
-export function createGraphQLSchema(
-  config: KeystoneConfig,
-  keystone: BaseKeystone,
-  adminMeta: SerializedAdminMeta
-) {
+export function createGraphQLSchema(config: KeystoneConfig, keystone: BaseKeystone) {
   // Start with the core keystone graphQL schema
   let graphQLSchema = makeExecutableSchema({
     typeDefs: ['scalar Upload', ...keystone.getTypeDefs({ schemaName: 'public' })],
@@ -73,7 +64,7 @@ export function createGraphQLSchema(
   // Merge in the admin-meta graphQL API
   graphQLSchema = mergeSchemas({
     schemas: [graphQLSchema],
-    ...getAdminMetaSchema({ adminMeta, config }),
+    ...getAdminMetaSchema({ keystone, config }),
   });
 
   return graphQLSchema;

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -4,7 +4,6 @@ import { KnexAdapter } from '@keystonejs/adapter-knex';
 // @ts-ignore
 import { PrismaAdapter } from '@keystonejs/adapter-prisma';
 import type { KeystoneConfig, KeystoneSystem, BaseKeystone } from '@keystone-next/types';
-import { createAdminMeta } from '@keystone-next/admin-ui/system';
 
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './createContext';
@@ -82,11 +81,9 @@ export function createKeystone(
 export function createSystem(config: KeystoneConfig): KeystoneSystem {
   const keystone = createKeystone(config, () => createContext);
 
-  const { adminMeta } = createAdminMeta(config, keystone);
-
-  const graphQLSchema = createGraphQLSchema(config, keystone, adminMeta);
+  const graphQLSchema = createGraphQLSchema(config, keystone);
 
   const createContext = makeCreateContext({ keystone, graphQLSchema });
 
-  return { keystone, adminMeta, graphQLSchema, createContext };
+  return { keystone, graphQLSchema, createContext };
 }

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -166,7 +166,6 @@ export type SessionImplementation = {
 
 export type KeystoneSystem = {
   keystone: BaseKeystone;
-  adminMeta: SerializedAdminMeta;
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;
 };


### PR DESCRIPTION
This object is only needed in `getAdminMetaSchema`, so we directly create it there.