### PR TITLE
Revert regression in mongoose queries

### DIFF
--- a/.changeset/nice-eggs-accept.md
+++ b/.changeset/nice-eggs-accept.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-mongoose': patch
+---
+
+Reverted query optimisations which introduced regressions in `10.1.0`.

--- a/packages/adapter-mongoose/lib/query-parser.js
+++ b/packages/adapter-mongoose/lib/query-parser.js
@@ -45,33 +45,35 @@ function queryParser({ listAdapter, getUID }, query, pathSoFar = [], include) {
       // A relationship query component
       const { matchTerm, relationshipInfo } = relationshipTokenizer(listAdapter, key, path, getUID);
 
-      // Greatly improve query using indexes
-      if (
-        Object.keys(value).length === 1 &&
-        (value.id || value.id_not || value.id_in || value.id_not_in)
-      ) {
-        const { ObjectId } = listAdapter.mongoose.Types;
-        const fieldParser = key.split(/(\_some|\_every|\_none)+$/gm);
-        const _path = fieldParser[0];
-        const filterType = fieldParser.length > 1 ? fieldParser[1] : '_only';
-        const queryCondition = {};
-        if (value.id) {
-          if (['_only', '_some', '_every'].includes(filterType)) {
-            queryCondition[_path] = { $eq: ObjectId(value.id) };
-          } else if (filterType === '_none') {
-            queryCondition[_path] = { $ne: ObjectId(value.id) };
-          }
-        } else if (value.id_not && ['_only', '_some', '_every', '_none'].includes(filterType)) {
-          queryCondition[_path] = { $ne: ObjectId(value.id_not) };
-        } else if (value.id_in && ['_only', '_some'].includes(filterType)) {
-          queryCondition[_path] = { $in: value.id_in.map(el => ObjectId(el)) };
-        } else if (value.id_not_in && ['_only', '_every'].includes(filterType)) {
-          queryCondition[_path] = { $not: { $in: value.id_not_in.map(el => ObjectId(el)) } };
-        }
-        if (Object.keys(queryCondition).length > 0) {
-          return { matchTerm: queryCondition };
-        }
-      }
+      // FIXME: This code introduced regressions. We need to add test coverage
+      // to unique exercise this code and verify its behaviour.
+      // // Greatly improve query using indexes
+      // if (
+      //   Object.keys(value).length === 1 &&
+      //   (value.id || value.id_not || value.id_in || value.id_not_in)
+      // ) {
+      //   const { ObjectId } = listAdapter.mongoose.Types;
+      //   const fieldParser = key.split(/(\_some|\_every|\_none)+$/gm);
+      //   const _path = fieldParser[0];
+      //   const filterType = fieldParser.length > 1 ? fieldParser[1] : '_only';
+      //   const queryCondition = {};
+      //   if (value.id) {
+      //     if (['_only', '_some', '_every'].includes(filterType)) {
+      //       queryCondition[_path] = { $eq: ObjectId(value.id) };
+      //     } else if (filterType === '_none') {
+      //       queryCondition[_path] = { $ne: ObjectId(value.id) };
+      //     }
+      //   } else if (value.id_not && ['_only', '_some', '_every', '_none'].includes(filterType)) {
+      //     queryCondition[_path] = { $ne: ObjectId(value.id_not) };
+      //   } else if (value.id_in && ['_only', '_some'].includes(filterType)) {
+      //     queryCondition[_path] = { $in: value.id_in.map(el => ObjectId(el)) };
+      //   } else if (value.id_not_in && ['_only', '_every'].includes(filterType)) {
+      //     queryCondition[_path] = { $not: { $in: value.id_not_in.map(el => ObjectId(el)) } };
+      //   }
+      //   if (Object.keys(queryCondition).length > 0) {
+      //     return { matchTerm: queryCondition };
+      //   }
+      // }
 
       return {
         // matchTerm is our filtering expression. This determines if the


### PR DESCRIPTION
The optimised queries introduced regressions which made it through our test coverage. We will need to investigate this more closely, but for now I'm going to revert the changes so we can go back to slow-and-correct, rather than fast-and-wrong.

Fixes #4580