### PR TITLE
Update CI to run on node 14 rather than 10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js 10.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: Install Dependencies
         # we have a postinstall script that uses is-ci which doesn't yet detect GitHub Actions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,11 +52,11 @@ jobs:
         uses: actions/checkout@v2
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
 
-      - name: Setup Node.js 10.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: Get yarn cache directory path
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
@@ -114,11 +114,11 @@ jobs:
         uses: actions/checkout@v2
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
 
-      - name: Setup Node.js 10.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: Get yarn cache directory path
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
@@ -154,10 +154,10 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
-      - name: Setup Node.js 10.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -212,11 +212,11 @@ jobs:
       - name: Checkout Repo
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         uses: actions/checkout@v2
-      - name: Setup Node.js 10.x
+      - name: Setup Node.js 14.x
         uses: actions/setup-node@main
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         with:
-          node-version: 10.x
+          node-version: 14.x
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
The currently active LTS release of Node is 14.x. We should be testing on CI against this release. https://nodejs.org/en/about/releases/

In the future we probably also want to test at least `master` against versions which are either `Maintenance` or `Current`, eg. 10, 12, 15 (as of this date).
