### PR TITLE
Test against postgres v12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:9.6.5
+        image: postgres:12
         env:
           POSTGRES_USER: keystone5
           POSTGRES_PASSWORD: k3yst0n3
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:9.6.5
+        image: postgres:12
         env:
           POSTGRES_USER: keystone5
           POSTGRES_PASSWORD: k3yst0n3


### PR DESCRIPTION
Postgres 12 is the mostly widely used recent version of postgres (citation needed, https://aws.amazon.com/rds/postgresql/). We should be testing against this release rather than the much older 9.6 series. https://www.postgresql.org/support/versioning/

In a future PR we should find a way to run CI on `master` against all supported versions.