### PR TITLE
pattern matching search that works with sqlite

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -624,7 +624,7 @@ class QueryBuilder {
     if (search !== undefined && searchField) {
       if (searchField.fieldName === 'Text') {
         const f = escapeRegExp;
-        this._query.andWhere(`${baseTableAlias}.name`, '~*', f(search));
+        this._query.andWhere(`${baseTableAlias}.name`, 'like', `%${f(search)}%`);
       } else {
         this._query.whereRaw('false'); // Return no results
       }


### PR DESCRIPTION
Admin UI for TODO demo app fails to display Todos due to unsupported operator `~*` when using a SQLite backend. [Using `like`](http://knexjs.org/#Builder-where) instead fixes this.