### PR TITLE
fix path separator in generated admin ui nextjs page

### DIFF
--- a/.changeset/swift-planes-hear.md
+++ b/.changeset/swift-planes-hear.md
@@ -2,4 +2,4 @@
 '@keystone-next/admin-ui': patch
 ---
 
-Fixed separator issue on Windows for new interface.
+Fixed import path separator on Windows when generating Admin UI code.

--- a/.changeset/swift-planes-hear.md
+++ b/.changeset/swift-planes-hear.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/admin-ui': patch
+---
+
+Fixed separator issue on Windows for new interface.

--- a/packages-next/admin-ui/src/system/generateAdminUI.ts
+++ b/packages-next/admin-ui/src/system/generateAdminUI.ts
@@ -90,10 +90,12 @@ export const generateAdminUI = async (
   // Add files to pages/ which point to any files which exist in admin/pages
   const userPagesDir = Path.join(process.cwd(), 'admin', 'pages');
   const files = await fastGlob('**/*.{js,jsx,ts,tsx}', { cwd: userPagesDir });
+  const makeImportPath = (path: string) => path.replace(new RegExp('\\' + Path.sep, 'g'), '/');
+
   await Promise.all(
     files.map(async filename => {
       const outputFilename = Path.join(projectAdminPath, 'pages', filename);
-      const path = Path.relative(Path.dirname(outputFilename), Path.join(userPagesDir, filename));
+      const path = makeImportPath(Path.relative(Path.dirname(outputFilename), Path.join(userPagesDir, filename)));
       await fs.outputFile(outputFilename, `export { default } from "${path}"`);
     })
   );

--- a/packages-next/admin-ui/src/system/generateAdminUI.ts
+++ b/packages-next/admin-ui/src/system/generateAdminUI.ts
@@ -90,13 +90,14 @@ export const generateAdminUI = async (
   // Add files to pages/ which point to any files which exist in admin/pages
   const userPagesDir = Path.join(process.cwd(), 'admin', 'pages');
   const files = await fastGlob('**/*.{js,jsx,ts,tsx}', { cwd: userPagesDir });
-  const makeImportPath = (path: string) => path.replace(new RegExp('\\' + Path.sep, 'g'), '/');
 
   await Promise.all(
     files.map(async filename => {
       const outputFilename = Path.join(projectAdminPath, 'pages', filename);
-      const path = makeImportPath(Path.relative(Path.dirname(outputFilename), Path.join(userPagesDir, filename)));
-      await fs.outputFile(outputFilename, `export { default } from "${path}"`);
+      const path = Path.relative(Path.dirname(outputFilename), Path.join(userPagesDir, filename));
+      // Convert filesystem path separator to the `/` expected in JS imports
+      const importPath = path.replace(new RegExp(`\\${Path.sep}`, 'g'), '/');
+      await fs.outputFile(outputFilename, `export { default } from "${importPath}"`);
     })
   );
 };

--- a/packages-next/admin-ui/src/templates/app.ts
+++ b/packages-next/admin-ui/src/templates/app.ts
@@ -44,12 +44,12 @@ export const appTemplate = (
   });
   const allViews = [..._allViews];
   const viewPaths: Record<string, string> = {};
-  const makeImportPath = (path: string) => path.replace(new RegExp('\\' + Path.sep, 'g'), '/');
   for (const views of allViews) {
     const viewPath = Path.isAbsolute(views)
-    ? Path.relative(Path.join(projectAdminPath, 'pages'), views)
-    : views;
-    viewPaths[views] = makeImportPath(viewPath);
+      ? Path.relative(Path.join(projectAdminPath, 'pages'), views)
+      : views;
+    // Convert filesystem path separator to the `/` expected in JS imports
+    viewPaths[views] = viewPath.replace(new RegExp(`\\${Path.sep}`, 'g'), '/');
   }
   // -- TEMPLATE START
   return `

--- a/packages-next/admin-ui/src/templates/app.ts
+++ b/packages-next/admin-ui/src/templates/app.ts
@@ -44,10 +44,12 @@ export const appTemplate = (
   });
   const allViews = [..._allViews];
   const viewPaths: Record<string, string> = {};
+  const makeImportPath = (path: string) => path.replace(new RegExp('\\' + Path.sep, 'g'), '/');
   for (const views of allViews) {
-    viewPaths[views] = Path.isAbsolute(views)
-      ? Path.relative(Path.join(projectAdminPath, 'pages'), views)
-      : views;
+    const viewPath = Path.isAbsolute(views)
+    ? Path.relative(Path.join(projectAdminPath, 'pages'), views)
+    : views;
+    viewPaths[views] = makeImportPath(viewPath);
   }
   // -- TEMPLATE START
   return `


### PR DESCRIPTION
there is major issues in generated admin ui pages on Windows

my custom pages exports are like this 
```js
export { default } from "..\..\..\..\admin\pages\posts\index.js"
```
and the _app.js imports are wrong too

```js
import * as viewda7c2d58 from '..........packages-next\fields\typesmongoId\views';
import * as view93e8d5f4 from '..........packages-next\fields\types\text\views';
import * as view37019afc from '..........packages-next\fields\typespassword\views';
import * as viewe8c8a4e7 from '..........packages-next\fields\typescheckbox\views';
import * as view22b325a2 from '..........packages-next\fields\types\relationship\views';
import * as view028bacf3 from '..........packages-next\fields\types\virtual\views';
import * as view8b57a6e9 from '..........packages-next\fields\types\timestamp\views';
import * as view74cada3f from '..........packages-next\fields\typesselect\views';
import * as view5bd2f691 from '..........packages-next\fields-document\views';
import * as view3a68b08b from '......admin\fieldViewsContent.tsx';
```

this breaks running it on windows. 

not a perfect PR, just shows what needs to be done, there is another way to change "\\" into "/", will have to decide which one is appropriate.
```js
Path.relative(Path.join(projectAdminPath, 'pages'), views).split(Path.sep).join('/');
```