### PR TITLE
Pass args from keystone.connect to onConnect

### DIFF
--- a/.changeset/dirty-clocks-shop.md
+++ b/.changeset/dirty-clocks-shop.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/types': minor
+'@keystonejs/keystone': minor
+---
+
+Added an `args` paramter to `Keystone.connect(args)`, which is passed through as the second argument to the config function `onConnect(keystone, args)`.

--- a/packages-next/types/src/base.ts
+++ b/packages-next/types/src/base.ts
@@ -17,7 +17,7 @@ export type BaseKeystone = {
       hooks?: Record<string, any>;
     }
   ) => BaseKeystoneList;
-  connect: () => Promise<void>;
+  connect: (args?: any) => Promise<void>;
   lists: Record<string, BaseKeystoneList>;
   createApolloServer: (args: { schemaName: string; dev: boolean }) => any;
   getTypeDefs: (args: { schemaName: string }) => any;

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -444,13 +444,13 @@ module.exports = class Keystone {
    * @return Promise<any> the result of executing `onConnect` as passed to the
    * constructor, or `undefined` if no `onConnect` method specified.
    */
-  async connect() {
+  async connect(args) {
     const { adapters } = this;
     const rels = this._consolidateRelationships();
     await resolveAllKeys(mapKeys(adapters, adapter => adapter.connect({ rels })));
 
     if (this.eventHandlers.onConnect) {
-      return this.eventHandlers.onConnect(this);
+      return this.eventHandlers.onConnect(this, args);
     }
   }
 


### PR DESCRIPTION
This will let us pass a context through in keystone-next in a less awkward fashion.