### PR TITLE
Import dotenv file on PORT exporting stage to allow set port in .env file

### DIFF
--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -38,6 +38,7 @@
     "apollo-server-express": "^2.19.1",
     "cookie": "^0.4.1",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
     "graphql": "^15.4.0",

--- a/packages-next/keystone/src/scripts/utils.ts
+++ b/packages-next/keystone/src/scripts/utils.ts
@@ -1,3 +1,4 @@
+require('dotenv').config();
 import path from 'path';
 // TODO: Read config path from process args
 export const CONFIG_PATH = path.join(process.cwd(), 'keystone');


### PR DESCRIPTION
At now PORT can be only set from real environment value manually on start. But if we didn't use docker, much more flexible way is to fill it "statically" via `.env` file. 

Best way is to read the PORT value from config, but seems in `scripts/utils.ts` stage the real config isn't initialized, because if I try to import it via
```
import KeystoneConfig from '@keystone-next/types';
console.log(KeystoneConfig);
```
\- it is `undefined`.

So I simply require the `dotenv` package via:
```
require('dotenv').config();
```
As result - it reads values from `.env` file before applying `process.env.PORT` to Keystone app, and all works well.

It is my first commit and I don't really sure that this is right way, but it works well on my instances. Please suggest better way, if this is not so good.