### PR TITLE
Explicit opposite field for 1:N relationships

### DIFF
--- a/.changeset/tame-jokes-grin.md
+++ b/.changeset/tame-jokes-grin.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-prisma': patch
+---
+
+Updated prisma schema generation to include explicit opposite field for one-sided 1:N relationships.

--- a/packages/adapter-prisma/lib/adapter-prisma.js
+++ b/packages/adapter-prisma/lib/adapter-prisma.js
@@ -172,6 +172,15 @@ class PrismaAdapter extends BaseKeystoneAdapter {
               `from_${path} ${listKey}[] @relation("${tableName}", references: [id])`,
             ])
         ),
+        ...flatten(
+          rels
+            .filter(({ right }) => !right)
+            .filter(({ left }) => left.refListKey === listAdapter.key)
+            .filter(({ cardinality }) => cardinality === '1:N' || cardinality === 'N:1')
+            .map(({ left: { path, listKey }, tableName, columnName }) => [
+              `from_${listKey}_${path} ${listKey}[] @relation("${tableName}${columnName}")`,
+            ])
+        ),
       ];
 
       return `


### PR DESCRIPTION
Prisma now requires an explicit relation field on both sides of a relationship.