### PR TITLE
Update adapter-knex.js

### DIFF
--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -648,7 +648,10 @@ class QueryBuilder {
         // SELECT ... ORDER BY <orderField>
         const [orderField, orderDirection] = this._getOrderFieldAndDirection(orderBy);
         const sortKey = listAdapter.fieldAdaptersByPath[orderField].sortKey || orderField;
-        this._query.orderBy(sortKey, orderDirection);
+        
+        if(listAdapter.realKeys.includes(sortKey)) {
+          this._query.orderBy(sortKey, orderDirection);  
+        }        
       }
       if (sortBy !== undefined) {
         // SELECT ... ORDER BY <orderField>[, <orderField>, ...]
@@ -657,8 +660,12 @@ class QueryBuilder {
             const [orderField, orderDirection] = this._getOrderFieldAndDirection(s);
             const sortKey = listAdapter.fieldAdaptersByPath[orderField].sortKey || orderField;
 
-            return { column: sortKey, order: orderDirection };
-          })
+            if(listAdapter.realKeys.includes(sortKey)) {            
+              return { column: sortKey, order: orderDirection };              
+            } else {            
+              return undefined;              
+            }
+          }).filter(s => typeof s !== "undefined");
         );
       }
     }

--- a/packages/adapter-knex/lib/adapter-knex.js
+++ b/packages/adapter-knex/lib/adapter-knex.js
@@ -665,7 +665,7 @@ class QueryBuilder {
             } else {            
               return undefined;              
             }
-          }).filter(s => typeof s !== "undefined");
+          }).filter(s => typeof s !== "undefined")
         );
       }
     }


### PR DESCRIPTION
Fixes an issue where List that have a relationship field as its first field will have this field used for orderBy clause in query. This will fail the query for those relationships where fields don't exist in the List.

Issue: https://github.com/keystonejs/keystone/issues/3164