### PR TITLE
Simplify code in parseAccess

### DIFF
--- a/.changeset/two-pots-vanish.md
+++ b/.changeset/two-pots-vanish.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/access-control': patch
+---
+
+Refactored `parseAccess` and inlined the code from `validateGranularConfigTypes` and `parseAccessCore`.


### PR DESCRIPTION
The inlining of code from `validateGranularConfigTypes` and `parseAccessCore` intentionally violates DRY for now in order to a) make adding types easier and b) to allow for a future refactoring with hopefully simpler code.