### PR TITLE
Hide config.graphql.path until implemented

### DIFF
--- a/.changeset/gold-crabs-pay.md
+++ b/.changeset/gold-crabs-pay.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/app-basic': patch
+'@keystone-next/types': patch
+---
+
+Remove unused configuration option `config.graphql.path` from the `KeystoneConfig` type.

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -28,10 +28,10 @@ export default auth.withAuth(
       adapter: 'mongoose',
       url: 'mongodb://localhost/keystone-examples-next-basic',
     },
-    graphql: {
-      // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
-      path: '/api/graphql',
-    },
+    // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
+    // graphql: {
+    //   path: '/api/graphql',
+    // },
     ui: {
       // NOTE -- this is not implemented, keystone currently always provides an admin ui at /
       path: '/admin',

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -60,6 +60,15 @@ export type DatabaseCommon = {
   onConnect?: (args: KeystoneContext) => Promise<void>;
 };
 
+export type GraphQLConfig = {
+  // FIXME: We currently hardcode `/api/graphql` in a bunch of places
+  // We should be able to use config.graphql.path to set this path.
+  // path?: string;
+  queryLimits?: {
+    maxTotalResults?: number;
+  };
+};
+
 export type KeystoneConfig = {
   db: DatabaseCommon &
     (
@@ -82,12 +91,7 @@ export type KeystoneConfig = {
           enableLogging?: boolean;
         }
     );
-  graphql?: {
-    path?: string;
-    queryLimits?: {
-      maxTotalResults?: number;
-    };
-  };
+  graphql?: GraphQLConfig;
   session?: () => SessionStrategy<any>;
   ui?: KeystoneAdminUIConfig;
   server?: {


### PR DESCRIPTION
Exposing this on the type implies functionality that isn't currently implemented.