### PR TITLE
Rename KeystoneAdminUIConfig to AdminUIConfig

### DIFF
--- a/.changeset/spotty-adults-turn.md
+++ b/.changeset/spotty-adults-turn.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/types': major
+'@keystone-next/auth': patch
+---
+
+Renamed the type `KeystoneAdminUIConfig` to `AdminUIConfig`.

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -1,8 +1,4 @@
-import {
-  BaseGeneratedListTypes,
-  KeystoneAdminUIConfig,
-  KeystoneConfig,
-} from '@keystone-next/types';
+import { BaseGeneratedListTypes, AdminUIConfig, KeystoneConfig } from '@keystone-next/types';
 
 export type AuthGqlNames = {
   CreateInitialInput: string;
@@ -66,10 +62,10 @@ export type AuthConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {
 
 export type Auth = {
   ui: {
-    enableSessionItem: NonNullable<KeystoneAdminUIConfig['enableSessionItem']>;
-    publicPages: NonNullable<KeystoneAdminUIConfig['publicPages']>;
-    pageMiddleware: NonNullable<KeystoneAdminUIConfig['pageMiddleware']>;
-    getAdditionalFiles: NonNullable<KeystoneAdminUIConfig['getAdditionalFiles']>[number];
+    enableSessionItem: NonNullable<AdminUIConfig['enableSessionItem']>;
+    publicPages: NonNullable<AdminUIConfig['publicPages']>;
+    pageMiddleware: NonNullable<AdminUIConfig['pageMiddleware']>;
+    getAdditionalFiles: NonNullable<AdminUIConfig['getAdditionalFiles']>[number];
   };
   extendGraphqlSchema: NonNullable<KeystoneConfig['extendGraphqlSchema']>;
   fields: { [prop: string]: any };

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -25,7 +25,7 @@ export type AdminFileToWrite =
       outputPath: string;
     };
 
-export type KeystoneAdminUIConfig = {
+export type AdminUIConfig = {
   /** Enables certain functionality in the Admin UI that expects the session to be an item */
   enableSessionItem?: boolean;
   /** A function that can be run to validate that the current session should have access to the Admin UI */
@@ -89,7 +89,7 @@ export type KeystoneConfig = {
     };
   };
   session?: () => SessionStrategy<any>;
-  ui?: KeystoneAdminUIConfig;
+  ui?: AdminUIConfig;
   server?: {
     /** Configuration options for the cors middleware. Set to `true` to use core Keystone defaults */
     cors?: CorsOptions | true;


### PR DESCRIPTION
This will allow a more consistent naming of our various config types. See #4760 more WIP changes related to this.