### PR TITLE
Remove SchemaConfig type

### DIFF
--- a/.changeset/cold-phones-type.md
+++ b/.changeset/cold-phones-type.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': major
+---
+
+Removed the type `SchemaConfig`. Updated the `keystone` parameter of `ExtendGraphqlSchema` to be `BaseKeystone`.

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -5,7 +5,7 @@ import type { FieldAccessControl } from './schema/access-control';
 import type { BaseGeneratedListTypes, JSONValue, GqlNames, MaybePromise } from './utils';
 import type { ListHooks } from './schema/hooks';
 import { SessionStrategy } from './session';
-import { SchemaConfig } from './schema';
+import { ListSchemaConfig, ExtendGraphqlSchema } from './schema';
 import { IncomingMessage, ServerResponse } from 'http';
 import { GraphQLSchema, ExecutionResult, DocumentNode } from 'graphql';
 import { AdminMetaRootVal } from './admin-meta';
@@ -61,6 +61,7 @@ export type DatabaseCommon = {
 };
 
 export type KeystoneConfig = {
+  lists: ListSchemaConfig;
   db: DatabaseCommon &
     (
       | {
@@ -96,7 +97,8 @@ export type KeystoneConfig = {
     /** Port number to start the server on. Defaults to process.env.PORT || 3000 */
     port?: number;
   };
-} & SchemaConfig;
+  extendGraphqlSchema?: ExtendGraphqlSchema;
+};
 
 export type MaybeItemFunction<T> =
   | T

--- a/packages-next/types/src/schema/index.ts
+++ b/packages-next/types/src/schema/index.ts
@@ -1,13 +1,9 @@
 import type { GraphQLSchema } from 'graphql';
 import type { FieldType, MaybeItemFunction, MaybeSessionFunction } from '..';
+import type { BaseKeystone } from '../base';
 import type { BaseGeneratedListTypes } from '../utils';
 import type { ListHooks } from './hooks';
 import type { ListAccessControl } from './access-control';
-
-export type SchemaConfig = {
-  lists: ListSchemaConfig;
-  extendGraphqlSchema?: ExtendGraphqlSchema;
-};
 
 export type ListSchemaConfig = Record<string, ListConfig<BaseGeneratedListTypes, any>>;
 
@@ -165,7 +161,4 @@ export type ListConfig<
   // queries, upserts, etc, in particular follow Prisma's design)
 };
 
-export type ExtendGraphqlSchema = (
-  schema: GraphQLSchema,
-  keystoneClassInstance: any
-) => GraphQLSchema;
+export type ExtendGraphqlSchema = (schema: GraphQLSchema, keystone: BaseKeystone) => GraphQLSchema;


### PR DESCRIPTION
The `SchemaConfig` type wasn't really helping, it's much more clear to have each of its components directly on the `KeystoneConfig` object.