### PR TITLE
Remove non-useful config.db.provider

### DIFF
--- a/.changeset/wet-rules-travel.md
+++ b/.changeset/wet-rules-travel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': patch
+---
+
+Removed `config.db.provider` option, which did not have any meaningful, viable value.

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -58,7 +58,6 @@ export type DatabaseConfig = DatabaseCommon &
     | {
         adapter: 'prisma_postgresql';
         dropDatabase?: boolean;
-        provider?: string;
         getPrismaPath?: (arg: { prismaSchema: any }) => string;
         getDbSchemaName?: (arg: { prismaSchema: any }) => string;
         enableLogging?: boolean;


### PR DESCRIPTION
Anything other than `postgresql` is going to cause the user a bad time, so let's not expose this in our API.