### PR TITLE
Remove unused types

### DIFF
--- a/.changeset/stale-experts-collect.md
+++ b/.changeset/stale-experts-collect.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': patch
+---
+
+Removed the unused `plural`, `singular`, `label`, and `db` list config options.

--- a/.changeset/stale-experts-collect.md
+++ b/.changeset/stale-experts-collect.md
@@ -2,4 +2,4 @@
 '@keystone-next/types': patch
 ---
 
-Removed the unused `plural`, `singular`, `label`, and `db` list config options.
+Removed the unused `plural`, `singular`, `label`, `db`, and `graphql.cacheHint` list config options.

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -13,7 +13,7 @@ import type {
   FieldConfig,
   MaybeSessionFunction,
   MaybeItemFunction,
-  CacheHint,
+  // CacheHint,
 } from './lists';
 
 import type { KeystoneContext } from '..';
@@ -42,7 +42,7 @@ export type {
   FieldConfig,
   MaybeSessionFunction,
   MaybeItemFunction,
-  CacheHint,
+  // CacheHint,
 };
 
 // config.db

--- a/packages-next/types/src/config/lists.ts
+++ b/packages-next/types/src/config/lists.ts
@@ -18,6 +18,8 @@ export type ListConfig<
     */
   fields: Fields;
 
+  idField?: FieldType<TGeneratedListTypes>;
+
   /**
    * Controls what data users of the Admin UI and GraphQL can access and change
    * @default true
@@ -26,83 +28,7 @@ export type ListConfig<
   access?: ListAccessControl<TGeneratedListTypes> | boolean;
 
   /** Config for how this list should act in the Admin UI */
-  ui?: {
-    /**
-     * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.
-     * @default 'name' if it exists, otherwise 'id'
-     */
-    labelField?: keyof Fields; // path of the field to use as the label for items in the list, defaults to 'name' or 'id'
-
-    /**
-     * Excludes this list from the Admin UI
-     * @default false
-     */
-    isHidden?: MaybeSessionFunction<boolean>;
-    /** The path that the list should be at in the Admin UI */
-    path?: string;
-    /**
-     * The description shown on the list page
-     * @default listConfig.description
-     */
-    description?: string; // the description displayed below the field in the Admin UI
-    /**
-     * Hides the create button in the Admin UI.
-     * Note that this does **not** disable creating items through the GraphQL API, it only hides the button to create an item for this list in the Admin UI.
-     * @default false
-     */
-    hideCreate?: MaybeSessionFunction<boolean>;
-    /**
-     * Hides the delete button in the Admin UI.
-     * Note that this does **not** disable deleting items through the GraphQL API, it only hides the button to delete an item for this list in the Admin UI.
-     * @default false
-     */
-    hideDelete?: MaybeSessionFunction<boolean>;
-    /**
-     * Configuration specific to the create view in the Admin UI
-     */
-    createView?: {
-      /**
-       * The default field mode for fields on the create view for this list.
-       * Specific field modes on a per-field basis via a field's config.
-       * @default 'edit'
-       */
-      defaultFieldMode?: MaybeSessionFunction<'edit' | 'hidden'>;
-    };
-    /**
-     * Configuration specific to the list view in the Admin UI
-     */
-    listView?: {
-      /**
-       * The default field mode for fields on the create view for this list.
-       * Specific field modes on a per-field basis via a field's config.
-       * @default 'read'
-       */
-      defaultFieldMode?: MaybeSessionFunction<'read' | 'hidden'>;
-      /**
-       * The columns(which refer to fields) that should be shown to users of the Admin UI.
-       * Users of the Admin UI can select different columns to show in the UI.
-       * @default the first three fields in the list
-       */
-      initialColumns?: (keyof Fields)[];
-      // was previously top-level defaultSort
-      initialSort?: { field: keyof Fields; direction: 'ASC' | 'DESC' };
-      // was previously defaultPageSize
-      pageSize?: number; // default number of items to display per page on the list screen
-      // note: we are removing maximumPageSize
-    };
-    /**
-     * Configuration specific to the item view in the Admin UI
-     */
-    itemView?: {
-      /**
-       * The default field mode for fields on the create view for this list.
-       * This controls what people can do for fields
-       * Specific field modes on a per-field basis via a field's config.
-       * @default 'edit'
-       */
-      defaultFieldMode?: MaybeItemFunction<'edit' | 'read' | 'hidden'>;
-    };
-  };
+  ui?: ListAdminUIConfig<TGeneratedListTypes, Fields>;
 
   /**
    * Hooks to modify the behaviour of GraphQL operations at certain points
@@ -115,51 +41,115 @@ export type ListConfig<
    */
   description?: string; // defaults both { adminUI: { description }, graphQL: { description } }
 
-  graphql?: {
-    // was previously top-level cacheHint
-    cacheHint?: CacheHint;
-    /**
-     * The description added to the GraphQL schema
-     * @default listConfig.description
-     */
-    description?: string;
-    // was previously top-level itemQueryName
-    itemQueryName?: string; // the name of the graphql query for getting a single item
-    // was previously top-level itemQueryName
-    listQueryName?: string; // the name of the graphql query for getting multiple items
-    // was previously top-level queryLimits
-    queryLimits?: {
-      maxResults?: number; // maximum number of items that can be returned in a query (or subquery)
-    };
-  };
+  graphql?: ListGraphQLConfig;
 
-  plugins?: any[]; // array of plugins that can modify the list config
+  // Not currently supported
+  // plugins?: any[]; // array of plugins that can modify the list config
 
   /**
    * The label used for the list
    * @default listKey.replace(/([a-z])([A-Z])/g, '$1 $2').split(/\s|_|\-/).filter(i => i).map(upcase).join(' ');
    */
-  label?: string;
+  // Not currently supported
+  // label?: string;
 
   /**
    * The singular form of the list key
    * @default pluralize.singular(label)
    */
-  singular?: string;
+  // Not currently supported
+  // singular?: string;
 
   /**
    * The plural form of the list key
    * @default pluralize.plural(label)
    */
-  plural?: string;
-
-  idField?: FieldType<TGeneratedListTypes>;
-
-  // TODO: Timl has thoughts, was previously adapterConfig
-  db?: Record<string, any>; // adapter-specific config
+  // Not currently supported
+  // plural?: string;
 
   // TODO: Come back to how we can facilitate unique fields and combinations of fields (for
   // queries, upserts, etc, in particular follow Prisma's design)
+};
+
+export type ListAdminUIConfig<
+  TGeneratedListTypes extends BaseGeneratedListTypes,
+  Fields extends BaseFields<TGeneratedListTypes>
+> = {
+  /**
+   * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.
+   * @default 'name' if it exists, otherwise 'id'
+   */
+  labelField?: keyof Fields; // path of the field to use as the label for items in the list, defaults to 'name' or 'id'
+
+  /**
+   * Excludes this list from the Admin UI
+   * @default false
+   */
+  isHidden?: MaybeSessionFunction<boolean>;
+  /** The path that the list should be at in the Admin UI */
+  path?: string;
+  /**
+   * The description shown on the list page
+   * @default listConfig.description
+   */
+  description?: string; // the description displayed below the field in the Admin UI
+  /**
+   * Hides the create button in the Admin UI.
+   * Note that this does **not** disable creating items through the GraphQL API, it only hides the button to create an item for this list in the Admin UI.
+   * @default false
+   */
+  hideCreate?: MaybeSessionFunction<boolean>;
+  /**
+   * Hides the delete button in the Admin UI.
+   * Note that this does **not** disable deleting items through the GraphQL API, it only hides the button to delete an item for this list in the Admin UI.
+   * @default false
+   */
+  hideDelete?: MaybeSessionFunction<boolean>;
+  /**
+   * Configuration specific to the create view in the Admin UI
+   */
+  createView?: {
+    /**
+     * The default field mode for fields on the create view for this list.
+     * Specific field modes on a per-field basis via a field's config.
+     * @default 'edit'
+     */
+    defaultFieldMode?: MaybeSessionFunction<'edit' | 'hidden'>;
+  };
+  /**
+   * Configuration specific to the list view in the Admin UI
+   */
+  listView?: {
+    /**
+     * The default field mode for fields on the create view for this list.
+     * Specific field modes on a per-field basis via a field's config.
+     * @default 'read'
+     */
+    defaultFieldMode?: MaybeSessionFunction<'read' | 'hidden'>;
+    /**
+     * The columns(which refer to fields) that should be shown to users of the Admin UI.
+     * Users of the Admin UI can select different columns to show in the UI.
+     * @default the first three fields in the list
+     */
+    initialColumns?: (keyof Fields)[];
+    // was previously top-level defaultSort
+    initialSort?: { field: keyof Fields; direction: 'ASC' | 'DESC' };
+    // was previously defaultPageSize
+    pageSize?: number; // default number of items to display per page on the list screen
+    // note: we are removing maximumPageSize
+  };
+  /**
+   * Configuration specific to the item view in the Admin UI
+   */
+  itemView?: {
+    /**
+     * The default field mode for fields on the create view for this list.
+     * This controls what people can do for fields
+     * Specific field modes on a per-field basis via a field's config.
+     * @default 'edit'
+     */
+    defaultFieldMode?: MaybeItemFunction<'edit' | 'read' | 'hidden'>;
+  };
 };
 
 export type BaseFields<TGeneratedListTypes extends BaseGeneratedListTypes> = {
@@ -211,5 +201,23 @@ export type MaybeItemFunction<T> =
       session: any;
       item: { id: string | number; [path: string]: any };
     }) => MaybePromise<T>);
+
+export type ListGraphQLConfig = {
+  // was previously top-level cacheHint
+  cacheHint?: CacheHint;
+  /**
+   * The description added to the GraphQL schema
+   * @default listConfig.description
+   */
+  description?: string;
+  // was previously top-level itemQueryName
+  itemQueryName?: string; // the name of the graphql query for getting a single item
+  // was previously top-level itemQueryName
+  listQueryName?: string; // the name of the graphql query for getting multiple items
+  // was previously top-level queryLimits
+  queryLimits?: {
+    maxResults?: number; // maximum number of items that can be returned in a query (or subquery)
+  };
+};
 
 export type CacheHint = { scope: 'PRIVATE' | 'PUBLIC'; maxAge: number };

--- a/packages-next/types/src/config/lists.ts
+++ b/packages-next/types/src/config/lists.ts
@@ -204,7 +204,7 @@ export type MaybeItemFunction<T> =
 
 export type ListGraphQLConfig = {
   // was previously top-level cacheHint
-  cacheHint?: CacheHint;
+  // cacheHint?: CacheHint;
   /**
    * The description added to the GraphQL schema
    * @default listConfig.description
@@ -220,4 +220,4 @@ export type ListGraphQLConfig = {
   };
 };
 
-export type CacheHint = { scope: 'PRIVATE' | 'PUBLIC'; maxAge: number };
+// export type CacheHint = { scope: 'PRIVATE' | 'PUBLIC'; maxAge: number };


### PR DESCRIPTION
`db` was always a placeholder in case we wanted to do something with it. We don't have a use for it right now.

The other three correspond to arguments to the old `keystone.createList`. We could possibly revive them in the near future, so not totally nuking them just yet.

Update: Also commented out `graphql.cacheHint` as it's currently not plumbed in, but could be quite easily.

Also, reorder some of the code in here to match the order we want to present it in docs.