### PR TITLE
[WIP] Simplify session implementation

### DIFF
--- a/examples-next/ecommerce/tests/mutations.test.ts
+++ b/examples-next/ecommerce/tests/mutations.test.ts
@@ -24,7 +24,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
       test(
         'Not logged in should throw',
         runner(setupKeystone, async ({ context }) => {
-          const _context = asUser(context, undefined);
+          const _context = await asUser(context, undefined);
           const { data, errors } = await _context.graphql.raw({
             query,
             variables: { token },
@@ -70,7 +70,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add some products to some carts
-          const q1 = asUser(context, user1.id).graphql.raw;
+          const q1 = (await asUser(context, user1.id)).graphql.raw;
           const q =
             'mutation m($productId: ID!){ addToCart(productId: $productId) { id label quantity product { id } user { id } } }';
           await q1({ query: q, variables: { productId: product1.id } });
@@ -78,7 +78,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           await q1({ query: q, variables: { productId: product1.id } });
           await q1({ query: q, variables: { productId: product2.id } });
           await q1({ query: q, variables: { productId: product1.id } });
-          const q2 = asUser(context, user2.id).graphql.raw;
+          const q2 = (await asUser(context, user2.id)).graphql.raw;
           await q2({ query: q, variables: { productId: product2.id } });
           await q2({ query: q, variables: { productId: product1.id } });
           await q2({ query: q, variables: { productId: product2.id } });
@@ -86,7 +86,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           await q2({ query: q, variables: { productId: product2.id } });
 
           // Checkout user 1
-          const result1 = await asUser(context, user1.id).graphql.raw({
+          const result1 = await (await asUser(context, user1.id)).graphql.raw({
             query,
             variables: { token },
           });
@@ -109,7 +109,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           expect(result1.data!.checkout.items[1].photo.id).toEqual(product2.photo.id);
 
           // Checkout user 2
-          const result2 = await asUser(context, user2.id).graphql.raw({
+          const result2 = await (await asUser(context, user2.id)).graphql.raw({
             query,
             variables: { token },
           });
@@ -140,7 +140,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
       test(
         'Not logged in should throw',
         runner(setupKeystone, async ({ context }) => {
-          const { graphql } = asUser(context, undefined);
+          const { graphql } = await asUser(context, undefined);
           const productId = '123456781234567812345678';
           const { data, errors } = await graphql.raw({ query, variables: { productId } });
           expect(data).toEqual({ addToCart: null });
@@ -152,7 +152,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
       test(
         'Adding a non-existant product should throw',
         runner(setupKeystone, async ({ context }) => {
-          const { graphql } = asUser(context, '123456781234567812345678');
+          const { graphql } = await asUser(context, '123456781234567812345678');
           const productId = '123456781234567812345678';
           const { data, errors } = await graphql.raw({ query, variables: { productId } });
           expect(data).toEqual({ addToCart: null });
@@ -164,7 +164,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
       test(
         'Adding a mis-formed product should throw',
         runner(setupKeystone, async ({ context }) => {
-          const { graphql } = asUser(context, '123456781234567812345678');
+          const { graphql } = await asUser(context, '123456781234567812345678');
           const productId = '123';
           const { data, errors } = await graphql.raw({ query, variables: { productId } });
           expect(data).toEqual({ addToCart: null });
@@ -178,7 +178,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
       test(
         'Adding a null product should throw',
         runner(setupKeystone, async ({ context }) => {
-          const { graphql } = asUser(context, '123456781234567812345678');
+          const { graphql } = await asUser(context, '123456781234567812345678');
           const { data, errors } = await graphql.raw({
             // Note: $pid can be null as we need to check the behaviour of addToCart
             query: 'mutation m($pid: ID){ addToCart(productId: $pid) { id } }',
@@ -207,7 +207,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add product to cart
-          const { data, errors } = await asUser(context, user.id).graphql.raw({
+          const { data, errors } = await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
@@ -232,7 +232,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add product to cart
-          const { data, errors } = await asUser(context, user.id).graphql.raw({
+          const { data, errors } = await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
@@ -257,7 +257,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add product to cart
-          const { data, errors } = await asUser(context, user.id).graphql.raw({
+          const { data, errors } = await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
@@ -284,15 +284,15 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add product to cart
-          await asUser(context, user.id).graphql.raw({
+          await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
-          await asUser(context, user.id).graphql.raw({
+          await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
-          const { data, errors } = await asUser(context, user.id).graphql.raw({
+          const { data, errors } = await (await asUser(context, user.id)).graphql.raw({
             query,
             variables: { productId: product.id },
           });
@@ -321,7 +321,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           });
 
           // Add products to cart
-          const q = asUser(context, user.id).graphql.raw;
+          const q = (await asUser(context, user.id)).graphql.raw;
           await q({ query, variables: { productId: product1.id } });
           await q({ query, variables: { productId: product2.id } });
           await q({ query, variables: { productId: product1.id } });

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -1,8 +1,7 @@
 import url from 'url';
 import next from 'next';
 import express from 'express';
-import type { KeystoneConfig, SessionStrategy, CreateContext } from '@keystone-next/types';
-import { createSessionContext } from '@keystone-next/keystone/session';
+import type { KeystoneConfig, CreateContext, SessionStrategy } from '@keystone-next/types';
 
 export const createAdminUIServer = async (
   ui: KeystoneConfig['ui'],
@@ -22,11 +21,7 @@ export const createAdminUIServer = async (
       handle(req, res);
       return;
     }
-    const context = createContext({
-      sessionContext: sessionStrategy
-        ? await createSessionContext(sessionStrategy, req, res, createContext)
-        : undefined,
-    });
+    const context = await createContext({ req, res, sessionStrategy });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
       : sessionStrategy

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -6,6 +6,7 @@ import type {
   BaseKeystone,
   SessionStrategy,
   CreateContext,
+  SessionContext,
 } from '@keystone-next/types';
 
 import { itemAPIForList, getArgsFactory } from './itemAPI';

--- a/packages-next/keystone/src/lib/createExpressServer.ts
+++ b/packages-next/keystone/src/lib/createExpressServer.ts
@@ -8,7 +8,6 @@ import { graphqlUploadExpress } from 'graphql-upload';
 import { formatError } from '@keystonejs/keystone/lib/Keystone/format-error';
 import type { KeystoneConfig, CreateContext, SessionStrategy } from '@keystone-next/types';
 import { createAdminUIServer } from '@keystone-next/admin-ui/system';
-import { createSessionContext } from '../session';
 
 const addApolloServer = ({
   server,
@@ -28,12 +27,7 @@ const addApolloServer = ({
     playground: { settings: { 'request.credentials': 'same-origin' } },
     formatError, // TODO: this needs to be discussed
     context: async ({ req, res }: { req: IncomingMessage; res: ServerResponse }) =>
-      createContext({
-        sessionContext: sessionStrategy
-          ? await createSessionContext(sessionStrategy, req, res, createContext)
-          : undefined,
-        req,
-      }),
+      createContext({ req, res, sessionStrategy }),
     // FIXME: support for apollo studio tracing
     // ...(process.env.ENGINE_API_KEY || process.env.APOLLO_KEY
     //   ? { tracing: true }

--- a/packages-next/keystone/src/scripts/migrate/generate.ts
+++ b/packages-next/keystone/src/scripts/migrate/generate.ts
@@ -19,7 +19,7 @@ export const generate = async ({ dotKeystonePath }: StaticPaths) => {
   await saveSchemaAndTypes(graphQLSchema, keystone, dotKeystonePath);
 
   console.log('✨ Generating migration');
-  await keystone.connect({ context: createContext().sudo() });
+  await keystone.connect({ context: (await createContext()).sudo() });
 
   await keystone.disconnect();
 };

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -35,7 +35,7 @@ export const dev = async ({ dotKeystonePath, projectAdminPath }: StaticPaths, sc
     await saveSchemaAndTypes(graphQLSchema, keystone, dotKeystonePath);
 
     console.log('✨ Connecting to the database');
-    await keystone.connect({ context: createContext().sudo() });
+    await keystone.connect({ context: (await createContext()).sudo() });
 
     if (config.ui?.isDisabled) {
       console.log('✨ Skipping Admin UI code generation');

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -18,7 +18,7 @@ export const start = async ({ dotKeystonePath, projectAdminPath }: StaticPaths) 
   const { keystone, graphQLSchema, createContext } = createSystem(config, dotKeystonePath, 'start');
 
   console.log('✨ Connecting to the database');
-  await keystone.connect({ context: createContext().sudo() });
+  await keystone.connect({ context: (await createContext()).sudo() });
 
   console.log('✨ Creating server');
   const server = await createExpressServer(

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -74,7 +74,7 @@ export function withItemData<T extends { listKey: string; itemId: string }>(
       ...sessionStrategy,
       get: async ({ req, createContext }) => {
         const session = await get({ req, createContext });
-        const sudoContext = createContext({}).sudo();
+        const sudoContext = (await createContext({})).sudo();
         if (
           !session ||
           !session.listKey ||

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -10,18 +10,11 @@ export type FieldDefaultValue<T> =
   | MaybePromise<(args: FieldDefaultValueArgs<T>) => T | null | undefined>;
 
 export type CreateContext = (args: {
-  sessionContext?: SessionContext<any>;
   skipAccessControl?: boolean;
   req?: IncomingMessage;
-}) => KeystoneContext;
-
-export type SessionImplementation = {
-  createSessionContext(
-    req: IncomingMessage,
-    res: ServerResponse,
-    createContext: CreateContext
-  ): Promise<SessionContext<any>>;
-};
+  res?: ServerResponse;
+  sessionStrategy?: SessionStrategy<any>;
+}) => Promise<KeystoneContext>;
 
 export type GraphQLResolver = (root: any, args: any, context: KeystoneContext) => any;
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -66,15 +66,8 @@ async function setupFromConfig({
   config.ui = { isDisabled: true };
   config = initConfig(config);
 
-  const { keystone, createContext, graphQLSchema } = createSystem(
-    config,
-    path.resolve('.keystone'),
-    ''
-  );
-
-  const app = await createExpressServer(config, graphQLSchema, createContext, true, '');
-
-  return { keystone, context: createContext().sudo(), app };
+  const { keystone, createContext } = createSystem(config, path.resolve('.keystone'), '');
+  return { keystone, context: (await createContext()).sudo() };
 }
 
 async function setupServer({


### PR DESCRIPTION
The `SessionImplementation` object was just a container for `createSessionContext` with the `isConnected` state bound in. Much easier to pass the strategy around and call `createSessionContext` function when needed, and let the `SessionStrategy's maintain their own state.