### PR TITLE
[WIP] Update KeystoneContext APIs

### DIFF
--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -2,14 +2,13 @@ import url from 'url';
 import next from 'next';
 import express from 'express';
 import type { KeystoneConfig, SessionStrategy, CreateContext } from '@keystone-next/types';
-import { createSessionContext } from '@keystone-next/keystone/session';
 
-export const createAdminUIServer = async (
+export const createAdminUIServer = async <SessionType>(
   ui: KeystoneConfig['ui'],
-  createContext: CreateContext,
+  createContext: CreateContext<SessionType>,
   dev: boolean,
   projectAdminPath: string,
-  sessionStrategy?: SessionStrategy<any>
+  sessionStrategy?: SessionStrategy<SessionType>
 ) => {
   const app = next({ dev, dir: projectAdminPath });
   const handle = app.getRequestHandler();
@@ -22,11 +21,7 @@ export const createAdminUIServer = async (
       handle(req, res);
       return;
     }
-    const context = createContext({
-      sessionContext: sessionStrategy
-        ? await createSessionContext(sessionStrategy, req, res, createContext)
-        : undefined,
-    });
+    const context = await createContext({ skipAccessControl: false, req, res, sessionStrategy });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
       : context.session !== undefined;

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -163,7 +163,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
 
     if (!session && initFirstItem) {
-      const count = await createContext({}).sudo().lists[listKey].count({});
+      const count = await (await createContext({})).sudo().lists[listKey].count({});
       if (count === 0) {
         if (pathname !== '/init') {
           return {

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -1,7 +1,6 @@
-import type { IncomingMessage } from 'http';
 import { execute, GraphQLSchema, parse } from 'graphql';
 import type {
-  SessionContext,
+  CreateContext,
   KeystoneContext,
   KeystoneGraphQLAPI,
   BaseKeystone,
@@ -24,15 +23,95 @@ export function makeCreateContext({
     getArgsByList[listKey] = getArgsFactory(list, graphQLSchema);
   }
 
-  const createContext = ({
-    sessionContext,
-    skipAccessControl = false,
+  // This context creation code is somewhat fiddly, because some parts of the
+  // KeystoneContext object need to reference the object itself! In order to
+  // make this happen, we first prepare the object (_prepareContext), putting in
+  // placeholders for those parts which require self-binding. We then use this
+  // object in _bindToContext to fill in the blanks.
+
+  const _prepareContext = <SessionType>({
+    skipAccessControl,
     req,
-  }: {
-    sessionContext?: SessionContext<any>;
-    skipAccessControl?: boolean;
-    req?: IncomingMessage;
-  } = {}): KeystoneContext => {
+  }: Parameters<CreateContext<SessionType>>[0]): KeystoneContext => ({
+    schemaName: 'public',
+    ...(skipAccessControl ? skipAccessControlContext : accessControlContext),
+    totalResults: 0,
+    keystone,
+    // Only one of these will be available on any given context
+    // TODO: Capture that in the type
+    knex: keystone.adapter.knex,
+    mongoose: keystone.adapter.mongoose,
+    prisma: keystone.adapter.prisma,
+    maxTotalResults: keystone.queryLimits.maxTotalResults,
+    req,
+    // Note: These two fields let us use the server-side-graphql-client library.
+    // We may want to remove them once the updated itemAPI w/ resolveFields is available.
+    executeGraphQL: undefined,
+    gqlNames: (listKey: string) => keystone.lists[listKey].gqlNames,
+
+    // These properties need to refer to this object. We will bind them later (see _bindToContext)
+    session: undefined,
+    startSession: undefined,
+    endSession: undefined,
+    sudo: (() => {}) as KeystoneContext['sudo'],
+    exitSudo: (() => {}) as KeystoneContext['exitSudo'],
+    withSession: ((() => {}) as unknown) as KeystoneContext['withSession'],
+    graphql: {} as KeystoneContext['graphql'],
+    lists: {} as KeystoneContext['lists'],
+  });
+
+  const _bindToContext = <SessionType>({
+    contextToReturn,
+    skipAccessControl,
+    req,
+    res,
+    sessionStrategy,
+    session,
+  }: Parameters<CreateContext<SessionType>>[0] & {
+    contextToReturn: KeystoneContext;
+    session?: SessionType;
+  }) => {
+    // Bind session
+    contextToReturn.session = session;
+    if (sessionStrategy) {
+      Object.assign(contextToReturn, {
+        startSession: (data: SessionType) =>
+          sessionStrategy.start({ res: res!, data, context: contextToReturn }),
+        endSession: () => sessionStrategy.end({ req: req!, res: res!, context: contextToReturn }),
+      });
+    }
+
+    // Bind sudo/leaveSudo/withSession
+    // We want .sudo()/.leaveSudo()/.withSession() to be a synchronous functions, so rather
+    // than calling createContext, we follow the same steps, but skip the async session object
+    // creation, instead passing through the session object we already have, or the paramter
+    // for .withSession().
+    contextToReturn.sudo = () => {
+      const args = { skipAccessControl: true, req, res, sessionStrategy };
+      const contextToReturn = _prepareContext(args);
+      return _bindToContext({ contextToReturn, ...args, session });
+    };
+    contextToReturn.exitSudo = () => {
+      const args = { skipAccessControl: false, req, res, sessionStrategy };
+      const contextToReturn = _prepareContext(args);
+      return _bindToContext({ contextToReturn, ...args, session });
+    };
+    contextToReturn.withSession = session => {
+      const args = { skipAccessControl, req, res, sessionStrategy };
+      const contextToReturn = _prepareContext(args);
+      return _bindToContext({ contextToReturn, ...args, session });
+    };
+
+    // Bind items API
+    for (const [listKey, list] of Object.entries(keystone.lists)) {
+      contextToReturn.lists[listKey] = itemAPIForList(
+        list,
+        contextToReturn,
+        getArgsByList[listKey]
+      );
+    }
+
+    // Bind graphql API
     const rawGraphQL: KeystoneGraphQLAPI<any>['raw'] = ({ query, context, variables }) => {
       if (typeof query === 'string') {
         query = parse(query);
@@ -53,39 +132,46 @@ export function makeCreateContext({
       }
       return result.data as Record<string, any>;
     };
-    const itemAPI: Record<string, ReturnType<typeof itemAPIForList>> = {};
-    const contextToReturn: KeystoneContext = {
-      schemaName: 'public',
-      ...(skipAccessControl ? skipAccessControlContext : accessControlContext),
-      lists: itemAPI,
-      totalResults: 0,
-      keystone,
-      // Only one of these will be available on any given context
-      // TODO: Capture that in the type
-      knex: keystone.adapter.knex,
-      mongoose: keystone.adapter.mongoose,
-      prisma: keystone.adapter.prisma,
-      graphql: { raw: rawGraphQL, run: runGraphQL, schema: graphQLSchema },
-      maxTotalResults: keystone.queryLimits.maxTotalResults,
-      sudo: () => createContext({ sessionContext, skipAccessControl: true, req }),
-      exitSudo: () => createContext({ sessionContext, skipAccessControl: false, req }),
-      withSession: session =>
-        createContext({
-          sessionContext: { ...sessionContext, session } as SessionContext<any>,
-          skipAccessControl,
-          req,
-        }),
-      req,
-      ...sessionContext,
-      // Note: These two fields let us use the server-side-graphql-client library.
-      // We may want to remove them once the updated itemAPI w/ resolveFields is available.
-      executeGraphQL: rawGraphQL,
-      gqlNames: (listKey: string) => keystone.lists[listKey].gqlNames,
+    contextToReturn.graphql = {
+      createContext,
+      raw: rawGraphQL,
+      run: runGraphQL,
+      schema: graphQLSchema,
     };
-    for (const [listKey, list] of Object.entries(keystone.lists)) {
-      itemAPI[listKey] = itemAPIForList(list, contextToReturn, getArgsByList[listKey]);
-    }
+    contextToReturn.executeGraphQL = rawGraphQL;
+
     return contextToReturn;
+  };
+
+  const createContext = async <SessionType>({
+    skipAccessControl = false,
+    req,
+    res,
+    sessionStrategy,
+  }: Parameters<CreateContext<SessionType>>[0] = {}): Promise<KeystoneContext> => {
+    const contextToReturn = _prepareContext({ skipAccessControl, req, res, sessionStrategy });
+
+    // Build session if necessary
+    const session = sessionStrategy
+      ? await sessionStrategy.get({
+          req: req!,
+          sudoContext: await createContext({
+            skipAccessControl: true,
+            req,
+            res,
+            sessionStrategy: undefined,
+          }),
+        })
+      : undefined;
+
+    return _bindToContext({
+      contextToReturn,
+      skipAccessControl,
+      req,
+      res,
+      sessionStrategy,
+      session,
+    });
   };
 
   return createContext;

--- a/packages-next/keystone/src/scripts/migrate/generate.ts
+++ b/packages-next/keystone/src/scripts/migrate/generate.ts
@@ -19,7 +19,7 @@ export const generate = async ({ dotKeystonePath }: StaticPaths) => {
   await saveSchemaAndTypes(graphQLSchema, keystone, dotKeystonePath);
 
   console.log('✨ Generating migration');
-  await keystone.connect({ context: createContext().sudo() });
+  await keystone.connect({ context: (await createContext()).sudo() });
 
   await keystone.disconnect();
 };

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -35,7 +35,7 @@ export const dev = async ({ dotKeystonePath, projectAdminPath }: StaticPaths, sc
     await saveSchemaAndTypes(graphQLSchema, keystone, dotKeystonePath);
 
     console.log('✨ Connecting to the database');
-    await keystone.connect({ context: createContext().sudo() });
+    await keystone.connect({ context: (await createContext()).sudo() });
 
     if (config.ui?.isDisabled) {
       console.log('✨ Skipping Admin UI code generation');

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -18,7 +18,7 @@ export const start = async ({ dotKeystonePath, projectAdminPath }: StaticPaths) 
   const { keystone, graphQLSchema, createContext } = createSystem(config, dotKeystonePath, 'start');
 
   console.log('✨ Connecting to the database');
-  await keystone.connect({ context: createContext().sudo() });
+  await keystone.connect({ context: (await createContext()).sudo() });
 
   console.log('✨ Creating server');
   const server = await createExpressServer(

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -83,7 +83,7 @@ export type AdminUIConfig = {
     req: IncomingMessage;
     session: any;
     isValidSession: boolean;
-    createContext: CreateContext;
+    createContext: CreateContext<any>;
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -3,6 +3,7 @@ import { GraphQLSchema, ExecutionResult, DocumentNode } from 'graphql';
 
 import type { BaseGeneratedListTypes, GqlNames, MaybePromise } from './utils';
 import { BaseKeystone } from './base';
+import { SessionStrategy } from './session';
 
 // DatabaseAPIs is used to provide access to the underlying database abstraction through
 // context and other developer-facing APIs in Keystone, so they can be used easily.
@@ -23,19 +24,12 @@ export type FieldDefaultValue<T> =
   | null
   | MaybePromise<(args: FieldDefaultValueArgs<T>) => T | null | undefined>;
 
-export type CreateContext = (args: {
-  sessionContext?: SessionContext<any>;
+export type CreateContext<SessionType> = (args: {
   skipAccessControl?: boolean;
   req?: IncomingMessage;
-}) => KeystoneContext;
-
-export type SessionImplementation = {
-  createSessionContext(
-    req: IncomingMessage,
-    res: ServerResponse,
-    createContext: CreateContext
-  ): Promise<SessionContext<any>>;
-};
+  res?: ServerResponse;
+  sessionStrategy?: SessionStrategy<SessionType>;
+}) => Promise<KeystoneContext>;
 
 export type AccessControlContext = {
   getListAccessControlForUser: any; // TODO

--- a/packages-next/types/src/session.ts
+++ b/packages-next/types/src/session.ts
@@ -1,25 +1,25 @@
 import type { JSONValue } from './utils';
 import type { ServerResponse, IncomingMessage } from 'http';
-import { CreateContext } from '.';
+import { KeystoneContext } from './core';
 
 export type SessionStrategy<StoredSessionData, StartSessionData = never> = {
   // creates token from data, sets the cookie with token via res, returns token
   start: (args: {
     res: ServerResponse;
     data: StoredSessionData | StartSessionData;
-    createContext: CreateContext;
+    context: KeystoneContext;
   }) => Promise<string>;
   // resets the cookie via res
   end: (args: {
     req: IncomingMessage;
     res: ServerResponse;
-    createContext: CreateContext;
+    context: KeystoneContext;
   }) => Promise<void>;
   // -- this one is invoked at the start of every request
   // reads the token, gets the data, returns it
   get: (args: {
     req: IncomingMessage;
-    createContext: CreateContext;
+    sudoContext: KeystoneContext;
   }) => Promise<StoredSessionData | undefined>;
 };
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -66,15 +66,8 @@ async function setupFromConfig({
   config.ui = { isDisabled: true };
   config = initConfig(config);
 
-  const { keystone, createContext, graphQLSchema } = createSystem(
-    config,
-    path.resolve('.keystone'),
-    ''
-  );
-
-  const app = await createExpressServer(config, graphQLSchema, createContext, true, '');
-
-  return { keystone, context: createContext().sudo(), app };
+  const { keystone, createContext } = createSystem(config, path.resolve('.keystone'), '');
+  return { keystone, context: (await createContext()).sudo() };
 }
 
 async function setupServer({


### PR DESCRIPTION
There's a few different things going on here at the moment, but the end goal is to replace `context.createContext()` with explicit `.sudo()`, `.exitSudo()` and `.withSession()` helpers. This will probably end up taking a few different PRs to land completely.