### PR TITLE
Add .exitSudo and .withSession to context

### DIFF
--- a/.changeset/thirty-peaches-shake.md
+++ b/.changeset/thirty-peaches-shake.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+'@keystone-next/example-ecommerce': patch
+---
+
+Added `context.exitSudo()` and `context.withSession(session)` methods. Removed `context.createContext()`.

--- a/examples-next/ecommerce/tests/mutations.test.ts
+++ b/examples-next/ecommerce/tests/mutations.test.ts
@@ -7,14 +7,7 @@ function setupKeystone(adapterName: AdapterName) {
 }
 
 const asUser = (context: KeystoneContext, itemId?: string) =>
-  context.createContext({
-    skipAccessControl: false,
-    sessionContext: {
-      session: { itemId, data: {} },
-      startSession: async () => '',
-      endSession: async () => {},
-    },
-  });
+  context.exitSudo().withSession({ itemId, data: {} });
 
 multiAdapterRunners('mongoose').map(({ runner }) =>
   describe(`Custom mutations`, () => {

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -54,9 +54,6 @@ export function makeCreateContext({
       return result.data as Record<string, any>;
     };
     const itemAPI: Record<string, ReturnType<typeof itemAPIForList>> = {};
-    const _sessionContext = sessionContext;
-    const _skipAccessControl = skipAccessControl;
-    const _req = req;
     const contextToReturn: KeystoneContext = {
       schemaName: 'public',
       ...(skipAccessControl ? skipAccessControlContext : accessControlContext),
@@ -75,12 +72,14 @@ export function makeCreateContext({
         schema: graphQLSchema,
       } as KeystoneGraphQLAPI<any>,
       maxTotalResults: keystone.queryLimits.maxTotalResults,
-      createContext: ({
-        sessionContext = _sessionContext,
-        skipAccessControl = _skipAccessControl,
-        req = _req,
-      } = {}) => createContext({ sessionContext, skipAccessControl, req }),
       sudo: () => createContext({ sessionContext, skipAccessControl: true, req }),
+      exitSudo: () => createContext({ sessionContext, skipAccessControl: false, req }),
+      withSession: session =>
+        createContext({
+          sessionContext: { ...sessionContext, session } as SessionContext<any>,
+          skipAccessControl,
+          req,
+        }),
       req,
       ...sessionContext,
       // Note: These two fields let us use the server-side-graphql-client library.

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -62,8 +62,9 @@ export type KeystoneContext = {
   /** @deprecated */
   gqlNames: (listKey: string) => Record<string, string>; // TODO: actual keys
   maxTotalResults: number;
-  createContext: CreateContext;
   sudo: () => KeystoneContext;
+  exitSudo: () => KeystoneContext;
+  withSession: (session: any) => KeystoneContext;
   req?: IncomingMessage;
 } & AccessControlContext &
   Partial<SessionContext<any>> &

--- a/yarn.lock
+++ b/yarn.lock
@@ -5986,7 +5986,7 @@ babel-plugin-macros@2.8.0, babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.8.
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-remove-graphql-queries@^2.7.2:
+babel-plugin-remove-graphql-queries@2.7.2, babel-plugin-remove-graphql-queries@^2.7.2:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.2.tgz#101c8b26567e35c217e817e892135a9a04a5a805"
   integrity sha512-kkIqi2+oZ7YCLbZbrhOGxPA/HuWpfvzRUxbD75SHqwxl9fZVWSLQhOUl72GEpAuEt4MeCEguKpMX100oDN3MQA==
@@ -11484,11 +11484,6 @@ from@~0:
   resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
   integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
-fs-capacitor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-2.0.4.tgz#5a22e72d40ae5078b4fe64fe4d08c0d3fc88ad3c"
-  integrity sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA==
-
 fs-capacitor@^6.1.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/fs-capacitor/-/fs-capacitor-6.2.0.tgz#fa79ac6576629163cb84561995602d8999afb7f5"
@@ -11679,7 +11674,7 @@ gatsby-graphiql-explorer@^0.2.3:
   dependencies:
     "@babel/runtime" "^7.8.7"
 
-gatsby-link@^2.2.2:
+gatsby-link@2.2.2, gatsby-link@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/gatsby-link/-/gatsby-link-2.2.2.tgz#789260f82ce0fdb657d1bd558a5863407def86bd"
   integrity sha512-5OHtZZ6V4k0dy+nHe51NVyWzBcHECA4Jx87qqqRja3s+ZKgcYHk4mAhPjt8bZl4sCIW51p+PyfsoKU7Verqd2Q==
@@ -11768,7 +11763,7 @@ gatsby-plugin-mdx@1.2.47:
     unist-util-remove "^1.0.3"
     unist-util-visit "^1.4.1"
 
-gatsby-plugin-page-creator@^2.1.5:
+gatsby-plugin-page-creator@2.1.5, gatsby-plugin-page-creator@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.5.tgz#723fc0392a67978cab649a402ad88f6f06b74e4c"
   integrity sha512-nUcsaJAaMy9UQS66QY0Dys6Xx+2CGG2EVyvDQ4NQ713la62jicOU764Bmi5G7sE2QGgpNoBtUQCW+aE6UMGpLQ==
@@ -12745,7 +12740,7 @@ graphql-type-json@^0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql-upload@^11.0.0:
+graphql-upload@^11.0.0, graphql-upload@^8.0.2:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-11.0.0.tgz#24b245ff18f353bab6715e8a055db9fd73035e10"
   integrity sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==
@@ -12754,16 +12749,6 @@ graphql-upload@^11.0.0:
     fs-capacitor "^6.1.0"
     http-errors "^1.7.3"
     isobject "^4.0.0"
-    object-path "^0.11.4"
-
-graphql-upload@^8.0.2:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/graphql-upload/-/graphql-upload-8.1.0.tgz#6d0ab662db5677a68bfb1f2c870ab2544c14939a"
-  integrity sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==
-  dependencies:
-    busboy "^0.3.1"
-    fs-capacitor "^2.0.4"
-    http-errors "^1.7.3"
     object-path "^0.11.4"
 
 graphql@^14.1.1, graphql@^14.5.8:
@@ -26349,10 +26334,8 @@ watchpack@^1.5.0, watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
This PR replaces `context.createContext()` with the trio `context.sudo()`, `context.exitSudo()` and `context.withSession()`, which provide more explicit APIs to solve the use cases that `createContext` provided.