### PR TITLE
Allow custom idField types and pass id field value on GraphQL create mutations

### DIFF
--- a/.changeset/dry-ears-tell.md
+++ b/.changeset/dry-ears-tell.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/keystone': patch
+---
+
+Allow set id value on GraphQL create mutations input

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -30,7 +30,7 @@ export const integer =
   meta =>
     fieldType({
       kind: 'scalar',
-      mode: 'optional',
+      mode: isRequired ? 'required' : 'optional',
       scalar: 'Int',
       index: getIndexType({ isIndexed, isUnique }),
     })({

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -33,7 +33,7 @@ export const text =
   meta =>
     fieldType({
       kind: 'scalar',
-      mode: 'optional',
+      mode: isRequired ? 'required' : 'optional',
       scalar: 'String',
       index: getIndexType({ isIndexed, isUnique }),
     })({

--- a/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -297,6 +297,8 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
       .join('\n');
     return {
       selectedFields,
+      // Option 2: Here we must detect id field type for list and replace "ID!" to it,
+      // and same for all other places, where ID! is hard-coded.
       query: gql`
         query ItemPage($id: ID!, $listKey: String!) {
           item: ${list.gqlNames.itemQueryName}(where: {id: $id}) {

--- a/packages-next/keystone/src/lib/core/field-assertions.ts
+++ b/packages-next/keystone/src/lib/core/field-assertions.ts
@@ -69,30 +69,12 @@ function assertIdFieldGraphQLTypesCorrect(list: ListForValidation) {
       `The idField on a list must define a uniqueWhere GraphQL input with the ID GraphQL scalar type but the idField for ${list.listKey} does not define one`
     );
   }
-  if (idField.input.uniqueWhere.arg.type !== schema.ID) {
-    throw new Error(
-      `The idField on a list must define a uniqueWhere GraphQL input with the ID GraphQL scalar type but the idField for ${
-        list.listKey
-      } defines the type ${idField.input.uniqueWhere.arg.type.graphQLType.toString()}`
-    );
-  }
-  // we may want to loosen these constraints in the future
-  if (idField.input.create !== undefined) {
-    throw new Error(
-      `The idField on a list must not define a create GraphQL input but the idField for ${list.listKey} does define one`
-    );
-  }
-  if (idField.input.update !== undefined) {
-    throw new Error(
-      `The idField on a list must not define an update GraphQL input but the idField for ${list.listKey} does define one`
-    );
-  }
   if (idField.access.read === false) {
     throw new Error(
       `The idField on a list must not have access.read be set to false but ${list.listKey} does`
     );
   }
-  if (idField.output.type.kind !== 'non-null' || idField.output.type.of !== schema.ID) {
+  if (idField.output.type.kind !== 'non-null' && idField.dbField.mode !== 'required') {
     throw new Error(
       `The idField on a list must define a GraphQL output field with a non-nullable ID GraphQL scalar type but the idField for ${
         list.listKey

--- a/packages-next/keystone/src/lib/core/prisma-schema.ts
+++ b/packages-next/keystone/src/lib/core/prisma-schema.ts
@@ -21,6 +21,10 @@ const modifiers = {
 };
 
 function printIndex(fieldPath: string, index: undefined | 'index' | 'unique') {
+  // For id fields we already have the primary index
+  if (fieldPath === 'id') {
+    return '';
+  }
   return {
     none: '',
     unique: '@unique',
@@ -177,13 +181,13 @@ function assertDbFieldIsValidForIdField(
       } field`
     );
   }
-  if (field.index !== undefined) {
+  if (field.index !== undefined && field.index !== 'unique') {
     throw new Error(
       `id fields must not specify indexes themselves but the id field for the ${listKey} list specifies an index`
     );
   }
   // this will likely be loosened in the future
-  if (field.default === undefined) {
+  if (field.mode !== 'required' && field.default === undefined) {
     throw new Error(
       `id fields must specify a Prisma/database level default value but the id field for the ${listKey} list does not`
     );

--- a/packages-next/keystone/src/lib/core/types-for-lists.ts
+++ b/packages-next/keystone/src/lib/core/types-for-lists.ts
@@ -70,6 +70,8 @@ export function initialiseLists(
         return {
           ...Object.fromEntries(
             Object.entries(fields).flatMap(([fieldPath, field]) => {
+              // Option 1: Somewhere here we must set the "ID" type of 'id' field
+              // in GraphQL schema to keep all id fields with same type.
               if (field.access.read === false) return [];
               return [
                 [fieldPath, field.output] as const,


### PR DESCRIPTION
Very often, when we syncing data from some external storage, we need to set exact id of list item on `create` mutation, instead of using the generated `autoIncrement` or `uuid` value.

But at now isn't possible to set desired `id` field value on Keystone when creating List items via GraphQL `create` mutation query, because `id` field is excluded from schema, even if we manually implement the custom `id` field in custom List schema and giving access to edit it on create operations.

This PR fix this problem via deleting forced removal of the `id` field in all query types, staying this check to access function, that is already successfully remove the `id` field by default.

How to reproduce the problem:
1. Get the `examples/blog` project, and give the `edit` permission to `id` field via lines:
```js
export const lists = createSchema({
...
  Post: list({
    fields: {
...
    },
    idField: integer({
      isUnique: true,
      isRequired: true,
      isIndexed: false,
      access: {
        create: true,
      },
      ui: {
        createView: { fieldMode: 'edit' },
        itemView: { fieldMode: 'hidden' },
      },
    }),
```

2. Try to create the `Post` item with desired id:
```graphql
mutation {
  createPost(data: {
    id: "777",
    title: "My prosperous post!",
  }) {
    id, title
  }
}
```
You will receive the error:
```
TypeError: Cannot assign to read only property 'path' of object '#<Object>'",
```

3. Apply this PR and repeat the query, it will execute well and successfully create the list item with id = 777.
Tested successfully also with "text" field as idField.

Resolves #4824.