### PR TITLE
Remove context.graphql.createContext

### DIFF
--- a/.changeset/unlucky-dragons-judge.md
+++ b/.changeset/unlucky-dragons-judge.md
@@ -3,4 +3,4 @@
 '@keystone-next/types': major
 ---
 
-Remove `context.graphql.createContext` from `KeystoneContext`.
+Removed `context.graphql.createContext` from `KeystoneContext`.

--- a/.changeset/unlucky-dragons-judge.md
+++ b/.changeset/unlucky-dragons-judge.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Remove `context.graphql.createContext` from `KeystoneContext`.

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -65,12 +65,7 @@ export function makeCreateContext({
       knex: keystone.adapter.knex,
       mongoose: keystone.adapter.mongoose,
       prisma: keystone.adapter.prisma,
-      graphql: {
-        createContext,
-        raw: rawGraphQL,
-        run: runGraphQL,
-        schema: graphQLSchema,
-      } as KeystoneGraphQLAPI<any>,
+      graphql: { raw: rawGraphQL, run: runGraphQL, schema: graphQLSchema },
       maxTotalResults: keystone.queryLimits.maxTotalResults,
       sudo: () => createContext({ sessionContext, skipAccessControl: true, req }),
       exitSudo: () => createContext({ sessionContext, skipAccessControl: false, req }),

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -87,7 +87,6 @@ export type KeystoneGraphQLAPI<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   KeystoneListsTypeInfo extends Record<string, BaseGeneratedListTypes>
 > = {
-  createContext: CreateContext;
   schema: GraphQLSchema;
 
   run: (args: GraphQLExecutionArguments) => Promise<Record<string, any>>;


### PR DESCRIPTION
This functionality is now provided by `.sudo`, `.exitSudo` and `.withSession`.