### PR TITLE
Stop enabling lignatures with the `optimizeLegibility` prop in `Core`

### DIFF
--- a/.changeset/popular-roses-hope.md
+++ b/.changeset/popular-roses-hope.md
@@ -2,4 +2,4 @@
 '@keystone-ui/core': patch
 ---
 
-Stopped enabing lignatures with the `optimizeLegibility` prop in `Core`
+Stopped enabling lignatures with the `optimizeLegibility` prop in `Core`

--- a/.changeset/popular-roses-hope.md
+++ b/.changeset/popular-roses-hope.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/core': patch
+---
+
+Stopped enabing lignatures with the `optimizeLegibility` prop in `Core`

--- a/design-system/packages/core/src/components/Core.tsx
+++ b/design-system/packages/core/src/components/Core.tsx
@@ -55,11 +55,9 @@ const BaseCSS = ({ includeNormalize, optimizeLegibility }: BaseCSSProps) => {
 
             // optimize legibility
             ...(optimizeLegibility && {
-              fontFeatureSettings: '"liga" 1', // Enable OpenType ligatures in IE
               textRendering: 'optimizeLegibility',
               WebkitFontSmoothing: 'antialiased',
               MozOsxFontSmoothing: 'grayscale',
-              MozFontFeatureSettings: '"liga" on',
             }),
           },
 


### PR DESCRIPTION
Mainly doing this because of the docs website, have a look at `config` inside a code block on the currently deployed version vs this PR.

Before:
<img width="75" alt="Before" src="https://user-images.githubusercontent.com/11481355/108007846-a6026e00-704a-11eb-8945-f2bb15212247.png">

After:
<img width="84" alt="After" src="https://user-images.githubusercontent.com/11481355/108007845-a4d14100-704a-11eb-86ef-1084d77b0520.png">