### PR TITLE
Dim out Placeholder pages in the new docs nav

### DIFF
--- a/docs-next/components/Navigation.tsx
+++ b/docs-next/components/Navigation.tsx
@@ -13,15 +13,16 @@ const Section = ({ label, children }: SectionProps) => {
   );
 };
 
-type NavItemProps = { href: string; children: ReactNode };
-const NavItem = ({ href, children }: NavItemProps) => {
+type NavItemProps = { href: string; isPlaceholder?: boolean; children: ReactNode };
+const NavItem = ({ href, isPlaceholder, children }: NavItemProps) => {
   const router = useRouter();
   const isSelected = router.pathname === href;
+  // const baseColor = ;
   return (
     <Link href={href} passHref>
       <a
         className={cx(
-          isSelected ? 'text-gray-900' : 'text-gray-500 hover:text-gray-800',
+          isSelected ? 'text-gray-900' : `${isPlaceholder ? 'text-gray-300' : 'text-gray-500'} hover:text-gray-800`,
           'block no-underline py-1'
         )}
       >
@@ -31,24 +32,6 @@ const NavItem = ({ href, children }: NavItemProps) => {
   );
 };
 
-// const SubSection: React.ComponentType<{ label: string }> = ({ children, label }) => {
-//   return (
-//     <Fragment>
-//       <h4
-//         css={{
-//           fontWeight: 500,
-//           fontSize: '1em',
-//           textTransform: 'uppercase',
-//           margin: '0.5em 0',
-//         }}
-//       >
-//         {label}
-//       </h4>
-//       <ul css={{ padding: 0 }}>{children}</ul>
-//     </Fragment>
-//   );
-// };
-
 export const Navigation = () => {
   return (
     <div className="font-medium">
@@ -56,25 +39,25 @@ export const Navigation = () => {
       <NavItem href="/whats-new">What's New</NavItem>
       <NavItem href="/roadmap">Roadmap</NavItem>
       <Section label="Guides">
-        <NavItem href="/guides/getting-started">Getting Started</NavItem>
-        <NavItem href="/guides/installation">Installation</NavItem>
+        <NavItem href="/guides/getting-started" isPlaceholder>Getting Started</NavItem>
+        <NavItem href="/guides/installation" isPlaceholder>Installation</NavItem>
         <NavItem href="/guides/cli">Command Line</NavItem>
-        <NavItem href="/guides/access-control">Access Control</NavItem>
-        <NavItem href="/guides/hooks">Hooks</NavItem>
-        <NavItem href="/guides/schema-extension">Schema Extension</NavItem>
+        <NavItem href="/guides/access-control" isPlaceholder>Access Control</NavItem>
+        <NavItem href="/guides/hooks" isPlaceholder>Hooks</NavItem>
+        <NavItem href="/guides/schema-extension" isPlaceholder>Schema Extension</NavItem>
         <NavItem href="/guides/document">Document Fields</NavItem>
-        <NavItem href="/guides/virtual">Virtual Fields</NavItem>
+        <NavItem href="/guides/virtual" isPlaceholder>Virtual Fields</NavItem>
       </Section>
       <Section label="API">
         <NavItem href="/apis/config">Config API</NavItem>
         <NavItem href="/apis/schema">Schema API</NavItem>
         <NavItem href="/apis/fields">Fields API</NavItem>
-        <NavItem href="/apis/access-control">Access Control API</NavItem>
-        <NavItem href="/apis/hooks">Hooks API</NavItem>
+        <NavItem href="/apis/access-control" isPlaceholder>Access Control API</NavItem>
+        <NavItem href="/apis/hooks" isPlaceholder>Hooks API</NavItem>
         <NavItem href="/apis/session">Session API</NavItem>
-        <NavItem href="/apis/auth">Authentication API</NavItem>
-        <NavItem href="/apis/context">Context API</NavItem>
-        <NavItem href="/apis/graphql">GraphQL API</NavItem>
+        <NavItem href="/apis/auth" isPlaceholder>Authentication API</NavItem>
+        <NavItem href="/apis/context" isPlaceholder>Context API</NavItem>
+        <NavItem href="/apis/graphql" isPlaceholder>GraphQL API</NavItem>
       </Section>
     </div>
   );

--- a/docs-next/components/Navigation.tsx
+++ b/docs-next/components/Navigation.tsx
@@ -17,12 +17,13 @@ type NavItemProps = { href: string; isPlaceholder?: boolean; children: ReactNode
 const NavItem = ({ href, isPlaceholder, children }: NavItemProps) => {
   const router = useRouter();
   const isSelected = router.pathname === href;
-  // const baseColor = ;
   return (
     <Link href={href} passHref>
       <a
         className={cx(
-          isSelected ? 'text-gray-900' : `${isPlaceholder ? 'text-gray-300' : 'text-gray-500'} hover:text-gray-800`,
+          isSelected
+            ? 'text-gray-900'
+            : `${isPlaceholder ? 'text-gray-300' : 'text-gray-500'} hover:text-gray-800`,
           'block no-underline py-1'
         )}
       >
@@ -39,25 +40,47 @@ export const Navigation = () => {
       <NavItem href="/whats-new">What's New</NavItem>
       <NavItem href="/roadmap">Roadmap</NavItem>
       <Section label="Guides">
-        <NavItem href="/guides/getting-started" isPlaceholder>Getting Started</NavItem>
-        <NavItem href="/guides/installation" isPlaceholder>Installation</NavItem>
+        <NavItem href="/guides/getting-started" isPlaceholder>
+          Getting Started
+        </NavItem>
+        <NavItem href="/guides/installation" isPlaceholder>
+          Installation
+        </NavItem>
         <NavItem href="/guides/cli">Command Line</NavItem>
-        <NavItem href="/guides/access-control" isPlaceholder>Access Control</NavItem>
-        <NavItem href="/guides/hooks" isPlaceholder>Hooks</NavItem>
-        <NavItem href="/guides/schema-extension" isPlaceholder>Schema Extension</NavItem>
+        <NavItem href="/guides/access-control" isPlaceholder>
+          Access Control
+        </NavItem>
+        <NavItem href="/guides/hooks" isPlaceholder>
+          Hooks
+        </NavItem>
+        <NavItem href="/guides/schema-extension" isPlaceholder>
+          Schema Extension
+        </NavItem>
         <NavItem href="/guides/document">Document Fields</NavItem>
-        <NavItem href="/guides/virtual" isPlaceholder>Virtual Fields</NavItem>
+        <NavItem href="/guides/virtual" isPlaceholder>
+          Virtual Fields
+        </NavItem>
       </Section>
       <Section label="API">
         <NavItem href="/apis/config">Config API</NavItem>
         <NavItem href="/apis/schema">Schema API</NavItem>
         <NavItem href="/apis/fields">Fields API</NavItem>
-        <NavItem href="/apis/access-control" isPlaceholder>Access Control API</NavItem>
-        <NavItem href="/apis/hooks" isPlaceholder>Hooks API</NavItem>
+        <NavItem href="/apis/access-control" isPlaceholder>
+          Access Control API
+        </NavItem>
+        <NavItem href="/apis/hooks" isPlaceholder>
+          Hooks API
+        </NavItem>
         <NavItem href="/apis/session">Session API</NavItem>
-        <NavItem href="/apis/auth" isPlaceholder>Authentication API</NavItem>
-        <NavItem href="/apis/context" isPlaceholder>Context API</NavItem>
-        <NavItem href="/apis/graphql" isPlaceholder>GraphQL API</NavItem>
+        <NavItem href="/apis/auth" isPlaceholder>
+          Authentication API
+        </NavItem>
+        <NavItem href="/apis/context" isPlaceholder>
+          Context API
+        </NavItem>
+        <NavItem href="/apis/graphql" isPlaceholder>
+          GraphQL API
+        </NavItem>
       </Section>
     </div>
   );


### PR DESCRIPTION
This helps the new docs site a lot, because you can see which pages actually have content. Makes it easier for us to see which bits still need to be written, and should frustrate our audience a lot less because they're not clicking around pages that have no content.