### PR TITLE
Add operation argument to validateAuthAccessControl

### DIFF
--- a/.changeset/late-nails-tease.md
+++ b/.changeset/late-nails-tease.md
@@ -1,0 +1,6 @@
+---
+'@keystonejs/access-control': major
+'@keystonejs/keystone': patch
+---
+
+Updated `validateAuthAccessControl` to now require an explicit `operation` argument.

--- a/packages/access-control/src/access-control.ts
+++ b/packages/access-control/src/access-control.ts
@@ -404,8 +404,8 @@ export async function validateAuthAccessControl({
   authentication,
   gqlName,
   context,
-}: { access: AuthAccess<AuthAccessArgs> } & Omit<AuthAccessArgs, 'operation'>) {
-  const operation = 'auth';
+  operation,
+}: { access: AuthAccess<AuthAccessArgs> } & AuthAccessArgs) {
   // Either a boolean or an object describing a where clause
   let result: Static | Declarative = false;
   const acc = access[operation];

--- a/packages/access-control/tests/access-control.test.ts
+++ b/packages/access-control/tests/access-control.test.ts
@@ -513,19 +513,19 @@ describe('Access control package tests', () => {
     // Test the static case: returning a boolean
     const authArgs = { listKey: 'listKey', authentication: {}, gqlName: 'gqlName', context: {} };
     await expect(
-      validateAuthAccessControl({ access: { [operation]: true }, ...authArgs })
+      validateAuthAccessControl({ access: { [operation]: true }, operation, ...authArgs })
     ).resolves.toBe(true);
     await expect(
-      validateAuthAccessControl({ access: { [operation]: false }, ...authArgs })
+      validateAuthAccessControl({ access: { [operation]: false }, operation, ...authArgs })
     ).resolves.toBe(false);
     await expect(
       // @ts-ignore
-      validateAuthAccessControl({ access: { [operation]: 10 }, ...authArgs })
+      validateAuthAccessControl({ access: { [operation]: 10 }, operation, ...authArgs })
     ).rejects.toThrow(Error);
 
     const accessFn = jest.fn(() => true);
 
-    await validateAuthAccessControl({ access: { [operation]: accessFn }, ...authArgs });
+    await validateAuthAccessControl({ access: { [operation]: accessFn }, operation, ...authArgs });
 
     expect(accessFn).toHaveBeenCalledTimes(1);
 
@@ -535,6 +535,7 @@ describe('Access control package tests', () => {
       await expect(
         validateAuthAccessControl({
           access: { [operation]: () => true },
+          operation,
           ...authArgs,
           authentication,
         })
@@ -542,6 +543,7 @@ describe('Access control package tests', () => {
       await expect(
         validateAuthAccessControl({
           access: { [operation]: () => false },
+          operation,
           ...authArgs,
           authentication,
         })
@@ -550,6 +552,7 @@ describe('Access control package tests', () => {
       await expect(
         validateAuthAccessControl({
           access: { [operation]: () => ({ a: 1 }) },
+          operation,
           ...authArgs,
           authentication,
         })
@@ -560,6 +563,7 @@ describe('Access control package tests', () => {
         validateAuthAccessControl({
           // @ts-ignore
           access: { create: () => ({ a: 1 }) },
+          operation,
           ...authArgs,
           authentication,
         })
@@ -567,8 +571,13 @@ describe('Access control package tests', () => {
 
       // Number function
       await expect(
-        // @ts-ignore
-        validateAuthAccessControl({ access: { create: () => 10 }, ...authArgs, authentication })
+        validateAuthAccessControl({
+          // @ts-ignore
+          access: { create: () => 10 },
+          operation,
+          ...authArgs,
+          authentication,
+        })
       ).rejects.toThrow(Error);
     }
   });

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -171,6 +171,7 @@ module.exports = class Keystone {
           listKey,
           gqlName,
           context,
+          operation: 'auth',
         });
       },
       { isPromise: true }


### PR DESCRIPTION
This change will allow for more consistent type definitions across the package.