### PR TITLE
Fix admin meta fetching

### DIFF
--- a/.changeset/metal-cooks-change.md
+++ b/.changeset/metal-cooks-change.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/admin-ui': patch
+---
+
+Fixed fetching admin meta causing an infinite loop.

--- a/packages-next/admin-ui/src/utils/useAdminMeta.tsx
+++ b/packages-next/admin-ui/src/utils/useAdminMeta.tsx
@@ -50,6 +50,15 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
   if (typeof window !== 'undefined' && adminMetaFromLocalStorage === undefined && !called) {
     fetchStaticAdminMeta();
   }
+
+  let shouldFetchAdminMeta = adminMetaFromLocalStorage === undefined && !called;
+
+  useEffect(() => {
+    if (shouldFetchAdminMeta) {
+      fetchStaticAdminMeta();
+    }
+  }, [shouldFetchAdminMeta, fetchStaticAdminMeta]);
+
   const runtimeAdminMeta = useMemo(() => {
     if ((!data || error) && !adminMetaFromLocalStorage) {
       return undefined;


### PR DESCRIPTION
Close #4828

I'm not really sure when this broke or why it broke, my best guess is the react 17 bump or the bump to @apollo/client in #4512. (it was hard to catch because it only happens when the admin meta hasn't been cached)