### PR TITLE
Make the document field toolbar wrap

### DIFF
--- a/.changeset/twelve-tools-care.md
+++ b/.changeset/twelve-tools-care.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/fields-document": patch
+---
+
+Allowed the document field toolbar to wrap on smaller screens

--- a/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { ButtonHTMLAttributes, HTMLAttributes, createContext, useContext, ReactNode } from 'react';
-import { Box, Inline, MarginProps, forwardRefWithAs, jsx, useTheme } from '@keystone-ui/core';
+import { Inline, MarginProps, forwardRefWithAs, jsx, useTheme } from '@keystone-ui/core';
 
 // Spacers and Separators
 // ------------------------------
@@ -43,10 +43,12 @@ const useToolbarGroupContext = () => useContext(ToolbarGroupContext);
 type ToolbarGroupProps = { direction?: DirectionType } & MarginProps &
   HTMLAttributes<HTMLDivElement>;
 export const ToolbarGroup = forwardRefWithAs<'div', ToolbarGroupProps>(
-  ({ direction = 'row', ...props }, ref) => {
+  ({ children, direction = 'row', ...props }, ref) => {
     return (
       <ToolbarGroupContext.Provider value={{ direction }}>
-        <Inline ref={ref} {...props} />
+        <Inline ref={ref} {...props}>
+          {children}
+        </Inline>
       </ToolbarGroupContext.Provider>
     );
   }

--- a/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
@@ -44,16 +44,13 @@ type ToolbarGroupProps = { direction?: DirectionType } & MarginProps &
   HTMLAttributes<HTMLDivElement>;
 export const ToolbarGroup = forwardRefWithAs<'div', ToolbarGroupProps>(
   ({ direction = 'row', ...props }, ref) => {
-    const { spacing } = useTheme();
-
     return (
       <ToolbarGroupContext.Provider value={{ direction }}>
         <Box
           ref={ref}
           css={{
-            display: 'inline-grid',
-            gap: spacing.xxsmall,
-            gridAutoFlow: autoFlowDirection[direction],
+            display: 'flex',
+            flexWrap: 'wrap',
           }}
           {...props}
         />

--- a/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/primitives/toolbar.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 
 import { ButtonHTMLAttributes, HTMLAttributes, createContext, useContext, ReactNode } from 'react';
-import { Box, MarginProps, forwardRefWithAs, jsx, useTheme } from '@keystone-ui/core';
+import { Box, Inline, MarginProps, forwardRefWithAs, jsx, useTheme } from '@keystone-ui/core';
 
 // Spacers and Separators
 // ------------------------------
@@ -46,14 +46,7 @@ export const ToolbarGroup = forwardRefWithAs<'div', ToolbarGroupProps>(
   ({ direction = 'row', ...props }, ref) => {
     return (
       <ToolbarGroupContext.Provider value={{ direction }}>
-        <Box
-          ref={ref}
-          css={{
-            display: 'flex',
-            flexWrap: 'wrap',
-          }}
-          {...props}
-        />
+        <Inline ref={ref} {...props} />
       </ToolbarGroupContext.Provider>
     );
   }


### PR DESCRIPTION
This change make the toolbar wrap when the viewport is small enough.

@mitchellhamilton I'm not sure why it was a grid in the first place, this doesn't seem to have changed anything else... I also removed the spacing, we could add it back but it looks fine and is slightly less likely to wrap this way