### PR TITLE
Remove duplicate call to fetchStaticAdminMeta

### DIFF
--- a/.changeset/empty-ghosts-count.md
+++ b/.changeset/empty-ghosts-count.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/admin-ui": patch
+---
+
+Fixed an issue that would cause the Admin UI to get stuck in an infinite loop when loading adminMeta without a local cache

--- a/packages-next/admin-ui/src/utils/useAdminMeta.tsx
+++ b/packages-next/admin-ui/src/utils/useAdminMeta.tsx
@@ -47,9 +47,6 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
   const [fetchStaticAdminMeta, { data, error, called }] = useLazyQuery(staticAdminMetaQuery, {
     fetchPolicy: 'network-only',
   });
-  if (typeof window !== 'undefined' && adminMetaFromLocalStorage === undefined && !called) {
-    fetchStaticAdminMeta();
-  }
 
   let shouldFetchAdminMeta = adminMetaFromLocalStorage === undefined && !called;
 


### PR DESCRIPTION
This corrects an error in #4879 and actually fixes #4828

The right fix was added, but the previous code wasn't removed so the infinite loop was still happening.

Sorry about this -- you actually have to clear your localStorage to reproduce this error so it took us longer to properly fix than it should have. We'll be adding some cypress tests shortly to catch things like this sooner.