### PR TITLE
Fix the max-height bug for the expanded Document editor view

### DIFF
--- a/packages-next/admin-ui/src/pages/ItemPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ItemPage/index.tsx
@@ -577,7 +577,7 @@ const ColumnLayout = (props: HTMLAttributes<HTMLDivElement>) => {
   const { spacing } = useTheme();
 
   return (
-    <Container css={{ position: 'relative' }}>
+    <Container css={{ position: 'relative', height: '100%' }}>
       <div
         css={{
           alignItems: 'start',

--- a/packages-next/admin-ui/src/pages/ItemPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ItemPage/index.tsx
@@ -577,6 +577,8 @@ const ColumnLayout = (props: HTMLAttributes<HTMLDivElement>) => {
   const { spacing } = useTheme();
 
   return (
+    // this container must be relative to catch absolute children
+    // particularly the "expanded" document-field, which needs a height of 100%
     <Container css={{ position: 'relative', height: '100%' }}>
       <div
         css={{


### PR DESCRIPTION
As mentioned by @gautamsi in #4883

This feels like a bit of a hack, but it fixes the bug and doesn't seem to have any unintended side effects.

@jossmac wouldn't mind your eyes on this, in case there's something I've missed