### PR TITLE
Add support for idField to Integer and Text field types in knex adapter

### DIFF
--- a/.changeset/curly-jokes-act.md
+++ b/.changeset/curly-jokes-act.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': minor
+---
+
+Add support for idField to Integer and Text field types in knex adapter

--- a/packages/fields/src/types/Integer/Implementation.js
+++ b/packages/fields/src/types/Integer/Implementation.js
@@ -76,6 +76,20 @@ export class KnexIntegerInterface extends CommonIntegerInterface(KnexFieldAdapte
     if (this.isNotNullable) column.notNullable();
     if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
+
+  addToForeignTableSchema(table, { path, isUnique, isIndexed, isNotNullable }) {
+    if (!this.field.isPrimaryKey) {
+      throw (
+        `Can't create foreign key '${path}' on table "${table._tableName}"; ` +
+        `'${this.path}' on list '${this.field.listKey}' as is not the primary key.`
+      );
+    }
+
+    const column = table.integer(path).unsigned();
+    if (isUnique) column.unique();
+    else if (isIndexed) column.index();
+    if (isNotNullable) column.notNullable();
+  }
 }
 
 export class PrismaIntegerInterface extends CommonIntegerInterface(PrismaFieldAdapter) {

--- a/packages/fields/src/types/Text/Implementation.js
+++ b/packages/fields/src/types/Text/Implementation.js
@@ -78,6 +78,20 @@ export class KnexTextInterface extends CommonTextInterface(KnexFieldAdapter) {
     if (this.isNotNullable) column.notNullable();
     if (typeof this.defaultTo !== 'undefined') column.defaultTo(this.defaultTo);
   }
+
+  addToForeignTableSchema(table, { path, isUnique, isIndexed, isNotNullable }) {
+    if (!this.field.isPrimaryKey) {
+      throw (
+        `Can't create foreign key '${path}' on table "${table._tableName}"; ` +
+        `'${this.path}' on list '${this.field.listKey}' as is not the primary key.`
+      );
+    }
+
+    const column = table.text(path);
+    if (isUnique) column.unique();
+    else if (isIndexed) column.index();
+    if (isNotNullable) column.notNullable();
+  }
 }
 
 export class PrismaTextInterface extends CommonTextInterface(PrismaFieldAdapter) {


### PR DESCRIPTION
To resolve #4897 I simply cloned the `addToForeignTableSchema()` function from `packages/fields-auto-increment/src/Implementation.js` field type to `Integer` and `Text` field types, with change column type for Text field type.

I tested this via extending the `examples-next/todo` example as described in issue #4897 and find no problems.

Please lookup, is all done right, or I must modify something else? Thanks!