### PR TITLE
fix types for hooks

### DIFF
--- a/.changeset/lovely-ducks-cry.md
+++ b/.changeset/lovely-ducks-cry.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': patch
+---
+
+Fixed typing for `afterDelete` or `beforeDelete` hooks. Also added type for `updatedItem` in the afterChange or beforeChange hook

--- a/.changeset/lovely-ducks-cry.md
+++ b/.changeset/lovely-ducks-cry.md
@@ -2,4 +2,4 @@
 '@keystone-next/types': patch
 ---
 
-Fixed typing for `afterDelete` or `beforeDelete` hooks. Also added type for `updatedItem` in the afterChange or beforeChange hook
+Fixed typing for `afterDelete` or `beforeDelete` hooks. Also added type for `updatedItem` in the `afterChange` or `beforeChange` hook

--- a/packages-next/types/src/config/hooks.ts
+++ b/packages-next/types/src/config/hooks.ts
@@ -92,7 +92,9 @@ type ValidateInputHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
 ) => Promise<void> | void;
 
 type BeforeOrAfterChangeHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
-  args: ArgsForCreateOrUpdateOperation<TGeneratedListTypes> & ({ updatedItem: TGeneratedListTypes['inputs']['update']})
+  args: ArgsForCreateOrUpdateOperation<TGeneratedListTypes> & {
+    updatedItem: TGeneratedListTypes['inputs']['create'] | TGeneratedListTypes['inputs']['update'];
+  }
 ) => Promise<void> | void;
 
 type ArgsForDeleteOperation<TGeneratedListTypes extends BaseGeneratedListTypes> = {

--- a/packages-next/types/src/config/hooks.ts
+++ b/packages-next/types/src/config/hooks.ts
@@ -29,7 +29,7 @@ export type ListHooks<TGeneratedListTypes extends BaseGeneratedListTypes> = {
   /**
    * Used to **cause side effects** after a delete operation operation has occurred
    */
-  afterDelete?: BeforeOrAfterChangeHook<TGeneratedListTypes>;
+  afterDelete?: BeforeOrAfterDeleteHook<TGeneratedListTypes>;
 };
 
 type ArgsForCreateOrUpdateOperation<TGeneratedListTypes extends BaseGeneratedListTypes> = (
@@ -92,7 +92,7 @@ type ValidateInputHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
 ) => Promise<void> | void;
 
 type BeforeOrAfterChangeHook<TGeneratedListTypes extends BaseGeneratedListTypes> = (
-  args: ArgsForCreateOrUpdateOperation<TGeneratedListTypes>
+  args: ArgsForCreateOrUpdateOperation<TGeneratedListTypes> & ({ updatedItem: TGeneratedListTypes['inputs']['update']})
 ) => Promise<void> | void;
 
 type ArgsForDeleteOperation<TGeneratedListTypes extends BaseGeneratedListTypes> = {


### PR DESCRIPTION
I found soem inconsistencies in the afterDelete and beforeDelete hook types.

found missing `updatedItem` in the hook for afterChange and beforeChange hook