### PR TITLE
assorted fixes

### DIFF
--- a/docs-next/components/Page.tsx
+++ b/docs-next/components/Page.tsx
@@ -60,9 +60,12 @@ export const Page = ({ children, isProse }: { children: ReactNode; isProse?: boo
         <aside className="flex-none md:w-52 md:mr-4 md:text-sm">
           {mobileNavCollapsed ? (
             <a
-              href="javascript:;"
+              href="#"
               className="block text-gray-600 hover:text-gray-900 py-4 px-2 border-b border-grey-200 font-semibold md:hidden"
-              onClick={() => setMobileNavCollapsed(false)}
+              onClick={event => {
+                event.preventDefault();
+                setMobileNavCollapsed(false);
+              }}
             >
               Show Nav
             </a>
@@ -72,9 +75,12 @@ export const Page = ({ children, isProse }: { children: ReactNode; isProse?: boo
           </div>
           {!mobileNavCollapsed ? (
             <a
-              href="javascript:;"
+              href="#"
               className="block text-gray-600 hover:text-gray-900 py-4 px-2 mt-4 border-b border-t border-grey-200 font-semibold md:hidden"
-              onClick={() => setMobileNavCollapsed(true)}
+              onClick={event => {
+                event.preventDefault();
+                setMobileNavCollapsed(true);
+              }}
             >
               Hide Nav
             </a>

--- a/docs-next/components/SubscribeForm.tsx
+++ b/docs-next/components/SubscribeForm.tsx
@@ -28,7 +28,6 @@ export const SubscribeForm = ({
     // and there's a valid email address.
     // Basic validation check on the email?
     setLoading(true);
-    return setFormSubmitted(true);
     if (validEmail(email)) {
       // if good add email to mailing list
       // and redirect to dashboard.
@@ -84,7 +83,7 @@ export const SubscribeForm = ({
               {error ? 'Try again' : 'Subscribe'}
             </Button>
           </Stack>
-          <p css={{ margin: '0 !important', color: 'red' }}>{error}</p>
+          {error ? <p css={{ margin: '0 !important', color: 'red' }}>{error}</p> : null}
         </Stack>
       </form>
     </Fragment>


### PR DESCRIPTION
- correct early return that was committed to our repo from https://github.com/keystonejs/keystone/commit/b7a516c5685e031b573a2a4dba979b1f998452a7 that ensured no forms were actually being submitted 
- provide alternative to `href=javascript:;' applied to anchors, to fix react warnings.  src commit https://github.com/keystonejs/keystone/commit/4f35df0c6ab7cc3625b6ca3dc9fd2c998c8e475d