### PR TITLE
Add config.graphql.apolloConfig

### DIFF
--- a/.changeset/tricky-fans-serve.md
+++ b/.changeset/tricky-fans-serve.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/website': minor
+'@keystone-next/keystone': minor
+'@keystone-next/types': minor
+---
+
+Added a `config.graphql.apolloConfig` option to allow developers to configure the `ApolloServer` object provided by Keystone.

--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -267,11 +267,14 @@ Options:
 
 - `queryLimits` (default: `undefined`): Allows you to limit the total number of results returned from a query to your GraphQL API.
   See also the per-list `graphql.queryLimits` option in the [Schema API](./schema).
+- `apolloConfig` (default: `undefined`): Allows you to pass extra options into the `ApolloServer` constructor.
+  See the [Apollo docs](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructor) for supported options.
 
 ```typescript
 export default config({
   graphql: {
     queryLimits: { maxTotalResults: 100 },
+    apolloConfig: { /* ... */ },
   },
   /* ... */
 });

--- a/packages-next/admin-ui/src/templates/api.ts
+++ b/packages-next/admin-ui/src/templates/api.ts
@@ -16,6 +16,7 @@ const apolloServer = createApolloServerMicro({
   graphQLSchema,
   createContext,
   sessionStrategy: initializedKeystoneConfig.session ? initializedKeystoneConfig.session() : undefined,
+  apolloConfig: config.graphql?.apolloConfig,
   connectionPromise: keystone.connect(),
 });
 

--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -38,6 +38,7 @@
     "@types/uid-safe": "^2.1.2",
     "apollo-server-express": "^2.21.1",
     "apollo-server-micro": "^2.21.1",
+    "apollo-server-types": "^0.6.3",
     "cookie": "^0.4.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",

--- a/packages-next/types/package.json
+++ b/packages-next/types/package.json
@@ -8,6 +8,7 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
+    "apollo-server-types": "^0.6.3",
     "cors": "^2.8.5",
     "graphql": "^15.5.0"
   },

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -2,6 +2,7 @@ import type { ConnectOptions } from 'mongoose';
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import { IncomingMessage } from 'http';
+import type { Config } from 'apollo-server-express';
 
 import type { ListHooks } from './hooks';
 import type { ListAccessControl, FieldAccessControl } from './access-control';
@@ -121,6 +122,11 @@ export type GraphQLConfig = {
   queryLimits?: {
     maxTotalResults?: number;
   };
+  /**
+   *  Additional options to pass into the ApolloServer constructor.
+   *  @see https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructor
+   */
+  apolloConfig?: Config;
 };
 
 // config.extendGraphqlSchema


### PR DESCRIPTION
This PR adds a config option which allows the user to specify additional config to be applied to their ApolloServer. This is required for customising things like query limiting and the GraphQL playground, among other things.

See the ApolloServer constructor docs here: https://www.apollographql.com/docs/apollo-server/api/apollo-server/#constructor

This PR is a blocker for #4894. 