### PR TITLE
Fix isAccessAllowed default

### DIFF
--- a/.changeset/eighty-lies-hide.md
+++ b/.changeset/eighty-lies-hide.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/keystone': major
+---
+
+Fixed isAccessAllowed default so that if a session strategy is not used, access is always allowed to the Admin UI rather than never allowing access

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -29,7 +29,9 @@ export const createAdminUIServer = async (
     });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
-      : context.session !== undefined;
+      : sessionStrategy
+      ? context.session !== undefined
+      : true;
     const maybeRedirect = await ui?.pageMiddleware?.({
       req,
       session: context.session,


### PR DESCRIPTION
To test this, you can put this into an example, run it and see that you can access the Admin UI.

```ts
import { config, createSchema, list } from '@keystone-next/keystone/schema';
import { text, checkbox } from '@keystone-next/fields';

export default config({
  db: {
    adapter: 'mongoose',
    url: 'mongodb://localhost/keystone-basic-todo',
  },
  lists: createSchema({
    Todo: list({
      fields: {
        title: text({ isRequired: true }),
        isComplete: checkbox(),
      },
    }),
  }),
});
```