### PR TITLE
Disable Netlify integration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,0 @@
-[build]
-  command = "yarn website build"
-  publish = "website/public"
-  ignore = "git diff --quiet HEAD^ HEAD website/ yarn.lock packages/**/*.md docs/"
-[build.environment]
-  NODE_VERSION = "10"
-  YARN_VERSION = "1.15.2"
-  YARN_FLAGS = "--frozen-lockfile"


### PR DESCRIPTION
We no longer want to build and deploy the site intended for `keystone-5` in this repository.

The repo located at https://github.com/keystonejs/keystone-5 now handles this on it's own.

Deleting this file to close the loop, has already been disabled in Netlify's end.