### PR TITLE
Port access control tests to new interfaces

### DIFF
--- a/.changeset/red-hornets-admire.md
+++ b/.changeset/red-hornets-admire.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone-legacy': patch
+---
+
+Updated schema generation to no longer consider `access.auth`, as it is no longer used in Keystone Next.

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -946,13 +946,7 @@ module.exports = class List {
     // We want to include `id` fields
     // If read is globally set to false, makes sense to never show it
     const readFields = this.getAllFieldsWithAccess({ schemaName, access: 'read' });
-    if (
-      schemaAccess.read ||
-      schemaAccess.create ||
-      schemaAccess.update ||
-      schemaAccess.delete ||
-      schemaAccess.auth
-    ) {
+    if (schemaAccess.read || schemaAccess.create || schemaAccess.update || schemaAccess.delete) {
       types.push(
         ...flatten(this.fields.map(field => field.getGqlAuxTypes({ schemaName }))),
         `
@@ -1143,13 +1137,7 @@ module.exports = class List {
 
   gqlAuxFieldResolvers({ schemaName }) {
     const schemaAccess = this.access[schemaName];
-    if (
-      schemaAccess.read ||
-      schemaAccess.create ||
-      schemaAccess.update ||
-      schemaAccess.delete ||
-      schemaAccess.auth
-    ) {
+    if (schemaAccess.read || schemaAccess.create || schemaAccess.update || schemaAccess.delete) {
       return objMerge(this.fields.map(field => field.gqlAuxFieldResolvers({ schemaName })));
     }
     return {};

--- a/tests/api-tests/access-control/not-authed.test.js
+++ b/tests/api-tests/access-control/not-authed.test.js
@@ -1,9 +1,5 @@
 const { multiAdapterRunners } = require('@keystone-next/test-utils-legacy');
-const {
-  deleteItem,
-  createItems,
-  updateItem,
-} = require('@keystone-next/server-side-graphql-client-legacy');
+const { createItems, updateItem } = require('@keystone-next/server-side-graphql-client-legacy');
 const {
   FAKE_ID,
   nameFn,
@@ -27,10 +23,11 @@ const expectNoAccess = (data, errors, name) => {
 
 multiAdapterRunners().map(({ before, after, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    let keystone, items;
+    let keystone, items, context;
     beforeAll(async () => {
       const _before = await before(setupKeystone);
       keystone = _before.keystone;
+      context = _before.context;
 
       // ensure every list has at least some data
       const initialData = listAccessVariations.reduce(
@@ -44,7 +41,6 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
       );
 
       items = {};
-      const context = keystone.createContext({ schemaName: 'internal' });
       for (const [listKey, _items] of Object.entries(initialData)) {
         items[listKey] = await createItems({
           keystone,
@@ -68,7 +64,7 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
               test(`denied: ${JSON.stringify(access)}`, async () => {
                 const createMutationName = `create${nameFn[mode](access)}`;
                 const query = `mutation { ${createMutationName}(data: { name: "bar" }) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, createMutationName);
               });
             });
@@ -86,26 +82,24 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const createMutationName = `create${nameFn[mode](listAccess)}`;
                 const fieldName = getFieldName(access);
                 const query = `mutation { ${createMutationName}(data: { ${fieldName}: "bar" }) { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
-                // If create is not allowed on a field then there's no error, it's just set to null
-                expect(errors).toBe(undefined);
-                expect(data[createMutationName]).not.toBe(null);
-                expect(data[createMutationName].id).not.toBe(null);
-                if (access.read) {
-                  expect(data[createMutationName][fieldName]).toBe(null);
-                } else {
-                  expect(data[createMutationName][fieldName]).toBe(undefined);
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
+                // If create is not allowed on a field then there will be a query validation error
+                expect(errors).toHaveLength(access.read ? 1 : 2);
+                expect(errors[0].message).toContain(
+                  `Field "${fieldName}" is not defined by type "${nameFn[mode](
+                    listAccess
+                  )}CreateInput".`
+                );
+                if (!access.read) {
+                  expect(errors[1].message).toContain(
+                    `Cannot query field "${fieldName}" on type "${nameFn[mode](listAccess)}".`
+                  );
                 }
-                await deleteItem({
-                  keystone,
-                  listKey: nameFn[mode](listAccess),
-                  itemId: data[createMutationName].id,
-                });
+                expect(data).toBe(undefined);
               });
             });
         });
@@ -121,12 +115,11 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const createMutationName = `create${nameFn[mode](listAccess)}`;
                 const fieldName = getFieldName(access);
                 const query = `mutation { ${createMutationName}(data: { ${fieldName}: "bar" }) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expect(data[createMutationName]).toEqual(null);
                 expect(errors).not.toBe(undefined);
                 expect(errors).toHaveLength(1);
@@ -148,14 +141,14 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
               test(`'all' denied: ${JSON.stringify(access)}`, async () => {
                 const allQueryName = `all${nameFn[mode](access)}s`;
                 const query = `query { ${allQueryName} { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, allQueryName);
               });
 
               test(`meta denied: ${JSON.stringify(access)}`, async () => {
                 const metaName = `_all${nameFn[mode](access)}sMeta`;
                 const query = `query { ${metaName} { count } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expect(data[metaName].count).toBe(null);
                 expect(errors).toHaveLength(1);
                 const error = errors[0];
@@ -168,7 +161,7 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
               test(`single denied: ${JSON.stringify(access)}`, async () => {
                 const singleQueryName = nameFn[mode](access);
                 const query = `query { ${singleQueryName}(where: { id: "abc123" }) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, singleQueryName);
               });
             });
@@ -185,19 +178,18 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
                 const singleQueryName = listKey;
                 await updateItem({
-                  context: keystone.createContext({ schemaName: 'internal' }),
+                  context,
                   listKey,
                   item: { id: item.id, data: { [fieldName]: 'hello' } },
                 });
                 const query = `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expect(errors).not.toBe(null);
                 expect(errors).toHaveLength(1);
                 expect(errors[0].name).toEqual('GraphQLError');
@@ -213,19 +205,18 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
                 const allQueryName = `all${listKey}s`;
                 await updateItem({
-                  context: keystone.createContext({ schemaName: 'internal' }),
+                  context,
                   listKey,
                   item: { id: item.id, data: { [fieldName]: 'hello' } },
                 });
                 const query = `query { ${allQueryName} { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expect(errors).not.toBe(null);
                 expect(errors).toHaveLength(2);
                 expect(errors[0].name).toEqual('GraphQLError');
@@ -255,23 +246,23 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
                 const singleQueryName = listKey;
                 await updateItem({
-                  context: keystone.createContext({ schemaName: 'internal' }),
+                  context,
                   listKey,
                   item: { id: item.id, data: { [fieldName]: 'hello' } },
                 });
                 const query = `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
-                expect(errors).toEqual(undefined);
-                expect(data[singleQueryName]).not.toBe(null);
-                expect(data[singleQueryName].id).not.toBe(null);
-                expect(data[singleQueryName][fieldName]).toBe(undefined);
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
+                expect(errors).toHaveLength(1);
+                expect(errors[0].message).toContain(
+                  `Cannot query field "${fieldName}" on type "${listKey}".`
+                );
+                expect(data).toBe(undefined);
               });
               test(`field allowed - multi: ${JSON.stringify(access)}`, async () => {
                 const listAccess = {
@@ -279,26 +270,23 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
                 const allQueryName = `all${listKey}s`;
                 await updateItem({
-                  context: keystone.createContext({ schemaName: 'internal' }),
+                  context,
                   listKey,
                   item: { id: item.id, data: { [fieldName]: 'hello' } },
                 });
                 const query = `query { ${allQueryName} { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
-                expect(errors).toBe(undefined);
-                expect(data[allQueryName]).not.toBe(null);
-                expect(data[allQueryName]).toHaveLength(2);
-                for (const _item of data[allQueryName]) {
-                  expect(_item.id).not.toBe(null);
-                  expect(_item[fieldName]).toEqual(undefined);
-                }
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
+                expect(errors).toHaveLength(1);
+                expect(errors[0].message).toContain(
+                  `Cannot query field "${fieldName}" on type "${listKey}".`
+                );
+                expect(data).toBe(undefined);
               });
             });
         });
@@ -314,7 +302,7 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
               test(`denies: ${JSON.stringify(access)}`, async () => {
                 const updateMutationName = `update${nameFn[mode](access)}`;
                 const query = `mutation { ${updateMutationName}(id: "${FAKE_ID}", data: { name: "bar" }) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, updateMutationName);
               });
             });
@@ -332,23 +320,21 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const updateMutationName = `update${nameFn[mode](listAccess)}`;
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
-                const query = `mutation { ${updateMutationName}(id: "${item.id}", data: { ${fieldName}: "bar" }) { id ${fieldName} } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
-                // If update is not allowed on a field then there's no error, it's just set to null
-                expect(errors).toBe(undefined);
-                expect(data[updateMutationName]).not.toBe(null);
-                expect(data[updateMutationName].id).not.toBe(null);
-                if (access.read) {
-                  expect(data[updateMutationName][fieldName]).toBe(null);
-                } else {
-                  expect(data[updateMutationName][fieldName]).toBe(undefined);
-                }
+                const query = `mutation { ${updateMutationName}(id: "${
+                  item.id
+                }", data: { ${fieldName}: "bar" }) { id ${access.read ? fieldName : ''} } }`;
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
+                // If update is not allowed on a field then there will be a query validation error
+                expect(errors).toHaveLength(1);
+                expect(errors[0].message).toContain(
+                  `Field "${fieldName}" is not defined by type "${listKey}UpdateInput".`
+                );
+                expect(data).toBe(undefined);
               });
             });
         });
@@ -364,14 +350,13 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
                   read: true,
                   update: true,
                   delete: true,
-                  auth: false,
                 };
                 const updateMutationName = `update${nameFn[mode](listAccess)}`;
                 const listKey = nameFn[mode](listAccess);
                 const item = items[listKey][0];
                 const fieldName = getFieldName(access);
                 const query = `mutation { ${updateMutationName}(id: "${item.id}", data: { ${fieldName}: "bar" }) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expect(data[updateMutationName]).toEqual(null);
                 expect(errors).not.toBe(undefined);
                 expect(errors).toHaveLength(1);
@@ -393,14 +378,14 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
               test(`single denied: ${JSON.stringify(access)}`, async () => {
                 const deleteMutationName = `delete${nameFn[mode](access)}`;
                 const query = `mutation { ${deleteMutationName}(id: "${FAKE_ID}") { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, deleteMutationName);
               });
 
               test(`multi denied: ${JSON.stringify(access)}`, async () => {
                 const multiDeleteMutationName = `delete${nameFn[mode](access)}s`;
                 const query = `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID}"]) { id } }`;
-                const { data, errors } = await keystone.executeGraphQL({ query });
+                const { data, errors } = await context.exitSudo().executeGraphQL({ query });
                 expectNoAccess(data, errors, multiDeleteMutationName);
               });
             });

--- a/tests/api-tests/access-control/schema.test.js
+++ b/tests/api-tests/access-control/schema.test.js
@@ -44,12 +44,13 @@ const imperativeList = getImperativeListName({
 
 multiAdapterRunners().map(({ before, after, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
-    let keystone, queries, mutations, types, fieldTypes;
+    let keystone, queries, mutations, types, fieldTypes, context;
     beforeAll(async () => {
       const _before = await before(setupKeystone);
       keystone = _before.keystone;
+      context = _before.context;
 
-      const { data, errors } = await keystone.executeGraphQL({
+      const { data, errors } = await context.exitSudo().executeGraphQL({
         query: introspectionQuery,
       });
       expect(errors).toBe(undefined);
@@ -72,7 +73,7 @@ multiAdapterRunners().map(({ before, after, adapterName }) =>
         test(JSON.stringify(access), async () => {
           const name = getStaticListName(access);
           // The type is used in all the queries and mutations as a return type
-          if (access.create || access.read || access.update || access.delete || access.auth) {
+          if (access.create || access.read || access.update || access.delete) {
             expect(types).toContain(`${name}`);
             // Filter types are also available for update/delete/create (thanks
             // to nested mutations)

--- a/tests/api-tests/access-control/utils.js
+++ b/tests/api-tests/access-control/utils.js
@@ -1,16 +1,19 @@
-const { setupServer } = require('@keystone-next/test-utils-legacy');
-const { Text } = require('@keystone-next/fields-legacy');
-const { PasswordAuthStrategy } = require('@keystone-next/auth-password-legacy');
+const { text, password } = require('@keystone-next/fields');
+const { createSchema, list } = require('@keystone-next/keystone/schema');
+const { statelessSessions, withItemData } = require('@keystone-next/keystone/session');
+const { setupFromConfig } = require('@keystone-next/test-utils-legacy');
+const { createAuth } = require('@keystone-next/auth');
 const { objMerge } = require('@keystone-next/utils-legacy');
 
 const FAKE_ID = { mongoose: '5b3eabd9e9f2e3e4866742ea', knex: 137, prisma: 137 };
 const FAKE_ID_2 = { mongoose: '5b3eabd9e9f2e3e4866742eb', knex: 138, prisma: 138 };
+const COOKIE_SECRET = 'qwertyuiopasdfghjlkzxcvbmnm1234567890';
 
 const yesNo = truthy => (truthy ? 'Yes' : 'No');
 
 const getPrefix = access => {
   // prettier-ignore
-  let prefix = `${yesNo(access.create)}Create${yesNo(access.read)}Read${yesNo(access.update)}Update${yesNo(access.auth)}Auth`;
+  let prefix = `${yesNo(access.create)}Create${yesNo(access.read)}Read${yesNo(access.update)}Update`;
   if (Object.prototype.hasOwnProperty.call(access, 'delete')) {
     prefix = `${prefix}${yesNo(access.delete)}Delete`;
   }
@@ -23,7 +26,7 @@ const getDeclarativeListName = access => `${getPrefix(access)}DeclarativeList`;
 
 /* Generated with:
   const result = [];
-  const options = ['create', 'read', 'update', 'delete', 'auth'];
+  const options = ['create', 'read', 'update', 'delete'];
   // All possible combinations are contained in the set 0..2^n-1
   for(let flags = 0; flags < Math.pow(2, options.length); flags++) {
     // Generate an object of true/false values for the particular combination
@@ -35,38 +38,22 @@ const getDeclarativeListName = access => `${getPrefix(access)}DeclarativeList`;
   }
   */
 const listAccessVariations = [
-  { create: false, read: false, update: false, delete: false, auth: true },
-  { create: true, read: false, update: false, delete: false, auth: true },
-  { create: false, read: true, update: false, delete: false, auth: true },
-  { create: true, read: true, update: false, delete: false, auth: true },
-  { create: false, read: false, update: true, delete: false, auth: true },
-  { create: true, read: false, update: true, delete: false, auth: true },
-  { create: false, read: true, update: true, delete: false, auth: true },
-  { create: true, read: true, update: true, delete: false, auth: true },
-  { create: false, read: false, update: false, delete: true, auth: true },
-  { create: true, read: false, update: false, delete: true, auth: true },
-  { create: false, read: true, update: false, delete: true, auth: true },
-  { create: true, read: true, update: false, delete: true, auth: true },
-  { create: false, read: false, update: true, delete: true, auth: true },
-  { create: true, read: false, update: true, delete: true, auth: true },
-  { create: false, read: true, update: true, delete: true, auth: true },
-  { create: true, read: true, update: true, delete: true, auth: true },
-  { create: false, read: false, update: false, delete: false, auth: false },
-  { create: true, read: false, update: false, delete: false, auth: false },
-  { create: false, read: true, update: false, delete: false, auth: false },
-  { create: true, read: true, update: false, delete: false, auth: false },
-  { create: false, read: false, update: true, delete: false, auth: false },
-  { create: true, read: false, update: true, delete: false, auth: false },
-  { create: false, read: true, update: true, delete: false, auth: false },
-  { create: true, read: true, update: true, delete: false, auth: false },
-  { create: false, read: false, update: false, delete: true, auth: false },
-  { create: true, read: false, update: false, delete: true, auth: false },
-  { create: false, read: true, update: false, delete: true, auth: false },
-  { create: true, read: true, update: false, delete: true, auth: false },
-  { create: false, read: false, update: true, delete: true, auth: false },
-  { create: true, read: false, update: true, delete: true, auth: false },
-  { create: false, read: true, update: true, delete: true, auth: false },
-  { create: true, read: true, update: true, delete: true, auth: false },
+  { create: false, read: false, update: false, delete: false },
+  { create: true, read: false, update: false, delete: false },
+  { create: false, read: true, update: false, delete: false },
+  { create: true, read: true, update: false, delete: false },
+  { create: false, read: false, update: true, delete: false },
+  { create: true, read: false, update: true, delete: false },
+  { create: false, read: true, update: true, delete: false },
+  { create: true, read: true, update: true, delete: false },
+  { create: false, read: false, update: false, delete: true },
+  { create: true, read: false, update: false, delete: true },
+  { create: false, read: true, update: false, delete: true },
+  { create: true, read: true, update: false, delete: true },
+  { create: false, read: false, update: true, delete: true },
+  { create: true, read: false, update: true, delete: true },
+  { create: false, read: true, update: true, delete: true },
+  { create: true, read: true, update: true, delete: true },
 ];
 
 const fieldMatrix = [
@@ -88,75 +75,70 @@ const nameFn = {
 };
 
 const createFieldStatic = fieldAccess => ({
-  [getFieldName(fieldAccess)]: {
-    type: Text,
-    access: fieldAccess,
-  },
+  [getFieldName(fieldAccess)]: text({ access: fieldAccess }),
 });
 const createFieldImperative = fieldAccess => ({
-  [getFieldName(fieldAccess)]: {
-    type: Text,
+  [getFieldName(fieldAccess)]: text({
     access: {
       create: () => fieldAccess.create,
       read: () => fieldAccess.read,
       update: () => fieldAccess.update,
     },
-  },
+  }),
 });
 function setupKeystone(adapterName) {
-  return setupServer({
-    adapterName,
-    createLists: keystone => {
-      keystone.createList('User', {
-        fields: {
-          name: { type: Text },
-          noRead: { type: Text, access: { read: () => false } },
-          yesRead: { type: Text, access: { read: () => true } },
-        },
-      });
-      keystone.createAuthStrategy({ type: PasswordAuthStrategy, list: 'User' });
+  const lists = {
+    User: list({
+      fields: {
+        name: text(),
+        email: text(),
+        password: password(),
+        noRead: text({ access: { read: () => false } }),
+        yesRead: text({ access: { read: () => true } }),
+      },
+    }),
+  };
 
-      listAccessVariations.forEach(access => {
-        keystone.createList(getStaticListName(access), {
-          fields: {
-            name: { type: Text },
-            ...objMerge(fieldMatrix.map(variation => createFieldStatic(variation))),
-          },
-          access,
-        });
-        if (access.auth) {
-          keystone.createAuthStrategy({
-            type: PasswordAuthStrategy,
-            list: getStaticListName(access),
-            config: {},
-          });
-        }
-        keystone.createList(getImperativeListName(access), {
-          fields: {
-            name: { type: Text },
-            ...objMerge(fieldMatrix.map(variation => createFieldImperative(variation))),
-          },
-          access: {
-            create: () => access.create,
-            read: () => access.read,
-            update: () => access.update,
-            delete: () => access.delete,
-            auth: () => access.auth,
-          },
-        });
-        keystone.createList(getDeclarativeListName(access), {
-          fields: { name: { type: Text } },
-          access: {
-            create: access.create,
-            // arbitrarily restrict the data to a single item (see data.js)
-            read: () => access.read && { name_starts_with: 'Hello' },
-            update: () => access.update && { name_starts_with: 'Hello' },
-            delete: () => access.delete && { name_starts_with: 'Hello' },
-            auth: access.auth,
-          },
-        });
-      });
-    },
+  listAccessVariations.forEach(access => {
+    lists[getStaticListName(access)] = list({
+      fields: {
+        name: text(),
+        ...objMerge(fieldMatrix.map(variation => createFieldStatic(variation))),
+      },
+      access,
+    });
+    lists[getImperativeListName(access)] = list({
+      fields: {
+        name: text(),
+        ...objMerge(fieldMatrix.map(variation => createFieldImperative(variation))),
+      },
+      access: {
+        create: () => access.create,
+        read: () => access.read,
+        update: () => access.update,
+        delete: () => access.delete,
+      },
+    });
+    lists[getDeclarativeListName(access)] = list({
+      fields: { name: text() },
+      access: {
+        create: access.create,
+        // arbitrarily restrict the data to a single item (see data.js)
+        read: () => access.read && { name_starts_with: 'Hello' },
+        update: () => access.update && { name_starts_with: 'Hello' },
+        delete: () => access.delete && { name_starts_with: 'Hello' },
+      },
+    });
+  });
+  const auth = createAuth({ listKey: 'User', identityField: 'email', secretField: 'password' });
+  return setupFromConfig({
+    adapterName,
+    config: auth.withAuth(
+      createSchema({
+        lists,
+        session: withItemData(statelessSessions({ secret: COOKIE_SECRET }), { User: 'id' }),
+      })
+    ),
   });
 }
 module.exports = {


### PR DESCRIPTION
We need to test the access control API of the new interfaces. This PR ports the existing tests to use the new interfaces.

This has exposed various internal fixes which need to happen before these tests will pass. I will ship separate PRs for each of these changes, and then put this PR up for review once they are complete.