### PR TITLE
Deprecate KeystoneContext.keystone

### DIFF
--- a/.changeset/sharp-news-speak.md
+++ b/.changeset/sharp-news-speak.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': minor
+---
+
+Deprecated `KeystoneContext.keystone`.

--- a/packages-next/types/src/context.ts
+++ b/packages-next/types/src/context.ts
@@ -17,6 +17,7 @@ export type KeystoneContext = {
   gqlNames: (listKey: string) => Record<string, string>; // TODO: actual keys
   /** @deprecated */
   executeGraphQL: any; // TODO: type this
+  /** @deprecated */
   keystone: BaseKeystone;
 } & AccessControlContext &
   Partial<SessionContext<any>> &


### PR DESCRIPTION
This API will evaporate at some point soon, so deprecating now so that it can be documented as such in #4940 .