### PR TITLE
Remove context arg from raw() and run()

### DIFF
--- a/.changeset/modern-squids-move.md
+++ b/.changeset/modern-squids-move.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+---
+
+Removed the `context` argument from `KeystoneContext.graphql.raw` and `KeystoneContext.graphql.run`.

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -33,7 +33,7 @@ export function makeCreateContext({
     skipAccessControl?: boolean;
     req?: IncomingMessage;
   } = {}): KeystoneContext => {
-    const rawGraphQL: KeystoneGraphQLAPI<any>['raw'] = ({ query, context, variables }) => {
+    const rawGraphQL: KeystoneGraphQLAPI<any>['raw'] = ({ query, variables }) => {
       if (typeof query === 'string') {
         query = parse(query);
       }
@@ -41,13 +41,13 @@ export function makeCreateContext({
         execute({
           schema: graphQLSchema,
           document: query,
-          contextValue: context ?? contextToReturn,
+          contextValue: contextToReturn,
           variableValues: variables,
         })
       );
     };
-    const runGraphQL: KeystoneGraphQLAPI<any>['run'] = async args => {
-      let result = await rawGraphQL(args);
+    const runGraphQL: KeystoneGraphQLAPI<any>['run'] = async ({ query, variables }) => {
+      let result = await rawGraphQL({ query, variables });
       if (result.errors?.length) {
         throw result.errors[0];
       }

--- a/packages-next/types/src/context.ts
+++ b/packages-next/types/src/context.ts
@@ -82,7 +82,6 @@ export type KeystoneGraphQLAPI<
 };
 
 type GraphQLExecutionArguments = {
-  context?: any;
   query: string | DocumentNode;
   variables: Record<string, any>;
 };


### PR DESCRIPTION
This argument was mostly for backwards compatibility which is no longer required. None of our remaining use cases need this argument, and it makes the documentation much more confusing to explain.