### PR TITLE
Remove packages-next and examples-next from skip CI filter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           filters: |
             shouldRunTests:
-              - '!{{website,docs,examples,packages-next,examples-next,design-system}/**,**/*.md}'
+              - '!{{website,docs,examples,design-system}/**,**/*.md}'
       - run: echo "SHOULD_RUN_TESTS=$SHOULD_RUN" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
Changes in both `packages-next` and `examples-next` are now covered by unit tests and we should be running CI on them 👍 