### PR TITLE
Fix bug in passwordResetLink

### DIFF
--- a/.changeset/soft-stingrays-happen.md
+++ b/.changeset/soft-stingrays-happen.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Fixed bug when using `passwordResetLink` with a secretField other than 'password'.

--- a/.changeset/soft-stingrays-happen.md
+++ b/.changeset/soft-stingrays-happen.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-next/auth': patch
+'@keystone-next/auth': major
 ---
 
-Fixed bug when using `passwordResetLink` with a secretField other than 'password'.
+Fixed a bug when using `passwordResetLink` with a `secretField` other than `'password'`. If you used a `secretField` other than `'password'` then the generated fields in your schema will change.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -62,9 +62,9 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   } as const;
 
   const additionalListFields = {
-    [`${secretField}ResetToken`]: password({ ...fieldConfig }),
-    [`${secretField}ResetIssuedAt`]: timestamp({ ...fieldConfig }),
-    [`${secretField}ResetRedeemedAt`]: timestamp({ ...fieldConfig }),
+    [`passwordResetToken`]: password({ ...fieldConfig }),
+    [`passwordResetIssuedAt`]: timestamp({ ...fieldConfig }),
+    [`passwordResetRedeemedAt`]: timestamp({ ...fieldConfig }),
     [`magicAuthToken`]: password({ ...fieldConfig }),
     [`magicAuthIssuedAt`]: timestamp({ ...fieldConfig }),
     [`magicAuthRedeemedAt`]: timestamp({ ...fieldConfig }),


### PR DESCRIPTION
These field names need to correspond to `const tokenType = 'passwordReset';` in `getPasswordSchemaReset.ts`. They aren't meant to be dynamic on the field name.