### PR TITLE
Pin react-day-picker version

### DIFF
--- a/.changeset/lazy-jeans-sell.md
+++ b/.changeset/lazy-jeans-sell.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/fields': patch
+---
+
+Pinned dependency `react-day-picker` to `8.0.0-beta.3`.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -58,7 +58,7 @@
     "p-settle": "^4.1.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
-    "react-day-picker": "^8.0.0-beta.3",
+    "react-day-picker": "8.0.0-beta.3",
     "react-dom": "^17.0.1",
     "react-image": "^4.0.3",
     "react-select": "^3.2.0",


### PR DESCRIPTION
Upgrading to latest versions of the beta cause breakage to our CI that I'd rather not deal with immediately. This will allow our renovate PRs to go through more cleanly without needing manual intervention.