### PR TITLE
Fix crash if the prisma client directory exists but the prisma schema doesn't

### DIFF
--- a/.changeset/wet-nails-move.md
+++ b/.changeset/wet-nails-move.md
@@ -1,0 +1,5 @@
+---
+'@keystonejs/adapter-prisma': patch
+---
+
+Fixed crash if the prisma client directory existed but the prisma schema didn't.

--- a/.changeset/wet-nails-move.md
+++ b/.changeset/wet-nails-move.md
@@ -2,4 +2,4 @@
 '@keystonejs/adapter-prisma': patch
 ---
 
-Fixed crash if the prisma client directory existed but the prisma schema didn't.
+Fixed crash if the prisma client directory exists but the prisma schema doesn't.


### PR DESCRIPTION
Found this when writing tests for the examples. Also made it so the checking logic does fewer file system operations.

I would write a test for this but I couldn't find a nice place for it where there are tests for generating migrations or something?