### PR TITLE
Remove protectIdentities from the createAuth API

### DIFF
--- a/.changeset/honest-poems-compete.md
+++ b/.changeset/honest-poems-compete.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': major
+---
+
+Removed `protectIdentities` from the `createAuth` arguments. The behaviour is now the same as having `protectIdentities: true`.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -20,12 +20,16 @@ import { initTemplate } from './templates/init';
 export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   listKey,
   secretField,
-  protectIdentities = true,
   initFirstItem,
   identityField,
   magicAuthLink,
   passwordResetLink,
 }: AuthConfig<GeneratedListTypes>): Auth {
+  // The protectIdentities flag is currently under review to see whether it should be
+  // part of the createAuth API (in which case its use cases need to be documented and tested)
+  // or whether always being true is what we want, in which case we can refactor our code
+  // to match this. -TL
+  const protectIdentities = true;
   const gqlNames: AuthGqlNames = {
     CreateInitialInput: `CreateInitial${listKey}Input`,
     createInitialItem: `createInitial${listKey}`,

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -41,8 +41,6 @@ export type AuthConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {
   identityField: GeneratedListTypes['fields'];
   /** The path of the field the secret is stored in; must be password-ish */
   secretField: GeneratedListTypes['fields'];
-  /** Attempts to prevent consumers of the API from being able to determine the value of identity fields */
-  protectIdentities?: boolean;
   /** Password reset link functionality */
   passwordResetLink?: AuthTokenTypeConfig;
   /** "Magic link" functionality */


### PR DESCRIPTION
The protectIdentities flag is currently under review to see whether it should be part of the createAuth API (in which case its use cases need to be documented and tested) or whether always being true is what we want, in which case we can refactor our code to match this.