### PR TITLE
Only create password reset fields if needed

### DIFF
--- a/.changeset/nine-bees-clean.md
+++ b/.changeset/nine-bees-clean.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': major
+---
+
+The `passwordReset*` fields and `magicAuth*` fields are only added to the system if `passwordResetLink` and `magicAuthLink` respectively are set.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -60,14 +60,16 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
       listView: { fieldMode: 'hidden' },
     },
   } as const;
-
+  // These field names have to follow this format so that for e.g
+  // validateAuthToken() behaves correctly.
+  const tokenFields = (tokenType: 'passwordReset' | 'magicAuth') => ({
+    [`${tokenType}Token`]: password({ ...fieldConfig }),
+    [`${tokenType}IssuedAt`]: timestamp({ ...fieldConfig }),
+    [`${tokenType}RedeemedAt`]: timestamp({ ...fieldConfig }),
+  });
   const additionalListFields = {
-    [`passwordResetToken`]: password({ ...fieldConfig }),
-    [`passwordResetIssuedAt`]: timestamp({ ...fieldConfig }),
-    [`passwordResetRedeemedAt`]: timestamp({ ...fieldConfig }),
-    [`magicAuthToken`]: password({ ...fieldConfig }),
-    [`magicAuthIssuedAt`]: timestamp({ ...fieldConfig }),
-    [`magicAuthRedeemedAt`]: timestamp({ ...fieldConfig }),
+    ...(passwordResetLink && tokenFields('passwordReset')),
+    ...(magicAuthLink && tokenFields('magicAuth')),
   };
 
   /**


### PR DESCRIPTION
The `passwordReset*` fields and `magicAuth*` fields should only added to the system if `passwordResetLink` and `magicAuthLink` respectively are set.