### PR TITLE
Pass context to sendToken

### DIFF
--- a/.changeset/lazy-foxes-mate.md
+++ b/.changeset/lazy-foxes-mate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': minor
+---
+
+Added `context` argument to `sendToken` function used by `passwordResetLink` and `magicAuthLink`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 <br>
 
 <!-- ![CI](https://github.com/keystonejs/keystone/workflows/CI/badge.svg) -->
+
 <!-- [![slack](https://keystone-community.now.sh//badge.svg)](https://keystone-community.now.sh/) -->
+
 <!-- [![Supported by Thinkmill](https://thinkmill.github.io/badge/heart.svg)](http://thinkmill.com.au/?utm_source=github&utm_medium=badge&utm_campaign=react-select) -->
 
 ## Contents
@@ -36,6 +38,7 @@ The [Keystone 5](https://github.com/keystonejs/keystone-5) codebase is now in ac
 For more information please read our [Keystone 5 and beyond](https://github.com/keystonejs/keystone-5/issues/21) post.
 
 <!-- ## Getting Started -->
+
 <!-- TBC -->
 
 ## Documentation
@@ -49,27 +52,35 @@ In the next month you'll see a new project starter and getting started guide, as
 We'd love to hear your feedback, reach out on Twitter at [KeystoneJS](https://twitter.com/keystonejs) and [subscribe](https://next.keystonejs.com/roadmap#project-status) to be notified of our progress.
 
 <!-- ## Version control -->
+
 <!-- TBC -->
 
 <!-- ## Contributing -->
+
 <!-- TBC -->
 
 <!-- ### Demo Projects -->
+
 <!-- TBC -->
 
 <!-- ### Development Practices -->
+
 <!-- TBC -->
 
 <!-- ### Setup -->
+
 <!-- TBC -->
 
 <!-- ### Testing -->
+
 <!-- TBC -->
 
 <!-- ### Unit Tests -->
+
 <!-- TBC -->
 
 <!-- ### End-to-End Tests -->
+
 <!-- TBC -->
 
 ## Code of Conduct

--- a/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages-next/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -90,7 +90,7 @@ export function getMagicAuthLinkSchema<I extends string>({
               resolveFields: false,
             });
 
-            await magicAuthLink.sendToken({ itemId, identity, token });
+            await magicAuthLink.sendToken({ itemId, identity, token, context });
           }
           return null;
         },

--- a/packages-next/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages-next/auth/src/gql/getPasswordResetSchema.ts
@@ -92,7 +92,7 @@ export function getPasswordResetSchema<I extends string, S extends string>({
               resolveFields: false,
             });
 
-            await passwordResetLink.sendToken({ itemId, identity, token });
+            await passwordResetLink.sendToken({ itemId, identity, token, context });
           }
           return null;
         },

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -1,4 +1,9 @@
-import { BaseGeneratedListTypes, AdminUIConfig, KeystoneConfig } from '@keystone-next/types';
+import {
+  BaseGeneratedListTypes,
+  AdminUIConfig,
+  KeystoneConfig,
+  KeystoneContext,
+} from '@keystone-next/types';
 
 export type AuthGqlNames = {
   CreateInitialInput: string;
@@ -25,6 +30,7 @@ export type SendTokenFn = (args: {
   itemId: string | number;
   identity: string;
   token: string;
+  context: KeystoneContext;
 }) => Promise<void> | void;
 
 export type AuthTokenTypeConfig = {


### PR DESCRIPTION
The system designer will probably want more than just an `id` and `email` address when sending the password reset/auth link emails. Passing a context lets them pull in the info they need to customise their password reset/magic link emails. 