### PR TITLE
No /init in publicPages if not using initFirstItem

### DIFF
--- a/.changeset/spotty-rockets-design.md
+++ b/.changeset/spotty-rockets-design.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Updated `creatAuth` to only include `/init` in `publicPages` if `initFirstItem` is being used.

--- a/.changeset/spotty-rockets-design.md
+++ b/.changeset/spotty-rockets-design.md
@@ -2,4 +2,4 @@
 '@keystone-next/auth': patch
 ---
 
-Updated `creatAuth` to only include `/init` in `publicPages` if `initFirstItem` is being used.
+Updated `createAuth` to only include `/init` in `publicPages` if `initFirstItem` is being used.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -157,7 +157,10 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    *
    * Must be added to the ui.publicPages config
    */
-  const publicAuthPages = ['/signin', '/init'];
+  const publicAuthPages = ['/signin'];
+  if (initFirstItem) {
+    publicAuthPages.push('/init');
+  }
 
   /**
    * extendGraphqlSchema


### PR DESCRIPTION
 Updated `creatAuth` to only include `/init` in `publicPages` if `initFirstItem` is being used.