### PR TITLE
form submit tests

### DIFF
--- a/docs-next/cypress.json
+++ b/docs-next/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "experimentalFetchPolyfill": true
+}

--- a/docs-next/cypress/integration/subscribe-form.js
+++ b/docs-next/cypress/integration/subscribe-form.js
@@ -1,0 +1,65 @@
+const SIGNUP_ENDPOINT = 'https://signup.keystonejs.cloud/api/newsletter-signup';
+describe('on successful submit', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8000');
+    cy.server();
+    cy.route('POST', SIGNUP_ENDPOINT, {
+      success: true,
+      email: 'cc.lee@live.com.au',
+    }).as('newsletterSignup');
+    cy.get('input[type=text]').type('cc.lee@live.com.au');
+    cy.get('form button').click();
+  });
+  it('should replace the form with a thank you message', () => {
+    cy.wait('@newsletterSignup').then(() => {
+      cy.contains('❤️ Thank you for subscribing!');
+    });
+  });
+  it('should post the email to the expected URL', () => {
+    cy.wait('@newsletterSignup').then(({ request }) => {
+      expect(request.body.email).to.equal('cc.lee@live.com.au');
+      expect(request.body.source).to.equal('@keystone-next/website');
+    });
+  });
+});
+
+describe('on unsuccessful server side validation', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8000');
+    cy.server();
+    cy.route({
+      method: 'POST',
+      url: SIGNUP_ENDPOINT,
+      status: 400,
+      response: {
+        error: 'Invalid email address',
+      },
+    }).as('newsletterSignup');
+    cy.get('input[type=text]').type('cc.lee@live.com.au');
+    cy.get('form button').click();
+  });
+  it('should prompt the user to try again', () => {
+    cy.wait('@newsletterSignup').then(() => {
+      cy.get('form button').contains('Try again');
+    });
+  });
+  it.only('should display an appropriate error message', () => {
+    cy.wait('@newsletterSignup').then(() => {
+      cy.contains('Invalid email address');
+    });
+  });
+});
+
+describe('on unsuccessful client side validation', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8000');
+    cy.get('input[type=text]').type('cc.le');
+    cy.get('form button').click();
+  });
+  it('should prompt the user to try again', () => {
+    cy.get('form button').contains('Try again');
+  });
+  it('shold display an appropriate error message', () => {
+    cy.contains('Please enter a valid email');
+  });
+});

--- a/docs-next/cypress/integration/subscribe-form.js
+++ b/docs-next/cypress/integration/subscribe-form.js
@@ -11,12 +11,12 @@ describe('on successful submit', () => {
     cy.get('form button').click();
   });
   it('should replace the form with a thank you message', () => {
-    cy.wait('@newsletterSignup').then(() => {
+    return cy.wait('@newsletterSignup').then(() => {
       cy.contains('❤️ Thank you for subscribing!');
     });
   });
   it('should post the email to the expected URL', () => {
-    cy.wait('@newsletterSignup').then(({ request }) => {
+    return cy.wait('@newsletterSignup').then(({ request }) => {
       expect(request.body.email).to.equal('cc.lee@live.com.au');
       expect(request.body.source).to.equal('@keystone-next/website');
     });
@@ -39,12 +39,12 @@ describe('on unsuccessful server side validation', () => {
     cy.get('form button').click();
   });
   it('should prompt the user to try again', () => {
-    cy.wait('@newsletterSignup').then(() => {
+    return cy.wait('@newsletterSignup').then(() => {
       cy.get('form button').contains('Try again');
     });
   });
-  it.only('should display an appropriate error message', () => {
-    cy.wait('@newsletterSignup').then(() => {
+  it('should display an appropriate error message', () => {
+    return cy.wait('@newsletterSignup').then(() => {
       cy.contains('Invalid email address');
     });
   });


### PR DESCRIPTION
This PR includes:
* enabling the experimental fetch polyfill feature flag, so that cypress can stub fetch requests. **
* adding basic tests for the submission form on the welcome page. 

** This flag is marked for deprecation, and as such we should upgrade cypress from 5.6 --> 6 ASAP to make use of the new (less hacky) intercept() api. 