### PR TITLE
Add tests for null relationship input

### DIFF
--- a/.changeset/three-bikes-speak.md
+++ b/.changeset/three-bikes-speak.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone-legacy': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Added explicit handling of `null` values for relationship fields in `create` and `update` mutations.

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -614,6 +614,8 @@ module.exports = class List {
   async _resolveRelationship(data, existingItem, context, getItem, mutationState) {
     const fields = this._fieldsFromObject(data).filter(field => field.isRelationship);
     const resolvedRelationships = await mapToFields(fields, async field => {
+      // Treat `null` as `undefined`, e.g. a no-op
+      if (data[field.path] === null) return undefined;
       const { create, connect, disconnect, currentValue } = await field.resolveNestedOperations(
         data[field.path],
         existingItem,

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.js
@@ -235,6 +235,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createUser(data: {
+                    friends: null
+                  }) { id friends { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Friends should be empty
+            expect(data.createUser.friends).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -345,6 +364,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Check the link has been broken
             const result = await getUserAndFriend(context, user.id, friend.id);
             expect(result.User.friends).toEqual([]);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateUser(
+                    id: "${user.id}",
+                    data: { friends: null }
+                  ) { id friends { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the friends are still there
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toHaveLength(1);
+            expect(data.updateUser.friends[0].id).toEqual(friend.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many.test.js
@@ -334,6 +334,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createUser(data: {
+                    friends: null
+                  }) { id friends { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Friends should be empty
+            expect(data.createUser.friends).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -449,6 +468,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getUserAndFriend(context, user.id, friend.id);
             expect(result.User.friends).toEqual([]);
             expect(result.Friend.friendOf).toEqual([]);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateUser(
+                    id: "${user.id}",
+                    data: { friends: null }
+                  ) { id friends { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the friends are still there
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toHaveLength(1);
+            expect(data.updateUser.friends[0].id).toEqual(friend.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.js
@@ -227,6 +227,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(User.friend.id.toString()).toBe(Friend.id.toString());
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createUser(data: {
+                    friend: null
+                  }) { id friend { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Friend should be empty
+            expect(data.createUser.friend).toBe(null);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -337,6 +356,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Check the link has been broken
             const result = await getUserAndFriend(context, user.id, friend.id);
             expect(result.User.friend).toBe(null);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { friend, user } = await createUserAndFriend(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateUser(
+                    id: "${user.id}",
+                    data: { friend: null }
+                  ) { id friend { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the friend is still there
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friend).not.toBe(null);
+            expect(data.updateUser.friend.id).toEqual(friend.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.js
@@ -370,6 +370,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               });
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createUser(data: {
+                    friends: null
+                  }) { id friends { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Friends should be empty
+            expect(data.createUser.friends).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -485,6 +504,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getUserAndFriend(context, user.id, friend.id);
             expect(result.User.friends).toEqual([]);
             expect(result.Friend.friendOf).toBe(null);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateUser(
+                    id: "${user.id}",
+                    data: { friends: null }
+                  ) { id friends { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the friends are still there
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friends).toHaveLength(1);
+            expect(data.updateUser.friends[0].id).toEqual(friend.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.js
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.js
@@ -384,6 +384,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               });
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createUser(data: {
+                    friend: null
+                  }) { id friend { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Friend should be empty
+            expect(data.createUser.friend).toBe(null);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -499,6 +518,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getUserAndFriend(context, user.id, friend.id);
             expect(result.User.friend).toBe(null);
             expect(result.Friend.friendOf).toBe(null);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { user, friend } = await createUserAndFriend(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateUser(
+                    id: "${user.id}",
+                    data: { friend: null }
+                  ) { id friend { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the friend is still there
+            expect(data.updateUser.id).toEqual(user.id);
+            expect(data.updateUser.friend).not.toBe(null);
+            expect(data.updateUser.friend.id).toEqual(friend.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.js
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.js
@@ -323,6 +323,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             ]);
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createCompany(data: {
+                    locations: null
+                  }) { id locations { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Locations should be empty
+            expect(data.createCompany.locations).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -441,6 +460,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Check the link has been broken
             const result = await getCompanyAndLocation(context, company.id, location.id);
             expect(result.Company.locations).toEqual([]);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { locations: null }
+                  ) { id locations { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the locations are still there
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toHaveLength(1);
+            expect(data.updateCompany.locations[0].id).toEqual(location.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud/many-to-many.test.js
+++ b/tests/api-tests/relationships/crud/many-to-many.test.js
@@ -423,6 +423,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             );
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createCompany(data: {
+                    locations: null
+                  }) { id locations { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Locations should be empty
+            expect(data.createCompany.locations).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -550,6 +569,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getCompanyAndLocation(context, company.id, location.id);
             expect(result.Company.locations).toEqual([]);
             expect(result.Location.companies).toEqual([]);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { locations: null }
+                  ) { id locations { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the locations are still there
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toHaveLength(1);
+            expect(data.updateCompany.locations[0].id).toEqual(location.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.js
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.js
@@ -248,6 +248,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(Company.location.id.toString()).toBe(Location.id.toString());
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createCompany(data: {
+                    location: null
+                  }) { id location { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Location should be empty
+            expect(data.createCompany.location).toBe(null);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -362,6 +381,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             // Check the link has been broken
             const result = await getCompanyAndLocation(context, company.id, location.id);
             expect(result.Company.location).toBe(null);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { location: null }
+                  ) { id location { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the location is still there
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).not.toBe(null);
+            expect(data.updateCompany.location.id).toEqual(location.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud/one-to-many.test.js
+++ b/tests/api-tests/relationships/crud/one-to-many.test.js
@@ -396,6 +396,25 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               });
           })
         );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createCompany(data: {
+                    locations: null
+                  }) { id locations { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Locations should be empty
+            expect(data.createCompany.locations).toHaveLength(0);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -519,6 +538,32 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getCompanyAndLocation(context, company.id, location.id);
             expect(result.Company.locations).toEqual([]);
             expect(result.Location.company).toBe(null);
+          })
+        );
+
+        test(
+          'With null',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { locations: null }
+                  ) { id locations { id name } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the locations are still there
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.locations).toHaveLength(1);
+            expect(data.updateCompany.locations[0].id).toEqual(location.id);
           })
         );
       });

--- a/tests/api-tests/relationships/crud/one-to-one.test.js
+++ b/tests/api-tests/relationships/crud/one-to-one.test.js
@@ -670,6 +670,44 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(result2.company).toEqual({ id: company.id });
           })
         );
+
+        test(
+          'With null A',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createCompany(data: {
+                    location: null
+                  }) { id location { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Location should be empty
+            expect(data.createCompany.location).toBe(null);
+          })
+        );
+
+        test(
+          'With null B',
+          runner(setupKeystone, async ({ context }) => {
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  createLocation(data: {
+                    company: null
+                  }) { id company { id } }
+                }
+            `,
+            });
+            expect(errors).toBe(undefined);
+
+            // Company should be empty
+            expect(data.createLocation.company).toBe(null);
+          })
+        );
       });
 
       describe('Update', () => {
@@ -1030,6 +1068,56 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const result = await getCompanyAndLocation(context, company.id, location.id);
             expect(result.Company.location).toBe(null);
             expect(result.Location.company).toBe(null);
+          })
+        );
+
+        test(
+          'With null A',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createCompanyAndLocation(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateCompany(
+                    id: "${company.id}",
+                    data: { location: null }
+                  ) { id location { id name } }
+                }`,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the location is still there
+            expect(data.updateCompany.id).toEqual(company.id);
+            expect(data.updateCompany.location).not.toBe(null);
+            expect(data.updateCompany.location.id).toEqual(location.id);
+          })
+        );
+
+        test(
+          'With null B',
+          runner(setupKeystone, async ({ context }) => {
+            // Manually setup a connected Company <-> Location
+            const { location, company } = await createLocationAndCompany(context);
+
+            // Run the query with a null operation
+            const { data, errors } = await context.executeGraphQL({
+              query: `
+                mutation {
+                  updateLocation(
+                    id: "${location.id}",
+                    data: { company: null }
+                  ) { id company { id name } }
+                }`,
+            });
+            expect(errors).toBe(undefined);
+
+            // Check that the company is still there
+            expect(data.updateLocation.id).toEqual(location.id);
+            expect(data.updateLocation.company).not.toBe(null);
+            expect(data.updateLocation.company.id).toEqual(company.id);
           })
         );
       });


### PR DESCRIPTION
Relationship fields in `create` and `update` operations currently accept `null` as a valid GraphQL input. This is not currently handled correctly, see #5014 .

This PR adds tests and clarifies that `null` input is equivalent to `undefined` input, e.g. does not set or change the field value.

In the future we might need to revisit whether we want to disallow `null` as an input value, or apply different semantics (e.g. `null` being equivalent to `disconnectAll` in update). This PR is simply setting a well defined baseline to build on.