### PR TITLE
Reorder tests to kick off critical path early

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,78 @@ jobs:
       - run: echo "SHOULD_RUN_TESTS=true" >> $GITHUB_ENV
         if: github.event_name != 'pull_request'
 
+  cypress:
+    name: Cypress tests
+    needs: should_run_tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: keystone5
+          POSTGRES_PASSWORD: k3yst0n3
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+    env:
+      DATABASE_URL: 'postgres://keystone5:k3yst0n3@localhost:5432/test_db'
+      CLOUDINARY_CLOUD_NAME: $CLOUDINARY_CLOUD_NAME
+      CLOUDINARY_KEY: $CLOUDINARY_KEY
+      CLOUDINARY_SECRET: $CLOUDINARY_SECRET
+      PORT: 3000
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - docs-next
+          - tests/test-projects/basic
+          - tests/test-projects/login
+          - tests/test-projects/access-control
+          - tests/test-projects/client-validation
+    steps:
+      - name: Checkout Repo
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+        uses: actions/checkout@v2
+      - name: Setup Node.js 14.x
+        uses: actions/setup-node@main
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+        with:
+          node-version: 14.x
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+        with:
+          path: |
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            node_modules
+          key: ${{ runner.os }}-yarn-v4-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-v4-
+
+      - name: Install Dependencies
+        run: yarn
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+      - run: yarn --cwd ${{ matrix.project }} cypress install
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+      - run: yarn --cwd ${{ matrix.project }} cypress:run:ci
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-videos
+          path: cypress/videos
+
   api-tests:
     name: API Tests
     needs: should_run_tests
@@ -238,75 +310,3 @@ jobs:
         run: yarn build
       - name: Remark
         run: yarn lint:markdown
-
-  cypress:
-    name: Cypress tests
-    needs: should_run_tests
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: keystone5
-          POSTGRES_PASSWORD: k3yst0n3
-          POSTGRES_DB: test_db
-        ports:
-          - 5432:5432
-    env:
-      DATABASE_URL: 'postgres://keystone5:k3yst0n3@localhost:5432/test_db'
-      CLOUDINARY_CLOUD_NAME: $CLOUDINARY_CLOUD_NAME
-      CLOUDINARY_KEY: $CLOUDINARY_KEY
-      CLOUDINARY_SECRET: $CLOUDINARY_SECRET
-      PORT: 3000
-    strategy:
-      fail-fast: false
-      matrix:
-        project:
-          - tests/test-projects/basic
-          - tests/test-projects/login
-          - tests/test-projects/access-control
-          - tests/test-projects/client-validation
-          - docs-next
-    steps:
-      - name: Checkout Repo
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        uses: actions/checkout@v2
-      - name: Setup Node.js 14.x
-        uses: actions/setup-node@main
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        with:
-          node-version: 14.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        id: yarn-cache
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            node_modules
-          key: ${{ runner.os }}-yarn-v4-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-v4-
-
-      - name: Install Dependencies
-        run: yarn
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-      - run: yarn --cwd ${{ matrix.project }} cypress install
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-      - run: yarn --cwd ${{ matrix.project }} cypress:run:ci
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-videos
-          path: cypress/videos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
           path: cypress/videos
 
   graphql-api-tests:
-    name: GraphQL API Tests
+    name: API Tests
     needs: should_run_tests
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
           path: cypress/videos
 
   api-tests:
-    name: API Tests
+    name: GraphQL API Tests
     needs: should_run_tests
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           name: cypress-videos
           path: cypress/videos
 
-  api-tests:
+  graphql-api-tests:
     name: GraphQL API Tests
     needs: should_run_tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'm hoping this will get our longest running tests kicked off first to reduce the length of the critical path in CI.

Update: Moving `docs-next` to the top of the matrix worked. Reordering blocks in the file, and changing the `name` field of the jobs made no difference. Change the actual `job` name (e.g. `api-tests` -> `graphql-api-tests`) made a difference. It would seem that jobs run in alphabetical order based on their `job` name, so we now kick off `docs-next` as the first test in the first job that gets run, which is what we want 👍 