### PR TITLE
Tweak renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
     }
   ],
   "rangeStrategy": "bump",
-  "schedule": ["before 7pm on Tuesday"],
+  "schedule": ["before 7am on Tuesday", "before 7am on Wednesday"],
   "timezone": "Australia/Sydney",
   "updateNotScheduled": false
 }


### PR DESCRIPTION
I recently noticed that for some reason renovate bot wasn't getting around to creating PRs for all the branches it had. Not sure why 🤷‍♂️ . We bumped the schedule to give it until `7pm` to get its work done.

Now I remember why we scheduled it for outside work hours: It's way too enthusiastic about updating all its PRs all the time!

This changes the schedule back to before 7am, but lets it run on both Tuesday and Wednesday morning. Let's see if this schedule gives us the right balance between eternally chasing deps, and being able to keep everything up to date.