### PR TITLE
Tell prettier to leave our docs code alone

### DIFF
--- a/docs-next/pages/apis/graphql.mdx
+++ b/docs-next/pages/apis/graphql.mdx
@@ -196,7 +196,7 @@ type User {
 }
 ```
 
-### _allUsersMeta
+### \_allUsersMeta
 
 ```graphql
 type Query {

--- a/docs-next/pages/apis/graphql.mdx
+++ b/docs-next/pages/apis/graphql.mdx
@@ -196,7 +196,7 @@ type User {
 }
 ```
 
-### \_allUsersMeta
+### _allUsersMeta
 
 ```graphql
 type Query {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,13 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "printWidth": 100,
-    "arrowParens": "avoid"
+    "arrowParens": "avoid",
+    "overrides": [{
+      "files": "docs-next/**",
+      "options": {
+        "embeddedLanguageFormatting": "off"
+      }
+    }]
   },
   "remarkConfig": {
     "settings": {


### PR DESCRIPTION
The way we write code in docs does not conform to our regular prettier config, as it needs to present code in a more concise way than we normally would in fully fledged code.

This PR tells prettier to ignore the inline code snippets, while still checking the docs themselves.