### PR TITLE
Prebuild docs site before tests

### DIFF
--- a/.changeset/cyan-buckets-happen.md
+++ b/.changeset/cyan-buckets-happen.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/website': patch
+---
+
+Updated cypress tests to pre-build the site before running the tests.

--- a/docs-next/package.json
+++ b/docs-next/package.json
@@ -5,9 +5,11 @@
   "license": "MIT",
   "scripts": {
     "dev": "next -p 8000",
+    "build": "next build",
+    "start": "next start -p 8000",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cypress:run:ci": "start-server-and-test dev http://localhost:8000 cy:run"
+    "cypress:run:ci": "yarn build && start-server-and-test start http://localhost:8000 cy:run"
   },
   "dependencies": {
     "@babel/runtime": "^7.13.9",


### PR DESCRIPTION
Experiment to see if building the docs site up front will speed up the cypress tests.

Update: Success! This change brings the total time for the test down from ~9 minutes to under 5 minutes, which means this test is no longer on the critical path 👍 