### PR TITLE
Fix viewport meta tag

### DIFF
--- a/.changeset/chilled-items-call.md
+++ b/.changeset/chilled-items-call.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/website': patch
+---
+
+Moved viewport meta tag from \_document to \_app to avoid dedupe issues and next warnings.

--- a/docs-next/pages/_app.tsx
+++ b/docs-next/pages/_app.tsx
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx, Core } from '@keystone-ui/core';
+import Head from 'next/head';
 import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
@@ -21,6 +22,12 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <Core>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
+        />
+      </Head>
       <ToastProvider>
         <Component {...pageProps} />
       </ToastProvider>

--- a/docs-next/pages/_document.tsx
+++ b/docs-next/pages/_document.tsx
@@ -20,11 +20,6 @@ class MyDocument extends Document {
           <link rel="mask-icon" color="#2684FF" href="/safari-pinned-tab.svg" />
           <link rel="shortcut icon" href="/favicon.ico" />
 
-          <meta
-            name="viewport"
-            content="width=device-width,initial-scale=1,shrink-to-fit=no,viewport-fit=cover"
-          />
-
           <meta property="og:image" content={`${siteUrl}/og-image-landscape.png`} />
           <meta property="og:image:width" content="761" />
           <meta property="og:image:height" content="410" />


### PR DESCRIPTION
Viewport meta tags shouldn't be in `_document.tsx` for the following [reasons](https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md)

Viewport meta tag now moved to the `_app.tsx` file instead
