### PR TITLE
Change createKeystone and createSystem to accept a migration mode rather than script

### DIFF
--- a/.changeset/new-bears-train.md
+++ b/.changeset/new-bears-train.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': minor
+---
+
+Added `MigrationMode` type

--- a/.changeset/nice-crews-jog.md
+++ b/.changeset/nice-crews-jog.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/admin-ui': major
+'@keystone-next/test-utils-legacy': major
+---
+
+Updated `createKeystone` to accept a migration mode rather than script

--- a/.changeset/nice-crews-jog.md
+++ b/.changeset/nice-crews-jog.md
@@ -4,4 +4,4 @@
 '@keystone-next/test-utils-legacy': major
 ---
 
-Updated `createKeystone` to accept a migration mode rather than script
+Updated `createKeystone` and `createSystem` to accept a migration mode rather than script

--- a/packages-next/admin-ui/src/templates/api.ts
+++ b/packages-next/admin-ui/src/templates/api.ts
@@ -11,7 +11,7 @@ import { initConfig, createSystem, createApolloServerMicro } from '@keystone-nex
 import { PrismaClient } from '../../../../../prisma/generated-client';
 
 const initializedKeystoneConfig = initConfig(keystoneConfig);
-const { graphQLSchema, keystone, createContext } = createSystem(initializedKeystoneConfig, '.keystone', 'start', PrismaClient);
+const { graphQLSchema, keystone, createContext } = createSystem(initializedKeystoneConfig, '.keystone', 'none', PrismaClient);
 const apolloServer = createApolloServerMicro({
   graphQLSchema,
   createContext,

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -7,12 +7,12 @@ import { MongooseAdapter } from '@keystone-next/adapter-mongoose-legacy';
 import { KnexAdapter } from '@keystone-next/adapter-knex-legacy';
 // @ts-ignore
 import { PrismaAdapter } from '@keystone-next/adapter-prisma-legacy';
-import type { KeystoneConfig, BaseKeystone } from '@keystone-next/types';
+import type { KeystoneConfig, BaseKeystone, MigrationMode } from '@keystone-next/types';
 
 export function createKeystone(
   config: KeystoneConfig,
   dotKeystonePath: string,
-  script: string,
+  migrationMode: MigrationMode,
   prismaClient?: any
 ) {
   // Note: For backwards compatibility we may want to expose
@@ -31,14 +31,7 @@ export function createKeystone(
   } else if (db.adapter === 'prisma_postgresql') {
     adapter = new PrismaAdapter({
       getPrismaPath: () => path.join(dotKeystonePath, 'prisma'),
-      migrationMode:
-        script === 'prototype'
-          ? 'prototype'
-          : script === 'generate'
-          ? 'createOnly'
-          : script === 'dev'
-          ? 'dev'
-          : 'none',
+      migrationMode,
       prismaClient,
       ...db,
     });

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,4 +1,4 @@
-import type { KeystoneConfig } from '@keystone-next/types';
+import type { KeystoneConfig, MigrationMode } from '@keystone-next/types';
 
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './createContext';
@@ -7,10 +7,10 @@ import { createKeystone } from './createKeystone';
 export function createSystem(
   config: KeystoneConfig,
   dotKeystonePath: string,
-  script: string,
+  migrationMode: MigrationMode,
   prismaClient?: any
 ) {
-  const keystone = createKeystone(config, dotKeystonePath, script, prismaClient);
+  const keystone = createKeystone(config, dotKeystonePath, migrationMode, prismaClient);
 
   const graphQLSchema = createGraphQLSchema(config, keystone);
 

--- a/packages-next/keystone/src/scripts/build/build.ts
+++ b/packages-next/keystone/src/scripts/build/build.ts
@@ -88,7 +88,7 @@ export async function build({ dotKeystonePath, projectAdminPath }: StaticPaths) 
 
   const config = initConfig(requireSource(CONFIG_PATH).default);
 
-  const { keystone, graphQLSchema } = createSystem(config, dotKeystonePath, 'build');
+  const { keystone, graphQLSchema } = createSystem(config, dotKeystonePath, 'none');
 
   console.log('✨ Generating graphQL schema');
   await saveSchemaAndTypes(graphQLSchema, keystone, dotKeystonePath);

--- a/packages-next/keystone/src/scripts/migrate/deploy.ts
+++ b/packages-next/keystone/src/scripts/migrate/deploy.ts
@@ -8,7 +8,7 @@ export const deploy = async ({ dotKeystonePath }: StaticPaths) => {
   console.log('🤞 Migrating Keystone');
 
   const config = initConfig(requireSource(CONFIG_PATH).default);
-  const keystone = createKeystone(config, dotKeystonePath, 'deploy');
+  const keystone = createKeystone(config, dotKeystonePath, 'none');
 
   console.log('✨ Deploying migrations');
   await keystone.adapter.deploy(keystone._consolidateRelationships());

--- a/packages-next/keystone/src/scripts/migrate/generate.ts
+++ b/packages-next/keystone/src/scripts/migrate/generate.ts
@@ -12,7 +12,7 @@ export const generate = async ({ dotKeystonePath }: StaticPaths) => {
   const { keystone, graphQLSchema, createContext } = createSystem(
     config,
     dotKeystonePath,
-    'generate'
+    'createOnly'
   );
 
   console.log('✨ Generating graphQL schema');

--- a/packages-next/keystone/src/scripts/migrate/reset.ts
+++ b/packages-next/keystone/src/scripts/migrate/reset.ts
@@ -8,7 +8,7 @@ export const reset = async ({ dotKeystonePath }: StaticPaths) => {
   console.log('🤞 Migrating Keystone');
 
   const config = initConfig(requireSource(CONFIG_PATH).default);
-  const keystone = createKeystone(config, dotKeystonePath, 'reset');
+  const keystone = createKeystone(config, dotKeystonePath, 'none');
 
   console.log('✨ Resetting database');
   await keystone.adapter._prepareSchema(keystone._consolidateRelationships());

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -8,6 +8,7 @@ import { createExpressServer } from '../../lib/createExpressServer';
 import { saveSchemaAndTypes } from '../../lib/saveSchemaAndTypes';
 import { CONFIG_PATH } from '../utils';
 import type { StaticPaths } from '..';
+import { MigrationMode } from '@keystone-next/types';
 
 // TODO: Don't generate or start an Admin UI if it isn't configured!!
 const devLoadingHTMLFilepath = path.join(
@@ -17,7 +18,10 @@ const devLoadingHTMLFilepath = path.join(
   'dev-loading.html'
 );
 
-export const dev = async ({ dotKeystonePath, projectAdminPath }: StaticPaths, script = 'dev') => {
+export const dev = async (
+  { dotKeystonePath, projectAdminPath }: StaticPaths,
+  migrationMode: MigrationMode = 'dev'
+) => {
   console.log('🤞 Starting Keystone');
 
   const server = express();
@@ -28,7 +32,7 @@ export const dev = async ({ dotKeystonePath, projectAdminPath }: StaticPaths, sc
     const { keystone, graphQLSchema, createContext } = createSystem(
       config,
       dotKeystonePath,
-      script
+      migrationMode
     );
 
     console.log('✨ Generating graphQL schema');

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -15,7 +15,7 @@ export const start = async ({ dotKeystonePath, projectAdminPath }: StaticPaths) 
     throw new Error('keystone-next build must be run before running keystone-next start');
   }
   const config = initConfig(require(apiFile).config);
-  const { keystone, graphQLSchema, createContext } = createSystem(config, dotKeystonePath, 'start');
+  const { keystone, graphQLSchema, createContext } = createSystem(config, dotKeystonePath, 'none');
 
   console.log('✨ Connecting to the database');
   await keystone.connect({ context: createContext().sudo() });

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -65,3 +65,5 @@ export function getGqlNames({
     relateToOneInputName: `${_itemQueryName}RelateToOneInput`,
   };
 }
+
+export type MigrationMode = 'none' | 'createOnly' | 'dev' | 'prototype';

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -72,7 +72,7 @@ async function setupFromConfig({
   const { keystone, createContext, graphQLSchema } = createSystem(
     config,
     path.resolve('.keystone'),
-    ''
+    'prototype'
   );
 
   const app = await createExpressServer(config, graphQLSchema, createContext, true, '', false);


### PR DESCRIPTION
This is extracted out of #5059. There's no behavior change here, I just feel like accepting a migration mode is more clear than the current script arg.