### PR TITLE
Make sure that yarn format doesn't break things

### DIFF
--- a/docs-next/pages/apis/graphql.mdx
+++ b/docs-next/pages/apis/graphql.mdx
@@ -196,6 +196,7 @@ type User {
 }
 ```
 
+<!-- prettier-ignore -->
 ### _allUsersMeta
 
 ```graphql

--- a/examples-next/graphql-api-endpoint/CHANGELOG.md
+++ b/examples-next/graphql-api-endpoint/CHANGELOG.md
@@ -1,6 +1,7 @@
 # keystone-next-app
 
 ## 0.0.2
+
 ### Patch Changes
 
 - Updated dependencies [[`a2c52848a`](https://github.com/keystonejs/keystone/commit/a2c52848a3a7b66a1968a430040887194e6138d1), [`acc6e9772`](https://github.com/keystonejs/keystone/commit/acc6e9772b4a312a62ea756777034638c03a3761), [`acc6e9772`](https://github.com/keystonejs/keystone/commit/acc6e9772b4a312a62ea756777034638c03a3761)]:

--- a/packages/app-graphql/README.md
+++ b/packages/app-graphql/README.md
@@ -37,11 +37,11 @@ module.exports = {
 
 ## Config
 
-| Option         | Type     | Default           | Description                                      |
-| -------------- | -------- | ----------------- | ------------------------------------------------ |
-| `apiPath`      | `String` | `/admin/api`      | Change the API path                              |
-| `schemaName`   | `String` | `admin`           | Change the graphQL schema name (not recommended) |
-| `apollo`       | `Object` | `{}`              | Options passed directly to Apollo Server         |
+| Option       | Type     | Default      | Description                                      |
+| ------------ | -------- | ------------ | ------------------------------------------------ |
+| `apiPath`    | `String` | `/admin/api` | Change the API path                              |
+| `schemaName` | `String` | `admin`      | Change the graphQL schema name (not recommended) |
+| `apollo`     | `Object` | `{}`         | Options passed directly to Apollo Server         |
 
 ## Setting a custom schemaName
 


### PR DESCRIPTION
A few files needed formatting, and one file was doing the wrong thing when we formatted it, so added an ignore tag.