### PR TITLE
Support access: false in items API and schema type printer

### DIFF
--- a/.changeset/friendly-timers-bathe.md
+++ b/.changeset/friendly-timers-bathe.md
@@ -1,6 +1,5 @@
 ---
 '@keystone-next/keystone': patch
-'@keystone-next/types': patch
 ---
 
 Updated items API to handle static `false` access control.

--- a/.changeset/friendly-timers-bathe.md
+++ b/.changeset/friendly-timers-bathe.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': patch
+'@keystone-next/types': patch
+---
+
+Updated items API to handle static `false` access control.

--- a/packages-next/keystone/src/lib/getCoerceAndValidateArgumentsFnForGraphQLField.ts
+++ b/packages-next/keystone/src/lib/getCoerceAndValidateArgumentsFnForGraphQLField.ts
@@ -43,8 +43,9 @@ function getTypeNodeForType(type: GraphQLType): TypeNode {
 
 export function getCoerceAndValidateArgumentsFnForGraphQLField(
   schema: GraphQLSchema,
-  field: GraphQLField<any, any>
+  field?: GraphQLField<any, any>
 ) {
+  if (!field) return;
   const variableDefintions: VariableDefinitionNode[] = [];
 
   for (const arg of field.args) {

--- a/packages-next/keystone/src/lib/itemAPI.ts
+++ b/packages-next/keystone/src/lib/itemAPI.ts
@@ -43,6 +43,7 @@ export function itemAPIForList(
   const listKey = list.key;
   return {
     findOne({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.findOne) throw new Error('You do not have access to this resource');
       const args = getArgs.findOne(rawArgs) as { where: { id: string } };
       if (resolveFields) {
         return getItem({ listKey, context, returnFields: resolveFields, itemId: args.where.id });
@@ -51,6 +52,7 @@ export function itemAPIForList(
       }
     },
     findMany({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.findMany) throw new Error('You do not have access to this resource');
       const args = getArgs.findMany(rawArgs);
       if (resolveFields) {
         return getItems({ listKey, context, returnFields: resolveFields, ...args });
@@ -59,10 +61,12 @@ export function itemAPIForList(
       }
     },
     async count(rawArgs) {
-      const args = getArgs.count(rawArgs);
+      if (!getArgs.count) throw new Error('You do not have access to this resource');
+      const args = getArgs.count(rawArgs!);
       return (await list.listQueryMeta(args, context)).getCount();
     },
     createOne({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.createOne) throw new Error('You do not have access to this resource');
       const { data } = getArgs.createOne(rawArgs);
       if (resolveFields) {
         return createItem({ listKey, context, returnFields: resolveFields, item: data });
@@ -71,6 +75,7 @@ export function itemAPIForList(
       }
     },
     createMany({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.createMany) throw new Error('You do not have access to this resource');
       const { data } = getArgs.createMany(rawArgs);
       if (resolveFields) {
         return createItems({ listKey, context, returnFields: resolveFields, items: data });
@@ -79,6 +84,7 @@ export function itemAPIForList(
       }
     },
     updateOne({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.updateOne) throw new Error('You do not have access to this resource');
       const { id, data } = getArgs.updateOne(rawArgs);
       if (resolveFields) {
         return updateItem({ listKey, context, returnFields: resolveFields, item: { id, data } });
@@ -87,6 +93,7 @@ export function itemAPIForList(
       }
     },
     updateMany({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.updateMany) throw new Error('You do not have access to this resource');
       const { data } = getArgs.updateMany(rawArgs);
       if (resolveFields) {
         return updateItems({ listKey, context, returnFields: resolveFields, items: data });
@@ -95,6 +102,7 @@ export function itemAPIForList(
       }
     },
     deleteOne({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.deleteOne) throw new Error('You do not have access to this resource');
       const { id } = getArgs.deleteOne(rawArgs);
       if (resolveFields) {
         return deleteItem({ listKey, context, returnFields: resolveFields, itemId: id });
@@ -103,6 +111,7 @@ export function itemAPIForList(
       }
     },
     deleteMany({ resolveFields = 'id', ...rawArgs }) {
+      if (!getArgs.deleteMany) throw new Error('You do not have access to this resource');
       const { ids } = getArgs.deleteMany(rawArgs);
       if (resolveFields) {
         return deleteItems({ listKey, context, returnFields: resolveFields, items: ids });

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -147,7 +147,11 @@ export type ${listTypeInfoName} = {
     update: ${gqlNames.updateInputName};
   };
   args: {
-    listQuery: ${listQuery ? printArgs(listQuery.arguments!) : undefined}
+    listQuery: ${
+      listQuery
+        ? printArgs(listQuery.arguments!)
+        : 'import("@keystone-next-types").BaseGeneratedListTypes["args"]["listQuery"]'
+    }
   };
 };
 

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -133,6 +133,7 @@ export function printGeneratedTypes(
 
     const { gqlNames } = list;
     let listTypeInfoName = `${listKey}ListTypeInfo`;
+    const listQuery = queryNodeFieldsByName[gqlNames.listQueryName];
     printedTypes += `
 export type ${listTypeInfoName} = {
   key: ${JSON.stringify(listKey)};
@@ -146,7 +147,7 @@ export type ${listTypeInfoName} = {
     update: ${gqlNames.updateInputName};
   };
   args: {
-    listQuery: ${printArgs(queryNodeFieldsByName[gqlNames.listQueryName].arguments!)}
+    listQuery: ${listQuery ? printArgs(listQuery.arguments!) : undefined}
   };
 };
 

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -150,7 +150,7 @@ export type ${listTypeInfoName} = {
     listQuery: ${
       listQuery
         ? printArgs(listQuery.arguments!)
-        : 'import("@keystone-next-types").BaseGeneratedListTypes["args"]["listQuery"]'
+        : 'import("@keystone-next/types").BaseGeneratedListTypes["args"]["listQuery"]'
     }
   };
 };

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -4,7 +4,7 @@ export type BaseGeneratedListTypes = {
   backing: BackingTypeForItem;
   inputs: { create: GraphQLInput; update: GraphQLInput; where: GraphQLInput };
   args: {
-    listQuery?: {
+    listQuery: {
       readonly where?: GraphQLInput | null;
       readonly search?: string | null;
       readonly first?: number | null;

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -4,7 +4,7 @@ export type BaseGeneratedListTypes = {
   backing: BackingTypeForItem;
   inputs: { create: GraphQLInput; update: GraphQLInput; where: GraphQLInput };
   args: {
-    listQuery: {
+    listQuery?: {
       readonly where?: GraphQLInput | null;
       readonly search?: string | null;
       readonly first?: number | null;


### PR DESCRIPTION
At the moment, using [static `false` access control](https://next.keystonejs.com/apis/access-control#static-list) breaks the items API and the schema type printer, because we completely parts of the graphQL schema that these systems expect to exist.

This PR is a first pass to unblock the porting of the existing access control tests #4931 and #5097 to keystone-next. These changes are not intended to reflect a final locked in design, but will unblock us from moving forward so that we can follow up with design and testing of this use case in the items API and schema type printer. 