### PR TITLE
Use graphql() instead of execute()

### DIFF
--- a/.changeset/calm-gifts-yawn.md
+++ b/.changeset/calm-gifts-yawn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated `context.graphql.raw` and `context.graphql.run` to use the GraphQL function `graphql` rather than `execute`. This function performs more rigorous query validation before executing the query.

--- a/examples-next/ecommerce/tests/mutations.test.ts
+++ b/examples-next/ecommerce/tests/mutations.test.ts
@@ -76,7 +76,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
           // Add some products to some carts
           const q1 = asUser(context, user1.id).graphql.raw;
           const q =
-            'mutation m($productId: ID!){ addToCart(productId: $productId) { id label quantity product { id } user { id } } }';
+            'mutation m($productId: ID!){ addToCart(productId: $productId) { id quantity product { id } user { id } } }';
           await q1({ query: q, variables: { productId: product1.id } });
           await q1({ query: q, variables: { productId: product2.id } });
           await q1({ query: q, variables: { productId: product1.id } });
@@ -140,7 +140,7 @@ multiAdapterRunners('mongoose').map(({ runner }) =>
 
     describe('addToCart(productId)', () => {
       const query =
-        'mutation m($productId: ID!){ addToCart(productId: $productId) { id label quantity product { id } user { id } } }';
+        'mutation m($productId: ID!){ addToCart(productId: $productId) { id quantity product { id } user { id } } }';
       test(
         'Not logged in should throw',
         runner(setupKeystone, async ({ context }) => {

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from 'http';
-import { execute, GraphQLSchema, parse } from 'graphql';
+import { graphql, GraphQLSchema, print } from 'graphql';
 import type {
   SessionContext,
   KeystoneContext,
@@ -45,16 +45,9 @@ export function makeCreateContext({
     const schema = schemaName === 'public' ? graphQLSchema : internalSchema;
 
     const rawGraphQL: KeystoneGraphQLAPI<any>['raw'] = ({ query, variables }) => {
-      if (typeof query === 'string') {
-        query = parse(query);
-      }
+      const source = typeof query === 'string' ? query : print(query);
       return Promise.resolve(
-        execute({
-          schema,
-          document: query,
-          contextValue: contextToReturn,
-          variableValues: variables,
-        })
+        graphql({ schema, source, contextValue: contextToReturn, variableValues: variables })
       );
     };
     const runGraphQL: KeystoneGraphQLAPI<any>['run'] = async ({ query, variables }) => {

--- a/tests/api-tests/queries/filters.test.js
+++ b/tests/api-tests/queries/filters.test.js
@@ -32,7 +32,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'filter works when there is no dash in list name',
         runner(setupKeystone, async ({ context }) => {
           const { data, errors } = await context.executeGraphQL({
-            query: `{ allUsers(where: { noDash: "aValue" })}`,
+            query: `{ allUsers(where: { noDash: "aValue" }) { id } }`,
           });
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
@@ -42,7 +42,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'filter works when there is one dash in list name',
         runner(setupKeystone, async ({ context }) => {
           const { data, errors } = await context.executeGraphQL({
-            query: `{ allUsers(where: { single_dash: "aValue" })}`,
+            query: `{ allUsers(where: { single_dash: "aValue" }) { id } }`,
           });
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
@@ -52,7 +52,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'filter works when there are multiple dashes in list name',
         runner(setupKeystone, async ({ context }) => {
           const { data, errors } = await context.executeGraphQL({
-            query: `{ allUsers(where: { many_many_many_dashes: "aValue" })}`,
+            query: `{ allUsers(where: { many_many_many_dashes: "aValue" }) { id } }`,
           });
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
@@ -62,7 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'filter works when there are multiple dashes in a row in a list name',
         runner(setupKeystone, async ({ context }) => {
           const { data, errors } = await context.executeGraphQL({
-            query: `{ allUsers(where: { multi____dash: "aValue" })}`,
+            query: `{ allUsers(where: { multi____dash: "aValue" }) { id } }`,
           });
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
@@ -72,7 +72,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'filter works when there is one dash in list name as part of a relationship',
         runner(setupKeystone, async ({ context }) => {
           const { data, errors } = await context.executeGraphQL({
-            query: `{ allSecondaryLists(where: { user_is_null: true })}`,
+            query: `{ allSecondaryLists(where: { someUser_is_null: true }) { id } }`,
           });
           expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allSecondaryLists', []);

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.js
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.js
@@ -329,7 +329,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
                 if (group.name === 'GroupNoCreateHard') {
                   // For { create: false } the mutation won't even exist, so we expect a different behaviour
-                  expect(data[`createEventTo${group.name}`]).toBe(null);
+                  expect(data).toBe(undefined);
+                  expect(errors).toHaveLength(1);
+                  expect(errors[0].message).toEqual(
+                    `Field "create" is not defined by type "${group.name}RelateToOneInput".`
+                  );
                 } else {
                   // Assert it throws an access denied error
                   expect(data[`createEventTo${group.name}`]).toBe(null);
@@ -401,7 +405,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 // Assert it throws an access denied error
                 if (group.name === 'GroupNoCreateHard') {
                   // For { create: false } the mutation won't even exist, so we expect a different behaviour
-                  expect(data[`updateEventTo${group.name}`]).toBe(null);
+                  expect(data).toBe(undefined);
+                  expect(errors).toHaveLength(1);
+                  expect(errors[0].message).toEqual(
+                    `Field "create" is not defined by type "${group.name}RelateToOneInput".`
+                  );
                 } else {
                   expect(data[`updateEventTo${group.name}`]).toBe(null);
                   expect(errors).toHaveLength(1);


### PR DESCRIPTION
`graphql()` performs query validation before executing the query, which catches certain edge cases we want to protect against. c.f. #4931 