### PR TITLE
Skip generating prisma client in keystone-next start

### DIFF
--- a/.changeset/lovely-days-smile.md
+++ b/.changeset/lovely-days-smile.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/adapter-prisma-legacy': minor
+'@keystone-next/types': minor
+'@keystone-next/keystone': minor
+---
+
+Added `none-skip-client-generation` migrationMode

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -15,7 +15,11 @@ export const start = async ({ dotKeystonePath, projectAdminPath }: StaticPaths) 
     throw new Error('keystone-next build must be run before running keystone-next start');
   }
   const config = initConfig(require(apiFile).config);
-  const { keystone, graphQLSchema, createContext } = createSystem(config, dotKeystonePath, 'none');
+  const { keystone, graphQLSchema, createContext } = createSystem(
+    config,
+    dotKeystonePath,
+    'none-skip-client-generation'
+  );
 
   console.log('✨ Connecting to the database');
   await keystone.connect({ context: createContext().sudo() });

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -66,4 +66,9 @@ export function getGqlNames({
   };
 }
 
-export type MigrationMode = 'none' | 'createOnly' | 'dev' | 'prototype';
+export type MigrationMode =
+  | 'none-skip-client-generation'
+  | 'none'
+  | 'createOnly'
+  | 'dev'
+  | 'prototype';

--- a/packages/adapter-prisma/src/adapter-prisma.js
+++ b/packages/adapter-prisma/src/adapter-prisma.js
@@ -67,7 +67,9 @@ class PrismaAdapter extends BaseKeystoneAdapter {
     if (this._prismaClient) {
       return this._prismaClient;
     }
-    await this._generateClient(rels);
+    if (this.migrationMode !== 'none-skip-client-generation') {
+      await this._generateClient(rels);
+    }
     return require(this.clientPath).PrismaClient;
   }
 


### PR DESCRIPTION
(note this is tested in the smoke tests for the examples and should marginally decrease the test time there)