### PR TITLE
Add indexes to relationship fields

### DIFF
--- a/.changeset/seven-waves-change.md
+++ b/.changeset/seven-waves-change.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': major
+---
+
+Updated schema generation to add an index on all foreign key values for relationship fields.


### PR DESCRIPTION
When generating a `@relation` in Prisma with a corresponding ID field, e.g.

```
  assignedTo   User?     @relation("TodoassignedTo", fields: [assignedToId], references: [id])
  assignedToId Int?      @map("assignedTo")
```

We want to make sure that the `assignedTo` field in the database is indexed, as not doing so will kill performance of queries involving joins. This PR adds corresponding index statements, e.g.

```
  @@index([assignedToId])
```
