### PR TITLE
Convert field API tests to typescript

### DIFF
--- a/.changeset/little-pants-exercise.md
+++ b/.changeset/little-pants-exercise.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/test-utils-legacy': patch
+---
+
+Updated types for `setupServer`.

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -108,16 +108,16 @@ async function setupServer({
   schemaName = 'public',
   schemaNames = ['public'],
   createLists = () => {},
-  keystoneOptions,
+  keystoneOptions = {},
   graphqlOptions = {},
 }: {
   adapterName: AdapterName;
-  schemaName: string;
-  schemaNames: string[];
+  schemaName?: string;
+  schemaNames?: string[];
   createLists: (args: Keystone<string>) => void;
-  keystoneOptions: Record<string, any>; // FIXME: should match args of Keystone constructor
-  graphqlOptions: Record<string, any>; // FIXME: should match args of GraphQLApp constuctor
-}) {
+  keystoneOptions?: Record<string, any>; // FIXME: should match args of Keystone constructor
+  graphqlOptions?: Record<string, any>; // FIXME: should match args of GraphQLApp constuctor
+}): Promise<Setup> {
   const Adapter = {
     mongoose: MongooseAdapter,
     knex: KnexAdapter,
@@ -155,7 +155,7 @@ async function setupServer({
   const app = express();
   app.use(middlewares);
 
-  return { keystone, app };
+  return ({ keystone, app } as unknown) as Setup;
 }
 
 function networkedGraphqlRequest({
@@ -230,7 +230,7 @@ type Setup = {
 function _keystoneRunner(adapterName: AdapterName, tearDownFunction: () => Promise<void> | void) {
   return function (
     setupKeystoneFn: (adaptername: AdapterName) => Promise<Setup>,
-    testFn: (setup: Setup) => Promise<void>
+    testFn?: (setup: Setup) => Promise<void>
   ) {
     return async function () {
       if (!testFn) {

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -1,12 +1,13 @@
-const globby = require('globby');
-const path = require('path');
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
+import globby from 'globby';
+import path from 'path';
+import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 import {
   createItem,
   deleteItem,
   getItems,
   getItem,
   updateItem,
+  // @ts-ignore
 } from '@keystone-next/server-side-graphql-client-legacy';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
@@ -23,12 +24,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           !skipCrudTest && !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           const listKey = 'Test';
-          const keystoneTestWrapper = (testFn = () => {}) =>
+          const keystoneTestWrapper = (testFn: (args: any) => void = () => {}) =>
             runner(
               () => {
-                const createLists = keystone => {
+                const createLists = (keystone: any) => {
                   // Create a list with all the fields required for testing
                   keystone.createList(listKey, { fields: mod.getTestFields(matrixValue) });
                 };
@@ -85,8 +86,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ? `id name ${fieldName} { ${subfieldName} }`
                 : `id name ${fieldName}`;
 
-              const withHelpers = wrappedFn => {
-                return async ({ keystone, listKey }) => {
+              const withHelpers = (wrappedFn: (args: any) => void | Promise<void>) => {
+                return async ({ keystone, listKey }: { keystone: any; listKey: string }) => {
                   const items = await getItems({
                     keystone,
                     listKey,

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -1,6 +1,7 @@
-const globby = require('globby');
-const path = require('path');
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
+import globby from 'globby';
+import path from 'path';
+import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
+// @ts-ignore
 import { createItem, getItems } from '@keystone-next/server-side-graphql-client-legacy';
 import memoizeOne from 'memoize-one';
 
@@ -18,14 +19,14 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           !skipCrudTest && !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           const listKey = 'Test';
 
           // we want to memoize the server creation since it's the same fields
           // for all the tests and setting up a keystone instance for prisma
           // can be a bit slow
           const _getServer = () => {
-            const createLists = keystone => {
+            const createLists = (keystone: any) => {
               // Create a list with all the fields required for testing
               keystone.createList(listKey, { fields: mod.getTestFields(matrixValue) });
             };
@@ -35,7 +36,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // we don't memoize it for mongoose though since it has a cleanup which messes the memoization up
           const getServer = adapterName === 'mongoose' ? _getServer : memoizeOne(_getServer);
 
-          const withKeystone = (testFn = () => {}) =>
+          const withKeystone = (testFn: (args: any) => void = () => {}) =>
             runner(getServer, async ({ keystone, ...rest }) => {
               // Populate the database before running the tests
               // Note: this seeding has to be in an order defined by the array returned by `mod.initItems()`
@@ -81,7 +82,12 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 ? `name ${fieldName} { ${subfieldName} }`
                 : `name ${fieldName}`;
 
-              const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
+              const match = async (
+                keystone: any,
+                where: Record<string, any> | undefined,
+                expected: any[],
+                sortBy = 'name_ASC'
+              ) =>
                 expect(await getItems({ keystone, listKey, where, returnFields, sortBy })).toEqual(
                   expected.map(i => storedValues[i])
                 );

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -1,6 +1,7 @@
-const globby = require('globby');
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
-const { Text } = require('@keystone-next/fields-legacy');
+import globby from 'globby';
+import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
+// @ts-ignore
+import { Text } from '@keystone-next/fields-legacy';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
   absolute: true,
@@ -14,7 +15,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           !skipRequiredTest && !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           describe(`${mod.name} - ${matrixValue} - isRequired`, () => {
             beforeAll(() => {
               if (mod.beforeAll) {
@@ -26,7 +27,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 await mod.afterAll();
               }
             });
-            const keystoneTestWrapper = testFn =>
+            const keystoneTestWrapper = (testFn: (setup: any) => Promise<void>) =>
               runner(
                 () =>
                   setupServer({

--- a/tests/api-tests/fields/types/AuthedRelationship.test.ts
+++ b/tests/api-tests/fields/types/AuthedRelationship.test.ts
@@ -1,15 +1,21 @@
+import express from 'express';
 // We don't currently have uniqueness tests for Relationship field types
+// @ts-ignore
 import { Text, Password } from '@keystone-next/fields-legacy';
+// @ts-ignore
 import { PasswordAuthStrategy } from '@keystone-next/auth-password-legacy';
 import {
+  AdapterName,
   multiAdapterRunners,
   networkedGraphqlRequest,
   setupServer,
 } from '@keystone-next/test-utils-legacy';
+// @ts-ignore
 import { AuthedRelationship } from '@keystone-next/fields-authed-relationship-legacy';
-const { createItem } = require('@keystone-next/server-side-graphql-client-legacy');
+// @ts-ignore
+import { createItem } from '@keystone-next/server-side-graphql-client-legacy';
 
-function setupKeystone(adapterName) {
+function setupKeystone(adapterName: AdapterName) {
   return setupServer({
     adapterName,
     createLists: keystone => {
@@ -42,7 +48,7 @@ function setupKeystone(adapterName) {
   });
 }
 
-async function login(app, username, password) {
+async function login(app: express.Application, username: string, password: string) {
   const { data } = await networkedGraphqlRequest({
     app,
     query: `

--- a/tests/api-tests/fields/types/CalendarDay.test.ts
+++ b/tests/api-tests/fields/types/CalendarDay.test.ts
@@ -1,8 +1,8 @@
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
+import { AdapterName, multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 
 const { CalendarDay } = require('@keystone-next/fields-legacy');
 
-function setupKeystone(adapterName) {
+function setupKeystone(adapterName: AdapterName) {
   return setupServer({
     adapterName,
     createLists: keystone => {

--- a/tests/api-tests/fields/types/DateTime.test.ts
+++ b/tests/api-tests/fields/types/DateTime.test.ts
@@ -1,8 +1,10 @@
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
-const { Text, DateTime } = require('@keystone-next/fields-legacy');
-const { createItem } = require('@keystone-next/server-side-graphql-client-legacy');
+import { AdapterName, multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
+// @ts-ignore
+import { Text, DateTime } from '@keystone-next/fields-legacy';
+// @ts-ignore
+import { createItem } from '@keystone-next/server-side-graphql-client-legacy';
 
-function setupKeystone(adapterName) {
+function setupKeystone(adapterName: AdapterName) {
   return setupServer({
     adapterName,
     createLists: keystone => {

--- a/tests/api-tests/fields/types/Slug.test.ts
+++ b/tests/api-tests/fields/types/Slug.test.ts
@@ -3,11 +3,13 @@ import {
   createItem,
   deleteItem,
   updateItem,
+  // @ts-ignore
 } from '@keystone-next/server-side-graphql-client-legacy';
-import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
+import { AdapterName, multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
+// @ts-ignore
 import { Text, Slug } from '@keystone-next/fields-legacy';
 
-const reverse = str => str.split('').reverse().join('');
+const reverse = (str: string) => str.split('').reverse().join('');
 
 const generateListName = () =>
   // Ensure we prefix with something easy to delete, but also must always start
@@ -18,7 +20,7 @@ const generateListName = () =>
   // Ensure plurality isn't a problem
   'foo';
 
-const setupList = (adapterName, fields) => () =>
+const setupList = (adapterName: AdapterName, fields: any) => () =>
   setupServer({
     adapterName,
     createLists: keystone => {
@@ -34,7 +36,7 @@ describe('Slug#implementation', () => {
           runner(
             setupList(adapterName, { url: { type: Slug, from: 'foo' } }),
             // Empty test, we just want to assert the setup works
-            () => {}
+            async () => {}
           )();
         }).not.toThrow();
       });
@@ -192,7 +194,11 @@ describe('Slug#implementation', () => {
           runner(
             setupList(adapterName, {
               name: { type: Text },
-              url: { type: Slug, from: 'name', makeUnique: ({ slug }) => reverse(slug) },
+              url: {
+                type: Slug,
+                from: 'name',
+                makeUnique: ({ slug }: { slug: string }) => reverse(slug),
+              },
             }),
             async ({ keystone }) => {
               const { key: listKey } = keystone.listsArray[0];
@@ -250,7 +256,7 @@ describe('Slug#implementation', () => {
                 type: Slug,
                 from: 'name',
                 alwaysMakeUnique: true,
-                makeUnique: ({ slug }) => reverse(slug),
+                makeUnique: ({ slug }: { slug: string }) => reverse(slug),
               },
             }),
             async ({ keystone }) => {
@@ -666,7 +672,7 @@ describe('Slug#implementation', () => {
           runner(
             setupList(adapterName, {
               name: { type: Text },
-              url: { type: Slug, makeUnique: ({ slug }) => slug },
+              url: { type: Slug, makeUnique: ({ slug }: { slug: string }) => slug },
             }),
             async ({ keystone }) => {
               const { key: listKey } = keystone.listsArray[0];

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -1,20 +1,25 @@
-const { integer, virtual } = require('@keystone-next/fields');
-const { createSchema, list } = require('@keystone-next/keystone/schema');
-const { multiAdapterRunners, setupFromConfig } = require('@keystone-next/test-utils-legacy');
+import { integer, virtual } from '@keystone-next/fields';
+import { BaseFields, createSchema, list } from '@keystone-next/keystone/schema';
+import {
+  AdapterName,
+  multiAdapterRunners,
+  setupFromConfig,
+  testConfig,
+} from '@keystone-next/test-utils-legacy';
 
-function makeSetupKeystone(fields) {
-  return function setupKeystone(adapterName) {
+function makeSetupKeystone(fields: BaseFields<any>) {
+  return function setupKeystone(adapterName: AdapterName) {
     return setupFromConfig({
       adapterName,
-      config: createSchema({
-        lists: {
+      config: testConfig({
+        lists: createSchema({
           Post: list({
             fields: {
               value: integer(),
               ...fields,
             },
           }),
-        },
+        }),
       }),
     });
   };

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -1,6 +1,7 @@
-const globby = require('globby');
-const { Text } = require('@keystone-next/fields-legacy');
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
+import globby from 'globby';
+// @ts-ignore
+import { Text } from '@keystone-next/fields-legacy';
+import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
   absolute: true,
@@ -14,7 +15,7 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
           supportsUnique && !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           describe(`${mod.name} - ${matrixValue} - isUnique`, () => {
             beforeAll(() => {
               if (mod.beforeAll) {
@@ -26,7 +27,7 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
                 await mod.afterAll();
               }
             });
-            const keystoneTestWrapper = testFn =>
+            const keystoneTestWrapper = (testFn: (setup: any) => Promise<void>) =>
               runner(
                 () =>
                   setupServer({
@@ -136,7 +137,7 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
           !unSupportedAdapterList.includes(adapterName)
       )
       .forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           describe(`${mod.name} - ${matrixValue} - isUnique`, () => {
             test('Ensure non-supporting fields throw an error', async () => {
               // Try to create a thing and have it fail

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -1,6 +1,6 @@
-const globby = require('globby');
-const path = require('path');
-const { multiAdapterRunners, setupServer } = require('@keystone-next/test-utils-legacy');
+import globby from 'globby';
+import path from 'path';
+import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
   absolute: true,
@@ -14,7 +14,7 @@ multiAdapterRunners().map(({ adapterName, after }) => {
   if (unsupportedModules.length > 0) {
     describe(`${adapterName} adapter`, () => {
       unsupportedModules.forEach(mod => {
-        (mod.testMatrix || ['default']).forEach(matrixValue => {
+        (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
           const listKey = 'Test';
 
           describe(`${mod.name} - Unsupported field type`, () => {
@@ -32,7 +32,7 @@ multiAdapterRunners().map(({ adapterName, after }) => {
             });
 
             test('Delete', async () => {
-              const createLists = keystone => {
+              const createLists = (keystone: any) => {
                 // Create a list with all the fields required for testing
                 keystone.createList(listKey, { fields: mod.getTestFields(matrixValue) });
               };


### PR DESCRIPTION
Porting these tests uncovered some gaps in the `setupServer` types. Also added a missing default value for `keystoneOptions`.