### PR TITLE
Fix type for float defaultValue

### DIFF
--- a/.changeset/chilly-pigs-sleep.md
+++ b/.changeset/chilly-pigs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': patch
+---
+
+Fixed type for `float({ defaultValue })`.

--- a/packages-next/fields/src/types/float/index.ts
+++ b/packages-next/fields/src/types/float/index.ts
@@ -10,7 +10,7 @@ export type FloatFieldConfig<
   isRequired?: boolean;
   isIndexed?: boolean;
   isUnique?: boolean;
-  defaultValue?: FieldDefaultValue<string>;
+  defaultValue?: FieldDefaultValue<number>;
 };
 
 export const float = <TGeneratedListTypes extends BaseGeneratedListTypes>(


### PR DESCRIPTION
Fixes a bug reported on Slack: https://keystonejs.slack.com/archives/CAXTZ552S/p1615676656009900?thread_ts=1615616958.009600&cid=CAXTZ552S