### PR TITLE
Add some missing references to prisma_sqlite in the docs

### DIFF
--- a/docs-next/pages/apis/context.mdx
+++ b/docs-next/pages/apis/context.mdx
@@ -110,7 +110,7 @@ The following functions will create a new `KeystoneContext` object with this beh
 
 The `KeystoneContext` object exposes the underlying database driver directly, depending on the value of [`config.db.adapter`](http://localhost:8000/apis/config#db).
 
-If `config.db.adapter === 'prisma_postgresql'`, then `context.prisma` will be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
+If `config.db.adapter === 'prisma_postgresql'` or `prisma_sqlite`, then `context.prisma` will be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
 
 If `config.db.adapter === 'knex'`, then `context.knex` will be a [Knex connection](http://knexjs.org/) object.
 

--- a/docs-next/pages/apis/context.mdx
+++ b/docs-next/pages/apis/context.mdx
@@ -110,7 +110,7 @@ The following functions will create a new `KeystoneContext` object with this beh
 
 The `KeystoneContext` object exposes the underlying database driver directly, depending on the value of [`config.db.adapter`](http://localhost:8000/apis/config#db).
 
-If `config.db.adapter === 'prisma_postgresql'` or `prisma_sqlite`, then `context.prisma` will be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
+If `config.db.adapter === 'prisma_postgresql'` or `'prisma_sqlite'`, then `context.prisma` will be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
 
 If `config.db.adapter === 'knex'`, then `context.knex` will be a [Knex connection](http://knexjs.org/) object.
 

--- a/docs-next/pages/apis/schema.mdx
+++ b/docs-next/pages/apis/schema.mdx
@@ -57,7 +57,7 @@ For full details on the available field types and their configuration options pl
 ## idField
 
 The `idField` option lets you override the default ID field used by Keystone.
-By default the `prisma_postgresql` and `knex` adapters use `autoincrement`, and `mongoose` uses `mongoId`, as an ID field type.
+By default the `prisma_postgresql`, `prisma_sqlite`, and `knex` adapters use `autoincrement`, and `mongoose` uses `mongoId`, as an ID field type.
 The default configuration (e.g. when `idField: undefined` ) is equivalent to:
 
 ```typescript
@@ -68,7 +68,7 @@ export default config({
   lists: createSchema({
     ListName: list({
       fields: { /* ... */ },
-      // prisma_postgresql and knex adapters
+      // prisma_postgresql, prisma_sqlite and knex adapters
       idField: autoincrement({
         ui: {
           createView: { fieldMode: 'hidden' },


### PR DESCRIPTION
A few of the newer reference docs weren't updated to include `prisma_sqlite` as an option. This rectifies that.