### PR TITLE
Remove custom access control

### DIFF
--- a/.changeset/rich-llamas-smash.md
+++ b/.changeset/rich-llamas-smash.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone-legacy': major
+---
+
+Removed `context.getCustomAccessControlForUser()`.

--- a/.changeset/silent-llamas-look.md
+++ b/.changeset/silent-llamas-look.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/access-control-legacy': major
+---
+
+Removed `parseCustomAccess` and `validateCustomAccessControl`.

--- a/packages-next/keystone/src/lib/createAccessControlContext.ts
+++ b/packages-next/keystone/src/lib/createAccessControlContext.ts
@@ -77,9 +77,6 @@ async function validateFieldAccessControl({
   return result;
 }
 
-// getCustomAccessControlForUser and getAuthAccessControlForUser do not exist here
-// since the places where they're used are not used in the new interfaces
-
 export const skipAccessControlContext = {
   getListAccessControlForUser: () => true,
   getFieldAccessControlForUser: () => true,

--- a/packages/access-control/src/access-control.ts
+++ b/packages/access-control/src/access-control.ts
@@ -62,37 +62,6 @@ const checkSchemaNames = ({
   return keyedBySchemaName;
 };
 
-export function parseCustomAccess<SN extends string, Args>({
-  defaultAccess,
-  access = defaultAccess,
-  schemaNames,
-}: {
-  defaultAccess: CustomAccess<Args>;
-  access?: Partial<Record<SN, CustomAccess<Args>>> | CustomAccess<Args>;
-  schemaNames: SN[];
-}) {
-  const accessTypes = [] as string[];
-
-  const keyedBySchemaName = checkSchemaNames({ schemaNames, accessTypes, access });
-
-  type GG = CustomAccess<Args>;
-  const fullAccess = keyedBySchemaName
-    ? { ...defaultObj(schemaNames, defaultAccess), ...(access as Partial<Record<SN, GG>>) } // Access keyed by schemaName
-    : defaultObj(schemaNames, access as GG); // Access not keyed by schemaName
-
-  const fullParsedAccess = { ...fullAccess, internal: true as const };
-
-  Object.values(fullParsedAccess).forEach(access => {
-    if (typeof access !== 'boolean' && typeof access !== 'function' && typeof access !== 'object') {
-      throw new Error(
-        `Expected a Boolean, Object, or Function for custom access, but got ${typeof access}`
-      );
-    }
-  });
-
-  return fullParsedAccess;
-}
-
 type ListAuthAccess<Args> = ListAccess<Args> & AuthAccess<Args>;
 export function parseListAccess<SN extends string, Args>({
   listKey,
@@ -246,29 +215,6 @@ export function parseFieldAccess<SN extends string, Args>({
   });
 
   return fullParsedAccess;
-}
-
-export async function validateCustomAccessControl<Args>({
-  access,
-  args,
-}: {
-  access: CustomAccess<Args>;
-  args: Args;
-}) {
-  // Either a boolean or an object describing a where clause
-  let result: Static | Declarative = false;
-  if (typeof access !== 'function') {
-    result = access;
-  } else {
-    result = await access(args);
-  }
-
-  if (!['object', 'boolean'].includes(typeof result)) {
-    throw new Error(
-      `Must return an Object or Boolean from Imperative or Declarative access control function. Got ${typeof result}`
-    );
-  }
-  return result;
 }
 
 export async function validateListAccessControl<

--- a/packages/access-control/src/index.ts
+++ b/packages/access-control/src/index.ts
@@ -1,8 +1,6 @@
 export {
-  parseCustomAccess,
   parseListAccess,
   parseFieldAccess,
-  validateCustomAccessControl,
   validateListAccessControl,
   validateFieldAccessControl,
   validateAuthAccessControl,

--- a/packages/access-control/tests/access-control.test.ts
+++ b/packages/access-control/tests/access-control.test.ts
@@ -1,7 +1,6 @@
 import {
   parseListAccess,
   parseFieldAccess,
-  parseCustomAccess,
   validateListAccessControl,
   validateFieldAccessControl,
   validateAuthAccessControl,
@@ -269,67 +268,6 @@ describe('Access control package tests', () => {
           fieldKey: 'fieldKey',
         })
       ).toThrow(Error);
-    });
-  });
-
-  describe('parseCustomAccess', () => {
-    const statics = [true, false]; // type StaticAccess = boolean;
-    const imperatives = [() => true, () => false]; // type ImperativeAccess = AccessInput => boolean;
-    const where = { name: 'foo' }; // GraphQLWhere
-    const whereFn = () => where; // (AccessInput => GraphQLWhere)
-    const declaratives = [where, whereFn]; // type DeclarativeAccess = GraphQLWhere | (AccessInput => GraphQLWhere);
-    const schemaNames = ['public'];
-
-    test('StaticAccess | ImperativeAccess are valid defaults', () => {
-      [...statics, ...imperatives].forEach(defaultAccess => {
-        expect(parseCustomAccess({ defaultAccess, schemaNames })).toEqual({
-          internal: true,
-          public: defaultAccess,
-        });
-      });
-    });
-
-    test('StaticAccess | ImperativeAccess | DeclarativeAccess are valid access modes, and should override the defaults', () => {
-      [...statics, ...imperatives, ...declaratives].forEach(defaultAccess => {
-        [...statics, ...imperatives, ...declaratives].forEach(access => {
-          expect(parseCustomAccess({ defaultAccess, access, schemaNames })).toEqual({
-            internal: true,
-            public: access,
-          });
-        });
-
-        // Misc values are not valid per-operation access modes
-        // @ts-ignore
-        expect(() => parseCustomAccess({ defaultAccess, access: 10, schemaNames })).toThrow(Error);
-      });
-    });
-
-    test('Misc values are not value inputs for defaultAccess', () => {
-      // @ts-ignore
-      expect(() => parseCustomAccess({ defaultAccess: 10, schemaNames })).toThrow(Error);
-    });
-
-    test('Misc values are not value inputs for access', () => {
-      // @ts-ignore
-      expect(() => parseCustomAccess({ access: 10, schemaNames })).toThrow(Error);
-    });
-
-    test('Schema names matching the access keys', () => {
-      const schemaNames = ['public', 'private'];
-      const access = { public: true };
-      const defaultAccess = false;
-      expect(parseCustomAccess({ defaultAccess, access, schemaNames })).toEqual({
-        internal: true,
-        public: true,
-        private: false,
-      });
-    });
-
-    test('Access keys which dont match the schema keys should throw', () => {
-      const schemaNames = ['public', 'private'];
-      const access = { public: true, missing: false };
-      const defaultAccess = false;
-      expect(() => parseCustomAccess({ defaultAccess, access, schemaNames })).toThrow(Error);
     });
   });
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -15,7 +15,6 @@ const {
 const {
   validateFieldAccessControl,
   validateListAccessControl,
-  validateCustomAccessControl,
   validateAuthAccessControl,
 } = require('@keystone-next/access-control-legacy');
 const { SessionManager } = require('@keystone-next/session-legacy');
@@ -78,7 +77,6 @@ module.exports = class Keystone {
   _getAccessControlContext({ schemaName, authentication, skipAccessControl }) {
     if (skipAccessControl) {
       return {
-        getCustomAccessControlForUser: () => true,
         getListAccessControlForUser: () => true,
         getFieldAccessControlForUser: () => true,
         getAuthAccessControlForUser: () => true,
@@ -87,23 +85,6 @@ module.exports = class Keystone {
     // memoizing to avoid requests that hit the same type multiple times.
     // We do it within the request callback so we can resolve it based on the
     // request info (like who's logged in right now, etc)
-    const getCustomAccessControlForUser = memoize(
-      async (item, args, context, info, access, gqlName) => {
-        return validateCustomAccessControl({
-          access: access[schemaName],
-          args: {
-            item,
-            args,
-            context,
-            info,
-            authentication: authentication && authentication.item ? authentication : {},
-            gqlName,
-          },
-        });
-      },
-      { isPromise: true }
-    );
-
     const getListAccessControlForUser = memoize(
       async (
         access,
@@ -175,7 +156,6 @@ module.exports = class Keystone {
     );
 
     return {
-      getCustomAccessControlForUser,
       getListAccessControlForUser,
       getFieldAccessControlForUser,
       getAuthAccessControlForUser,


### PR DESCRIPTION
See #5025 

Now that #5145 (remove keystone.extendGraphQLSchema) is complete, we no longer need to custom access control parsers and checkers.