### PR TITLE
Remove legacy keystone.dumpSchema()

### DIFF
--- a/.changeset/pretty-mirrors-kneel.md
+++ b/.changeset/pretty-mirrors-kneel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone-legacy': major
+---
+
+Removed unused `keystone.dumpSchema()`.

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -129,7 +129,6 @@ Please note: We use these internally but provide no support or assurance if used
 
 | Method                | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
-| `dumpSchema`          | Dump schema to a string.                                                     |
 | `getTypeDefs`         | Remove from user documentation?                                              |
 | `getResolvers`        | Remove from user documentation?                                              |
 | `getAdminMeta`        | Remove from user documentation?                                              |

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -3,7 +3,7 @@ const flattenDeep = require('lodash.flattendeep');
 const memoize = require('micro-memoize');
 const falsey = require('falsey');
 const createCorsMiddleware = require('cors');
-const { execute, print } = require('graphql');
+const { execute } = require('graphql');
 const { GraphQLUpload } = require('graphql-upload');
 const {
   arrayToObject,
@@ -529,12 +529,6 @@ module.exports = class Keystone {
       },
       o => Object.entries(o).length > 0
     );
-  }
-
-  dumpSchema(schemaName = 'public') {
-    return this.getTypeDefs({ schemaName })
-      .map(t => print(t))
-      .join('\n');
   }
 
   async _prepareMiddlewares({ dev, apps, distDir, pinoOptions, cors }) {

--- a/packages/keystone/tests/Keystone.test.js
+++ b/packages/keystone/tests/Keystone.test.js
@@ -63,29 +63,6 @@ test('Check require', () => {
   expect(Keystone).not.toBeNull();
 });
 
-test('unique typeDefs', () => {
-  const config = {
-    adapter: new MockAdapter(),
-    cookieSecret: 'secretForTesting',
-  };
-  const keystone = new Keystone(config);
-
-  keystone.createList('User', {
-    fields: {
-      images: { type: MockFieldType },
-    },
-  });
-
-  keystone.createList('Post', {
-    fields: {
-      hero: { type: MockFieldType },
-    },
-  });
-  const schema = keystone.dumpSchema();
-  expect(schema.match(/scalar Foo/g) || []).toHaveLength(1);
-  expect(schema.match(/getFoo: Boolean/g) || []).toHaveLength(1);
-});
-
 describe('Keystone.createList()', () => {
   test('basic', () => {
     const config = {


### PR DESCRIPTION
See #5025 

This method is no longer required.