### PR TITLE
Document editor documentation wasn't being passed inlined prose styles

### DIFF
--- a/docs-next/components/Page.tsx
+++ b/docs-next/components/Page.tsx
@@ -9,7 +9,6 @@ import Link from 'next/link';
 import { H1, H2, H3, H4, H5, H6 } from '../components/Heading';
 import { Code, InlineCode } from '../components/Code';
 import { getHeadings, Heading } from '../lib/getHeadings';
-import { proseStyles } from '../lib/prose-lite';
 import { Navigation } from './Navigation';
 import { TableOfContents } from './TableOfContents';
 

--- a/docs-next/components/Page.tsx
+++ b/docs-next/components/Page.tsx
@@ -113,10 +113,9 @@ export const Page = ({
             className="min-w-0 md:flex w-full flex-auto max-h-full overflow-visible px-2"
           >
             <main
-              className={cx('w-full max-w-none mt-6', {
+              className={cx({ prose: isProse }, 'w-full max-w-none mt-6', {
                 'md:w-3/4': headings.length,
               })}
-              css={isProse ? proseStyles : undefined}
             >
               {children}
             </main>

--- a/docs-next/pages/_app.tsx
+++ b/docs-next/pages/_app.tsx
@@ -1,10 +1,11 @@
 /** @jsx jsx */
-import { jsx, Core } from '@keystone-ui/core';
+import { jsx, Core, Global, css } from '@keystone-ui/core';
 import Head from 'next/head';
 import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import { ToastProvider } from '@keystone-ui/toast';
+import { proseStyles } from '../lib/prose-lite';
 
 import { handleRouteChange } from '../lib/analytics';
 
@@ -22,6 +23,13 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <Core>
+      <Global
+        styles={css`
+        .prose {
+          ${proseStyles}
+        }
+      `}
+      />
       <Head>
         <meta
           name="viewport"

--- a/docs-next/pages/guides/document-fields.mdx
+++ b/docs-next/pages/guides/document-fields.mdx
@@ -1,11 +1,10 @@
 import { Page, components } from '../../components/Page';
 import { H1 } from '../../components/Heading';
 import { getHeadings } from '../../lib/getHeadings';
-import { proseStyles } from '../../lib/prose-lite';
 import {
-DocumentEditorDemo,
-DocumentFeaturesFormAndCode,
-DocumentFeaturesProvider,
+  DocumentEditorDemo,
+  DocumentFeaturesFormAndCode,
+  DocumentFeaturesProvider,
 } from '../../components/DocumentEditorDemo';
 import { MDXProvider } from '@mdx-js/react';
 
@@ -494,9 +493,7 @@ export default ({ children }) => {
         </div>
         <DocumentEditorDemo />
         <div className="prose max-w-none">
-          <MDXProvider components={components}>
-              {children}
-          </MDXProvider>
+          <MDXProvider components={components}>{children}</MDXProvider>
         </div>
       </DocumentFeaturesProvider>
     </Page>

--- a/docs-next/pages/guides/document-fields.mdx
+++ b/docs-next/pages/guides/document-fields.mdx
@@ -1,10 +1,11 @@
 import { Page, components } from '../../components/Page';
 import { H1 } from '../../components/Heading';
 import { getHeadings } from '../../lib/getHeadings';
+import { proseStyles } from '../../lib/prose-lite';
 import {
-  DocumentEditorDemo,
-  DocumentFeaturesFormAndCode,
-  DocumentFeaturesProvider,
+DocumentEditorDemo,
+DocumentFeaturesFormAndCode,
+DocumentFeaturesProvider,
 } from '../../components/DocumentEditorDemo';
 import { MDXProvider } from '@mdx-js/react';
 
@@ -493,7 +494,9 @@ export default ({ children }) => {
         </div>
         <DocumentEditorDemo />
         <div className="prose max-w-none">
-          <MDXProvider components={components}>{children}</MDXProvider>
+          <MDXProvider components={components}>
+              {children}
+          </MDXProvider>
         </div>
       </DocumentFeaturesProvider>
     </Page>


### PR DESCRIPTION
Moved inline prose styles to a Global declaration in _app using emotion.
Continue to leverage classnames to toggle on and off prose styles. 
To be completely clear this is an interim solution until we encapsulate specific style rules from `prose` into components passed into the mdx provider. See https://thinkmill.atlassian.net/browse/KEY-357 for details.

Before: 
<img width="1053" alt="Screen Shot 2021-03-22 at 10 27 41 am" src="https://user-images.githubusercontent.com/12119389/111924553-5572aa80-8af9-11eb-8965-88a96f72649b.png">

After:
<img width="704" alt="Screen Shot 2021-03-22 at 10 27 55 am" src="https://user-images.githubusercontent.com/12119389/111924558-5dcae580-8af9-11eb-81d5-bfd05e74d624.png">
