### PR TITLE
Allow showing id field in list view UI

### DIFF
--- a/.changeset/long-foxes-suffer.md
+++ b/.changeset/long-foxes-suffer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': minor
+---
+
+Allow showing id field in list view UI

--- a/packages-next/types/src/config/lists.ts
+++ b/packages-next/types/src/config/lists.ts
@@ -150,7 +150,7 @@ export type ListAdminUIConfig<
      * Users of the Admin UI can select different columns to show in the UI.
      * @default the first three fields in the list
      */
-    initialColumns?: (keyof Fields)[];
+    initialColumns?: ('id' | keyof Fields)[];
     // was previously top-level defaultSort
     initialSort?: { field: keyof Fields; direction: 'ASC' | 'DESC' };
     // was previously defaultPageSize


### PR DESCRIPTION
Sometimes we need to show the ID field value in Admin UI - something like this:
```js
export const lists = createSchema({
  User: list({
    ui: {
      listView: {
        initialColumns: ['id', 'name', 'posts'],
      },
    },
```
This works well, but produces TypeScript error:
```
Type '"id"' is not assignable to type ....
```
I fix this via adding the `id` as hard-coded field name to allowed values, hope this is right way.