### PR TITLE
Fix updateMany with declarative access control

### DIFF
--- a/.changeset/lucky-snakes-marry.md
+++ b/.changeset/lucky-snakes-marry.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone-legacy': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Fixed bug with updateMany on lists with declarative access control.

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -122,9 +122,9 @@ class MockListAdapter {
     this.parentAdapter = parentAdapter;
     this.index = 3;
     this.items = {
-      0: { name: 'a', email: 'a@example.com', index: 0 },
-      1: { name: 'b', email: 'b@example.com', index: 1 },
-      2: { name: 'c', email: 'c@example.com', index: 2 },
+      0: { name: 'a', email: 'a@example.com', id: 0 },
+      1: { name: 'b', email: 'b@example.com', id: 1 },
+      2: { name: 'c', email: 'c@example.com', id: 2 },
     };
   }
   newFieldAdapter = () => new MockFieldAdapter();
@@ -788,7 +788,7 @@ test('getAccessControlledItem', async () => {
   ).toEqual({
     name: 'b',
     email: 'b@example.com',
-    index: 1,
+    id: 1,
   });
   await expect(
     list.getAccessControlledItem(10, true, { context, operation: 'read', gqlName: 'testing' })
@@ -803,7 +803,7 @@ test('getAccessControlledItem', async () => {
   ).toEqual({
     name: 'b',
     email: 'b@example.com',
-    index: 1,
+    id: 1,
   });
   await expect(
     list.getAccessControlledItem(1, { id: 2 }, { context, operation: 'read', gqlName: 'testing' })
@@ -818,7 +818,7 @@ test('getAccessControlledItem', async () => {
   ).toEqual({
     name: 'b',
     email: 'b@example.com',
-    index: 1,
+    id: 1,
   });
   await expect(
     list.getAccessControlledItem(
@@ -837,7 +837,7 @@ test('getAccessControlledItem', async () => {
   ).toEqual({
     name: 'b',
     email: 'b@example.com',
-    index: 1,
+    id: 1,
   });
   await expect(
     list.getAccessControlledItem(
@@ -856,7 +856,7 @@ test('getAccessControlledItem', async () => {
   ).toEqual({
     name: 'b',
     email: 'b@example.com',
-    index: 1,
+    id: 1,
   });
   await expect(
     list.getAccessControlledItem(
@@ -871,43 +871,43 @@ test('getAccessControlledItems', async () => {
   const list = setup();
   expect(await list.getAccessControlledItems([], true)).toEqual([]);
   expect(await list.getAccessControlledItems([1, 2], true)).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
   expect(await list.getAccessControlledItems([1, 2, 1, 2], true)).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
 
   expect(await list.getAccessControlledItems([1, 2], { id: 1 })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'b', email: 'b@example.com', id: 1 },
   ]);
   expect(await list.getAccessControlledItems([1, 2], { id: 3 })).toEqual([]);
 
   expect(await list.getAccessControlledItems([1, 2], { id_in: [1, 2, 3] })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
   expect(await list.getAccessControlledItems([1, 2], { id_in: [2, 3] })).toEqual([
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
   expect(await list.getAccessControlledItems([1, 2], { id_in: [3, 4] })).toEqual([]);
 
   expect(await list.getAccessControlledItems([1, 2], { id_not: 2 })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'b', email: 'b@example.com', id: 1 },
   ]);
   expect(await list.getAccessControlledItems([1, 2], { id_not: 3 })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
 
   expect(await list.getAccessControlledItems([1, 2], { id_not_in: [1, 2, 3] })).toEqual([]);
   expect(await list.getAccessControlledItems([1, 2], { id_not_in: [2, 3] })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'b', email: 'b@example.com', id: 1 },
   ]);
   expect(await list.getAccessControlledItems([1, 2], { id_not_in: [3, 4] })).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
 });
 
@@ -929,7 +929,7 @@ test(`gqlQueryResolvers`, () => {
 test('listQuery', async () => {
   const list = setup();
   expect(await list.listQuery({ where: { id: 1 } }, context, 'testing')).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
+    { name: 'b', email: 'b@example.com', id: 1 },
   ]);
 });
 
@@ -1023,7 +1023,7 @@ test('itemQuery', async () => {
   expect(await list.itemQuery({ where: { id: 0 } }, context)).toEqual({
     name: 'a',
     email: 'a@example.com',
-    index: 0,
+    id: 0,
   });
   await expect(list.itemQuery({ where: { id: 4 } }, context)).rejects.toThrow(AccessDeniedError);
 });
@@ -1106,7 +1106,7 @@ test('updateMutation', async () => {
     { name: 'update', email: 'update@example.com' },
     context
   );
-  expect(result).toEqual({ name: 'update', email: 'update@example.com', index: 1 });
+  expect(result).toEqual({ name: 'update', email: 'update@example.com', id: 1 });
 });
 
 test('updateManyMutation', async () => {
@@ -1119,23 +1119,23 @@ test('updateManyMutation', async () => {
     context
   );
   expect(result).toEqual([
-    { name: 'update1', email: 'update1@example.com', index: 1 },
-    { name: 'c', email: 'update2@example.com', index: 2 },
+    { name: 'update1', email: 'update1@example.com', id: 1 },
+    { name: 'c', email: 'update2@example.com', id: 2 },
   ]);
 });
 
 test('deleteMutation', async () => {
   const list = setup();
   const result = await list.deleteMutation(1, context);
-  expect(result).toEqual({ name: 'b', email: 'b@example.com', index: 1 });
+  expect(result).toEqual({ name: 'b', email: 'b@example.com', id: 1 });
 });
 
 test('deleteManyMutation', async () => {
   const list = setup();
   const result = await list.deleteManyMutation([1, 2], context);
   expect(result).toEqual([
-    { name: 'b', email: 'b@example.com', index: 1 },
-    { name: 'c', email: 'c@example.com', index: 2 },
+    { name: 'b', email: 'b@example.com', id: 1 },
+    { name: 'c', email: 'c@example.com', id: 2 },
   ]);
 });
 

--- a/tests/api-tests/access-control/updateMany.test.ts
+++ b/tests/api-tests/access-control/updateMany.test.ts
@@ -1,0 +1,58 @@
+import { text, checkbox } from '@keystone-next/fields';
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import type { AdapterName } from '@keystone-next/test-utils-legacy';
+import { createItems } from '@keystone-next/server-side-graphql-client-legacy';
+
+const setupKeystone = (adapterName: AdapterName) =>
+  setupFromConfig({
+    adapterName,
+    config: testConfig({
+      lists: createSchema({
+        User: list({
+          fields: {
+            name: text(),
+            isUpdatable: checkbox(),
+          },
+          access: {
+            create: true,
+            read: true,
+            update: { isUpdatable: true },
+            delete: true,
+          },
+        }),
+      }),
+    }),
+  });
+
+multiAdapterRunners().map(({ runner, adapterName }) =>
+  describe(`Adapter: ${adapterName}`, () => {
+    test(
+      'updateMany with declarative access control',
+      runner(setupKeystone, async ({ context }) => {
+        // Create some items, half of which have `isUpdatable: true`
+        const users = (await createItems({
+          context,
+          listKey: 'User',
+          items: [
+            { data: { name: 'Jess', isUpdatable: true } },
+            { data: { name: 'Johanna', isUpdatable: false } },
+            { data: { name: 'Sam', isUpdatable: true } },
+            { data: { name: 'Theo', isUpdatable: false } },
+          ],
+        })) as { id: any }[];
+        // Attempt to update all four items
+        const data = await context.exitSudo().graphql.run({
+          query: `mutation ($data: [UsersUpdateInput]){
+              updateUsers(data: $data) { id name isUpdatable }
+            }`,
+          variables: { data: users.map(({ id }) => ({ id, data: { name: 'new name' } })) },
+        });
+        // We don't expect an error, but only two of the items should get updated and returned
+        expect(data.updateUsers).toHaveLength(2);
+        expect(data.updateUsers[0].name).toEqual('new name');
+        expect(data.updateUsers[1].name).toEqual('new name');
+      })
+    );
+  })
+);

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -94,14 +94,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           // Seed the db
           const seedItems = await seedDb({ context });
           // Update multiple items
-          const items = await updateItems({
+          const items = (await updateItems({
             context,
             listKey,
             items: seedItems.map((item, i) => ({ id: item.id, data: { name: `update-${i}` } })),
             returnFields,
-          });
-
-          expect(items).toEqual(seedItems.map((item, i) => ({ name: `update-${i}`, age: 10 * i })));
+          })) as { name: string; age: number }[];
+          expect(items.sort((a, b) => (a.age > b.age ? 1 : -1))).toEqual(
+            seedItems.map((item, i) => ({ name: `update-${i}`, age: 10 * i }))
+          );
         })
       );
     });


### PR DESCRIPTION
When declarative access control is used, only those items which are returned from the query should be updated. The `updateMany` mutation was actually updating all the items, because we were iterating over the wrong list when creating the list of items to be updated. This PR fixes this issue and adds a test to verify that it's behaving correctly.