### PR TITLE
Sqlite file support

### DIFF
--- a/.changeset/chilly-zebras-rush.md
+++ b/.changeset/chilly-zebras-rush.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields-legacy': minor
+---
+
+Added support for the `File` field type with Primsa + SQLite.

--- a/packages/fields/src/types/File/test-fixtures.js
+++ b/packages/fields/src/types/File/test-fixtures.js
@@ -11,7 +11,6 @@ export const type = File;
 export const supportsUnique = false;
 export const fieldName = 'image';
 export const subfieldName = 'originalFilename';
-export const unSupportedAdapterList = ['prisma_sqlite'];
 
 // Grab all the image files from the directory
 const directory = './files';


### PR DESCRIPTION
This adds support for using the File legacy field type, and as such the new `cloudinary` field type, with the `prisma_sqlite` adapter.

It follows the same pattern as the document field where we use a Prisma `String` rather than the unsupported `Json` type on SQLite.