### PR TITLE
Add sqlite support for cloudinary

### DIFF
--- a/.changeset/fast-jeans-fix.md
+++ b/.changeset/fast-jeans-fix.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields-cloudinary-image-legacy': minor
+---
+
+Added support for the `Cloudinary` field type with Primsa + SQLite.

--- a/packages/fields-cloudinary-image/src/Implementation.js
+++ b/packages/fields-cloudinary-image/src/Implementation.js
@@ -79,6 +79,13 @@ class CloudinaryImage extends File.implementation {
         if (!itemValues) {
           return null;
         }
+        if (this.adapter.listAdapter.parentAdapter.provider === 'sqlite') {
+          // we store document data as a string on sqlite because Prisma doesn't support Json on sqlite
+          // https://github.com/prisma/prisma/issues/3786
+          try {
+            itemValues = JSON.parse(itemValues);
+          } catch (err) {}
+        }
 
         return {
           publicUrl: this.fileAdapter.publicUrl(itemValues),


### PR DESCRIPTION
Following on from #5188, this adds the required transforms to the cloudinary field type itself, to allow it to work with sqlite.