### PR TITLE
Remove legacy keystone.getAdminViews

### DIFF
--- a/.changeset/stupid-penguins-argue.md
+++ b/.changeset/stupid-penguins-argue.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone-legacy': major
+---
+
+Removed legacy method `Keystone.getAdminViews()`.

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -5,13 +5,7 @@ const falsey = require('falsey');
 const createCorsMiddleware = require('cors');
 const { execute } = require('graphql');
 const { GraphQLUpload } = require('graphql-upload');
-const {
-  arrayToObject,
-  objMerge,
-  flatten,
-  unique,
-  filterValues,
-} = require('@keystone-next/utils-legacy');
+const { objMerge, flatten, unique, filterValues } = require('@keystone-next/utils-legacy');
 const {
   validateFieldAccessControl,
   validateListAccessControl,
@@ -452,16 +446,6 @@ module.exports = class Keystone {
    */
   async disconnect() {
     await this.adapter.disconnect();
-  }
-
-  getAdminViews({ schemaName }) {
-    return {
-      listViews: arrayToObject(
-        this.listsArray.filter(list => list.access[schemaName].read && !list.isAuxList),
-        'key',
-        list => list.views
-      ),
-    };
   }
 
   getTypeDefs({ schemaName }) {


### PR DESCRIPTION
See #5025.

This method was used by the legacy Admin UI and is no longer required.