### PR TITLE
Remove legacy getAdminMeta() method

### DIFF
--- a/.changeset/curvy-buttons-argue.md
+++ b/.changeset/curvy-buttons-argue.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/fields-legacy': major
+'@keystone-next/keystone-legacy': major
+---
+
+Removed legacy method `.getAdminMeta` from `Keystone`, `List` and `Field` classes.

--- a/packages/fields/src/Implementation.js
+++ b/packages/fields/src/Implementation.js
@@ -168,31 +168,6 @@ class Field {
   gqlUpdateInputFields() {
     return [];
   }
-  getAdminMeta({ schemaName }) {
-    const schemaAccess = this.access[schemaName];
-    return this.extendAdminMeta({
-      label: this.label,
-      path: this.path,
-      type: this.constructor.name,
-      isRequired: this.isRequired,
-      isOrderable: this.isOrderable,
-      // We can only pass scalar default values through to the admin ui, not
-      // functions
-      defaultValue: typeof this.defaultValue !== 'function' ? this.defaultValue : undefined,
-      isPrimaryKey: this.isPrimaryKey,
-      ...this.adminConfig,
-      // NOTE: This data is serialised, so we're unable to pass through any
-      // access control _functions_. But we can still check for the boolean case
-      // and pass that through (we assume that if there is a function, it's a
-      // "maybe" true, so default it to true).
-      access: {
-        create: !!schemaAccess.create,
-        read: !!schemaAccess.read,
-        update: !!schemaAccess.update,
-      },
-      adminDoc: this.adminDoc,
-    });
-  }
   extendAdminMeta(meta) {
     return meta;
   }

--- a/packages/fields/tests/Implementation.test.js
+++ b/packages/fields/tests/Implementation.test.js
@@ -103,50 +103,6 @@ test('gqlOutputFieldResolvers', () => {
   expect(impl.gqlOutputFieldResolvers({ schemaName })).toEqual({});
 });
 
-describe('getAdminMeta()', () => {
-  test('meta is as expect', () => {
-    const impl = new Field('path', { label: 'config label', defaultValue: 'default' }, args);
-    const schemaName = 'public';
-
-    const value = impl.getAdminMeta({ schemaName });
-    expect(value).toEqual({
-      access: {
-        create: true,
-        read: true,
-        update: true,
-      },
-      label: 'config label',
-      path: 'path',
-      type: 'Field',
-      defaultValue: 'default',
-      isOrderable: false,
-      isPrimaryKey: false,
-      isRequired: false,
-    });
-  });
-
-  test('when defaultValue is a function, forced to `undefined`', () => {
-    const impl = new Field('path', { label: 'config label', defaultValue: () => 'default' }, args);
-    const schemaName = 'public';
-
-    const value = impl.getAdminMeta({ schemaName });
-    expect(value).toEqual({
-      access: {
-        create: true,
-        read: true,
-        update: true,
-      },
-      label: 'config label',
-      path: 'path',
-      type: 'Field',
-      defaultValue: undefined,
-      isOrderable: false,
-      isPrimaryKey: false,
-      isRequired: false,
-    });
-  });
-});
-
 test('extendAdminMeta()', () => {
   const impl = new Field('path', {}, args);
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -454,27 +454,6 @@ module.exports = class Keystone {
     await this.adapter.disconnect();
   }
 
-  getAdminMeta({ schemaName }) {
-    // We've consciously made a design choice that the `read` permission on a
-    // list is a master switch in the Admin UI (not the GraphQL API).
-    // Justification: If you want to Create without the Read permission, you
-    // technically don't have permission to read the result of your creation.
-    // If you want to Update an item, you can't see what the current values
-    // are. If you want to delete an item, you'd need to be given direct
-    // access to it (direct URI), but can't see anything about that item. And
-    // in fact, being able to load a page with a 'delete' button on it
-    // violates the read permission as it leaks the fact that item exists.
-    // In all these cases, the Admin UI becomes unnecessarily complex.
-    // So we only allow all these actions if you also have read access.
-    const lists = arrayToObject(
-      this.listsArray.filter(list => list.access[schemaName].read && !list.isAuxList),
-      'key',
-      list => list.getAdminMeta({ schemaName })
-    );
-
-    return { lists };
-  }
-
   getAdminViews({ schemaName }) {
     return {
       listViews: arrayToObject(

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -233,26 +233,6 @@ module.exports = class List {
     });
   }
 
-  getAdminMeta({ schemaName }) {
-    const schemaAccess = this.access[schemaName];
-    return {
-      key: this.key,
-      // Reduce to truthy values (functions can't be passed over the webpack
-      // boundary)
-      access: mapKeys(schemaAccess, val => !!val),
-      label: this.adminUILabels.label,
-      singular: this.adminUILabels.singular,
-      plural: this.adminUILabels.plural,
-      path: this.adminUILabels.path,
-      gqlNames: this.gqlNames,
-      fields: this.fields
-        .filter(field => field.access[schemaName].read)
-        .map(field => field.getAdminMeta({ schemaName })),
-      adminDoc: this.adminDoc,
-      adminConfig: this.adminConfig,
-    };
-  }
-
   getFieldsWithAccess({ schemaName, access }) {
     return this.fields
       .filter(({ path }) => path !== 'id') // Exclude the id fields update types

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -73,9 +73,6 @@ class MockFieldImplementation {
     this.config = {};
     this.hooks = {};
   }
-  getAdminMeta() {
-    return { path: 'id' };
-  }
   gqlOutputFields() {
     return ['id: ID'];
   }
@@ -399,73 +396,6 @@ test('labelResolver', () => {
     listExtras()
   );
   expect(list4.labelResolver({ email: 'a@example.com', id: '4' })).toEqual('4');
-});
-
-describe('getAdminMeta()', () => {
-  test('adminMeta() - Smoke test', () => {
-    const list = setup();
-    const schemaName = 'public';
-    const adminMeta = list.getAdminMeta({ schemaName });
-    expect(adminMeta).not.toBeNull();
-  });
-
-  test('getAdminMeta() - labels', () => {
-    const list = setup();
-    const schemaName = 'public';
-    const adminMeta = list.getAdminMeta({ schemaName });
-
-    expect(adminMeta.key).toEqual('Test');
-    expect(adminMeta.access).toEqual({
-      create: true,
-      delete: true,
-      read: true,
-      update: true,
-      auth: true,
-    });
-    expect(adminMeta.label).toEqual('Tests');
-    expect(adminMeta.singular).toEqual('Test');
-    expect(adminMeta.plural).toEqual('Tests');
-    expect(adminMeta.path).toEqual('tests');
-    expect(adminMeta.gqlNames).toEqual({
-      outputTypeName: 'Test',
-      itemQueryName: 'Test',
-      listQueryName: 'allTests',
-      listQueryMetaName: '_allTestsMeta',
-      listSortName: 'SortTestsBy',
-      listMetaName: '_TestsMeta',
-      deleteMutationName: 'deleteTest',
-      deleteManyMutationName: 'deleteTests',
-      updateMutationName: 'updateTest',
-      createMutationName: 'createTest',
-      updateManyMutationName: 'updateTests',
-      createManyMutationName: 'createTests',
-      whereInputName: 'TestWhereInput',
-      whereUniqueInputName: 'TestWhereUniqueInput',
-      updateInputName: 'TestUpdateInput',
-      createInputName: 'TestCreateInput',
-      updateManyInputName: 'TestsUpdateInput',
-      createManyInputName: 'TestsCreateInput',
-      relateToManyInputName: 'TestRelateToManyInput',
-      relateToOneInputName: 'TestRelateToOneInput',
-    });
-    expect(adminMeta.adminConfig).toEqual({
-      defaultColumns: 'name,email',
-      defaultSort: 'name',
-    });
-  });
-
-  test('getAdminMeta() - fields', () => {
-    const list = setup();
-    const schemaName = 'public';
-    const adminMeta = list.getAdminMeta({ schemaName });
-
-    expect(adminMeta.fields).toHaveLength(5);
-    expect(adminMeta.fields[0].path).toEqual('id');
-    expect(adminMeta.fields[1].path).toEqual('name');
-    expect(adminMeta.fields[2].path).toEqual('email');
-    expect(adminMeta.fields[3].path).toEqual('other');
-    expect(adminMeta.fields[4].path).toEqual('writeOnce');
-  });
 });
 
 describe(`getGqlTypes()`, () => {


### PR DESCRIPTION
See #5025.

These methods were used by the legacy Admin UI and can now be removed.