### PR TITLE
Remove unused functions from utils package

### DIFF
--- a/.changeset/few-poets-think.md
+++ b/.changeset/few-poets-think.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/utils-legacy': major
+---
+
+Removed unused functions `captureSuspensePromises` and `countArrays`.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.13.10",
-    "p-is-promise": "^3.0.0",
     "p-lazy": "^3.1.0",
     "p-reflect": "^2.1.0",
     "semver": "^7.3.4"

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,5 @@
 import pLazy from 'p-lazy';
 import pReflect from 'p-reflect';
-import isPromise from 'p-is-promise';
 import semver from 'semver';
 
 export const noop = <T>(x: T): T => x;
@@ -211,45 +210,6 @@ export const createLazyDeferred = <T, S>() => {
     },
   };
 };
-
-/**
- * Given an array of functions which may throw a Promise when executed, we want
- * to ensure all functions are executed, reducing any thrown Promises to a
- * single Promise, which is itself rethrown.
- * If no Promises are thrown, this is the equivalent of a .map
- * @param {Array} executors
- */
-export const captureSuspensePromises = <T>(executors: (() => T)[]) => {
-  const values: T[] = [];
-  const promises = executors
-    .map(executor => {
-      try {
-        values.push(executor());
-      } catch (loadingPromiseOrError) {
-        // An actual error was thrown, so we want to bubble that up
-        if (!isPromise(loadingPromiseOrError)) {
-          throw loadingPromiseOrError;
-        }
-        // Return a Suspense promise
-        return loadingPromiseOrError;
-      }
-    })
-    .filter(Boolean);
-
-  if (promises.length) {
-    // All the suspense promises are reduced to a single promise then rethrown
-    throw Promise.all(promises);
-  }
-
-  return values;
-};
-
-/**
- * Returns the length of all arrays in obj
- * @param {*} obj An objects whose property values are arrays.
- */
-export const countArrays = (obj: Record<string, any[]>) =>
-  Object.values(obj).reduce((total, items) => total + (items ? items.length : 0), 0);
 
 /**
  * Compares two version strings or number arrays in the major.minor.patch format.

--- a/packages/utils/tests/utils.test.js
+++ b/packages/utils/tests/utils.test.js
@@ -1,4 +1,3 @@
-const isPromise = require('p-is-promise');
 const {
   getType,
   escapeRegExp,
@@ -15,7 +14,6 @@ const {
   arrayToObject,
   flatten,
   zipObj,
-  captureSuspensePromises,
   upcase,
   ...utils
 } = require('../src');
@@ -274,128 +272,6 @@ describe('utils', () => {
           { d: 20, c: ['3', '4'] },
         ],
       },
-    });
-  });
-
-  describe('captureSuspensePromises', () => {
-    test('executes all fns sync when no Promises thrown', () => {
-      const funcs = [jest.fn(), jest.fn()];
-
-      try {
-        captureSuspensePromises(funcs);
-      } catch (e) {}
-
-      expect(funcs[0]).toHaveBeenCalledTimes(1);
-      expect(funcs[1]).toHaveBeenCalledTimes(1);
-    });
-
-    test('does not throw when no executors throw', () => {
-      const funcs = [jest.fn(), jest.fn()];
-
-      try {
-        captureSuspensePromises(funcs);
-      } catch (e) {
-        expect(true).toBeFalsey();
-      }
-
-      expect(funcs[0]).toHaveBeenCalledTimes(1);
-      expect(funcs[1]).toHaveBeenCalledTimes(1);
-    });
-
-    test('executes all fns sync when a Promise is thrown', () => {
-      const funcs = [
-        jest.fn(),
-        jest.fn(() => {
-          throw Promise.resolve();
-        }),
-        jest.fn(),
-      ];
-
-      try {
-        captureSuspensePromises(funcs);
-      } catch (e) {}
-
-      expect(funcs[0]).toHaveBeenCalledTimes(1);
-      expect(funcs[1]).toHaveBeenCalledTimes(1);
-      expect(funcs[2]).toHaveBeenCalledTimes(1);
-    });
-
-    test('throws a Promise when executor throws a Promise', () => {
-      const funcs = [
-        jest.fn(),
-        jest.fn(() => {
-          throw Promise.resolve();
-        }),
-        jest.fn(),
-      ];
-
-      try {
-        captureSuspensePromises(funcs);
-        expect(true).toBeFalsey();
-      } catch (maybePromise) {
-        expect(isPromise(maybePromise)).toBeTruthy();
-      }
-    });
-
-    test('thrown Promise resolves all thrown Promises', () => {
-      const resolvers = [jest.fn(), jest.fn(), jest.fn()];
-
-      const funcs = [
-        jest.fn(() => {
-          throw new Promise(resolve => {
-            // Artificially delay this promise's resolution to the next tick
-            // which will ensure the microtask (aka: Promise) queue is fully
-            // flushed
-            process.nextTick(() => {
-              resolvers[0]();
-              resolve();
-            });
-          });
-        }),
-        jest.fn(() => {
-          throw Promise.resolve().then(resolvers[1]);
-        }),
-        jest.fn(() => {
-          throw Promise.resolve().then(resolvers[2]);
-        }),
-      ];
-
-      try {
-        captureSuspensePromises(funcs);
-      } catch (thrownPromise) {
-        return thrownPromise.then(() => {
-          expect(resolvers[0]).toHaveBeenCalledTimes(1);
-          expect(resolvers[1]).toHaveBeenCalledTimes(1);
-          expect(resolvers[2]).toHaveBeenCalledTimes(1);
-        });
-      }
-
-      expect(true).toBeFalsey();
-    });
-
-    test('throws a Error when executor throws a Error', () => {
-      const funcs = [
-        jest.fn(),
-        jest.fn(() => {
-          throw new Error();
-        }),
-        jest.fn(),
-      ];
-
-      try {
-        captureSuspensePromises(funcs);
-        expect(true).toBeFalsey();
-      } catch (maybePromise) {
-        expect(!isPromise(maybePromise)).toBeTruthy();
-      }
-    });
-
-    test('acts like .map when no promises thrown', () => {
-      const funcs = [jest.fn(() => 'foo'), jest.fn(() => 'bar')];
-
-      const result = captureSuspensePromises(funcs);
-
-      expect(result).toMatchObject(['foo', 'bar']);
     });
   });
 });


### PR DESCRIPTION
This package is for our own internal usage, so if we no longer use functions then we should stop maintaining them.