### PR TITLE
Remove unused args from setupServer

### DIFF
--- a/.changeset/tame-jars-search.md
+++ b/.changeset/tame-jars-search.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/test-utils-legacy': major
+---
+
+Removed unused arguments `schemaName`, `schemaNames`, `keystoneOptions`, and `graphqlOptions` from `setupServer()`.

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -105,18 +105,10 @@ async function setupFromConfig({
 
 async function setupServer({
   adapterName,
-  schemaName = 'public',
-  schemaNames = ['public'],
-  createLists = () => {},
-  keystoneOptions = {},
-  graphqlOptions = {},
+  createLists,
 }: {
   adapterName: AdapterName;
-  schemaName?: string;
-  schemaNames?: string[];
   createLists: (args: Keystone<string>) => void;
-  keystoneOptions?: Record<string, any>; // FIXME: should match args of Keystone constructor
-  graphqlOptions?: Record<string, any>; // FIXME: should match args of GraphQLApp constuctor
 }): Promise<Setup> {
   const Adapter = {
     mongoose: MongooseAdapter,
@@ -129,23 +121,14 @@ async function setupServer({
     adapter: new Adapter(await argGenerator[adapterName]()),
     // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
     defaultAccess: { list: true, field: true },
-    schemaNames,
-    ...keystoneOptions,
   });
 
   createLists(keystone);
 
   const apps = [
     new GraphQLApp({
-      schemaName,
       apiPath: '/api/graphql',
-      apollo: {
-        tracing: true,
-        cacheControl: {
-          defaultMaxAge: 3600,
-        },
-      },
-      ...graphqlOptions,
+      apollo: { tracing: true, cacheControl: { defaultMaxAge: 3600 } },
     }),
   ];
 


### PR DESCRIPTION
Moving towards being able to remove the legacy `setupServer` completely.