### PR TITLE
Move test-fixtures into the new field packages

### DIFF
--- a/.changeset/calm-bags-study.md
+++ b/.changeset/calm-bags-study.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/fields': patch
+'@keystone-next/fields-document': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Moved test fixtures into the new packages.

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
       "!packages/**/dist/**",
       "!packages/core/tests/default-entry/index.js",
       "!packages/fields/**/test-fixtures.js",
+      "!packages/fields/**/test-fixtures.ts",
       "!packages/fields/types.js"
     ]
   },

--- a/packages-next/fields-document/src/tests/test-fixtures.ts
+++ b/packages-next/fields-document/src/tests/test-fixtures.ts
@@ -1,5 +1,6 @@
+// @ts-ignore
 import { Text } from '@keystone-next/fields-legacy';
-import { DocumentFieldType } from './base-field-type';
+import { DocumentFieldType } from '../base-field-type';
 
 export const name = 'Document';
 export const type = DocumentFieldType;
@@ -12,11 +13,11 @@ export const supportsUnique = false;
 export const fieldName = 'content';
 export const subfieldName = 'document';
 
-export const fieldConfig = () => ({ ___validateAndNormalize: x => x });
+export const fieldConfig = () => ({ ___validateAndNormalize: (x: any) => x });
 
 export const getTestFields = () => ({
   name: { type: Text },
-  content: { type, ___validateAndNormalize: x => x },
+  content: { type, ___validateAndNormalize: (x: any) => x },
 });
 
 export const initItems = () => {

--- a/packages-next/fields/package.json
+++ b/packages-next/fields/package.json
@@ -5,6 +5,8 @@
   "main": "dist/fields.cjs.js",
   "module": "dist/fields.esm.js",
   "devDependencies": {
+    "@keystone-next/server-side-graphql-client-legacy": "2.0.1",
+    "@keystone-next/test-utils-legacy": "14.0.1",
     "typescript": "^4.2.3"
   },
   "dependencies": {

--- a/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
@@ -1,12 +1,17 @@
+// @ts-ignore
 import { getItems } from '@keystone-next/server-side-graphql-client-legacy';
+// @ts-ignore
 import { Text } from '@keystone-next/fields-legacy';
-import { AutoIncrement } from './index';
+// @ts-ignore
+import { AutoIncrement } from '@keystone-next/fields-auto-increment-legacy/src';
+
+type MatrixValue = typeof testMatrix[number];
 
 export const name = 'AutoIncrement';
 export const type = AutoIncrement;
-export const testMatrix = ['ID', 'Int'];
-export const exampleValue = matrixValue => (matrixValue === 'ID' ? '35' : 35);
-export const exampleValue2 = matrixValue => (matrixValue === 'ID' ? '36' : 36);
+export const testMatrix = ['ID', 'Int'] as const;
+export const exampleValue = (matrixValue: MatrixValue) => (matrixValue === 'ID' ? '35' : 35);
+export const exampleValue2 = (matrixValue: MatrixValue) => (matrixValue === 'ID' ? '36' : 36);
 export const supportsUnique = true;
 export const fieldName = 'orderNumber';
 export const skipCreateTest = false;
@@ -16,12 +21,12 @@ export const skipUpdateTest = true;
 export const unSupportedAdapterList = ['mongoose', 'prisma_sqlite'];
 
 // Be default, `AutoIncrement` are read-only. But for `isRequired` test purpose, we need to bypass these restrictions.
-export const fieldConfig = matrixValue => ({
+export const fieldConfig = (matrixValue: MatrixValue) => ({
   gqlType: matrixValue,
   access: { create: true, update: true },
 });
 
-export const getTestFields = matrixValue => ({
+export const getTestFields = (matrixValue: MatrixValue) => ({
   name: { type: Text },
   orderNumber: { type, gqlType: matrixValue, access: { create: true } },
 });
@@ -38,7 +43,7 @@ export const initItems = () => {
   ];
 };
 
-export const storedValues = matrixValue =>
+export const storedValues = (matrixValue: MatrixValue) =>
   matrixValue === 'ID'
     ? [
         { name: 'product1', orderNumber: '1' },
@@ -61,10 +66,10 @@ export const storedValues = matrixValue =>
 
 export const supportedFilters = () => [];
 
-export const filterTests = (withKeystone, matrixValue) => {
+export const filterTests = (withKeystone: (arg: any) => any, matrixValue: MatrixValue) => {
   const _storedValues = storedValues(matrixValue);
-  const _f = matrixValue === 'ID' ? x => x.toString() : x => x;
-  const match = async (keystone, where, expected) =>
+  const _f = matrixValue === 'ID' ? (x: any) => x.toString() : (x: any) => x;
+  const match = async (keystone: any, where: Record<string, any>, expected: any[]) =>
     expect(
       await getItems({
         keystone,
@@ -77,75 +82,87 @@ export const filterTests = (withKeystone, matrixValue) => {
 
   test(
     'Filter: orderNumber',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber: _f(1) }, [0]))
+    withKeystone(({ keystone }: { keystone: any }) => match(keystone, { orderNumber: _f(1) }, [0]))
   );
 
   test(
     'Filter: orderNumber_not',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_not: _f(1) }, [1, 2, 3, 4, 5, 6]))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_not: _f(1) }, [1, 2, 3, 4, 5, 6])
+    )
   );
 
   test(
     'Filter: orderNumber_not null',
-    withKeystone(({ keystone }) =>
+    withKeystone(({ keystone }: { keystone: any }) =>
       match(keystone, { orderNumber_not: null }, [0, 1, 2, 3, 4, 5, 6])
     )
   );
 
   test(
     'Filter: orderNumber_lt',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_lt: _f(2) }, [0]))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_lt: _f(2) }, [0])
+    )
   );
 
   test(
     'Filter: orderNumber_lte',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_lte: _f(2) }, [0, 1]))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_lte: _f(2) }, [0, 1])
+    )
   );
 
   test(
     'Filter: orderNumber_gt',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_gt: _f(2) }, [2, 3, 4, 5, 6]))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_gt: _f(2) }, [2, 3, 4, 5, 6])
+    )
   );
 
   test(
     'Filter: orderNumber_gte',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_gte: _f(2) }, [1, 2, 3, 4, 5, 6]))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_gte: _f(2) }, [1, 2, 3, 4, 5, 6])
+    )
   );
 
   test(
     'Filter: orderNumber_in (empty list)',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_in: [] }, []))
+    withKeystone(({ keystone }: { keystone: any }) => match(keystone, { orderNumber_in: [] }, []))
   );
 
   test(
     'Filter: orderNumber_not_in (empty list)',
-    withKeystone(({ keystone }) =>
+    withKeystone(({ keystone }: { keystone: any }) =>
       match(keystone, { orderNumber_not_in: [] }, [0, 1, 2, 3, 4, 5, 6])
     )
   );
 
   test(
     'Filter: orderNumber_in',
-    withKeystone(({ keystone }) =>
-      match(keystone, { orderNumber_in: [1, 2, 3].map(_f) }, [0, 1, 2])
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_in: ([1, 2, 3] as const).map(_f) }, [0, 1, 2])
     )
   );
 
   test(
     'Filter: orderNumber_not_in',
-    withKeystone(({ keystone }) =>
+    withKeystone(({ keystone }: { keystone: any }) =>
       match(keystone, { orderNumber_not_in: [1, 2, 3].map(_f) }, [3, 4, 5, 6])
     )
   );
 
   test(
     'Filter: orderNumber_in null',
-    withKeystone(({ keystone }) => match(keystone, { orderNumber_in: [null] }, []))
+    withKeystone(({ keystone }: { keystone: any }) =>
+      match(keystone, { orderNumber_in: [null] }, [])
+    )
   );
 
   test(
     'Filter: orderNumber_not_in null',
-    withKeystone(({ keystone }) =>
+    withKeystone(({ keystone }: { keystone: any }) =>
       match(keystone, { orderNumber_not_in: [null] }, [0, 1, 2, 3, 4, 5, 6])
     )
   );

--- a/packages-next/fields/src/types/checkbox/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/checkbox/tests/test-fixtures.ts
@@ -1,5 +1,5 @@
-import Text from '../Text';
-import Checkbox from './';
+// @ts-ignore
+import { Checkbox, Text } from '@keystone-next/fields-legacy';
 
 export const name = 'Checkbox';
 export const type = Checkbox;

--- a/packages-next/fields/src/types/decimal/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/decimal/tests/test-fixtures.ts
@@ -1,5 +1,6 @@
-import Text from '../Text';
-import Decimal from './';
+// @ts-ignore
+import { Text, Decimal } from '@keystone-next/fields-legacy';
+import { AdapterName } from '@keystone-next/test-utils-legacy';
 
 export const name = 'Decimal';
 export const type = Decimal;
@@ -36,7 +37,7 @@ export const storedValues = () => [
   { name: 'price7', price: null },
 ];
 
-export const supportedFilters = adapterName => [
+export const supportedFilters = (adapterName: AdapterName) => [
   'null_equality',
   'equality',
   'ordering',

--- a/packages-next/fields/src/types/float/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/float/tests/test-fixtures.ts
@@ -1,5 +1,5 @@
-import Text from '../Text';
-import Float from '.';
+// @ts-ignore
+import { Text, Float } from '@keystone-next/fields-legacy';
 
 export const name = 'Float';
 export const type = Float;

--- a/packages-next/fields/src/types/integer/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/integer/tests/test-fixtures.ts
@@ -1,5 +1,5 @@
-import Text from '../Text';
-import Integer from './';
+// @ts-ignore
+import { Text, Integer } from '@keystone-next/fields-legacy';
 
 export const name = 'Integer';
 export const type = Integer;

--- a/packages-next/fields/src/types/mongoId/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/mongoId/tests/test-fixtures.ts
@@ -1,6 +1,7 @@
+// @ts-ignore
 import { Text } from '@keystone-next/fields-legacy';
-
-import { MongoId } from './index';
+// @ts-ignore
+import { MongoId } from '@keystone-next/fields-mongoid-legacy';
 
 export const name = 'MongoId';
 export const type = MongoId;

--- a/packages-next/fields/src/types/password/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/password/tests/test-fixtures.ts
@@ -1,5 +1,5 @@
-import Text from '../Text';
-import Password from './';
+// @ts-ignore
+import { Text, Password } from '@keystone-next/fields-legacy';
 
 export const name = 'Password';
 export const type = Password;

--- a/packages-next/fields/src/types/select/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/select/tests/test-fixtures.ts
@@ -1,14 +1,16 @@
-import Text from '../Text';
-import Select from './';
+// @ts-ignore
+import { Text, Select } from '@keystone-next/fields-legacy';
+
+type MatrixValue = typeof testMatrix[number];
 
 export const name = 'Select';
 export const type = Select;
-export const exampleValue = matrixValue =>
+export const exampleValue = (matrixValue: MatrixValue) =>
   matrixValue === 'enum' ? 'thinkmill' : matrixValue === 'string' ? 'a string' : 1;
-export const exampleValue2 = matrixValue =>
+export const exampleValue2 = (matrixValue: MatrixValue) =>
   matrixValue === 'enum' ? 'atlassian' : matrixValue === 'string' ? '1number' : 2;
 export const supportsUnique = true;
-export const fieldConfig = matrixValue => ({
+export const fieldConfig = (matrixValue: MatrixValue) => ({
   dataType: matrixValue,
   options:
     matrixValue === 'enum'
@@ -41,14 +43,14 @@ export const fieldName = 'company';
 
 export const supportedFilters = () => ['null_equality', 'equality', 'in_empty_null', 'in_equal'];
 
-export const testMatrix = ['enum', 'string', 'integer'];
+export const testMatrix = ['enum', 'string', 'integer'] as const;
 
-export const getTestFields = matrixValue => ({
+export const getTestFields = (matrixValue: MatrixValue) => ({
   name: { type: Text },
   company: { type, ...fieldConfig(matrixValue) },
 });
 
-export const initItems = matrixValue => {
+export const initItems = (matrixValue: MatrixValue) => {
   if (matrixValue === 'enum') {
     return [
       { name: 'a', company: 'thinkmill' },
@@ -83,7 +85,7 @@ export const initItems = matrixValue => {
   return [];
 };
 
-export const storedValues = matrixValue => {
+export const storedValues = (matrixValue: MatrixValue) => {
   if (matrixValue === 'enum') {
     return [
       { name: 'a', company: 'thinkmill' },

--- a/packages-next/fields/src/types/text/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/text/tests/test-fixtures.ts
@@ -1,4 +1,6 @@
-import Text from './';
+// @ts-ignore
+import { Text } from '@keystone-next/fields-legacy';
+import { AdapterName } from '@keystone-next/test-utils-legacy';
 
 export const name = 'Text';
 export const type = Text;
@@ -31,7 +33,7 @@ export const storedValues = () => [
   { name: 'g', testField: null },
 ];
 
-export const supportedFilters = adapterName => [
+export const supportedFilters = (adapterName: AdapterName) => [
   'null_equality',
   'equality',
   adapterName !== 'prisma_sqlite' && 'equality_case_insensitive',

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -1,6 +1,8 @@
+// @ts-ignore
 import { getItems } from '@keystone-next/server-side-graphql-client-legacy';
-import Text from '../Text';
-import DateTimeUtc from './';
+// @ts-ignore
+import { Text, DateTimeUtc } from '@keystone-next/fields-legacy';
+import { AdapterName } from '@keystone-next/test-utils-legacy';
 
 export const name = 'DateTimeUtc';
 export const type = DateTimeUtc;
@@ -41,8 +43,13 @@ export const supportedFilters = () => [
   'in_equal',
 ];
 
-export const filterTests = withKeystone => {
-  const match = async (keystone, where, expected, sortBy = 'name_ASC') =>
+export const filterTests = (withKeystone: (args: any) => any) => {
+  const match = async (
+    keystone: any,
+    where: Record<string, any> | undefined,
+    expected: any,
+    sortBy = 'name_ASC'
+  ) =>
     expect(
       await getItems({
         keystone,
@@ -55,7 +62,7 @@ export const filterTests = withKeystone => {
 
   test(
     'Sorting: sortBy: lastOnline_ASC',
-    withKeystone(({ keystone, adapterName }) =>
+    withKeystone(({ keystone, adapterName }: { keystone: any; adapterName: AdapterName }) =>
       match(
         keystone,
         undefined,
@@ -95,7 +102,7 @@ export const filterTests = withKeystone => {
 
   test(
     'Sorting: sortBy: lastOnline_DESC',
-    withKeystone(({ keystone, adapterName }) =>
+    withKeystone(({ keystone, adapterName }: { keystone: any; adapterName: AdapterName }) =>
       match(
         keystone,
         undefined,

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -29,17 +29,17 @@ Keystone contains a set of primitive fields types that can be imported from the 
 
 In addition to these, some complex types are packaged separately:
 
-| Field type                                                             | Description                                                                                                                                                           |
-| :--------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`AutoIncrement`](/packages/fields-auto-increment/README.md)           | An automatically incrementing integer; the default type for `id` fields when using the Knex DB adapter                                                                |
-| [`Markdown`](/packages/fields-markdown/README.md)                      | Markdown content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [CodeMirror](https://codemirror.net/) editor in the Admin UI    |
-| [`MongoId`](/packages/fields-mongoid/README.md)                        | Arbitrary [Mongo `ObjectId`](https://docs.mongodb.com/manual/reference/method/ObjectId/) values; the default type for `id` fields when using the Mongoose DB adapter  |
-| [`Wysiwyg`](/packages/fields-wysiwyg-tinymce/README.md)                | Rich text content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [TinyMCE](https://www.tiny.cloud/) editor in the Admin UI      |
-| [`LocationGoogle`](/packages/fields-location-google/README.md)         | Data from the [Google Maps API](https://developers.google.com/maps/documentation/javascript/reference)                                                                |
-| [`Color`](/packages/fields-color/README.md)                            | Hexidecimal RGBA color values; uses a color picker in the Admin UI                                                                                                    |
-| [`OEmbed`](/packages/fields-oembed/README.md)                          | Data in the [oEmbed format](https://oembed.com/); allowing an embedded representation of a URL on third party sites                                                   |
-| [`CloudinaryImage`](/packages/fields-cloudinary-image/README.md)       | Allows uploading images to the [Cloudinary](https://cloudinary.com/) image hosting service                                                                            |
-| [`Unsplash`](/packages/fields-unsplash/README.md)                      | Meta data from the [Unsplash API](https://unsplash.com/developers) and generates URLs to dynamically transformed images                                               |
+| Field type                                                       | Description                                                                                                                                                          |
+| :--------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`AutoIncrement`](/packages/fields-auto-increment/README.md)     | An automatically incrementing integer; the default type for `id` fields when using the Knex DB adapter                                                               |
+| [`Markdown`](/packages/fields-markdown/README.md)                | Markdown content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [CodeMirror](https://codemirror.net/) editor in the Admin UI   |
+| [`MongoId`](/packages/fields-mongoid/README.md)                  | Arbitrary [Mongo `ObjectId`](https://docs.mongodb.com/manual/reference/method/ObjectId/) values; the default type for `id` fields when using the Mongoose DB adapter |
+| [`Wysiwyg`](/packages/fields-wysiwyg-tinymce/README.md)          | Rich text content; based on the [`Text`](/packages/fields/src/types/Text/README.md) type and using the [TinyMCE](https://www.tiny.cloud/) editor in the Admin UI     |
+| [`LocationGoogle`](/packages/fields-location-google/README.md)   | Data from the [Google Maps API](https://developers.google.com/maps/documentation/javascript/reference)                                                               |
+| [`Color`](/packages/fields-color/README.md)                      | Hexidecimal RGBA color values; uses a color picker in the Admin UI                                                                                                   |
+| [`OEmbed`](/packages/fields-oembed/README.md)                    | Data in the [oEmbed format](https://oembed.com/); allowing an embedded representation of a URL on third party sites                                                  |
+| [`CloudinaryImage`](/packages/fields-cloudinary-image/README.md) | Allows uploading images to the [Cloudinary](https://cloudinary.com/) image hosting service                                                                           |
+| [`Unsplash`](/packages/fields-unsplash/README.md)                | Meta data from the [Unsplash API](https://unsplash.com/developers) and generates URLs to dynamically transformed images                                              |
 
 > **Tip:** Need something else? Keystone lets you create [custom field types](/docs/guides/custom-field-types.md) to support almost any use case.
 

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -10,7 +10,7 @@ import {
   // @ts-ignore
 } from '@keystone-next/server-side-graphql-client-legacy';
 
-const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
+const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
 });
 testModules.push(path.resolve('packages/fields/tests/test-fixtures.js'));

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -5,7 +5,7 @@ import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-lega
 import { createItem, getItems } from '@keystone-next/server-side-graphql-client-legacy';
 import memoizeOne from 'memoize-one';
 
-const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
+const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
 });
 testModules.push(path.resolve('packages/fields/tests/test-fixtures.js'));

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -3,7 +3,7 @@ import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-lega
 // @ts-ignore
 import { Text } from '@keystone-next/fields-legacy';
 
-const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
+const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
 });
 multiAdapterRunners().map(({ runner, adapterName }) =>

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -3,7 +3,7 @@ import globby from 'globby';
 import { Text } from '@keystone-next/fields-legacy';
 import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 
-const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
+const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
 });
 multiAdapterRunners().map(({ runner, adapterName, after }) =>

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import globby from 'globby';
 import { multiAdapterRunners, setupServer } from '@keystone-next/test-utils-legacy';
 
-const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.js`, {
+const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
 });
 testModules.push(path.resolve('packages/fields/tests/test-fixtures.js'));


### PR DESCRIPTION
This moves all the test-fixtures for the supported fields into `tests` subdirectories in the new packages. This is a preparation for more of the controlled demolition process in #5025.