### PR TITLE
Add default config for mongoId

### DIFF
--- a/.changeset/brave-birds-fold.md
+++ b/.changeset/brave-birds-fold.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': patch
+---
+
+Added a default config value of `{}` for the `mongoId` field type.

--- a/packages-next/fields/src/types/mongoId/index.ts
+++ b/packages-next/fields/src/types/mongoId/index.ts
@@ -14,7 +14,7 @@ export type MongoIdFieldConfig<
 };
 
 export const mongoId = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: MongoIdFieldConfig<TGeneratedListTypes>
+  config: MongoIdFieldConfig<TGeneratedListTypes> = {}
 ): FieldType<TGeneratedListTypes> => ({
   type: MongoId,
   config,


### PR DESCRIPTION
This makes it consistent with our other field types.