### PR TITLE
Fix select field type

### DIFF
--- a/.changeset/moody-apricots-hear.md
+++ b/.changeset/moody-apricots-hear.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': major
+---
+
+Fixed the `select` field type to always use the correct underlying types.

--- a/packages-next/fields/src/types/select/index.ts
+++ b/packages-next/fields/src/types/select/index.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import { Text } from '@keystone-next/fields-legacy';
+import { Select } from '@keystone-next/fields-legacy';
 import type { FieldType, BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 import type { FieldConfig } from '../../interfaces';
@@ -30,7 +30,7 @@ export type SelectFieldConfig<
 export const select = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   config: SelectFieldConfig<TGeneratedListTypes>
 ): FieldType<TGeneratedListTypes> => ({
-  type: Text,
+  type: Select,
   config,
   views: resolveView('select/views'),
   getAdminMeta: () => ({


### PR DESCRIPTION
With this bug we would generally expect default usage with the `string` data type to work more or less as expected, most of the time, but `enum` an `interger` would be completely broken.

Fixing this will potentially change peoples graphQL and database schema.