### PR TITLE
Port auth-hooks tests to new APIs

### DIFF
--- a/tests/api-tests/package.json
+++ b/tests/api-tests/package.json
@@ -30,7 +30,6 @@
     "testcheck": "^1.0.0-rc.2"
   },
   "dependencies": {
-    "@keystone-next/auth-password-legacy": "^6.0.3",
     "@keystone-next/fields-legacy": "^23.1.0",
     "@keystone-next/test-utils-legacy": "^14.0.0",
     "@keystone-next/types": "^15.0.0",


### PR DESCRIPTION
We haven't implemented authentication hooks yet. This PR converts the system setup to the new APIs and then disables the tests completely (`.skip` in the filename). We will revive these tests once we have implemented auth hooks in the new APIs.