### PR TITLE
Remove keystone argument from server-side-graphql-client functions

### DIFF
--- a/.changeset/cold-olives-decide.md
+++ b/.changeset/cold-olives-decide.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/server-side-graphql-client-legacy': major
+---
+
+Removed the legacy `keystone` argument from all exported functions.

--- a/packages/server-side-graphql-client/README.md
+++ b/packages/server-side-graphql-client/README.md
@@ -28,7 +28,7 @@ Using `@keystone-next/server-side-graphql-client-legacy` we can replace this wit
 const { createItem } = require('@keystone-next/server-side-graphql-client-legacy');
 
 const user = await createItem({
-  keystone,
+  context,
   listKey: 'User',
   item: { name: 'Alice' },
   returnFields: `id name`,
@@ -47,7 +47,7 @@ These utilities can be used for a wide range of specific use-cases, some more co
 
 ```js
 const seedUsers = async usersData => {
-  await createItems({ keystone, listKey: 'User', items: usersData });
+  await createItems({ context, listKey: 'User', items: usersData });
 };
 ```
 
@@ -66,7 +66,7 @@ keystone.createList('Page', {
       // Whenever copy field is set fetch the related data
       const pageToCopy = resolvedData.copy
         ? await getItem({
-            keystone,
+            context,
             listKey: 'Page',
             itemId: resolvedData.copy,
             returnFields: 'name, content',
@@ -127,7 +127,7 @@ keystone.createList('User', {
 
 const addUser = async userInput => {
   const user = await createItem({
-    keystone,
+    context,
     listKey: 'User',
     item: userInput,
     returnFields: `name, email`,
@@ -171,7 +171,7 @@ const dummyUsers = [
 
 const addUsers = async () => {
   const users = await createItems({
-    keystone,
+    context,
     listKey: 'User',
     items: dummyUsers,
     returnFields: `name`,
@@ -208,7 +208,7 @@ keystone.createList('User', {
 
 const getUser = async ({ itemId }) => {
   const user = await getItem({
-    keystone,
+    context,
     listKey: 'User',
     itemId,
     returnFields: 'id, name',
@@ -243,9 +243,9 @@ keystone.createList('User', {
 });
 
 const getUsers = async () => {
-  const allUsers = await getItems({ keystone, listKey: 'User', returnFields: 'name' });
+  const allUsers = await getItems({ context, listKey: 'User', returnFields: 'name' });
   const someUsers = await getItems({
-    keystone,
+    context,
     listKey: 'User',
     returnFields: 'name',
     where: { name: 'user1' },
@@ -286,7 +286,7 @@ keystone.createList('User', {
 
 const updateUser = async updateUser => {
   const updatedUser = await updateItem({
-    keystone,
+    context,
     listKey: 'User',
     item: updateUser,
     returnFields: 'name',
@@ -322,7 +322,7 @@ keystone.createList('User', {
 
 const updateUsers = async updateUsers => {
   const users = await updateItems({
-    keystone,
+    context,
     listKey: 'User',
     items: updateUsers,
     returnFields: 'name',
@@ -394,7 +394,7 @@ keystone.createList('User', {
 });
 
 const deletedUsers = async items => {
-  const users = await deleteItems({ keystone, listKey: 'User', items });
+  const users = await deleteItems({ context, listKey: 'User', items });
   console.log(users); // [{id: '123'}, {id: '456'}]
 };
 deletedUsers(['123', '456']);
@@ -417,7 +417,6 @@ Execute a custom query.
 
 | Properties  | Type     | Default    | Description                                                                                                                                                                                                         |
 | ----------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `keystone`  | Object   | (required) | Keystone instance.                                                                                                                                                                                                  |
 | `query`     | String   | (required) | The GraphQL query to execute.                                                                                                                                                                                       |
 | `variables` | Object   | (required) | Object containing variables your custom query needs.                                                                                                                                                                |
 | `context`   | `Object` | N/A        | An Apollo [`context` object](https://www.apollographql.com/docs/apollo-server/data/resolvers/#the-context-argument). See the [server side graphQL docs](/docs/discussions/server-side-graphql.md) for more details. |

--- a/packages/server-side-graphql-client/lib/server-side-graphql-client.js
+++ b/packages/server-side-graphql-client/lib/server-side-graphql-client.js
@@ -1,7 +1,4 @@
-const getContext = keystone =>
-  keystone.createContext({ schemaName: 'public', authentication: {} }).sudo();
-
-const runQuery = async ({ keystone, query, variables, context = getContext(keystone) }) => {
+const runQuery = async ({ query, variables, context }) => {
   const { data, errors } = await context.executeGraphQL({
     query,
     variables,
@@ -38,31 +35,18 @@ const _runChunkedMutation = async ({ query, gqlName, pageSize, items, context })
   return [].concat(...result.map(item => item[gqlName]));
 };
 
-const createItem = async ({
-  keystone,
-  listKey,
-  item,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const createItem = async ({ listKey, item, returnFields = `id`, context }) => {
   const { createMutationName, createInputName } = context.gqlNames(listKey);
 
   const query = `mutation ($item: ${createInputName}){
     ${createMutationName}(data: $item) { ${returnFields} }
   }`;
 
-  const result = await runQuery({ keystone, query, variables: { item }, context });
+  const result = await runQuery({ query, variables: { item }, context });
   return result[createMutationName];
 };
 
-const createItems = async ({
-  keystone,
-  listKey,
-  items,
-  pageSize = 500,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const createItems = async ({ listKey, items, pageSize = 500, returnFields = `id`, context }) => {
   const { createManyMutationName, createManyInputName } = context.gqlNames(listKey);
 
   const query = `mutation ($items: [${createManyInputName}]){
@@ -78,13 +62,7 @@ const createItems = async ({
   });
 };
 
-const getItem = async ({
-  keystone,
-  listKey,
-  itemId,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const getItem = async ({ listKey, itemId, returnFields = `id`, context }) => {
   const { itemQueryName } = context.gqlNames(listKey);
 
   const query = `query ($id: ID!) { ${itemQueryName}(where: { id: $id }) { ${returnFields} }  }`;
@@ -93,7 +71,6 @@ const getItem = async ({
 };
 
 const getItems = async ({
-  keystone,
   listKey,
   where = {},
   sortBy,
@@ -101,7 +78,7 @@ const getItems = async ({
   skip,
   pageSize = 500,
   returnFields = `id`,
-  context = getContext(keystone),
+  context,
 }) => {
   const { listQueryName, whereInputName, listSortName } = context.gqlNames(listKey);
 
@@ -139,13 +116,7 @@ const getItems = async ({
   return allItems;
 };
 
-const updateItem = async ({
-  keystone,
-  listKey,
-  item,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const updateItem = async ({ listKey, item, returnFields = `id`, context }) => {
   const { updateMutationName, updateInputName } = context.gqlNames(listKey);
 
   const query = `mutation ($id: ID!, $data: ${updateInputName}){
@@ -161,14 +132,7 @@ const updateItem = async ({
   return result[updateMutationName];
 };
 
-const updateItems = async ({
-  keystone,
-  listKey,
-  items,
-  pageSize = 500,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const updateItems = async ({ listKey, items, pageSize = 500, returnFields = `id`, context }) => {
   const { updateManyMutationName, updateManyInputName } = context.gqlNames(listKey);
 
   const query = `mutation ($items: [${updateManyInputName}]){
@@ -183,13 +147,7 @@ const updateItems = async ({
   });
 };
 
-const deleteItem = async ({
-  keystone,
-  listKey,
-  itemId,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const deleteItem = async ({ listKey, itemId, returnFields = `id`, context }) => {
   const { deleteMutationName } = context.gqlNames(listKey);
 
   const query = `mutation ($id: ID!){
@@ -200,14 +158,7 @@ const deleteItem = async ({
   return result[deleteMutationName];
 };
 
-const deleteItems = async ({
-  keystone,
-  listKey,
-  items,
-  pageSize = 500,
-  returnFields = `id`,
-  context = getContext(keystone),
-}) => {
+const deleteItems = async ({ listKey, items, pageSize = 500, returnFields = `id`, context }) => {
   const { deleteManyMutationName } = context.gqlNames(listKey);
 
   const query = `mutation ($items: [ID!]){


### PR DESCRIPTION
We no longer need to support the `keystone` argument, it should always be used with a `context` argument.

There's a cursory attempt to update the docs, but these need a complete overhaul/integration into the items API, so not too fussed about having them be completely correct right this minute.