### PR TITLE
Use new interfaces for ID field tests

### DIFF
--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -17,6 +17,7 @@
     "@keystone-next/adapter-knex-legacy": "^13.2.2",
     "@keystone-next/adapter-mongoose-legacy": "^11.1.2",
     "@keystone-next/adapter-prisma-legacy": "^4.0.0",
+    "@keystone-next/fields": "5.3.0",
     "@keystone-next/utils-legacy": "^7.0.0",
     "apollo-errors": "^1.9.0",
     "bcryptjs": "^2.4.3",

--- a/packages/fields/tests/test-fixtures.js
+++ b/packages/fields/tests/test-fixtures.js
@@ -1,13 +1,14 @@
 import { getItems } from '@keystone-next/server-side-graphql-client-legacy';
-import Text from '../src/types/Text';
+import { text } from '@keystone-next/fields';
 
 export const name = 'ID';
-export { Text as type };
+
 export const exampleValue = () => '"foo"';
 
+export const newInterfaces = true;
 export const getTestFields = () => {
   return {
-    name: { type: Text },
+    name: text(),
   };
 };
 

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -46,6 +46,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     }),
                   });
                 } else {
+                  throw new Error('Old interfaces no longer supportes');
                   return setupServer({
                     adapterName,
                     createLists: (keystone: any) => {

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -43,6 +43,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }),
               });
             } else {
+              throw new Error('Old interfaces no longer supportes');
               return setupServer({
                 adapterName,
                 createLists: (keystone: any) => {

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -35,42 +35,43 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }
             });
             const keystoneTestWrapper = (testFn: (setup: any) => Promise<void>) =>
-              runner(
-                () =>
-                  mod.newInterfaces
-                    ? setupFromConfig({
-                        adapterName,
-                        config: testConfig({
-                          lists: createSchema({
-                            Test: list({
-                              fields: {
-                                name: text(),
-                                testField: mod.typeFunction({
-                                  isRequired: true,
-                                  ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
-                                }),
-                              },
+              runner(() => {
+                if (mod.newInterfaces) {
+                  return setupFromConfig({
+                    adapterName,
+                    config: testConfig({
+                      lists: createSchema({
+                        Test: list({
+                          fields: {
+                            name: text(),
+                            testField: mod.typeFunction({
+                              isRequired: true,
+                              ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
                             }),
-                          }),
+                          },
                         }),
-                      })
-                    : setupServer({
-                        adapterName,
-                        createLists: keystone => {
-                          keystone.createList('Test', {
-                            fields: {
-                              name: { type: Text },
-                              testField: {
-                                type: mod.type,
-                                isRequired: true,
-                                ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
-                              },
-                            },
-                          });
-                        },
                       }),
-                testFn
-              );
+                    }),
+                  });
+                } else {
+                  throw new Error('Old interfaces no longer supportes');
+                  return setupServer({
+                    adapterName,
+                    createLists: keystone => {
+                      keystone.createList('Test', {
+                        fields: {
+                          name: { type: Text },
+                          testField: {
+                            type: mod.type,
+                            isRequired: true,
+                            ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
+                          },
+                        },
+                      });
+                    },
+                  });
+                }
+              }, testFn);
             test(
               'Create an object without the required field',
               keystoneTestWrapper(async ({ keystone, context }) => {

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -35,42 +35,43 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
               }
             });
             const keystoneTestWrapper = (testFn: (setup: any) => Promise<void>) =>
-              runner(
-                () =>
-                  mod.newInterfaces
-                    ? setupFromConfig({
-                        adapterName,
-                        config: testConfig({
-                          lists: createSchema({
-                            Test: list({
-                              fields: {
-                                name: text(),
-                                testField: mod.typeFunction({
-                                  isUnique: true,
-                                  ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
-                                }),
-                              },
+              runner(() => {
+                if (mod.newInterfaces) {
+                  return setupFromConfig({
+                    adapterName,
+                    config: testConfig({
+                      lists: createSchema({
+                        Test: list({
+                          fields: {
+                            name: text(),
+                            testField: mod.typeFunction({
+                              isUnique: true,
+                              ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
                             }),
-                          }),
+                          },
                         }),
-                      })
-                    : setupServer({
-                        adapterName,
-                        createLists: keystone => {
-                          keystone.createList('Test', {
-                            fields: {
-                              name: { type: Text },
-                              testField: {
-                                type: mod.type,
-                                isUnique: true,
-                                ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
-                              },
-                            },
-                          });
-                        },
                       }),
-                testFn
-              );
+                    }),
+                  });
+                } else {
+                  throw new Error('Old interfaces no longer supportes');
+                  return setupServer({
+                    adapterName,
+                    createLists: keystone => {
+                      keystone.createList('Test', {
+                        fields: {
+                          name: { type: Text },
+                          testField: {
+                            type: mod.type,
+                            isUnique: true,
+                            ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
+                          },
+                        },
+                      });
+                    },
+                  });
+                }
+              }, testFn);
             test(
               'uniqueness is enforced over multiple mutations',
               keystoneTestWrapper(async ({ keystone, context }) => {
@@ -185,6 +186,7 @@ multiAdapterRunners().map(({ runner, adapterName, after }) =>
                     }),
                   });
                 } else {
+                  throw new Error('Old interfaces no longer supportes');
                   await setupServer({
                     adapterName,
                     createLists: keystone => {

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -38,6 +38,8 @@ multiAdapterRunners().map(({ adapterName, after }) => {
             });
 
             test('Throws', async () => {
+              if (!mod.newInterfaces) throw new Error('Old interfaces no longer supportes');
+
               await expect(async () =>
                 mod.newInterfaces
                   ? setupFromConfig({


### PR DESCRIPTION
This ports the final test fixture to the new interfaces. It also adds checks into our tests to make sure we're not using the old interfaces. This will all be cleaned up after #5223 goes through, so ignore the grossness/unreachable code for now 🙏 