### PR TITLE
Remove knex and mongoose from public APIs

### DIFF
--- a/.changeset/rare-avocados-mate.md
+++ b/.changeset/rare-avocados-mate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': major
+---
+
+Removed support for the `mongoId` field type.

--- a/.changeset/smart-lizards-mate.md
+++ b/.changeset/smart-lizards-mate.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/fields': major
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+'@keystone-next/test-utils-legacy': major
+---
+
+Removed support for the `knex` and `mongoose` database adapters. We now only support `prisma_postgresql` and `prisma_sqlite`.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         index: [0, 1, 2, 3, 4, 5, 6, 7, 8]
-        adapter: ['mongoose', 'knex', 'prisma_postgresql', 'prisma_sqlite']
+        adapter: ['prisma_postgresql', 'prisma_sqlite']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -56,10 +56,8 @@ import type { DatabaseConfig } from '@keystone-next/types';
 
 The `db` config option configures the database used to store data in your Keystone system.
 It has a TypeScript type of `DatabaseConfig`.
-Keystone supports three different database types; **Prisma**, **PostgreSQL**, and **MongoDB**.
-Prisma in turn support both **PostgreSQL** and **SQLite** databases.
-These database types are powered by their corresponding Keystone database adapter; `prisma_postgresql`, `prisma_sqlite`, `knex`, and `mongoose`.
-The `prisma_postgresql` and `prisma_sqlite` adapters includes support for the **migrate** commands of the Keystone [command line](../guides/cli).
+Keystone supports the database types **PostgreSQL** and **SQLite**.
+These database types are powered by their corresponding Keystone database adapters; `prisma_postgresql` and `prisma_sqlite`.
 
 All database adapters require the `url` argument, which defines the connection URL for your database.
 They also all have an optional `onConnect` async function, which takes a [`KeystoneContext`](./context) object, and lets perform any actions you might need at startup, such as data seeding.
@@ -131,46 +129,6 @@ The `prisma_sqlite` is not intended to be used in production systems, and has ce
 - `text`: The `text` field type does not support the advanced filtering operations `contains`, `starts_with`, `ends_with`, or case insensitive filtering.
 - `autoIncrement`: The `autoIncrement` field type can only be used as an `id` field.
 - `select`: Using the `dataType: 'enum'` will use a GraphQL `String` type, rather than an `Enum` type.
-
-### knex
-
-Advanced configuration:
-
-- `schemaName` (default: `'public'` ): Set the schema named used in the database.
-- `dropDatabase` (default: `false`): Setting this to `true` will cause Keystone to drop your database and then recreate the tables after connecting to the database.
-
-```typescript
-export default config({
-  db: {
-    adapter: 'knex',
-    url: 'postgres://dbuser:dbpass@localhost:5432/keystone',
-    onConnect: async context => { /* ... */ },
-    // Optional advanced configuration
-    schemaName: 'public',
-    dropDatabase: false,
-  },
-  /* ... */
-});
-```
-
-### mongoose
-
-Advanced configuration:
-
-- `mongooseOptions` (default: `{}` ): Additional options to be passed into `mongoose.connect()`. See the [Mongoose docs](https://mongoosejs.com/docs/api.html#mongoose_Mongoose-connect) for a detailed list of options
-
-```typescript
-export default config({
-  db: {
-    adapter: 'mongoose':
-    url: 'mongodb://localhost/keystone',
-    onConnect: async context => { /* ... */ },
-    // Optional advanced configuration
-    mongooseOptions: { /* ... */ },
-  },
-  /* ... */
-});
-```
 
 ## ui
 

--- a/docs-next/pages/apis/context.mdx
+++ b/docs-next/pages/apis/context.mdx
@@ -37,9 +37,7 @@ context = {
   withSession,
 
   // Database access
-  knex,
   prisma,
-  mongoose,
 
   // Access control helpers
   getListAccessControlForUser,
@@ -108,13 +106,7 @@ The following functions will create a new `KeystoneContext` object with this beh
 
 ### Database access
 
-The `KeystoneContext` object exposes the underlying database driver directly, depending on the value of [`config.db.adapter`](http://localhost:8000/apis/config#db).
-
-If `config.db.adapter === 'prisma_postgresql'` or `'prisma_sqlite'`, then `context.prisma` will be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
-
-If `config.db.adapter === 'knex'`, then `context.knex` will be a [Knex connection](http://knexjs.org/) object.
-
-if `config.db.adapter === 'mongoose'`, then `context.mongoose` will be a [Mongoose](https://mongoosejs.com/docs/api/mongoose.html) object.
+The `KeystoneContext` object exposes the underlying database driver directly via `context.prisma`, which is be a [Prisma Client](https://www.prisma.io/docs/reference/api-reference/prisma-client-reference) object.
 
 ### Access control helpers
 

--- a/docs-next/pages/apis/fields.mdx
+++ b/docs-next/pages/apis/fields.mdx
@@ -25,7 +25,6 @@ import {
 
   // Index types
   autoIncrement,
-  mongoId,
 
   // Virtual type
   virtual,
@@ -147,7 +146,6 @@ Options:
   `context` is a [`KeystoneContext`](./context) object.
   `originalItem` is an object containing the data passed in to the `create` mutation.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 
 ```typescript
@@ -161,7 +159,6 @@ export default config({
         fieldName: integer({
           defaultValue: 0,
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
         }),
         /* ... */
@@ -184,7 +181,6 @@ Options:
   `context` is a [`KeystoneContext`](./context) object.
   `originalItem` is an object containing the data passed in to the `create` mutation.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 
 ```typescript
@@ -198,7 +194,6 @@ export default config({
         fieldName: float({
           defaultValue: 3.14159,
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
         }),
         /* ... */
@@ -223,7 +218,6 @@ Options:
 - `precision` (default: `18`): Maximum number of digits that are present in the number.
 - `scale` (default: `4`): Maximum number of decimal places.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 
 ```typescript
@@ -239,7 +233,6 @@ export default config({
           precision: 12,
           scale: 3,
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
         }),
         /* ... */
@@ -303,7 +296,6 @@ Options:
   `context` is a [`KeystoneContext`](./context) object.
   `originalItem` is an object containing the data passed in to the `create` mutation.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 - `ui` (default: `{ displayMode: 'select' }`): Configures the display mode of the field in the Admin UI.
   Can be one of `['select', 'segmented-control']`.
@@ -324,7 +316,6 @@ export default config({
           ],
           defaultValue: '...',
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
           ui: { displayMode: 'select' },
         }),
@@ -348,7 +339,6 @@ Options:
   `context` is a [`KeystoneContext`](./context) object.
   `originalItem` is an object containing the data passed in to the `create` mutation.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 - `ui` (default: `{ displayMode: 'input' }`): Configures the display mode of the field in the Admin UI.
   Can be one of `['input', 'textarea']`.
@@ -364,7 +354,6 @@ export default config({
         fieldName: text({
           defaultValue: '...',
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
           ui: { displayMode: 'textarea' },
         }),
@@ -389,7 +378,6 @@ Options:
   `context` is a [`KeystoneContext`](./context) object.
   `originalItem` is an object containing the data passed in to the `create` mutation.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
-- `isIndexed` (`knex` and `mongoose` adapters only. Default: `false`): If `true` a database level index will be applied to this field, which can make searching faster.
 - `isUnique` (default: `false`): If `true` then all values of this field must be unique.
 
 ```typescript
@@ -403,7 +391,6 @@ export default config({
         fieldName: timestamp({
           defaultValue: '1970-01-01T00:00:00.000Z',
           isRequired: true,
-          isIndexed: true,
           isUnique: true,
         }),
         /* ... */
@@ -436,7 +423,6 @@ export default config({
           many: false,
           ui: { /* ... */ },
           defaultValue: '...',
-          isIndexed: '...',
           isUnique: '...',
         }),
         /* ... */
@@ -458,7 +444,6 @@ Options:
 
 - `defaultValue`
 - `isRequired`
-- `isIndexed` (`knex` and `mongoose` adapters only)
 - `isUnique`
 
 ```typescript
@@ -472,41 +457,6 @@ export default config({
         fieldName: autoIncrement({
           defaultValue: 0,
           isRequired: true,
-          isIndexed: true,
-          isUnique: true,
-        }),
-        /* ... */
-      },
-    }),
-    /* ... */
-  }),
-  /* ... */
-});
-```
-
-### mongoId
-
-(coming soon)
-
-Options:
-
-- `defaultValue`
-- `isRequired`
-- `isIndexed` (`knex` and `mongoose` adapters only)
-- `isUnique`
-
-```typescript
-import { config, createSchema, list } from '@keystone-next/keystone/schema';
-import { mongoId } from '@keystone-next/fields';
-
-export default config({
-  lists: createSchema({
-    ListName: list({
-      fields: {
-        fieldName: mongoId({
-          defaultValue: '...',
-          isRequired: true,
-          isIndexed: true,
           isUnique: true,
         }),
         /* ... */

--- a/docs-next/pages/apis/schema.mdx
+++ b/docs-next/pages/apis/schema.mdx
@@ -57,26 +57,18 @@ For full details on the available field types and their configuration options pl
 ## idField
 
 The `idField` option lets you override the default ID field used by Keystone.
-By default the `prisma_postgresql`, `prisma_sqlite`, and `knex` adapters use `autoIncrement`, and `mongoose` uses `mongoId`, as an ID field type.
+By default the `autoIncrement` field type is used as an ID field type.
 The default configuration (e.g. when `idField: undefined` ) is equivalent to:
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
-import { autoIncrement, mongoId } from '@keystone-next/fields';
+import { autoIncrement } from '@keystone-next/fields';
 
 export default config({
   lists: createSchema({
     ListName: list({
       fields: { /* ... */ },
-      // prisma_postgresql, prisma_sqlite and knex adapters
       idField: autoIncrement({
-        ui: {
-          createView: { fieldMode: 'hidden' },
-          itemView: { fieldMode: 'hidden' },
-        },
-      }),
-      // mongoose adapter
-      idField: mongoId({
         ui: {
           createView: { fieldMode: 'hidden' },
           itemView: { fieldMode: 'hidden' },

--- a/packages-next/fields/src/index.ts
+++ b/packages-next/fields/src/index.ts
@@ -6,7 +6,6 @@ export { timestamp } from './types/timestamp';
 export { integer } from './types/integer';
 export { float } from './types/float';
 export { decimal } from './types/decimal';
-export { mongoId } from './types/mongoId';
 export { autoIncrement } from './types/autoIncrement';
 export { select } from './types/select';
 export { virtual } from './types/virtual';

--- a/packages-next/fields/src/types/autoIncrement/index.ts
+++ b/packages-next/fields/src/types/autoIncrement/index.ts
@@ -8,7 +8,6 @@ export type AutoIncrementFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
   defaultValue?: FieldDefaultValue<number>;
 };

--- a/packages-next/fields/src/types/decimal/index.ts
+++ b/packages-next/fields/src/types/decimal/index.ts
@@ -8,7 +8,6 @@ export type DecimalFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
   precision?: number;
   scale?: number;

--- a/packages-next/fields/src/types/float/index.ts
+++ b/packages-next/fields/src/types/float/index.ts
@@ -8,7 +8,6 @@ export type FloatFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
   defaultValue?: FieldDefaultValue<number>;
 };

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -8,7 +8,6 @@ export type IntegerFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
   defaultValue?: FieldDefaultValue<number>;
 };

--- a/packages-next/fields/src/types/mongoId/index.ts
+++ b/packages-next/fields/src/types/mongoId/index.ts
@@ -8,7 +8,6 @@ export type MongoIdFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
   defaultValue?: FieldDefaultValue<string>;
 };

--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -45,7 +45,6 @@ export type RelationshipFieldConfig<
     hideCreate?: boolean;
   };
   defaultValue?: FieldDefaultValue<Record<string, unknown>>;
-  isIndexed?: boolean;
   isUnique?: boolean;
 } & (SelectDisplayConfig | CardsDisplayConfig);
 

--- a/packages-next/fields/src/types/select/index.ts
+++ b/packages-next/fields/src/types/select/index.ts
@@ -23,7 +23,6 @@ export type SelectFieldConfig<
       displayMode?: 'select' | 'segmented-control';
     };
     isRequired?: boolean;
-    isIndexed?: boolean;
     isUnique?: boolean;
   };
 

--- a/packages-next/fields/src/types/text/index.ts
+++ b/packages-next/fields/src/types/text/index.ts
@@ -10,7 +10,6 @@ export type TextFieldConfig<
   defaultValue?: FieldDefaultValue<string>;
   isRequired?: boolean;
   isUnique?: boolean;
-  isIndexed?: boolean;
   ui?: {
     displayMode?: 'input' | 'textarea';
   };

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -9,7 +9,6 @@ export type TimestampFieldConfig<
 > = FieldConfig<TGeneratedListTypes> & {
   defaultValue?: FieldDefaultValue<string>;
   isRequired?: boolean;
-  isIndexed?: boolean;
   isUnique?: boolean;
 };
 

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -67,17 +67,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
         match(
           context,
           undefined,
-          adapterName === 'mongoose'
-            ? [
-                { name: 'person7', lastOnline: null },
-                { name: 'person6', lastOnline: null },
-                { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
-                { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
-                { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
-                { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
-                { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
-              ]
-            : adapterName === 'prisma_sqlite'
+          adapterName === 'prisma_sqlite'
             ? [
                 { name: 'person6', lastOnline: null },
                 { name: 'person7', lastOnline: null },
@@ -108,7 +98,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
         match(
           context,
           undefined,
-          adapterName === 'mongoose' || adapterName === 'prisma_sqlite'
+          adapterName === 'prisma_sqlite'
             ? [
                 { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
                 { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },

--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -15,8 +15,6 @@
     "@graphql-tools/schema": "^7.1.3",
     "@graphql-tools/utils": "^7.6.0",
     "@hapi/iron": "^6.0.0",
-    "@keystone-next/adapter-knex-legacy": "^13.2.3",
-    "@keystone-next/adapter-mongoose-legacy": "^11.1.3",
     "@keystone-next/adapter-prisma-legacy": "4.0.1",
     "@keystone-next/admin-ui": "^12.0.1",
     "@keystone-next/fields": "^5.4.0",

--- a/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
+++ b/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
@@ -1,5 +1,5 @@
 import type { KeystoneConfig } from '@keystone-next/types';
-import { autoIncrement, mongoId } from '@keystone-next/fields';
+import { autoIncrement } from '@keystone-next/fields';
 
 /* Validate lists config and default the id field */
 export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
@@ -16,8 +16,6 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['li
     let idField =
       config.lists[key].idField ??
       {
-        mongoose: mongoId({}),
-        knex: autoIncrement({}),
         prisma_postgresql: autoIncrement({}),
         prisma_sqlite: autoIncrement({}),
       }[config.db.adapter];

--- a/packages-next/keystone/src/lib/createContext.ts
+++ b/packages-next/keystone/src/lib/createContext.ts
@@ -64,10 +64,6 @@ export function makeCreateContext({
       lists: itemAPI,
       totalResults: 0,
       keystone,
-      // Only one of these will be available on any given context
-      // TODO: Capture that in the type
-      knex: keystone.adapter.knex,
-      mongoose: keystone.adapter.mongoose,
       prisma: keystone.adapter.prisma,
       graphql: { raw: rawGraphQL, run: runGraphQL, schema },
       maxTotalResults: keystone.queryLimits.maxTotalResults,

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -1,11 +1,6 @@
 import path from 'path';
 // @ts-ignore
 import { Keystone } from '@keystone-next/keystone-legacy';
-// @ts-ignore
-import { MongooseAdapter } from '@keystone-next/adapter-mongoose-legacy';
-// @ts-ignore
-import { KnexAdapter } from '@keystone-next/adapter-knex-legacy';
-// @ts-ignore
 import { PrismaAdapter } from '@keystone-next/adapter-prisma-legacy';
 import type { KeystoneConfig, BaseKeystone, MigrationAction } from '@keystone-next/types';
 
@@ -21,14 +16,7 @@ export function createKeystone(
   // it in their existing custom servers or original CLI systems.
   const { db, graphql, lists } = config;
   let adapter;
-  if (db.adapter === 'knex') {
-    adapter = new KnexAdapter({
-      knexOptions: { connection: db.url },
-      dropDatabase: db.dropDatabase,
-    });
-  } else if (db.adapter === 'mongoose') {
-    adapter = new MongooseAdapter({ mongoUri: db.url, ...db.mongooseOptions });
-  } else if (db.adapter === 'prisma_postgresql') {
+  if (db.adapter === 'prisma_postgresql') {
     adapter = new PrismaAdapter({
       getPrismaPath: () => path.join(dotKeystonePath, 'prisma'),
       migrationMode:

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -1,5 +1,4 @@
 import { IncomingMessage } from 'http';
-import type { ConnectOptions } from 'mongoose';
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import type { Config } from 'apollo-server-express';
@@ -75,8 +74,6 @@ export type DatabaseConfig = DatabaseCommon &
         enableLogging?: boolean;
         getPrismaPath?: (arg: { prismaSchema: any }) => string;
       }
-    | { adapter: 'knex'; dropDatabase?: boolean; schemaName?: string }
-    | { adapter: 'mongoose'; mongooseOptions?: { mongoUri?: string } & ConnectOptions }
   );
 
 // config.ui

--- a/packages-next/types/src/context.ts
+++ b/packages-next/types/src/context.ts
@@ -106,12 +106,6 @@ export type SessionContext<T> = {
 
 // DatabaseAPIs is used to provide access to the underlying database abstraction through
 // context and other developer-facing APIs in Keystone, so they can be used easily.
-
-// The implementation is very basic, and assumes there's a single adapter keyed by the constructor
-// name. Since there's no option _not_ to do that using the new config, we probably don't need
-// anything more sophisticated than this.
 export type DatabaseAPIs = {
-  knex?: any;
-  mongoose?: any;
   prisma?: any;
 };

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -36,8 +36,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }),
             });
 
-          // we don't memoize it for mongoose though since it has a cleanup which messes the memoization up
-          const getServer = adapterName === 'mongoose' ? _getServer : memoizeOne(_getServer);
+          const getServer = memoizeOne(_getServer);
 
           const withKeystone = (testFn: (args: any) => void = () => {}) =>
             runner(getServer, async ({ context, ...rest }) => {

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -98,95 +98,93 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
   describe(`Adapter: ${adapterName}`, () => {
     describe(`One-to-one relationships`, () => {
       describe('Read', () => {
-        if (adapterName !== 'mongoose') {
-          test(
-            'Where - friend',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              const { user, friend } = await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where - friend',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            const { user, friend } = await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friend: { name: "${friend.name}"} }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(1);
-              expect(data.allUsers[0].id).toEqual(user.id);
-            })
-          );
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(1);
+            expect(data.allUsers[0].id).toEqual(user.id);
+          })
+        );
 
-          test(
-            'Where - friendOf',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              const { user, friend } = await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where - friendOf',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            const { user, friend } = await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friendOf: { name: "${user.name}"} }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(1);
-              expect(data.allUsers[0].id).toEqual(friend.id);
-            })
-          );
-          test(
-            'Where friend: is_null: true',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(1);
+            expect(data.allUsers[0].id).toEqual(friend.id);
+          })
+        );
+        test(
+          'Where friend: is_null: true',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friend_is_null: true }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(4);
-            })
-          );
-          test(
-            'Where friendOf: is_null: true',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(4);
+          })
+        );
+        test(
+          'Where friendOf: is_null: true',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friendOf_is_null: true }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(4);
-            })
-          );
-          test(
-            'Where friend: is_null: false',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(4);
+          })
+        );
+        test(
+          'Where friend: is_null: false',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friend_is_null: false }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(1);
-            })
-          );
-          test(
-            'Where friendOf: is_null: false',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(1);
+          })
+        );
+        test(
+          'Where friendOf: is_null: false',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allUsers(where: { friendOf_is_null: false }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allUsers.length).toEqual(1);
-            })
-          );
-        }
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allUsers.length).toEqual(1);
+          })
+        );
 
         test(
           'Count',
@@ -204,66 +202,64 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           })
         );
 
-        if (adapterName !== 'mongoose') {
-          test(
-            'Where with count - friend',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              const { friend } = await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where with count - friend',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            const { friend } = await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allUsersMeta(where: { friend: { name: "${friend.name}"} }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(1);
-            })
-          );
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(1);
+          })
+        );
 
-          test(
-            'Where with count - friendOf',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              const { user } = await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where with count - friendOf',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            const { user } = await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allUsersMeta(where: { friendOf: { name: "${user.name}"} }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(1);
-            })
-          );
-          test(
-            'Where null with count - friend',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(1);
+          })
+        );
+        test(
+          'Where null with count - friend',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allUsersMeta(where: { friend_is_null: true }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(4);
-            })
-          );
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(4);
+          })
+        );
 
-          test(
-            'Where null with count - friendOf',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createUserAndFriend(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where null with count - friendOf',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createUserAndFriend(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allUsersMeta(where: { friendOf_is_null: true }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allUsersMeta.count).toEqual(4);
-            })
-          );
-        }
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allUsersMeta.count).toEqual(4);
+          })
+        );
       });
 
       describe('Create', () => {

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -191,72 +191,70 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allCompanies[0].id).toEqual(company.id);
           })
         );
-        if (adapterName !== 'mongoose') {
-          test(
-            'Where A: is_null: true',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createCompanyAndLocation(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where A: is_null: true',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createCompanyAndLocation(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(4);
-              expect(data.allCompanies.length).toEqual(3);
-            })
-          );
-          test(
-            'Where B: is_null: true',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createLocationAndCompany(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(4);
+            expect(data.allCompanies.length).toEqual(3);
+          })
+        );
+        test(
+          'Where B: is_null: true',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createLocationAndCompany(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(4);
-              expect(data.allCompanies.length).toEqual(3);
-            })
-          );
-          test(
-            'Where A: is_null: false',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createCompanyAndLocation(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(4);
+            expect(data.allCompanies.length).toEqual(3);
+          })
+        );
+        test(
+          'Where A: is_null: false',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createCompanyAndLocation(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(1);
-              expect(data.allCompanies.length).toEqual(1);
-            })
-          );
-          test(
-            'Where B: is_null: false',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createLocationAndCompany(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(1);
+            expect(data.allCompanies.length).toEqual(1);
+          })
+        );
+        test(
+          'Where B: is_null: false',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createLocationAndCompany(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data.allLocations.length).toEqual(1);
-              expect(data.allCompanies.length).toEqual(1);
-            })
-          );
-        }
+            });
+            expect(errors).toBe(undefined);
+            expect(data.allLocations.length).toEqual(1);
+            expect(data.allCompanies.length).toEqual(1);
+          })
+        );
 
         test(
           'Count',
@@ -308,40 +306,38 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data._allLocationsMeta.count).toEqual(1);
           })
         );
-        if (adapterName !== 'mongoose') {
-          test(
-            'Where null with count A',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createCompanyAndLocation(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+        test(
+          'Where null with count A',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createCompanyAndLocation(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allLocationsMeta(where: { company_is_null: true }) { count }
                   _allCompaniesMeta(where: { location_is_null: true }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(4);
-            })
-          );
-          test(
-            'Where null with count B',
-            runner(setupKeystone, async ({ context }) => {
-              await createInitialData(context);
-              await createLocationAndCompany(context);
-              const { data, errors } = await context.executeGraphQL({
-                query: `{
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(4);
+          })
+        );
+        test(
+          'Where null with count B',
+          runner(setupKeystone, async ({ context }) => {
+            await createInitialData(context);
+            await createLocationAndCompany(context);
+            const { data, errors } = await context.executeGraphQL({
+              query: `{
                   _allLocationsMeta(where: { company_is_null: true }) { count }
                   _allCompaniesMeta(where: { location_is_null: true }) { count }
                 }`,
-              });
-              expect(errors).toBe(undefined);
-              expect(data._allCompaniesMeta.count).toEqual(3);
-              expect(data._allLocationsMeta.count).toEqual(4);
-            })
-          );
-        }
+            });
+            expect(errors).toBe(undefined);
+            expect(data._allCompaniesMeta.count).toEqual(3);
+            expect(data._allLocationsMeta.count).toEqual(4);
+          })
+        );
       });
 
       describe('Create', () => {

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -374,7 +374,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'errors if connecting items which cannot be found during creating',
         runner(setupKeystone, async ({ context }) => {
-          const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
+          const FAKE_ID = 100;
 
           // Create an item that does the linking
           const { errors } = await context.executeGraphQL({
@@ -399,7 +399,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'errors if connecting items which cannot be found during update',
         runner(setupKeystone, async ({ context }) => {
-          const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
+          const FAKE_ID = 100;
 
           // Create an item to link against
           const createUser = await createItem({ context, listKey: 'User', item: {} });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -182,7 +182,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'errors if connecting an item which cannot be found during creating',
         runner(setupKeystone, async ({ context }) => {
-          const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
+          const FAKE_ID = 100;
 
           // Create an item that does the linking
           const { errors } = await context.executeGraphQL({
@@ -205,7 +205,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'errors if connecting an item which cannot be found during update',
         runner(setupKeystone, async ({ context }) => {
-          const FAKE_ID = adapterName === 'mongoose' ? '5b84f38256d3c2df59a0d9bf' : 100;
+          const FAKE_ID = 100;
 
           // Create an item to link against
           const createEvent = await createItem({ context, listKey: 'Event', item: {} });


### PR DESCRIPTION
As per our [roadmap](https://next.keystonejs.com/roadmap#streamlined-back-end-with-prisma) we're moving towards `Prisma` being the core of our backend database support.

This PR removes `knex` and `mongoose` as supported adapters from the public API. It also removes the `mongoId` field type, which was used exclusively by the `mongoose` adapter.

By focusing on a single backend database adapter we will be able to provide a more consistent experience for all users while still supporting a range of backends, including MongoDB, which is [currently being worked on](https://www.notion.so/Prisma-Roadmap-50766227b779464ab98899accb98295f).

It will also significantly reduce the complexity of our backend code, allowing us to add support for new field types and features much more easily than is currently possible.

Notes for reviewer: This PR is the minimal set of changes required to remove the `knex`, `mongoose`, and `mongoId` values from the public API. Once these are gone there will be a series of follow up PRs to clean up the code which is now inaccessible.