### PR TITLE
Remove runCustomQuery from server-side-graphql-client

### DIFF
--- a/.changeset/popular-elephants-explode.md
+++ b/.changeset/popular-elephants-explode.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/server-side-graphql-client-legacy': major
+'@keystone-next/benchmarks-legacy': patch
+---
+
+Removed legacy `runCustomQuery` function.

--- a/packages/server-side-graphql-client/README.md
+++ b/packages/server-side-graphql-client/README.md
@@ -92,8 +92,6 @@ To perform CRUD operations, use the following functions:
 - [`deleteItem`](#deleteitem)
 - [`deleteItems`](#deleteitems)
 
-For custom queries use [`runCustomQuery`](#runcustomquery).
-
 > NOTE: All functions accept a config object as an argument, and return a `Promise`.
 
 ### Shared Config Options
@@ -408,15 +406,3 @@ deletedUsers(['123', '456']);
 | ---------- | ---------- | ---------- | ------------------------------------------------------------------------- |
 | `items`    | `String[]` | (required) | Array of item `id`s to be deleted.                                        |
 | `pageSize` | `Number`   | 500        | The delete mutation batch size. Useful when deleting a large set of data. |
-
-### `runCustomQuery`
-
-Execute a custom query.
-
-#### Config
-
-| Properties  | Type     | Default    | Description                                                                                                                                                                                                         |
-| ----------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `query`     | String   | (required) | The GraphQL query to execute.                                                                                                                                                                                       |
-| `variables` | Object   | (required) | Object containing variables your custom query needs.                                                                                                                                                                |
-| `context`   | `Object` | N/A        | An Apollo [`context` object](https://www.apollographql.com/docs/apollo-server/data/resolvers/#the-context-argument). See the [server side graphQL docs](/docs/discussions/server-side-graphql.md) for more details. |

--- a/packages/server-side-graphql-client/index.js
+++ b/packages/server-side-graphql-client/index.js
@@ -1,5 +1,4 @@
 const {
-  runCustomQuery,
   getItem,
   getItems,
   createItems,
@@ -11,7 +10,6 @@ const {
 } = require('./lib/server-side-graphql-client');
 
 module.exports = {
-  runCustomQuery,
   getItem,
   getItems,
   createItems,

--- a/packages/server-side-graphql-client/lib/server-side-graphql-client.js
+++ b/packages/server-side-graphql-client/lib/server-side-graphql-client.js
@@ -185,5 +185,4 @@ module.exports = {
   updateItems,
   deleteItem,
   deleteItems,
-  runCustomQuery: runQuery,
 };

--- a/tests/benchmarks/lib/utils.js
+++ b/tests/benchmarks/lib/utils.js
@@ -1,12 +1,11 @@
 const { multiAdapterRunners } = require('@keystone-next/test-utils-legacy');
-const { runCustomQuery } = require('@keystone-next/server-side-graphql-client-legacy');
 
 const timeQuery = async ({ context, query, variables, repeat = 1 }) => {
   const t0_us = process.hrtime.bigint();
   const allErrors = [];
   for (let i = 0; i < repeat; i++) {
     try {
-      await runCustomQuery({ context, query, variables });
+      await context.graphql.run({ query, variables });
     } catch (error) {
       allErrors.push(error);
     }


### PR DESCRIPTION
We now have `context.graphql.run` to do exactly this, so it doesn't need to be exported from the package.