### PR TITLE
Remove outdated debug comments

### DIFF
--- a/packages/adapter-prisma/src/adapter-prisma.js
+++ b/packages/adapter-prisma/src/adapter-prisma.js
@@ -281,12 +281,6 @@ class PrismaAdapter extends BaseKeystoneAdapter {
 
   disconnect() {
     return this.prisma.$disconnect();
-    // Everything below here is being cleaned up in an attempt to help out the garbage collector
-    // delete this.prisma;
-    // Object.values(this.listAdapters).forEach(listAdapter => {
-    //   delete listAdapter.prisma;
-    // });
-    // delete require.cache[require.resolve(this.clientPath)];
   }
 
   getDefaultPrimaryKeyConfig() {


### PR DESCRIPTION
At one point of I had this code in an attempt to trigger the garbage collector, as it didn't seem to be working as expected. This issue is long gone, and the commented code can now go away.