### PR TITLE
Convert more tests to use context.graphql

### DIFF
--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -36,50 +36,45 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'filter works when there is no dash in list name',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `{ allUsers(where: { noDash: "aValue" }) { id } }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
         })
       );
       test(
         'filter works when there is one dash in list name',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `{ allUsers(where: { single_dash: "aValue" }) { id } }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
         })
       );
       test(
         'filter works when there are multiple dashes in list name',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `{ allUsers(where: { many_many_many_dashes: "aValue" }) { id } }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
         })
       );
       test(
         'filter works when there are multiple dashes in a row in a list name',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `{ allUsers(where: { multi____dash: "aValue" }) { id } }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allUsers', []);
         })
       );
       test(
         'filter works when there is one dash in list name as part of a relationship',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `{ allSecondaryLists(where: { someUser_is_null: true }) { id } }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('allSecondaryLists', []);
         })
       );

--- a/tests/api-tests/queries/meta.test.ts
+++ b/tests/api-tests/queries/meta.test.ts
@@ -37,7 +37,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
           query {
             _CompaniesMeta {
@@ -58,7 +58,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
@@ -80,7 +79,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema.relatedFields' returns empty array when none exist`,
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
           query {
             _PostsMeta {
@@ -101,7 +100,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_PostsMeta.schema');
           expect(data._PostsMeta.schema).toMatchObject({
             type: 'Post',
@@ -120,7 +118,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all lists',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
           query {
             _ksListsMeta {
@@ -146,7 +144,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {
@@ -254,7 +251,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for one list',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
           query {
             _ksListsMeta(where: { key: "User" }) {
@@ -280,7 +277,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {
@@ -327,7 +323,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for one list and one type of field',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
           query {
             _ksListsMeta(where: { key: "Company" }) {
@@ -353,7 +349,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -84,7 +84,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allPosts(where: {
@@ -97,7 +97,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allPosts');
             expect(data.allPosts).toHaveLength(3);
 
@@ -131,7 +130,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allPosts(where: {
@@ -151,7 +150,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allPosts: [{ id: posts[0].id, title: posts[0].title }],
             });
-            expect(errors).toBe(undefined);
           })
         );
       });
@@ -191,7 +189,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -211,7 +209,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allUsers: [{ id: users[2].id, feed: [{ title: 'I like Jelly' }] }],
             });
-            expect(errors).toBe(undefined);
           })
         );
 
@@ -223,7 +220,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -238,7 +235,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allUsers');
             expect(data.allUsers).toHaveLength(2);
 
@@ -261,7 +257,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -281,7 +277,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data).toMatchObject({
               allUsers: [{ id: users[1].id, feed: [{ title: 'Bye' }] }],
             });
-            expect(errors).toBe(undefined);
           })
         );
       });
@@ -317,7 +312,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -335,7 +330,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(data.allUsers).toHaveLength(2);
             expect(data.allUsers).toContainEqual({ id: users[2].id, feed: [] });
             expect(data.allUsers).toContainEqual({ id: users[3].id, feed: [] });
-            expect(errors).toBe(undefined);
           })
         );
 
@@ -347,7 +341,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -370,7 +364,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               ],
             });
             expect(data.allUsers).toHaveLength(1);
-            expect(errors).toBe(undefined);
           })
         );
 
@@ -382,7 +375,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -398,7 +391,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allUsers');
             expect(data.allUsers).toHaveLength(3);
 
@@ -432,7 +424,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -455,7 +447,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(allUsers).toContainEqual({ id: users[1].id, feed: [] });
             expect(allUsers).toContainEqual({ id: users[2].id, feed: [] });
             expect(allUsers).toContainEqual({ id: users[3].id, feed: [] });
-            expect(errors).toBe(undefined);
           })
         );
 
@@ -467,7 +458,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // SOME
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -485,7 +476,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
             expect(data).toMatchObject({ allUsers: [] });
             expect(data.allUsers).toHaveLength(0);
-            expect(errors).toBe(undefined);
           })
         );
 
@@ -497,7 +487,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const { users } = await setup(create);
 
             // NONE
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
           query {
             allUsers(where: {
@@ -512,7 +502,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
             });
 
-            expect(errors).toBe(undefined);
             expect(data).toHaveProperty('allUsers');
             expect(data.allUsers).toHaveLength(4);
 

--- a/tests/api-tests/queries/search.test.ts
+++ b/tests/api-tests/queries/search.test.ts
@@ -47,7 +47,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -58,7 +58,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([{ name: 'one' }]);
       })
@@ -75,7 +74,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -86,7 +85,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([{ name: 'one' }]);
       })
@@ -103,7 +101,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -114,7 +112,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([{ name: 'one' }]);
       })
@@ -131,7 +128,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -142,7 +139,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([{ name: '%islikelike%' }]);
       })
@@ -160,7 +156,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -171,7 +167,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([]); // No results
       })
@@ -188,7 +183,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allNumbers(
@@ -199,7 +194,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allNumbers');
         expect(data.allNumbers).toEqual([]); // No results
       })
@@ -216,7 +210,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Number', { name: 12345 }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allTests(
@@ -228,7 +222,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allTests');
         expect(data.allTests).toEqual([
           { name: '%islikelike%' },
@@ -250,7 +243,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           create('Custom', { other: 'two' }),
         ]);
 
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `
           query {
             allCustoms(
@@ -261,7 +254,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           }
       `,
         });
-        expect(errors).toBe(undefined);
         expect(data).toHaveProperty('allCustoms');
         expect(data.allCustoms).toEqual([{ other: 'one' }]);
       })


### PR DESCRIPTION
Removing usage of the deprecated `executeGraphQL`, one group of tests at a time.