### PR TITLE
Remove experimental.prismaSqlite

### DIFF
--- a/.changeset/lucky-carrots-juggle.md
+++ b/.changeset/lucky-carrots-juggle.md
@@ -1,0 +1,13 @@
+---
+'@keystone-next/keystone': minor
+'@keystone-next/types': minor
+'@keystone-next/website': patch
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-ecommerce': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/example-sandbox': patch
+'@keystone-next/test-utils-legacy': patch
+---
+
+The flag `{ experimental: { prismaSqlite: true } }` is no longer required to use the SQLite adapter.

--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -87,9 +87,6 @@ export default config({
 
 ### prisma_sqlite
 
-Support for SQLite with Prisma is still in preview.
-To use this option you must also set `{ experimental: { prismaSqlite: true } }`.
-
 Advanced configuration:
 
 - `enableLogging` (default: `false`): Enable logging from the Prisma client.
@@ -265,7 +262,6 @@ import { config } from '@keystone-next/keystone/schema';
 export default config({
   experimental: {
     enableNextJsGraphqlApiEndpoint: true,
-    prismaSqlite: true,
   }
   /* ... */
 });
@@ -274,7 +270,5 @@ export default config({
 Options:
 
 - `enableNextJsGraphqlApiEndpoint`: (coming soon)
-- `prismaSqlite`: Enables the use of SQLite with Prisma.
-  This flag is required when setting `{ db: { adapter: 'prisma_sqlite' } }`.
 
 export default ({ children }) => <Markdown>{children}</Markdown>;

--- a/examples-next/auth/keystone.ts
+++ b/examples-next/auth/keystone.ts
@@ -60,7 +60,6 @@ export default withAuth(
     db: process.env.DATABASE_URL
       ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
       : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
-    experimental: { prismaSqlite: true },
     lists,
     ui: {},
     session: withItemData(

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -27,7 +27,6 @@ export default auth.withAuth(
     db: process.env.DATABASE_URL
       ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
       : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
-    experimental: { prismaSqlite: true },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {
     //   path: '/api/graphql',

--- a/examples-next/ecommerce/keystone.ts
+++ b/examples-next/ecommerce/keystone.ts
@@ -58,7 +58,6 @@ export default withAuth(
             }
           },
         },
-    experimental: { prismaSqlite: true },
     lists: createSchema({
       // Schema items go in here
       User,

--- a/examples-next/roles/keystone.ts
+++ b/examples-next/roles/keystone.ts
@@ -43,7 +43,6 @@ export default withAuth(
     db: process.env.DATABASE_URL
       ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
       : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
-    experimental: { prismaSqlite: true },
     lists,
     ui: {
       /* Everyone who is signed in can access the Admin UI */

--- a/examples-next/sandbox/keystone.ts
+++ b/examples-next/sandbox/keystone.ts
@@ -16,6 +16,5 @@ export default config({
         adapter: 'prisma_sqlite',
         url: process.env.DATABASE_URL || 'file:./dev.db',
       },
-  experimental: { prismaSqlite: true },
   lists,
 });

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -17,11 +17,6 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
       provider: 'postgresql',
     });
   } else if (db.adapter === 'prisma_sqlite') {
-    if (!config.experimental?.prismaSqlite) {
-      throw new Error(
-        'SQLite support is still experimental. You must set { experimental: { prismaSqlite: true } } in your config to use this feature.'
-      );
-    }
     adapter = new PrismaAdapter({
       prismaClient,
       ...db,

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -34,8 +34,6 @@ export type KeystoneConfig = {
   experimental?: {
     /** Enables nextjs graphql api route mode */
     enableNextJsGraphqlApiEndpoint?: boolean;
-    /** Enable Prisma+SQLite support */
-    prismaSqlite?: boolean;
   };
 };
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -55,17 +55,12 @@ async function setupFromConfig({
   adapterName: AdapterName;
   config: TestKeystoneConfig;
 }) {
-  let db: KeystoneConfig['db'];
-  if (adapterName === 'prisma_postgresql') {
-    const adapterArgs = await argGenerator[adapterName]();
-    db = { adapter: adapterName, ...adapterArgs };
-  } else if (adapterName === 'prisma_sqlite') {
-    const adapterArgs = await argGenerator[adapterName]();
-    db = { adapter: adapterName, ...adapterArgs };
-    _config = { ..._config, experimental: { prismaSqlite: true } };
-  }
-
-  const config = initConfig({ ..._config, db: db!, ui: { isDisabled: true } });
+  const adapterArgs = await argGenerator[adapterName]();
+  const config = initConfig({
+    ..._config,
+    db: { adapter: adapterName, ...adapterArgs },
+    ui: { isDisabled: true },
+  });
 
   const prismaClient = await (async () => {
     const { keystone, graphQLSchema } = createSystem(config);


### PR DESCRIPTION
As of the upcoming release we're confident that this feature is generally useful, so no longer needs the experimental flag.

We'll ship this PR on the morning of the release to get the timing of the docs update right, as nothing else is blocked by it.