### PR TITLE
Fixing problems with the Status component

### DIFF
--- a/docs-next/components/Status.tsx
+++ b/docs-next/components/Status.tsx
@@ -1,44 +1,40 @@
 /** @jsx jsx */
 import { jsx } from '@keystone-ui/core';
 
-interface StatusProps {
-  look: 'notStarted' | 'figuringItOut' | 'theresAPlan' | 'makingItHappen' | 'cleaningUp';
-}
-export function Status({ look }: StatusProps) {
-  const statusMap = {
-    notStarted: {
-      label: 'Not started',
-      icon: '🛑',
-      color: '#DC2626',
-      backgroundColor: '#FEE2E2',
-    },
-    figuringItOut: {
-      label: 'Figuring it out',
-      icon: '🖊️',
-      color: '#D97706',
-      backgroundColor: '#FEF3C7',
-    },
-    theresAPlan: {
-      label: 'There’s a plan',
-      icon: '📋',
-      color: '#DB2777',
-      backgroundColor: '#FCE7F3',
-    },
-    makingItHappen: {
-      label: 'Making it happen',
-      icon: '🔧',
-      color: '#1D4ED8',
-      backgroundColor: '#DBEAFE',
-    },
-    cleaningUp: {
-      label: 'Cleaning up',
-      icon: '🧹',
-      color: '#15803D',
-      backgroundColor: '#DCFCE7',
-    },
-  };
+const statusMap = {
+  notStarted: {
+    label: 'Not started',
+    color: '#666666',
+    backgroundColor: '#eeeeee',
+  },
+  figuringItOut: {
+    label: 'Figuring it out',
+    color: '#D97706',
+    backgroundColor: '#FEF3C7',
+  },
+  theresAPlan: {
+    label: 'There’s a plan',
+    color: '#DB2777',
+    backgroundColor: '#FCE7F3',
+  },
+  makingItHappen: {
+    label: 'Making it happen',
+    color: '#1D4ED8',
+    backgroundColor: '#DBEAFE',
+  },
+  cleaningUp: {
+    label: 'Cleaning up',
+    color: '#15803D',
+    backgroundColor: '#DCFCE7',
+  },
+};
 
-  const commonStyles = {
+type StatusProps = {
+  look: keyof typeof statusMap;
+};
+export function Status({ look }: StatusProps) {
+  const status = statusMap[look];
+  const styles = {
     '&::before': {
       display: 'none',
     },
@@ -48,20 +44,10 @@ export function Status({ look }: StatusProps) {
     fontSize: '85%',
     fontFamily: 'SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace',
     padding: '0.25rem 0.375rem',
-    borderRadius: '0.125rem',
+    borderRadius: 6,
+    color: status.color,
+    backgroundColor: status.backgroundColor,
   };
 
-  return (
-    <span
-      css={{
-        ...commonStyles,
-        ...statusMap[look],
-      }}
-    >
-      <span aria-hidden="true" role="img">
-        {statusMap[look].icon}
-      </span>{' '}
-      {statusMap[look].label}
-    </span>
-  );
+  return <span css={styles}>{status.label}</span>;
 }


### PR DESCRIPTION
This PR fixes some issues with the new Status component on the roadmap, including:

* Props should be a `type` not an `interface`
* The whole status meta was being put in the styles, which is not valid CSS
* The possible statuses don't need to be created every time

I also tweaked the styling so not started is grey, not red; imo not started is not a "bad" thing it's just a "nothing to see yet" thing. Which I think grey conveys better.

Coming in another update to the PR:

* Clearer attribution for Redwood, this is more their pattern than Basecamp's
* I think I'm going to change the whole styles to tailwind for color consistency and accessibility on the text