### PR TITLE
[WIP] Fixing DB data type for DateTimeUtc field type

### DIFF
--- a/packages/fields/src/types/DateTimeUtc/Implementation.js
+++ b/packages/fields/src/types/DateTimeUtc/Implementation.js
@@ -48,7 +48,7 @@ export class PrismaDateTimeUtcInterface extends PrismaFieldAdapter {
   }
 
   getPrismaSchema() {
-    return [this._schemaField({ type: 'DateTime' })];
+    return [this._schemaField({ type: 'DateTime', extra: '@postgresql.Timestamptz(3)' })];
   }
 
   _stringToDate(s) {


### PR DESCRIPTION
Adding native database type attribute for the DateTimeUtc field to produce the `timestamp(3) with time zone` type in pg.

https://thinkmill.atlassian.net/browse/KEY-345