### PR TITLE
Update Slack channel links in roadmap.mdx

### DIFF
--- a/docs-next/pages/roadmap.mdx
+++ b/docs-next/pages/roadmap.mdx
@@ -14,7 +14,7 @@ There is a lot more to do, and with a larger than ever team at [Thinkmill](https
 
 We'll be updating this roadmap fortnightly (or as often as we need to) to help you track our progress and plans, find info that matters to your project, and communicate with us more dynamically while we grow the platform.
 
-If you’re looking for active conversations and interactions, please join our [KeystoneJS Slack](https://community.slack.com), and feel free to [open a PR](https://github.com/keystonejs/keystone/pulls).
+If you’re looking for active conversations and interactions, please join our [KeystoneJS Slack](http://community.keystonejs.com), and feel free to [open a PR](https://github.com/keystonejs/keystone/pulls).
 
 ## Project Status
 
@@ -148,6 +148,6 @@ better authoring experience out of the box.
 
 ## Feedback
 
-We'd love to hear from you! If you’ve got feedback (or praise 🙌), send it our way at [@KeystoneJS](https://twitter.com/keystonejs) on Twitter, or start a discussion / ask a question / make some friends in our [KeystoneJS Slack community](https://github.com/keystonejs/keystone/discussions).
+We'd love to hear from you! If you’ve got feedback (or praise 🙌), send it our way at [@KeystoneJS](https://twitter.com/keystonejs) on Twitter, start a discussion / ask a question / make some friends in our [KeystoneJS Slack community](http://community.keystonejs.com), or join in the [discussion on GitHub](https://github.com/keystonejs/keystone/discussions).
 
 export default ({ children }) => <Markdown>{children}</Markdown>;

--- a/docs-next/pages/roadmap.mdx
+++ b/docs-next/pages/roadmap.mdx
@@ -148,6 +148,6 @@ better authoring experience out of the box.
 
 ## Feedback
 
-We'd love to hear from you! If you’ve got feedback (or praise 🙌), send it our way at [@KeystoneJS](https://twitter.com/keystonejs) on Twitter, start a discussion / ask a question / make some friends in our [KeystoneJS Slack community](http://community.keystonejs.com), or join in the [discussion on GitHub](https://github.com/keystonejs/keystone/discussions).
+We'd love to hear from you! If you’ve got feedback (or praise 🙌), send it our way at [@KeystoneJS](https://twitter.com/keystonejs) on Twitter, or start a discussion / ask a question / make some friends in our [KeystoneJS Slack community](http://community.keystonejs.com).
 
 export default ({ children }) => <Markdown>{children}</Markdown>;


### PR DESCRIPTION
update roadmap.mdx so KeystoneJS Slack has the correct links