### PR TITLE
Cleanups in the prisma adapter

### DIFF
--- a/.changeset/afraid-pumpkins-lick.md
+++ b/.changeset/afraid-pumpkins-lick.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': major
+---
+
+Removed legacy `PrismaAdapter.listAdapterClass`, `PrismaAdapter.postConnect()`, and `PrismaAdapter.checkDatabaseVersion()`.


### PR DESCRIPTION
This PR cleans up some methods and properties we no longer need, along with some unused code paths. Makes it much easier to follow what happens during the `connect()` operation.