### PR TITLE
Remove legacy default ID support

### DIFF
--- a/.changeset/shy-dancers-fix.md
+++ b/.changeset/shy-dancers-fix.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/adapter-prisma-legacy': major
+'@keystone-next/fields-auto-increment-legacy': major
+'@keystone-next/keystone-legacy': major
+---
+
+Removed legacy default ID field support.

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -10,7 +10,6 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@keystone-next/fields-auto-increment-legacy": "^9.0.0",
     "@keystone-next/keystone-legacy": "^22.0.0",
     "@keystone-next/utils-legacy": "^8.0.0",
     "p-waterfall": "^2.1.1"

--- a/packages/adapter-prisma/src/adapter-prisma.js
+++ b/packages/adapter-prisma/src/adapter-prisma.js
@@ -191,12 +191,6 @@ class PrismaAdapter {
     return this.prisma.$disconnect();
   }
 
-  getDefaultPrimaryKeyConfig() {
-    // Required here due to circular refs
-    const { AutoIncrement } = require('@keystone-next/fields-auto-increment-legacy');
-    return AutoIncrement.primaryKeyDefaults[this.name].getConfig();
-  }
-
   async checkDatabaseVersion() {
     // FIXME: Decide what/how we want to check things here
   }

--- a/packages/fields-auto-increment/src/index.js
+++ b/packages/fields-auto-increment/src/index.js
@@ -6,11 +6,4 @@ export const AutoIncrement = {
   adapters: {
     prisma: PrismaAutoIncrementInterface,
   },
-
-  primaryKeyDefaults: {
-    prisma: {
-      // Uniqueness, non-nullability and GraphQL type are implied
-      getConfig: () => ({ type: AutoIncrement }),
-    },
-  },
 };

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -165,18 +165,7 @@ module.exports = class List {
 
     // Add an 'id' field if none supplied
     if (!sanitisedFieldsConfig.id) {
-      if (typeof this.adapter.parentAdapter.getDefaultPrimaryKeyConfig !== 'function') {
-        throw new Error(
-          `No 'id' field given for the '${this.key}' list and the list adapter ` +
-            `in used (${this.adapter.key}) doesn't supply a default primary key config ` +
-            `(no 'getDefaultPrimaryKeyConfig()' function)`
-        );
-      }
-      // Rebuild the object so id is "first"
-      sanitisedFieldsConfig = {
-        id: this.adapter.parentAdapter.getDefaultPrimaryKeyConfig(),
-        ...sanitisedFieldsConfig,
-      };
+      throw new Error(`No 'id' field given for the '${this.key}' list.`);
     }
 
     // Helpful errors for misconfigured lists

--- a/packages/keystone/tests/Keystone.test.js
+++ b/packages/keystone/tests/Keystone.test.js
@@ -51,7 +51,6 @@ class MockListAdapter {
 class MockAdapter {
   name = 'mock';
   newListAdapter = () => new MockListAdapter(this);
-  getDefaultPrimaryKeyConfig = () => ({ type: MockFieldType });
 }
 
 test('Check require', () => {

--- a/packages/keystone/tests/Keystone.test.js
+++ b/packages/keystone/tests/Keystone.test.js
@@ -69,6 +69,7 @@ describe('Keystone.createList()', () => {
 
     keystone.createList('User', {
       fields: {
+        id: { type: MockFieldType },
         name: { type: MockFieldType },
         email: { type: MockFieldType },
       },

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -164,7 +164,6 @@ class MockListAdapter {
 class MockAdapter {
   name = 'mock';
   newListAdapter = () => new MockListAdapter(this);
-  getDefaultPrimaryKeyConfig = () => ({ type: MockIdType });
 }
 
 const listExtras = () => ({

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -25,16 +25,6 @@ const context = {
 // Needs to be wrapped in a mock type for gql to correctly parse it.
 const normalise = s => print(gql(`type t { ${s} }`));
 
-const config = {
-  fields: {
-    name: { type: Text },
-    email: { type: Text },
-    other: { type: Relationship, ref: 'Other' },
-    hidden: { type: Text, access: { read: false, create: true, update: true, delete: true } },
-    writeOnce: { type: Text, access: { read: true, create: true, update: false, delete: true } },
-  },
-};
-
 const getListByKey = listKey => {
   if (listKey === 'Other') {
     return {
@@ -174,6 +164,17 @@ const listExtras = () => ({
   schemaNames: ['public'],
 });
 
+const config = {
+  fields: {
+    id: { type: MockIdType },
+    name: { type: Text },
+    email: { type: Text },
+    other: { type: Relationship, ref: 'Other' },
+    hidden: { type: Text, access: { read: false, create: true, update: true, delete: true } },
+    writeOnce: { type: Text, access: { read: true, create: true, update: false, delete: true } },
+  },
+};
+
 const setup = extraConfig => {
   const list = new List('Test', { ...config, ...extraConfig }, listExtras());
   list.initFields();
@@ -276,7 +277,7 @@ describe('new List()', () => {
     expect(list.fieldsByPath['hidden']).toBeInstanceOf(Text.implementation);
     expect(list.fieldsByPath['writeOnce']).toBeInstanceOf(Text.implementation);
 
-    const idOnlyList = new List('NoField', { fields: {} }, listExtras());
+    const idOnlyList = new List('NoField', { fields: { id: { type: MockIdType } } }, listExtras());
     idOnlyList.initFields();
     expect(idOnlyList.fields).toHaveLength(1);
     expect(list.fields[0]).toBeInstanceOf(MockIdType.implementation);


### PR DESCRIPTION
This functionality is now handled by `applyIdFieldDefaults`.