### PR TITLE
Remove legacy list adapter methods

### DIFF
--- a/.changeset/funny-needles-remember.md
+++ b/.changeset/funny-needles-remember.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/adapter-prisma-legacy': major
+'@keystone-next/fields-legacy': patch
+'@keystone-next/keystone-legacy': patch
+---
+
+Removed legacy `.find()`, `.findAll()`, `.findOne()`, `.findById()`, `.itemsQueryMeta()`, `.getFieldAdapterByPath()`, and `.getPrimaryKeyAdapter()` methods from `PrismaListAdapter`.

--- a/packages/adapter-prisma/src/adapter-prisma.js
+++ b/packages/adapter-prisma/src/adapter-prisma.js
@@ -216,39 +216,9 @@ class PrismaListAdapter {
     return this.onPostRead(this._update(id, await this.onPreSave(data)));
   }
 
-  async findAll() {
-    return Promise.all((await this._itemsQuery({})).map(item => this.onPostRead(item)));
-  }
-
-  async findById(id) {
-    return this.onPostRead((await this._itemsQuery({ where: { id }, first: 1 }))[0] || null);
-  }
-
-  async find(condition) {
-    return Promise.all(
-      (await this._itemsQuery({ where: condition })).map(item => this.onPostRead(item))
-    );
-  }
-
-  async findOne(condition) {
-    return this.onPostRead((await this._itemsQuery({ where: condition, first: 1 }))[0]);
-  }
-
   async itemsQuery(args, { meta = false, from = {} } = {}) {
     const results = await this._itemsQuery(args, { meta, from });
     return meta ? results : Promise.all(results.map(item => this.onPostRead(item)));
-  }
-
-  itemsQueryMeta(args) {
-    return this.itemsQuery(args, { meta: true });
-  }
-
-  getFieldAdapterByPath(path) {
-    return this.fieldAdaptersByPath[path];
-  }
-
-  getPrimaryKeyAdapter() {
-    return this.fieldAdaptersByPath['id'];
   }
 
   _setupModel({ rels, prisma }) {

--- a/packages/fields/tests/test-fixtures.js
+++ b/packages/fields/tests/test-fixtures.js
@@ -21,7 +21,7 @@ export const skipCommonFilterTest = true;
 
 const getIDs = async keystone => {
   const IDs = {};
-  await keystone.lists['Test'].adapter.findAll().then(data => {
+  await keystone.lists['Test'].adapter.itemsQuery({}).then(data => {
     data.forEach(entry => {
       IDs[entry.name] = entry.id.toString();
     });

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -126,7 +126,6 @@ class MockListAdapter {
     this.index += 1;
     return this.items[this.index - 1];
   };
-  findById = id => this.items[id];
   delete = async id => {
     this.items[id] = undefined;
   };
@@ -144,7 +143,6 @@ class MockListAdapter {
         : ids.filter(i => !id_not_in || !id_not_in.includes(i)).map(i => this.items[i]);
     }
   };
-  itemsQueryMeta = async args => this.itemsQuery(args, { meta: true });
   update = (id, item) => {
     this.items[id] = { ...this.items[id], ...item };
     return this.items[id];


### PR DESCRIPTION
These methods were all either unused or barely used, and no longer things we want to explicitly expose in our APIs.