### PR TITLE
Add purgecss safelist to preserve colors that are used dynamically

### DIFF
--- a/docs-next/tailwind.config.js
+++ b/docs-next/tailwind.config.js
@@ -1,7 +1,18 @@
 const colors = require('tailwindcss/colors');
 
+const preserveColors = ['gray', 'orange', 'pink', 'blue', 'green'];
+
 module.exports = {
-  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  purge: {
+    enabled: true,
+    content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+    options: {
+      safelist: [
+        ...preserveColors.map(i => `bg-${i}-100`),
+        ...preserveColors.map(i => `text-${i}-700`),
+      ],
+    },
+  },
   darkMode: false, // or 'media' or 'class'
   theme: {
     colors: {


### PR DESCRIPTION
This fixes the bug where our roadmap status colours aren't preserved in the production CSS build.

It also always enables purging for local dev so we don't end up with a mismatch again between dev and prod.