### PR TITLE
Allow pass custom config object to dev and start run scripts

### DIFF
--- a/.changeset/ten-timers-matter.md
+++ b/.changeset/ten-timers-matter.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': minor
+---
+
+Allow pass custom config object to dev run

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import express from 'express';
 import { generateAdminUI } from '@keystone-next/admin-ui/system';
+import { KeystoneConfig } from '@keystone-next/types';
 import { devMigrations, pushPrismaSchemaToDatabase } from '../../lib/migrations';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/initConfig';
@@ -22,13 +23,17 @@ const devLoadingHTMLFilepath = path.join(
   'dev-loading.html'
 );
 
-export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
+export const dev = async (
+  cwd: string,
+  shouldDropDatabase: boolean,
+  customConfig?: KeystoneConfig
+) => {
   console.log('✨ Starting Keystone');
 
   const server = express();
   let expressServer: null | ReturnType<typeof express> = null;
 
-  const config = initConfig(requireSource(CONFIG_PATH).default);
+  const config = customConfig ?? initConfig(requireSource(CONFIG_PATH).default);
   const initKeystone = async () => {
     {
       const { keystone, graphQLSchema } = createSystem(config);

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -1,12 +1,13 @@
 import path from 'path';
 import * as fs from 'fs-extra';
+import { KeystoneConfig } from '@keystone-next/types';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/initConfig';
 import { createExpressServer } from '../../lib/createExpressServer';
 import { getAdminPath } from '../utils';
 import { requirePrismaClient } from '../../artifacts';
 
-export const start = async (cwd: string) => {
+export const start = async (cwd: string, customConfig?: KeystoneConfig) => {
   console.log('✨ Starting Keystone');
 
   // This is the compiled version of the configuration which was generated during the build step.
@@ -15,7 +16,7 @@ export const start = async (cwd: string) => {
   if (!fs.existsSync(apiFile)) {
     throw new Error('keystone-next build must be run before running keystone-next start');
   }
-  const config = initConfig(require(apiFile).config);
+  const config = customConfig ?? initConfig(require(apiFile).config);
   const { keystone, graphQLSchema, createContext } = createSystem(config, requirePrismaClient(cwd));
 
   console.log('✨ Connecting to the database');


### PR DESCRIPTION
Sometimes we need to initialize Keystone with custom config, especially for debug reasons. At now seems isn't possible to pass custom `KeystoneConfig` to run scripts such as `dev` and `start`, the config is always read from `keystone.ts` file at root.

This PR adds the ability to pass custom KeystoneConfig object to those run scripts, here is example how to use it:
```js
import { default as config } from "keystone";

config.db.onConnect = async function (context) {
  console.log('My custom code is launched!');
  let users = await context.lists.User.findMany({resolveFields: false});
  console.log(users);
}
dev('', false, config);
```
