### PR TITLE
Remove more usage of executeGraphQL

### DIFF
--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -64,32 +64,27 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'Executes custom queries correctly',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               query {
                 double(x: 10)
               }
             `,
           });
-
-          if (errors && errors.length) {
-            throw errors;
-          }
-
           expect(data.double).toEqual(20);
         })
       );
       it(
         'Denies access acording to access control',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const { data, errors } = await context.graphql.raw({
             query: `
               query {
                 quads(x: 10)
               }
             `,
           });
-          expect(data.quads).toBe(null);
+          expect(data?.quads).toBe(null);
           expect(errors).not.toBe(undefined);
           expect(errors).toHaveLength(1);
         })
@@ -97,17 +92,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'Executes custom mutations correctly',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 triple(x: 10)
               }
             `,
           });
-
-          if (errors && errors.length) {
-            throw errors;
-          }
 
           expect(data.triple).toEqual(30);
         })

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -51,7 +51,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             test(
               'Create an object without the required field',
               keystoneTestWrapper(async ({ context }) => {
-                const { data, errors } = await context.executeGraphQL({
+                const { data, errors } = await context.graphql.raw({
                   query: `
                   mutation {
                     createTest(data: { name: "test entry" } ) { id }
@@ -68,7 +68,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             test(
               'Update an object with the required field having a null value',
               keystoneTestWrapper(async ({ context }) => {
-                const { data: data0, errors: errors0 } = await context.executeGraphQL({
+                const data0 = await context.graphql.run({
                   query: `
                   mutation($data: TestCreateInput) {
                     createTest(data: $data ) { id }
@@ -80,8 +80,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     },
                   },
                 });
-                expect(errors0).toBe(undefined);
-                const { data, errors } = await context.executeGraphQL({
+                const { data, errors } = await context.graphql.raw({
                   query: `
                   mutation {
                     updateTest(id: "${data0.createTest.id}" data: { name: "updated test entry", testField: null } ) { id }
@@ -98,7 +97,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             test(
               'Update an object without the required field',
               keystoneTestWrapper(async ({ context }) => {
-                const { data: data0, errors: errors0 } = await context.executeGraphQL({
+                const data0 = await context.graphql.run({
                   query: `
                   mutation($data: TestCreateInput) {
                     createTest(data: $data ) { id }
@@ -110,15 +109,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                     },
                   },
                 });
-                expect(errors0).toBe(undefined);
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `
                   mutation {
                     updateTest(id: "${data0.createTest.id}" data: { name: "updated test entry" } ) { id }
                   }`,
                 });
                 expect(data.updateTest).not.toBe(null);
-                expect(errors).toBe(undefined);
               })
             );
           });

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -35,12 +35,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             foo: virtual({ resolver: () => 'Hello world!' }),
           }),
           async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.createPost.value).toEqual(1);
             expect(data.createPost.foo).toEqual('Hello world!');
           }
@@ -54,12 +53,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             foo: virtual({ graphQLReturnType: 'Int', resolver: () => 42 }),
           }),
           async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.createPost.value).toEqual(1);
             expect(data.createPost.foo).toEqual(42);
           }
@@ -80,12 +78,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             }),
           }),
           async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo(x: 10, y: 20) }
               }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.createPost.value).toEqual(1);
             expect(data.createPost.foo).toEqual(200);
           }
@@ -106,12 +103,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             }),
           }),
           async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo }
               }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.createPost.value).toEqual(1);
             expect(data.createPost.foo).toEqual(30);
           }
@@ -129,12 +125,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             }),
           }),
           async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation {
                 createPost(data: { value: 1 }) { value, foo { title rating } }
               }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.createPost.value).toEqual(1);
             expect(data.createPost.foo).toEqual([{ title: 'CATS!', rating: 100 }]);
           }

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -37,17 +37,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       it(
         'resolves fields first, then passes them to the list',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: { name: "jess" }) { name }
               }
             `,
           });
-
-          if (errors && errors.length) {
-            throw errors;
-          }
 
           // Field should be executed first, appending `-field`, then the list
           // should be executed which appends `-list`, and finally that total

--- a/tests/api-tests/queries-access-control/meta.test.ts
+++ b/tests/api-tests/queries-access-control/meta.test.ts
@@ -43,7 +43,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.exitSudo().executeGraphQL({
+          const data = await context.exitSudo().graphql.run({
             query: `
           query {
             _CompaniesMeta {
@@ -58,7 +58,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.access');
           expect(data._CompaniesMeta.access).toMatchObject({
             create: true,
@@ -72,7 +71,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'schema' field returns results`,
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.exitSudo().executeGraphQL({
+          const data = await context.exitSudo().graphql.run({
             query: `
           query {
             _CompaniesMeta {
@@ -93,7 +92,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_CompaniesMeta.schema');
           expect(data._CompaniesMeta.schema).toMatchObject({
             type: 'Company',
@@ -118,7 +116,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         `'access' field returns results`,
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.exitSudo().executeGraphQL({
+          const data = await context.exitSudo().graphql.run({
             query: `
           query {
             _ksListsMeta {
@@ -134,7 +132,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {
@@ -162,7 +159,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       test(
         'returns results for all visible lists',
         runner(setupKeystone, async ({ context }) => {
-          const { data, errors } = await context.exitSudo().executeGraphQL({
+          const data = await context.exitSudo().graphql.run({
             query: `
           query {
             _ksListsMeta {
@@ -184,7 +181,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       `,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toHaveProperty('_ksListsMeta');
           expect(data._ksListsMeta).toMatchObject([
             {

--- a/tests/api-tests/relationships/many-to-one-to-one.test.ts
+++ b/tests/api-tests/relationships/many-to-one-to-one.test.ts
@@ -11,11 +11,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 type IdType = any;
 
 const createInitialData = async (context: KeystoneContext) => {
-  type T = {
-    data: { createCompanies: { id: IdType }[]; createLocations: { id: IdType }[] };
-    errors: unknown;
-  };
-  const { data, errors }: T = await context.executeGraphQL({
+  const data = (await context.graphql.run({
     query: `
       mutation {
         createCompanies(data: [
@@ -30,8 +26,7 @@ const createInitialData = async (context: KeystoneContext) => {
           { data: { name: "${sampleOne(alphanumGenerator)}" } }
         ]) { id }
       }`,
-  });
-  expect(errors).toBe(undefined);
+  })) as { createCompanies: { id: IdType }[]; createLocations: { id: IdType }[] };
   const owners = await createItems({
     context,
     listKey: 'Owner',
@@ -145,12 +140,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             await createInitialData(context);
             const owner = await createCompanyAndLocation(context);
             const name1 = owner.companies[0].location.custodians[0].name;
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allOwners(where: { companies_some: { location: { custodians_some: { name: "${name1}" } } } }) { id companies { location { custodians { name } } } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allOwners.length).toEqual(1);
             expect(data.allOwners[0].id).toEqual(owner.id);
           })
@@ -161,12 +155,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             await createInitialData(context);
             const owner = await createCompanyAndLocation(context);
             const name1 = owner.name;
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allCustodians(where: { locations_some: { company: { owners_some: { name: "${name1}" } } } }) { id locations { company { owners { name } } } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allCustodians.length).toEqual(2);
           })
         );
@@ -176,12 +169,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             await createInitialData(context);
             const owner = await createCompanyAndLocation(context);
             const name1 = owner.name;
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allOwners(where: { companies_some: { location: { custodians_some: { locations_some: { company: { owners_some: { name: "${name1}" } } } } } } }) { id companies { location { custodians { name } } } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allOwners.length).toEqual(1);
             expect(data.allOwners[0].id).toEqual(owner.id);
           })
@@ -193,12 +185,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const owner = await createCompanyAndLocation(context);
             const name1 = owner.companies[0].location.custodians[0].name;
 
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allCustodians(where: { locations_some: { company: { owners_some: { companies_some: { location: { custodians_some: { name: "${name1}" } } } } } } }) { id locations { company { owners { name } } } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allCustodians.length).toEqual(2);
           })
         );

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -110,10 +110,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(errors).toBe(undefined);
 
           // Sanity check that the items are actually created
-          const {
-            data: { allNotes },
-            errors: errors2,
-          } = await context.executeGraphQL({
+          const { allNotes } = await context.graphql.run({
             query: `
               query {
                 allNotes(where: { id_in: [${data.createUser.notes
@@ -124,7 +121,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-          expect(errors2).toBe(undefined);
           expect(allNotes).toHaveLength(data.createUser.notes.length);
         })
       );

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
@@ -31,7 +31,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'when neither id or create data passed',
         runner(setupKeystone, async ({ context }) => {
           // Create an item that does the linking
-          const { errors } = await context.executeGraphQL({
+          const { errors } = await context.graphql.raw({
             query: `
               mutation {
                 createEvent(data: { group: {} }) {
@@ -50,7 +50,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'when both id and create data passed',
         runner(setupKeystone, async ({ context }) => {
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const { data, errors } = await context.graphql.raw({
             query: `
               mutation {
                 createEvent(data: { group: {
@@ -62,7 +62,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }`,
           });
 
-          expect(data.createEvent).toBe(null);
+          expect(data?.createEvent).toBe(null);
           expect(errors).toMatchObject([
             { message: 'Nested mutation operation invalid for Event.group<Group>' },
           ]);

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -279,7 +279,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item that does the nested create
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -295,11 +295,11 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             expect(errors).toHaveLength(1);
-            const error = errors[0];
+            const error = errors![0];
             expect(error.message).toEqual('You do not have access to this resource');
             expect(error.path).toHaveLength(2);
-            expect(error.path[0]).toEqual('createUserToNotesNoRead');
-            expect(error.path[1]).toEqual('notes');
+            expect(error.path![0]).toEqual('createUserToNotesNoRead');
+            expect(error.path![1]).toEqual('notes');
           })
         );
 
@@ -309,7 +309,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item that does the nested create
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -338,7 +338,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update an item that does the nested create
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -366,7 +366,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             const noteContent = sampleOne(alphanumGenerator);
 
             // Create an item that does the nested create
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   createUserToNotesNoCreate(data: {
@@ -380,18 +380,15 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
 
             // Assert it throws an access denied error
             expect(errors).toHaveLength(1);
-            const error = errors[0];
+            const error = errors![0];
             expect(error.message).toEqual(
               'Unable to create and/or connect 1 UserToNotesNoCreate.notes<NoteNoCreate>'
             );
             expect(error.path).toHaveLength(1);
-            expect(error.path[0]).toEqual('createUserToNotesNoCreate');
+            expect(error.path![0]).toEqual('createUserToNotesNoCreate');
 
             // Confirm it didn't insert either of the records anyway
-            const {
-              data: { allNoteNoCreates, allUserToNotesNoCreates },
-              errors: errors2,
-            } = await context.executeGraphQL({
+            const { allNoteNoCreates, allUserToNotesNoCreates } = await context.graphql.run({
               query: `
                 query {
                   allNoteNoCreates(where: { content: "${noteContent}" }) {
@@ -404,7 +401,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   }
                 }`,
             });
-            expect(errors2).toBe(undefined);
             expect(allNoteNoCreates).toMatchObject([]);
             expect(allUserToNotesNoCreates).toMatchObject([]);
           })

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -364,7 +364,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 expect(result.data[`all${group.name}s`]).toMatchObject([]);
 
                 // Confirm it didn't insert either of the records anyway
-                const result2 = await context.executeGraphQL({
+                const data2 = await context.graphql.run({
                   query: `
                     query {
                       allEventTo${group.name}s(where: { title: "${eventName}" }) {
@@ -373,8 +373,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                       }
                     }`,
                 });
-                expect(result2.errors).toBe(undefined);
-                expect(result2.data[`allEventTo${group.name}s`]).toMatchObject([]);
+                expect(data2[`allEventTo${group.name}s`]).toMatchObject([]);
               })
             );
 

--- a/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
@@ -92,7 +92,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -112,7 +112,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           expect(data).toMatchObject({ updateUser: { id: expect.any(String), notes: [] } });
-          expect(errors).toBe(undefined);
         })
       );
 
@@ -120,7 +119,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ context }) => {
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -136,7 +135,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               }`,
           });
 
-          expect(errors).toBe(undefined);
           expect(data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
@@ -167,7 +165,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await context.exitSudo().executeGraphQL({
+            await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -182,9 +180,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }`,
             });
 
-            expect(errors).toBe(undefined);
-
-            const result = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 query getUserNodes($userId: ID!){
                   UserToNotesNoRead(where: { id: $userId }) {
@@ -193,10 +189,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   }
                 }`,
               variables: { userId: createUser.id },
-              context,
             });
-            expect(result.errors).toBe(undefined);
-            expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
+            expect(data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );
       });

--- a/tests/api-tests/relationships/nested-mutations/disconnect-all-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-all-singular.test.ts
@@ -73,7 +73,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -91,7 +91,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           expect(data).toMatchObject({ updateEvent: { id: expect.any(String), group: null } });
-          expect(errors).toBe(undefined);
 
           // Avoid false-positives by checking the database directly
           const eventData = await getItem({
@@ -109,7 +108,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ context }) => {
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createEvent(data: {
@@ -124,7 +123,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.createEvent).toMatchObject({ id: expect.any(String), group: null });
           expect(data.createEvent).not.toHaveProperty('errors');
         })
@@ -137,7 +135,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createEvent = await createItem({ context, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -155,7 +153,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({ id: expect.any(String), group: null });
           expect(data.updateEvent).not.toHaveProperty('errors');
         })
@@ -189,7 +186,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await context.exitSudo().executeGraphQL({
+            await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   updateEventToGroupNoRead(
@@ -202,8 +199,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   }
                 }`,
             });
-
-            expect(errors).toBe(undefined);
 
             // Avoid false-positives by checking the database directly
             const eventData = await getItem({

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -92,7 +92,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -117,7 +117,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               notes: [{ id: createNote.id, content: noteContent }],
             },
           });
-          expect(errors).toBe(undefined);
         })
       );
 
@@ -127,7 +126,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -142,7 +141,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
           expect(data.createUser).not.toHaveProperty('errors');
         })
@@ -159,7 +157,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           const createUser = await createItem({ context, listKey: 'User', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -177,7 +175,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.updateUser).toMatchObject({ id: expect.any(String), notes: [] });
           expect(data.updateUser).not.toHaveProperty('errors');
         })
@@ -213,7 +210,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -237,7 +234,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
               notes: [{ id: expect.any(String), content: noteContent2 }],
             },
           });
-          expect(errors).toBe(undefined);
         })
       );
     });
@@ -267,7 +263,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await context.exitSudo().executeGraphQL({
+            await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -282,9 +278,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }`,
             });
 
-            expect(errors).toBe(undefined);
-
-            const result = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 query getUserNodes($userId: ID!){
                   UserToNotesNoRead(where: { id: $userId }) {
@@ -293,10 +287,8 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                   }
                 }`,
               variables: { userId: createUser.id },
-              context, // : context.createContext().sudo(),
             });
-            expect(result.errors).toBe(undefined);
-            expect(result.data.UserToNotesNoRead.notes).toHaveLength(0);
+            expect(data.UserToNotesNoRead.notes).toHaveLength(0);
           })
         );
       });

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
@@ -38,7 +38,7 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
         'nested create',
         runner(setupKeystone, async ({ context }) => {
           const locationName = sampleOne(alphanumGenerator);
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createCompany(data: {
@@ -51,8 +51,6 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
                 }
               }`,
           });
-
-          expect(errors).toBe(undefined);
 
           const companyId = data.createCompany.id;
           const locationId = data.createCompany.location.id;

--- a/tests/api-tests/relationships/shared-names.test.ts
+++ b/tests/api-tests/relationships/shared-names.test.ts
@@ -163,14 +163,13 @@ multiAdapterRunners().map(({ runner, adapterName }) =>
       'Query',
       runner(setupKeystone, async ({ context }) => {
         await createInitialData(context);
-        const { data, errors } = await context.executeGraphQL({
+        const data = await context.graphql.run({
           query: `{
                   allEmployees(where: {
                     company: { employees_some: { role: { name: "RoleA" } } }
                   }) { id name }
                 }`,
         });
-        expect(errors).toBe(undefined);
         expect(data.allEmployees).toHaveLength(1);
         expect(data.allEmployees[0].name).toEqual('EmployeeA');
       })


### PR DESCRIPTION
This deprecated API will be gone just as soon as I can chip away at all the remaining usages in the tests. There's still 18 test files to go after these ones 😅 