### PR TITLE
Add db.provider to replace db.adapter

### DIFF
--- a/.changeset/hungry-ladybugs-fly.md
+++ b/.changeset/hungry-ladybugs-fly.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/website': minor
+'@keystone-next/keystone': minor
+'@keystone-next/types': minor
+'@keystone-next/test-utils-legacy': patch
+---
+
+The config option `db.adapter` is now deprecated. It has been repaced with `db.provider` which can take the values `postgresql` or `sqlite`.

--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -57,14 +57,14 @@ import type { DatabaseConfig } from '@keystone-next/types';
 The `db` config option configures the database used to store data in your Keystone system.
 It has a TypeScript type of `DatabaseConfig`.
 Keystone supports the database types **PostgreSQL** and **SQLite**.
-These database types are powered by their corresponding Keystone database adapters; `prisma_postgresql` and `prisma_sqlite`.
+These database types are powered by their corresponding Prisma database providers; `postgresql` and `sqlite`.
 
 All database adapters require the `url` argument, which defines the connection URL for your database.
 They also all have an optional `onConnect` async function, which takes a [`KeystoneContext`](./context) object, and lets perform any actions you might need at startup, such as data seeding.
 
-As well as these common options, each adapter supports a number of optional advanced configuration options.
+As well as these common options, each provider supports a number of optional advanced configuration options.
 
-### prisma_postgresql
+### postgresql
 
 Advanced configuration:
 
@@ -74,7 +74,7 @@ Advanced configuration:
 ```typescript
 export default config({
   db: {
-    adapter: 'prisma_postgresql',
+    provider: 'postgresql',
     url: 'postgres://dbuser:dbpass@localhost:5432/keystone',
     onConnect: async context => { /* ... */ },
     // Optional advanced configuration
@@ -85,7 +85,7 @@ export default config({
 });
 ```
 
-### prisma_sqlite
+### sqlite
 
 Advanced configuration:
 
@@ -95,7 +95,7 @@ Advanced configuration:
 ```typescript
 export default config({
   db: {
-    adapter: 'prisma_sqlite',
+    provider: 'sqlite',
     url: 'file:./keystone.db',
     onConnect: async context => { /* ... */ },
     // Optional advanced configuration
@@ -108,7 +108,7 @@ export default config({
 
 #### Limitations
 
-The `prisma_sqlite` is not intended to be used in production systems, and has certain limitations:
+The `sqlite` provider is not intended to be used in production systems, and has certain limitations:
 
 - `document`: The `document` field type is not supported.
 - `decimal`: The `decimal` field type is not supported.

--- a/packages-next/keystone/src/artifacts.ts
+++ b/packages-next/keystone/src/artifacts.ts
@@ -126,7 +126,7 @@ const makeVercelIncludeTheSQLiteDB = (
   directoryOfFileToBeWritten: string,
   config: KeystoneConfig
 ) => {
-  if (config.db.adapter === 'prisma_sqlite') {
+  if (config.db.adapter === 'prisma_sqlite' || config.db.provider === 'sqlite') {
     const sqliteDbAbsolutePath = path.resolve(cwd, config.db.url.replace('file:', ''));
 
     return `import path from 'path';

--- a/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
+++ b/packages-next/keystone/src/lib/applyIdFieldDefaults.ts
@@ -13,12 +13,7 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['li
         )} list. This is not allowed, use the idField option instead.`
       );
     }
-    let idField =
-      config.lists[key].idField ??
-      {
-        prisma_postgresql: autoIncrement({}),
-        prisma_sqlite: autoIncrement({}),
-      }[config.db.adapter];
+    let idField = config.lists[key].idField ?? autoIncrement({});
     idField = {
       ...idField,
       config: {

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -10,13 +10,13 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
   // it in their existing custom servers or original CLI systems.
   const { db, graphql, lists } = config;
   let adapter;
-  if (db.adapter === 'prisma_postgresql') {
+  if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
     adapter = new PrismaAdapter({
       prismaClient,
       ...db,
       provider: 'postgresql',
     });
-  } else if (db.adapter === 'prisma_sqlite') {
+  } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {
     adapter = new PrismaAdapter({
       prismaClient,
       ...db,

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -63,16 +63,28 @@ export type DatabaseCommon = {
 
 export type DatabaseConfig = DatabaseCommon &
   (
-    | {
-        adapter: 'prisma_postgresql';
+    | ((
+        | {
+            /** @deprecated: The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
+            adapter: 'prisma_postgresql';
+            provider?: undefined;
+          }
+        | { adapter?: undefined; provider: 'postgresql' }
+      ) & {
         useMigrations?: boolean;
         enableLogging?: boolean;
-      }
-    | {
-        adapter: 'prisma_sqlite';
+      })
+    | ((
+        | {
+            /** @deprecated: The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
+            adapter: 'prisma_sqlite';
+            provider?: undefined;
+          }
+        | { adapter?: undefined; provider: 'sqlite' }
+      ) & {
         useMigrations?: boolean;
         enableLogging?: boolean;
-      }
+      })
   );
 
 // config.ui

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -65,22 +65,30 @@ export type DatabaseConfig = DatabaseCommon &
   (
     | ((
         | {
-            /** @deprecated: The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
+            /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
             adapter: 'prisma_postgresql';
             provider?: undefined;
           }
-        | { adapter?: undefined; provider: 'postgresql' }
+        | {
+            /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
+            adapter?: undefined;
+            provider: 'postgresql';
+          }
       ) & {
         useMigrations?: boolean;
         enableLogging?: boolean;
       })
     | ((
         | {
-            /** @deprecated: The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
+            /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
             adapter: 'prisma_sqlite';
             provider?: undefined;
           }
-        | { adapter?: undefined; provider: 'sqlite' }
+        | {
+            /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
+            adapter?: undefined;
+            provider: 'sqlite';
+          }
       ) & {
         useMigrations?: boolean;
         enableLogging?: boolean;

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -27,14 +27,14 @@ const hashPrismaSchema = memoizeOne(prismaSchema =>
 const argGenerator = {
   prisma_postgresql: () => ({
     url: process.env.DATABASE_URL!,
-    provider: 'postgresql',
+    provider: 'postgresql' as const,
     getDbSchemaName: () => null as any,
     // Turn this on if you need verbose debug info
     enableLogging: false,
   }),
   prisma_sqlite: () => ({
     url: process.env.DATABASE_URL!,
-    provider: 'sqlite',
+    provider: 'sqlite' as const,
     // Turn this on if you need verbose debug info
     enableLogging: false,
   }),
@@ -58,7 +58,7 @@ async function setupFromConfig({
   const adapterArgs = await argGenerator[adapterName]();
   const config = initConfig({
     ..._config,
-    db: { adapter: adapterName, ...adapterArgs },
+    db: adapterArgs,
     ui: { isDisabled: true },
   });
 


### PR DESCRIPTION
Now that we only support Prisma the question isn't "which keystone adapter do you want?" as much as "which Prisma provider do you want to use?". This deprecates `db.adapter`, which will be removed in the next release.