### PR TITLE
Use db.provider in example projects

### DIFF
--- a/.changeset/orange-toes-develop.md
+++ b/.changeset/orange-toes-develop.md
@@ -1,0 +1,12 @@
+---
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-ecommerce': patch
+'keystone-next-app': patch
+'@keystone-next/example-next-lite': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/example-sandbox': patch
+'@keystone-next/example-todo': patch
+---
+
+Updated example project to use the new `db.provider` config option over the deprecated `db.adapter` option.

--- a/examples-next/auth/keystone.ts
+++ b/examples-next/auth/keystone.ts
@@ -58,8 +58,8 @@ const { withAuth } = createAuth({
 export default withAuth(
   config({
     db: process.env.DATABASE_URL
-      ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
-      : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
+      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
+      : { provider: 'sqlite', url: 'file:./keystone.db' },
     lists,
     ui: {},
     session: withItemData(

--- a/examples-next/basic/keystone.ts
+++ b/examples-next/basic/keystone.ts
@@ -25,8 +25,8 @@ const auth = createAuth({
 export default auth.withAuth(
   config({
     db: process.env.DATABASE_URL
-      ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
-      : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
+      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
+      : { provider: 'sqlite', url: 'file:./keystone.db' },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {
     //   path: '/api/graphql',

--- a/examples-next/ecommerce/keystone.ts
+++ b/examples-next/ecommerce/keystone.ts
@@ -47,9 +47,9 @@ export default withAuth(
       },
     },
     db: process.env.DATABASE_URL
-      ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
+      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
       : {
-          adapter: 'prisma_sqlite',
+          provider: 'sqlite',
           url: databaseURL,
           async onConnect(keystone) {
             console.log('Connected to the database!');

--- a/examples-next/graphql-api-endpoint/keystone.ts
+++ b/examples-next/graphql-api-endpoint/keystone.ts
@@ -32,7 +32,7 @@ export default auth.withAuth(
       enableNextJsGraphqlApiEndpoint: true,
     },
     db: {
-      adapter: 'prisma_postgresql',
+      provider: 'postgresql',
       url: process.env.DATABASE_URL || 'postgres://username:password@localhost/database-name',
     },
     ui: {

--- a/examples-next/next-lite/keystone.ts
+++ b/examples-next/next-lite/keystone.ts
@@ -3,7 +3,7 @@ import { config } from '@keystone-next/keystone/schema';
 import { Post } from './schema';
 
 export default config({
-  db: { adapter: 'prisma_sqlite', url: 'file:./app.db' },
+  db: { provider: 'sqlite', url: 'file:./app.db' },
   experimental: {
     generateNextGraphqlAPI: true,
     generateNodeAPI: true,

--- a/examples-next/roles/keystone.ts
+++ b/examples-next/roles/keystone.ts
@@ -41,8 +41,8 @@ const { withAuth } = createAuth({
 export default withAuth(
   config({
     db: process.env.DATABASE_URL
-      ? { adapter: 'prisma_postgresql', url: process.env.DATABASE_URL }
-      : { adapter: 'prisma_sqlite', url: 'file:./keystone.db' },
+      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
+      : { provider: 'sqlite', url: 'file:./keystone.db' },
     lists,
     ui: {
       /* Everyone who is signed in can access the Admin UI */

--- a/examples-next/sandbox/keystone.ts
+++ b/examples-next/sandbox/keystone.ts
@@ -9,11 +9,11 @@ import { lists } from './schema';
 export default config({
   db: process.env.DATABASE_URL?.startsWith('postgres')
     ? {
-        adapter: 'prisma_postgresql',
+        provider: 'postgresql',
         url: process.env.DATABASE_URL,
       }
     : {
-        adapter: 'prisma_sqlite',
+        provider: 'sqlite',
         url: process.env.DATABASE_URL || 'file:./dev.db',
       },
   lists,

--- a/examples-next/todo/keystone.ts
+++ b/examples-next/todo/keystone.ts
@@ -22,7 +22,7 @@ const { withAuth } = createAuth({
 export default withAuth(
   config({
     db: {
-      adapter: 'prisma_postgresql',
+      provider: 'postgresql',
       url: process.env.DATABASE_URL || 'postgres://keystone5:k3yst0n3@localhost:5432/todo-example',
     },
     lists,


### PR DESCRIPTION
`db.adapter` is now deprecated, so this converts the example projects to use the new `db.provider` option.