### PR TITLE
Replace executeGraphQL with graphql.run

### DIFF
--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
@@ -10,11 +10,8 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  type T = {
-    data: { createLocations: { id: IdType }[]; createCompanies: { id: IdType }[] };
-    errors: unknown;
-  };
-  const { data, errors }: T = await context.executeGraphQL({
+  type T = { createLocations: { id: IdType }[]; createCompanies: { id: IdType }[] };
+  const data = (await context.graphql.run({
     query: `
       mutation {
         createCompanies(data: [
@@ -28,28 +25,20 @@ const createInitialData = async (context: KeystoneContext) => {
           { data: { name: "${sampleOne(alphanumGenerator)}" } }
         ]) { id }
       }`,
-  });
-  expect(errors).toBe(undefined);
+  })) as T;
   return { locations: data.createLocations, companies: data.createCompanies };
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  type T = {
-    data: { createCompany: { id: IdType; locations: { id: IdType }[] } };
-    errors: unknown;
-  };
-  const {
-    data: { createCompany },
-    errors,
-  }: T = await context.executeGraphQL({
+  type T = { createCompany: { id: IdType; locations: { id: IdType }[] } };
+  const { createCompany } = (await context.graphql.run({
     query: `
       mutation {
         createCompany(data: {
           locations: { create: [{ name: "${sampleOne(alphanumGenerator)}" }] }
         }) { id locations { id } }
       }`,
-  });
-  expect(errors).toBe(undefined);
+  })) as T;
   const { Company, Location } = await getCompanyAndLocation(
     context,
     createCompany.id,
@@ -70,13 +59,13 @@ const getCompanyAndLocation = async (
   type T = {
     data: { Company: { id: IdType; locations: { id: IdType }[] }; Location: { id: IdType } };
   };
-  const { data }: T = await context.executeGraphQL({
+  const { data } = (await context.graphql.raw({
     query: `
       {
         Company(where: { id: "${companyId}"} ) { id locations { id } }
         Location(where: { id: "${locationId}"} ) { id }
       }`,
-  });
+  })) as T;
   return data;
 };
 
@@ -147,10 +136,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 3],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data.allCompanies.length).toEqual(count);
               })
             );
@@ -225,10 +213,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 3],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ _allCompaniesMeta(where: { locations_some: { name: "${name}"}}) { count }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data._allCompaniesMeta.count).toEqual(count);
               })
             );
@@ -280,11 +267,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { locations } = await createInitialData(context);
             const location = locations[0];
-            type T = {
-              data: { createCompany: { id: IdType; locations: { id: IdType }[] } };
-              errors: unknown;
-            };
-            const { data, errors }: T = await context.executeGraphQL({
+            type T = { createCompany: { id: IdType; locations: { id: IdType }[] } };
+            const data = (await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -292,8 +276,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }) { id locations { id } }
                 }
             `,
-            });
-            expect(errors).toBe(undefined);
+            })) as T;
             expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
               location.id,
             ]);
@@ -340,7 +323,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null',
           runner(setupKeystone, async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -349,7 +332,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             // Locations should be empty
             expect(data.createCompany.locations).toHaveLength(0);
@@ -396,7 +378,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { companies } = await createInitialData(context);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -406,7 +388,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -428,7 +409,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -438,7 +419,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateCompany.id).toEqual(company.id);
             expect(data.updateCompany.locations).toEqual([]);
 

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -196,13 +196,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createCompanyAndLocation(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(4);
             expect(data.allCompanies.length).toEqual(3);
           })
@@ -212,13 +211,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createLocationAndCompany(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allLocations(where: { company_is_null: true }) { id }
                   allCompanies(where: { location_is_null: true }) { id }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(4);
             expect(data.allCompanies.length).toEqual(3);
           })
@@ -228,13 +226,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createCompanyAndLocation(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(1);
             expect(data.allCompanies.length).toEqual(1);
           })
@@ -244,13 +241,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createLocationAndCompany(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   allLocations(where: { company_is_null: false }) { id }
                   allCompanies(where: { location_is_null: false }) { id }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(1);
             expect(data.allCompanies.length).toEqual(1);
           })
@@ -260,7 +256,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'Count',
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 {
                   _allCompaniesMeta { count }
@@ -268,7 +264,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(3);
             expect(data._allLocationsMeta.count).toEqual(4);
           })
@@ -279,13 +274,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             const { location, company } = await createCompanyAndLocation(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(1);
             expect(data._allLocationsMeta.count).toEqual(1);
           })
@@ -295,13 +289,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             const { location, company } = await createLocationAndCompany(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   _allLocationsMeta(where: { company: { name: "${company.name}"} }) { count }
                   _allCompaniesMeta(where: { location: { name: "${location.name}"} }) { count }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(1);
             expect(data._allLocationsMeta.count).toEqual(1);
           })
@@ -311,13 +304,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createCompanyAndLocation(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   _allLocationsMeta(where: { company_is_null: true }) { count }
                   _allCompaniesMeta(where: { location_is_null: true }) { count }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(3);
             expect(data._allLocationsMeta.count).toEqual(4);
           })
@@ -327,13 +319,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
             await createLocationAndCompany(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{
                   _allLocationsMeta(where: { company_is_null: true }) { count }
                   _allCompaniesMeta(where: { location_is_null: true }) { count }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(3);
             expect(data._allLocationsMeta.count).toEqual(4);
           })
@@ -346,7 +337,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { locations } = await createInitialData(context);
             const location = locations[0];
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -355,7 +346,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data.createCompany.location.id.toString()).toEqual(location.id);
 
             const { Company, Location } = await getCompanyAndLocation(
@@ -401,7 +391,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create A',
           runner(setupKeystone, async ({ context }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -410,7 +400,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -428,7 +417,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create B',
           runner(setupKeystone, async ({ context }) => {
             const companyName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createLocation(data: {
@@ -437,7 +426,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -458,7 +446,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -467,7 +455,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -510,7 +497,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const location = locations[0];
             const companyName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createLocation(data: {
@@ -518,7 +505,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }) { id company { id location { id } } }
                 }`,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -741,7 +727,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null B',
           runner(setupKeystone, async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createLocation(data: {
@@ -750,7 +736,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             // Company should be empty
             expect(data.createLocation.company).toBe(null);
@@ -803,7 +788,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             expect(company.location).not.toBe(expect.anything());
             expect(location.company).not.toBe(expect.anything());
 
-            const { errors } = await context.executeGraphQL({
+            await context.graphql.run({
               query: `
                 mutation {
                   updateLocation(
@@ -811,7 +796,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     data: { company: { connect: { id: "${company.id}" } } }
                   ) { id company { id } } }`,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -829,7 +813,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { companies } = await createInitialData(context);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -839,7 +823,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -859,7 +842,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { locations } = await createInitialData(context);
             let location = locations[0];
             const companyName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateLocation(
@@ -869,7 +852,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -892,7 +874,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
             // Update company.location to be a new thing.
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -902,7 +884,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -980,7 +961,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const originalCompanyId = Company.id;
             await (async () => {
               const companyName = sampleOne(alphanumGenerator);
-              const { data, errors } = await context.executeGraphQL({
+              const data = await context.graphql.run({
                 query: `
                   mutation {
                     updateLocation(
@@ -990,7 +971,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
               `,
               });
-              expect(errors).toBe(undefined);
 
               const { Company, Location } = await getCompanyAndLocation(
                 context,
@@ -1002,11 +982,10 @@ multiAdapterRunners().map(({ runner, provider }) =>
               expect(Company.location.id.toString()).toBe(Location.id.toString());
               expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-              const result = await context.executeGraphQL({
+              const data2 = await context.graphql.run({
                 query: `{ Company(where: { id: "${originalCompanyId}" }) { id location { id } } }`,
               });
-              expect(result.errors).toBe(undefined);
-              expect(result.data.Company.location).toBe(null);
+              expect(data2.Company.location).toBe(null);
             })();
           })
         );
@@ -1018,7 +997,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -1028,7 +1007,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateCompany.id).toEqual(company.id);
             expect(data.updateCompany.location).toBe(null);
 
@@ -1046,7 +1024,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createLocationAndCompany(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateLocation(
@@ -1055,7 +1033,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   ) { id company { id name } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateLocation.id).toEqual(location.id);
             expect(data.updateLocation.company).toBe(null);
 
@@ -1072,7 +1049,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -1081,7 +1058,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   ) { id location { id name } }
                 }`,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateCompany.id).toEqual(company.id);
             expect(data.updateCompany.location).toBe(null);
 
@@ -1126,7 +1102,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query with a null operation
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -1135,7 +1111,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   ) { id location { id name } }
                 }`,
             });
-            expect(errors).toBe(undefined);
 
             // Check that the location is still there
             expect(data.updateCompany.id).toEqual(company.id);
@@ -1151,7 +1126,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createLocationAndCompany(context);
 
             // Run the query with a null operation
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateLocation(
@@ -1160,7 +1135,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   ) { id company { id name } }
                 }`,
             });
-            expect(errors).toBe(undefined);
 
             // Check that the company is still there
             expect(data.updateLocation.id).toEqual(location.id);

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -73,7 +73,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const noteContent3 = `c${sampleOne(alphanumGenerator)}`;
 
           // Create an item that does the nested create
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -89,7 +89,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
               }`,
           });
 
-          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             createUser: {
               id: expect.any(String),
@@ -98,15 +97,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item that does the nested create
-          type T = {
-            data: { createUser: { id: IdType; notes: { id: IdType; content: string }[] } };
-            errors: unknown;
-          };
+          type T = { createUser: { id: IdType; notes: { id: IdType; content: string }[] } };
 
-          const {
-            data: { createUser },
-            errors: errors2,
-          }: T = await context.executeGraphQL({
+          const { createUser } = (await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -122,8 +115,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }
               }`,
-          });
-          expect(errors2).toBe(undefined);
+          })) as T;
           expect(createUser).toMatchObject({
             id: expect.any(String),
             notes: [
@@ -133,10 +125,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Sanity check that the items are actually created
-          const {
-            data: { allNotes },
-            errors: errors3,
-          } = await context.executeGraphQL({
+          const { allNotes } = await context.graphql.run({
             query: `
               query {
                 allNotes(where: { id_in: [${createUser.notes
@@ -147,11 +136,10 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors3).toBe(undefined);
           expect(allNotes).toHaveLength(createUser.notes.length);
 
           // Test an empty list of related notes
-          const result = await context.executeGraphQL({
+          const data2 = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -163,8 +151,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(result.errors).toBe(undefined);
-          expect(result.data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
+          expect(data2.createUser).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
 
@@ -183,7 +170,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Update an item that does the nested create
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -201,7 +188,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data).toMatchObject({
             updateUser: {
               id: expect.any(String),
@@ -209,14 +195,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
             },
           });
 
-          type T = {
-            data: { updateUser: { id: IdType; notes: { id: IdType; content: string }[] } };
-            errors: unknown;
-          };
-          const {
-            data: { updateUser },
-            errors: errors2,
-          }: T = await context.executeGraphQL({
+          type T = { updateUser: { id: IdType; notes: { id: IdType; content: string }[] } };
+          const { updateUser } = (await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -238,9 +218,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }
               }`,
-          });
+          })) as T;
 
-          expect(errors2).toBe(undefined);
           expect(updateUser).toMatchObject({
             id: expect.any(String),
             notes: [
@@ -251,10 +230,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Sanity check that the items are actually created
-          const {
-            data: { allNotes },
-            errors: errors3,
-          } = await context.executeGraphQL({
+          const { allNotes } = await context.graphql.run({
             query: `
               query {
                 allNotes(where: { id_in: [${updateUser.notes
@@ -265,7 +241,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors3).toBe(undefined);
           expect(allNotes).toHaveLength(updateUser.notes.length);
         })
       );
@@ -419,7 +394,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Update an item that does the nested create
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   updateUserToNotesNoCreate(
@@ -436,18 +411,15 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
             // Assert it throws an access denied error
             expect(errors).toHaveLength(1);
-            const error = errors[0];
+            const error = errors![0];
             expect(error.message).toEqual(
               'Unable to create and/or connect 1 UserToNotesNoCreate.notes<NoteNoCreate>'
             );
             expect(error.path).toHaveLength(1);
-            expect(error.path[0]).toEqual('updateUserToNotesNoCreate');
+            expect(error.path![0]).toEqual('updateUserToNotesNoCreate');
 
             // Confirm it didn't insert the record anyway
-            const {
-              data: { allNoteNoCreates },
-              errors: errors2,
-            } = await context.executeGraphQL({
+            const { allNoteNoCreates } = await context.graphql.run({
               query: `
                 query {
                   allNoteNoCreates(where: { content: "${noteContent}" }) {
@@ -456,7 +428,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }`,
             });
-            expect(errors2).toBe(undefined);
             expect(allNoteNoCreates).toMatchObject([]);
           })
         );

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -76,7 +76,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -94,7 +94,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           expect(data).toMatchObject({ updateEvent: { id: expect.any(String), group: null } });
-          expect(errors).toBe(undefined);
 
           // Avoid false-positives by checking the database directly
           const eventData = await getItem({
@@ -114,7 +113,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createEvent(data: {
@@ -129,7 +128,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
 
           expect(data.createEvent).toMatchObject({ id: expect.any(String), group: null });
           expect(data.createEvent).not.toHaveProperty('errors');
@@ -145,7 +143,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const createEvent = await createItem({ context, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -163,7 +161,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({ id: expect.any(String), group: null });
           expect(data.updateEvent).not.toHaveProperty('errors');
         })
@@ -188,7 +185,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -206,7 +203,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors).toBe(undefined);
           expect(data.updateEvent).toMatchObject({
             id: expect.any(String),
             group: { id: createGroup.id },
@@ -243,7 +239,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
             // Update the item and link the relationship field
-            const { errors } = await context.exitSudo().executeGraphQL({
+            await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   updateEventToGroupNoRead(
@@ -256,7 +252,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }`,
             });
-            expect(errors).toBe(undefined);
 
             // Avoid false-positives by checking the database directly
             const eventData = await getItem({


### PR DESCRIPTION
More test code conversion to replace the usage of the deprecated API.