### PR TITLE
Silence logging in CI

### DIFF
--- a/.changeset/sour-berries-run.md
+++ b/.changeset/sour-berries-run.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Silenced logging when running CI tests.

--- a/packages-next/keystone/src/lib/migrations.ts
+++ b/packages-next/keystone/src/lib/migrations.ts
@@ -54,7 +54,9 @@ export async function pushPrismaSchemaToDatabase(
           schema,
         })
       );
-      console.log('✨ Your database has been reset');
+      if (!process.env.TEST_ADAPTER) {
+        console.log('✨ Your database has been reset');
+      }
       return migration;
     }
     // what does force on migrate.engine.schemaPush mean?
@@ -113,12 +115,14 @@ export async function pushPrismaSchemaToDatabase(
     return migration;
   });
 
-  if (migration.warnings.length === 0 && migration.executedSteps === 0) {
-    console.info(`✨ The database is already in sync with the Prisma schema.`);
-  } else {
-    console.info(
-      `✨ Your database is now in sync with your schema. Done in ${formatms(Date.now() - before)}`
-    );
+  if (!process.env.TEST_ADAPTER) {
+    if (migration.warnings.length === 0 && migration.executedSteps === 0) {
+      console.info(`✨ The database is already in sync with the Prisma schema.`);
+    } else {
+      console.info(
+        `✨ Your database is now in sync with your schema. Done in ${formatms(Date.now() - before)}`
+      );
+    }
   }
 }
 
@@ -146,7 +150,9 @@ export async function devMigrations(
   return withMigrate(dbUrl, schemaPath, async migrate => {
     if (shouldDropDatabase) {
       await runMigrateWithDbUrl(dbUrl, () => migrate.reset());
-      console.log('✨ Your database has been reset');
+      if (!process.env.TEST_ADAPTER) {
+        console.log('✨ Your database has been reset');
+      }
     } else {
       // see if we need to reset the database
       // note that the other action devDiagnostic can return is createMigration


### PR DESCRIPTION
Currently on CI the output is spammed with log messages related to the migrations being run. In general we don't really care about these messages when testing, and they make it hard to see the actual error logs when there's a test failure.

This isn't a particularly elegant solution, but it gets the job done for now.