### PR TITLE
Decouple CloudinaryImage from File implementation

### DIFF
--- a/.changeset/good-weeks-study.md
+++ b/.changeset/good-weeks-study.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields-cloudinary-image-legacy': patch
+---
+
+Refactored the core implementation to not depend on the `File` type.

--- a/packages/fields-cloudinary-image/package.json
+++ b/packages/fields-cloudinary-image/package.json
@@ -10,7 +10,9 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@keystone-next/fields-legacy": "^25.0.0"
+    "@keystone-next/adapter-prisma-legacy": "^5.0.0",
+    "@keystone-next/fields-legacy": "^25.0.0",
+    "cuid": "^2.1.8"
   },
   "main": "dist/fields-cloudinary-image-legacy.cjs.js",
   "module": "dist/fields-cloudinary-image-legacy.esm.js",

--- a/packages/fields-cloudinary-image/src/Implementation.js
+++ b/packages/fields-cloudinary-image/src/Implementation.js
@@ -1,27 +1,51 @@
-import { File } from '@keystone-next/fields-legacy';
+import cuid from 'cuid';
+import { PrismaFieldAdapter } from '@keystone-next/adapter-prisma-legacy';
+import { Implementation } from '@keystone-next/fields-legacy';
 
-class CloudinaryImage extends File.implementation {
-  constructor() {
+class CloudinaryImage extends Implementation {
+  constructor(path, { adapter }) {
     super(...arguments);
     this.graphQLOutputType = 'CloudinaryImage_File';
+    this.fileAdapter = adapter;
 
+    if (!this.fileAdapter) {
+      throw new Error(`No file adapter provided for File field.`);
+    }
     // Ducktype the adapter
     if (typeof this.fileAdapter.publicUrlTransformed !== 'function') {
       throw new Error('CloudinaryImage field must be used with CloudinaryAdapter');
     }
   }
 
+  get _supportsUnique() {
+    return false;
+  }
+
   gqlOutputFields() {
     return [`${this.path}: ${this.graphQLOutputType}`];
+  }
+
+  gqlQueryInputFields() {
+    return [...this.equalityInputFields('String'), ...this.inInputFields('String')];
   }
 
   getFileUploadType() {
     return 'Upload';
   }
 
-  getGqlAuxTypes({ schemaName }) {
+  getGqlAuxTypes() {
     return [
-      ...super.getGqlAuxTypes({ schemaName }),
+      `
+      type ${this.graphQLOutputType} {
+        id: ID
+        path: String
+        filename: String
+        originalFilename: String
+        mimetype: String
+        encoding: String
+        publicUrl: String
+      }
+    `,
       `
       """
       Mirrors the formatting options [Cloudinary provides](https://cloudinary.com/documentation/image_transformation_reference).
@@ -92,11 +116,92 @@ class CloudinaryImage extends File.implementation {
     };
   }
 
+  async resolveInput({ resolvedData, existingItem }) {
+    const previousData = existingItem && existingItem[this.path];
+    const uploadData = resolvedData[this.path];
+
+    // NOTE: The following two conditions could easily be combined into a
+    // single `if (!uploadData) return uploadData`, but that would lose the
+    // nuance of returning `undefined` vs `null`.
+    // Premature Optimisers; be ware!
+    if (typeof uploadData === 'undefined') {
+      // Nothing was passed in, so we can bail early.
+      return undefined;
+    }
+
+    if (uploadData === null) {
+      // `null` was specifically uploaded, and we should set the field value to
+      // null. To do that we... return `null`
+      return null;
+    }
+
+    const { createReadStream, filename: originalFilename, mimetype, encoding } = await uploadData;
+    const stream = createReadStream();
+
+    if (!stream && previousData) {
+      // TODO: FIXME: Handle when stream is null. Can happen when:
+      // Updating some other part of the item, but not the file (gets null
+      // because no File DOM element is uploaded)
+      return previousData;
+    }
+
+    const { id, filename, _meta } = await this.fileAdapter.save({
+      stream,
+      filename: originalFilename,
+      mimetype,
+      encoding,
+      id: cuid(),
+    });
+
+    const ret = { id, filename, originalFilename, mimetype, encoding, _meta };
+    if (this.adapter.listAdapter.parentAdapter.provider === 'sqlite') {
+      // we store document data as a string on sqlite because Prisma doesn't support Json on sqlite
+      // https://github.com/prisma/prisma/issues/3786
+      return JSON.stringify(ret);
+    }
+    return ret;
+  }
+
+  gqlUpdateInputFields() {
+    return [`${this.path}: ${this.getFileUploadType()}`];
+  }
+
+  gqlCreateInputFields() {
+    return [`${this.path}: ${this.getFileUploadType()}`];
+  }
+
   getBackingTypes() {
     return { [this.path]: { optional: true, type: 'any' } };
   }
 }
 
-const PrismaCloudinaryImageInterface = File.adapters.prisma;
+class PrismaCloudinaryImageInterface extends PrismaFieldAdapter {
+  constructor() {
+    super(...arguments);
+    // Error rather than ignoring invalid config
+    // We totally can index these values, it's just not trivial. See issue #1297
+    if (this.config.isIndexed) {
+      throw (
+        `The CloudinaryImage field type doesn't support indexes on Prisma. ` +
+        `Check the config for ${this.path} on the ${this.field.listKey} list`
+      );
+    }
+  }
+  getPrismaSchema() {
+    // we store document data as a string on sqlite because Prisma doesn't support Json on sqlite
+    // https://github.com/prisma/prisma/issues/3786
+    return [
+      this._schemaField({
+        type: this.listAdapter.parentAdapter.provider === 'sqlite' ? 'String' : 'Json',
+      }),
+    ];
+  }
+  getQueryConditions(dbPath) {
+    return {
+      ...this.equalityConditions(dbPath),
+      ...this.inConditions(dbPath),
+    };
+  }
+}
 
 export { CloudinaryImage, PrismaCloudinaryImageInterface };


### PR DESCRIPTION
This change results in some duplicated code for now, but it lets us move the `File` and `CloudinaryImage` code around independently, which is what we need right now.

I have confirmed that the `CloudinaryImage` tests pass on CI 👍 