### PR TITLE
Move CloudinaryAdapter into cloudinary package

### DIFF
--- a/.changeset/chatty-carpets-invite.md
+++ b/.changeset/chatty-carpets-invite.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/file-adapters-legacy': major
+---
+
+Removed the `CloudinaryAdapter` class.

--- a/.changeset/green-actors-dress.md
+++ b/.changeset/green-actors-dress.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/cloudinary': patch
+---
+
+Moved the implementation of the `CloudinaryAdapter` into this package.

--- a/packages-next/cloudinary/package.json
+++ b/packages-next/cloudinary/package.json
@@ -9,19 +9,18 @@
     "@keystone-next/adapter-prisma-legacy": "^5.0.0",
     "@keystone-next/admin-ui": "^13.0.0",
     "@keystone-next/fields-legacy": "^25.0.0",
-    "@keystone-next/file-adapters-legacy": "^8.0.0",
     "@keystone-next/types": "^16.0.0",
     "@keystone-ui/button": "^3.0.1",
     "@keystone-ui/core": "^2.0.2",
     "@keystone-ui/fields": "^2.1.0",
     "@keystone-ui/pill": "^2.0.1",
     "@types/react": "^17.0.3",
+    "cloudinary": "^1.25.1",
     "cuid": "^2.1.8",
     "react": "^17.0.2"
   },
   "devDependencies": {
     "@keystone-next/fields": "*",
-    "cloudinary": "^1.25.1",
     "graphql-upload": "^11.0.0",
     "mime": "^2.5.2"
   },

--- a/packages-next/cloudinary/src/cloudinary.d.ts
+++ b/packages-next/cloudinary/src/cloudinary.d.ts
@@ -1,0 +1,4 @@
+// preconstruct(kinda rightfully) gets annoying if you have an import from a ts file
+// to a non-ts file in the same package with no declarations so we need this
+
+export const CloudinaryAdapter: any;

--- a/packages-next/cloudinary/src/cloudinary.js
+++ b/packages-next/cloudinary/src/cloudinary.js
@@ -13,7 +13,7 @@ function uploadStream(stream, options) {
   });
 }
 
-module.exports = class CloudinaryAdapter {
+export class CloudinaryAdapter {
   constructor({ cloudName, apiKey, apiSecret, folder }) {
     if (!cloudName || !apiKey || !apiSecret) {
       throw new Error('CloudinaryAdapter requires cloudName, apiKey, and apiSecret');
@@ -100,4 +100,4 @@ module.exports = class CloudinaryAdapter {
       cloud_name: this.cloudName,
     });
   }
-};
+}

--- a/packages-next/cloudinary/src/index.ts
+++ b/packages-next/cloudinary/src/index.ts
@@ -1,7 +1,6 @@
 import path from 'path';
-// @ts-ignore
-import { CloudinaryAdapter } from '@keystone-next/file-adapters-legacy';
 import type { FieldType, FieldConfig, BaseGeneratedListTypes } from '@keystone-next/types';
+import { CloudinaryAdapter } from './cloudinary';
 import { CloudinaryImage, PrismaCloudinaryImageInterface } from './Implementation';
 
 type CloudinaryImageFieldConfig<

--- a/packages/file-adapters/index.js
+++ b/packages/file-adapters/index.js
@@ -1,4 +1,3 @@
 const LocalFileAdapter = require('./lib/local-file');
-const CloudinaryAdapter = require('./lib/cloudinary');
 
-module.exports = { LocalFileAdapter, CloudinaryAdapter };
+module.exports = { LocalFileAdapter };


### PR DESCRIPTION
Moves the cloudinary adapter implementation into the package where it is used. I've confirmed the cloudinary tests still pass 👍 