### PR TITLE
Exclude string filters for SQLite

### DIFF
--- a/.changeset/beige-masks-pretend.md
+++ b/.changeset/beige-masks-pretend.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/fields': patch
+'@keystone-next/adapter-prisma-legacy': patch
+---
+
+Fixed a bug which added unsupported string filter options to the GraphQL API for the SQLite provider.
+Added a `.containsInputFields()` method to include string filters just for the `contains` and `not_contains` options.

--- a/.changeset/forty-ducks-call.md
+++ b/.changeset/forty-ducks-call.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': minor
+---
+
+Added a `.containsConditions()` method to include string filters just for the `contains` and `not_contains` options.

--- a/packages-next/fields/src/Implementation.js
+++ b/packages-next/fields/src/Implementation.js
@@ -131,10 +131,12 @@ class Field {
       `${this.path}_gte: ${type}`,
     ];
   }
+  containsInputFields(type) {
+    return [`${this.path}_contains: ${type}`, `${this.path}_not_contains: ${type}`];
+  }
   stringInputFields(type) {
     return [
-      `${this.path}_contains: ${type}`,
-      `${this.path}_not_contains: ${type}`,
+      ...this.containsInputFields(type),
       `${this.path}_starts_with: ${type}`,
       `${this.path}_not_starts_with: ${type}`,
       `${this.path}_ends_with: ${type}`,

--- a/packages-next/fields/src/types/text/Implementation.js
+++ b/packages-next/fields/src/types/text/Implementation.js
@@ -22,8 +22,8 @@ export class Text extends Implementation {
     const { listAdapter } = this.adapter;
     return [
       ...this.equalityInputFields('String'),
-      ...(listAdapter.name === 'prisma' && listAdapter.provider === 'sqlite'
-        ? []
+      ...(listAdapter.parentAdapter.provider === 'sqlite'
+        ? this.containsInputFields('String')
         : [
             ...this.stringInputFields('String'),
             ...this.equalityInputFieldsInsensitive('String'),
@@ -58,8 +58,8 @@ export class PrismaTextInterface extends PrismaFieldAdapter {
     const { listAdapter } = this;
     return {
       ...this.equalityConditions(dbPath),
-      ...(listAdapter.provider === 'sqlite'
-        ? {}
+      ...(listAdapter.parentAdapter.provider === 'sqlite'
+        ? this.containsConditions(dbPath)
         : {
             ...this.stringConditions(dbPath),
             ...this.equalityConditionsInsensitive(dbPath),

--- a/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -26,18 +26,6 @@ export type TodoWhereInput = {
   readonly title_not?: Scalars['String'] | null;
   readonly title_contains?: Scalars['String'] | null;
   readonly title_not_contains?: Scalars['String'] | null;
-  readonly title_starts_with?: Scalars['String'] | null;
-  readonly title_not_starts_with?: Scalars['String'] | null;
-  readonly title_ends_with?: Scalars['String'] | null;
-  readonly title_not_ends_with?: Scalars['String'] | null;
-  readonly title_i?: Scalars['String'] | null;
-  readonly title_not_i?: Scalars['String'] | null;
-  readonly title_contains_i?: Scalars['String'] | null;
-  readonly title_not_contains_i?: Scalars['String'] | null;
-  readonly title_starts_with_i?: Scalars['String'] | null;
-  readonly title_not_starts_with_i?: Scalars['String'] | null;
-  readonly title_ends_with_i?: Scalars['String'] | null;
-  readonly title_not_ends_with_i?: Scalars['String'] | null;
   readonly title_in?: ReadonlyArray<Scalars['String'] | null> | null;
   readonly title_not_in?: ReadonlyArray<Scalars['String'] | null> | null;
 };

--- a/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -21,18 +21,6 @@ input TodoWhereInput {
   title_not: String
   title_contains: String
   title_not_contains: String
-  title_starts_with: String
-  title_not_starts_with: String
-  title_ends_with: String
-  title_not_ends_with: String
-  title_i: String
-  title_not_i: String
-  title_contains_i: String
-  title_not_contains_i: String
-  title_starts_with_i: String
-  title_not_starts_with_i: String
-  title_ends_with_i: String
-  title_not_ends_with_i: String
   title_in: [String]
   title_not_in: [String]
 }

--- a/packages/adapter-prisma/src/adapter-prisma.ts
+++ b/packages/adapter-prisma/src/adapter-prisma.ts
@@ -687,12 +687,18 @@ class PrismaFieldAdapter<P extends string> {
     };
   }
 
-  stringConditions(dbPath: string, f = identity) {
+  containsConditions(dbPath: string, f = identity) {
     return {
       [`${this.path}_contains`]: (value: string) => ({ [dbPath]: { contains: f(value) } }),
       [`${this.path}_not_contains`]: (value: string) => ({
         OR: [{ NOT: { [dbPath]: { contains: f(value) } } }, { [dbPath]: null }],
       }),
+    };
+  }
+
+  stringConditions(dbPath: string, f = identity) {
+    return {
+      ...this.containsConditions(dbPath, f),
       [`${this.path}_starts_with`]: (value: string) => ({ [dbPath]: { startsWith: f(value) } }),
       [`${this.path}_not_starts_with`]: (value: string) => ({
         OR: [{ NOT: { [dbPath]: { startsWith: f(value) } } }, { [dbPath]: null }],

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -108,7 +108,7 @@ class MockFieldImplementation {
   async afterDelete() {}
 }
 class MockFieldAdapter {
-  listAdapter = { name: 'mock' };
+  listAdapter = { name: 'mock', parentAdapter: {} };
 }
 
 const MockIdType = {

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -127,9 +127,9 @@ function setupKeystone(provider: ProviderName) {
       access: {
         create: access.create,
         // arbitrarily restrict the data to a single item (see data.js)
-        read: () => access.read && { name_starts_with: 'Hello' },
-        update: () => access.update && { name_starts_with: 'Hello' },
-        delete: () => access.delete && { name_starts_with: 'Hello' },
+        read: () => access.read && { name: 'Hello' },
+        update: () => access.update && { name: 'Hello' },
+        delete: () => access.delete && { name: 'Hello' },
       },
     });
   });


### PR DESCRIPTION
The SQLite provider doesn't support a number of string filter operations, so we don't include them in the GraphQL schema. We were performing the check for SQLite incorrectly, which meant the were actually included in the schema! This PR fixes this issue, and correctly only includes those filter options which are supported.

Fixes #5362 