### PR TITLE
Fix context.prisma undefined in onConnect

### DIFF
--- a/.changeset/silly-numbers-thank.md
+++ b/.changeset/silly-numbers-thank.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed a bug where `context.prisma` was `undefined` in the `onConnect()` function.

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -27,8 +27,10 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
   const keystone: BaseKeystone = new Keystone({
     adapter,
     queryLimits: graphql?.queryLimits,
+    // We call context.sudo() here to regenerate the `context` object *after* the keystone.connect()
+    // step. This ensures that context.prisma is correctly set up.
     // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
-    onConnect: (keystone, { context } = {}) => config.db.onConnect?.(context),
+    onConnect: (keystone, { context } = {}) => config.db.onConnect?.(context?.sudo()),
     // FIXME: Unsupported options: Need to work which of these we want to support with backwards
     // compatibility options.
     // defaultAccess


### PR DESCRIPTION
The `prisma` object is only available after `keystone.connect()` has happened, so we need to recreate the `context` object before passing it to `onConnect` to ensure that `context.prisma` is not undefined.

Fixes #5398