### PR TITLE
Fix access control for virtual fields

### DIFF
--- a/.changeset/tiny-ants-cough.md
+++ b/.changeset/tiny-ants-cough.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': patch
+---
+
+Fixed an issue where `virtual` fields could have `create` and `update` access control set to something other than `false`.

--- a/packages-next/fields/src/Implementation.js
+++ b/packages-next/fields/src/Implementation.js
@@ -37,13 +37,19 @@ class Field {
     // Should be overwritten by types that implement a Relationship interface
     this.isRelationship = false;
 
-    this.access = parseFieldAccess({ schemaNames, listKey, fieldKey: path, defaultAccess, access });
+    this.access = this._modifyAccess(
+      parseFieldAccess({ schemaNames, listKey, fieldKey: path, defaultAccess, access })
+    );
   }
 
   // By default we assume that fields do not support unique constraints.
   // Fields should override this method if they want to support uniqueness.
   get _supportsUnique() {
     return false;
+  }
+
+  _modifyAccess(access) {
+    return access;
   }
 
   // Field types should replace this if they want to any fields to the output type

--- a/packages-next/fields/src/types/virtual/Implementation.js
+++ b/packages-next/fields/src/types/virtual/Implementation.js
@@ -1,5 +1,4 @@
 import { PrismaFieldAdapter } from '@keystone-next/adapter-prisma-legacy';
-import { parseFieldAccess } from '@keystone-next/access-control-legacy';
 import { Implementation } from '../../Implementation';
 
 export class Virtual extends Implementation {
@@ -41,11 +40,12 @@ export class Virtual extends Implementation {
     return [];
   }
 
-  parseFieldAccess(args) {
-    const parsedAccess = parseFieldAccess(args);
-    const fieldDefaults = { create: false, update: false, delete: false };
+  _modifyAccess(parsedAccess) {
+    // The virtual field is not just a read-only field, it fundamentally doesn't
+    // mean anything to do a create/update on this field. As such, we explicitly
+    // set the access control to false for these operations.
     return Object.keys(parsedAccess).reduce((prev, schemaName) => {
-      prev[schemaName] = { ...fieldDefaults, read: parsedAccess[schemaName].read };
+      prev[schemaName] = { create: false, update: false, read: parsedAccess[schemaName].read };
       return prev;
     }, {});
   }


### PR DESCRIPTION
The Virtual field doesn't support create or update operations. We had a regression which meant the code to enforce this wasn't being called any more. This PR re-enables this code to ensure we explicitly set the access control to `false` for these operations.