### PR TITLE
Remove unused isMultiline option from text

### DIFF
--- a/packages-next/fields/src/types/text/Implementation.ts
+++ b/packages-next/fields/src/types/text/Implementation.ts
@@ -4,14 +4,8 @@ import { FieldConfigArgs, FieldExtraArgs, Implementation } from '../../Implement
 type List = { adapter: PrismaListAdapter };
 
 export class Text<P extends string> extends Implementation<P> {
-  isMultiline?: boolean;
-  constructor(
-    path: P,
-    { isMultiline, ...configArgs }: FieldConfigArgs & { isMultiline?: boolean },
-    extraArgs: FieldExtraArgs
-  ) {
-    super(path, { isMultiline, ...configArgs }, extraArgs);
-    this.isMultiline = isMultiline;
+  constructor(path: P, configArgs: FieldConfigArgs, extraArgs: FieldExtraArgs) {
+    super(path, configArgs, extraArgs);
     this.isOrderable = true;
   }
 


### PR DESCRIPTION
This legacy code wasn't actually used anywhere. No changeset as its covered in by existing changesets.