### PR TITLE
Remove legacy _label_ field

### DIFF
--- a/.changeset/cuddly-fireants-thank.md
+++ b/.changeset/cuddly-fireants-thank.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/keystone-legacy': major
+---
+
+Removed the internal `_label_` field which is no longer used.

--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -25,7 +25,6 @@
     "@babel/runtime": "^7.13.10",
     "@graphql-tools/merge": "^6.2.11",
     "@graphql-tools/schema": "^7.1.3",
-    "@graphql-tools/utils": "^7.7.1",
     "@hapi/iron": "^6.0.0",
     "@keystone-next/adapter-prisma-legacy": "5.0.0",
     "@keystone-next/admin-ui": "^13.0.0",

--- a/packages-next/keystone/src/lib/createGraphQLSchema.ts
+++ b/packages-next/keystone/src/lib/createGraphQLSchema.ts
@@ -1,5 +1,3 @@
-import { GraphQLObjectType } from 'graphql';
-import { mapSchema } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import type { KeystoneConfig, BaseKeystone } from '@keystone-next/types';
 import { getAdminMetaSchema } from '@keystone-next/admin-ui/system';
@@ -14,24 +12,6 @@ export function createGraphQLSchema(
   let graphQLSchema = makeExecutableSchema({
     typeDefs: keystone.getTypeDefs({ schemaName }),
     resolvers: keystone.getResolvers({ schemaName }),
-  });
-
-  // Filter out the _label_ field from all lists
-  graphQLSchema = mapSchema(graphQLSchema, {
-    'MapperKind.OBJECT_TYPE'(type) {
-      if (
-        config.lists[type.name] !== undefined &&
-        config.lists[type.name].fields._label_ === undefined
-      ) {
-        let {
-          fields: { _label_, ...fields },
-          ...objectTypeConfig
-        } = type.toConfig();
-        return new GraphQLObjectType({ fields, ...objectTypeConfig });
-      }
-
-      return type;
-    },
   });
 
   // TODO: find a way to not pass keystone in here, if we can - it's too broad and makes

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -51,8 +51,6 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
       // FIXME: Unsupported options: Need to work which of these we want to support with backwards
       // compatibility options.
       // adminDoc
-      // labelResolver
-      // labelField
       // adminConfig
       // label
       // singular

--- a/packages/keystone/lib/ListTypes/utils.js
+++ b/packages/keystone/lib/ListTypes/utils.js
@@ -23,14 +23,6 @@ const opToType = {
   delete: 'mutation',
 };
 
-const getDefaultLabelResolver = labelField => item => {
-  const value = item[labelField || 'name'];
-  if (typeof value === 'number') {
-    return value.toString();
-  }
-  return value || item.id;
-};
-
 const mapToFields = (fields, action) =>
   resolveAllKeys(arrayToObject(fields, 'path', action)).catch(error => {
     if (!error.errors) {
@@ -47,6 +39,5 @@ module.exports = {
   labelToPath,
   labelToClass,
   opToType,
-  getDefaultLabelResolver,
   mapToFields,
 };

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -4,7 +4,6 @@ const { Text: TextImplementation } = require('@keystone-next/fields/src/types/te
 const {
   Relationship: RelationshipImplementation,
 } = require('@keystone-next/fields/src/types/relationship/Implementation');
-const { Integer } = require('@keystone-next/fields/src/types/integer/Implementation');
 const { List } = require('../lib/ListTypes');
 const { AccessDeniedError } = require('../lib/ListTypes/graphqlErrors');
 
@@ -204,7 +203,6 @@ describe('new List()', () => {
 
   test('new List() - config', () => {
     const list = setup();
-    expect(list.labelResolver).toBeInstanceOf(Function);
     expect(list.fields).toBeInstanceOf(Object);
     expect(list.adminConfig).toEqual({
       defaultColumns: 'name,email',
@@ -298,82 +296,9 @@ describe('new List()', () => {
   });
 });
 
-test('labelResolver', () => {
-  // Default: Use name
-  const list = setup();
-  expect(list.labelResolver({ name: 'a', email: 'a@example.com', id: '1' })).toEqual('a');
-
-  // Use config.labelField if supplied
-  const list2 = new List(
-    'List2',
-    {
-      fields: {
-        name: { type: Text },
-        email: { type: Text },
-      },
-      labelField: 'email',
-    },
-    listExtras()
-  );
-  expect(list2.labelResolver({ name: 'a', email: 'a@example.com', id: '2' })).toEqual(
-    'a@example.com'
-  );
-
-  // Use Integer as a labelField
-  const list21 = new List(
-    'List21',
-    {
-      fields: {
-        index: { type: Integer },
-        name: { type: Text },
-      },
-      labelField: 'index',
-    },
-    listExtras()
-  );
-  expect(list21.labelResolver({ name: 'Test integer', index: 0, id: '21' })).toEqual('0');
-
-  // Use labelResolver if supplied (over-rides labelField)
-  const list3 = new List(
-    'List3',
-    {
-      fields: {
-        name: { type: Text },
-        email: { type: Text },
-      },
-      labelField: 'email',
-      labelResolver: item => `${item.name} - ${item.email}`,
-    },
-    listExtras()
-  );
-  expect(list3.labelResolver({ name: 'a', email: 'a@example.com', id: '3' })).toEqual(
-    'a - a@example.com'
-  );
-
-  // Fall back to id if no name or label resolvers available
-  const list4 = new List(
-    'List4',
-    {
-      fields: {
-        email: { type: Text },
-      },
-    },
-    listExtras()
-  );
-  expect(list4.labelResolver({ email: 'a@example.com', id: '4' })).toEqual('4');
-});
-
 describe(`getGqlTypes()`, () => {
   const type = `""" A keystone list """
       type Test {
-        """
-        This virtual field will be resolved in one of the following ways (in this order):
-        1. Execution of 'labelResolver' set on the Test List config, or
-        2. As an alias to the field set on 'labelField' in the Test List config, or
-        3. As an alias to a 'name' field on the Test List (if one exists), or
-        4. As an alias to the 'id' field on the Test List.
-        """
-        _label_: String
         id: ID
         name: String
         email: String
@@ -624,7 +549,6 @@ test('_wrapFieldResolverWith', async () => {
 test('gqlFieldResolvers', () => {
   const schemaName = 'public';
   const resolvers = setup().gqlFieldResolvers({ schemaName });
-  expect(resolvers.Test._label_).toBeInstanceOf(Function);
   expect(resolvers.Test.email).toBeInstanceOf(Function);
   expect(resolvers.Test.name).toBeInstanceOf(Function);
   expect(resolvers.Test.other).toBeInstanceOf(Function);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,7 +1457,7 @@
     "@graphql-tools/utils" "^7.1.2"
     tslib "~2.1.0"
 
-"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@^7.7.1":
+"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0":
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.7.1.tgz#81f32cb4819b34b3a378d51ab2cd60935977f0b4"
   integrity sha512-SFT4/dTfrwWer1wSOLU+jqgv3oa/xTR8q+MiNbE9nCH2FXyMsqIOaXKm9wHfKIWFWHozqBdcnwFkQZrdD7H2TQ==


### PR DESCRIPTION
This is how we used to do labels in the Admin UI. We no longer need the implementation in core which means we can also take out the workaround in `keystone-next`.