### PR TITLE
Remove support for aux lists

### DIFF
--- a/.changeset/proud-apricots-punch.md
+++ b/.changeset/proud-apricots-punch.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone-legacy': major
+---
+
+Removed legacy support for auxilliary lists.

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -34,9 +34,9 @@ module.exports = class Keystone {
     }
   }
 
-  createList(key, config, { isAuxList = false } = {}) {
+  createList(key, config) {
     const { getListByKey, adapter } = this;
-    const isReservedName = !isAuxList && key[0] === '_';
+    const isReservedName = key[0] === '_';
 
     if (isReservedName) {
       throw new Error(`Invalid list name "${key}". List names cannot start with an underscore.`);
@@ -61,15 +61,6 @@ module.exports = class Keystone {
       adapter,
       defaultAccess: this.defaultAccess,
       registerType: type => this.registeredTypes.add(type),
-      isAuxList,
-      createAuxList: (auxKey, auxConfig) => {
-        if (isAuxList) {
-          throw new Error(
-            `Aux list "${key}" shouldn't be creating more aux lists ("${auxKey}"). Something's probably not right here.`
-          );
-        }
-        return this.createList(auxKey, auxConfig, { isAuxList: true });
-      },
     });
     this.lists[key] = list;
     this.listsArray.push(list);


### PR DESCRIPTION
Auxiliary lists were a feature which allowed field types to instantiate their own lists in the background. This was a feature that was required by the `Content` field. We have moved away from this pattern and so this feature is no longer required.