### PR TITLE
Remove defaultAccess from Keystone constructor

### DIFF
--- a/.changeset/brown-ties-wait.md
+++ b/.changeset/brown-ties-wait.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone-legacy': major
+'@keystone-next/fields': patch
+'@keystone-next/keystone': patch
+---
+
+Removed the legacy `defaultAccess` argument from the `Keystone` constructor.

--- a/packages-next/fields/src/Implementation.ts
+++ b/packages-next/fields/src/Implementation.ts
@@ -18,7 +18,6 @@ export type FieldExtraArgs = {
   listKey: string;
   listAdapter: PrismaListAdapter;
   fieldAdapterClass: typeof PrismaFieldAdapter;
-  defaultAccess: any;
   schemaNames: string[];
 };
 
@@ -52,14 +51,7 @@ class Field<P extends string> {
       schemaDoc,
       ...config
     }: FieldConfigArgs & Record<string, any>,
-    {
-      getListByKey,
-      listKey,
-      listAdapter,
-      fieldAdapterClass,
-      defaultAccess,
-      schemaNames,
-    }: FieldExtraArgs
+    { getListByKey, listKey, listAdapter, fieldAdapterClass, schemaNames }: FieldExtraArgs
   ) {
     this.path = path;
     this.isPrimaryKey = path === 'id';
@@ -93,7 +85,7 @@ class Field<P extends string> {
     this.refListKey = '';
 
     this.access = this._modifyAccess(
-      parseFieldAccess({ schemaNames, listKey, fieldKey: path, defaultAccess, access })
+      parseFieldAccess({ schemaNames, listKey, fieldKey: path, defaultAccess: true, access })
     );
   }
 

--- a/packages-next/fields/src/tests/Implementation.test.ts
+++ b/packages-next/fields/src/tests/Implementation.test.ts
@@ -6,7 +6,6 @@ const args = {
   getListByKey: () => undefined,
   listKey: 'key',
   listAdapter: ({ newFieldAdapter: jest.fn() } as unknown) as PrismaListAdapter,
-  defaultAccess: true,
   schemaNames: ['public'],
   fieldAdapterClass: {} as typeof PrismaFieldAdapter,
 };
@@ -20,7 +19,6 @@ describe('new Implementation()', () => {
         getListByKey: () => undefined,
         listKey: 'key',
         listAdapter: ({ newFieldAdapter: jest.fn() } as unknown) as PrismaListAdapter,
-        defaultAccess: true,
         schemaNames: ['public'],
         fieldAdapterClass: {} as typeof PrismaFieldAdapter,
       }

--- a/packages-next/fields/src/types/relationship/tests/implementation.test.ts
+++ b/packages-next/fields/src/types/relationship/tests/implementation.test.ts
@@ -88,7 +88,6 @@ function createRelationship({
     listKey: 'FakeList',
     listAdapter: (new MockListAdapter() as unknown) as PrismaListAdapter,
     fieldAdapterClass: (MockFieldAdapter as unknown) as typeof PrismaFieldAdapter,
-    defaultAccess: true,
     schemaNames: ['public'],
   });
 }

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -31,9 +31,6 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
     // step. This ensures that context.prisma is correctly set up.
     // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
     onConnect: (keystone, { context } = {}) => config.db.onConnect?.(context?.sudo()),
-    // FIXME: Unsupported options: Need to work which of these we want to support with backwards
-    // compatibility options.
-    // defaultAccess
   });
 
   Object.entries(lists).forEach(([key, { fields, graphql, access, hooks, description, db }]) => {

--- a/packages/keystone/README.md
+++ b/packages/keystone/README.md
@@ -13,7 +13,6 @@ const { Keystone } = require('@keystone-next/keystone-legacy');
 
 const keystone = new Keystone({
   adapter,
-  defaultAccess,
   onConnect,
   queryLimits,
   schemaNames,
@@ -38,20 +37,6 @@ const keystone = new Keystone({
   },
 });
 ```
-
-### `defaultAccess`
-
-_**Default:**_
-
-```js
-{
-  list: true,
-  field: true,
-  custom: true
-}
-```
-
-Default list and field access. See the [Access Control](https://www.keystonejs.com/api/access-control#defaults) page for more details.
 
 ### `onConnect`
 

--- a/packages/keystone/lib/Keystone/index.js
+++ b/packages/keystone/lib/Keystone/index.js
@@ -5,8 +5,7 @@ const { List } = require('../ListTypes');
 const { ListCRUDProvider } = require('../providers');
 
 module.exports = class Keystone {
-  constructor({ defaultAccess, adapter, onConnect, queryLimits = {} }) {
-    this.defaultAccess = { list: true, field: true, custom: true, ...defaultAccess };
+  constructor({ adapter, onConnect, queryLimits = {} }) {
     this.lists = {};
     this.listsArray = [];
     this.getListByKey = key => this.lists[key];
@@ -42,8 +41,7 @@ module.exports = class Keystone {
       );
     }
 
-    const { defaultAccess } = this;
-    const list = new List(key, config, { getListByKey, adapter, defaultAccess });
+    const list = new List(key, config, { getListByKey, adapter });
     this.lists[key] = list;
     this.listsArray.push(list);
     this._listCRUDProvider.lists.push(list);

--- a/packages/keystone/lib/ListTypes/list.js
+++ b/packages/keystone/lib/ListTypes/list.js
@@ -42,7 +42,7 @@ module.exports = class List {
       queryLimits = {},
       cacheHint,
     },
-    { getListByKey, adapter, defaultAccess }
+    { getListByKey, adapter }
   ) {
     this.key = key;
     this._fields = fields;
@@ -51,7 +51,6 @@ module.exports = class List {
     this.adminDoc = adminDoc;
 
     this.getListByKey = getListByKey;
-    this.defaultAccess = defaultAccess;
 
     const _label = label || keyToLabel(key);
     const _singular = singular || pluralize.singular(_label);
@@ -104,7 +103,7 @@ module.exports = class List {
       schemaNames: this._schemaNames,
       listKey: key,
       access,
-      defaultAccess: this.defaultAccess.list,
+      defaultAccess: true,
     });
 
     this.queryLimits = {
@@ -160,7 +159,6 @@ module.exports = class List {
           listKey: this.key,
           listAdapter: this.adapter,
           fieldAdapterClass: type.adapter,
-          defaultAccess: this.defaultAccess.field,
           schemaNames: this._schemaNames,
         })
     );

--- a/packages/keystone/tests/List.test.js
+++ b/packages/keystone/tests/List.test.js
@@ -162,7 +162,6 @@ class MockAdapter {
 const listExtras = () => ({
   getListByKey,
   adapter: new MockAdapter(),
-  defaultAccess: { list: true, field: true },
   schemaNames: ['public'],
 });
 
@@ -189,7 +188,6 @@ describe('new List()', () => {
     expect(list).not.toBeNull();
     expect(list.key).toEqual('Test');
     expect(list.getListByKey).toBe(getListByKey);
-    expect(list.defaultAccess).toEqual({ list: true, field: true });
   });
 
   test('new List() - Plural throws error', () => {


### PR DESCRIPTION
This API is no longer used or required.