### PR TITLE
Set PRISMA_HIDE_UPDATE_MESSAGE=1 to silence update messages

### DIFF
--- a/.changeset/orange-snakes-smell.md
+++ b/.changeset/orange-snakes-smell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Set PRISMA_HIDE_UPDATE_MESSAGE=1 to silence Prisma update messages, since these are out of the hands of the developer.

--- a/packages-next/keystone/src/lib/migrations.ts
+++ b/packages-next/keystone/src/lib/migrations.ts
@@ -13,13 +13,20 @@ import { confirmPrompt, textPrompt } from './prompts';
 
 // note that we could only run this once per Migrate instance but we're going to do it consistently for all migrate calls
 // so that calls can moved around freely without implictly relying on some other migrate command being called before it
+
+// We also want to silence messages from Prisma about available updates, since the developer is
+// not in control of their Prisma version.
+// https://www.prisma.io/docs/reference/api-reference/environment-variables-reference#prisma_hide_update_message
 function runMigrateWithDbUrl<T>(dbUrl: string, cb: () => T): T {
   let prevDBURLFromEnv = process.env.DATABASE_URL;
+  let prevHiddenUpdateMessage = process.env.PRISMA_HIDE_UPDATE_MESSAGE;
   try {
     process.env.DATABASE_URL = dbUrl;
+    process.env.PRISMA_HIDE_UPDATE_MESSAGE = '1';
     return cb();
   } finally {
     process.env.DATABASE_URL = prevDBURLFromEnv;
+    process.env.PRISMA_HIDE_UPDATE_MESSAGE = prevHiddenUpdateMessage;
   }
 }
 

--- a/packages-next/keystone/src/scripts/prisma.ts
+++ b/packages-next/keystone/src/scripts/prisma.ts
@@ -20,6 +20,7 @@ export async function prisma(cwd: string, args: string[]) {
     env: {
       ...process.env,
       DATABASE_URL: config.db.url,
+      PRISMA_HIDE_UPDATE_MESSAGE: '1',
     },
   });
   if (result.exitCode !== 0) {


### PR DESCRIPTION
Keystone users don't get to choose which prisma version they're using. As such, a message informing them of Prisma updates is not helpful, so we want to silence it.

https://www.prisma.io/docs/reference/api-reference/environment-variables-reference#prisma_hide_update_message