### PR TITLE
Simplify test-utils

### DIFF
--- a/.changeset/shy-turkeys-try.md
+++ b/.changeset/shy-turkeys-try.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/test-utils-legacy': patch
+---
+
+Simplified internal implementation now that Prisma is the only database adapter supported.

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -24,22 +24,6 @@ const hashPrismaSchema = memoizeOne(prismaSchema =>
   crypto.createHash('md5').update(prismaSchema).digest('hex')
 );
 
-const argGenerator = {
-  postgresql: () => ({
-    url: process.env.DATABASE_URL!,
-    provider: 'postgresql' as const,
-    getDbSchemaName: () => null as any,
-    // Turn this on if you need verbose debug info
-    enableLogging: false,
-  }),
-  sqlite: () => ({
-    url: process.env.DATABASE_URL!,
-    provider: 'sqlite' as const,
-    // Turn this on if you need verbose debug info
-    enableLogging: false,
-  }),
-};
-
 // Users should use testConfig({ ... }) in place of config({ ... }) when setting up
 // their system for test. We explicitly don't allow them to control the 'db' or 'ui'
 // properties as we're going to set that up as part of setupFromConfig.
@@ -55,10 +39,13 @@ async function setupFromConfig({
   provider: ProviderName;
   config: TestKeystoneConfig;
 }) {
-  const adapterArgs = await argGenerator[provider]();
   const config = initConfig({
     ..._config,
-    db: adapterArgs,
+    db: {
+      url: process.env.DATABASE_URL!,
+      provider,
+      enableLogging: false, // Turn this on if you need verbose debug info
+    },
     ui: { isDisabled: true },
   });
 
@@ -80,7 +67,7 @@ async function setupFromConfig({
       config.db.url,
       artifacts.prisma,
       path.join(cwd, 'schema.prisma'),
-      true
+      true // shouldDropDatabase
     );
     return requirePrismaClient(cwd);
   })();
@@ -175,20 +162,14 @@ function _after(tearDownFunction: () => Promise<void> | void) {
 }
 
 function multiAdapterRunners(only = process.env.TEST_ADAPTER) {
-  return [
-    {
-      runner: _keystoneRunner('postgresql', () => {}),
-      provider: 'postgresql' as const,
-      before: _before('postgresql'),
+  return (['postgresql', 'sqlite'] as const)
+    .filter(provider => typeof only === 'undefined' || provider === only)
+    .map(provider => ({
+      provider,
+      runner: _keystoneRunner(provider, () => {}),
+      before: _before(provider),
       after: _after(() => {}),
-    },
-    {
-      runner: _keystoneRunner('sqlite', () => {}),
-      provider: 'sqlite' as const,
-      before: _before('sqlite'),
-      after: _after(() => {}),
-    },
-  ].filter(a => typeof only === 'undefined' || a.provider === only);
+    }));
 }
 
 export { setupFromConfig, multiAdapterRunners, networkedGraphqlRequest };


### PR DESCRIPTION
No functional changes, just tidying things up now that we're only supporting Prisma, which requires much less paramterisation of the various setup functions.