### PR TITLE
Remove last usages of executeGraphQL

### DIFF
--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -53,11 +53,13 @@ const createUserAndFriend = async (context: KeystoneContext) => {
 
 const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friendId: IdType) => {
   type T = {
-    User: { id: IdType; friend: { id: IdType } };
-    Friend: { id: IdType; friendOf: { id: IdType } };
+    data: {
+      User: { id: IdType; friend: { id: IdType } };
+      Friend: { id: IdType; friendOf: { id: IdType } };
+    };
   };
 
-  const data = (await context.graphql.run({
+  const { data } = (await context.graphql.raw({
     query: `
       {
         User(where: { id: "${userId}"} ) { id friend { id } }

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -106,8 +106,10 @@ const getCompanyAndLocation = async (
   companyId: IdType,
   locationId: IdType
 ) => {
-  type T = { Company: { id: IdType; location: { id: IdType } }; Location: { id: IdType } };
-  const data = (await context.graphql.run({
+  type T = {
+    data: { Company: { id: IdType; location: { id: IdType } }; Location: { id: IdType } };
+  };
+  const { data } = (await context.graphql.raw({
     query: `
   {
     Company(where: { id: "${companyId}"} ) { id location { id } }

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -58,10 +58,12 @@ const getCompanyAndLocation = async (
   locationId: IdType
 ) => {
   type T = {
-    Company: { id: IdType; locations: { id: IdType }[] };
-    Location: { id: IdType; company: { id: IdType } };
+    data: {
+      Company: { id: IdType; locations: { id: IdType }[] };
+      Location: { id: IdType; company: { id: IdType } };
+    };
   };
-  const data = (await context.graphql.run({
+  const { data } = (await context.graphql.raw({
     query: `
       {
         Company(where: { id: "${companyId}"} ) { id locations { id } }

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -10,11 +10,8 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  type T = {
-    data: { createLocations: { id: IdType }[]; createCompanies: { id: IdType }[] };
-    errors: unknown;
-  };
-  const { data, errors }: T = await context.executeGraphQL({
+  type T = { createLocations: { id: IdType }[]; createCompanies: { id: IdType }[] };
+  const data = (await context.graphql.run({
     query: `
       mutation {
         createCompanies(data: [
@@ -28,28 +25,20 @@ const createInitialData = async (context: KeystoneContext) => {
           { data: { name: "${sampleOne(alphanumGenerator)}" } }
         ]) { id }
       }`,
-  });
-  expect(errors).toBe(undefined);
+  })) as T;
   return { locations: data.createLocations, companies: data.createCompanies };
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  type T = {
-    data: { createCompany: { id: IdType; locations: { id: IdType; company: { id: IdType } }[] } };
-    errors: unknown;
-  };
-  const {
-    data: { createCompany },
-    errors,
-  }: T = await context.executeGraphQL({
+  type T = { createCompany: { id: IdType; locations: { id: IdType; company: { id: IdType } }[] } };
+  const { createCompany } = (await context.graphql.run({
     query: `
       mutation {
         createCompany(data: {
           locations: { create: [{ name: "${sampleOne(alphanumGenerator)}" }] }
         }) { id locations { id company { id } } }
       }`,
-  });
-  expect(errors).toBe(undefined);
+  })) as T;
   const { Company, Location } = await getCompanyAndLocation(
     context,
     createCompany.id,
@@ -69,30 +58,27 @@ const getCompanyAndLocation = async (
   locationId: IdType
 ) => {
   type T = {
-    data: {
-      Company: { id: IdType; locations: { id: IdType }[] };
-      Location: { id: IdType; company: { id: IdType } };
-    };
+    Company: { id: IdType; locations: { id: IdType }[] };
+    Location: { id: IdType; company: { id: IdType } };
   };
-  const { data }: T = await context.executeGraphQL({
+  const data = (await context.graphql.run({
     query: `
       {
         Company(where: { id: "${companyId}"} ) { id locations { id } }
         Location(where: { id: "${locationId}"} ) { id company { id } }
       }`,
-  });
+  })) as T;
   return data;
 };
 
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C, D];
-  const { data, errors } = await context.executeGraphQL({
+  const data = await context.graphql.run({
     query: `mutation create($locations: [LocationsCreateInput]) { createLocations(data: $locations) { id name } }`,
     variables: {
       locations: ['A', 'A', 'B', 'B', 'C', 'C', 'D'].map(name => ({ data: { name } })),
     },
   });
-  expect(errors).toBe(undefined);
   const { createLocations } = data;
   await Promise.all(
     Object.entries({
@@ -102,14 +88,13 @@ const createReadData = async (context: KeystoneContext) => {
       '': [], //  -> []
     }).map(async ([name, locationIdxs]) => {
       const ids = locationIdxs.map((i: number) => ({ id: createLocations[i].id }));
-      const { errors } = await context.executeGraphQL({
+      await context.graphql.run({
         query: `mutation create($locations: [LocationWhereUniqueInput], $name: String) { createCompany(data: {
           name: $name
     locations: { connect: $locations }
   }) { id locations { name }}}`,
         variables: { locations: ids, name },
       });
-      expect(errors).toBe(undefined);
     })
   );
 };
@@ -150,10 +135,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 4],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ allLocations(where: { company: { name_contains: "${name}"}}) { id }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data.allLocations.length).toEqual(count);
               })
             );
@@ -163,10 +147,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'is_null: true',
           runner(setupKeystone, async ({ context }) => {
             await createReadData(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{ allLocations(where: { company_is_null: true }) { id }}`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(1);
           })
         );
@@ -174,10 +157,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'is_null: false',
           runner(setupKeystone, async ({ context }) => {
             await createReadData(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `{ allLocations(where: { company_is_null: false }) { id }}`,
             });
-            expect(errors).toBe(undefined);
             expect(data.allLocations.length).toEqual(6);
           })
         );
@@ -192,10 +174,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 2],
                 ['D', 0],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ allCompanies(where: { locations_some: { name: "${name}"}}) { id }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data.allCompanies.length).toEqual(count);
               })
             );
@@ -212,10 +193,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 2],
                 ['D', 4],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ allCompanies(where: { locations_none: { name: "${name}"}}) { id }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data.allCompanies.length).toEqual(count);
               })
             );
@@ -232,10 +212,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 ['C', 2],
                 ['D', 1],
               ].map(async ([name, count]) => {
-                const { data, errors } = await context.executeGraphQL({
+                const data = await context.graphql.run({
                   query: `{ allCompanies(where: { locations_every: { name: "${name}"}}) { id }}`,
                 });
-                expect(errors).toBe(undefined);
                 expect(data.allCompanies.length).toEqual(count);
               })
             );
@@ -248,7 +227,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'Count',
           runner(setupKeystone, async ({ context }) => {
             await createInitialData(context);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 {
                   _allCompaniesMeta { count }
@@ -256,7 +235,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data._allCompaniesMeta.count).toEqual(3);
             expect(data._allLocationsMeta.count).toEqual(3);
           })
@@ -269,11 +247,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { locations } = await createInitialData(context);
             const location = locations[0];
-            type T = {
-              data: { createCompany: { id: IdType; locations: { id: IdType }[] } };
-              errors: unknown;
-            };
-            const { data, errors }: T = await context.executeGraphQL({
+            type T = { createCompany: { id: IdType; locations: { id: IdType }[] } };
+            const data = (await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -281,8 +256,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }) { id locations { id } }
                 }
             `,
-            });
-            expect(errors).toBe(undefined);
+            })) as T;
             expect(data.createCompany.locations.map(({ id }) => id.toString())).toEqual([
               location.id,
             ]);
@@ -305,7 +279,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create',
           runner(setupKeystone, async ({ context }) => {
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -314,7 +288,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -337,7 +310,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -346,7 +319,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -359,21 +331,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
             expect(Location.company.id.toString()).toBe(Company.id.toString());
 
             type T = {
-              data: {
-                allCompanies: {
-                  id: IdType;
-                  locations: { id: IdType; company: { id: IdType } }[];
-                }[];
-              };
-              errors: unknown;
+              allCompanies: {
+                id: IdType;
+                locations: { id: IdType; company: { id: IdType } }[];
+              }[];
             };
-            const {
-              data: { allCompanies },
-              errors: errors2,
-            }: T = await context.executeGraphQL({
+            const { allCompanies } = (await context.graphql.run({
               query: `{ allCompanies { id locations { id company { id } } } }`,
-            });
-            expect(errors2).toBe(undefined);
+            })) as T;
             // The nested company should not have a location
             expect(
               allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
@@ -392,7 +357,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const locationName = sampleOne(alphanumGenerator);
             const companyName = sampleOne(alphanumGenerator);
 
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -401,7 +366,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -414,21 +378,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
             // The nested company should not have a location
             type T = {
-              data: {
-                allCompanies: {
-                  id: IdType;
-                  locations: { id: IdType; company: { id: IdType } }[];
-                }[];
-              };
-              errors: unknown;
+              allCompanies: {
+                id: IdType;
+                locations: { id: IdType; company: { id: IdType } }[];
+              }[];
             };
-            const {
-              data: { allCompanies },
-              errors: errors2,
-            }: T = await context.executeGraphQL({
+            const { allCompanies } = (await context.graphql.run({
               query: `{ allCompanies { id locations { id company { id } } } }`,
-            });
-            expect(errors2).toBe(undefined);
+            })) as T;
             expect(
               allCompanies.filter(({ id }) => id === Company.id)[0].locations[0].company.id
             ).toEqual(Company.id);
@@ -443,7 +400,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null',
           runner(setupKeystone, async ({ context }) => {
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   createCompany(data: {
@@ -452,7 +409,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             // Locations should be empty
             expect(data.createCompany.locations).toHaveLength(0);
@@ -472,7 +428,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             expect(company.locations).not.toBe(expect.anything());
             expect(location.company).not.toBe(expect.anything());
 
-            const { errors } = await context.executeGraphQL({
+            await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -481,7 +437,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   ) { id locations { id } } }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -502,7 +457,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { companies } = await createInitialData(context);
             let company = companies[0];
             const locationName = sampleOne(alphanumGenerator);
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -512,7 +467,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             const { Company, Location } = await getCompanyAndLocation(
               context,
@@ -535,7 +489,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -545,7 +499,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateCompany.id).toEqual(company.id);
             expect(data.updateCompany.locations).toEqual([]);
 
@@ -563,7 +516,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -573,7 +526,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
             expect(data.updateCompany.id).toEqual(company.id);
             expect(data.updateCompany.locations).toEqual([]);
 
@@ -591,7 +543,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query with a null operation
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `
                 mutation {
                   updateCompany(
@@ -601,7 +553,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
             `,
             });
-            expect(errors).toBe(undefined);
 
             // Check that the locations are still there
             expect(data.updateCompany.id).toEqual(company.id);
@@ -619,10 +570,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { location, company } = await createCompanyAndLocation(context);
 
             // Run the query to disconnect the location from company
-            const { data, errors } = await context.executeGraphQL({
+            const data = await context.graphql.run({
               query: `mutation { deleteCompany(id: "${company.id}") { id } } `,
             });
-            expect(errors).toBe(undefined);
             expect(data.deleteCompany.id).toBe(company.id);
 
             // Check the link has been broken

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -72,7 +72,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -88,13 +88,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
           expect(data).toMatchObject({
             createUser: { id: expect.any(String), notes: expect.any(Array) },
           });
-          expect(errors).toBe(undefined);
 
           // Create an item that does the linking
-          const {
-            data: { createUser },
-            errors: errors2,
-          } = await context.executeGraphQL({
+          const { createUser } = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -106,11 +102,10 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors2).toBe(undefined);
           expect(createUser).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
 
           // Test an empty list of related notes
-          const result = await context.executeGraphQL({
+          const data2 = await context.graphql.run({
             query: `
               mutation {
                 createUser(data: {
@@ -122,8 +117,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(result.errors).toBe(undefined);
-          expect(result.data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
+          expect(data2.createUser).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
 
@@ -146,7 +140,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createUsers(data: [
@@ -161,7 +155,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
           expect(data).toMatchObject({
             createUsers: [{ id: expect.any(String) }, { id: expect.any(String) }],
           });
-          expect(errors).toBe(undefined);
         })
       );
 
@@ -191,7 +184,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -216,13 +209,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
               notes: [{ id: expect.any(String), content: noteContent }],
             },
           });
-          expect(errors).toBe(undefined);
 
           // Update the item and link multiple relationship fields
-          const {
-            data: { updateUser },
-            errors: errors2,
-          } = await context.executeGraphQL({
+          const { updateUser } = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -242,7 +231,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors2).toBe(undefined);
           expect(updateUser).toMatchObject({
             id: expect.any(String),
             notes: [
@@ -279,7 +267,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Update the item and link the relationship field
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUser(
@@ -307,7 +295,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
               ],
             },
           });
-          expect(errors).toBe(undefined);
         })
       );
 
@@ -344,7 +331,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             item: { username: 'user2' },
           });
 
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateUsers(data: [
@@ -365,7 +352,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
               { id: expect.any(String), notes: [{ id: createNote2.id, content: noteContent2 }] },
             ],
           });
-          expect(errors).toBe(undefined);
         })
       );
     });
@@ -377,7 +363,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const FAKE_ID = 100;
 
           // Create an item that does the linking
-          const { errors } = await context.executeGraphQL({
+          const { errors } = await context.graphql.raw({
             query: `
               mutation {
                 createUser(data: {
@@ -405,7 +391,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const createUser = await createItem({ context, listKey: 'User', item: {} });
 
           // Create an item that does the linking
-          const { errors } = await context.executeGraphQL({
+          const { errors } = await context.graphql.raw({
             query: `
               mutation {
                 updateUser(
@@ -442,7 +428,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               item: { content: noteContent },
             });
 
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -455,12 +441,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             expect(errors).toHaveLength(1);
-            const error = errors[0];
+            const error = errors![0];
             expect(error.message).toEqual(
               'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>'
             );
             expect(error.path).toHaveLength(1);
-            expect(error.path[0]).toEqual('createUserToNotesNoRead');
+            expect(error.path![0]).toEqual('createUserToNotesNoRead');
           })
         );
 
@@ -484,7 +470,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Update the item and link the relationship field
-            const { errors } = await context.exitSudo().executeGraphQL({
+            const { errors } = await context.exitSudo().graphql.raw({
               query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -500,12 +486,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             expect(errors).toHaveLength(1);
-            const error = errors[0];
+            const error = errors![0];
             expect(error.message).toEqual(
               'Unable to create and/or connect 1 UserToNotesNoRead.notes<NoteNoRead>'
             );
             expect(error.path).toHaveLength(1);
-            expect(error.path[0]).toEqual('updateUserToNotesNoRead');
+            expect(error.path![0]).toEqual('updateUserToNotesNoRead');
           })
         );
       });
@@ -524,7 +510,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Create an item that does the linking
-            const { data, errors } = await context.exitSudo().executeGraphQL({
+            const data = await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   createUserToNotesNoCreate(data: {
@@ -536,7 +522,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }`,
             });
 
-            expect(errors).toBe(undefined);
             expect(data.createUserToNotesNoCreate).toMatchObject({ id: expect.any(String) });
           })
         );
@@ -561,7 +546,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Update the item and link the relationship field
-            const { data, errors } = await context.exitSudo().executeGraphQL({
+            const data = await context.exitSudo().graphql.run({
               query: `
                 mutation {
                   updateUserToNotesNoCreate(
@@ -578,7 +563,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }`,
             });
 
-            expect(errors).toBe(undefined);
             expect(data.updateUserToNotesNoCreate).toMatchObject({ id: expect.any(String) });
           })
         );

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -110,7 +110,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item that does the linking
-          const { data, errors } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 createEvent(data: {
@@ -123,7 +123,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           expect(data).toMatchObject({ createEvent: { id: expect.any(String) } });
-          expect(errors).toBe(undefined);
         })
       );
 
@@ -140,16 +139,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create an item to update
-          const {
-            data: { createEvent },
-            errors,
-          } = await context.executeGraphQL({
+          const { createEvent } = await context.graphql.run({
             query: 'mutation { createEvent(data: { title: "A thing", }) { id } }',
           });
-          expect(errors).toBe(undefined);
 
           // Update the item and link the relationship field
-          const { data, errors: errors2 } = await context.executeGraphQL({
+          const data = await context.graphql.run({
             query: `
               mutation {
                 updateEvent(
@@ -167,7 +162,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 }
               }`,
           });
-          expect(errors2).toBe(undefined);
           expect(data).toMatchObject({
             updateEvent: {
               id: expect.any(String),
@@ -185,7 +179,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const FAKE_ID = 100;
 
           // Create an item that does the linking
-          const { errors } = await context.executeGraphQL({
+          const { errors } = await context.graphql.raw({
             query: `
               mutation {
                 createEvent(data: {
@@ -211,7 +205,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const createEvent = await createItem({ context, listKey: 'Event', item: {} });
 
           // Create an item that does the linking
-          const { errors } = await context.executeGraphQL({
+          const { errors } = await context.graphql.raw({
             query: `
               mutation {
                 updateEvent(
@@ -258,7 +252,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 expect(id).toBeTruthy();
 
                 // Create an item that does the linking
-                const { data, errors } = await context.exitSudo().executeGraphQL({
+                const data = await context.exitSudo().graphql.run({
                   query: `
                     mutation {
                       createEventTo${group.name}(data: {
@@ -276,7 +270,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 expect(data).toMatchObject({
                   [`createEventTo${group.name}`]: { id: expect.any(String), group: { id } },
                 });
-                expect(errors).toBe(undefined);
               })
             );
             test(
@@ -301,7 +294,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 expect(eventModel.id).toBeTruthy();
 
                 // Update the item and link the relationship field
-                const { data, errors } = await context.exitSudo().executeGraphQL({
+                const data = await context.exitSudo().graphql.run({
                   query: `
                     mutation {
                       updateEventTo${group.name}(
@@ -326,7 +319,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     group: { id: expect.any(String), name: groupName },
                   },
                 });
-                expect(errors).toBe(undefined);
 
                 // See that it actually stored the group ID on the Event record
                 const event = await getItem({
@@ -363,7 +355,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 expect(eventModel.id).toBeTruthy();
 
                 // Update the item and link the relationship field
-                const { errors } = await context.exitSudo().executeGraphQL({
+                const { errors } = await context.exitSudo().graphql.raw({
                   query: `
                     mutation {
                       updateEventTo${group.name}(
@@ -378,12 +370,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     }`,
                 });
                 expect(errors).toHaveLength(1);
-                const error = errors[0];
+                const error = errors![0];
                 expect(error.message).toEqual(
                   `Unable to connect a EventTo${group.name}.group<${group.name}>`
                 );
                 expect(error.path).toHaveLength(1);
-                expect(error.path[0]).toEqual(`updateEventTo${group.name}`);
+                expect(error.path![0]).toEqual(`updateEventTo${group.name}`);
               })
             );
 
@@ -401,7 +393,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 expect(id).toBeTruthy();
 
                 // Create an item that does the linking
-                const { errors } = await context.exitSudo().executeGraphQL({
+                const { errors } = await context.exitSudo().graphql.raw({
                   query: `
                     mutation {
                       createEventTo${group.name}(data: {
@@ -413,12 +405,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     }`,
                 });
                 expect(errors).toHaveLength(1);
-                const error = errors[0];
+                const error = errors![0];
                 expect(error.message).toEqual(
                   `Unable to connect a EventTo${group.name}.group<${group.name}>`
                 );
                 expect(error.path).toHaveLength(1);
-                expect(error.path[0]).toEqual(`createEventTo${group.name}`);
+                expect(error.path![0]).toEqual(`createEventTo${group.name}`);
               })
             );
           }


### PR DESCRIPTION
This PR removes the final uses of `executeGraphQL`. This means we can remove this deprecated function from the `context` API.