### PR TITLE
Convert core Keystone class to typescript

### DIFF
--- a/.changeset/red-rice-cheer.md
+++ b/.changeset/red-rice-cheer.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/fields': patch
+'@keystone-next/keystone': patch
+'@keystone-next/types': patch
+'@keystone-next/adapter-prisma-legacy': patch
+---
+
+Improved the `BaseKeystone` type to be more correct.

--- a/packages-next/fields/src/types/relationship/Implementation.ts
+++ b/packages-next/fields/src/types/relationship/Implementation.ts
@@ -23,6 +23,7 @@ export class Relationship<P extends string> extends Implementation<P> {
   many: boolean;
   refFieldPath?: string;
   withMeta: boolean;
+  ref: string;
   // adapter: PrismaRelationshipInterface<P>;
   constructor(
     path: P,
@@ -37,6 +38,7 @@ export class Relationship<P extends string> extends Implementation<P> {
     super(path, { ref, many, withMeta, ...configArgs }, extraArgs);
 
     // JM: It bugs me this is duplicated in the field adapters but initialisation order makes it hard to avoid
+    this.ref = ref;
     const [refListKey, refFieldPath] = ref.split('.');
     this.refListKey = refListKey;
     this.refFieldPath = refFieldPath;

--- a/packages-next/keystone/src/lib/core/Keystone/index.d.ts
+++ b/packages-next/keystone/src/lib/core/Keystone/index.d.ts
@@ -1,1 +1,0 @@
-export const Keystone: any;

--- a/packages-next/keystone/src/lib/core/Keystone/index.ts
+++ b/packages-next/keystone/src/lib/core/Keystone/index.ts
@@ -1,11 +1,37 @@
 import { gql } from 'apollo-server-express';
 import { GraphQLUpload } from 'graphql-upload';
 import { objMerge, flatten, unique, filterValues } from '@keystone-next/utils-legacy';
+import {
+  BaseKeystone,
+  BaseKeystoneList,
+  BaseListConfig,
+  KeystoneContext,
+  Rel,
+} from '@keystone-next/types';
+import { PrismaAdapter } from '@keystone-next/adapter-prisma-legacy';
+import { Relationship } from '@keystone-next/fields/src/types/relationship/Implementation';
 import { List } from '../ListTypes';
 import { ListCRUDProvider } from '../providers';
 
-export class Keystone {
-  constructor({ adapter, onConnect, queryLimits = {} }) {
+export class Keystone implements BaseKeystone {
+  lists: Record<string, BaseKeystoneList>;
+  listsArray: BaseKeystoneList[];
+  getListByKey: (key: string) => BaseKeystoneList | undefined;
+  onConnect: (keystone: BaseKeystone, args?: { context: KeystoneContext }) => Promise<void>;
+  _listCRUDProvider: any;
+  _providers: any[];
+  adapter: PrismaAdapter;
+  queryLimits: { maxTotalResults: number };
+
+  constructor({
+    adapter,
+    onConnect,
+    queryLimits = {},
+  }: {
+    adapter: PrismaAdapter;
+    onConnect: (keystone: BaseKeystone, args?: { context: KeystoneContext }) => Promise<void>;
+    queryLimits: { maxTotalResults?: number | undefined } | undefined;
+  }) {
     this.lists = {};
     this.listsArray = [];
     this.getListByKey = key => this.lists[key];
@@ -19,7 +45,7 @@ export class Keystone {
     }
   }
 
-  createList(key, config) {
+  createList(key: string, config: BaseListConfig) {
     const { getListByKey, adapter } = this;
     const isReservedName = key[0] === '_';
 
@@ -41,7 +67,7 @@ export class Keystone {
       );
     }
 
-    const list = new List(key, config, { getListByKey, adapter });
+    const list: BaseKeystoneList = new List(key, config, { getListByKey, adapter });
     this.lists[key] = list;
     this.listsArray.push(list);
     this._listCRUDProvider.lists.push(list);
@@ -50,12 +76,13 @@ export class Keystone {
   }
 
   _consolidateRelationships() {
-    const rels = {};
-    const otherSides = {};
+    const rels: Record<string, Rel> = {};
+    const otherSides: Record<string, string> = {};
     this.listsArray.forEach(list => {
       list.fields
         .filter(f => f.isRelationship)
-        .forEach(f => {
+        .forEach(_f => {
+          const f = _f as Relationship<any>;
           const myRef = `${f.listKey}.${f.path}`;
           if (otherSides[myRef]) {
             // I'm already there, go and update rels[otherSides[myRef]] with my info
@@ -63,17 +90,15 @@ export class Keystone {
 
             // Make sure I'm actually referencing the thing on the left
             const { left } = rels[otherSides[myRef]];
-            if (f.config.ref !== `${left.listKey}.${left.path}`) {
-              throw new Error(
-                `${myRef} refers to ${f.config.ref}. Expected ${left.listKey}.${left.path}`
-              );
+            if (f.ref !== `${left.listKey}.${left.path}`) {
+              throw new Error(`${myRef} refers to ${f.ref}. Expected ${left.listKey}.${left.path}`);
             }
           } else {
             // Got us a new relationship!
             rels[myRef] = { left: f };
             if (f.refFieldPath) {
               // Populate otherSides
-              otherSides[f.config.ref] = myRef;
+              otherSides[f.ref] = myRef;
             }
           }
         });
@@ -82,9 +107,7 @@ export class Keystone {
     const badRel = Object.values(rels).find(({ left, right }) => left.refFieldPath && !right);
     if (badRel) {
       const { left } = badRel;
-      throw new Error(
-        `${left.listKey}.${left.path} refers to a non-existant field, ${left.config.ref}`
-      );
+      throw new Error(`${left.listKey}.${left.path} refers to a non-existant field, ${left.ref}`);
     }
 
     // Ensure that the left/right pattern is always the same no matter what order
@@ -109,10 +132,10 @@ export class Keystone {
 
     Object.values(rels).forEach(rel => {
       const { left, right } = rel;
-      let cardinality;
-      if (left.config.many) {
+      let cardinality: Rel['cardinality'];
+      if (left.many) {
         if (right) {
-          if (right.config.many) {
+          if (right.many) {
             cardinality = 'N:N';
           } else {
             cardinality = '1:N';
@@ -123,7 +146,7 @@ export class Keystone {
         }
       } else {
         if (right) {
-          if (right.config.many) {
+          if (right.many) {
             cardinality = 'N:1';
           } else {
             cardinality = '1:1';
@@ -150,18 +173,18 @@ export class Keystone {
           };
         } else {
           const leftKey = `${left.listKey}.${left.path}`;
-          const rightKey = `${left.config.ref}`;
+          const rightKey = `${left.ref}`;
           rel.columnNames = {
-            [leftKey]: { near: `${left.listKey}_left_id`, far: `${left.config.ref}_right_id` },
-            [rightKey]: { near: `${left.config.ref}_right_id`, far: `${left.listKey}_left_id` },
+            [leftKey]: { near: `${left.listKey}_left_id`, far: `${left.ref}_right_id` },
+            [rightKey]: { near: `${left.ref}_right_id`, far: `${left.listKey}_left_id` },
           };
         }
       } else if (cardinality === '1:1') {
         tableName = left.listKey;
         columnName = left.path;
       } else if (cardinality === '1:N') {
-        tableName = right.listKey;
-        columnName = right.path;
+        tableName = right!.listKey;
+        columnName = right!.path;
       } else {
         tableName = left.listKey;
         columnName = left.path;
@@ -173,7 +196,7 @@ export class Keystone {
     return Object.values(rels);
   }
 
-  async connect(args) {
+  async connect(args?: { context: KeystoneContext }): Promise<void> {
     await this.adapter.connect({ rels: this._consolidateRelationships() });
 
     if (this.onConnect) {
@@ -185,7 +208,7 @@ export class Keystone {
     await this.adapter.disconnect();
   }
 
-  getTypeDefs({ schemaName }) {
+  getTypeDefs({ schemaName }: { schemaName: string }) {
     const queries = unique(flatten(this._providers.map(p => p.getQueries({ schemaName }))));
     const mutations = unique(flatten(this._providers.map(p => p.getMutations({ schemaName }))));
     const subscriptions = unique(
@@ -208,26 +231,22 @@ export class Keystone {
       .map(s => gql(s));
   }
 
-  getResolvers({ schemaName }) {
+  getResolvers({ schemaName }: { schemaName: string }) {
     // Like the `typeDefs`, we want to dedupe the resolvers. We rely on the
     // semantics of the JS spread operator here (duplicate keys are overridden
     // - last one wins)
     // TODO: Document this order of precedence, because it's not obvious, and
     // there's no errors thrown
     // TODO: console.warn when duplicate keys are detected?
-    return filterValues(
-      {
-        // Order of spreading is important here - we don't want user-defined types
-        // to accidentally override important things like `Query`.
-        ...objMerge(this._providers.map(p => p.getTypeResolvers({ schemaName }))),
-        Query: objMerge(this._providers.map(p => p.getQueryResolvers({ schemaName }))),
-        Mutation: objMerge(this._providers.map(p => p.getMutationResolvers({ schemaName }))),
-        Subscription: objMerge(
-          this._providers.map(p => p.getSubscriptionResolvers({ schemaName }))
-        ),
-        Upload: GraphQLUpload,
-      },
-      o => Object.entries(o).length > 0
-    );
+    const resolvers: Record<string, any> = {
+      // Order of spreading is important here - we don't want user-defined types
+      // to accidentally override important things like `Query`.
+      ...objMerge(this._providers.map(p => p.getTypeResolvers({ schemaName }))),
+      Query: objMerge(this._providers.map(p => p.getQueryResolvers({ schemaName }))),
+      Mutation: objMerge(this._providers.map(p => p.getMutationResolvers({ schemaName }))),
+      Subscription: objMerge(this._providers.map(p => p.getSubscriptionResolvers({ schemaName }))),
+      Upload: GraphQLUpload,
+    };
+    return filterValues(resolvers, o => Object.entries(o).length > 0);
   }
 }

--- a/packages-next/keystone/src/lib/core/ListTypes/index.d.ts
+++ b/packages-next/keystone/src/lib/core/ListTypes/index.d.ts
@@ -1,0 +1,1 @@
+export const List: any;

--- a/packages-next/keystone/src/lib/core/providers/index.d.ts
+++ b/packages-next/keystone/src/lib/core/providers/index.d.ts
@@ -1,0 +1,1 @@
+export const ListCRUDProvider: any;

--- a/packages-next/keystone/src/lib/core/tests/Keystone.test.js
+++ b/packages-next/keystone/src/lib/core/tests/Keystone.test.js
@@ -1,4 +1,4 @@
-import { Keystone } from '../Keystone';
+import { Keystone } from '../Keystone/index.ts';
 import { List } from '../ListTypes';
 
 class MockFieldAdapter {}

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -8,7 +8,7 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
   // by using this pattern for creating their Keystone object before using
   // it in their existing custom servers or original CLI systems.
   const { db, graphql, lists } = config;
-  let adapter;
+  let adapter: PrismaAdapter;
   if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
     adapter = new PrismaAdapter({
       prismaClient,
@@ -21,6 +21,10 @@ export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
       ...db,
       provider: 'sqlite',
     });
+  } else {
+    throw new Error(
+      'Invalid db configuration. Please specify db.provider as either "sqlite" or "postgresql"'
+    );
   }
   // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
   const keystone: BaseKeystone = new Keystone({

--- a/packages-next/types/src/base.ts
+++ b/packages-next/types/src/base.ts
@@ -1,42 +1,48 @@
 import { PrismaAdapter, PrismaListAdapter } from '@keystone-next/adapter-prisma-legacy';
 import { Implementation } from '@keystone-next/fields';
+import { Relationship } from '@keystone-next/fields/src/types/relationship/Implementation';
+import { DocumentNode } from 'graphql';
 import type { KeystoneContext } from './context';
 import type { BaseGeneratedListTypes, GqlNames } from './utils';
 
-type Rel = {
-  left: Implementation<any>;
-  right: Implementation<any>;
-  cardinality: 'N:N' | 'N:1' | '1:N' | '1:1';
-  tableName: string;
-  columnName: string;
+export type Rel = {
+  left: Relationship<any>;
+  right?: Relationship<any>;
+  cardinality?: 'N:N' | 'N:1' | '1:N' | '1:1';
+  tableName?: string;
+  columnName?: string;
+  columnNames?: Record<string, { near: string; far: string }>;
 };
-type Rels = Rel[];
+
+export type BaseListConfig = {
+  fields: Record<string, any>;
+  access: any;
+  queryLimits?: { maxResults?: number };
+  schemaDoc?: string;
+  listQueryName?: string;
+  itemQueryName?: string;
+  hooks?: Record<string, any>;
+  adapterConfig?: { searchField?: string };
+};
 
 // TODO: This is only a partial typing of the core Keystone class.
 // We should definitely invest some time into making this more correct.
 export type BaseKeystone = {
-  adapter: PrismaAdapter;
-  createList: (
-    key: string,
-    config: {
-      fields: Record<string, any>;
-      access: any;
-      queryLimits?: { maxResults?: number };
-      schemaDoc?: string;
-      listQueryName?: string;
-      itemQueryName?: string;
-      hooks?: Record<string, any>;
-      adapterConfig?: { searchField?: string };
-    }
-  ) => BaseKeystoneList;
-  connect: (args?: any) => Promise<void>;
-  disconnect: () => Promise<void>;
   lists: Record<string, BaseKeystoneList>;
-  createApolloServer: (args: { schemaName: string; dev: boolean }) => any;
-  getTypeDefs: (args: { schemaName: string }) => any;
-  getResolvers: (args: { schemaName: string }) => any;
+  listsArray: BaseKeystoneList[];
+  getListByKey: (key: string) => BaseKeystoneList | undefined;
+  onConnect: (keystone: BaseKeystone, args?: { context: KeystoneContext }) => Promise<void>;
+  _listCRUDProvider: any;
+  _providers: any[];
+  adapter: PrismaAdapter;
   queryLimits: { maxTotalResults: number };
-  _consolidateRelationships: () => Rels;
+
+  createList: (key: string, config: BaseListConfig) => BaseKeystoneList;
+  _consolidateRelationships: () => Rel[];
+  connect: (args?: { context: KeystoneContext }) => Promise<void>;
+  disconnect: () => Promise<void>;
+  getTypeDefs: (args: { schemaName: string }) => DocumentNode[];
+  getResolvers: (args: { schemaName: string }) => Record<string, any>;
 };
 
 // TODO: This needs to be reviewed and expanded
@@ -53,6 +59,7 @@ export type BaseKeystoneList = {
     path: string;
   };
   gqlNames: GqlNames;
+  initFields: () => {};
   listQuery(
     args: BaseGeneratedListTypes['args']['listQuery'],
     context: KeystoneContext,

--- a/packages/adapter-prisma/src/adapter-prisma.ts
+++ b/packages/adapter-prisma/src/adapter-prisma.ts
@@ -1,17 +1,10 @@
 import pWaterfall from 'p-waterfall';
 import { defaultObj, mapKeys, identity, flatten } from '@keystone-next/utils-legacy';
 import { Implementation } from '@keystone-next/fields';
-import { BaseKeystoneList } from '@keystone-next/types';
+import { BaseKeystoneList, Rel } from '@keystone-next/types';
 
 // Note: These type definitions are preliminary while we're working towards
 // a full TypeScript conversion.
-type Rel = {
-  left: Implementation<any>;
-  right: Implementation<any>;
-  cardinality: 'N:N' | 'N:1' | '1:N' | '1:1';
-  tableName: string;
-  columnName: string;
-};
 type Rels = Rel[];
 
 type ListAdapterConfig = { searchField?: string };
@@ -324,7 +317,7 @@ class PrismaListAdapter {
     const include = defaultObj(
       this.fieldAdapters
         .filter(({ isRelationship }) => isRelationship)
-        .filter(a => a.config.many || (a.rel!.cardinality === '1:1' && a.rel!.right.adapter === a))
+        .filter(a => a.config.many || (a.rel!.cardinality === '1:1' && a.rel!.right!.adapter === a))
         .map(a => a.path),
       { select: { id: true } }
     );
@@ -448,7 +441,7 @@ class PrismaListAdapter {
           : `from_${a.rel.left.listKey}_${a.rel.left.path}`; // One-sided
         ret.where[path] = { some: { id: Number(from.fromId) } };
       } else {
-        ret.where[a.rel.columnName] = { id: Number(from.fromId) };
+        ret.where[a.rel.columnName!] = { id: Number(from.fromId) };
       }
     }
 


### PR DESCRIPTION
Converts the Keystone class to typescript and updates the types related to it. Going to update the core stuff to typescript incrementally then loop back at the end to do a holistic review of our types and what we're exposing in our public APIs.