### PR TITLE
[ON HOLD] POC for MongoDB Prisma adapter

### DIFF
--- a/examples-staging/basic/keystone.ts
+++ b/examples-staging/basic/keystone.ts
@@ -25,10 +25,8 @@ const auth = createAuth({
 
 export default auth.withAuth(
   config({
-    db: {
-      provider: 'sqlite',
-      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
-    },
+    // ts-ignore
+    db: { useMigrations: false, provider: 'mongodb', url: 'mongodb://localhost/keystone-basic-mongo-prisma', },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {
     //   path: '/api/graphql',

--- a/examples-staging/basic/keystone.ts
+++ b/examples-staging/basic/keystone.ts
@@ -25,7 +25,6 @@ const auth = createAuth({
 
 export default auth.withAuth(
   config({
-    // ts-ignore
     db: { useMigrations: false, provider: 'mongodb', url: 'mongodb://localhost/keystone-basic-mongo-prisma', },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {

--- a/examples-staging/basic/schema.graphql
+++ b/examples-staging/basic/schema.graphql
@@ -121,12 +121,36 @@ input UserWhereInput {
   name_not: String
   name_contains: String
   name_not_contains: String
+  name_starts_with: String
+  name_not_starts_with: String
+  name_ends_with: String
+  name_not_ends_with: String
+  name_i: String
+  name_not_i: String
+  name_contains_i: String
+  name_not_contains_i: String
+  name_starts_with_i: String
+  name_not_starts_with_i: String
+  name_ends_with_i: String
+  name_not_ends_with_i: String
   name_in: [String]
   name_not_in: [String]
   email: String
   email_not: String
   email_contains: String
   email_not_contains: String
+  email_starts_with: String
+  email_not_starts_with: String
+  email_ends_with: String
+  email_not_ends_with: String
+  email_i: String
+  email_not_i: String
+  email_contains_i: String
+  email_not_contains_i: String
+  email_starts_with_i: String
+  email_not_starts_with_i: String
+  email_ends_with_i: String
+  email_not_ends_with_i: String
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
@@ -136,6 +160,18 @@ input UserWhereInput {
   roles_not: String
   roles_contains: String
   roles_not_contains: String
+  roles_starts_with: String
+  roles_not_starts_with: String
+  roles_ends_with: String
+  roles_not_ends_with: String
+  roles_i: String
+  roles_not_i: String
+  roles_contains_i: String
+  roles_not_contains_i: String
+  roles_starts_with_i: String
+  roles_not_starts_with_i: String
+  roles_ends_with_i: String
+  roles_not_ends_with_i: String
   roles_in: [String]
   roles_not_in: [String]
 
@@ -295,6 +331,18 @@ input PhoneNumberWhereInput {
   value_not: String
   value_contains: String
   value_not_contains: String
+  value_starts_with: String
+  value_not_starts_with: String
+  value_ends_with: String
+  value_not_ends_with: String
+  value_i: String
+  value_not_i: String
+  value_contains_i: String
+  value_not_contains_i: String
+  value_starts_with_i: String
+  value_not_starts_with_i: String
+  value_ends_with_i: String
+  value_not_ends_with_i: String
   value_in: [String]
   value_not_in: [String]
 }
@@ -377,6 +425,18 @@ input PostWhereInput {
   title_not: String
   title_contains: String
   title_not_contains: String
+  title_starts_with: String
+  title_not_starts_with: String
+  title_ends_with: String
+  title_not_ends_with: String
+  title_i: String
+  title_not_i: String
+  title_contains_i: String
+  title_not_contains_i: String
+  title_starts_with_i: String
+  title_not_starts_with_i: String
+  title_ends_with_i: String
+  title_not_ends_with_i: String
   title_in: [String]
   title_not_in: [String]
   status: String

--- a/examples-staging/basic/schema.prisma
+++ b/examples-staging/basic/schema.prisma
@@ -1,15 +1,16 @@
-datasource sqlite {
+datasource mongodb {
   url      = env("DATABASE_URL")
-  provider = "sqlite"
+  provider = "mongodb"
 }
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "node_modules/.prisma/client"
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongodb"]
+  output          = "node_modules/.prisma/client"
 }
 
 model User {
-  id                  Int           @id @default(autoincrement())
+  id                  String        @id @default(dbgenerated()) @map("_id") @mongodb.ObjectId
   name                String?
   email               String?       @unique
   avatar_filesize     Int?
@@ -29,23 +30,23 @@ model User {
 }
 
 model PhoneNumber {
-  id     Int     @id @default(autoincrement())
-  user   User?   @relation("PhoneNumber_user", fields: [userId], references: [id])
-  userId Int?    @map("user")
+  id     String  @id @default(dbgenerated()) @map("_id") @mongodb.ObjectId
   type   String?
   value  String?
+  user   User?   @relation("PhoneNumberuser", fields: [userId], references: [id])
+  userId String? @map("user") @mongodb.ObjectId
 
   @@index([userId])
 }
 
 model Post {
-  id          Int       @id @default(autoincrement())
+  id          String    @id @default(dbgenerated()) @map("_id") @mongodb.ObjectId
   title       String?
   status      String?
-  content     String?
+  content     Json?
   publishDate DateTime?
-  author      User?     @relation("Post_author", fields: [authorId], references: [id])
-  authorId    Int?      @map("author")
+  author      User?     @relation("Postauthor", fields: [authorId], references: [id])
+  authorId    String?   @map("author") @mongodb.ObjectId
 
   @@index([authorId])
 }

--- a/examples/json/keystone.ts
+++ b/examples/json/keystone.ts
@@ -2,9 +2,6 @@ import { config } from '@keystone-next/keystone/schema';
 import { lists } from './schema';
 
 export default config({
-  db: {
-    provider: 'sqlite',
-    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
-  },
+  db: { useMigrations: false, provider: 'mongodb', url: 'mongodb://localhost/keystone-json-mongo-prisma', },
   lists,
 });

--- a/examples/json/schema.graphql
+++ b/examples/json/schema.graphql
@@ -24,6 +24,18 @@ input PackageWhereInput {
   label_not: String
   label_contains: String
   label_not_contains: String
+  label_starts_with: String
+  label_not_starts_with: String
+  label_ends_with: String
+  label_not_ends_with: String
+  label_i: String
+  label_not_i: String
+  label_contains_i: String
+  label_not_contains_i: String
+  label_starts_with_i: String
+  label_not_starts_with_i: String
+  label_ends_with_i: String
+  label_not_ends_with_i: String
   label_in: [String]
   label_not_in: [String]
   isPrivate: Boolean
@@ -135,6 +147,18 @@ input PersonWhereInput {
   name_not: String
   name_contains: String
   name_not_contains: String
+  name_starts_with: String
+  name_not_starts_with: String
+  name_ends_with: String
+  name_not_ends_with: String
+  name_i: String
+  name_not_i: String
+  name_contains_i: String
+  name_not_contains_i: String
+  name_starts_with_i: String
+  name_not_starts_with_i: String
+  name_ends_with_i: String
+  name_not_ends_with_i: String
   name_in: [String]
   name_not_in: [String]
 

--- a/examples/json/schema.prisma
+++ b/examples/json/schema.prisma
@@ -1,26 +1,27 @@
-datasource sqlite {
+datasource mongodb {
   url      = env("DATABASE_URL")
-  provider = "sqlite"
+  provider = "mongodb"
 }
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "node_modules/.prisma/client"
+  provider        = "prisma-client-js"
+  previewFeatures = ["mongodb"]
+  output          = "node_modules/.prisma/client"
 }
 
 model Package {
-  id        Int      @id @default(autoincrement())
+  id        String   @id @default(dbgenerated()) @map("_id") @mongodb.ObjectId
   label     String?
-  pkgjson   String?
+  pkgjson   Json?
   isPrivate Boolean?
-  ownedBy   Person?  @relation("Package_ownedBy", fields: [ownedById], references: [id])
-  ownedById Int?     @map("ownedBy")
+  ownedBy   Person?  @relation("PackageownedBy", fields: [ownedById], references: [id])
+  ownedById String?  @map("ownedBy") @mongodb.ObjectId
 
   @@index([ownedById])
 }
 
 model Person {
-  id       Int       @id @default(autoincrement())
+  id       String    @id @default(dbgenerated()) @map("_id") @mongodb.ObjectId
   name     String?
   packages Package[] @relation("Package_ownedBy")
 }

--- a/packages-next/fields/src/index.ts
+++ b/packages-next/fields/src/index.ts
@@ -11,4 +11,5 @@ export { relationship } from './types/relationship';
 export { select } from './types/select';
 export { text } from './types/text';
 export { timestamp } from './types/timestamp';
+export { mongoId } from './types/mongoId';
 export { virtual } from './types/virtual';

--- a/packages-next/fields/src/types/mongoId/Implementation.ts
+++ b/packages-next/fields/src/types/mongoId/Implementation.ts
@@ -1,0 +1,121 @@
+import { PrismaFieldAdapter, PrismaListAdapter } from '@keystone-next/adapter-prisma-legacy';
+import { BaseKeystoneList } from '@keystone-next/types';
+import { FieldConfigArgs, FieldExtraArgs, Implementation } from '../../Implementation';
+
+export class MongoIdImplementation<P extends string> extends Implementation<P> {
+  gqlType: 'ID' | 'String';
+  constructor(
+    path: P,
+    {
+      gqlType,
+      isUnique = true,
+      access = {},
+      ...configArgs
+    }: FieldConfigArgs & { gqlType: 'ID' | 'String'; isUnique: boolean },
+    extraArgs: FieldExtraArgs
+  ) {
+    // Apply some field type defaults before we hand off to super; see README.md
+    if (typeof access === 'object') {
+      access = { create: false, update: false, delete: false, ...access };
+    }
+
+    // The base implementation takes care of everything else
+    super(path, { gqlType, isUnique, access, ...configArgs }, extraArgs);
+
+    // If no valid gqlType is supplied, default based on whether or not we're the primary key
+    this.gqlType = ['ID', 'String'].includes(gqlType) ? gqlType : this.isPrimaryKey ? 'ID' : 'String';
+  }
+
+  get _supportsUnique() {
+    return true;
+  }
+
+  gqlOutputFields() {
+    return [`${this.path}: ${this.gqlType}${this.isPrimaryKey ? '!' : ''}`];
+  }
+  gqlOutputFieldResolvers() {
+    return { [`${this.path}`]: (item: Record<P, any>) => item[this.path] };
+  }
+  gqlQueryInputFields() {
+    return [
+      ...this.equalityInputFields(this.gqlType),
+      ...this.orderingInputFields(this.gqlType),
+      ...this.inInputFields(this.gqlType),
+    ];
+  }
+  gqlUpdateInputFields() {
+    return [`${this.path}: ${this.gqlType}`];
+  }
+  gqlCreateInputFields() {
+    return [`${this.path}: ${this.gqlType}`];
+  }
+
+  getBackingTypes() {
+    if (this.path === 'id') {
+      return { [this.path]: { optional: false, type: 'string' } };
+    }
+    return { [this.path]: { optional: true, type: 'string | null' } };
+  }
+}
+
+export class PrismaMongoIdInterface<P extends string> extends PrismaFieldAdapter<P> {
+  isUnique: boolean;
+  isIndexed: boolean;
+  constructor(
+    fieldName: string,
+    path: P,
+    field: MongoIdImplementation<P>,
+    listAdapter: PrismaListAdapter,
+    getListByKey: (arg: string) => BaseKeystoneList | undefined,
+    config = {}
+  ) {
+    super(fieldName, path, field, listAdapter, getListByKey, config);
+    if (this.listAdapter.parentAdapter.provider === 'sqlite' && !this.field.isPrimaryKey) {
+      throw new Error(
+        `PrismaAdapter provider "sqlite" does not support field type "${this.field.constructor.name}"`
+      );
+    }
+    // Default isUnique to true if not specified
+    this.isUnique = typeof this.config.isUnique === 'undefined' ? true : !!this.config.isUnique;
+    this.isIndexed = !!this.config.isIndexed && !this.config.isUnique;
+  }
+
+  getPrismaSchema() {
+    return [this._schemaField({ type: 'String', extra: '@default(dbgenerated()) @map("_id") @mongodb.ObjectId' })];
+  }
+
+  gqlToPrisma(value: any) {
+    // If we're an ID type then we'll be getting strings from GQL
+    return String(value);
+    // console.log(this.field.gqlType);
+    // return this.field.gqlType === 'ID' ? Number(value) : value;
+  }
+
+  equalityConditions<T>(dbPath: string, f: (a: any) => any) {
+    return {
+      [this.path]: (value: T) => ({ [dbPath]: f(value) }),
+      [`${this.path}_not`]: (value: T) => ({ NOT: { [this.path]: f(value) } }),
+    };
+  }
+
+  inConditions<T>(dbPath: string, f: (a: any) => any) {
+    return {
+      [`${this.path}_in`]: (value: (T | null)[]) =>
+        value.includes(null)
+          ? { [dbPath]: { in: f(value.filter(x => x !== null)) } }
+          : { [dbPath]: { in: f(value) } },
+      [`${this.path}_not_in`]: (value: (T | null)[]) =>
+        value.includes(null)
+          ? { AND: [{ NOT: { [dbPath]: { in: f(value.filter(x => x !== null)) } } }] }
+          : { NOT: { [dbPath]: { in: f(value) } } },
+    };
+  }
+
+  getQueryConditions(dbPath: string) {
+    return {
+      ...this.equalityConditions(dbPath, x => String(x) || -1),
+      ...this.orderingConditions(dbPath, x => String(x) || -1),
+      ...this.inConditions(dbPath, x => x.map((xx: any) => String(xx) || -1)),
+    };
+  }
+}

--- a/packages-next/fields/src/types/mongoId/index.ts
+++ b/packages-next/fields/src/types/mongoId/index.ts
@@ -1,0 +1,28 @@
+import type { FieldType, BaseGeneratedListTypes, FieldDefaultValue } from '@keystone-next/types';
+import { resolveView } from '../../resolve-view';
+import type { FieldConfig } from '../../interfaces';
+import { MongoIdImplementation, PrismaMongoIdInterface } from './Implementation';
+
+export type MongoIdFieldConfig<
+  TGeneratedListTypes extends BaseGeneratedListTypes
+> = FieldConfig<TGeneratedListTypes> & {
+  isRequired?: boolean;
+  isUnique?: boolean;
+  ui?: {
+    displayMode?: 'input' | 'textarea';
+  };
+  defaultValue?: FieldDefaultValue<string>;
+};
+
+export const mongoId = <TGeneratedListTypes extends BaseGeneratedListTypes>(
+  config: MongoIdFieldConfig<TGeneratedListTypes> = {}
+): FieldType<TGeneratedListTypes> => ({
+  type: {
+    type: 'MongoId',
+    implementation: MongoIdImplementation,
+    adapter: PrismaMongoIdInterface,
+  },
+  config,
+  views: resolveView('text/views'),
+  getAdminMeta: () => ({ displayMode: config.ui?.displayMode ?? 'input' }),
+});

--- a/packages-next/fields/src/types/mongoId/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/mongoId/tests/test-fixtures.ts
@@ -1,0 +1,176 @@
+import { getItems } from '@keystone-next/server-side-graphql-client-legacy';
+import { KeystoneContext } from '@keystone-next/types';
+import { text } from '../../text';
+import { autoIncrement } from '..';
+
+type MatrixValue = typeof testMatrix[number];
+
+export const name = 'AutoIncrement';
+export const typeFunction = autoIncrement;
+export const testMatrix = ['ID', 'Int'] as const;
+export const exampleValue = (matrixValue: MatrixValue) => (matrixValue === 'ID' ? '35' : 35);
+export const exampleValue2 = (matrixValue: MatrixValue) => (matrixValue === 'ID' ? '36' : 36);
+export const supportsUnique = true;
+export const fieldName = 'orderNumber';
+export const skipCreateTest = false;
+export const skipUpdateTest = true;
+
+export const unSupportedAdapterList = ['sqlite'];
+
+// Be default, `AutoIncrement` are read-only. But for `isRequired` test purpose, we need to bypass these restrictions.
+export const fieldConfig = (matrixValue: MatrixValue) => ({
+  gqlType: matrixValue,
+  access: { create: true, update: true },
+});
+
+export const getTestFields = (matrixValue: MatrixValue) => ({
+  name: text(),
+  orderNumber: autoIncrement({
+    // The gqlType argument is not currently available on the type.
+    // This will be reviewed when we do our full field type API review
+    // @ts-ignore
+    gqlType: matrixValue,
+    access: { create: true },
+  }),
+});
+
+export const initItems = () => {
+  return [
+    { name: 'product1' },
+    { name: 'product2' },
+    { name: 'product3' },
+    { name: 'product4' },
+    { name: 'product5' },
+    { name: 'product6' },
+    { name: 'product7' },
+  ];
+};
+
+export const storedValues = (matrixValue: MatrixValue) =>
+  matrixValue === 'ID'
+    ? [
+        { name: 'product1', orderNumber: '1' },
+        { name: 'product2', orderNumber: '2' },
+        { name: 'product3', orderNumber: '3' },
+        { name: 'product4', orderNumber: '4' },
+        { name: 'product5', orderNumber: '5' },
+        { name: 'product6', orderNumber: '6' },
+        { name: 'product7', orderNumber: '7' },
+      ]
+    : [
+        { name: 'product1', orderNumber: 1 },
+        { name: 'product2', orderNumber: 2 },
+        { name: 'product3', orderNumber: 3 },
+        { name: 'product4', orderNumber: 4 },
+        { name: 'product5', orderNumber: 5 },
+        { name: 'product6', orderNumber: 6 },
+        { name: 'product7', orderNumber: 7 },
+      ];
+
+export const supportedFilters = () => [];
+
+export const filterTests = (withKeystone: (arg: any) => any, matrixValue: MatrixValue) => {
+  const _storedValues = storedValues(matrixValue);
+  const _f = matrixValue === 'ID' ? (x: any) => x.toString() : (x: any) => x;
+  const match = async (context: KeystoneContext, where: Record<string, any>, expected: any[]) =>
+    expect(
+      await getItems({
+        context,
+        listKey: 'Test',
+        where,
+        returnFields: 'name orderNumber',
+        sortBy: 'name_ASC',
+      })
+    ).toEqual(expected.map(i => _storedValues[i]));
+
+  test(
+    'Filter: orderNumber',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber: _f(1) }, [0])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_not: _f(1) }, [1, 2, 3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not null',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_not: null }, [0, 1, 2, 3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_lt',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_lt: _f(2) }, [0])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_lte',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_lte: _f(2) }, [0, 1])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_gt',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_gt: _f(2) }, [2, 3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_gte',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_gte: _f(2) }, [1, 2, 3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in (empty list)',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_in: [] }, [])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not_in (empty list)',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_not_in: [] }, [0, 1, 2, 3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_in: ([1, 2, 3] as const).map(_f) }, [0, 1, 2])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not_in',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_not_in: [1, 2, 3].map(_f) }, [3, 4, 5, 6])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_in null',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_in: [null] }, [])
+    )
+  );
+
+  test(
+    'Filter: orderNumber_not_in null',
+    withKeystone(({ context }: { context: KeystoneContext }) =>
+      match(context, { orderNumber_not_in: [null] }, [0, 1, 2, 3, 4, 5, 6])
+    )
+  );
+};

--- a/packages-next/keystone/src/admin-ui/components/Errors.tsx
+++ b/packages-next/keystone/src/admin-ui/components/Errors.tsx
@@ -17,6 +17,7 @@ type ErrorBoundaryState = {
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { hasError: false, isReloading: false };
   static getDerivedStateFromError(error: any) {
+    console.log(error);
     return { error, hasError: true };
   }
   reloadPage = () => {

--- a/packages-next/keystone/src/lib/config/applyIdFieldDefaults.ts
+++ b/packages-next/keystone/src/lib/config/applyIdFieldDefaults.ts
@@ -1,5 +1,5 @@
 import type { FieldData, KeystoneConfig, NextFieldType } from '@keystone-next/types';
-import { autoIncrement } from '@keystone-next/fields';
+import { autoIncrement, mongoId } from '@keystone-next/fields';
 
 /* Validate lists config and default the id field */
 export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
@@ -13,11 +13,11 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['li
         )} list. This is not allowed, use the idField option instead.`
       );
     }
-    const idFieldOption = config.lists[key].idField ?? autoIncrement({});
+    const idFieldOption = config.lists[key].idField ?? mongoId({}); // autoIncrement({});
     const actualIdField = (args: FieldData): NextFieldType => {
-      const idField = idFieldOption(args);
-      return {
-        ...idField,
+    const idField = idFieldOption(args);
+    return {
+      ...idField,
         ui: {
           createView: { fieldMode: 'hidden', ...idField.ui?.createView },
           itemView: { fieldMode: 'hidden', ...idField.ui?.itemView },

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -10,6 +10,8 @@ export function getDBProvider(db: KeystoneConfig['db']): DatabaseProvider {
     return 'postgresql';
   } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {
     return 'sqlite';
+  } else if (db.adapter === 'prisma_mongodb' || db.provider === 'mongodb') {
+    return 'mongodb';
   } else {
     throw new Error(
       'Invalid db configuration. Please specify db.provider as either "sqlite" or "postgresql"'

--- a/packages-next/keystone/src/lib/migrations.ts
+++ b/packages-next/keystone/src/lib/migrations.ts
@@ -52,7 +52,7 @@ export async function pushPrismaSchemaToDatabase(
   shouldDropDatabase = false
 ) {
   let before = Date.now();
-
+  return;
   let migration = await withMigrate(dbUrl, schemaPath, async migrate => {
     if (shouldDropDatabase) {
       await runMigrateWithDbUrl(dbUrl, () => migrate.engine.reset());

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -82,7 +82,19 @@ export type DatabaseConfig = {
           provider: 'sqlite';
         }
     )
-);
+    | (
+      | {
+          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
+          adapter: 'prisma_mongodb';
+          provider?: undefined;
+        }
+      | {
+          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'mongodb' }` */
+          adapter?: undefined;
+          provider: 'mongodb';
+        }
+    )
+  );
 
 // config.ui
 

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -8,7 +8,7 @@ type FieldDefaultValueArgs<TGeneratedListTypes extends BaseGeneratedListTypes> =
   originalInput: TGeneratedListTypes['inputs']['create'];
 };
 
-export type DatabaseProvider = 'sqlite' | 'postgresql';
+export type DatabaseProvider = 'sqlite' | 'postgresql' | 'mongodb';
 
 export type FieldDefaultValue<T, TGeneratedListTypes extends BaseGeneratedListTypes> =
   | T


### PR DESCRIPTION
for POC

added
* support for mongodb provider in prisma
* tried to run basic example
* relationship works fine but the two way connection is not saved properly
* tried to make minimal mongoid field which does nothing but facilitates `dbgenerated` ids for mongo

Issues:
1. ~Panic in Document field, possibly JSON type not implemented in Prisma mongo engine yet~ fixed with prisma 2.24
2. had to disable Migration engine otherwise it throws error in subsequent run.
3. ~throws aggregate error for Lists not having corresponding mongodb collection created, possibly related to number 2 - migration issue~ fixed in prisma 2.24
4. Two way relationships are not connecting properly

### update on 4th June 2021 with prisma@2.24
JSON field work, including Document field
no longer throws error in aggregating number of items in the list or for missing collections


> some help from - https://github.com/prisma/prisma-engines/pull/1612