### PR TITLE
Disable renovate for the slate packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,12 @@
   "prConcurrentLimit": 0,
   "packageRules": [
     {
-      "packagePatterns": ["remark", "babel-plugin-remove-graphql-queries", "react-day-picker", "^slate"],
+      "packagePatterns": [
+        "remark",
+        "babel-plugin-remove-graphql-queries",
+        "react-day-picker",
+        "^slate"
+      ],
       "enabled": false
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "prConcurrentLimit": 0,
   "packageRules": [
     {
-      "packagePatterns": ["remark", "babel-plugin-remove-graphql-queries", "react-day-picker"],
+      "packagePatterns": ["remark", "babel-plugin-remove-graphql-queries", "react-day-picker", "^slate"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Upgrading slate currently requires some significant type updates in order to pass CI. For now we'll tell renovate to ignore these packages. See #5373.