### PR TITLE
Add docs for the image field type

### DIFF
--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -21,6 +21,7 @@ export default config({
   session: () => { /* ... */ },
   graphql: { /* ... */ },
   extendGraphqlSchema: { /* ... */ },
+  images: { /* ... */ },
   experimental: { /* ... */ },
 });
 ```
@@ -250,6 +251,35 @@ export default config({
 ```
 
 See the [schema extension guide](../guides/schema-extension) for more details on how to use `graphQLSchemaExtension()` to extend your GraphQL API.
+
+## images
+
+Keystone supports image handling via the [`image`](./fields#image) field type.
+In order to use this field type you need to configure Keystone with information about where your images will be stored and served from.
+At the moment Keystone supports storing files on the local filesystem, and is agnostic about how images are served.
+
+```typescript
+import { config } from '@keystone-next/keystone/schema';
+
+export default config({
+  images: {
+    upload: 'local',
+    local: {
+      storagePath: 'public/images',
+      baseUrl: '/images',
+    },
+  }
+  /* ... */
+});
+```
+
+Options:
+
+- `upload`: The storage target when uploading images. Currently only `local` is supported.
+- `local`: Configuration options when using the `local` storage target.
+  - `storagePath`: The path local images are uploaded to.
+  - `baseUrl`: The base of the URL local images will be served from, outside of keystone.
+
 
 ## experimental
 

--- a/docs-next/pages/apis/fields.mdx
+++ b/docs-next/pages/apis/fields.mdx
@@ -28,6 +28,9 @@ import {
 
   // Virtual type
   virtual,
+
+  // File types
+  image,
 } from '@keystone-next/fields';
 
 // Complex types
@@ -501,6 +504,43 @@ export default config({
             { name: '...', type: 'String' },
             /* ... */
           ],
+        }),
+        /* ... */
+      },
+    }),
+    /* ... */
+  }),
+  /* ... */
+});
+```
+## File types
+
+File types allow you to upload different types of files to your Keystone system.
+
+### file
+
+(coming soon)
+
+### image
+
+An `image` field represents an image file, i.e. `.jpg`, `.png`, `.webp`, or `.gif`.
+
+See [`config.images`](./config#images) for details on how to configure your Keystone system with support for the `image` field type.
+
+Options:
+
+- `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
+
+```typescript
+import { config, createSchema, list } from '@keystone-next/keystone/schema';
+import { image } from '@keystone-next/fields';
+
+export default config({
+  lists: createSchema({
+    ListName: list({
+      fields: {
+        avatar: image({
+          isRequired: true,
         }),
         /* ... */
       },


### PR DESCRIPTION
Adds API docs for the image field type. A full guide on how to use this feature still needs to be written.