### PR TITLE
Fix Syntax Error in example code block

### DIFF
--- a/docs-next/pages/apis/session.mdx
+++ b/docs-next/pages/apis/session.mdx
@@ -98,7 +98,7 @@ Keystone provides a [Redis](https://redis.io/) based session store in the packag
 
 ```typescript
 import redis from `redis`;
-import { redisSessionStore } from '@keystone-next/session-store-redis`;
+import { redisSessionStore } from '@keystone-next/session-store-redis';
 import { config } from '@keystone-next/keystone/schema';
 import { storedSessions } from '@keystone-next/keystone/session';
 


### PR DESCRIPTION
Fix `Unterminated string constant` syntax error in example code