### PR TITLE
Change backticks to single quotes in example module import

### DIFF
--- a/docs-next/pages/apis/session.mdx
+++ b/docs-next/pages/apis/session.mdx
@@ -97,7 +97,7 @@ Interface:
 Keystone provides a [Redis](https://redis.io/) based session store in the package `@keystone-next/session-store-redis`.
 
 ```typescript
-import redis from `redis`;
+import redis from 'redis';
 import { redisSessionStore } from '@keystone-next/session-store-redis`;
 import { config } from '@keystone-next/keystone/schema';
 import { storedSessions } from '@keystone-next/keystone/session';


### PR DESCRIPTION
You cannot use backticks to import modules