### PR TITLE
Change addFieldValidationError to addValidationError

### DIFF
--- a/.changeset/healthy-pumas-appear.md
+++ b/.changeset/healthy-pumas-appear.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/fields': patch
+'@keystone-next/keystone': patch
+---
+
+The field hooks API has deprecated the `addFieldValidationError` argument. It has been replaced with the argument `addValidationError`, and will be removed in a future release.

--- a/docs-next/pages/apis/config.mdx
+++ b/docs-next/pages/apis/config.mdx
@@ -280,7 +280,6 @@ Options:
   - `storagePath`: The path local images are uploaded to.
   - `baseUrl`: The base of the URL local images will be served from, outside of keystone.
 
-
 ## experimental
 
 The following flags allow you to enable features which are still in preview.

--- a/docs-next/pages/apis/fields.mdx
+++ b/docs-next/pages/apis/fields.mdx
@@ -513,6 +513,7 @@ export default config({
   /* ... */
 });
 ```
+
 ## File types
 
 File types allow you to upload different types of files to your Keystone system.

--- a/docs-next/pages/apis/hooks.mdx
+++ b/docs-next/pages/apis/hooks.mdx
@@ -126,20 +126,19 @@ The `validateInput` function is used to validate the [`resolvedData`](#resolved-
 
 It is invoked after the `resolveInput` hooks have been run.
 
-If the `resolvedData` is invalid then the function should report validation errors with `addValidationError(msg)` for list hooks, or `addFieldValidationError(msg)` for field hooks.
+If the `resolvedData` is invalid then the function should report validation errors with `addValidationError(msg)`.
 These error messages will be returned as a `ValidationFailureError` from the GraphQL API, and the operation will not be completed.
 
-| Argument                       | Description                                                                                                                                                                                                 |
-| :----------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`                      | The key of the list being operated on.                                                                                                                                                                      |
-| `fieldPath`                    | The path of the field being operated on (field hooks only).                                                                                                                                                 |
-| `operation`                    | The operation being performed (`'create'` or `'update'`).                                                                                                                                                   |
-| `originalInput`                | The value of `data` passed into the mutation.                                                                                                                                                               |
-| `existingItem`                 | The current value of the item being updated (`undefined` for `create` operations). This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `resolvedData`                 | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                              |
-| `context`                      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                             |
-| `addFieldValidationError(msg)` | Used to set a field validation error (field hooks only).                                                                                                                                                    |
-| `addValidationError(msg)`      | Used to set a validation error (list hooks only).                                                                                                                                                           |
+| Argument                  | Description                                                                                                                                                                                                 |
+| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`                 | The key of the list being operated on.                                                                                                                                                                      |
+| `fieldPath`               | The path of the field being operated on (field hooks only).                                                                                                                                                 |
+| `operation`               | The operation being performed (`'create'` or `'update'`).                                                                                                                                                   |
+| `originalInput`           | The value of `data` passed into the mutation.                                                                                                                                                               |
+| `existingItem`            | The current value of the item being updated (`undefined` for `create` operations). This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
+| `resolvedData`            | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                              |
+| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                             |
+| `addValidationError(msg)` | Used to set a validation error.                                                                                                                                                                             |
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
@@ -170,7 +169,7 @@ export default config({
               existingItem,
               resolvedData,
               context,
-              addFieldValidationError,
+              addValidationError,
             }) => { /* ... */ },
           },
         }),
@@ -295,18 +294,17 @@ The `validateDelete` function is used to validate that deleting the selected ite
 
 It is invoked after access control has been applied.
 
-If the delete operation is invalid then the function should report validation errors with `addValidationError(msg)` for list hooks, or `addFieldValidationError(msg)` for field hooks.
+If the delete operation is invalid then the function should report validation errors with `addValidationError(msg)`.
 These error messages will be returned as a `ValidationFailureError` from the GraphQL API.
 
-| Argument                       | Description                                                                                                                                                   |
-| :----------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `listKey`                      | The key of the list being operated on.                                                                                                                        |
-| `fieldPath`                    | The path of the field being operated on (field hooks only).                                                                                                   |
-| `operation`                    | The operation being performed (`'delete'`).                                                                                                                   |
-| `existingItem`                 | The value of the item to be deleted. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `context`                      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                               |
-| `addValidationError(msg)`      | Used to set a validation error (list hooks only).                                                                                                             |
-| `addFieldValidationError(msg)` | Used to set a field validation error (field hooks only).                                                                                                      |
+| Argument                  | Description                                                                                                                                                   |
+| :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `listKey`                 | The key of the list being operated on.                                                                                                                        |
+| `fieldPath`               | The path of the field being operated on (field hooks only).                                                                                                   |
+| `operation`               | The operation being performed (`'delete'`).                                                                                                                   |
+| `existingItem`            | The value of the item to be deleted. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
+| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                               |
+| `addValidationError(msg)` | Used to set a validation error.                                                                                                                               |
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
@@ -333,7 +331,7 @@ export default config({
               operation,
               existingItem,
               context,
-              addFieldValidationError,
+              addValidationError,
             }) => { /* ... */ },
           },
         }),

--- a/packages-next/fields/src/Implementation.ts
+++ b/packages-next/fields/src/Implementation.ts
@@ -170,7 +170,7 @@ class Field<P extends string> {
     listKey: string;
     fieldPath: P;
     operation: 'create' | 'update';
-    addFieldValidationError: (msg: string) => void;
+    addValidationError: (msg: string) => void;
   }) {}
 
   async beforeChange() {}

--- a/packages-next/keystone/src/lib/core/ListTypes/hooks.ts
+++ b/packages-next/keystone/src/lib/core/ListTypes/hooks.ts
@@ -178,9 +178,18 @@ export class HookManager {
     const { originalInput } = args;
     const fieldValidationErrors: ValidationError[] = [];
     // FIXME: Can we do this in a way where we simply return validation errors instead?
-    const addFieldValidationError = (msg: string, _data = {}, internalData = {}) =>
-      fieldValidationErrors.push({ msg, data: _data, internalData });
-    const fieldArgs = { addFieldValidationError, ...args };
+    const fieldArgs = {
+      ...args,
+      addValidationError: (msg: string, _data = {}, internalData = {}) =>
+        fieldValidationErrors.push({ msg, data: _data, internalData }),
+      // deprecated: Will be removed in a future release.
+      addFieldValidationError: (msg: string, _data = {}, internalData = {}) => {
+        console.log(
+          'addFieldValidationError is deprecated. Please use addValidationError instead.'
+        );
+        return fieldValidationErrors.push({ msg, data: _data, internalData });
+      },
+    };
     await mapToFields(fields, (field: Implementation<any>) =>
       field[hookName]({ fieldPath: field.path, ...fieldArgs })
     );


### PR DESCRIPTION
This simplifies the API while making the implementation more consistent with the defined types. A future major release will remove the deprecated `addFieldValidationError` function.