### PR TITLE
Use terminal-link command rather than link

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "version-packages": "changeset version",
     "build": "preconstruct build",
     "prepare": "manypkg check && preconstruct dev && yarn run --silent contributing-guide",
-    "contributing-guide": "is-ci && exit 0 || chalk -t \"{bold 📝 Contributing to KeystoneJS?}\" && link \"🔗 Read the full Contributing Guide\" \"https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md\"",
+    "contributing-guide": "is-ci && exit 0 || chalk -t \"{bold 📝 Contributing to KeystoneJS?}\" && terminal-link \"🔗 Read the full Contributing Guide\" \"https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md\"",
     "npm-tag": "manypkg npm-tag",
     "update": "manypkg upgrade",
     "no-cypress-install": "cross-env CYPRESS_INSTALL_BINARY=0 yarn"


### PR DESCRIPTION
The correct command to use is `terminal-link`, not `link`. This appears to have changed in `v3` (though wasn't mentioned in the release notes, and isn't run on CI, so we missed it when updating that package).