### PR TITLE
Remove un-implememented singleton export

### DIFF
--- a/.changeset/odd-dogs-taste.md
+++ b/.changeset/odd-dogs-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Removed un-implemented export `singleton` from `schema/`.

--- a/packages-next/keystone/src/schema/index.ts
+++ b/packages-next/keystone/src/schema/index.ts
@@ -1,4 +1,4 @@
-export { createSchema, list, singleton, gql, graphQLSchemaExtension, config } from './schema';
+export { createSchema, list, gql, graphQLSchemaExtension, config } from './schema';
 export type {
   ListSchemaConfig,
   ListConfig,

--- a/packages-next/keystone/src/schema/schema.ts
+++ b/packages-next/keystone/src/schema/schema.ts
@@ -25,12 +25,6 @@ export function list<Fields extends BaseFields<BaseGeneratedListTypes>>(
   return config;
 }
 
-export function singleton<Fields extends BaseFields<BaseGeneratedListTypes>>(
-  config: ListConfig<BaseGeneratedListTypes, Fields>
-) {
-  return config;
-}
-
 export function gql(strings: TemplateStringsArray) {
   return strings[0];
 }


### PR DESCRIPTION
Marking this as a `patch` change, as this export is undocumented and should not have been used.