### PR TITLE
Update required node to >=12.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,6 @@
     "babel-plugin-remove-graphql-queries": "2.7.2"
   },
   "engines": {
-    "node": ">=v12.13.1"
+    "node": ">=v12.17.0"
   }
 }


### PR DESCRIPTION
This is the minimum node version that works with the `terminal-link-cli` package which we use.

```
(base) ➜  keystone-5 git:(master) ✗ nvm install 12.17      
Downloading and installing node v12.17.0...
Downloading https://nodejs.org/dist/v12.17.0/node-v12.17.0-darwin-x64.tar.xz...
######################################################################################################################################################################################################################################################### 100.0%
Computing checksum with shasum -a 256
Checksums matched!
Now using node v12.17.0 (npm v6.14.4)
(base) ➜  keystone-5 git:(master) ✗ yarn contributing-guide
yarn run v1.22.10
$ is-ci && exit 0 || chalk -t "{bold 📝 Contributing to KeystoneJS?}" && terminal-link "🔗 Read the full Contributing Guide" "https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md"
📝 Contributing to KeystoneJS?
(node:61142) ExperimentalWarning: The ESM module loader is experimental.
🔗 Read the full Contributing Guide (​https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md​)
✨  Done in 0.71s.
```