### PR TITLE
Replace graphql.run with items API calls

### DIFF
--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -20,11 +20,7 @@ function setupKeystone(provider: ProviderName) {
             multi____dash: text(),
           },
         }),
-        SecondaryList: list({
-          fields: {
-            someUser: relationship({ ref: 'User' }),
-          },
-        }),
+        SecondaryList: list({ fields: { someUser: relationship({ ref: 'User' }) } }),
       }),
     }),
   });
@@ -32,50 +28,44 @@ function setupKeystone(provider: ProviderName) {
 
 multiAdapterRunners().map(({ runner, provider }) =>
   describe(`Provider: ${provider}`, () => {
-    describe('filtering on list name', () => {
+    describe('filtering on field name', () => {
       test(
-        'filter works when there is no dash in list name',
+        'filter works when there is no dash in field name',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `{ allUsers(where: { noDash: "aValue" }) { id } }`,
-          });
-          expect(data).toHaveProperty('allUsers', []);
+          const users = await context.lists.User.findMany({ where: { noDash: 'aValue' } });
+          expect(users).toEqual([]);
         })
       );
       test(
-        'filter works when there is one dash in list name',
+        'filter works when there is one dash in field name',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `{ allUsers(where: { single_dash: "aValue" }) { id } }`,
-          });
-          expect(data).toHaveProperty('allUsers', []);
+          const users = await context.lists.User.findMany({ where: { single_dash: 'aValue' } });
+          expect(users).toEqual([]);
         })
       );
       test(
-        'filter works when there are multiple dashes in list name',
+        'filter works when there are multiple dashes in field name',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `{ allUsers(where: { many_many_many_dashes: "aValue" }) { id } }`,
+          const users = await context.lists.User.findMany({
+            where: { many_many_many_dashes: 'aValue' },
           });
-          expect(data).toHaveProperty('allUsers', []);
+          expect(users).toEqual([]);
         })
       );
       test(
-        'filter works when there are multiple dashes in a row in a list name',
+        'filter works when there are multiple dashes in a row in a field name',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `{ allUsers(where: { multi____dash: "aValue" }) { id } }`,
-          });
-          expect(data).toHaveProperty('allUsers', []);
+          const users = await context.lists.User.findMany({ where: { multi____dash: 'aValue' } });
+          expect(users).toEqual([]);
         })
       );
       test(
-        'filter works when there is one dash in list name as part of a relationship',
+        'filter works when there is one dash in field name as part of a relationship',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `{ allSecondaryLists(where: { someUser_is_null: true }) { id } }`,
+          const secondaries = await context.lists.SecondaryList.findMany({
+            where: { someUser_is_null: null },
           });
-          expect(data).toHaveProperty('allSecondaryLists', []);
+          expect(secondaries).toEqual([]);
         })
       );
     });

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -79,23 +79,11 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Create an item that does the linking
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allPosts(where: {
-              author: { name_contains: "J" }
-            }) {
-              id
-              title
-            }
-          }
-      `,
+            const allPosts = await context.lists.Post.findMany({
+              where: { author: { name_contains: 'J' } },
+              query: 'id title',
             });
-
-            expect(data).toHaveProperty('allPosts');
-            expect(data.allPosts).toHaveLength(3);
-
-            const { allPosts } = data;
+            expect(allPosts).toHaveLength(3);
 
             // We don't know the order, so we have to check individually
             expect(allPosts).toContainEqual({ id: posts[0].id, title: posts[0].title });
@@ -123,26 +111,11 @@ multiAdapterRunners().map(({ runner, provider }) =>
             });
 
             // Create an item that does the linking
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allPosts(where: {
-              author: { name_contains: "J" }
-            }) {
-              id
-              title
-              author {
-                id
-                name
-              }
-            }
-          }
-      `,
+            const _posts = await context.lists.Post.findMany({
+              where: { author: { name_contains: 'J' } },
+              query: 'id title author { id name }',
             });
-
-            expect(data).toMatchObject({
-              allPosts: [{ id: posts[0].id, title: posts[0].title }],
-            });
+            expect(_posts).toMatchObject([{ id: posts[0].id, title: posts[0].title }]);
           })
         );
       });
@@ -182,26 +155,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_every: { title_contains: "J" }
-            }) {
-              id
-              name
-              feed {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_every: { title_contains: 'J' } },
+              query: 'id name feed { id title }',
             });
 
-            expect(data).toMatchObject({
-              allUsers: [{ id: users[2].id, feed: [{ title: 'I like Jelly' }] }],
-            });
+            expect(_users).toMatchObject([{ id: users[2].id, feed: [{ title: 'I like Jelly' }] }]);
           })
         );
 
@@ -213,32 +172,18 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // SOME
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_some: { title_contains: "J" }
-            }) {
-              id
-              feed(sortBy: title_ASC) {
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_some: { title_contains: 'J' } },
+              query: 'id feed(sortBy: [title_ASC]) { title }',
             });
 
-            expect(data).toHaveProperty('allUsers');
-            expect(data.allUsers).toHaveLength(2);
-
-            const { allUsers } = data;
-
+            expect(_users).toHaveLength(2);
             // We don't know the order, so we have to check individually
-            expect(allUsers).toContainEqual({
+            expect(_users).toContainEqual({
               id: users[0].id,
               feed: [{ title: 'Hello' }, { title: 'Just in time' }],
             });
-            expect(allUsers).toContainEqual({ id: users[2].id, feed: [{ title: 'I like Jelly' }] });
+            expect(_users).toContainEqual({ id: users[2].id, feed: [{ title: 'I like Jelly' }] });
           })
         );
 
@@ -250,26 +195,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // NONE
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_none: { title_contains: "J" }
-            }) {
-              id
-              name
-              feed {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_none: { title_contains: 'J' } },
+              query: 'id name feed { id title }',
             });
 
-            expect(data).toMatchObject({
-              allUsers: [{ id: users[1].id, feed: [{ title: 'Bye' }] }],
-            });
+            expect(_users).toMatchObject([{ id: users[1].id, feed: [{ title: 'Bye' }] }]);
           })
         );
       });
@@ -305,24 +236,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_every: { title_contains: "J" }
-            }) {
-              id
-              feed {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_every: { title_contains: 'J' } },
+              query: 'id feed { id title }',
             });
-            expect(data.allUsers).toHaveLength(2);
-            expect(data.allUsers).toContainEqual({ id: users[2].id, feed: [] });
-            expect(data.allUsers).toContainEqual({ id: users[3].id, feed: [] });
+
+            expect(_users).toHaveLength(2);
+            expect(_users).toContainEqual({ id: users[2].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[3].id, feed: [] });
           })
         );
 
@@ -334,29 +255,15 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // SOME
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_some: { title_contains: "J" }
-            }) {
-              id
-              name
-              feed(sortBy: title_ASC) {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_some: { title_contains: 'J' } },
+              query: 'id name feed(sortBy: [title_ASC]) { id title }',
             });
 
-            expect(data).toMatchObject({
-              allUsers: [
-                { id: users[0].id, feed: [{ title: 'Hello' }, { title: 'I like Jelly' }] },
-              ],
-            });
-            expect(data.allUsers).toHaveLength(1);
+            expect(_users).toMatchObject([
+              { id: users[0].id, feed: [{ title: 'Hello' }, { title: 'I like Jelly' }] },
+            ]);
+            expect(_users).toHaveLength(1);
           })
         );
 
@@ -368,31 +275,16 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // NONE
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_none: { title_contains: "J" }
-            },
-            sortBy: id_ASC) {
-              id
-              feed {
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_none: { title_contains: 'J' } },
+              query: 'id feed { title }',
             });
 
-            expect(data).toHaveProperty('allUsers');
-            expect(data.allUsers).toHaveLength(3);
-
-            const { allUsers } = data;
-
+            expect(_users).toHaveLength(3);
             // We don't know the order, so we have to check individually
-            expect(allUsers).toContainEqual({ id: users[1].id, feed: [{ title: 'Hello' }] });
-            expect(allUsers).toContainEqual({ id: users[2].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[3].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[1].id, feed: [{ title: 'Hello' }] });
+            expect(_users).toContainEqual({ id: users[2].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[3].id, feed: [] });
           })
         );
       });
@@ -417,29 +309,17 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // EVERY
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_every: { title_contains: "J" }
-            }) {
-              id
-              feed {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_every: { title_contains: 'J' } },
+              query: 'id feed { id title }',
             });
-            const { allUsers } = data;
-            expect(allUsers).toHaveLength(4);
 
+            expect(_users).toHaveLength(4);
             // We don't know the order, so we have to check individually
-            expect(allUsers).toContainEqual({ id: users[0].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[1].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[2].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[3].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[0].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[1].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[2].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[3].id, feed: [] });
           })
         );
 
@@ -451,24 +331,11 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // SOME
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_some: { author: { id: "${users[0].id}"} }
-            }) {
-              id
-              name
-              feed {
-                id
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_some: { author: { id: users[0].id } } },
+              query: 'id name feed { id title }',
             });
-            expect(data).toMatchObject({ allUsers: [] });
-            expect(data.allUsers).toHaveLength(0);
+            expect(_users).toEqual([]);
           })
         );
 
@@ -480,31 +347,18 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const { users } = await setup(create);
 
             // NONE
-            const data = await context.graphql.run({
-              query: `
-          query {
-            allUsers(where: {
-              feed_none: { title_contains: "J" }
-            }) {
-              id
-              feed {
-                title
-              }
-            }
-          }
-      `,
+            const _users = await context.lists.User.findMany({
+              where: { feed_none: { title_contains: 'J' } },
+              query: 'id feed { title }',
             });
 
-            expect(data).toHaveProperty('allUsers');
-            expect(data.allUsers).toHaveLength(4);
-
-            const { allUsers } = data;
+            expect(_users).toHaveLength(4);
 
             // We don't know the order, so we have to check individually
-            expect(allUsers).toContainEqual({ id: users[0].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[1].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[2].id, feed: [] });
-            expect(allUsers).toContainEqual({ id: users[3].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[0].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[1].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[2].id, feed: [] });
+            expect(_users).toContainEqual({ id: users[3].id, feed: [] });
           })
         );
       });


### PR DESCRIPTION
For most of our tests we don't need a hand crafted GraphQL query, and the items API gives us what we need in a much more readable format.