### PR TITLE
Use the GraphQL API for lists.<list>.count

### DIFF
--- a/.changeset/modern-pears-exist.md
+++ b/.changeset/modern-pears-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Update `context.lists.<list>.count()` to use the GraphQL API rather than directly calling the resolver.

--- a/.changeset/moody-oranges-shout.md
+++ b/.changeset/moody-oranges-shout.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': patch
+---
+
+Improved handling of null filter inputs.

--- a/packages-next/keystone/src/lib/context/itemAPI.ts
+++ b/packages-next/keystone/src/lib/context/itemAPI.ts
@@ -83,8 +83,11 @@ export function itemAPIForList(
     },
     async count(rawArgs = {}) {
       if (!getArgs.count) throw new Error('You do not have access to this resource');
-      const args = getArgs.count(rawArgs!);
-      return (await list.listQueryMeta(args, context)).getCount();
+      const { first, skip, where } = rawArgs;
+      const { listQueryMetaName, whereInputName } = context.gqlNames(listKey);
+      const query = `query ($first: Int, $skip: Int, $where: ${whereInputName}) { ${listQueryMetaName}(first: $first, skip: $skip, where: $where) { count }  }`;
+      const response = await context.graphql.run({ query, variables: { first, skip, where } });
+      return response[listQueryMetaName].count;
     },
     createOne({ query, resolveFields, ...rawArgs }) {
       if (!getArgs.createOne) throw new Error('You do not have access to this resource');

--- a/packages/adapter-prisma/src/adapter-prisma.ts
+++ b/packages/adapter-prisma/src/adapter-prisma.ts
@@ -391,10 +391,10 @@ class PrismaListAdapter {
       const { first, skip } = args;
 
       // Adjust the count as appropriate
-      if (skip !== undefined) {
+      if (skip !== undefined && skip !== null) {
         count -= skip;
       }
-      if (first !== undefined) {
+      if (first !== undefined && first !== null) {
         count = Math.min(count, first);
       }
       count = Math.max(0, count); // Don't want to go negative from a skip!
@@ -410,9 +410,9 @@ class PrismaListAdapter {
     from,
   }: {
     args: {
-      where?: Record<string, any>;
-      first?: number;
-      skip?: number;
+      where?: Record<string, any> | null;
+      first?: number | null;
+      skip?: number | null;
       sortBy?: string[];
       orderBy?: Record<string, any>;
       search?: string;
@@ -475,11 +475,11 @@ class PrismaListAdapter {
 
     // Add query modifiers as required
     if (!meta) {
-      if (first !== undefined) {
+      if (first !== undefined && first !== null) {
         // SELECT ... LIMIT <first>
         ret.take = first;
       }
-      if (skip !== undefined) {
+      if (skip !== undefined && skip !== null) {
         // SELECT ... OFFSET <skip>
         ret.skip = skip;
       }
@@ -509,7 +509,8 @@ class PrismaListAdapter {
     return ret;
   }
 
-  processWheres(where: Record<string, any>): Record<string, any> | undefined {
+  processWheres(where: Record<string, any> | null): Record<string, any> | undefined {
+    if (where === null) return undefined;
     const processRelClause = (fieldPath: string, clause: Record<string, any>) =>
       this.getListAdapterByKey(this.fieldAdaptersByPath[fieldPath].refListKey!)!.processWheres(
         clause


### PR DESCRIPTION
This makes the `.count()` method consistent with the rest of the API, which execute GraphQL queries via `context.graphql.run` to get their results.