### PR TITLE
Use the items API in tests

### DIFF
--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -37,18 +37,15 @@ multiAdapterRunners().map(({ runner, provider }) =>
       it(
         'resolves fields first, then passes them to the list',
         runner(setupKeystone, async ({ context }) => {
-          const data = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: { name: "jess" }) { name }
-              }
-            `,
+          const user = await context.lists.User.createOne({
+            data: { name: 'jess' },
+            query: 'name',
           });
 
           // Field should be executed first, appending `-field`, then the list
           // should be executed which appends `-list`, and finally that total
           // result should be stored.
-          expect(data.createUser.name).toBe('jess-field-list');
+          expect(user.name).toBe('jess-field-list');
         })
       );
     });

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
@@ -25,23 +25,18 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  type T = { createUser: { id: IdType; friends: { id: IdType }[] } };
-  const { createUser } = (await context.graphql.run({
-    query: `
-      mutation {
-        createUser(data: {
-          friends: { create: [{ name: "${sampleOne(alphanumGenerator)}" }] }
-        }) { id friends { id } }
-      }`,
-  })) as T;
-  const { User, Friend } = await getUserAndFriend(context, createUser.id, createUser.friends[0].id);
+  const user = await context.lists.User.createOne({
+    data: { friends: { create: [{ name: sampleOne(alphanumGenerator) }] } },
+    query: 'id friends { id }',
+  });
+  const { User, Friend } = await getUserAndFriend(context, user.id, user.friends[0].id);
 
   // Sanity check the links are setup correctly
   expect(User.friends.map(({ id }: { id: IdType }) => id.toString())).toStrictEqual([
     Friend.id.toString(),
   ]);
 
-  return { user: createUser, friend: createUser.friends[0] };
+  return { user, friend: user.friends[0] };
 };
 
 const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friendId: IdType) => {
@@ -183,19 +178,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { users } = await createInitialData(context);
             const user = users[0];
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { connect: [{ id: "${user.id}" }] }
-                  }) { id friends { id } }
-                }
-            `,
-            });
-            const createUser: { id: IdType; friends: { id: IdType }[] } = data.createUser;
+            const _user = (await context.lists.User.createOne({
+              data: { friends: { connect: [{ id: user.id }] } },
+              query: 'id friends { id }',
+            })) as { id: IdType; friends: { id: IdType }[] };
+            const createUser: { id: IdType; friends: { id: IdType }[] } = _user;
             expect(createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
 
-            const { User, Friend } = await getUserAndFriend(context, data.createUser.id, user.id);
+            const { User, Friend } = await getUserAndFriend(context, _user.id, user.id);
             // Everything should now be connected
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
           })
@@ -205,21 +195,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create',
           runner(setupKeystone, async ({ context }) => {
             const friendName = sampleOne(alphanumGenerator);
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { create: [{ name: "${friendName}" }] }
-                  }) { id friends { id } }
-                }
-            `,
+            const user = await context.lists.User.createOne({
+              data: { friends: { create: [{ name: friendName }] } },
+              query: 'id friends { id }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friends[0].id
-            );
+            const { User, Friend } = await getUserAndFriend(context, user.id, user.friends[0].id);
 
             // Everything should now be connected
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
@@ -229,18 +210,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null',
           runner(setupKeystone, async ({ context }) => {
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: null
-                  }) { id friends { id } }
-                }
-            `,
+            const user = await context.lists.User.createOne({
+              data: { friends: null },
+              query: 'id friends { id }',
             });
 
             // Friends should be empty
-            expect(data.createUser.friends).toHaveLength(0);
+            expect(user.friends).toHaveLength(0);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
@@ -25,22 +25,17 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  type T = { createUser: { id: IdType; friends: { id: IdType; friendOf: { id: IdType } }[] } };
-  const { createUser } = (await context.graphql.run({
-    query: `
-      mutation {
-        createUser(data: {
-          friends: { create: [{ name: "${sampleOne(alphanumGenerator)}" }] }
-        }) { id friends { id friendOf { id } } }
-      }`,
-  })) as T;
-  const { User, Friend } = await getUserAndFriend(context, createUser.id, createUser.friends[0].id);
+  const user = await context.lists.User.createOne({
+    data: { friends: { create: [{ name: sampleOne(alphanumGenerator) }] } },
+    query: 'id friends { id friendOf { id } }',
+  });
+
+  const { User, Friend } = await getUserAndFriend(context, user.id, user.friends[0].id);
 
   // Sanity check the links are setup correctly
   expect(User.friends.map(({ id }: { id: IdType }) => id.toString())).toEqual([Friend.id]);
   expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
-  const user = createUser;
   return { user, friend: user.friends[0] };
 };
 
@@ -80,12 +75,9 @@ const createReadData = async (context: KeystoneContext) => {
       '': [], //  -> []
     }).map(async ([name, locationIdxs]) => {
       const ids = locationIdxs.map((i: number) => ({ id: createUsers[i].id }));
-      await context.graphql.run({
-        query: `mutation create($friends: [UserWhereUniqueInput], $name: String) { createUser(data: {
-          name: $name
-          friends: { connect: $friends }
-  }) { id friends { name }}}`,
-        variables: { friends: ids, name },
+      await context.lists.User.createOne({
+        data: { name, friends: { connect: ids } },
+        query: 'id friends { id friendOf { id } }',
       });
     })
   );
@@ -226,22 +218,17 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { users } = await createInitialData(context);
             const user = users[0];
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { connect: [{ id: "${user.id}" }] }
-                  }) { id friends { id } }
-                }
-            `,
-            });
-            const createUser: { id: IdType; friends: { id: IdType }[] } = data.createUser;
-            expect(createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
+            const _user = (await context.lists.User.createOne({
+              data: { friends: { connect: [{ id: user.id }] } },
+              query: 'id friends { id  }',
+            })) as { id: IdType; friends: { id: IdType }[] };
 
-            const { User, Friend } = await getUserAndFriend(context, createUser.id, user.id);
+            expect(_user.friends.map(({ id }) => id.toString())).toEqual([user.id]);
+
+            const { User, Friend } = await getUserAndFriend(context, _user.id, user.id);
 
             // Everything should now be connected
-            expect(createUser.friends.map(({ id }) => id.toString())).toEqual([user.id]);
+            expect(_user.friends.map(({ id }) => id.toString())).toEqual([user.id]);
             expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
           })
         );
@@ -250,21 +237,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create',
           runner(setupKeystone, async ({ context }) => {
             const friendName = sampleOne(alphanumGenerator);
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { create: [{ name: "${friendName}" }] }
-                  }) { id friends { id } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: { friends: { create: [{ name: friendName }] } },
+              query: 'id friends { id }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friends[0].id
-            );
+            const { User, Friend } = await getUserAndFriend(context, _user.id, _user.friends[0].id);
 
             // Everything should now be connected
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id.toString()]);
@@ -279,21 +257,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const user = users[0];
             const friendName = sampleOne(alphanumGenerator);
 
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { create: [{ name: "${friendName}" friendOf: { connect: { id: "${user.id}" } } }] }
-                  }) { id friends { id friendOf { id } } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: {
+                friends: { create: [{ name: friendName, friendOf: { connect: { id: user.id } } }] },
+              },
+              query: 'id friends { id friendOf { id } }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friends[0].id
-            );
+            const { User, Friend } = await getUserAndFriend(context, _user.id, _user.friends[0].id);
 
             // Everything should now be connected
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
@@ -324,21 +295,16 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const friendName = sampleOne(alphanumGenerator);
             const friendOfName = sampleOne(alphanumGenerator);
 
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: { create: [{ name: "${friendName}" friendOf: { create: { name: "${friendOfName}" } } }] }
-                  }) { id friends { id friendOf { id } } }
-                }
-            `,
+            const user = await context.lists.User.createOne({
+              data: {
+                friends: {
+                  create: [{ name: friendName, friendOf: { create: { name: friendOfName } } }],
+                },
+              },
+              query: 'id friends { id friendOf { id } }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friends[0].id
-            );
+            const { User, Friend } = await getUserAndFriend(context, user.id, user.friends[0].id);
             // Everything should now be connected
             expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
             expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
@@ -365,18 +331,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null',
           runner(setupKeystone, async ({ context }) => {
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friends: null
-                  }) { id friends { id } }
-                }
-            `,
+            const user = await context.lists.User.createOne({
+              data: { friends: null },
+              query: 'id friends { id }',
             });
 
             // Friends should be empty
-            expect(data.createUser.friends).toHaveLength(0);
+            expect(user.friends).toHaveLength(0);
           })
         );
       });

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -25,30 +25,21 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  type T = {
-    createUser: {
-      id: IdType;
-      name: string;
-      friend: { id: IdType; name: string; friendOf: { id: IdType } };
-    };
-  };
+  const user = await context.lists.User.createOne({
+    data: {
+      name: sampleOne(alphanumGenerator),
+      friend: { create: { name: sampleOne(alphanumGenerator) } },
+    },
+    query: 'id name friend { id name friendOf { id } }',
+  });
 
-  const { createUser } = (await context.graphql.run({
-    query: `
-      mutation {
-        createUser(data: {
-          name: "${sampleOne(alphanumGenerator)}"
-          friend: { create: { name: "${sampleOne(alphanumGenerator)}" } }
-        }) { id name friend { id name friendOf { id } } }
-      }`,
-  })) as T;
-  const { User, Friend } = await getUserAndFriend(context, createUser.id, createUser.friend.id);
+  const { User, Friend } = await getUserAndFriend(context, user.id, user.friend.id);
 
   // Sanity check the links are setup correctly
   expect(User.friend.id.toString()).toBe(Friend.id.toString());
   expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
-  return { user: createUser, friend: createUser.friend };
+  return { user, friend: user.friend };
 };
 
 const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friendId: IdType) => {
@@ -230,18 +221,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
           runner(setupKeystone, async ({ context }) => {
             const { users } = await createInitialData(context);
             const user = users[0];
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friend: { connect: { id: "${user.id}" } }
-                  }) { id friend { id } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: { friend: { connect: { id: user.id } } },
+              query: 'id friend { id friendOf { id } }',
             });
-            expect(data.createUser.friend.id.toString()).toEqual(user.id);
 
-            const { User, Friend } = await getUserAndFriend(context, data.createUser.id, user.id);
+            expect(_user.friend.id.toString()).toEqual(user.id);
+
+            const { User, Friend } = await getUserAndFriend(context, _user.id, user.id);
             // Everything should now be connected
             expect(User.friend.id.toString()).toBe(Friend.id.toString());
             expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
@@ -252,21 +239,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           'With create',
           runner(setupKeystone, async ({ context }) => {
             const friendName = sampleOne(alphanumGenerator);
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friend: { create: { name: "${friendName}" } }
-                  }) { id friend { id } }
-                }
-            `,
+            const user = await context.lists.User.createOne({
+              data: { friend: { create: { name: friendName } } },
+              query: 'id friend { id friendOf { id } }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friend.id
-            );
+            const { User, Friend } = await getUserAndFriend(context, user.id, user.friend.id);
 
             // Everything should now be connected
             expect(User.friend.id.toString()).toBe(Friend.id.toString());
@@ -281,21 +259,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const user = users[0];
             const friendName = sampleOne(alphanumGenerator);
 
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friend: { create: { name: "${friendName}" friendOf: { connect: { id: "${user.id}" } } } }
-                  }) { id friend { id friendOf { id } } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: {
+                friend: { create: { name: friendName, friendOf: { connect: { id: user.id } } } },
+              },
+              query: 'id friend { id friendOf { id } }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friend.id
-            );
+            const { User, Friend } = await getUserAndFriend(context, _user.id, _user.friend.id);
             // Everything should now be connected
             expect(User.friend.id.toString()).toBe(Friend.id.toString());
             expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
@@ -325,21 +296,16 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const friendName = sampleOne(alphanumGenerator);
             const friendOfName = sampleOne(alphanumGenerator);
 
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friend: { create: { name: "${friendName}" friendOf: { create: { name: "${friendOfName}" } } } }
-                  }) { id friend { id friendOf { id } } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: {
+                friend: {
+                  create: { name: friendName, friendOf: { create: { name: friendOfName } } },
+                },
+              },
+              query: 'id friend { id friendOf { id } }',
             });
 
-            const { User, Friend } = await getUserAndFriend(
-              context,
-              data.createUser.id,
-              data.createUser.friend.id
-            );
+            const { User, Friend } = await getUserAndFriend(context, _user.id, _user.friend.id);
             // Everything should now be connected
             expect(User.friend.id.toString()).toBe(Friend.id.toString());
             expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
@@ -366,18 +332,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
         test(
           'With null',
           runner(setupKeystone, async ({ context }) => {
-            const data = await context.graphql.run({
-              query: `
-                mutation {
-                  createUser(data: {
-                    friend: null
-                  }) { id friend { id } }
-                }
-            `,
+            const _user = await context.lists.User.createOne({
+              data: { friend: null },
+              query: 'id friend { id  }',
             });
 
             // Friend should be empty
-            expect(data.createUser.friend).toBe(null);
+            expect(_user.friend).toBe(null);
           })
         );
       });

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -67,52 +67,31 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
 
           // Create an item that does the linking
-          const data = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  username: "A thing",
-                  notes: { connect: [{ id: "${createNote.id}" }] }
-                }) {
-                  id
-                  notes { id }
-                }
-              }`,
+          const user = await context.lists.User.createOne({
+            data: { username: 'A thing', notes: { connect: [{ id: createNote.id }] } },
+            query: 'id notes { id }',
           });
 
-          expect(data).toMatchObject({
-            createUser: { id: expect.any(String), notes: expect.any(Array) },
-          });
+          expect(user).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
 
           // Create an item that does the linking
-          const { createUser } = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  username: "A thing",
-                  notes: { connect: [{ id: "${createNote.id}" }, { id: "${createNote.id}" }] }
-                }) {
-                  id
-                  notes { id }
-                }
-              }`,
+          const user1 = await context.lists.User.createOne({
+            data: {
+              username: 'A thing',
+              notes: { connect: [{ id: createNote.id }, { id: createNote.id }] },
+            },
+            query: 'id notes { id }',
           });
-          expect(createUser).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
+
+          expect(user1).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
 
           // Test an empty list of related notes
-          const data2 = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  username: "A thing",
-                  notes: { connect: [] }
-                }) {
-                  id
-                  notes { id }
-                }
-              }`,
+          const user2 = await context.lists.User.createOne({
+            data: { username: 'A thing', notes: { connect: [] } },
+            query: 'id notes { id }',
           });
-          expect(data2.createUser).toMatchObject({ id: expect.any(String), notes: [] });
+
+          expect(user2).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
 

--- a/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
@@ -110,23 +110,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
         'silently succeeds if used during create',
         runner(setupKeystone, async ({ context }) => {
           // Create an item that does the linking
-          const data = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  notes: {
-                    disconnectAll: true
-                  }
-                }) {
-                  id
-                  notes {
-                    id
-                  }
-                }
-              }`,
+          const user = await context.lists.User.createOne({
+            data: { notes: { disconnectAll: true } },
+            query: 'id notes { id }',
           });
 
-          expect(data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
+          expect(user).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
     });

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -117,23 +117,11 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const FAKE_ID = '5b84f38256d3c2df59a0d9bf';
 
           // Create an item that does the linking
-          const data = await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  notes: {
-                    disconnect: [{ id: "${FAKE_ID}" }]
-                  }
-                }) {
-                  id
-                  notes {
-                    id
-                  }
-                }
-              }`,
+          const user = await context.lists.User.createOne({
+            data: { notes: { disconnect: [{ id: FAKE_ID }] } },
+            query: 'id notes { id content }',
           });
-          expect(data.createUser).toMatchObject({ id: expect.any(String), notes: [] });
-          expect(data.createUser).not.toHaveProperty('errors');
+          expect(user).toMatchObject({ id: expect.any(String), notes: [] });
         })
       );
     });

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -48,37 +48,22 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           // Create some users that does the linking
-          type T = { createUser: { id: IdType; notes: { id: IdType; title: string }[] } };
-          const alice = (await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  username: "Alice",
-                  notes: { connect: [{ id: "${noteA.id}" }, { id: "${noteB.id}" }] }
-                }) {
-                  id
-                  notes(sortBy: title_ASC) { id title }
-                }
-              }`,
+          type T = { id: IdType; notes: { id: IdType; title: string }[] };
+          const alice = (await context.lists.User.createOne({
+            data: { username: 'Alice', notes: { connect: [{ id: noteA.id }, { id: noteB.id }] } },
+            query: 'id notes(sortBy: [title_ASC]) { id title }',
           })) as T;
 
-          const bob = (await context.graphql.run({
-            query: `
-              mutation {
-                createUser(data: {
-                  username: "Bob",
-                  notes: { connect: [{ id: "${noteC.id}" }, { id: "${noteD.id}" }] }
-                }) {
-                  id
-                  notes(sortBy: title_ASC) { id title }
-                }
-              }`,
+          const bob = (await context.lists.User.createOne({
+            data: { username: 'Bob', notes: { connect: [{ id: noteC.id }, { id: noteD.id }] } },
+            query: 'id notes(sortBy: [title_ASC]) { id title }',
           })) as T;
+
           // Make sure everyone has the correct notes
-          expect(alice.createUser).toEqual({ id: expect.any(String), notes: expect.any(Array) });
-          expect(alice.createUser.notes.map(({ title }) => title)).toEqual(['A', 'B']);
-          expect(bob.createUser).toEqual({ id: expect.any(String), notes: expect.any(Array) });
-          expect(bob.createUser.notes.map(({ title }) => title)).toEqual(['C', 'D']);
+          expect(alice).toEqual({ id: expect.any(String), notes: expect.any(Array) });
+          expect(alice.notes.map(({ title }) => title)).toEqual(['A', 'B']);
+          expect(bob).toEqual({ id: expect.any(String), notes: expect.any(Array) });
+          expect(bob.notes.map(({ title }) => title)).toEqual(['C', 'D']);
 
           // Set Bob as the author of note B
           await (async () => {
@@ -86,7 +71,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const data = (await context.graphql.run({
               query: `
                 mutation {
-                  updateUser(id: "${bob.createUser.id}" data: {
+                  updateUser(id: "${bob.id}" data: {
                     notes: { connect: [{ id: "${noteB.id}" }] }
                   }) {
                     id
@@ -94,7 +79,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }`,
             })) as T;
-            expect(data.updateUser).toEqual({ id: bob.createUser.id, notes: expect.any(Array) });
+            expect(data.updateUser).toEqual({ id: bob.id, notes: expect.any(Array) });
             expect(data.updateUser.notes.map(({ title }) => title)).toEqual(['B', 'C', 'D']);
           })();
 
@@ -109,10 +94,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   }
                 }`,
             });
-            expect(data.Note).toEqual({
-              id: noteB.id,
-              author: { id: bob.createUser.id, username: 'Bob' },
-            });
+            expect(data.Note).toEqual({ id: noteB.id, author: { id: bob.id, username: 'Bob' } });
           })();
 
           // Alice should no longer see `B` in her notes
@@ -121,13 +103,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const data = (await context.graphql.run({
               query: `
                 query {
-                  User(where: { id: "${alice.createUser.id}"}) {
+                  User(where: { id: "${alice.id}"}) {
                     id
                     notes(sortBy: title_ASC) { id title }
                   }
                 }`,
             })) as T;
-            expect(data.User).toEqual({ id: alice.createUser.id, notes: expect.any(Array) });
+            expect(data.User).toEqual({ id: alice.id, notes: expect.any(Array) });
             expect(data.User.notes.map(({ title }) => title)).toEqual(['A']);
           })();
         })


### PR DESCRIPTION
Use the `createOne` API when creating users in tests. This is a progressive change towards using the items API rather than raw GraphQL where appropriate in our tests.