### PR TITLE
Remove unused enableSessionItem

### DIFF
--- a/.changeset/silent-dogs-run.md
+++ b/.changeset/silent-dogs-run.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/auth': major
+'@keystone-next/types': major
+---
+
+Removed the `enableSessionItem` value from `config.ui` and the GraphQL type `KeystoneAdminMeta`.

--- a/docs/pages/apis/config.mdx
+++ b/docs/pages/apis/config.mdx
@@ -144,7 +144,6 @@ export default config({
     isDisabled: false,
     isAccessAllowed: async context => true,
     // Optional advanced configuration
-    enableSessionItem: true,
     publicPages: [],
     getAdditionalFiles: async () => [],
     pageMiddleware: async () = {},

--- a/packages-next/admin-ui/src/admin-meta-graphql.ts
+++ b/packages-next/admin-ui/src/admin-meta-graphql.ts
@@ -8,7 +8,6 @@ export const staticAdminMetaQuery = gql`
       adminMeta {
         __typename
         enableSignout
-        enableSessionItem
         lists {
           __typename
           key
@@ -61,10 +60,7 @@ type Maybe<T> = T | null;
 
 export type StaticAdminMetaQuery = { __typename?: 'Query' } & {
   keystone: { __typename: 'KeystoneMeta' } & {
-    adminMeta: { __typename: 'KeystoneAdminMeta' } & Pick<
-      KeystoneAdminMeta,
-      'enableSignout' | 'enableSessionItem'
-    > & {
+    adminMeta: { __typename: 'KeystoneAdminMeta' } & Pick<KeystoneAdminMeta, 'enableSignout'> & {
         lists: Array<
           { __typename: 'KeystoneAdminUIListMeta' } & Pick<
             KeystoneAdminUIListMeta,
@@ -116,7 +112,6 @@ type KeystoneMeta = {
 type KeystoneAdminMeta = {
   __typename: 'KeystoneAdminMeta';
   enableSignout: Scalars['Boolean'];
-  enableSessionItem: Scalars['Boolean'];
   lists: Array<KeystoneAdminUIListMeta>;
   list: Maybe<KeystoneAdminUIListMeta>;
 };

--- a/packages-next/admin-ui/src/system/createAdminMeta.ts
+++ b/packages-next/admin-ui/src/system/createAdminMeta.ts
@@ -1,9 +1,8 @@
 import type { KeystoneConfig, BaseKeystone, AdminMetaRootVal } from '@keystone-next/types';
 
 export function createAdminMeta(config: KeystoneConfig, keystone: BaseKeystone) {
-  const { ui, lists, session } = config;
+  const { lists, session } = config;
   const adminMetaRoot: AdminMetaRootVal = {
-    enableSessionItem: ui?.enableSessionItem || false,
     enableSignout: session !== undefined,
     listsByKey: {},
     lists: [],

--- a/packages-next/admin-ui/src/system/getAdminMetaSchema.ts
+++ b/packages-next/admin-ui/src/system/getAdminMetaSchema.ts
@@ -233,9 +233,6 @@ export function getAdminMetaSchema({
       enableSignout: types.field({
         type: types.nonNull(types.Boolean),
       }),
-      enableSessionItem: types.field({
-        type: types.nonNull(types.Boolean),
-      }),
       lists: types.field({
         type: types.nonNull(types.list(types.nonNull(KeystoneAdminUIListMeta))),
       }),

--- a/packages-next/admin-ui/src/utils/useAdminMeta.tsx
+++ b/packages-next/admin-ui/src/utils/useAdminMeta.tsx
@@ -64,7 +64,6 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
       ? adminMetaFromLocalStorage
       : data.keystone.adminMeta;
     const runtimeAdminMeta: AdminMeta = {
-      enableSessionItem: adminMeta.enableSessionItem,
       enableSignout: adminMeta.enableSignout,
       lists: {},
     };

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -259,7 +259,6 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
         getAdditionalFiles: [...(keystoneConfig.ui?.getAdditionalFiles || []), getAdditionalFiles],
         pageMiddleware: async args =>
           (await pageMiddleware(args)) ?? keystoneConfig?.ui?.pageMiddleware?.(args),
-        enableSessionItem: true,
         isAccessAllowed: async (context: KeystoneContext) => {
           // Allow access to the adminMeta data from the /init path to correctly render that page
           // even if the user isn't logged in (which should always be the case if they're seeing /init)
@@ -304,7 +303,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     // In the future we may want to return the following so that developers can
     // roll their own. This is pending a review of the use cases this might be
     // appropriate for, along with documentation and testing.
-    // ui: { enableSessionItem: true, pageMiddleware, getAdditionalFiles, publicPages },
+    // ui: { pageMiddleware, getAdditionalFiles, publicPages },
     // fields,
     // extendGraphqlSchema,
     // validateConfig,

--- a/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -140,7 +140,6 @@ type KeystoneMeta {
 
 type KeystoneAdminMeta {
   enableSignout: Boolean!
-  enableSessionItem: Boolean!
   lists: [KeystoneAdminUIListMeta!]!
   list(key: String!): KeystoneAdminUIListMeta
 }

--- a/packages-next/types/src/admin-meta.ts
+++ b/packages-next/types/src/admin-meta.ts
@@ -72,7 +72,6 @@ export type ListMeta = {
 
 export type AdminMeta = {
   enableSignout: boolean;
-  enableSessionItem: boolean;
   lists: { [list: string]: ListMeta };
 };
 
@@ -150,7 +149,6 @@ export type ListMetaRootVal = {
 
 export type AdminMetaRootVal = {
   enableSignout: boolean;
-  enableSessionItem: boolean;
   lists: Array<ListMetaRootVal>;
   listsByKey: Record<string, ListMetaRootVal>;
 };

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -93,8 +93,6 @@ export type DatabaseConfig = {
 export type AdminUIConfig = {
   /** Completely disables the Admin UI */
   isDisabled?: boolean;
-  /** Enables certain functionality in the Admin UI that expects the session to be an item */
-  enableSessionItem?: boolean;
   /** A function that can be run to validate that the current session should have access to the Admin UI */
   isAccessAllowed?: (context: KeystoneContext) => MaybePromise<boolean>;
   /** An array of page routes that can be accessed without passing the isAccessAllowed check */


### PR DESCRIPTION
AFAICT this feature isn't used. I'm not sure if there was an intent to keep it around for an upcoming feature, but I suspect it's legacy and should go away.