### PR TITLE
[RFC] Rename pageMiddleware to redirects

### DIFF
--- a/.changeset/twelve-sloths-yell.md
+++ b/.changeset/twelve-sloths-yell.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/auth': major
+'@keystone-next/types': major
+---
+
+Updated the arguments of `config.ui.pageMiddleware()` to accept `{ isValidSession: boolean; context: KeystoneContext; }`.

--- a/docs/pages/apis/config.mdx
+++ b/docs/pages/apis/config.mdx
@@ -147,7 +147,7 @@ export default config({
     enableSessionItem: true,
     publicPages: [],
     getAdditionalFiles: async () => [],
-    pageMiddleware: async () = {},
+    redirects: async () = {},
   },
   /* ... */
 });

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -28,18 +28,14 @@ export const createAdminUIServer = async (
       sessionContext: sessionStrategy
         ? await createSessionContext(sessionStrategy, req, res, createContext)
         : undefined,
+      req,
     });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
       : sessionStrategy
       ? context.session !== undefined
       : true;
-    const maybeRedirect = await ui?.pageMiddleware?.({
-      req,
-      session: context.session,
-      isValidSession,
-      createContext,
-    });
+    const maybeRedirect = await ui?.pageMiddleware?.({ isValidSession, context });
     if (maybeRedirect) {
       res.redirect(maybeRedirect.to);
       return;

--- a/packages-next/admin-ui/src/system/createAdminUIServer.ts
+++ b/packages-next/admin-ui/src/system/createAdminUIServer.ts
@@ -35,10 +35,15 @@ export const createAdminUIServer = async (
       : sessionStrategy
       ? context.session !== undefined
       : true;
-    const maybeRedirect = await ui?.pageMiddleware?.({ isValidSession, context });
-    if (maybeRedirect) {
-      res.redirect(maybeRedirect.to);
-      return;
+    for (const redirect of ui?.redirects || []) {
+      const maybeRedirect = await redirect({ isValidSession, context });
+      if (maybeRedirect && maybeRedirect.to) {
+        res.redirect(maybeRedirect.to);
+        return;
+      }
+      if (maybeRedirect && maybeRedirect.never) {
+        break;
+      }
     }
     if (!isValidSession && !publicPages.includes(url.parse(req.url).pathname!)) {
       app.render(req, res, '/no-access');

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -91,13 +91,8 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    *  - to the init page when initFirstItem is configured, and there are no user in the database
    *  - to the signin page when no valid session is present
    */
-  const pageMiddleware: AdminUIConfig['pageMiddleware'] = async ({
-    req,
-    isValidSession,
-    createContext,
-    session,
-  }) => {
-    const pathname = url.parse(req.url!).pathname!;
+  const pageMiddleware: AdminUIConfig['pageMiddleware'] = async ({ isValidSession, context }) => {
+    const pathname = url.parse(context.req!.url!).pathname!;
 
     if (isValidSession) {
       if (pathname === '/signin' || (initFirstItem && pathname === '/init')) {
@@ -106,8 +101,8 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
       return;
     }
 
-    if (!session && initFirstItem) {
-      const count = await createContext({}).sudo().lists[listKey].count({});
+    if (!context.session && initFirstItem) {
+      const count = await context.sudo().lists[listKey].count({});
       if (count === 0) {
         if (pathname !== '/init') {
           return { kind: 'redirect', to: '/init' };
@@ -116,8 +111,8 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
       }
     }
 
-    if (!session && pathname !== '/signin') {
-      return { kind: 'redirect', to: `/signin?from=${encodeURIComponent(req.url!)}` };
+    if (!context.session && pathname !== '/signin') {
+      return { kind: 'redirect', to: `/signin?from=${encodeURIComponent(context.req!.url!)}` };
     }
   };
 

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -97,15 +97,17 @@ export type AdminUIConfig = {
   isAccessAllowed?: (context: KeystoneContext) => MaybePromise<boolean>;
   /** An array of page routes that can be accessed without passing the isAccessAllowed check */
   publicPages?: string[];
-  /** The basePath for the Admin UI App */
-  // FIXME: currently unused
-  // path?: string;
   getAdditionalFiles?: ((config: KeystoneConfig) => MaybePromise<AdminFileToWrite[]>)[];
-  pageMiddleware?: (args: {
-    isValidSession: boolean;
-    context: KeystoneContext;
-  }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
+  /** An array of functions to be called during the next.js request handler to potentionally
+   * redirect the user to a different route.
+   */
+  redirects?: AdminUiRedirect[];
 };
+
+export type AdminUiRedirect = (args: {
+  isValidSession: boolean;
+  context: KeystoneContext;
+}) => MaybePromise<{ to: string; never?: undefined } | { to: undefined; never: true } | void>;
 
 export type AdminFileToWrite =
   | { mode: 'write'; src: string; outputPath: string }

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -1,11 +1,9 @@
-import { IncomingMessage } from 'http';
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import type { Config } from 'apollo-server-express';
 
 import type { ImageMode, FileMode, KeystoneContext } from '..';
 
-import { CreateContext } from '../core';
 import type { BaseKeystone } from '../base';
 import { SessionStrategy } from '../session';
 import type { MaybePromise } from '../utils';
@@ -104,10 +102,8 @@ export type AdminUIConfig = {
   // path?: string;
   getAdditionalFiles?: ((config: KeystoneConfig) => MaybePromise<AdminFileToWrite[]>)[];
   pageMiddleware?: (args: {
-    req: IncomingMessage;
-    session: any;
     isValidSession: boolean;
-    createContext: CreateContext;
+    context: KeystoneContext;
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 


### PR DESCRIPTION
The config option `config.ui.pageMiddleware` is something of a misnomer, which is making it difficult to document. It's not a middleware in the traditional sense, it's more of a function which can indicate the need for a redirect, which in turn will be consumed by the actual middleware to perform the redirect.

Furthermore, the current use case of the `withAuth` decorator makes it impossible for user defined config to conditionally disable the redirect . For example, if the user wanted to always skip the auth redirects when setting up custom pages via `getAdditionalFiles` and `publicPages`, the current API doesn't allow for it.

The modified API allows a return value of `{ never: true }`, which indicates that no further redirects should be considered.

It also changes the signature to an array of functions rather than a single function, which means we don't need to handle function composition when writing helper wrappers like `withAuth`.