### PR TITLE
Explicitly kill the prisma process before exit

### DIFF
--- a/.changeset/large-kiwis-smoke.md
+++ b/.changeset/large-kiwis-smoke.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': patch
+---
+
+Added a `beforeExit` handler to explicitly terminate the prisma child process to avoid zombie processes when the server crashes.

--- a/packages/adapter-prisma/src/adapter-prisma.ts
+++ b/packages/adapter-prisma/src/adapter-prisma.ts
@@ -91,6 +91,13 @@ class PrismaAdapter {
       log: this.enableLogging && ['query'],
       datasources: { [this.provider]: { url: this.url } },
     });
+    this.prisma.$on('beforeExit', async () => {
+      // Prisma is failing to properly clean up its child processes
+      // https://github.com/keystonejs/keystone/issues/5477
+      // We explicitly send a SIGINT signal to the prisma child process on exit
+      // to ensure that the process is cleaned up appropriately.
+      this.prisma._engine.child.kill('SIGINT');
+    });
 
     // Set up all list adapter models
     Object.values(this.listAdapters).forEach(listAdapter => {


### PR DESCRIPTION
Calling `process.exit()` was terminating the server process without triggering the appropriate cleanup of the child process spawned by the Prisma client. It's not clear why exactly Prisma isn't able to clean itself up, but sending a `SIGINT` signal in the `beforeExit` handler seems to solve the problem.

Fixes #5477.