### PR TITLE
Replace mode on GraphQL output type of image field with an interface

### DIFF
--- a/.changeset/eight-lamps-wait.md
+++ b/.changeset/eight-lamps-wait.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': major
+---
+
+Replaced `mode` field on `ImageFieldOutput` GraphQL type with making `ImageFieldOutput` an interface and having a `LocalImageFieldOutput` type that implements `ImageFieldOutput`.

--- a/packages-next/fields/src/types/image/Implementation.ts
+++ b/packages-next/fields/src/types/image/Implementation.ts
@@ -15,18 +15,23 @@ export class ImageImplementation<P extends string> extends Implementation<P> {
 
   getGqlAuxTypes() {
     return [
-      `enum ImageMode {
-        local
-      }
-      input ImageFieldInput {
+      `input ImageFieldInput {
         upload: Upload
         ref: String
       }
       enum ImageExtension {
         ${SUPPORTED_IMAGE_EXTENSIONS.join('\n')}
       }
-      type ImageFieldOutput {
-        mode: ImageMode!
+      interface ImageFieldOutput {
+        id: ID!
+        filesize: Int!
+        width: Int!
+        height: Int!
+        extension: ImageExtension!
+        ref: String!
+        src: String!
+      }
+      type LocalImageFieldOutput implements ImageFieldOutput {
         id: ID!
         filesize: Int!
         width: Int!
@@ -41,6 +46,11 @@ export class ImageImplementation<P extends string> extends Implementation<P> {
   gqlAuxFieldResolvers() {
     return {
       ImageFieldOutput: {
+        __resolveType() {
+          return 'LocalImageFieldOutput';
+        },
+      },
+      LocalImageFieldOutput: {
         src(data: ImageData, _args: any, context: KeystoneContext) {
           if (!context.images) {
             throw new Error('Image context is undefined');

--- a/packages-next/fields/src/types/image/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/image/tests/test-fixtures.ts
@@ -72,8 +72,8 @@ export const crudTests = (keystoneTestWrapper: any) => {
             data: { avatar: prepareFile(filename) },
             query: `
               avatar {
+                __typename
                 id
-                mode
                 filesize
                 width
                 height
@@ -88,7 +88,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
             ref: `local:${data.avatar.id}.jpg`,
             src: `/images/${data.avatar.id}.jpg`,
             id: data.avatar.id,
-            mode: 'local',
+            __typename: 'LocalImageFieldOutput',
             filesize: 3250,
             width: 150,
             height: 152,
@@ -128,7 +128,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
           query: `
             avatar {
               id
-              mode
+              __typename
               filesize
               width
               height
@@ -147,7 +147,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
           query: `
             avatar {
               id
-              mode
+              __typename
               filesize
               width
               height


### PR DESCRIPTION
This means we can add different implementations of the `ImageFieldOutput` with potentially extra fields.