### PR TITLE
Only use sqlite in example projects

### DIFF
--- a/.changeset/grumpy-jokes-notice.md
+++ b/.changeset/grumpy-jokes-notice.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/example-todo': patch
+---
+
+Updated example projects to only use the sqlite provider.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,17 +208,8 @@ jobs:
     name: Smoke Tests For Examples
     runs-on: ubuntu-latest
     needs: should_run_tests
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: keystone5
-          POSTGRES_PASSWORD: k3yst0n3
-          POSTGRES_DB: test_db
-        ports:
-          - 5432:5432
     env:
-      DATABASE_URL: 'postgres://keystone5:k3yst0n3@localhost:5432/test_db'
+      DATABASE_URL: 'file:./test.db'
     strategy:
       matrix:
         test: ['auth.test.ts', 'basic.test.ts', 'roles.test.ts', 'todo.test.ts']

--- a/docs/pages/guides/hooks.mdx
+++ b/docs/pages/guides/hooks.mdx
@@ -90,7 +90,6 @@ This is available as the `existingItem` argument.
 
 Finally, all hooks are provided with a `context` argument, which gives you access to the full [context API](../apis/context).
 
-
 ?> The `resolveInput` hook shouldn't be used to set default values. This is handled by the `defaultValue` field config option.
 
 ## Validating inputs

--- a/docs/pages/guides/relationships.mdx
+++ b/docs/pages/guides/relationships.mdx
@@ -16,14 +16,13 @@ Your needs here will define whether your relationship needs to be [one, or two-s
 
 2. **How many connections do need on either side of my relationship?**
 
-Understanding this will determine the kind of [cardinality](#establishing-cardinality) you need to configure. 
+Understanding this will determine the kind of [cardinality](#establishing-cardinality) you need to configure.
 
 These topics are easier to understand by example. We’ll explore them, as well as the basics of setting up relationships through the use case of a **blog app** that has a `post` type for blog entries, and `user` type for post authors. Let’s get started…
 
 ## How to define a relationship in Keystone
 
 Relationships are made using the [`relationship`](../apis/fields#relationship) field type within a [`list()`](../apis/schema). In our blog example we can connect a blog `post` to some `users` using the relationship field’s `ref` configuration option like so:
-
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
@@ -42,6 +41,7 @@ export default config({
   }),
 });
 ```
+
 !> The `many` config option relates to _cardinality_ which we explore later
 
 ## One-sided & two-sided relationships
@@ -110,6 +110,7 @@ Query {
   }
 }
 ```
+
 ?> **Things to keep in mind:**<br/><br/>Two-sided relationships are declared in two places, but **there is only one relationship between both lists**.<br/><br/>**Both fields share the same data**. If you change the author of a post, that post will no longer show up in the original author’s posts.
 
 ### Self-referencing relationships
@@ -158,9 +159,9 @@ export default config({
 _Cardinality_ is a term used to describe how many items can exist on either side of a relationship. Each side can have either `one` or `many` related items. Since each relationship can have one and two sides, we have the following options available:
 
 | Relationship type | One to one | One to many | Many to many |
-| ------------- | ---------- | ----------- | ----------- |
-| One-sided | ❌ | ✅ | ✅ |
-| Two-sided | ✅ | ✅ | ✅ |
+| ----------------- | ---------- | ----------- | ------------ |
+| One-sided         | ❌         | ✅          | ✅           |
+| Two-sided         | ✅         | ✅          | ✅           |
 
 Cardinality is defined through the `relationship` field’s `many` configuration option. It’s a boolean where:
 
@@ -200,6 +201,7 @@ export default config({
   }),
 });
 ```
+
 #### Many-to-many
 
 - Posts can have multiple authors
@@ -226,7 +228,7 @@ export default config({
 
 ### Two-sided cardinalities
 
-?> In two-sided relationships the `many` option on both sides must be considered. 
+?> In two-sided relationships the `many` option on both sides must be considered.
 
 #### One-to-one
 
@@ -277,6 +279,7 @@ export default config({
   }),
 });
 ```
+
 !> Note that we’ve used `many: false` in the author field and `many: true` in the posts field.
 
 #### Many-to-many

--- a/examples/auth/keystone.ts
+++ b/examples/auth/keystone.ts
@@ -57,9 +57,10 @@ const { withAuth } = createAuth({
 // withAuth applies the signin functionality to the keystone config
 export default withAuth(
   config({
-    db: process.env.DATABASE_URL
-      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
-      : { provider: 'sqlite', url: 'file:./keystone.db' },
+    db: {
+      provider: 'sqlite',
+      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+    },
     lists,
     ui: {},
     session: withItemData(

--- a/examples/basic/keystone.ts
+++ b/examples/basic/keystone.ts
@@ -24,9 +24,10 @@ const auth = createAuth({
 
 export default auth.withAuth(
   config({
-    db: process.env.DATABASE_URL
-      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
-      : { provider: 'sqlite', url: 'file:./keystone.db' },
+    db: {
+      provider: 'sqlite',
+      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+    },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {
     //   path: '/api/graphql',

--- a/examples/roles/keystone.ts
+++ b/examples/roles/keystone.ts
@@ -40,9 +40,10 @@ const { withAuth } = createAuth({
 
 export default withAuth(
   config({
-    db: process.env.DATABASE_URL
-      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
-      : { provider: 'sqlite', url: 'file:./keystone.db' },
+    db: {
+      provider: 'sqlite',
+      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+    },
     lists,
     ui: {
       /* Everyone who is signed in can access the Admin UI */

--- a/examples/todo/keystone.ts
+++ b/examples/todo/keystone.ts
@@ -22,8 +22,8 @@ const { withAuth } = createAuth({
 export default withAuth(
   config({
     db: {
-      provider: 'postgresql',
-      url: process.env.DATABASE_URL || 'postgres://keystone5:k3yst0n3@localhost:5432/todo-example',
+      provider: 'sqlite',
+      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
     lists,
     ui: {


### PR DESCRIPTION
These examples should be easily runnable, so let's focus on the sqlite provider exclusively only we're explicitly testing something postgres related.