### PR TITLE
Update Prisma/MongoDB Connector to Early Access

### DIFF
--- a/docs/pages/guides/keystone-5-vs-keystone-next.mdx
+++ b/docs/pages/guides/keystone-5-vs-keystone-next.mdx
@@ -22,7 +22,7 @@ There are a few major things that will change between 5 and 6 which we’re curr
 
 ### DB adapters out. Prisma in.
 
-We’re also moving away from maintaining several database adapters to just using **Prisma**, which simplifies things. Until Prisma support MongoDB (which is [planned](https://www.notion.so/Prisma-Roadmap-50766227b779464ab98899accb98295f)) we’ll have a gap in our database support.
+We’re also moving away from maintaining several database adapters to just using **Prisma**, which simplifies things. Until Prisma supports MongoDB (which is [currently in Early Access](https://www.prisma.io/docs/concepts/database-connectors/mongodb)) we’ll have a gap in our database support.
 
 There are also differences between Knex and Prisma for Postgres users, which mainly matter for advanced use cases like migrations and raw SQL, etc.
 


### PR DESCRIPTION
The MongoDB connector for Prisma is still under development and classified as "Early Access." But unlike the [last year and half of it being under discussion](https://github.com/prisma/prisma/issues/1277), today it is actually live and can be used by anyone, so it's not really accurate to say it's still in the "planning" phase.

* [MongoDB provider for Prisma 2 and Keystone Next](https://gautamsi.medium.com/mongodb-provider-for-prisma-2-and-keystone-next-1618418c8937)
* [Can I use MongoDB with Prisma Yet?](https://dev.to/ajcwebdev/can-i-use-mongodb-with-prisma-yet-50go)
* [RedwoodJS Example Blog with MongoDB](https://redwoodjs-prisma-mongo.netlify.app/)

For explanation of Early Access versus General Availability see [Releases and maturity levels](https://www.prisma.io/docs/about/releases) from the Prisma docs.