### PR TITLE
Improve statelessSessions types

### DIFF
--- a/.changeset/mighty-drinks-suffer.md
+++ b/.changeset/mighty-drinks-suffer.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': patch
 ---
 
-Improved the types of `statelessSessions`.
+Improved the types of `statelessSessions` and `withItemData`.

--- a/.changeset/mighty-drinks-suffer.md
+++ b/.changeset/mighty-drinks-suffer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Improved the types of `statelessSessions`.

--- a/.changeset/mighty-drinks-suffer.md
+++ b/.changeset/mighty-drinks-suffer.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': patch
 ---
 
-Improved the types of `statelessSessions` and `withItemData`.
+Improved the types of `withItemData`.

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -74,10 +74,10 @@ type FieldSelections = {
   - [ ] We could support additional where input to validate item sessions (e.g an isEnabled boolean)
 */
 
-export function withItemData<U extends Record<string, any>>(
-  createSession: () => SessionStrategy<U>,
+export function withItemData(
+  createSession: () => SessionStrategy<Record<string, any>>,
   fieldSelections: FieldSelections = {}
-): () => SessionStrategy<U & { listKey: string; itemId: string; data: any }> {
+): () => SessionStrategy<{ listKey: string; itemId: string; data: any }> {
   return (): SessionStrategy<any> => {
     const { get, ...sessionStrategy } = createSession();
     return {
@@ -115,7 +115,7 @@ export function withItemData<U extends Record<string, any>>(
   };
 }
 
-export function statelessSessions<T extends Record<string, any>>({
+export function statelessSessions<T>({
   secret,
   maxAge = MAX_AGE,
   path = '/',


### PR DESCRIPTION
The type parameter of this function needs to be more specific to work with `withItemData`.