### PR TITLE
Fix withAuth when config.ui is undefined

### DIFF
--- a/.changeset/pretty-bugs-impress.md
+++ b/.changeset/pretty-bugs-impress.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Updated `withAuth` to respect `config.ui.isDisabled`. Now works as expected when `config.ui` is undefined.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -252,11 +252,11 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   const withAuth = (keystoneConfig: KeystoneConfig): KeystoneConfig => {
     validateConfig(keystoneConfig);
     let ui = keystoneConfig.ui;
-    if (keystoneConfig.ui) {
+    if (!keystoneConfig.ui?.isDisabled) {
       ui = {
         ...keystoneConfig.ui,
-        publicPages: [...(keystoneConfig.ui.publicPages || []), ...publicPages],
-        getAdditionalFiles: [...(keystoneConfig.ui.getAdditionalFiles || []), getAdditionalFiles],
+        publicPages: [...(keystoneConfig.ui?.publicPages || []), ...publicPages],
+        getAdditionalFiles: [...(keystoneConfig.ui?.getAdditionalFiles || []), getAdditionalFiles],
         pageMiddleware: async args =>
           (await pageMiddleware(args)) ?? keystoneConfig?.ui?.pageMiddleware?.(args),
         enableSessionItem: true,


### PR DESCRIPTION
Previously you need to explicitly set `ui: {}` if you wanted the default Admin UI to work with the `withAuth` helper.