### PR TITLE
Add placeholder to document editor block menu

### DIFF
--- a/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
@@ -1,10 +1,18 @@
 /** @jsx jsx */
 
-import { Fragment, ReactNode, forwardRef, useState, HTMLAttributes, useMemo } from 'react';
+import {
+  Fragment,
+  ReactNode,
+  forwardRef,
+  useState,
+  HTMLAttributes,
+  useMemo,
+  useContext,
+} from 'react';
 import { Editor, Transforms } from 'slate';
 import { applyRefs } from 'apply-ref';
 
-import { jsx, useTheme } from '@keystone-ui/core';
+import { jsx, useTheme, Text, Box } from '@keystone-ui/core';
 import { useControlledPopover } from '@keystone-ui/popover';
 import { Tooltip } from '@keystone-ui/tooltip';
 
@@ -25,12 +33,12 @@ import {
   ToolbarSeparator,
 } from './primitives';
 import { linkButton } from './link';
-import { BlockComponentsButtons } from './component-blocks';
+import { BlockComponentsButtons, ComponentBlockContext } from './component-blocks';
 import { clearFormatting, Mark, modifierKeyText } from './utils';
 import { LayoutsButton } from './layouts';
 import { ListButton } from './lists';
 import { blockquoteButton } from './blockquote';
-import { RelationshipButton } from './relationship';
+import { DocumentFieldRelationshipsContext, RelationshipButton } from './relationship';
 import { codeButton } from './code-block';
 import { TextAlignMenu } from './alignment';
 import { dividerButton } from './divider';
@@ -315,6 +323,11 @@ function HeadingDialog({
 
 function InsertBlockMenu() {
   const [showMenu, setShowMenu] = useState(false);
+  const relationships = useContext(DocumentFieldRelationshipsContext);
+  const blockComponents = useContext(ComponentBlockContext)!;
+  const relationshipsArray = Object.entries(relationships);
+  const blockComponentsArray = Object.keys(blockComponents);
+  const noItemsExist = !blockComponentsArray.length && !relationshipsArray.length;
   const { dialog, trigger } = useControlledPopover(
     {
       isOpen: showMenu,
@@ -367,8 +380,22 @@ function InsertBlockMenu() {
       {showMenu ? (
         <InlineDialog ref={dialog.ref} {...dialog.props}>
           <ToolbarGroup direction="column">
-            <RelationshipButton onClose={() => setShowMenu(false)} />
-            <BlockComponentsButtons onClose={() => setShowMenu(false)} />
+            {noItemsExist ? (
+              <Box
+                css={{
+                  minWidth: '200px',
+                }}
+                padding="small"
+                textAlign="center"
+              >
+                <Text size="small">No relationships or component blocks specified</Text>
+              </Box>
+            ) : (
+              <Fragment>
+                <RelationshipButton onClose={() => setShowMenu(false)} />
+                <BlockComponentsButtons onClose={() => setShowMenu(false)} />
+              </Fragment>
+            )}
           </ToolbarGroup>
         </InlineDialog>
       ) : null}

--- a/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
@@ -325,9 +325,8 @@ function InsertBlockMenu() {
   const [showMenu, setShowMenu] = useState(false);
   const relationships = useContext(DocumentFieldRelationshipsContext);
   const blockComponents = useContext(ComponentBlockContext)!;
-  const relationshipsArray = Object.entries(relationships);
-  const blockComponentsArray = Object.keys(blockComponents);
-  const noItemsExist = !blockComponentsArray.length && !relationshipsArray.length;
+  const noItemsExist =
+    !Object.entries(blockComponents).length && !Object.keys(relationships).length;
   const { dialog, trigger } = useControlledPopover(
     {
       isOpen: showMenu,

--- a/packages-next/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/relationship.tsx
@@ -30,7 +30,7 @@ export type Relationships = Record<
   )
 >;
 
-const DocumentFieldRelationshipsContext = createContext<Relationships>({});
+export const DocumentFieldRelationshipsContext = createContext<Relationships>({});
 
 export function useDocumentFieldRelationships() {
   return useContext(DocumentFieldRelationshipsContext);


### PR DESCRIPTION
Description: 
Add a placeholder to the document editor `insertBlockMenu` component, previously this would display an empty inline dialog. Now we have an empty state placeholder. Imo this is better than not rendering the toolbar item at all, since it makes it obvious that this functionality exists, rather than hiding it completely, but I'm non-committal on this.

Before: 
<img width="728" alt="Screen Shot 2021-05-05 at 2 35 26 pm" src="https://user-images.githubusercontent.com/12119389/117097516-3bdaa900-adaf-11eb-9401-9aa2469a9cef.png">

After: 
<img width="723" alt="Screen Shot 2021-05-05 at 2 34 55 pm" src="https://user-images.githubusercontent.com/12119389/117097529-409f5d00-adaf-11eb-99dc-547f08b602a8.png">

