### PR TITLE
 Add placeholder to document editor block menu

### DIFF
--- a/.changeset/hip-peas-sip.md
+++ b/.changeset/hip-peas-sip.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields-document': patch
+---
+
+Added logic to ensure the block-menu in the toolbar is hidden when no component blocks or relationships are provided.

--- a/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/Toolbar.tsx
@@ -1,6 +1,14 @@
 /** @jsx jsx */
 
-import { Fragment, ReactNode, forwardRef, useState, HTMLAttributes, useMemo } from 'react';
+import {
+  Fragment,
+  ReactNode,
+  forwardRef,
+  useState,
+  HTMLAttributes,
+  useMemo,
+  useContext,
+} from 'react';
 import { Editor, Transforms } from 'slate';
 import { applyRefs } from 'apply-ref';
 
@@ -25,12 +33,12 @@ import {
   ToolbarSeparator,
 } from './primitives';
 import { linkButton } from './link';
-import { BlockComponentsButtons } from './component-blocks';
+import { BlockComponentsButtons, ComponentBlockContext } from './component-blocks';
 import { clearFormatting, Mark, modifierKeyText } from './utils';
 import { LayoutsButton } from './layouts';
 import { ListButton } from './lists';
 import { blockquoteButton } from './blockquote';
-import { RelationshipButton } from './relationship';
+import { DocumentFieldRelationshipsContext, RelationshipButton } from './relationship';
 import { codeButton } from './code-block';
 import { TextAlignMenu } from './alignment';
 import { dividerButton } from './divider';
@@ -44,6 +52,9 @@ export function Toolbar({
   viewState?: { expanded: boolean; toggle: () => void };
 }) {
   const ExpandIcon = viewState?.expanded ? Minimize2Icon : Maximize2Icon;
+  const relationship = useContext(DocumentFieldRelationshipsContext);
+  const blockComponent = useContext(ComponentBlockContext);
+  const hasBlockItems = Object.entries(relationship).length || Object.keys(blockComponent).length;
 
   return (
     <ToolbarContainer>
@@ -105,7 +116,7 @@ export function Toolbar({
       {documentFeatures.formatting.blockTypes.blockquote && blockquoteButton}
       {!!documentFeatures.layouts.length && <LayoutsButton layouts={documentFeatures.layouts} />}
       {documentFeatures.formatting.blockTypes.code && codeButton}
-      <InsertBlockMenu />
+      {!!hasBlockItems && <InsertBlockMenu />}
 
       <ToolbarSeparator />
       {useMemo(

--- a/packages-next/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages-next/fields-document/src/DocumentEditor/relationship.tsx
@@ -30,7 +30,7 @@ export type Relationships = Record<
   )
 >;
 
-const DocumentFieldRelationshipsContext = createContext<Relationships>({});
+export const DocumentFieldRelationshipsContext = createContext<Relationships>({});
 
 export function useDocumentFieldRelationships() {
   return useContext(DocumentFieldRelationshipsContext);


### PR DESCRIPTION
Description: 
Add a placeholder to the document editor `insertBlockMenu` component, previously this would display an empty inline dialog. Now we have an empty state placeholder. Imo this is better than not rendering the toolbar item at all, since it makes it obvious that this functionality exists, rather than hiding it completely, but I'm non-committal on this.

--- EDIT ---
Updated now to omit the toolbar item completely if no block items or relationship items exist. 



Before: 
<img width="728" alt="Screen Shot 2021-05-05 at 2 35 26 pm" src="https://user-images.githubusercontent.com/12119389/117097516-3bdaa900-adaf-11eb-9401-9aa2469a9cef.png">

After: 
<img width="724" alt="Screen Shot 2021-05-05 at 3 35 42 pm" src="https://user-images.githubusercontent.com/12119389/117100639-911ab880-adb7-11eb-801f-bbe4446abb85.png">


