### PR TITLE
Disable sorting on many relationships

### DIFF
--- a/.changeset/weak-ants-work.md
+++ b/.changeset/weak-ants-work.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/app-basic': patch
+'@keystone-next/example-todo': patch
+'@keystone-next/fields': patch
+---
+
+Disabled sorting for `many` relationship fields.

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -189,10 +189,6 @@ enum SortUsersBy {
   isAdmin_DESC
   roles_ASC
   roles_DESC
-  phoneNumbers_ASC
-  phoneNumbers_DESC
-  posts_ASC
-  posts_DESC
 }
 
 input UserUpdateInput {

--- a/examples/todo/schema.graphql
+++ b/examples/todo/schema.graphql
@@ -176,8 +176,6 @@ enum SortPeopleBy {
   id_DESC
   name_ASC
   name_DESC
-  tasks_ASC
-  tasks_DESC
 }
 
 input PersonUpdateInput {

--- a/packages-next/fields/src/types/relationship/Implementation.ts
+++ b/packages-next/fields/src/types/relationship/Implementation.ts
@@ -42,7 +42,10 @@ export class Relationship<P extends string> extends Implementation<P> {
     const [refListKey, refFieldPath] = ref.split('.');
     this.refListKey = refListKey;
     this.refFieldPath = refFieldPath;
-    this.isOrderable = true;
+    // FIXME: In general we need to dig deeper on what it means to order by a relationship,
+    // but for now this lets us order one to many related items by their ID, which is
+    // an ok first approximation.
+    this.isOrderable = !many;
 
     this.isRelationship = true;
     this.many = !!many;


### PR DESCRIPTION
Sorting a list by a many relationship doesn't have a meaningful interpretation. In practice, attempting to do this would return errors. This change prevents the Admin UI from throwing errors from the list view when a user attempts to sort by a man relationship.