### PR TITLE
Disable the forgot your password button

### DIFF
--- a/.changeset/sour-sheep-tie.md
+++ b/.changeset/sour-sheep-tie.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Disabled the `Forgot your password` button on the signin page, which is not yet functional.

--- a/packages-next/auth/src/pages/SigninPage.tsx
+++ b/packages-next/auth/src/pages/SigninPage.tsx
@@ -35,7 +35,7 @@ export const SigninPage = ({
         ... on ${successTypename} {
           item {
             id
-          }  
+          }
         }
         ... on ${failureTypename} {
           message
@@ -142,9 +142,10 @@ export const SigninPage = ({
             >
               Sign In
             </Button>
-            <Button weight="none" tone="active" onClick={() => setMode('forgot password')}>
+            {/* Disabled until we come up with a complete password reset workflow */}
+            {/* <Button weight="none" tone="active" onClick={() => setMode('forgot password')}>
               Forgot your password?
-            </Button>
+            </Button> */}
           </Stack>
         )}
       </Stack>


### PR DESCRIPTION
At the moment this button doesn't actually do anything. Disabling it for now so as not to lead to confusion until we finish putting in the plumbing to complete this feature.