### PR TITLE
Disable ordering for all relationships

### DIFF
--- a/.changeset/weak-ants-work.md
+++ b/.changeset/weak-ants-work.md
@@ -4,4 +4,4 @@
 '@keystone-next/fields': patch
 ---
 
-Disabled sorting for `many` relationship fields.
+Disabled sorting for relationship fields.

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -274,8 +274,6 @@ input PhoneNumberWhereUniqueInput {
 enum SortPhoneNumbersBy {
   id_ASC
   id_DESC
-  user_ASC
-  user_DESC
   type_ASC
   type_DESC
   value_ASC
@@ -365,8 +363,6 @@ enum SortPostsBy {
   status_DESC
   publishDate_ASC
   publishDate_DESC
-  author_ASC
-  author_DESC
 }
 
 input PostUpdateInput {

--- a/examples/todo/schema.graphql
+++ b/examples/todo/schema.graphql
@@ -71,8 +71,6 @@ enum SortTasksBy {
   priority_DESC
   isComplete_ASC
   isComplete_DESC
-  assignedTo_ASC
-  assignedTo_DESC
   finishBy_ASC
   finishBy_DESC
 }

--- a/packages-next/fields/src/types/relationship/Implementation.ts
+++ b/packages-next/fields/src/types/relationship/Implementation.ts
@@ -42,10 +42,10 @@ export class Relationship<P extends string> extends Implementation<P> {
     const [refListKey, refFieldPath] = ref.split('.');
     this.refListKey = refListKey;
     this.refFieldPath = refFieldPath;
-    // FIXME: In general we need to dig deeper on what it means to order by a relationship,
-    // but for now this lets us order one to many related items by their ID, which is
-    // an ok first approximation.
-    this.isOrderable = !many;
+    // FIXME: We should be able to sort by the "one" side of a relationship
+    // but for now this isn't actually implemented, so we explicitly disable
+    // ordering here.
+    this.isOrderable = false;
 
     this.isRelationship = true;
     this.many = !!many;

--- a/packages-next/keystone/src/lib/core/tests/List.test.ts
+++ b/packages-next/keystone/src/lib/core/tests/List.test.ts
@@ -398,8 +398,6 @@ describe(`getGqlTypes()`, () => {
         name_DESC
         email_ASC
         email_DESC
-        other_ASC
-        other_DESC
         writeOnce_ASC
         writeOnce_DESC
       }`;


### PR DESCRIPTION
Updates the previous PR. I thought that the one side of a relationship worked for ordering, but it turns out I was wrong. Disabling them across the board for now 👍 