### PR TITLE
Add displayMode: 'count' to relationship field

### DIFF
--- a/.changeset/famous-countries-tell.md
+++ b/.changeset/famous-countries-tell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': minor
+---
+
+Added `ui.displayMode: 'count'` to `many` relationship fields 

--- a/docs/pages/apis/fields.mdx
+++ b/docs/pages/apis/fields.mdx
@@ -458,7 +458,7 @@ export default config({
             inlineCreate: { fields: [...] },
             inlineEdit: { fields: [...] },
             inlineConnect: true,
-            // Display mode: 'select'
+            // Display mode: 'count'
             // requires many: true above
             displayMode: 'count',
            },

--- a/docs/pages/apis/fields.mdx
+++ b/docs/pages/apis/fields.mdx
@@ -431,6 +431,7 @@ Read our [relationships guide](../guides/relationships) for details on Keystoneâ
   - `inlineCreate` (default: `null`): If not `null`, an object of the form `{ fields: [...] }`, where `fields` is a list of field paths from the related list should be provided. An inline `Create` button will be included in the cards allowing a new related item to be created based on the configured field paths.
   - `inlineEdit` (default: `null`): If not `null`, an object of the form `{ fields: [...] }`, where `fields` is a list of field paths from the related list should be provided. An `Edit` button will be included in each card, allowing the configured fields to be edited for each related item.
   - `inlineConnect` (default: `false`): If `true`, an inline `Link existing item` button will be present, allowing existing items of the related list to be connected in this field.
+- `ui.displayMode === 'count'` only supports `many` relationships
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
@@ -457,6 +458,9 @@ export default config({
             inlineCreate: { fields: [...] },
             inlineEdit: { fields: [...] },
             inlineConnect: true,
+            // Display mode: 'select'
+            // requires many: true above
+            displayMode: 'count',
            },
         }),
         /* ... */

--- a/packages-next/fields/src/types/relationship/index.ts
+++ b/packages-next/fields/src/types/relationship/index.ts
@@ -35,6 +35,14 @@ type CardsDisplayConfig = {
   };
 };
 
+type CountDisplayConfig = {
+  many: true;
+  ui?: {
+    // Sets the relationship to display as a count
+    displayMode: 'count';
+  };
+};
+
 export type RelationshipFieldConfig<
   TGeneratedListTypes extends BaseGeneratedListTypes
 > = FieldConfig<TGeneratedListTypes> & {
@@ -45,7 +53,7 @@ export type RelationshipFieldConfig<
   };
   defaultValue?: FieldDefaultValue<Record<string, unknown>>;
   isUnique?: boolean;
-} & (SelectDisplayConfig | CardsDisplayConfig);
+} & (SelectDisplayConfig | CardsDisplayConfig | CountDisplayConfig);
 
 export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>(
   config: RelationshipFieldConfig<TGeneratedListTypes>
@@ -83,6 +91,8 @@ export const relationship = <TGeneratedListTypes extends BaseGeneratedListTypes>
             inlineEdit: config.ui.inlineEdit ?? null,
             inlineConnect: config.ui.inlineConnect ?? false,
           }
+        : config.ui?.displayMode === 'count'
+        ? { displayMode: 'count' }
         : {
             displayMode: 'select',
             refLabelField: adminMetaRoot.listsByKey[refListKey].labelField,


### PR DESCRIPTION
This is intended as a stopgap solution to the fact that the relationship field in the Admin UI doesn't currently paginate. Note when displayMode: 'count' is set, you can't add/remove items from the side of the relationship that has displayMode: 'count' in the Admin UI.