### PR TITLE
5604/fix query caching

### DIFF
--- a/.changeset/red-kings-attend.md
+++ b/.changeset/red-kings-attend.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/admin-ui': patch
+---
+
+Fixed cache querying logic and added explicit query clearing flow to admin-ui.

--- a/packages-next/admin-ui/src/pages/ListPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ListPage/index.tsx
@@ -239,7 +239,6 @@ const ListPage = ({ listKey }: ListPageProps) => {
 
   const theme = useTheme();
   const showCreate = !(metaQuery.data?.keystone.adminMeta.list?.hideCreate ?? true) || null;
-  console.log(query, Object.keys(query).length);
 
   return (
     <PageContainer header={<ListPageHeader listKey={listKey} />}>

--- a/packages-next/admin-ui/src/pages/ListPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ListPage/index.tsx
@@ -77,7 +77,7 @@ let listMetaGraphqlQuery: TypedDocumentNode<
 function useQueryParamsFromLocalStorage(listKey: string) {
   const router = useRouter();
   const localStorageKey = `keystone.list.${listKey}.list.page.info`;
-  const cacheableQueries = ['sortBy', 'fields'];
+  const storeableQueries = ['sortBy', 'fields'];
 
   const resetToDefaults = () => {
     localStorage.removeItem(`keystone.list.${listKey}.list.page.info`);
@@ -90,7 +90,7 @@ function useQueryParamsFromLocalStorage(listKey: string) {
   // MERGE QUERY PARAMS FROM CACHE WITH QUERY PARAMS FROM ROUTER
   useEffect(() => {
     let hasSomeQueryParamsWhichAreAboutListPage = Object.keys(router.query).some(x => {
-      return x.startsWith('!') || cacheableQueries.includes(x);
+      return x.startsWith('!') || storeableQueries.includes(x);
     });
 
     if (!hasSomeQueryParamsWhichAreAboutListPage && router.isReady) {
@@ -112,7 +112,7 @@ function useQueryParamsFromLocalStorage(listKey: string) {
   useEffect(() => {
     let queryParamsToSerialize: Record<string, string> = {};
     Object.keys(router.query).forEach(key => {
-      if (key.startsWith('!') || cacheableQueries.includes(key)) {
+      if (key.startsWith('!') || storeableQueries.includes(key)) {
         queryParamsToSerialize[key] = router.query[key] as string;
       }
     });

--- a/packages-next/admin-ui/src/pages/ListPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ListPage/index.tsx
@@ -77,11 +77,23 @@ let listMetaGraphqlQuery: TypedDocumentNode<
 function useQueryParamsFromLocalStorage(listKey: string) {
   const router = useRouter();
   const localStorageKey = `keystone.list.${listKey}.list.page.info`;
+  const cacheableQueries = ['sortBy', 'fields'];
+
+  const resetToDefaults = () => {
+    localStorage.removeItem(`keystone.list.${listKey}.list.page.info`);
+    router.replace({
+      query: null,
+    });
+  };
+
+  // GET QUERY FROM CACHE IF CONDITIONS ARE RIGHT
+  // MERGE QUERY PARAMS FROM CACHE WITH QUERY PARAMS FROM ROUTER
   useEffect(() => {
-    let hasSomeQueryParamsWhichAreAboutListPage = Object.keys(router.query).some(
-      x => x.startsWith('!') || x === 'page' || x === 'pageSize' || x === 'fields'
-    );
-    if (!hasSomeQueryParamsWhichAreAboutListPage) {
+    let hasSomeQueryParamsWhichAreAboutListPage = Object.keys(router.query).some(x => {
+      return x.startsWith('!') || cacheableQueries.includes(x);
+    });
+
+    if (!hasSomeQueryParamsWhichAreAboutListPage && router.isReady) {
       const queryParamsFromLocalStorage = localStorage.getItem(localStorageKey);
       let parsed;
       try {
@@ -96,11 +108,11 @@ function useQueryParamsFromLocalStorage(listKey: string) {
         });
       }
     }
-  }, [localStorageKey]);
+  }, [localStorageKey, router.isReady]);
   useEffect(() => {
     let queryParamsToSerialize: Record<string, string> = {};
     Object.keys(router.query).forEach(key => {
-      if (key.startsWith('!') || key === 'page' || key === 'pageSize' || key === 'fields') {
+      if (key.startsWith('!') || cacheableQueries.includes(key)) {
         queryParamsToSerialize[key] = router.query[key] as string;
       }
     });
@@ -113,6 +125,8 @@ function useQueryParamsFromLocalStorage(listKey: string) {
       localStorage.removeItem(`keystone.list.${listKey}.list.page.info`);
     }
   }, [localStorageKey, router]);
+
+  return { resetToDefaults };
 }
 
 export const getListPage = (props: ListPageProps) => () => <ListPage {...props} />;
@@ -122,7 +136,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
 
   const { query } = useRouter();
 
-  useQueryParamsFromLocalStorage(listKey);
+  const { resetToDefaults } = useQueryParamsFromLocalStorage(listKey);
 
   let currentPage =
     typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1;
@@ -225,6 +239,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
 
   const theme = useTheme();
   const showCreate = !(metaQuery.data?.keystone.adminMeta.list?.hideCreate ?? true) || null;
+  console.log(query, Object.keys(query).length);
 
   return (
     <PageContainer header={<ListPageHeader listKey={listKey} />}>
@@ -237,6 +252,11 @@ const ListPage = ({ listKey }: ListPageProps) => {
             {showCreate && <CreateButton listKey={listKey} />}
             {data.meta.count || filters.filters.length ? <FilterAdd listKey={listKey} /> : null}
             {filters.filters.length ? <FilterList filters={filters.filters} list={list} /> : null}
+            {Boolean(Object.keys(query).length) && (
+              <Button size="small" onClick={resetToDefaults}>
+                Reset to defaults
+              </Button>
+            )}
           </Stack>
           {data.meta.count ? (
             <Fragment>


### PR DESCRIPTION
Fixes #5604: 
* pageSize query no longer cached
* page query no longer cached 
* sortBy query now cached 
* field filters remain cached 
* column queries remain cached 
* caching effect now checks for whether the router is ready or not. 
* Added a 'reset to defaults' button**

This needs better design and thought, but gets the job done for now. 

https://user-images.githubusercontent.com/12119389/117245314-ff29b300-ae7d-11eb-8051-e82cc351dbbb.mov

