### PR TITLE
Export cli functions from keystone

### DIFF
--- a/.changeset/few-doors-jog.md
+++ b/.changeset/few-doors-jog.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Adds `cli` functions as exports to `@keystone-6/core/scripts/cli`, assumed as an experimental unstable export and may change in a minor release.
+Adds `cli` functions as exports to `@keystone-6/core/scripts/cli`, assume to be an experimental unstable export and may change in a patch release.

--- a/.changeset/few-doors-jog.md
+++ b/.changeset/few-doors-jog.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds `cli` functions as exports to `@keystone-6/core/scripts/cli`, assumed as an experimental unstable export and may change in a minor release.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -149,6 +149,7 @@
       "testing.ts",
       "session/index.ts",
       "scripts/index.ts",
+      "scripts/cli.ts",
       "admin-ui/components/index.ts",
       "admin-ui/apollo.tsx",
       "admin-ui/context.tsx",

--- a/packages/core/scripts/cli/package.json
+++ b/packages/core/scripts/cli/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystone-6-core-scripts-cli.cjs.js",
+  "module": "dist/keystone-6-core-scripts-cli.esm.js"
+}


### PR DESCRIPTION
this lets me run keystone programmatically from another nodejs app

```ts
import { cli } from '@keystone-next/keystone/scripts/cli';
```