### PR TITLE
Added top margin to nav when session isn't configured

### DIFF
--- a/.changeset/mighty-impalas-appear.md
+++ b/.changeset/mighty-impalas-appear.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/admin-ui": patch
+---
+
+Fixed navigation margin when session isn't configured

--- a/packages-next/admin-ui/src/components/Navigation.tsx
+++ b/packages-next/admin-ui/src/components/Navigation.tsx
@@ -65,7 +65,8 @@ const AuthenticatedItem = ({ item }: { item: { id: string; label: string } }) =>
         display: 'flex',
         flexDirection: 'row',
         justifyContent: 'space-between',
-        padding: spacing.xlarge,
+        margin: spacing.xlarge,
+        marginBottom: 0,
       }}
     >
       <div css={{ fontSize: typography.fontSize.small }}>
@@ -127,6 +128,7 @@ export const Navigation = () => {
     authenticatedItem,
     visibleLists,
   } = useKeystone();
+  const { spacing } = useTheme();
 
   return (
     <div
@@ -139,7 +141,7 @@ export const Navigation = () => {
       {authenticatedItem.state === 'authenticated' && (
         <AuthenticatedItem item={authenticatedItem} />
       )}
-      <nav>
+      <nav css={{ marginTop: spacing.xlarge }}>
         <NavItem href="/">Dashboard</NavItem>
         {(() => {
           if (visibleLists.state === 'loading') return null;


### PR DESCRIPTION
When you have a Keystone system without session configured, the session item UI is missing from above the navigation, and the first nav item sits right up against the top border.

This fixes that:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/872310/117673043-c1b28600-b1ed-11eb-8017-766549a8a874.png">
