### PR TITLE
Ssgc updates

### DIFF
--- a/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
+++ b/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
@@ -119,7 +119,7 @@ const getItems = async ({
 }: {
   listKey: string;
   where?: Record<string, any> | null;
-  orderBy?: readonly Record<string, 'asc' | 'desc'>[] | null;
+  orderBy?: readonly Record<string, any>[] | null;
   first?: number | null;
   skip?: number | null;
   pageSize?: number;

--- a/packages-next/types/src/context.ts
+++ b/packages-next/types/src/context.ts
@@ -46,7 +46,7 @@ export type KeystoneListsAPI<KeystoneListsTypeInfo extends Record<string, BaseGe
       updateMany(
         args: {
           readonly data: readonly {
-            readonly id: string;
+            where: { readonly id: string };
             readonly data: KeystoneListsTypeInfo[Key]['inputs']['update'];
           }[];
         } & ResolveFields
@@ -97,7 +97,7 @@ export type KeystoneDbAPI<KeystoneListsTypeInfo extends Record<string, BaseGener
     }): Promise<KeystoneListsTypeInfo[Key]['backing']>;
     updateMany(args: {
       readonly data: readonly {
-        readonly id: string;
+        where: { readonly id: string };
         readonly data: KeystoneListsTypeInfo[Key]['inputs']['update'];
       }[];
     }): Promise<KeystoneListsTypeInfo[Key]['backing'][]>;

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -9,7 +9,7 @@ export type BaseGeneratedListTypes = {
       readonly search?: string | null;
       readonly first?: number | null;
       readonly skip?: number | null;
-      readonly orderBy?: ReadonlyArray<Record<string, 'asc' | 'desc'>> | null;
+      readonly orderBy?: ReadonlyArray<Record<string, any>> | null;
     };
   };
 };

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -9,8 +9,7 @@ export type BaseGeneratedListTypes = {
       readonly search?: string | null;
       readonly first?: number | null;
       readonly skip?: number | null;
-      readonly orderBy?: string;
-      readonly sortBy?: ReadonlyArray<string> | null;
+      readonly orderBy?: ReadonlyArray<Record<string, 'asc' | 'desc'>> | null;
     };
   };
 };

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -188,7 +188,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           // Seed the db
           await seedDb({ context });
 
-          const getItemsBySortOrder = (orderBy: Record<string, 'asc' | 'desc'>) =>
+          const getItemsBySortOrder = (orderBy: Record<string, any>) =>
             getItems({ context, listKey, returnFields, orderBy: [orderBy] });
 
           const allItemsAscAge = await getItemsBySortOrder({ age: 'asc' });
@@ -238,7 +238,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
         runner(setupKeystone, async ({ context }) => {
           await seedDb({ context });
           const first = 4;
-          const getSortItems = (orderBy: Record<string, 'asc' | 'desc'>) =>
+          const getSortItems = (orderBy: Record<string, any>) =>
             getItems({ context, listKey, returnFields, skip: 3, first, orderBy: [orderBy] });
           const itemsDESC = await getSortItems({ age: 'desc' });
           expect(itemsDESC.length).toEqual(first);

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -209,7 +209,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               returnFields,
               pageSize,
               first,
-              orderBy: [{ age: 'desc' }],
+              orderBy: [{ age: 'asc' }],
             });
           expect(await getFirstItems(9, 5)).toEqual(testData.slice(0, 9).map(d => d.data));
           expect(await getFirstItems(5, 9)).toEqual(testData.slice(0, 5).map(d => d.data));

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -97,7 +97,10 @@ multiAdapterRunners().map(({ runner, provider }) =>
           const items = (await updateItems({
             context,
             listKey,
-            items: seedItems.map((item, i) => ({ id: item.id, data: { name: `update-${i}` } })),
+            items: seedItems.map((item, i) => ({
+              where: { id: item.id },
+              data: { name: `update-${i}` },
+            })),
             returnFields,
           })) as { name: string; age: number }[];
           expect(items.sort((a, b) => (a.age > b.age ? 1 : -1))).toEqual(
@@ -180,16 +183,16 @@ multiAdapterRunners().map(({ runner, provider }) =>
         })
       );
       test(
-        'sortBy: Should get all sorted items',
+        'orderBy: Should get all sorted items',
         runner(setupKeystone, async ({ context }) => {
           // Seed the db
           await seedDb({ context });
 
-          const getItemsBySortOrder = (sortBy: string) =>
-            getItems({ context, listKey, returnFields, sortBy: [sortBy] });
+          const getItemsBySortOrder = (orderBy: Record<string, 'asc' | 'desc'>) =>
+            getItems({ context, listKey, returnFields, orderBy: [orderBy] });
 
-          const allItemsAscAge = await getItemsBySortOrder('age_ASC');
-          const allItemsDescAge = await getItemsBySortOrder('age_DESC');
+          const allItemsAscAge = await getItemsBySortOrder({ age: 'asc' });
+          const allItemsDescAge = await getItemsBySortOrder({ age: 'desc' });
           expect(allItemsAscAge[0]).toEqual(testData.map(x => x.data)[0]);
           expect(allItemsDescAge[0]).toEqual(testData.map(x => x.data).slice(-1)[0]);
         })
@@ -206,7 +209,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               returnFields,
               pageSize,
               first,
-              sortBy: ['age_ASC'],
+              orderBy: [{ age: 'desc' }],
             });
           expect(await getFirstItems(9, 5)).toEqual(testData.slice(0, 9).map(d => d.data));
           expect(await getFirstItems(5, 9)).toEqual(testData.slice(0, 5).map(d => d.data));
@@ -235,13 +238,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
         runner(setupKeystone, async ({ context }) => {
           await seedDb({ context });
           const first = 4;
-          const getSortItems = (sortBy: string) =>
-            getItems({ context, listKey, returnFields, skip: 3, first, sortBy: [sortBy] });
-          const itemsDESC = await getSortItems('age_DESC');
+          const getSortItems = (orderBy: Record<string, 'asc' | 'desc'>) =>
+            getItems({ context, listKey, returnFields, skip: 3, first, orderBy: [orderBy] });
+          const itemsDESC = await getSortItems({ age: 'desc' });
           expect(itemsDESC.length).toEqual(first);
           expect(itemsDESC[0]).toEqual({ name: 'test46', age: 460 });
 
-          const itemsASC = await getSortItems('age_ASC');
+          const itemsASC = await getSortItems({ age: 'asc' });
           expect(itemsASC.length).toEqual(4);
           expect(itemsASC[0]).toEqual({ name: 'test03', age: 30 });
         })


### PR DESCRIPTION
Update the server-side-graphql-library to use the updated GraphQL APIs, unblocking tests which use this API indirectly via the items API.