### PR TITLE
Add getDBProvider

### DIFF
--- a/.changeset/short-cougars-travel.md
+++ b/.changeset/short-cougars-travel.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/keystone': patch
+'@keystone-next/types': patch
+---
+
+Refactored code to parse `config.db`. No functional changes.

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -1,31 +1,14 @@
 import { PrismaAdapter } from '@keystone-next/adapter-prisma-legacy';
-import type { KeystoneConfig, BaseKeystone } from '@keystone-next/types';
+import type { KeystoneConfig, BaseKeystone, Provider } from '@keystone-next/types';
 import { Keystone } from './core/Keystone/index';
 
-export function createKeystone(config: KeystoneConfig, prismaClient?: any) {
+export function createKeystone(config: KeystoneConfig, provider: Provider, prismaClient?: any) {
   // Note: For backwards compatibility we may want to expose
   // this as a public API so that users can start their transition process
   // by using this pattern for creating their Keystone object before using
   // it in their existing custom servers or original CLI systems.
   const { db, graphql, lists } = config;
-  let adapter: PrismaAdapter;
-  if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
-    adapter = new PrismaAdapter({
-      prismaClient,
-      ...db,
-      provider: 'postgresql',
-    });
-  } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {
-    adapter = new PrismaAdapter({
-      prismaClient,
-      ...db,
-      provider: 'sqlite',
-    });
-  } else {
-    throw new Error(
-      'Invalid db configuration. Please specify db.provider as either "sqlite" or "postgresql"'
-    );
-  }
+  const adapter = new PrismaAdapter({ prismaClient, ...db, provider });
   // @ts-ignore The @types/keystonejs__keystone package has the wrong type for KeystoneOptions
   const keystone: BaseKeystone = new Keystone({
     adapter,

--- a/packages-next/keystone/src/lib/createKeystone.ts
+++ b/packages-next/keystone/src/lib/createKeystone.ts
@@ -1,8 +1,12 @@
 import { PrismaAdapter } from '@keystone-next/adapter-prisma-legacy';
-import type { KeystoneConfig, BaseKeystone, Provider } from '@keystone-next/types';
+import type { KeystoneConfig, BaseKeystone, DatabaseProvider } from '@keystone-next/types';
 import { Keystone } from './core/Keystone/index';
 
-export function createKeystone(config: KeystoneConfig, provider: Provider, prismaClient?: any) {
+export function createKeystone(
+  config: KeystoneConfig,
+  provider: DatabaseProvider,
+  prismaClient?: any
+) {
   // Note: For backwards compatibility we may want to expose
   // this as a public API so that users can start their transition process
   // by using this pattern for creating their Keystone object before using

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,11 +1,25 @@
-import type { KeystoneConfig } from '@keystone-next/types';
+import type { KeystoneConfig, Provider } from '@keystone-next/types';
 
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './context/createContext';
 import { createKeystone } from './createKeystone';
 
+export function getDBProvider(db: KeystoneConfig['db']): Provider {
+  if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
+    return 'postgresql';
+  } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {
+    return 'sqlite';
+  } else {
+    throw new Error(
+      'Invalid db configuration. Please specify db.provider as either "sqlite" or "postgresql"'
+    );
+  }
+}
+
 export function createSystem(config: KeystoneConfig, prismaClient?: any) {
-  const keystone = createKeystone(config, prismaClient);
+  const provider = getDBProvider(config.db);
+
+  const keystone = createKeystone(config, provider, prismaClient);
 
   const graphQLSchema = createGraphQLSchema(config, keystone, 'public');
 

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,10 +1,10 @@
-import type { KeystoneConfig, Provider } from '@keystone-next/types';
+import type { KeystoneConfig, DatabaseProvider } from '@keystone-next/types';
 
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './context/createContext';
 import { createKeystone } from './createKeystone';
 
-export function getDBProvider(db: KeystoneConfig['db']): Provider {
+export function getDBProvider(db: KeystoneConfig['db']): DatabaseProvider {
   if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
     return 'postgresql';
   } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -5,7 +5,7 @@ import type { KeystoneContext, SessionContext } from './context';
 /* TODO: Review these types */
 type FieldDefaultValueArgs<T> = { context: KeystoneContext; originalInput?: T };
 
-export type Provider = 'sqlite' | 'postgresql';
+export type DatabaseProvider = 'sqlite' | 'postgresql';
 
 export type FieldDefaultValue<T> =
   | T

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -5,6 +5,8 @@ import type { KeystoneContext, SessionContext } from './context';
 /* TODO: Review these types */
 type FieldDefaultValueArgs<T> = { context: KeystoneContext; originalInput?: T };
 
+export type Provider = 'sqlite' | 'postgresql';
+
 export type FieldDefaultValue<T> =
   | T
   | null


### PR DESCRIPTION
Ports code #5665 to pre-emptively remove dependency on legacy Keystone object.

This is the first of a few PRs which will aim to remove our usage of the Keystone object throughout the system without introducing breaking changes.