### PR TITLE
Use order by

### DIFF
--- a/docs/pages/apis/db-items.mdx
+++ b/docs/pages/apis/db-items.mdx
@@ -16,7 +16,7 @@ For each list in your system the following API is available at `context.db.lists
 ```
 {
   findOne({ where: { id } }),
-  findMany({ where, first, skip, sortBy }),
+  findMany({ where, first, skip, orderBy }),
   count({ where, first, skip }),
   createOne({ data }),
   createMany({ data }),
@@ -47,7 +47,7 @@ const users = await context.db.lists.User.findMany({
   where: { name_starts_with: 'A' },
   first: 10,
   skip: 20,
-  sortBy: ['name_ASC'],
+  orderBy: [{ name: 'asc'],
 });
 ```
 

--- a/docs/pages/apis/list-items.mdx
+++ b/docs/pages/apis/list-items.mdx
@@ -8,7 +8,7 @@ For each list in your system the following API is available at `context.lists.<l
 ```
 {
   findOne({ where: { id }, query }),
-  findMany({ where, first, skip, sortBy, query }),
+  findMany({ where, first, skip, orderBy, query }),
   count({ where, first, skip }),
   createOne({ data, query }),
   createMany({ data, query }),
@@ -44,7 +44,7 @@ const users = await context.lists.User.findMany({
   where: { name_starts_with: 'A' },
   first: 10,
   skip: 20,
-  sortBy: ['name_ASC'],
+  orderBy: [{ name: 'asc' }],
   query: 'id name posts { id title }',
 });
 ```

--- a/examples/ecommerce/tests/mutations.test.ts
+++ b/examples/ecommerce/tests/mutations.test.ts
@@ -31,7 +31,7 @@ multiAdapterRunners('postgresql').map(({ runner }) =>
             id
             label
             total
-            items(sortBy: [name_ASC]) { name description price quantity photo { id } }
+            items(orderBy: [{ name: "asc" }]) { name description price quantity photo { id } }
             user { id }
             charge
           } }`;

--- a/examples/ecommerce/tests/mutations.test.ts
+++ b/examples/ecommerce/tests/mutations.test.ts
@@ -31,7 +31,7 @@ multiAdapterRunners('postgresql').map(({ runner }) =>
             id
             label
             total
-            items(orderBy: [{ name: "asc" }]) { name description price quantity photo { id } }
+            items(orderBy: [{ name: asc }]) { name description price quantity photo { id } }
             user { id }
             charge
           } }`;

--- a/packages-next/admin-ui/src/pages/ListPage/index.tsx
+++ b/packages-next/admin-ui/src/pages/ListPage/index.tsx
@@ -174,12 +174,12 @@ const ListPage = ({ listKey }: ListPageProps) => {
         })
         .join('\n');
       return gql`
-      query ($where: ${list.gqlNames.whereInputName}, $first: Int!, $skip: Int!, $sortBy: [${
+      query ($where: ${list.gqlNames.whereInputName}, $first: Int!, $skip: Int!, $orderBy: [${
         list.gqlNames.listSortName
       }!]) {
         items: ${
           list.gqlNames.listQueryName
-        }(where: $where,first: $first, skip: $skip, orderBy: $sortBy) {
+        }(where: $where,first: $first, skip: $skip, orderBy: $orderBy) {
           ${
             // TODO: maybe namespace all the fields instead of doing this
             selectedFields.has('id') ? '' : 'id'
@@ -199,7 +199,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
         where: filters.where,
         first: pageSize,
         skip: (currentPage - 1) * pageSize,
-        sortBy: sort ? [`${sort.field}_${sort.direction}`] : undefined,
+        orderBy: sort ? [{ [sort.field]: sort.direction }] : undefined,
       },
     }
   );

--- a/packages-next/fields/src/tests/test-fixtures.ts
+++ b/packages-next/fields/src/tests/test-fixtures.ts
@@ -38,7 +38,7 @@ export const filterTests = (withKeystone: any) => {
     expected: any[]
   ) =>
     expect(
-      await context.lists.Test.findMany({ where, sortBy: ['name_ASC'], query: 'id name' })
+      await context.lists.Test.findMany({ where, orderBy: [{ name: 'asc' }], query: 'id name' })
     ).toEqual(expected);
 
   test(

--- a/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
@@ -73,7 +73,11 @@ export const filterTests = (withKeystone: (arg: any) => any, matrixValue: Matrix
   const _f = matrixValue === 'ID' ? (x: any) => x.toString() : (x: any) => x;
   const match = async (context: KeystoneContext, where: Record<string, any>, expected: any[]) =>
     expect(
-      await context.lists.Test.findMany({ where, sortBy: ['name_ASC'], query: 'name orderNumber' })
+      await context.lists.Test.findMany({
+        where,
+        orderBy: [{ name: 'asc' }],
+        query: 'name orderNumber',
+      })
     ).toEqual(expected.map(i => _storedValues[i]));
 
   test(

--- a/packages-next/fields/src/types/checkbox/index.ts
+++ b/packages-next/fields/src/types/checkbox/index.ts
@@ -9,30 +9,31 @@ import {
 import { resolveView } from '../../resolve-view';
 import type { CommonFieldConfig } from '../../interfaces';
 
-export type CheckboxFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes> & {
-  defaultValue?: FieldDefaultValue<boolean>;
-  isRequired?: boolean;
-};
+export type CheckboxFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes> & {
+    defaultValue?: FieldDefaultValue<boolean>;
+    isRequired?: boolean;
+  };
 
-export const checkbox = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: CheckboxFieldConfig<TGeneratedListTypes> = {}
-): FieldTypeFunc => () => {
-  if (config.index === 'unique') {
-    throw Error("{ index: 'unique' } is not a supported option for field type checkbox");
-  }
+export const checkbox =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>(
+    config: CheckboxFieldConfig<TGeneratedListTypes> = {}
+  ): FieldTypeFunc =>
+  () => {
+    if (config.index === 'unique') {
+      throw Error("{ index: 'unique' } is not a supported option for field type checkbox");
+    }
 
-  return fieldType({ kind: 'scalar', mode: 'optional', scalar: 'Boolean' })({
-    ...config,
-    input: {
-      create: { arg: types.arg({ type: types.Boolean }) },
-      update: { arg: types.arg({ type: types.Boolean }) },
-      orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
-    },
-    output: types.field({
-      type: types.Boolean,
-    }),
-    views: resolveView('checkbox/views'),
-  });
-};
+    return fieldType({ kind: 'scalar', mode: 'optional', scalar: 'Boolean' })({
+      ...config,
+      input: {
+        create: { arg: types.arg({ type: types.Boolean }) },
+        update: { arg: types.arg({ type: types.Boolean }) },
+        orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
+      },
+      output: types.field({
+        type: types.Boolean,
+      }),
+      views: resolveView('checkbox/views'),
+    });
+  };

--- a/packages-next/fields/src/types/file/index.ts
+++ b/packages-next/fields/src/types/file/index.ts
@@ -11,9 +11,8 @@ import { getFileRef } from '@keystone-next/utils-legacy';
 import { FileUpload } from 'graphql-upload';
 import { resolveView } from '../../resolve-view';
 
-export type FileFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes>;
+export type FileFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes>;
 
 const FileFieldInput = types.inputObject({
   name: 'FileFieldInput',
@@ -69,36 +68,38 @@ async function inputResolver(data: ImageFieldInputType, context: KeystoneContext
   return context.files!.getDataFromStream(upload.createReadStream(), upload.filename);
 }
 
-export const file = <TGeneratedListTypes extends BaseGeneratedListTypes>(
-  config: FileFieldConfig<TGeneratedListTypes> = {}
-): FieldTypeFunc => () => {
-  if (config.index === 'unique') {
-    throw Error("{ index: 'unique' } is not a supported option for field type file");
-  }
+export const file =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>(
+    config: FileFieldConfig<TGeneratedListTypes> = {}
+  ): FieldTypeFunc =>
+  () => {
+    if (config.index === 'unique') {
+      throw Error("{ index: 'unique' } is not a supported option for field type file");
+    }
 
-  return fieldType({
-    kind: 'multi',
-    fields: {
-      mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
-      filename: { kind: 'scalar', scalar: 'String', mode: 'optional' },
-      filesize: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-    },
-  })({
-    ...config,
-    input: {
-      create: { arg: types.arg({ type: FileFieldInput }), resolve: inputResolver },
-      update: { arg: types.arg({ type: FileFieldInput }), resolve: inputResolver },
-    },
-    // TODO: THIS MUST BE CHANGED BACK TO THE INTERFACE BEFORE MERGING
-    output: types.field({
-      type: LocalFileFieldOutput,
-      resolve({ value: { filesize, filename, mode } }) {
-        if (filesize === null || filename === null || mode !== 'local') {
-          return null;
-        }
-        return { mode: 'local', filename, filesize };
+    return fieldType({
+      kind: 'multi',
+      fields: {
+        mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
+        filename: { kind: 'scalar', scalar: 'String', mode: 'optional' },
+        filesize: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
       },
-    }),
-    views: resolveView('file/views'),
-  });
-};
+    })({
+      ...config,
+      input: {
+        create: { arg: types.arg({ type: FileFieldInput }), resolve: inputResolver },
+        update: { arg: types.arg({ type: FileFieldInput }), resolve: inputResolver },
+      },
+      // TODO: THIS MUST BE CHANGED BACK TO THE INTERFACE BEFORE MERGING
+      output: types.field({
+        type: LocalFileFieldOutput,
+        resolve({ value: { filesize, filename, mode } }) {
+          if (filesize === null || filename === null || mode !== 'local') {
+            return null;
+          }
+          return { mode: 'local', filename, filesize };
+        },
+      }),
+      views: resolveView('file/views'),
+    });
+  };

--- a/packages-next/fields/src/types/image/index.ts
+++ b/packages-next/fields/src/types/image/index.ts
@@ -12,9 +12,8 @@ import { FileUpload } from 'graphql-upload';
 import { resolveView } from '../../resolve-view';
 import type { CommonFieldConfig } from '../../interfaces';
 
-export type ImageFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes>;
+export type ImageFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes>;
 
 const ImageExtensionEnum = types.enum({
   name: 'ImageExtension',
@@ -81,47 +80,49 @@ function isValidImageExtension(extension: string): extension is ImageExtension {
   return extensionsSet.has(extension);
 }
 
-export const image = <TGeneratedListTypes extends BaseGeneratedListTypes>({
-  ...config
-}: ImageFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc => () => {
-  if (config.index === 'unique') {
-    throw Error("{ index: 'unique' } is not a supported option for field type image");
-  }
+export const image =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>({
+    ...config
+  }: ImageFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc =>
+  () => {
+    if (config.index === 'unique') {
+      throw Error("{ index: 'unique' } is not a supported option for field type image");
+    }
 
-  return fieldType({
-    kind: 'multi',
-    fields: {
-      filesize: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-      extension: { kind: 'scalar', scalar: 'String', mode: 'optional' },
-      width: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-      height: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-      mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
-      id: { kind: 'scalar', scalar: 'String', mode: 'optional' },
-    },
-  })({
-    ...config,
-    input: {
-      create: { arg: types.arg({ type: ImageFieldInput }), resolve: inputResolver },
-      update: { arg: types.arg({ type: ImageFieldInput }), resolve: inputResolver },
-    },
-    // TODO: THIS MUST BE CHANGED BACK TO THE INTERFACE BEFORE MERGING
-    output: types.field({
-      type: LocalImageFieldOutput,
-      resolve({ value: { extension, filesize, height, id, mode, width } }) {
-        if (
-          extension === null ||
-          !isValidImageExtension(extension) ||
-          filesize === null ||
-          height === null ||
-          width === null ||
-          id === null ||
-          mode !== 'local'
-        ) {
-          return null;
-        }
-        return { mode: 'local', extension, filesize, height, width, id };
+    return fieldType({
+      kind: 'multi',
+      fields: {
+        filesize: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
+        extension: { kind: 'scalar', scalar: 'String', mode: 'optional' },
+        width: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
+        height: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
+        mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
+        id: { kind: 'scalar', scalar: 'String', mode: 'optional' },
       },
-    }),
-    views: resolveView('image/views'),
-  });
-};
+    })({
+      ...config,
+      input: {
+        create: { arg: types.arg({ type: ImageFieldInput }), resolve: inputResolver },
+        update: { arg: types.arg({ type: ImageFieldInput }), resolve: inputResolver },
+      },
+      // TODO: THIS MUST BE CHANGED BACK TO THE INTERFACE BEFORE MERGING
+      output: types.field({
+        type: LocalImageFieldOutput,
+        resolve({ value: { extension, filesize, height, id, mode, width } }) {
+          if (
+            extension === null ||
+            !isValidImageExtension(extension) ||
+            filesize === null ||
+            height === null ||
+            width === null ||
+            id === null ||
+            mode !== 'local'
+          ) {
+            return null;
+          }
+          return { mode: 'local', extension, filesize, height, width, id };
+        },
+      }),
+      views: resolveView('image/views'),
+    });
+  };

--- a/packages-next/fields/src/types/integer/index.ts
+++ b/packages-next/fields/src/types/integer/index.ts
@@ -8,22 +8,23 @@ import {
 import { resolveView } from '../../resolve-view';
 import type { CommonFieldConfig } from '../../interfaces';
 
-export type IntegerFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes> & { index?: 'index' | 'unique' };
+export type IntegerFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes> & { index?: 'index' | 'unique' };
 
-export const integer = <TGeneratedListTypes extends BaseGeneratedListTypes>({
-  index,
-  ...config
-}: IntegerFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc => () =>
-  fieldType({ kind: 'scalar', mode: 'optional', scalar: 'Int', index })({
-    ...config,
-    input: {
-      uniqueWhere: index === 'unique' ? { arg: types.arg({ type: types.Int }) } : undefined,
-      create: { arg: types.arg({ type: types.Int }) },
-      update: { arg: types.arg({ type: types.Int }) },
-      orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
-    },
-    output: types.field({ type: types.Int }),
-    views: resolveView('integer/views'),
-  });
+export const integer =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>({
+    index,
+    ...config
+  }: IntegerFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc =>
+  () =>
+    fieldType({ kind: 'scalar', mode: 'optional', scalar: 'Int', index })({
+      ...config,
+      input: {
+        uniqueWhere: index === 'unique' ? { arg: types.arg({ type: types.Int }) } : undefined,
+        create: { arg: types.arg({ type: types.Int }) },
+        update: { arg: types.arg({ type: types.Int }) },
+        orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
+      },
+      output: types.field({ type: types.Int }),
+      views: resolveView('integer/views'),
+    });

--- a/packages-next/fields/src/types/password/index.ts
+++ b/packages-next/fields/src/types/password/index.ts
@@ -3,19 +3,18 @@ import bcryptjs from 'bcryptjs';
 import { resolveView } from '../../resolve-view';
 import type { CommonFieldConfig } from '../../interfaces';
 
-type PasswordFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes> & {
-  /**
-   * @default 8
-   */
-  minLength?: number;
-  /**
-   * @default 10
-   */
-  workFactor?: number;
-  bcrypt?: Pick<typeof import('bcryptjs'), 'compare' | 'compareSync' | 'hash' | 'hashSync'>;
-};
+type PasswordFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes> & {
+    /**
+     * @default 8
+     */
+    minLength?: number;
+    /**
+     * @default 10
+     */
+    workFactor?: number;
+    bcrypt?: Pick<typeof import('bcryptjs'), 'compare' | 'compareSync' | 'hash' | 'hashSync'>;
+  };
 
 const PasswordState = types.object<{ isSet: boolean }>()({
   name: 'PasswordState',
@@ -24,66 +23,68 @@ const PasswordState = types.object<{ isSet: boolean }>()({
   },
 });
 
-export const password = <TGeneratedListTypes extends BaseGeneratedListTypes>({
-  bcrypt = bcryptjs,
-  minLength = 8,
-  workFactor = 10,
-  ...config
-}: PasswordFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc => field => {
-  // TODO: we should just throw not automatically fix it, yeah?
-  workFactor = Math.min(Math.max(workFactor, 4), 31);
+export const password =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>({
+    bcrypt = bcryptjs,
+    minLength = 8,
+    workFactor = 10,
+    ...config
+  }: PasswordFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc =>
+  field => {
+    // TODO: we should just throw not automatically fix it, yeah?
+    workFactor = Math.min(Math.max(workFactor, 4), 31);
 
-  if (workFactor < 6) {
-    console.warn(
-      `The workFactor for ${field.listKey}.${field.fieldKey} is very low! ` +
-        `This will cause weak hashes!`
-    );
-  }
-
-  function inputResolver(val: string | null | undefined) {
-    if (typeof val === 'string') {
-      return bcrypt.hash(val, 10);
+    if (workFactor < 6) {
+      console.warn(
+        `The workFactor for ${field.listKey}.${field.fieldKey} is very low! ` +
+          `This will cause weak hashes!`
+      );
     }
-    return val;
-  }
 
-  if (config.index === 'unique') {
-    throw Error("{ index: 'unique' } is not a supported option for field type password");
-  }
+    function inputResolver(val: string | null | undefined) {
+      if (typeof val === 'string') {
+        return bcrypt.hash(val, 10);
+      }
+      return val;
+    }
 
-  return fieldType({
-    kind: 'scalar',
-    scalar: 'String',
-    mode: 'optional',
-  })({
-    ...config,
-    input: {
-      create: {
-        arg: types.arg({ type: types.String }),
-        resolve: inputResolver,
-      },
-      update: {
-        arg: types.arg({ type: types.String }),
-        resolve: inputResolver,
-      },
-    },
-    views: resolveView('password/views'),
-    getAdminMeta: () => ({ minLength: minLength }),
-    output: types.field({
-      type: types.nonNull(PasswordState),
-      resolve(val) {
-        return { isSet: val.value !== null };
-      },
-      extensions: {
-        keystoneSecretField: {
-          generateHash: async (secret: string) => {
-            return bcrypt.hash(secret, workFactor);
-          },
-          compare: (secret: string, hash: string) => {
-            return bcrypt.compare(secret, hash);
-          },
+    if (config.index === 'unique') {
+      throw Error("{ index: 'unique' } is not a supported option for field type password");
+    }
+
+    return fieldType({
+      kind: 'scalar',
+      scalar: 'String',
+      mode: 'optional',
+    })({
+      ...config,
+      input: {
+        create: {
+          arg: types.arg({ type: types.String }),
+          resolve: inputResolver,
+        },
+        update: {
+          arg: types.arg({ type: types.String }),
+          resolve: inputResolver,
         },
       },
-    }),
-  });
-};
+      views: resolveView('password/views'),
+      getAdminMeta: () => ({ minLength: minLength }),
+      output: types.field({
+        type: types.nonNull(PasswordState),
+        resolve(val) {
+          return { isSet: val.value !== null };
+        },
+        extensions: {
+          keystoneSecretField: {
+            generateHash: async (secret: string) => {
+              return bcrypt.hash(secret, workFactor);
+            },
+            compare: (secret: string, hash: string) => {
+              return bcrypt.compare(secret, hash);
+            },
+          },
+        },
+      }),
+    });
+  };

--- a/packages-next/fields/src/types/password/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/password/tests/test-fixtures.ts
@@ -8,7 +8,7 @@ export const exampleValue2 = () => 'password2';
 export const supportsUnique = false;
 export const fieldName = 'password';
 export const readFieldName = 'password';
-export const subfieldName = 'isSet'
+export const subfieldName = 'isSet';
 export const skipCreateTest = true;
 export const skipUpdateTest = true;
 

--- a/packages-next/fields/src/types/timestamp/index.ts
+++ b/packages-next/fields/src/types/timestamp/index.ts
@@ -8,36 +8,37 @@ import {
 import { resolveView } from '../../resolve-view';
 import type { CommonFieldConfig } from '../../interfaces';
 
-export type TimestampFieldConfig<
-  TGeneratedListTypes extends BaseGeneratedListTypes
-> = CommonFieldConfig<TGeneratedListTypes> & {
-  index?: 'index' | 'unique';
-};
-
-export const timestamp = <TGeneratedListTypes extends BaseGeneratedListTypes>({
-  index,
-  ...config
-}: TimestampFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc => () => {
-  const inputResolver = (value: string | null | undefined) => {
-    if (value === null || value === undefined) {
-      return value;
-    }
-    return new Date(value);
+export type TimestampFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
+  CommonFieldConfig<TGeneratedListTypes> & {
+    index?: 'index' | 'unique';
   };
-  return fieldType({ kind: 'scalar', mode: 'optional', scalar: 'DateTime', index })({
-    ...config,
-    input: {
-      create: { arg: types.arg({ type: types.String }), resolve: inputResolver },
-      update: { arg: types.arg({ type: types.String }), resolve: inputResolver },
-      orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
-    },
-    output: types.field({
-      type: types.String,
-      resolve({ value }) {
-        if (value === null) return null;
-        return value.toISOString();
+
+export const timestamp =
+  <TGeneratedListTypes extends BaseGeneratedListTypes>({
+    index,
+    ...config
+  }: TimestampFieldConfig<TGeneratedListTypes> = {}): FieldTypeFunc =>
+  () => {
+    const inputResolver = (value: string | null | undefined) => {
+      if (value === null || value === undefined) {
+        return value;
+      }
+      return new Date(value);
+    };
+    return fieldType({ kind: 'scalar', mode: 'optional', scalar: 'DateTime', index })({
+      ...config,
+      input: {
+        create: { arg: types.arg({ type: types.String }), resolve: inputResolver },
+        update: { arg: types.arg({ type: types.String }), resolve: inputResolver },
+        orderBy: { arg: types.arg({ type: orderDirectionEnum }) },
       },
-    }),
-    views: resolveView('timestamp/views'),
-  });
-};
+      output: types.field({
+        type: types.String,
+        resolve({ value }) {
+          if (value === null) return null;
+          return value.toISOString();
+        },
+      }),
+      views: resolveView('timestamp/views'),
+    });
+  };

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -54,7 +54,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
     );
 
   test(
-    'Sorting: sortBy: lastOnline_ASC',
+    'Ordering: orderBy: { lastOnline: "asc" }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,
@@ -84,7 +84,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
   );
 
   test(
-    'Sorting: sortBy: lastOnline_DESC',
+    'Sorting: orderBy: { lastOnline: "desc" }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -54,7 +54,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
     );
 
   test(
-    'Ordering: orderBy: { lastOnline: "asc" }',
+    'Ordering: orderBy: { lastOnline: asc }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,
@@ -84,7 +84,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
   );
 
   test(
-    'Sorting: orderBy: { lastOnline: "desc" }',
+    'Sorting: orderBy: { lastOnline: desc }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -65,7 +65,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query {
             allUsers(
               where: { name_contains: "J" },
-              sortBy: name_ASC,
+              orderBy: [{ name: "asc" }],
             ) {
               name
             }
@@ -200,8 +200,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
               where: {
                 OR: [{ title: 'One author' }, { title: 'Two authors' }],
               },
-              sortBy: ['title_ASC'],
-              query: 'title author(sortBy: [name_ASC]) { name }',
+              orderBy: [{ title: 'asc' }],
+              query: 'title author(orderBy: [{ name: "ASC" }]) { name }',
             });
             expect(posts).toEqual([
               { title: 'One author', author: [{ name: 'Jess' }] },

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -65,7 +65,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query {
             allUsers(
               where: { name_contains: "J" },
-              orderBy: [{ name: "asc" }],
+              orderBy: [{ name: asc }],
             ) {
               name
             }
@@ -201,7 +201,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 OR: [{ title: 'One author' }, { title: 'Two authors' }],
               },
               orderBy: [{ title: 'asc' }],
-              query: 'title author(orderBy: [{ name: "ASC" }]) { name }',
+              query: 'title author(orderBy: [{ name: asc }]) { name }',
             });
             expect(posts).toEqual([
               { title: 'One author', author: [{ name: 'Jess' }] },

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -174,7 +174,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id feed(sortBy: [title_ASC]) { title }',
+              query: 'id feed(orderBy: [{ title: "asc" }]) { title }',
             });
 
             expect(_users).toHaveLength(2);
@@ -257,7 +257,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id name feed(sortBy: [title_ASC]) { id title }',
+              query: 'id name feed(orderBy: [{ title: "asc" }]) { id title }',
             });
 
             expect(_users).toMatchObject([

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -174,7 +174,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id feed(orderBy: [{ title: "asc" }]) { title }',
+              query: 'id feed(orderBy: [{ title: asc }]) { title }',
             });
 
             expect(_users).toHaveLength(2);
@@ -257,7 +257,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id name feed(orderBy: [{ title: "asc" }]) { id title }',
+              query: 'id name feed(orderBy: [{ title: asc }]) { id title }',
             });
 
             expect(_users).toMatchObject([

--- a/tests/api-tests/queries/search.test.ts
+++ b/tests/api-tests/queries/search.test.ts
@@ -220,7 +220,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query: `
           query {
             allTests(
-              sortBy: name_ASC,
+              orderBy: [{ name: "asc" }],
               search: "",
             ) {
               name

--- a/tests/api-tests/queries/search.test.ts
+++ b/tests/api-tests/queries/search.test.ts
@@ -220,7 +220,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query: `
           query {
             allTests(
-              orderBy: [{ name: "asc" }],
+              orderBy: [{ name: asc }],
               search: "",
             ) {
               name

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -346,7 +346,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: [{ name: 'asc' }],
                   query: 'id name friend { id name }',
                 })) as { name: string; friend: { name: string } }[];
                 const users = _users.filter(({ name }: { name: string }) => name.length === 1);
@@ -375,7 +375,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the friends look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: [{ name: 'asc' }],
                   query: 'id name',
                 })) as { name: string }[];
                 const friends = _users.filter(({ name }: { name: string }) => name.length === 2);
@@ -405,7 +405,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: [{ name: 'asc' }],
                   query: 'id name friend { id name }',
                 })) as { name: string; friend: { name: string } }[];
                 const users = _users.filter(({ name }) => name.length === 1);
@@ -440,7 +440,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the friends look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: [{ name: 'asc' }],
                   query: 'id name',
                 })) as { name: string }[];
                 const friends = _users.filter(({ name }) => name.length === 2);

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -426,7 +426,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               await (async () => {
                 const data = await context.graphql.run({
                   query:
-                    '{ allCompanies(orderBy: [{ name: "asc" }],) { id name location { id name } } }',
+                    '{ allCompanies(orderBy: [{ name: asc }],) { id name location { id name } } }',
                 });
 
                 const expected = [
@@ -454,7 +454,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the locations look how we expect
               await (async () => {
                 const data = await context.graphql.run({
-                  query: '{ allLocations(orderBy: [{ name: "asc" }],: name_ASC) { id name } }',
+                  query: '{ allLocations(orderBy: [{ name: asc }],: name_ASC) { id name } }',
                 });
                 expect(data.allLocations[0].name).toEqual('A');
                 expect(data.allLocations[1].name).toEqual('B');

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -425,7 +425,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const data = await context.graphql.run({
-                  query: '{ allCompanies(sortBy: name_ASC) { id name location { id name } } }',
+                  query:
+                    '{ allCompanies(orderBy: [{ name: "asc" }],) { id name location { id name } } }',
                 });
 
                 const expected = [
@@ -453,7 +454,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the locations look how we expect
               await (async () => {
                 const data = await context.graphql.run({
-                  query: '{ allLocations(sortBy: name_ASC) { id name } }',
+                  query: '{ allLocations(orderBy: [{ name: "asc" }],: name_ASC) { id name } }',
                 });
                 expect(data.allLocations[0].name).toEqual('A');
                 expect(data.allLocations[1].name).toEqual('B');
@@ -479,7 +480,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
               // Check all the companies look how we expect
               const companies = await context.lists.Company.findMany({
-                sortBy: ['name_ASC'],
+                orderBy: [{ name: 'asc' }],
                 query: 'id name location { id name }',
               });
               expect(companies[0].name).toEqual('A');
@@ -511,7 +512,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
               // Check all the locations look how we expect
               const _locations = await context.lists.Location.findMany({
-                sortBy: ['name_ASC'],
+                orderBy: [{ name: 'asc' }],
                 query: 'id name',
               });
               const expected = ['A', 'B', 'C', 'D'].filter(x => x !== name);

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -84,7 +84,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           const users = await context.lists.User.findMany({
-            query: 'id posts(first: 1, orderBy: [{ content: "asc" }]) { id }',
+            query: 'id posts(first: 1, orderBy: [{ content: asc }]) { id }',
           });
           expect(users).toContainEqual({ id: user.id, posts: [ids[0]] });
           expect(users).toContainEqual({ id: user2.id, posts: [ids[0]] });

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -84,7 +84,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           const users = await context.lists.User.findMany({
-            query: 'id posts(first: 1, sortBy: [content_ASC]) { id }',
+            query: 'id posts(first: 1, orderBy: [{ content: "asc" }]) { id }',
           });
           expect(users).toContainEqual({ id: user.id, posts: [ids[0]] });
           expect(users).toContainEqual({ id: user2.id, posts: [ids[0]] });

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -74,7 +74,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           // Create an item that does the nested create
           const user = await context.lists.User.createOne({
             data: { username: 'A thing', notes: { create: [{ content: noteContent }] } },
-            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
+            query: 'id notes(orderBy: [{ content: asc }]) { id content }',
           });
 
           expect(user).toMatchObject({
@@ -90,7 +90,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
+            query: 'id notes(orderBy: [{ content: asc }]) { id content }',
           })) as T;
 
           expect(user1).toMatchObject({
@@ -151,7 +151,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
+            query: 'id notes(orderBy: [{ content: asc }]) { id content }',
           })) as T;
 
           expect(_user).toMatchObject({

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -74,7 +74,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           // Create an item that does the nested create
           const user = await context.lists.User.createOne({
             data: { username: 'A thing', notes: { create: [{ content: noteContent }] } },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
           });
 
           expect(user).toMatchObject({
@@ -90,7 +90,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
           })) as T;
 
           expect(user1).toMatchObject({
@@ -151,7 +151,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: [{ content: "asc" }]) { id content }',
           })) as T;
 
           expect(_user).toMatchObject({

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -51,12 +51,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           type T = { id: IdType; notes: { id: IdType; title: string }[] };
           const alice = (await context.lists.User.createOne({
             data: { username: 'Alice', notes: { connect: [{ id: noteA.id }, { id: noteB.id }] } },
-            query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
+            query: 'id notes(orderBy: [{ title: asc }]) { id title }',
           })) as T;
 
           const bob = (await context.lists.User.createOne({
             data: { username: 'Bob', notes: { connect: [{ id: noteC.id }, { id: noteD.id }] } },
-            query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
+            query: 'id notes(orderBy: [{ title: asc }]) { id title }',
           })) as T;
 
           // Make sure everyone has the correct notes
@@ -71,7 +71,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const user = (await context.lists.User.updateOne({
               id: bob.id,
               data: { notes: { connect: [{ id: noteB.id }] } },
-              query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
+              query: 'id notes(orderBy: [{ title: asc }]) { id title }',
             })) as T;
 
             expect(user).toEqual({ id: bob.id, notes: expect.any(Array) });
@@ -100,7 +100,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 query {
                   User(where: { id: "${alice.id}"}) {
                     id
-                    notes(orderBy: [{ title: "asc" }]) { id title }
+                    notes(orderBy: [{ title: asc }]) { id title }
                   }
                 }`,
             })) as T;

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -51,12 +51,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           type T = { id: IdType; notes: { id: IdType; title: string }[] };
           const alice = (await context.lists.User.createOne({
             data: { username: 'Alice', notes: { connect: [{ id: noteA.id }, { id: noteB.id }] } },
-            query: 'id notes(sortBy: [title_ASC]) { id title }',
+            query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
           })) as T;
 
           const bob = (await context.lists.User.createOne({
             data: { username: 'Bob', notes: { connect: [{ id: noteC.id }, { id: noteD.id }] } },
-            query: 'id notes(sortBy: [title_ASC]) { id title }',
+            query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
           })) as T;
 
           // Make sure everyone has the correct notes
@@ -71,7 +71,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const user = (await context.lists.User.updateOne({
               id: bob.id,
               data: { notes: { connect: [{ id: noteB.id }] } },
-              query: 'id notes(sortBy: [title_ASC]) { id title }',
+              query: 'id notes(orderBy: [{ title: "asc" }]) { id title }',
             })) as T;
 
             expect(user).toEqual({ id: bob.id, notes: expect.any(Array) });
@@ -100,7 +100,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 query {
                   User(where: { id: "${alice.id}"}) {
                     id
-                    notes(sortBy: title_ASC) { id title }
+                    notes(orderBy: [{ title: "asc" }]) { id title }
                   }
                 }`,
             })) as T;

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -188,7 +188,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     }
                   ) {
                     id
-                    teachers(sortBy: id_ASC) {
+                    teachers(orderBy: [{ id: "asc" }]) {
                       id
                     }
                   }

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -188,7 +188,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                     }
                   ) {
                     id
-                    teachers(orderBy: [{ id: "asc" }]) {
+                    teachers(orderBy: [{ id: asc }]) {
                       id
                     }
                   }


### PR DESCRIPTION
Replaces `sortBy` with `orderBy` in tests, etc. Brings tests closer to working with the new API.