### PR TITLE
Allow pass custom app url via APP_URL and support for .env file in basic example

### DIFF
--- a/.changeset/yellow-plants-lie.md
+++ b/.changeset/yellow-plants-lie.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/app-basic': minor
+'@keystone-next/keystone': minor
+---
+
+Custom app url via APP_URL and .env file for basic example

--- a/.gitignore
+++ b/.gitignore
@@ -121,9 +121,5 @@ temp/
 
 .api-test-prisma-clients
 
-# Example files
-/examples/*/schema.graphql
-/examples/*/schema.prisma
-
 # SQLite databases
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,9 @@ temp/
 
 .api-test-prisma-clients
 
+# Example files
+/examples/*/schema.graphql
+/examples/*/schema.prisma
+
 # SQLite databases
 *.db

--- a/examples/basic/keystone.ts
+++ b/examples/basic/keystone.ts
@@ -1,4 +1,5 @@
 import { config } from '@keystone-next/keystone/schema';
+import 'dotenv/config';
 import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 
@@ -24,10 +25,15 @@ const auth = createAuth({
 
 export default auth.withAuth(
   config({
-    db: {
-      provider: 'sqlite',
-      url: process.env.DATABASE_URL || 'file:./keystone-example.db',
-    },
+    db: process.env.DATABASE_URL?.startsWith('postgres')
+      ? {
+          provider: 'postgresql',
+          url: process.env.DATABASE_URL,
+        }
+      : {
+          provider: 'sqlite',
+          url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+        },
     // NOTE -- this is not implemented, keystone currently always provides a graphql api at /api/graphql
     // graphql: {
     //   path: '/api/graphql',

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -25,6 +25,7 @@
     "@preconstruct/next": "^3.0.0",
     "@types/react": "^17.0.4",
     "apollo-server-micro": "^2.24.0",
+    "dotenv": "^9.0.2",
     "graphql": "^15.5.0",
     "graphql-tag": "^2.12.4",
     "next": "^10.2.0",

--- a/examples/basic/sample.env
+++ b/examples/basic/sample.env
@@ -1,0 +1,3 @@
+DATABASE_URL=postgresql://user:pass@localhost/keystone
+PORT=1337
+APP_URL=https://example.com/

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -95,7 +95,8 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   });
   const server = app.listen(port, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Dev Server Ready on http://localhost:${port}`);
+    const appUrl = process.env.APP_URL || `http://localhost:${port}`;
+    console.log(`⭐️ Dev Server Ready on ${appUrl}`);
     // Don't start initialising Keystone until the dev server is ready,
     // otherwise it slows down the first response significantly
     initKeystone()

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -39,6 +39,7 @@ export const start = async (cwd: string) => {
   const port = config.server?.port || process.env.PORT || 3000;
   server.listen(port, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Server Ready on http://localhost:${port}`);
+    const appUrl = process.env.APP_URL || `http://localhost:${port}`;
+    console.log(`⭐️ Server Ready on ${appUrl}`);
   });
 };


### PR DESCRIPTION
This PR adds ability to set custom app url from APP_URL environment variable, to output right url when Keystone works behind the reverse proxy (eg `https://myapp.org/api` redirects to `http://localhost:1337`) - this is very common usage.

This feature was already added via https://github.com/keystonejs/keystone/pull/4738 but seems somehow disappears now.

Also I added support for `.env` file into `examples/basic` with example how to use `APP_URL` env value, together with allowing pass database type (postgresql) via DATABASE_URL and adding generated `schema.graphql`, `schema.prisma` files to gitignore for not add them into git.