### PR TITLE
Investigate graphql-tools/utils issue

### DIFF
--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -26,6 +26,7 @@
     "@babel/runtime": "^7.14.0",
     "@graphql-tools/merge": "^6.2.14",
     "@graphql-tools/schema": "^7.1.5",
+    "@graphql-tools/utils": "7.9.0",
     "@hapi/iron": "^6.0.0",
     "@keystone-next/access-control-legacy": "^10.0.1",
     "@keystone-next/adapter-prisma-legacy": "^6.1.0",

--- a/packages-next/keystone/package.json
+++ b/packages-next/keystone/package.json
@@ -26,7 +26,6 @@
     "@babel/runtime": "^7.14.0",
     "@graphql-tools/merge": "^6.2.14",
     "@graphql-tools/schema": "^7.1.5",
-    "@graphql-tools/utils": "7.9.0",
     "@hapi/iron": "^6.0.0",
     "@keystone-next/access-control-legacy": "^10.0.1",
     "@keystone-next/adapter-prisma-legacy": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1483,9 +1483,9 @@
     value-or-promise "1.0.6"
 
 "@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0":
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.8.1.tgz#caa9f0f1b3c7ef12f48dc66215ef5413f288e131"
-  integrity sha512-LDbOweemjxPYgJuHXK5XZJgObsBkiD92ul98lcuZxgA49IzQazHho5Y1Hs3MluD93YtZpxsQg/f7gNPnAyR6yw==
+  version "7.9.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.9.1.tgz#265e12a0b8a396be97f459599f2f1150fceee4b1"
+  integrity sha512-k4bQWsOnSJSW7suBnVUJf3Sc8uXuvIYLHXujbEoSrwOEHjC+707GvXbQ7rg+8l7v8NMgpyARyuKFlqz3cfoxBQ==
   dependencies:
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,10 +1482,10 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
-"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.9.0.tgz#e0419657c76f249a6fea9c4c1ea3091fe08be6b1"
-  integrity sha512-WaYfdKmYFw7Rw5BmFehwo5zqoHNlO1soKVSdrh4qN0X1U34g4aqESAMYogtlp2yWDb2b3qKShiByCvRWNypbVA==
+"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0":
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.10.0.tgz#07a4cb5d1bec1ff1dc1d47a935919ee6abd38699"
+  integrity sha512-d334r6bo9mxdSqZW6zWboEnnOOFRrAPVQJ7LkU8/6grglrbcu6WhwCLzHb90E94JI3TD3ricC3YGbUqIi9Xg0w==
   dependencies:
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,10 +1482,10 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
-"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0":
-  version "7.9.1"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.9.1.tgz#265e12a0b8a396be97f459599f2f1150fceee4b1"
-  integrity sha512-k4bQWsOnSJSW7suBnVUJf3Sc8uXuvIYLHXujbEoSrwOEHjC+707GvXbQ7rg+8l7v8NMgpyARyuKFlqz3cfoxBQ==
+"@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.7.0", "@graphql-tools/utils@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.9.0.tgz#e0419657c76f249a6fea9c4c1ea3091fe08be6b1"
+  integrity sha512-WaYfdKmYFw7Rw5BmFehwo5zqoHNlO1soKVSdrh4qN0X1U34g4aqESAMYogtlp2yWDb2b3qKShiByCvRWNypbVA==
   dependencies:
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.2"


### PR DESCRIPTION
Updating the `yarn.lock` file to the latest version of `graphql-tools/utils` (https://github.com/ardatan/graphql-tools/releases/tag/%40graphql-tools%2Futils%407.9.1) causes test failures.

This PR is setup to run this update on CI and to investigate what might be going on there.

Update: All tests pass on 7.9.0, so the issue is with 7.9.1 itself.

Update: Upstream PR here: https://github.com/ardatan/graphql-tools/pull/2956

Update: Upstream PR has been shipped as `7.10.0`: https://github.com/ardatan/graphql-tools/issues/2955