### PR TITLE
Remove BaseKeystone from test-utils APIs

### DIFF
--- a/.changeset/famous-needles-brake.md
+++ b/.changeset/famous-needles-brake.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/test-utils-legacy': major
+---
+
+The `Setup` type, returned by `setupFromConfig` and passed into test functions in `multiAdapterRunners` now has `connect` and `disconnect` functions, rather than a `keystone` object.

--- a/tests/api-tests/access-control/authed.test.ts
+++ b/tests/api-tests/access-control/authed.test.ts
@@ -45,13 +45,13 @@ const expectNamedArray = <T extends { id: IdType }, N extends string>(
 
 multiAdapterRunners().map(({ before, after, provider }) =>
   describe(`Provider: ${provider}`, () => {
-    let keystone: any,
+    let disconnect: any,
       items: Record<string, { id: IdType; name: string }[]>,
       user: { id: IdType; name: string; yesRead: string; noRead: string },
       context: KeystoneContext;
     beforeAll(async () => {
       const _before = await before(setupKeystone);
-      keystone = _before.keystone;
+      disconnect = _before.disconnect;
       context = _before.context;
 
       // ensure every list has at least some data
@@ -78,7 +78,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
       })) as { id: IdType; name: string; yesRead: string; noRead: string };
     });
     afterAll(async () => {
-      await after(keystone);
+      await after(disconnect);
     });
 
     describe('create', () => {

--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -30,12 +30,12 @@ type IdType = any;
 
 multiAdapterRunners().map(({ before, after, provider }) =>
   describe(`Provider: ${provider}`, () => {
-    let keystone: any,
+    let disconnect: any,
       items: Record<string, { id: IdType; name: string }[]>,
       context: KeystoneContext;
     beforeAll(async () => {
       const _before = await before(setupKeystone);
-      keystone = _before.keystone;
+      disconnect = _before.disconnect;
       context = _before.context;
 
       // ensure every list has at least some data
@@ -58,7 +58,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
       }
     });
     afterAll(async () => {
-      await after(keystone);
+      await after(disconnect);
     });
 
     describe('create', () => {

--- a/tests/api-tests/access-control/schema.test.ts
+++ b/tests/api-tests/access-control/schema.test.ts
@@ -45,7 +45,7 @@ const imperativeList = getImperativeListName({
 
 multiAdapterRunners().map(({ before, after, provider }) =>
   describe(`Provider: ${provider}`, () => {
-    let keystone: any,
+    let disconnect: any,
       queries: string[],
       mutations: string[],
       types: string[],
@@ -56,7 +56,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
       context: KeystoneContext;
     beforeAll(async () => {
       const _before = await before(setupKeystone);
-      keystone = _before.keystone;
+      disconnect = _before.disconnect;
       context = _before.context;
 
       const data = await context.exitSudo().graphql.run({ query: introspectionQuery });
@@ -81,7 +81,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
       );
     });
     afterAll(async () => {
-      await after(keystone);
+      await after(disconnect);
     });
 
     describe('static', () => {

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -2,7 +2,6 @@ import globby from 'globby';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
-import { BaseKeystone } from '@keystone-next/types';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
@@ -170,7 +169,7 @@ multiAdapterRunners().map(({ runner, provider, after }) =>
                 expect(error.message).toMatch('isUnique is not a supported option for field type');
                 erroredOut = true;
               } finally {
-                after({ disconnect: async () => {} } as BaseKeystone);
+                after(async () => {});
               }
               expect(erroredOut).toEqual(true);
             });

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import globby from 'globby';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import { BaseKeystone } from '@keystone-next/types';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
@@ -40,7 +39,7 @@ multiAdapterRunners().map(({ provider, after }) => {
                 await mod.afterAll();
               }
               // We expect setup to fail, so disconnect can be a noop
-              await after({ disconnect: async () => {} } as BaseKeystone);
+              await after(async () => {});
             });
 
             test('Throws', async () => {


### PR DESCRIPTION
This removes the `BaseKeystone` type from the public APIs for test-utils, which is required as part of #5665.