### PR TITLE
Add connect and disconnect to createSystem

### DIFF
--- a/.changeset/eleven-fireants-drum.md
+++ b/.changeset/eleven-fireants-drum.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/admin-ui': major
+'@keystone-next/keystone': major
+'@keystone-next/test-utils-legacy': major
+---
+
+Added `connect` and `disconnect` functions to the object returned by `createSystem`.

--- a/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/next-graphql.ts
+++ b/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/next-graphql.ts
@@ -5,7 +5,7 @@ import { createApolloServerMicro } from '../lib/server/createApolloServer';
 
 export function nextGraphQLAPIRoute(keystoneConfig: KeystoneConfig, prismaClient: any) {
   const initializedKeystoneConfig = initConfig(keystoneConfig);
-  const { graphQLSchema, keystone, createContext } = createSystem(
+  const { graphQLSchema, connect, createContext } = createSystem(
     initializedKeystoneConfig,
     prismaClient
   );
@@ -15,7 +15,7 @@ export function nextGraphQLAPIRoute(keystoneConfig: KeystoneConfig, prismaClient
     createContext,
     sessionStrategy: initializedKeystoneConfig.session,
     apolloConfig: initializedKeystoneConfig.graphql?.apolloConfig,
-    connectionPromise: keystone.connect(),
+    connectionPromise: connect(),
   });
 
   return apolloServer.createHandler({ path: '/api/graphql' });

--- a/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
+++ b/packages-next/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
@@ -3,7 +3,7 @@ import { createSystem } from '../lib/createSystem';
 import { initConfig } from '../lib/config/initConfig';
 
 export function createListsAPI(config: KeystoneConfig, prismaClient: any) {
-  const { createContext, keystone } = createSystem(initConfig(config), prismaClient);
-  keystone.connect();
+  const { createContext, connect } = createSystem(initConfig(config), prismaClient);
+  connect();
   return createContext().sudo().lists;
 }

--- a/packages-next/keystone/src/admin-ui/templates/api.ts
+++ b/packages-next/keystone/src/admin-ui/templates/api.ts
@@ -4,13 +4,13 @@ import { initConfig, createSystem, createApolloServerMicro } from '@keystone-nex
 import { PrismaClient } from '.prisma/client';
 
 const initializedKeystoneConfig = initConfig(keystoneConfig);
-const { graphQLSchema, keystone, createContext } = createSystem(initializedKeystoneConfig, 'none', PrismaClient);
+const { graphQLSchema, connect, createContext } = createSystem(initializedKeystoneConfig, 'none', PrismaClient);
 const apolloServer = createApolloServerMicro({
   graphQLSchema,
   createContext,
   sessionStrategy: initializedKeystoneConfig.session ? initializedKeystoneConfig.session() : undefined,
   apolloConfig: initializedKeystoneConfig.graphql?.apolloConfig,
-  connectionPromise: keystone.connect(),
+  connectionPromise: connect(),
 });
 
 export const config = {

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -49,5 +49,11 @@ export function createSystem(config: KeystoneConfig, prismaClient?: any) {
     gqlNamesByList,
   });
 
-  return { keystone, graphQLSchema, createContext };
+  return {
+    connect: () => keystone.connect({ context: createContext().sudo() }),
+    disconnect: () => keystone.disconnect(),
+    keystone,
+    graphQLSchema,
+    createContext,
+  };
 }

--- a/packages-next/keystone/src/scripts/run/dev.ts
+++ b/packages-next/keystone/src/scripts/run/dev.ts
@@ -56,11 +56,11 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
     }
     const prismaClient = requirePrismaClient(cwd);
 
-    const { keystone, graphQLSchema, createContext } = createSystem(config, prismaClient);
-
+    const system = createSystem(config, prismaClient);
+    const { connect, keystone, graphQLSchema, createContext } = system;
     console.log('✨ Connecting to the database');
-    await keystone.connect({ context: createContext().sudo() });
-    disconnect = () => keystone.disconnect();
+    await connect();
+    disconnect = system.disconnect;
     if (config.ui?.isDisabled) {
       console.log('✨ Skipping Admin UI code generation');
     } else {

--- a/packages-next/keystone/src/scripts/run/start.ts
+++ b/packages-next/keystone/src/scripts/run/start.ts
@@ -17,10 +17,10 @@ export const start = async (cwd: string) => {
     throw new ExitError(1);
   }
   const config = initConfig(require(apiFile).config);
-  const { keystone, graphQLSchema, createContext } = createSystem(config, requirePrismaClient(cwd));
+  const { connect, graphQLSchema, createContext } = createSystem(config, requirePrismaClient(cwd));
 
   console.log('✨ Connecting to the database');
-  await keystone.connect({ context: createContext().sudo() });
+  await connect();
 
   console.log('✨ Creating server');
   const server = await createExpressServer(

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -70,16 +70,11 @@ async function setupFromConfig({
     return requirePrismaClient(cwd);
   })();
 
-  const { keystone, createContext, graphQLSchema } = createSystem(config, prismaClient);
+  const { connect, disconnect, createContext, graphQLSchema } = createSystem(config, prismaClient);
 
   const app = await createExpressServer(config, graphQLSchema, createContext, true, '', false);
 
-  return {
-    connect: () => keystone.connect(),
-    disconnect: () => keystone.disconnect(),
-    context: createContext().sudo(),
-    app,
-  };
+  return { connect, disconnect, context: createContext().sudo(), app };
 }
 
 function networkedGraphqlRequest({


### PR DESCRIPTION
The `keystone` property will be removed in #5665, so this provides updated APIs which can be used by scripts and tests so they no longer need to use the keystone object directly.