### PR TITLE
Allow null relationship on create

### DIFF
--- a/packages-next/keystone/src/lib/core/nested-mutation-input-resolvers.ts
+++ b/packages-next/keystone/src/lib/core/nested-mutation-input-resolvers.ts
@@ -74,11 +74,8 @@ export function resolveRelateToOneForCreateInput(inputResolvers: CreateAndUpdate
       tsgql.Arg<tsgql.NonNullType<TypesForList['relateTo']['one']['create']>>
     >
   ) => {
-    if (value === undefined) {
+    if (value === undefined || value === null) {
       return undefined;
-    }
-    if (value === null) {
-      throw new Error(`A relate to one for create input cannot be set to null`);
     }
     const numOfKeys = Object.keys(value).length;
     if (numOfKeys !== 1) {


### PR DESCRIPTION
Our GraphQL types allow a `one` relationship to be explicitly set to `null` on create, but the code then throws an error. I think the GraphQL types are correct and the following should be valid. 

```
            const company = await context.lists.Company.createOne({
              data: { location: null },
              query: 'id location { id }',
            });
```

This PR removes the error case to make it so. Let me know if you have other thoughts 👍 