### PR TITLE
Fix sorting by multiple values

### DIFF
--- a/.changeset/curly-jobs-tie.md
+++ b/.changeset/curly-jobs-tie.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/adapter-prisma-legacy': patch
+---
+
+Fixed failures in GraphQL queries using multiple `sortBy` values.

--- a/packages/adapter-prisma/src/adapter-prisma.ts
+++ b/packages/adapter-prisma/src/adapter-prisma.ts
@@ -503,15 +503,15 @@ class PrismaListAdapter {
         // SELECT ... ORDER BY <orderField>
         const [orderField, orderDirection] = orderBy.split('_');
         const sortKey = this.fieldAdaptersByPath[orderField].sortKey || orderField;
-        ret.orderBy = { [sortKey]: orderDirection.toLowerCase() };
+        ret.orderBy = [{ [sortKey]: orderDirection.toLowerCase() }];
       }
       if (sortBy !== undefined) {
         // SELECT ... ORDER BY <orderField>[, <orderField>, ...]
-        if (!ret.orderBy) ret.orderBy = {};
+        if (!ret.orderBy) ret.orderBy = [];
         sortBy.forEach(s => {
           const [orderField, orderDirection] = s.split('_');
           const sortKey = this.fieldAdaptersByPath[orderField].sortKey || orderField;
-          ret.orderBy![sortKey] = orderDirection.toLowerCase();
+          ret.orderBy!.push({ [sortKey]: orderDirection.toLowerCase() });
         });
       }
 

--- a/tests/api-tests/queries/sortBy.test.ts
+++ b/tests/api-tests/queries/sortBy.test.ts
@@ -1,0 +1,253 @@
+import { integer } from '@keystone-next/fields';
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import {
+  ProviderName,
+  multiAdapterRunners,
+  setupFromConfig,
+  testConfig,
+} from '@keystone-next/test-utils-legacy';
+import { KeystoneContext } from '@keystone-next/types';
+
+function setupKeystone(provider: ProviderName) {
+  return setupFromConfig({
+    provider,
+    config: testConfig({
+      lists: createSchema({
+        User: list({
+          fields: {
+            a: integer(),
+            b: integer(),
+          },
+        }),
+      }),
+    }),
+  });
+}
+
+const initialiseData = async ({ context }: { context: KeystoneContext }) => {
+  // Use shuffled data to ensure that sorting is actually happening.
+  await context.lists.User.createMany({
+    data: [
+      { data: { a: 1, b: 10 } },
+      { data: { a: 1, b: 30 } },
+      { data: { a: 1, b: 20 } },
+      { data: { a: 3, b: 30 } },
+      { data: { a: 3, b: 10 } },
+      { data: { a: 3, b: 20 } },
+      { data: { a: 2, b: 30 } },
+      { data: { a: 2, b: 20 } },
+      { data: { a: 2, b: 10 } },
+    ],
+  });
+};
+
+multiAdapterRunners().map(({ runner, provider }) =>
+  describe(`Provider: ${provider}`, () => {
+    describe('Sorting by a single field', () => {
+      test(
+        'Single ascending filter - a',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ sortBy: ['a_ASC'], query: 'a' });
+          expect(users.map(({ a }) => a)).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+        })
+      );
+      test(
+        'Single descending filter - a',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ sortBy: ['a_DESC'], query: 'a' });
+          expect(users.map(({ a }) => a)).toEqual([3, 3, 3, 2, 2, 2, 1, 1, 1]);
+        })
+      );
+      test(
+        'Single ascending filter - b',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ sortBy: ['b_ASC'], query: 'b' });
+          expect(users.map(({ b }) => b)).toEqual([10, 10, 10, 20, 20, 20, 30, 30, 30]);
+        })
+      );
+      test(
+        'Single descending filter - b',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ sortBy: ['b_DESC'], query: 'b' });
+          expect(users.map(({ b }) => b)).toEqual([30, 30, 30, 20, 20, 20, 10, 10, 10]);
+        })
+      );
+
+      test(
+        'Multi ascending/ascending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['a_ASC', 'b_ASC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 10],
+            [1, 20],
+            [1, 30],
+            [2, 10],
+            [2, 20],
+            [2, 30],
+            [3, 10],
+            [3, 20],
+            [3, 30],
+          ]);
+        })
+      );
+      test(
+        'Multi ascending/ascending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['b_ASC', 'a_ASC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 10],
+            [2, 10],
+            [3, 10],
+            [1, 20],
+            [2, 20],
+            [3, 20],
+            [1, 30],
+            [2, 30],
+            [3, 30],
+          ]);
+        })
+      );
+
+      test(
+        'Multi ascending/descending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['a_ASC', 'b_DESC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 30],
+            [1, 20],
+            [1, 10],
+            [2, 30],
+            [2, 20],
+            [2, 10],
+            [3, 30],
+            [3, 20],
+            [3, 10],
+          ]);
+        })
+      );
+      test(
+        'Multi ascending/descending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['b_ASC', 'a_DESC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 10],
+            [2, 10],
+            [1, 10],
+            [3, 20],
+            [2, 20],
+            [1, 20],
+            [3, 30],
+            [2, 30],
+            [1, 30],
+          ]);
+        })
+      );
+
+      test(
+        'Multi descending/ascending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['a_DESC', 'b_ASC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 10],
+            [3, 20],
+            [3, 30],
+            [2, 10],
+            [2, 20],
+            [2, 30],
+            [1, 10],
+            [1, 20],
+            [1, 30],
+          ]);
+        })
+      );
+      test(
+        'Multi descending/ascending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['b_DESC', 'a_ASC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 30],
+            [2, 30],
+            [3, 30],
+            [1, 20],
+            [2, 20],
+            [3, 20],
+            [1, 10],
+            [2, 10],
+            [3, 10],
+          ]);
+        })
+      );
+
+      test(
+        'Multi descending/descending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['a_DESC', 'b_DESC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 30],
+            [3, 20],
+            [3, 10],
+            [2, 30],
+            [2, 20],
+            [2, 10],
+            [1, 30],
+            [1, 20],
+            [1, 10],
+          ]);
+        })
+      );
+      test(
+        'Multi descending/descending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            sortBy: ['b_DESC', 'a_DESC'],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 30],
+            [2, 30],
+            [1, 30],
+            [3, 20],
+            [2, 20],
+            [1, 20],
+            [3, 10],
+            [2, 10],
+            [1, 10],
+          ]);
+        })
+      );
+    });
+  })
+);


### PR DESCRIPTION
Prisma no longer (if it ever? 🤔 ) accepts an object with multiple values for sorting. I've added tests to exercise this feature and to avoid any future regressions.