### PR TITLE
Add SKIP_PROMPTS to shouldPrompt in CLI commands

### DIFF
--- a/.changeset/wet-jeans-report.md
+++ b/.changeset/wet-jeans-report.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': minor
+---
+
+Added a `SKIP_PROMPTS` environment variable to explicitly disable prompts in the CLI.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -292,3 +292,5 @@ jobs:
         run: yarn build
       - name: Remark
         run: yarn lint:markdown
+      - name: Example schemas
+        run: yarn lint:examples

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "contributing-guide": "is-ci && exit 0 || chalk -t \"{bold 📝 Contributing to KeystoneJS?}\" && terminal-link \"🔗 Read the full Contributing Guide\" \"https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md\"",
     "npm-tag": "manypkg npm-tag",
     "update": "manypkg upgrade",
-    "no-cypress-install": "cross-env CYPRESS_INSTALL_BINARY=0 yarn"
+    "no-cypress-install": "cross-env CYPRESS_INSTALL_BINARY=0 yarn",
+    "postinstall-examples": "for d in `find examples -type d -maxdepth 1 -mindepth 1`; do cd $d; yarn keystone-next postinstall --fix; cd ../..; done",
+    "lint:examples": "for d in `find examples -type d -maxdepth 1 -mindepth 1`; do cd $d; echo $d; SKIP_PROMPTS=1 yarn keystone-next postinstall; if [ $? -ne 0 ]; then exit 1; fi; cd ../..; done"
   },
   "dependencies": {
     "@babel/core": "^7.14.3",

--- a/packages-next/keystone/src/lib/prompts.ts
+++ b/packages-next/keystone/src/lib/prompts.ts
@@ -28,7 +28,7 @@ async function textPromptImpl(message: string): Promise<string> {
   return value;
 }
 
-export let shouldPrompt = process.stdout.isTTY;
+export let shouldPrompt = process.stdout.isTTY && !process.env.SKIP_PROMPTS;
 
 export let confirmPrompt = confirmPromptImpl;
 export let textPrompt = textPromptImpl;


### PR DESCRIPTION
This PR adds a few things:

1. Adds a `SKIP_PROMPTS` env var check to `postinstall`, which ensures it won't  ever prompt, it will just exit with `1` on failure.
2. Adds a `lint:examples` script which uses `SKIP_PROMPTS=1 postinstall` to make sure our example schemas are up to date. This will prevent PRs getting through with out of date schemas.
3. Adds a `postinstall-examples` script which applies `postinstall --fix` to all the example projects for an easy fix, particularly when changing our GraphQL or prisma schema output.