### PR TITLE
Suppress console output when running tests

### DIFF
--- a/.changeset/sour-buckets-pump.md
+++ b/.changeset/sour-buckets-pump.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Suppresed migration console output when running tests.

--- a/packages-next/keystone/src/lib/migrations.ts
+++ b/packages-next/keystone/src/lib/migrations.ts
@@ -290,11 +290,13 @@ async function ensureDatabaseExists(dbUrl: string, schemaDir: string) {
   const created = await createDatabase(dbUrl, schemaDir);
   if (created) {
     const credentials = uriToCredentials(dbUrl);
-    console.log(
-      `✨ ${credentials.type} database "${credentials.database}" created at ${getDbLocation(
-        credentials
-      )}`
-    );
+    if (!process.env.TEST_ADAPTER) {
+      console.log(
+        `✨ ${credentials.type} database "${credentials.database}" created at ${getDbLocation(
+          credentials
+        )}`
+      );
+    }
   }
   // TODO: handle createDatabase returning a failure (prisma's cli does not handle it though so not super worried)
 }


### PR DESCRIPTION
This change stop this message from being printed for every test file run. This is consistent with other similar guards in the migration file.