### PR TITLE
Add 'as' to FieldContainer

### DIFF
--- a/.changeset/small-students-run.md
+++ b/.changeset/small-students-run.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/fields': minor
+---
+
+Added as prop to FieldContainer component.

--- a/design-system/packages/fields/src/FieldContainer.tsx
+++ b/design-system/packages/fields/src/FieldContainer.tsx
@@ -1,13 +1,19 @@
 /* @jsx jsx */
 
 import { ReactNode } from 'react';
-import { jsx } from '@keystone-ui/core';
+import { jsx, forwardRefWithAs } from '@keystone-ui/core';
 
 type FieldContainerProps = {
   children: ReactNode;
   className?: string;
 };
 
-export const FieldContainer = ({ children, ...props }: FieldContainerProps) => {
-  return <div {...props}>{children}</div>;
-};
+export const FieldContainer = forwardRefWithAs<'div', FieldContainerProps>(
+  ({ as: Tag = 'div', children, ...props }, ref) => {
+    return (
+      <Tag ref={ref} {...props}>
+        {children}
+      </Tag>
+    );
+  }
+);

--- a/design-system/packages/fields/src/FieldContainer.tsx
+++ b/design-system/packages/fields/src/FieldContainer.tsx
@@ -5,7 +5,6 @@ import { jsx, forwardRefWithAs } from '@keystone-ui/core';
 
 type FieldContainerProps = {
   children: ReactNode;
-  className?: string;
 };
 
 export const FieldContainer = forwardRefWithAs<'div', FieldContainerProps>(

--- a/design-system/packages/fields/src/FieldContainer.tsx
+++ b/design-system/packages/fields/src/FieldContainer.tsx
@@ -1,18 +1,6 @@
 /* @jsx jsx */
-
-import { ReactNode } from 'react';
 import { jsx, forwardRefWithAs } from '@keystone-ui/core';
 
-type FieldContainerProps = {
-  children: ReactNode;
-};
-
-export const FieldContainer = forwardRefWithAs<'div', FieldContainerProps>(
-  ({ as: Tag = 'div', children, ...props }, ref) => {
-    return (
-      <Tag ref={ref} {...props}>
-        {children}
-      </Tag>
-    );
-  }
-);
+export const FieldContainer = forwardRefWithAs<'div', {}>(({ as: Tag = 'div', ...props }, ref) => {
+  return <Tag ref={ref} {...props} />;
+});


### PR DESCRIPTION
Currently there are quite a few places where we use `legend` elements to denote field-groups. 
None of these are working because the FieldContainer parent is a div, not a `fieldset`. 

This is a minor patch to our ds component, in preparation for incoming a11y fixes in fields. 