### PR TITLE
Fix/signin page a11y

### DIFF
--- a/.changeset/funny-spies-exist.md
+++ b/.changeset/funny-spies-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Added visually hidden labels to signin / welcome fields for better screen reader experience.

--- a/packages-next/auth/src/pages/InitPage.tsx
+++ b/packages-next/auth/src/pages/InitPage.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import fetch from 'cross-fetch';
 
-import { jsx, H1, Stack, Inline } from '@keystone-ui/core';
+import { jsx, H1, Stack, Inline, VisuallyHidden } from '@keystone-ui/core';
 import { Button } from '@keystone-ui/button';
 import { Checkbox, TextInput } from '@keystone-ui/fields';
 import { useRawKeystone } from '@keystone-next/keystone/admin-ui/context';
@@ -122,9 +122,14 @@ const Welcome = ({ value }: { value: any }) => {
         </Checkbox>
       </div>
       <form onSubmit={onSubmit}>
+        <VisuallyHidden as="label" htmlFor="email-field">
+          Email
+        </VisuallyHidden>
         <TextInput
+          id="email-field"
           disabled={!subscribe}
           autoFocus
+          placeholder={'Email'}
           value={email}
           onChange={e => setEmail(e.target.value)}
         />

--- a/packages-next/auth/src/pages/InitPage.tsx
+++ b/packages-next/auth/src/pages/InitPage.tsx
@@ -123,7 +123,7 @@ const Welcome = ({ value }: { value: any }) => {
       </div>
       <form onSubmit={onSubmit}>
         <VisuallyHidden as="label" htmlFor="email-field">
-          Email
+          Email Address
         </VisuallyHidden>
         <TextInput
           id="email-field"

--- a/packages-next/auth/src/pages/SigninPage.tsx
+++ b/packages-next/auth/src/pages/SigninPage.tsx
@@ -1,8 +1,8 @@
 /* @jsx jsx */
 
-import { useState, FormEvent, useRef, useEffect } from 'react';
+import { useState, Fragment, FormEvent, useRef, useEffect } from 'react';
 
-import { jsx, H1, Stack } from '@keystone-ui/core';
+import { jsx, H1, Stack, VisuallyHidden } from '@keystone-ui/core';
 import { Button } from '@keystone-ui/button';
 import { TextInput } from '@keystone-ui/fields';
 import { Notice } from '@keystone-ui/notice';
@@ -101,7 +101,11 @@ export const SigninPage = ({
           </Notice>
         )}
         <Stack gap="medium">
+          <VisuallyHidden as="label" htmlFor="identity">
+            Email Address
+          </VisuallyHidden>
           <TextInput
+            id="identity"
             name="identity"
             value={state.identity}
             onChange={e => setState({ ...state, identity: e.target.value })}
@@ -109,13 +113,19 @@ export const SigninPage = ({
             ref={identityFieldRef}
           />
           {mode === 'signin' && (
-            <TextInput
-              name="password"
-              value={state.secret}
-              onChange={e => setState({ ...state, secret: e.target.value })}
-              placeholder="password"
-              type="password"
-            />
+            <Fragment>
+              <VisuallyHidden as="label" htmlFor="password">
+                Password
+              </VisuallyHidden>
+              <TextInput
+                id="password"
+                name="password"
+                value={state.secret}
+                onChange={e => setState({ ...state, secret: e.target.value })}
+                placeholder="password"
+                type="password"
+              />
+            </Fragment>
           )}
         </Stack>
 

--- a/packages-next/auth/src/pages/SigninPage.tsx
+++ b/packages-next/auth/src/pages/SigninPage.tsx
@@ -102,27 +102,27 @@ export const SigninPage = ({
         )}
         <Stack gap="medium">
           <VisuallyHidden as="label" htmlFor="identity">
-            Email Address
+            {identityField}
           </VisuallyHidden>
           <TextInput
             id="identity"
             name="identity"
             value={state.identity}
             onChange={e => setState({ ...state, identity: e.target.value })}
-            placeholder="Email Address"
+            placeholder={identityField}
             ref={identityFieldRef}
           />
           {mode === 'signin' && (
             <Fragment>
               <VisuallyHidden as="label" htmlFor="password">
-                Password
+                {secretField}
               </VisuallyHidden>
               <TextInput
                 id="password"
                 name="password"
                 value={state.secret}
                 onChange={e => setState({ ...state, secret: e.target.value })}
-                placeholder="password"
+                placeholder={secretField}
                 type="password"
               />
             </Fragment>

--- a/tests/examples-smoke-tests/basic.test.ts
+++ b/tests/examples-smoke-tests/basic.test.ts
@@ -14,7 +14,7 @@ exampleProjectTests('basic', browserType => {
   test('sign out and sign in', async () => {
     await page.click('[aria-label="Links and signout"]');
     await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign out")')]);
-    await page.fill('[placeholder="Email Address"]', 'admin@keystonejs.com');
+    await page.fill('[placeholder="email"]', 'admin@keystonejs.com');
     await page.fill('[placeholder="password"]', 'password');
     await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign In")')]);
   });


### PR DESCRIPTION
Sign-in page and welcome page inputs don't have labels.
While its ok to rely on placeholders for `VoiceOver`, JAWS and NVDA don't read out placeholders as whole words 
(read letter by letter). 

This PR adds a visually hidden label to amend this.