### PR TITLE
Update the orderBy GraphQL API

### DIFF
--- a/.changeset/rude-dots-join.md
+++ b/.changeset/rude-dots-join.md
@@ -1,0 +1,48 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/adapter-prisma-legacy': major
+'@keystone-next/website': patch
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-blog': patch
+'@keystone-next/example-ecommerce': patch
+'keystone-next-app': patch
+'@keystone-next/example-next-lite': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/example-sandbox': patch
+'@keystone-next/example-todo': patch
+'@keystone-next/example-with-auth': patch
+'@keystone-next/types': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Deprecated the `sortBy` GraphQL filter. Updated the `orderBy` GraphQL filter with an improved API.
+
+Previously a `User` list's `allUsers` query would have the argument:
+
+```graphql
+orderBy: String
+```
+
+The new API gives it the argument:
+
+```graphql
+orderBy: [UserOrderByInput!]! = []
+```
+
+where
+
+```graphql
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  score: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+```
+
+Rather than writing `allusers(orderBy: "name_ASC")` you now write `allUsers(orderBy: { name: asc })`. You can also now order by multiple fields, e.g. `allUsers(orderBy: [{ score: asc }, { name: asc }])`. Each `UserOrderByInput` must have exactly one key, or else an error will be returned.

--- a/.changeset/rude-dots-join.md
+++ b/.changeset/rude-dots-join.md
@@ -45,4 +45,4 @@ enum OrderDirection {
 }
 ```
 
-Rather than writing `allusers(orderBy: "name_ASC")` you now write `allUsers(orderBy: { name: asc })`. You can also now order by multiple fields, e.g. `allUsers(orderBy: [{ score: asc }, { name: asc }])`. Each `UserOrderByInput` must have exactly one key, or else an error will be returned.
+Rather than writing `allUsers(orderBy: "name_ASC")` you now write `allUsers(orderBy: { name: asc })`. You can also now order by multiple fields, e.g. `allUsers(orderBy: [{ score: asc }, { name: asc }])`. Each `UserOrderByInput` must have exactly one key, or else an error will be returned.

--- a/docs/pages/apis/graphql.mdx
+++ b/docs/pages/apis/graphql.mdx
@@ -28,10 +28,10 @@ type Query {
   User(where: UserWhereUniqueInput!): User
 
   """ Search for all User items which match the where clause. """
-  allUsers(where: UserWhereInput, search: String, sortBy: [SortUsersBy!], orderBy: String, first: Int, skip: Int! = 0): [User]
+  allUsers(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): [User]
 
   """ Perform a meta-query on all User items which match the where clause. """
-  _allUsersMeta(where: UserWhereInput, search: String, sortBy: [SortUsersBy!], orderBy: String, first: Int, skip: Int! = 0): _QueryMeta
+  _allUsersMeta(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta
 }
 
 type Mutation {
@@ -95,11 +95,14 @@ input UserWhereUniqueInput {
   id: ID!
 }
 
-enum SortUsersBy {
-  id_ASC
-  id_DESC
-  name_ASC
-  name_DESC
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 input UserUpdateInput {
@@ -149,7 +152,7 @@ type User {
 ```graphql
 type Query {
   """ Search for all User items which match the where clause. """
-  allUsers(where: UserWhereInput, search: String, sortBy: [SortUsersBy!], orderBy: String, first: Int, skip: Int! = 0): [User]
+  allUsers(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): [User]
 }
 
 input UserWhereInput {
@@ -183,11 +186,14 @@ input UserWhereInput {
   name_not_in: [String]
 }
 
-enum SortUsersBy {
-  id_ASC
-  id_DESC
-  name_ASC
-  name_DESC
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 type User {
@@ -202,7 +208,7 @@ type User {
 ```graphql
 type Query {
   """ Perform a meta-query on all User items which match the where clause. """
-  _allUsersMeta(where: UserWhereInput, search: String, sortBy: [SortUsersBy!], orderBy: String, first: Int, skip: Int! = 0): _QueryMeta
+  _allUsersMeta(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta
 }
 
 input UserWhereInput {
@@ -236,11 +242,14 @@ input UserWhereInput {
   name_not_in: [String]
 }
 
-enum SortUsersBy {
-  id_ASC
-  id_DESC
-  name_ASC
-  name_DESC
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 type _QueryMeta {

--- a/examples/auth/schema.graphql
+++ b/examples/auth/schema.graphql
@@ -52,6 +52,18 @@ enum SortUsersBy {
   isAdmin_DESC
 }
 
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  isAdmin: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input UserUpdateInput {
   name: String
   email: String
@@ -170,7 +182,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User]
@@ -187,7 +200,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -79,7 +79,8 @@ type User {
     where: PhoneNumberWhereInput
     search: String
     sortBy: [SortPhoneNumbersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PhoneNumberOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [PhoneNumber!]!
@@ -87,7 +88,8 @@ type User {
     where: PhoneNumberWhereInput
     search: String
     sortBy: [SortPhoneNumbersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PhoneNumberOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -95,7 +97,8 @@ type User {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post!]!
@@ -103,7 +106,8 @@ type User {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -189,6 +193,19 @@ enum SortUsersBy {
   isAdmin_DESC
   roles_ASC
   roles_DESC
+}
+
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  isAdmin: OrderDirection
+  roles: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 input UserUpdateInput {
@@ -280,6 +297,12 @@ enum SortPhoneNumbersBy {
   value_DESC
 }
 
+input PhoneNumberOrderByInput {
+  id: OrderDirection
+  type: OrderDirection
+  value: OrderDirection
+}
+
 input PhoneNumberUpdateInput {
   user: UserRelateToOneInput
   type: String
@@ -363,6 +386,13 @@ enum SortPostsBy {
   status_DESC
   publishDate_ASC
   publishDate_DESC
+}
+
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
 }
 
 input PostUpdateInput {
@@ -551,7 +581,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User]
@@ -568,7 +599,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -580,7 +612,8 @@ type Query {
     where: PhoneNumberWhereInput
     search: String
     sortBy: [SortPhoneNumbersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PhoneNumberOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [PhoneNumber]
@@ -597,7 +630,8 @@ type Query {
     where: PhoneNumberWhereInput
     search: String
     sortBy: [SortPhoneNumbersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PhoneNumberOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -609,7 +643,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post]
@@ -626,7 +661,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/blog/schema.graphql
+++ b/examples/blog/schema.graphql
@@ -78,6 +78,19 @@ enum SortPostsBy {
   publishDate_DESC
 }
 
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  status: OrderDirection
+  content: OrderDirection
+  publishDate: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input PostUpdateInput {
   title: String
   status: PostStatusType
@@ -121,7 +134,8 @@ type Author {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post!]!
@@ -129,7 +143,8 @@ type Author {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -186,6 +201,12 @@ enum SortAuthorsBy {
   name_DESC
   email_ASC
   email_DESC
+}
+
+input AuthorOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
 }
 
 input AuthorUpdateInput {
@@ -296,7 +317,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post]
@@ -313,7 +335,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -325,7 +348,8 @@ type Query {
     where: AuthorWhereInput
     search: String
     sortBy: [SortAuthorsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Author]
@@ -342,7 +366,8 @@ type Query {
     where: AuthorWhereInput
     search: String
     sortBy: [SortAuthorsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/ecommerce/schema.graphql
+++ b/examples/ecommerce/schema.graphql
@@ -38,7 +38,8 @@ type User {
     where: CartItemWhereInput
     search: String
     sortBy: [SortCartItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [CartItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [CartItem!]!
@@ -46,7 +47,8 @@ type User {
     where: CartItemWhereInput
     search: String
     sortBy: [SortCartItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [CartItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -54,7 +56,8 @@ type User {
     where: OrderWhereInput
     search: String
     sortBy: [SortOrdersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Order!]!
@@ -62,7 +65,8 @@ type User {
     where: OrderWhereInput
     search: String
     sortBy: [SortOrdersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -71,7 +75,8 @@ type User {
     where: ProductWhereInput
     search: String
     sortBy: [SortProductsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Product!]!
@@ -79,7 +84,8 @@ type User {
     where: ProductWhereInput
     search: String
     sortBy: [SortProductsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -193,6 +199,19 @@ enum SortUsersBy {
   passwordResetIssuedAt_DESC
   passwordResetRedeemedAt_ASC
   passwordResetRedeemedAt_DESC
+}
+
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  passwordResetIssuedAt: OrderDirection
+  passwordResetRedeemedAt: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
 }
 
 input UserUpdateInput {
@@ -313,6 +332,14 @@ enum SortProductsBy {
   status_DESC
   price_ASC
   price_DESC
+}
+
+input ProductOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  description: OrderDirection
+  status: OrderDirection
+  price: OrderDirection
 }
 
 input ProductUpdateInput {
@@ -445,6 +472,11 @@ enum SortProductImagesBy {
   altText_DESC
 }
 
+input ProductImageOrderByInput {
+  id: OrderDirection
+  altText: OrderDirection
+}
+
 input ProductImageUpdateInput {
   image: Upload
   altText: String
@@ -510,6 +542,11 @@ enum SortCartItemsBy {
   id_DESC
   quantity_ASC
   quantity_DESC
+}
+
+input CartItemOrderByInput {
+  id: OrderDirection
+  quantity: OrderDirection
 }
 
 input CartItemUpdateInput {
@@ -615,6 +652,14 @@ enum SortOrderItemsBy {
   quantity_DESC
 }
 
+input OrderItemOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  description: OrderDirection
+  price: OrderDirection
+  quantity: OrderDirection
+}
+
 input OrderItemUpdateInput {
   name: String
   description: String
@@ -660,7 +705,8 @@ type Order {
     where: OrderItemWhereInput
     search: String
     sortBy: [SortOrderItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [OrderItem!]!
@@ -668,7 +714,8 @@ type Order {
     where: OrderItemWhereInput
     search: String
     sortBy: [SortOrderItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -733,6 +780,12 @@ enum SortOrdersBy {
   charge_DESC
 }
 
+input OrderOrderByInput {
+  id: OrderDirection
+  total: OrderDirection
+  charge: OrderDirection
+}
+
 input OrderUpdateInput {
   total: Int
   items: OrderItemRelateToManyInput
@@ -779,7 +832,8 @@ type Role {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User!]!
@@ -787,7 +841,8 @@ type Role {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -860,6 +915,17 @@ enum SortRolesBy {
   canManageCart_DESC
   canManageOrders_ASC
   canManageOrders_DESC
+}
+
+input RoleOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  canManageProducts: OrderDirection
+  canSeeOtherUsers: OrderDirection
+  canManageUsers: OrderDirection
+  canManageRoles: OrderDirection
+  canManageCart: OrderDirection
+  canManageOrders: OrderDirection
 }
 
 input RoleUpdateInput {
@@ -1206,7 +1272,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User]
@@ -1223,7 +1290,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1235,7 +1303,8 @@ type Query {
     where: ProductWhereInput
     search: String
     sortBy: [SortProductsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Product]
@@ -1252,7 +1321,8 @@ type Query {
     where: ProductWhereInput
     search: String
     sortBy: [SortProductsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1264,7 +1334,8 @@ type Query {
     where: ProductImageWhereInput
     search: String
     sortBy: [SortProductImagesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductImageOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [ProductImage]
@@ -1281,7 +1352,8 @@ type Query {
     where: ProductImageWhereInput
     search: String
     sortBy: [SortProductImagesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [ProductImageOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1293,7 +1365,8 @@ type Query {
     where: CartItemWhereInput
     search: String
     sortBy: [SortCartItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [CartItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [CartItem]
@@ -1310,7 +1383,8 @@ type Query {
     where: CartItemWhereInput
     search: String
     sortBy: [SortCartItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [CartItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1322,7 +1396,8 @@ type Query {
     where: OrderItemWhereInput
     search: String
     sortBy: [SortOrderItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [OrderItem]
@@ -1339,7 +1414,8 @@ type Query {
     where: OrderItemWhereInput
     search: String
     sortBy: [SortOrderItemsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderItemOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1351,7 +1427,8 @@ type Query {
     where: OrderWhereInput
     search: String
     sortBy: [SortOrdersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Order]
@@ -1368,7 +1445,8 @@ type Query {
     where: OrderWhereInput
     search: String
     sortBy: [SortOrdersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [OrderOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -1380,7 +1458,8 @@ type Query {
     where: RoleWhereInput
     search: String
     sortBy: [SortRolesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [RoleOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Role]
@@ -1397,7 +1476,8 @@ type Query {
     where: RoleWhereInput
     search: String
     sortBy: [SortRolesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [RoleOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/embedded-nextjs/schema.graphql
+++ b/examples/embedded-nextjs/schema.graphql
@@ -54,6 +54,18 @@ enum SortPostsBy {
   content_DESC
 }
 
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  slug: OrderDirection
+  content: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input PostUpdateInput {
   title: String
   slug: String
@@ -132,7 +144,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post]
@@ -149,7 +162,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/graphql-api-endpoint/schema.graphql
+++ b/examples/graphql-api-endpoint/schema.graphql
@@ -17,7 +17,8 @@ type User {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post!]!
@@ -25,7 +26,8 @@ type User {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -109,6 +111,17 @@ enum SortUsersBy {
   email_DESC
 }
 
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input UserUpdateInput {
   name: String
   email: String
@@ -164,7 +177,8 @@ type Post {
     where: TagWhereInput
     search: String
     sortBy: [SortTagsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TagOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Tag!]!
@@ -172,7 +186,8 @@ type Post {
     where: TagWhereInput
     search: String
     sortBy: [SortTagsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TagOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -253,6 +268,13 @@ enum SortPostsBy {
   publishDate_DESC
 }
 
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
+}
+
 input PostUpdateInput {
   title: String
   status: String
@@ -290,7 +312,8 @@ type Tag {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post!]!
@@ -298,7 +321,8 @@ type Tag {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -359,6 +383,11 @@ enum SortTagsBy {
   id_DESC
   name_ASC
   name_DESC
+}
+
+input TagOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
 }
 
 input TagUpdateInput {
@@ -535,7 +564,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User]
@@ -552,7 +582,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -564,7 +595,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Post]
@@ -581,7 +613,8 @@ type Query {
     where: PostWhereInput
     search: String
     sortBy: [SortPostsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -593,7 +626,8 @@ type Query {
     where: TagWhereInput
     search: String
     sortBy: [SortTagsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TagOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Tag]
@@ -610,7 +644,8 @@ type Query {
     where: TagWhereInput
     search: String
     sortBy: [SortTagsBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TagOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/roles/schema.graphql
+++ b/examples/roles/schema.graphql
@@ -56,6 +56,18 @@ enum SortTodosBy {
   isPrivate_DESC
 }
 
+input TodoOrderByInput {
+  id: OrderDirection
+  label: OrderDirection
+  isComplete: OrderDirection
+  isPrivate: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input TodoUpdateInput {
   label: String
   isComplete: Boolean
@@ -106,7 +118,8 @@ type Person {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo!]!
@@ -114,7 +127,8 @@ type Person {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -176,6 +190,12 @@ enum SortPeopleBy {
   email_DESC
 }
 
+input PersonOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+}
+
 input PersonUpdateInput {
   name: String
   email: String
@@ -224,7 +244,8 @@ type Role {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Person!]!
@@ -232,7 +253,8 @@ type Role {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -305,6 +327,17 @@ enum SortRolesBy {
   canManagePeople_DESC
   canManageRoles_ASC
   canManageRoles_DESC
+}
+
+input RoleOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  canCreateTodos: OrderDirection
+  canManageAllTodos: OrderDirection
+  canSeeOtherPeople: OrderDirection
+  canEditOtherPeople: OrderDirection
+  canManagePeople: OrderDirection
+  canManageRoles: OrderDirection
 }
 
 input RoleUpdateInput {
@@ -493,7 +526,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo]
@@ -510,7 +544,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -522,7 +557,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Person]
@@ -539,7 +575,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -551,7 +588,8 @@ type Query {
     where: RoleWhereInput
     search: String
     sortBy: [SortRolesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [RoleOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Role]
@@ -568,7 +606,8 @@ type Query {
     where: RoleWhereInput
     search: String
     sortBy: [SortRolesBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [RoleOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/sandbox/schema.graphql
+++ b/examples/sandbox/schema.graphql
@@ -84,6 +84,20 @@ enum SortTodosBy {
   updatedAt_DESC
 }
 
+input TodoOrderByInput {
+  id: OrderDirection
+  label: OrderDirection
+  isComplete: OrderDirection
+  finishBy: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input TodoUpdateInput {
   label: String
   isComplete: Boolean
@@ -126,7 +140,8 @@ type User {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo!]!
@@ -134,7 +149,8 @@ type User {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -214,6 +230,14 @@ enum SortUsersBy {
   createdAt_DESC
   updatedAt_ASC
   updatedAt_DESC
+}
+
+input UserOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+  createdAt: OrderDirection
+  updatedAt: OrderDirection
 }
 
 input UserUpdateInput {
@@ -326,7 +350,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo]
@@ -343,7 +368,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -355,7 +381,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [User]
@@ -372,7 +399,8 @@ type Query {
     where: UserWhereInput
     search: String
     sortBy: [SortUsersBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [UserOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/todo/schema.graphql
+++ b/examples/todo/schema.graphql
@@ -75,6 +75,19 @@ enum SortTasksBy {
   finishBy_DESC
 }
 
+input TaskOrderByInput {
+  id: OrderDirection
+  label: OrderDirection
+  priority: OrderDirection
+  isComplete: OrderDirection
+  finishBy: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input TaskUpdateInput {
   label: String
   priority: TaskPriorityType
@@ -117,7 +130,8 @@ type Person {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Task!]!
@@ -125,7 +139,8 @@ type Person {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -174,6 +189,11 @@ enum SortPeopleBy {
   id_DESC
   name_ASC
   name_DESC
+}
+
+input PersonOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
 }
 
 input PersonUpdateInput {
@@ -282,7 +302,8 @@ type Query {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Task]
@@ -299,7 +320,8 @@ type Query {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -311,7 +333,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Person]
@@ -328,7 +351,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/examples/with-auth/schema.graphql
+++ b/examples/with-auth/schema.graphql
@@ -75,6 +75,19 @@ enum SortTasksBy {
   finishBy_DESC
 }
 
+input TaskOrderByInput {
+  id: OrderDirection
+  label: OrderDirection
+  priority: OrderDirection
+  isComplete: OrderDirection
+  finishBy: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input TaskUpdateInput {
   label: String
   priority: TaskPriorityType
@@ -119,7 +132,8 @@ type Person {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Task!]!
@@ -127,7 +141,8 @@ type Person {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -185,6 +200,12 @@ enum SortPeopleBy {
   name_DESC
   email_ASC
   email_DESC
+}
+
+input PersonOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
 }
 
 input PersonUpdateInput {
@@ -335,7 +356,8 @@ type Query {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Task]
@@ -352,7 +374,8 @@ type Query {
     where: TaskWhereInput
     search: String
     sortBy: [SortTasksBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TaskOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta
@@ -364,7 +387,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Person]
@@ -381,7 +405,8 @@ type Query {
     where: PersonWhereInput
     search: String
     sortBy: [SortPeopleBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PersonOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
+++ b/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
@@ -111,6 +111,7 @@ const getItems = async ({
   listKey,
   where = {},
   sortBy,
+  orderBy,
   first,
   skip,
   pageSize = 500,
@@ -120,17 +121,20 @@ const getItems = async ({
   listKey: string;
   where?: Record<string, any> | null;
   sortBy?: readonly string[] | null;
+  orderBy?: Record<string, 'asc' | 'desc'>[];
   first?: number | null;
   skip?: number | null;
   pageSize?: number;
   returnFields?: string;
   context: KeystoneContext;
 }): Promise<Record<string, any>[]> => {
-  const { listQueryName, whereInputName, listSortName } = context.gqlNames(listKey);
+  const { listQueryName, whereInputName, listSortName, listOrderName } = context.gqlNames(listKey);
 
   let query;
   if (sortBy) {
     query = `query ($first: Int!, $skip: Int!, $sortBy: [${listSortName}!], $where: ${whereInputName}) { ${listQueryName}(first: $first, skip: $skip, sortBy: $sortBy, where: $where) { ${returnFields} }  }`;
+  } else if (orderBy) {
+    query = `query ($first: Int!, $skip: Int!, $orderBy: [${listOrderName}!]! = [], $where: ${whereInputName}) { ${listQueryName}(first: $first, skip: $skip, orderBy: $orderBy, where: $where) { ${returnFields} }  }`;
   } else {
     query = `query ($first: Int!, $skip: Int!, $where: ${whereInputName}) { ${listQueryName}(first: $first, skip: $skip, where: $where) { ${returnFields} }  }`;
   }
@@ -148,7 +152,7 @@ const getItems = async ({
     }
     const response = await context.graphql.run({
       query,
-      variables: { first: _first, skip: _skip, sortBy, where },
+      variables: { first: _first, skip: _skip, sortBy, orderBy, where },
     });
 
     latestResult = response[Object.keys(response || {})[0]];

--- a/packages-next/keystone/src/lib/core/tests/List.test.ts
+++ b/packages-next/keystone/src/lib/core/tests/List.test.ts
@@ -230,6 +230,7 @@ describe('new List()', () => {
       listQueryName: 'allTests',
       listQueryMetaName: '_allTestsMeta',
       listSortName: 'SortTestsBy',
+      listOrderName: 'TestOrderByInput',
       deleteMutationName: 'deleteTest',
       deleteManyMutationName: 'deleteTests',
       updateMutationName: 'updateTest',
@@ -402,6 +403,12 @@ describe(`getGqlTypes()`, () => {
         writeOnce_ASC
         writeOnce_DESC
       }`;
+  const orderTestsBy = `input TestOrderByInput {
+       name: OrderDirection
+       email: OrderDirection
+       writeOnce: OrderDirection
+      }`;
+  const orderDirection = `enum OrderDirection { asc desc }`;
   const otherRelateToOneInput = `input OtherRelateToOneInput {
     connect: OtherWhereUniqueInput
     disconnect: OtherWhereUniqueInput
@@ -420,6 +427,8 @@ describe(`getGqlTypes()`, () => {
         whereInput,
         whereUniqueInput,
         sortTestsBy,
+        orderTestsBy,
+        orderDirection,
         updateInput,
         updateManyInput,
         createInput,
@@ -440,9 +449,15 @@ describe(`getGqlTypes()`, () => {
         .getGqlTypes({ schemaName })
         .map(s => print(gql(s)))
     ).toEqual(
-      [otherRelateToOneInput, type, whereInput, whereUniqueInput, sortTestsBy].map(s =>
-        print(gql(s))
-      )
+      [
+        otherRelateToOneInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        sortTestsBy,
+        orderTestsBy,
+        orderDirection,
+      ].map(s => print(gql(s)))
     );
   });
   test('create: true', () => {
@@ -457,6 +472,8 @@ describe(`getGqlTypes()`, () => {
         whereInput,
         whereUniqueInput,
         sortTestsBy,
+        orderTestsBy,
+        orderDirection,
         createInput,
         createManyInput,
       ].map(s => print(gql(s)))
@@ -474,6 +491,8 @@ describe(`getGqlTypes()`, () => {
         whereInput,
         whereUniqueInput,
         sortTestsBy,
+        orderTestsBy,
+        orderDirection,
         updateInput,
         updateManyInput,
       ].map(s => print(gql(s)))
@@ -485,9 +504,15 @@ describe(`getGqlTypes()`, () => {
         .getGqlTypes({ schemaName })
         .map(s => print(gql(s)))
     ).toEqual(
-      [otherRelateToOneInput, type, whereInput, whereUniqueInput, sortTestsBy].map(s =>
-        print(gql(s))
-      )
+      [
+        otherRelateToOneInput,
+        type,
+        whereInput,
+        whereUniqueInput,
+        sortTestsBy,
+        orderTestsBy,
+        orderDirection,
+      ].map(s => print(gql(s)))
     );
   });
 });
@@ -497,8 +522,8 @@ test('getGraphqlFilterFragment', () => {
   expect(list.getGraphqlFilterFragment()).toEqual([
     'where: TestWhereInput',
     'search: String',
-    'sortBy: [SortTestsBy!]',
-    'orderBy: String',
+    'sortBy: [SortTestsBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")',
+    'orderBy: [TestOrderByInput!]! = []',
     'first: Int',
     'skip: Int! = 0',
   ]);
@@ -513,8 +538,8 @@ describe(`getGqlQueries()`, () => {
           allTests(
           where: TestWhereInput
           search: String
-          sortBy: [SortTestsBy!]
-          orderBy: String
+          sortBy: [SortTestsBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+          orderBy: [TestOrderByInput!]! = []
           first: Int
           skip: Int! = 0
         ): [Test]`,
@@ -526,8 +551,8 @@ describe(`getGqlQueries()`, () => {
           _allTestsMeta(
           where: TestWhereInput
           search: String
-          sortBy: [SortTestsBy!]
-          orderBy: String
+          sortBy: [SortTestsBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+          orderBy: [TestOrderByInput!]! = []
           first: Int
           skip: Int! = 0
         ): _QueryMeta`,

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -113,7 +113,7 @@ export function printGeneratedTypes(
   let printArgs = (args: readonly InputValueDefinitionNode[]) => {
     let types = '{\n';
     for (const arg of args) {
-      if (arg.name.value === 'search' || arg.name.value === 'orderBy') continue;
+      if (arg.name.value === 'search') continue;
       types += `  readonly ${arg.name.value}${
         arg.type.kind === 'NonNullType' && !arg.defaultValue ? '' : '?'
       }: ${printTypeNode(arg.type)};\n`;

--- a/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -36,6 +36,13 @@ export type TodoWhereUniqueInput = {
 
 export type SortTodosBy = 'id_ASC' | 'id_DESC' | 'title_ASC' | 'title_DESC';
 
+export type TodoOrderByInput = {
+  readonly id?: OrderDirection | null;
+  readonly title?: OrderDirection | null;
+};
+
+export type OrderDirection = 'asc' | 'desc';
+
 export type TodoUpdateInput = {
   readonly title?: Scalars['String'] | null;
 };
@@ -80,6 +87,7 @@ export type TodoListTypeInfo = {
     listQuery: {
       readonly where?: TodoWhereInput | null;
       readonly sortBy?: ReadonlyArray<SortTodosBy> | null;
+      readonly orderBy: ReadonlyArray<TodoOrderByInput>;
       readonly first?: Scalars['Int'] | null;
       readonly skip?: Scalars['Int'];
     };

--- a/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages-next/keystone/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -87,7 +87,7 @@ export type TodoListTypeInfo = {
     listQuery: {
       readonly where?: TodoWhereInput | null;
       readonly sortBy?: ReadonlyArray<SortTodosBy> | null;
-      readonly orderBy: ReadonlyArray<TodoOrderByInput>;
+      readonly orderBy?: ReadonlyArray<TodoOrderByInput>;
       readonly first?: Scalars['Int'] | null;
       readonly skip?: Scalars['Int'];
     };

--- a/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -36,6 +36,16 @@ enum SortTodosBy {
   title_DESC
 }
 
+input TodoOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
 input TodoUpdateInput {
   title: String
 }
@@ -110,7 +120,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo]
@@ -127,7 +138,8 @@ type Query {
     where: TodoWhereInput
     search: String
     sortBy: [SortTodosBy!]
-    orderBy: String
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): _QueryMeta

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -55,6 +55,7 @@ export function getGqlNames({
     listQueryName: `all${_listQueryName}`,
     listQueryMetaName: `_all${_listQueryName}Meta`,
     listSortName: `Sort${_listQueryName}By`,
+    listOrderName: `${_itemQueryName}OrderByInput`,
     deleteMutationName: `delete${_itemQueryName}`,
     updateMutationName: `update${_itemQueryName}`,
     createMutationName: `create${_itemQueryName}`,

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -9,7 +9,7 @@ export type BaseGeneratedListTypes = {
       readonly search?: string | null;
       readonly first?: number | null;
       readonly skip?: number | null;
-      readonly orderBy?: string;
+      readonly orderBy?: Record<string, 'asc' | 'desc'>[];
       readonly sortBy?: ReadonlyArray<string> | null;
     };
   };
@@ -33,6 +33,7 @@ export type GqlNames = {
   listQueryName: string;
   listQueryMetaName: string;
   listSortName: string;
+  listOrderName: string;
   deleteMutationName: string;
   updateMutationName: string;
   createMutationName: string;

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -1,0 +1,278 @@
+import { integer } from '@keystone-next/fields';
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import {
+  ProviderName,
+  multiAdapterRunners,
+  setupFromConfig,
+  testConfig,
+} from '@keystone-next/test-utils-legacy';
+import { KeystoneContext } from '@keystone-next/types';
+
+function setupKeystone(provider: ProviderName) {
+  return setupFromConfig({
+    provider,
+    config: testConfig({
+      lists: createSchema({
+        User: list({
+          fields: {
+            a: integer(),
+            b: integer(),
+          },
+        }),
+      }),
+    }),
+  });
+}
+
+const initialiseData = async ({ context }: { context: KeystoneContext }) => {
+  // Use shuffled data to ensure that ordering is actually happening.
+  await context.lists.User.createMany({
+    data: [
+      { data: { a: 1, b: 10 } },
+      { data: { a: 1, b: 30 } },
+      { data: { a: 1, b: 20 } },
+      { data: { a: 3, b: 30 } },
+      { data: { a: 3, b: 10 } },
+      { data: { a: 3, b: 20 } },
+      { data: { a: 2, b: 30 } },
+      { data: { a: 2, b: 20 } },
+      { data: { a: 2, b: 10 } },
+    ],
+  });
+};
+
+multiAdapterRunners().map(({ runner, provider }) =>
+  describe(`Provider: ${provider}`, () => {
+    describe('Ordering by a single field', () => {
+      test(
+        'Single ascending filter - a',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ orderBy: [{ a: 'asc' }], query: 'a' });
+          expect(users.map(({ a }) => a)).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+        })
+      );
+      test(
+        'Single descending filter - a',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ orderBy: [{ a: 'desc' }], query: 'a' });
+          expect(users.map(({ a }) => a)).toEqual([3, 3, 3, 2, 2, 2, 1, 1, 1]);
+        })
+      );
+      test(
+        'Single ascending filter - b',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ orderBy: [{ b: 'asc' }], query: 'b' });
+          expect(users.map(({ b }) => b)).toEqual([10, 10, 10, 20, 20, 20, 30, 30, 30]);
+        })
+      );
+      test(
+        'Single descending filter - b',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ orderBy: [{ b: 'desc' }], query: 'b' });
+          expect(users.map(({ b }) => b)).toEqual([30, 30, 30, 20, 20, 20, 10, 10, 10]);
+        })
+      );
+
+      test(
+        'Single ascending filter - non-list - a',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({ orderBy: { a: 'asc' }, query: 'a' });
+          expect(users.map(({ a }) => a)).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
+        })
+      );
+
+      test(
+        'Multi ascending/ascending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ a: 'asc' }, { b: 'asc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 10],
+            [1, 20],
+            [1, 30],
+            [2, 10],
+            [2, 20],
+            [2, 30],
+            [3, 10],
+            [3, 20],
+            [3, 30],
+          ]);
+        })
+      );
+      test(
+        'Multi ascending/ascending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ b: 'asc' }, { a: 'asc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 10],
+            [2, 10],
+            [3, 10],
+            [1, 20],
+            [2, 20],
+            [3, 20],
+            [1, 30],
+            [2, 30],
+            [3, 30],
+          ]);
+        })
+      );
+
+      test(
+        'Multi ascending/descending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ a: 'asc' }, { b: 'desc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 30],
+            [1, 20],
+            [1, 10],
+            [2, 30],
+            [2, 20],
+            [2, 10],
+            [3, 30],
+            [3, 20],
+            [3, 10],
+          ]);
+        })
+      );
+      test(
+        'Multi ascending/descending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ b: 'asc' }, { a: 'desc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 10],
+            [2, 10],
+            [1, 10],
+            [3, 20],
+            [2, 20],
+            [1, 20],
+            [3, 30],
+            [2, 30],
+            [1, 30],
+          ]);
+        })
+      );
+
+      test(
+        'Multi descending/ascending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ a: 'desc' }, { b: 'asc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 10],
+            [3, 20],
+            [3, 30],
+            [2, 10],
+            [2, 20],
+            [2, 30],
+            [1, 10],
+            [1, 20],
+            [1, 30],
+          ]);
+        })
+      );
+      test(
+        'Multi descending/ascending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ b: 'desc' }, { a: 'asc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [1, 30],
+            [2, 30],
+            [3, 30],
+            [1, 20],
+            [2, 20],
+            [3, 20],
+            [1, 10],
+            [2, 10],
+            [3, 10],
+          ]);
+        })
+      );
+
+      test(
+        'Multi descending/descending filter - a,b ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ a: 'desc' }, { b: 'desc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 30],
+            [3, 20],
+            [3, 10],
+            [2, 30],
+            [2, 20],
+            [2, 10],
+            [1, 30],
+            [1, 20],
+            [1, 10],
+          ]);
+        })
+      );
+      test(
+        'Multi descending/descending filter - b,a ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+          const users = await context.lists.User.findMany({
+            orderBy: [{ b: 'desc' }, { a: 'desc' }],
+            query: 'a b',
+          });
+          expect(users.map(({ a, b }) => [a, b])).toEqual([
+            [3, 30],
+            [2, 30],
+            [1, 30],
+            [3, 20],
+            [2, 20],
+            [1, 20],
+            [3, 10],
+            [2, 10],
+            [1, 10],
+          ]);
+        })
+      );
+
+      test(
+        'Multi filter, bad format throws error ',
+        runner(setupKeystone, async ({ context }) => {
+          await initialiseData({ context });
+
+          const { data, errors } = await context.graphql.raw({
+            query: 'query { allUsers(orderBy: [{ a: asc, b: asc }]) { id } }',
+          });
+          expect(data?.allUsers).toBe(null);
+          expect(errors).toHaveLength(1);
+          expect(errors![0].message).toEqual(
+            'Only a single key must be passed to UserOrderByInput'
+          );
+        })
+      );
+    });
+  })
+);

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -195,6 +195,21 @@ multiAdapterRunners().map(({ runner, provider }) =>
         })
       );
       test(
+        'orderBy: Should get all ordered items',
+        runner(setupKeystone, async ({ context }) => {
+          // Seed the db
+          await seedDb({ context });
+
+          const getItemsBySortOrder = (orderBy: Record<string, 'asc' | 'desc'>) =>
+            getItems({ context, listKey, returnFields, orderBy: [orderBy] });
+
+          const allItemsAscAge = await getItemsBySortOrder({ age: 'asc' });
+          const allItemsDescAge = await getItemsBySortOrder({ age: 'desc' });
+          expect(allItemsAscAge[0]).toEqual(testData.map(x => x.data)[0]);
+          expect(allItemsDescAge[0]).toEqual(testData.map(x => x.data).slice(-1)[0]);
+        })
+      );
+      test(
         'first: Should get first specfied number of items',
         runner(setupKeystone, async ({ context }) => {
           await seedDb({ context });


### PR DESCRIPTION
Replaces the `orderBy` string with the more flexible list of order directions in the list query arguments. Deprecates `sortBy`, which is no longer required.