### PR TITLE
Add the new itemsCount query to GraphQL API

### DIFF
--- a/.changeset/soft-berries-yell.md
+++ b/.changeset/soft-berries-yell.md
@@ -1,0 +1,24 @@
+---
+'@keystone-next/keystone': minor
+'@keystone-next/website': patch
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-blog': patch
+'@keystone-next/example-ecommerce': patch
+'keystone-next-app': patch
+'@keystone-next/example-next-lite': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/example-sandbox': patch
+'@keystone-next/example-todo': patch
+'@keystone-next/example-with-auth': patch
+'@keystone-next/types': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+The GraphQL query `_all<Items>Meta { count }` generated for each list has been deprecated in favour of a new query `all<Items>Count`, which directy returns the count.
+
+A `User` list would have the following query added to the API:
+
+```graphql
+allUsersCount(where: UserWhereInput! = {}): Int!
+```

--- a/.changeset/soft-berries-yell.md
+++ b/.changeset/soft-berries-yell.md
@@ -15,10 +15,10 @@
 '@keystone-next/api-tests-legacy': patch
 ---
 
-The GraphQL query `_all<Items>Meta { count }` generated for each list has been deprecated in favour of a new query `all<Items>Count`, which directy returns the count.
+The GraphQL query `_all<Items>Meta { count }` generated for each list has been deprecated in favour of a new query `<items>Count`, which directy returns the count.
 
 A `User` list would have the following query added to the API:
 
 ```graphql
-allUsersCount(where: UserWhereInput! = {}): Int!
+usersCount(where: UserWhereInput! = {}): Int!
 ```

--- a/docs/pages/apis/graphql.mdx
+++ b/docs/pages/apis/graphql.mdx
@@ -203,12 +203,11 @@ type User {
 ```
 
 <!-- prettier-ignore -->
-### _allUsersMeta
+### usersCount
 
 ```graphql
 type Query {
-  """ Perform a meta-query on all User items which match the where clause. """
-  _allUsersMeta(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta
+  usersCount(where: UserWhereInput! = {}): Int!
 }
 
 input UserWhereInput {

--- a/examples/auth/schema.graphql
+++ b/examples/auth/schema.graphql
@@ -205,6 +205,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use usersCount instead."
+    )
+  usersCount(where: UserWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   keystone: KeystoneMeta!
 }

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -604,6 +604,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use usersCount instead."
+    )
+  usersCount(where: UserWhereInput! = {}): Int!
 
   """
    Search for all PhoneNumber items which match the where clause.
@@ -635,6 +639,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use phoneNumbersCount instead."
+    )
+  phoneNumbersCount(where: PhoneNumberWhereInput! = {}): Int!
 
   """
    Search for all Post items which match the where clause.
@@ -666,6 +674,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   randomNumber: RandomNumber
   keystone: KeystoneMeta!

--- a/examples/blog/schema.graphql
+++ b/examples/blog/schema.graphql
@@ -340,6 +340,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int!
 
   """
    Search for all Author items which match the where clause.
@@ -371,6 +375,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use authorsCount instead."
+    )
+  authorsCount(where: AuthorWhereInput! = {}): Int!
   keystone: KeystoneMeta!
 }
 

--- a/examples/ecommerce/schema.graphql
+++ b/examples/ecommerce/schema.graphql
@@ -1295,6 +1295,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use usersCount instead."
+    )
+  usersCount(where: UserWhereInput! = {}): Int!
 
   """
    Search for all Product items which match the where clause.
@@ -1326,6 +1330,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use productsCount instead."
+    )
+  productsCount(where: ProductWhereInput! = {}): Int!
 
   """
    Search for all ProductImage items which match the where clause.
@@ -1357,6 +1365,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use productImagesCount instead."
+    )
+  productImagesCount(where: ProductImageWhereInput! = {}): Int!
 
   """
    Search for all CartItem items which match the where clause.
@@ -1388,6 +1400,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use cartItemsCount instead."
+    )
+  cartItemsCount(where: CartItemWhereInput! = {}): Int!
 
   """
    Search for all OrderItem items which match the where clause.
@@ -1419,6 +1435,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use orderItemsCount instead."
+    )
+  orderItemsCount(where: OrderItemWhereInput! = {}): Int!
 
   """
    Search for all Order items which match the where clause.
@@ -1450,6 +1470,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use ordersCount instead."
+    )
+  ordersCount(where: OrderWhereInput! = {}): Int!
 
   """
    Search for all Role items which match the where clause.
@@ -1481,6 +1505,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use rolesCount instead."
+    )
+  rolesCount(where: RoleWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   validateUserPasswordResetToken(
     email: String!

--- a/examples/embedded-nextjs/schema.graphql
+++ b/examples/embedded-nextjs/schema.graphql
@@ -167,6 +167,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int!
   keystone: KeystoneMeta!
 }
 

--- a/examples/graphql-api-endpoint/schema.graphql
+++ b/examples/graphql-api-endpoint/schema.graphql
@@ -587,6 +587,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use usersCount instead."
+    )
+  usersCount(where: UserWhereInput! = {}): Int!
 
   """
    Search for all Post items which match the where clause.
@@ -618,6 +622,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int!
 
   """
    Search for all Tag items which match the where clause.
@@ -649,6 +657,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use tagsCount instead."
+    )
+  tagsCount(where: TagWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   keystone: KeystoneMeta!
 }

--- a/examples/roles/schema.graphql
+++ b/examples/roles/schema.graphql
@@ -549,6 +549,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use todosCount instead."
+    )
+  todosCount(where: TodoWhereInput! = {}): Int!
 
   """
    Search for all Person items which match the where clause.
@@ -580,6 +584,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use peopleCount instead."
+    )
+  peopleCount(where: PersonWhereInput! = {}): Int!
 
   """
    Search for all Role items which match the where clause.
@@ -611,6 +619,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use rolesCount instead."
+    )
+  rolesCount(where: RoleWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   keystone: KeystoneMeta!
 }

--- a/examples/sandbox/schema.graphql
+++ b/examples/sandbox/schema.graphql
@@ -373,6 +373,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use todosCount instead."
+    )
+  todosCount(where: TodoWhereInput! = {}): Int!
 
   """
    Search for all User items which match the where clause.
@@ -404,6 +408,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use usersCount instead."
+    )
+  usersCount(where: UserWhereInput! = {}): Int!
   keystone: KeystoneMeta!
 }
 

--- a/examples/todo/schema.graphql
+++ b/examples/todo/schema.graphql
@@ -325,6 +325,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use tasksCount instead."
+    )
+  tasksCount(where: TaskWhereInput! = {}): Int!
 
   """
    Search for all Person items which match the where clause.
@@ -356,6 +360,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use peopleCount instead."
+    )
+  peopleCount(where: PersonWhereInput! = {}): Int!
   keystone: KeystoneMeta!
 }
 

--- a/examples/with-auth/schema.graphql
+++ b/examples/with-auth/schema.graphql
@@ -379,6 +379,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use tasksCount instead."
+    )
+  tasksCount(where: TaskWhereInput! = {}): Int!
 
   """
    Search for all Person items which match the where clause.
@@ -410,6 +414,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use peopleCount instead."
+    )
+  peopleCount(where: PersonWhereInput! = {}): Int!
   authenticatedItem: AuthenticatedItem
   keystone: KeystoneMeta!
 }

--- a/packages-next/keystone/src/lib/core/tests/List.test.ts
+++ b/packages-next/keystone/src/lib/core/tests/List.test.ts
@@ -229,6 +229,7 @@ describe('new List()', () => {
       itemQueryName: 'Test',
       listQueryName: 'allTests',
       listQueryMetaName: '_allTestsMeta',
+      listQueryCountName: 'testsCount',
       listSortName: 'SortTestsBy',
       listOrderName: 'TestOrderByInput',
       deleteMutationName: 'deleteTest',
@@ -555,7 +556,8 @@ describe(`getGqlQueries()`, () => {
           orderBy: [TestOrderByInput!]! = []
           first: Int
           skip: Int! = 0
-        ): _QueryMeta`,
+        ): _QueryMeta @deprecated(reason: \"This query will be removed in a future version. Please use testsCount instead.\")`,
+        `testsCount(where: TestWhereInput! = {}): Int!`,
       ].map(normalise)
     );
   });

--- a/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages-next/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -143,6 +143,10 @@ type Query {
     first: Int
     skip: Int! = 0
   ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use todosCount instead."
+    )
+  todosCount(where: TodoWhereInput! = {}): Int!
   keystone: KeystoneMeta!
 }
 

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -49,11 +49,13 @@ export function getGqlNames({
   itemQueryName: string;
   listQueryName: string;
 }): GqlNames {
+  const _lowerListName = _listQueryName.slice(0, 1).toLowerCase() + _listQueryName.slice(1);
   return {
     outputTypeName: listKey,
     itemQueryName: _itemQueryName,
     listQueryName: `all${_listQueryName}`,
     listQueryMetaName: `_all${_listQueryName}Meta`,
+    listQueryCountName: `${_lowerListName}Count`,
     listSortName: `Sort${_listQueryName}By`,
     listOrderName: `${_itemQueryName}OrderByInput`,
     deleteMutationName: `delete${_itemQueryName}`,

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -32,6 +32,7 @@ export type GqlNames = {
   itemQueryName: string;
   listQueryName: string;
   listQueryMetaName: string;
+  listQueryCountName: string;
   listSortName: string;
   listOrderName: string;
   deleteMutationName: string;

--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -151,17 +151,18 @@ multiAdapterRunners().map(({ before, after, provider }) =>
                 expectNoAccess(data, errors, allQueryName);
               });
 
-              test(`meta denied: ${JSON.stringify(access)}`, async () => {
-                const metaName = `_all${nameFn[mode](access)}sMeta`;
-                const query = `query { ${metaName} { count } }`;
+              test(`count denied: ${JSON.stringify(access)}`, async () => {
+                const countName = `${
+                  nameFn[mode](access).slice(0, 1).toLowerCase() + nameFn[mode](access).slice(1)
+                }sCount`;
+                const query = `query { ${countName} }`;
                 const { data, errors } = await context.exitSudo().graphql.raw({ query });
-                expect(data?.[metaName].count).toBe(null);
+                expect(data).toBe(null);
                 expect(errors).toHaveLength(1);
                 const error = errors![0];
                 expect(error.message).toEqual('You do not have access to this resource');
-                expect(error.path).toHaveLength(2);
-                expect(error.path![0]).toEqual(metaName);
-                expect(error.path![1]).toEqual('count');
+                expect(error.path).toHaveLength(1);
+                expect(error.path![0]).toEqual(countName);
               });
 
               test(`single denied: ${JSON.stringify(access)}`, async () => {

--- a/tests/api-tests/access-control/schema.test.ts
+++ b/tests/api-tests/access-control/schema.test.ts
@@ -105,11 +105,11 @@ multiAdapterRunners().map(({ before, after, provider }) =>
           if (access.read) {
             expect(queries).toContain(`${name}`);
             expect(queries).toContain(`all${name}s`);
-            expect(queries).toContain(`_all${name}sMeta`);
+            expect(queries).not.toContain(`${name.slice(0, 1).toLowerCase() + name.slice(1)}Count`);
           } else {
             expect(queries).not.toContain(`${name}`);
             expect(queries).not.toContain(`all${name}s`);
-            expect(queries).not.toContain(`_all${name}sMeta`);
+            expect(queries).not.toContain(`${name.slice(0, 1).toLowerCase() + name.slice(1)}Count`);
           }
 
           if (access.create) {
@@ -205,7 +205,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
 
           expect(queries).toContain(`${name}`);
           expect(queries).toContain(`all${name}s`);
-          expect(queries).toContain(`_all${name}sMeta`);
+          expect(queries).not.toContain(`${name.slice(0, 1).toLowerCase() + name.slice(1)}Count`);
 
           expect(mutations).toContain(`create${name}`);
           expect(mutations).toContain(`update${name}`);
@@ -226,7 +226,7 @@ multiAdapterRunners().map(({ before, after, provider }) =>
 
           expect(queries).toContain(`${name}`);
           expect(queries).toContain(`all${name}s`);
-          expect(queries).toContain(`_all${name}sMeta`);
+          expect(queries).not.toContain(`${name.slice(0, 1).toLowerCase() + name.slice(1)}Count`);
 
           if (access.create) {
             expect(mutations).toContain(`create${name}`);

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -152,20 +152,14 @@ multiAdapterRunners().map(({ runner, provider }) =>
           expect(data).toHaveProperty('allUsers');
           expect(res.headers['cache-control']).toBe('max-age=10, private');
 
-          // Meta query
+          // Count query
           ({ data, errors, res } = await networkedGraphqlRequest({
             app,
-            query: `
-              query {
-                userCount: _allUsersMeta {
-                  count
-                }
-              }
-            `,
+            query: `query { usersCount }`,
           }));
 
           expect(errors).toBe(undefined);
-          expect(data).toHaveProperty('userCount');
+          expect(data).toHaveProperty('usersCount');
           expect(res.headers['cache-control']).toBe('max-age=90, public');
 
           // User post relationship

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -94,17 +94,11 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
             // Count is still correct
             data = await context.graphql.run({
-              query: `
-          query {
-            meta: _allUsersMeta {
-              count
-            }
-          }
-      `,
+              query: `query { usersCount }`,
             });
 
-            expect(data).toHaveProperty('meta');
-            expect(data.meta.count).toBe(users.length);
+            expect(data).toHaveProperty('usersCount');
+            expect(data.usersCount).toBe(users.length);
 
             // This query is only okay because of the "first" parameter
             data = await context.graphql.run({


### PR DESCRIPTION
This change deprecates `_allItemsMeta { count }` in favour of a new query `itemsCount` which simply returns a count. This change will make it easier to perform counts and will move away from the potentially confusing leading underscore syntax.