### PR TITLE
Add sameSite option to sessions

### DIFF
--- a/.changeset/shiny-drinks-camp.md
+++ b/.changeset/shiny-drinks-camp.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/website': minor
+'@keystone-next/keystone': minor
+---
+
+Added `sameSite` option to session options for cookies

--- a/docs/pages/apis/session.mdx
+++ b/docs/pages/apis/session.mdx
@@ -66,7 +66,7 @@ Options
   The forward slash (`/`) character is interpreted as a directory separator, and subdirectories will be matched as well: for `path: '/docs'`, `/docs`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
 - `domain` (default: current document URL): Host to which the cookie will be sent. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `domain` cookie attribute.
   **Note**: Only one domain is allowed. If a domain is specified then subdomains are always included.
-- `sameSite` (default: `'lax'`): Controls whether the cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks. Can be one of `'strict'`, `'lax'` or `'none'`. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `sameSite` cookie attribute.
+- `sameSite` (default: `'lax'`): Controls whether the cookie is sent with cross-origin requests. Can be one of `true`, `false`, `'strict'`, `'lax'` or `'none'`. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `sameSite` cookie attribute.
   **Note**: The `secure` attribute must also be set when `sameSite` is set to `none`!
 
 ### Session stores

--- a/docs/pages/apis/session.mdx
+++ b/docs/pages/apis/session.mdx
@@ -66,7 +66,7 @@ Options
   The forward slash (`/`) character is interpreted as a directory separator, and subdirectories will be matched as well: for `path: '/docs'`, `/docs`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
 - `domain` (default: current document URL): Host to which the cookie will be sent. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `domain` cookie attribute.
   **Note**: Only one domain is allowed. If a domain is specified then subdomains are always included.
-- `sameSite` (default: `'lax'`): Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `sameSite` cookie attribute, including the inline options.
+- `sameSite` (default: `'lax'`): Controls whether the cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks. Can be one of `'strict'`, `'lax'` or `'none'`. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `sameSite` cookie attribute.
   **Note**: The `secure` attribute must also be set when `sameSite` is set to `none`!
 
 ### Session stores

--- a/docs/pages/apis/session.mdx
+++ b/docs/pages/apis/session.mdx
@@ -19,6 +19,7 @@ export default config({
       secure: true,
       path: '/',
       domain: 'localhost',
+      sameSite: 'lax',
     }),
     { User: 'name isAdmin' }
   ),
@@ -63,8 +64,10 @@ Options
   For Firefox, the `https:` requirements are ignored when the `secure` attribute is set by localhost (since Firefox 75).
 - `path` (default: `'/'`): A path that must exist in the requested URL, or the browser won't send the cookie header.
   The forward slash (`/`) character is interpreted as a directory separator, and subdirectories will be matched as well: for `path: '/docs'`, `/docs`, `/docs/Web/`, and `/docs/Web/HTTP` will all match.
-- `domain` (default: current document URL): Host to which the cookie will be sent. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `domain` cookie attribute..
+- `domain` (default: current document URL): Host to which the cookie will be sent. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `domain` cookie attribute.
   **Note**: Only one domain is allowed. If a domain is specified then subdomains are always included.
+- `sameSite` (default: `'lax'`): Controls whether a cookie is sent with cross-origin requests, providing some protection against cross-site request forgery attacks. See [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes) for more details on the `sameSite` cookie attribute, including the inline options.
+  **Note**: The `secure` attribute must also be set when `sameSite` is set to `none`!
 
 ### Session stores
 

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -65,11 +65,11 @@ type StatelessSessionsOptions = {
    */
   domain?: string;
   /**
-   * Specifies the value for the `SameSite` `Set-Cookie` attribute
+   * Specifies the boolean or string to be the value for the {@link https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7|`SameSite` `Set-Cookie` attribute}.
    *
    * @default 'lax'
    */
-  sameSite?: 'lax' | 'strict' | 'none';
+  sameSite?: true | false | 'lax' | 'strict' | 'none';
 };
 
 type FieldSelections = {

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -64,6 +64,12 @@ type StatelessSessionsOptions = {
    * @default current domain
    */
   domain?: string;
+  /**
+   * Specifies the value for the `SameSite` `Set-Cookie` attribute
+   *
+   * @default 'lax'
+   */
+  sameSite?: 'lax' | 'strict' | 'none';
 };
 
 type FieldSelections = {
@@ -122,6 +128,7 @@ export function statelessSessions<T>({
   secure = process.env.NODE_ENV === 'production',
   ironOptions = Iron.defaults,
   domain,
+  sameSite = 'lax',
 }: StatelessSessionsOptions): () => SessionStrategy<T> {
   return () => {
     if (!secret) {
@@ -148,7 +155,7 @@ export function statelessSessions<T>({
             httpOnly: true,
             secure,
             path,
-            sameSite: 'lax',
+            sameSite,
             domain,
           })
         );
@@ -164,7 +171,7 @@ export function statelessSessions<T>({
             httpOnly: true,
             secure,
             path,
-            sameSite: 'lax',
+            sameSite,
             domain,
           })
         );


### PR DESCRIPTION
Adds a `sameSite` option to the session options for cookies. Can be one of `true`, `false`, `'strict'`, `'lax'` or `'none'` as per  [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes). The option defaults to `'lax'` which is in line with existing behaviour.

This option will be useful for users who have deployed their keystone instance to a different site from their frontend, e.g. hosting keystone on `example.herokuapp.com` with the frontend on `example.vercel.app`.