### PR TITLE
Fix schema type printer for default values

### DIFF
--- a/.changeset/flat-wasps-exist.md
+++ b/.changeset/flat-wasps-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed schema type printer to make arguments that have default values be optional

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -49,7 +49,7 @@ function printInputTypesFromSchema(
     let str = `export type ${node.name.value} = {\n`;
     node.fields?.forEach(node => {
       str += `  readonly ${node.name.value}${
-        node.type.kind === 'NonNullType' || node.defaultValue ? '' : '?'
+        node.type.kind === 'NonNullType' && !node.defaultValue ? '' : '?'
       }: ${printTypeNode(node.type)};\n`;
     });
     str += '};';

--- a/packages-next/keystone/src/lib/schema-type-printer.tsx
+++ b/packages-next/keystone/src/lib/schema-type-printer.tsx
@@ -115,7 +115,7 @@ export function printGeneratedTypes(
     for (const arg of args) {
       if (arg.name.value === 'search' || arg.name.value === 'orderBy') continue;
       types += `  readonly ${arg.name.value}${
-        arg.type.kind === 'NonNullType' || arg.defaultValue ? '' : '?'
+        arg.type.kind === 'NonNullType' && !arg.defaultValue ? '' : '?'
       }: ${printTypeNode(arg.type)};\n`;
     }
     return types + '}';


### PR DESCRIPTION
This is sorta wrong because we actually need to model the input and coerced inputs as different things but the main place where people are practically using these types today is the lists API so I think catering for the uncoerced input is better than catering for the coerced input types.

This is for #5767 and #5777 