### PR TITLE
Replace usage of sortBy with orderBy in tests

### DIFF
--- a/examples/ecommerce/tests/mutations.test.ts
+++ b/examples/ecommerce/tests/mutations.test.ts
@@ -31,7 +31,7 @@ multiAdapterRunners('postgresql').map(({ runner }) =>
             id
             label
             total
-            items(sortBy: [name_ASC]) { name description price quantity photo { id } }
+            items(orderBy: { name: asc }) { name description price quantity photo { id } }
             user { id }
             charge
           } }`;

--- a/packages-next/fields/src/tests/test-fixtures.ts
+++ b/packages-next/fields/src/tests/test-fixtures.ts
@@ -38,7 +38,7 @@ export const filterTests = (withKeystone: any) => {
     expected: any[]
   ) =>
     expect(
-      await context.lists.Test.findMany({ where, sortBy: ['name_ASC'], query: 'id name' })
+      await context.lists.Test.findMany({ where, orderBy: { name: 'asc' }, query: 'id name' })
     ).toEqual(expected);
 
   test(

--- a/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/autoIncrement/tests/test-fixtures.ts
@@ -73,7 +73,11 @@ export const filterTests = (withKeystone: (arg: any) => any, matrixValue: Matrix
   const _f = matrixValue === 'ID' ? (x: any) => x.toString() : (x: any) => x;
   const match = async (context: KeystoneContext, where: Record<string, any>, expected: any[]) =>
     expect(
-      await context.lists.Test.findMany({ where, sortBy: ['name_ASC'], query: 'name orderNumber' })
+      await context.lists.Test.findMany({
+        where,
+        orderBy: { name: 'asc' },
+        query: 'name orderNumber',
+      })
     ).toEqual(expected.map(i => _storedValues[i]));
 
   test(

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -47,14 +47,14 @@ export const filterTests = (withKeystone: (args: any) => any) => {
     context: KeystoneContext,
     where: Record<string, any> | undefined,
     expected: any,
-    sortBy = ['name_ASC']
+    orderBy: Record<string, 'asc' | 'desc'> = { name: 'asc' }
   ) =>
-    expect(await context.lists.Test.findMany({ where, sortBy, query: 'name lastOnline' })).toEqual(
+    expect(await context.lists.Test.findMany({ where, orderBy, query: 'name lastOnline' })).toEqual(
       expected
     );
 
   test(
-    'Sorting: sortBy: lastOnline_ASC',
+    'Ordering: orderBy: { lastOnline: asc }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,
@@ -78,13 +78,13 @@ export const filterTests = (withKeystone: (args: any) => any) => {
               { name: 'person6', lastOnline: null },
               { name: 'person7', lastOnline: null },
             ],
-        ['lastOnline_ASC']
+        { lastOnline: 'asc' }
       )
     )
   );
 
   test(
-    'Sorting: sortBy: lastOnline_DESC',
+    'Ordering: orderBy: { lastOnline: desc }',
     withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
       match(
         context,
@@ -108,7 +108,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
               { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
               { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
             ],
-        ['lastOnline_DESC']
+        { lastOnline: 'desc' }
       )
     )
   );

--- a/tests/api-tests/access-control/mutations-field-static.test.ts
+++ b/tests/api-tests/access-control/mutations-field-static.test.ts
@@ -129,7 +129,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // Valid users should exist in the database
           const users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(users).toHaveLength(3);
@@ -184,7 +184,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // All users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual([

--- a/tests/api-tests/access-control/mutations-list-declarative.test.ts
+++ b/tests/api-tests/access-control/mutations-list-declarative.test.ts
@@ -134,7 +134,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // All users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual([
@@ -185,7 +185,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // Three users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual(['good 5', 'no delete 1', 'no delete 2']);

--- a/tests/api-tests/access-control/mutations-list-static.test.ts
+++ b/tests/api-tests/access-control/mutations-list-static.test.ts
@@ -215,7 +215,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // All users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual([
@@ -266,7 +266,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // All users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual([

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -116,7 +116,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
                   listKey: string;
                 }) => {
                   const items = await context.lists[listKey].findMany({
-                    sortBy: ['name_ASC'],
+                    orderBy: { name: 'asc' },
                     query,
                   });
                   return wrappedFn({ context, listKey, items });

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -103,9 +103,9 @@ multiAdapterRunners().map(({ runner, provider }) =>
                 context: KeystoneContext,
                 where: Record<string, any> | undefined,
                 expected: any[],
-                sortBy = ['name_ASC']
+                orderBy: Record<string, 'asc' | 'desc'> = { name: 'asc' }
               ) =>
-                expect(await context.lists[listKey].findMany({ where, sortBy, query })).toEqual(
+                expect(await context.lists[listKey].findMany({ where, orderBy, query })).toEqual(
                   expected.map(i => storedValues[i])
                 );
 

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -139,7 +139,10 @@ multiAdapterRunners().map(({ runner, provider }) =>
           expect(errors![1].path).toEqual(['createUsers', 3]);
 
           // Three users should exist in the database
-          const users = await context.lists.User.findMany({ sortBy: 'name_ASC', query: 'id name' });
+          const users = await context.lists.User.findMany({
+            orderBy: { name: 'asc' },
+            query: 'id name',
+          });
           expect(users.map(({ name }) => name)).toEqual(['good 1', 'good 2', 'good 3']);
         })
       );
@@ -188,7 +191,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // All users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual([
@@ -238,7 +241,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
           // Three users should still exist in the database
           const _users = await context.lists.User.findMany({
-            sortBy: 'name_ASC',
+            orderBy: { name: 'asc' },
             query: 'id name',
           });
           expect(_users.map(({ name }) => name)).toEqual(['good 5', 'no delete 1', 'no delete 2']);

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -65,7 +65,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query {
             allUsers(
               where: { name_contains: "J" },
-              sortBy: name_ASC,
+              orderBy: { name: asc },
             ) {
               name
             }
@@ -194,8 +194,8 @@ multiAdapterRunners().map(({ runner, provider }) =>
               where: {
                 OR: [{ title: 'One author' }, { title: 'Two authors' }],
               },
-              sortBy: ['title_ASC'],
-              query: 'title author(sortBy: [name_ASC]) { name }',
+              orderBy: { title: 'asc' },
+              query: 'title author(orderBy: { name: asc }) { name }',
             });
             expect(posts).toEqual([
               { title: 'One author', author: [{ name: 'Jess' }] },

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -174,7 +174,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id feed(sortBy: [title_ASC]) { title }',
+              query: 'id feed(orderBy: { title: asc }) { title }',
             });
 
             expect(_users).toHaveLength(2);
@@ -257,7 +257,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // SOME
             const _users = await context.lists.User.findMany({
               where: { feed_some: { title_contains: 'J' } },
-              query: 'id name feed(sortBy: [title_ASC]) { id title }',
+              query: 'id name feed(orderBy: { title: asc }) { id title }',
             });
 
             expect(_users).toMatchObject([

--- a/tests/api-tests/queries/search.test.ts
+++ b/tests/api-tests/queries/search.test.ts
@@ -220,7 +220,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           query: `
           query {
             allTests(
-              sortBy: name_ASC,
+              orderBy: { name: asc },
               search: "",
             ) {
               name

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -333,7 +333,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name friend { id name }',
                 })) as { name: string; friend: { name: string } }[];
                 const users = _users.filter(({ name }: { name: string }) => name.length === 1);
@@ -362,7 +362,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the friends look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name',
                 })) as { name: string }[];
                 const friends = _users.filter(({ name }: { name: string }) => name.length === 2);
@@ -390,7 +390,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name friend { id name }',
                 })) as { name: string; friend: { name: string } }[];
                 const users = _users.filter(({ name }) => name.length === 1);
@@ -425,7 +425,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the friends look how we expect
               await (async () => {
                 const _users = (await context.lists.User.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name',
                 })) as { name: string }[];
                 const friends = _users.filter(({ name }) => name.length === 2);

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -376,7 +376,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the companies look how we expect
               await (async () => {
                 const _companies = await context.lists.Company.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name location { id name }',
                 });
                 const expected = [
@@ -404,7 +404,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               // Check all the locations look how we expect
               await (async () => {
                 const _locations = await context.lists.Location.findMany({
-                  sortBy: ['name_ASC'],
+                  orderBy: { name: 'asc' },
                   query: 'id name',
                 });
                 expect(_locations[0].name).toEqual('A');
@@ -431,7 +431,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
               // Check all the companies look how we expect
               const companies = await context.lists.Company.findMany({
-                sortBy: ['name_ASC'],
+                orderBy: { name: 'asc' },
                 query: 'id name location { id name }',
               });
               expect(companies[0].name).toEqual('A');
@@ -463,7 +463,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
 
               // Check all the locations look how we expect
               const _locations = await context.lists.Location.findMany({
-                sortBy: ['name_ASC'],
+                orderBy: { name: 'asc' },
                 query: 'id name',
               });
               const expected = ['A', 'B', 'C', 'D'].filter(x => x !== name);

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -84,7 +84,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           });
 
           const users = await context.lists.User.findMany({
-            query: 'id posts(first: 1, sortBy: [content_ASC]) { id }',
+            query: 'id posts(first: 1, orderBy: { content: asc }) { id }',
           });
           expect(users).toContainEqual({ id: user.id, posts: [ids[0]] });
           expect(users).toContainEqual({ id: user2.id, posts: [ids[0]] });

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -74,7 +74,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
           // Create an item that does the nested create
           const user = await context.lists.User.createOne({
             data: { username: 'A thing', notes: { create: [{ content: noteContent }] } },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: { content: asc }) { id content }',
           });
 
           expect(user).toMatchObject({
@@ -90,7 +90,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: { content: asc }) { id content }',
           })) as T;
 
           expect(user1).toMatchObject({
@@ -145,7 +145,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               username: 'A thing',
               notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
             },
-            query: 'id notes(sortBy: [content_ASC]) { id content }',
+            query: 'id notes(orderBy: { content: asc }) { id content }',
           })) as T;
 
           expect(_user).toMatchObject({

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -51,12 +51,12 @@ multiAdapterRunners().map(({ runner, provider }) =>
           type T = { id: IdType; notes: { id: IdType; title: string }[] };
           const alice = (await context.lists.User.createOne({
             data: { username: 'Alice', notes: { connect: [{ id: noteA.id }, { id: noteB.id }] } },
-            query: 'id notes(sortBy: [title_ASC]) { id title }',
+            query: 'id notes(orderBy: { title: asc }) { id title }',
           })) as T;
 
           const bob = (await context.lists.User.createOne({
             data: { username: 'Bob', notes: { connect: [{ id: noteC.id }, { id: noteD.id }] } },
-            query: 'id notes(sortBy: [title_ASC]) { id title }',
+            query: 'id notes(orderBy: { title: asc }) { id title }',
           })) as T;
 
           // Make sure everyone has the correct notes
@@ -71,7 +71,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             const user = (await context.lists.User.updateOne({
               id: bob.id,
               data: { notes: { connect: [{ id: noteB.id }] } },
-              query: 'id notes(sortBy: [title_ASC]) { id title }',
+              query: 'id notes(orderBy: { title: asc }) { id title }',
             })) as T;
 
             expect(user).toEqual({ id: bob.id, notes: expect.any(Array) });
@@ -92,7 +92,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             type T = { id: IdType; notes: { id: IdType; title: string }[] };
             const user = (await context.lists.User.findOne({
               where: { id: alice.id },
-              query: 'id notes(sortBy: [title_ASC]) { id title }',
+              query: 'id notes(orderBy: { title: asc }) { id title }',
             })) as T;
             expect(user).toEqual({ id: alice.id, notes: expect.any(Array) });
             expect(user.notes.map(({ title }) => title)).toEqual(['A']);

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -157,7 +157,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
             // Run the query to disconnect the teacher from student
             let newStudent = await context.lists.Student.createOne({
               data: { teachers: { create: [{ name: teacherName1 }, { name: teacherName2 }] } },
-              query: 'id teachers(sortBy: [id_ASC]) { id }',
+              query: 'id teachers(orderBy: { id: asc }) { id }',
             });
 
             let newTeachers = newStudent.teachers;

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -180,21 +180,6 @@ multiAdapterRunners().map(({ runner, provider }) =>
         })
       );
       test(
-        'sortBy: Should get all sorted items',
-        runner(setupKeystone, async ({ context }) => {
-          // Seed the db
-          await seedDb({ context });
-
-          const getItemsBySortOrder = (sortBy: string) =>
-            getItems({ context, listKey, returnFields, sortBy: [sortBy] });
-
-          const allItemsAscAge = await getItemsBySortOrder('age_ASC');
-          const allItemsDescAge = await getItemsBySortOrder('age_DESC');
-          expect(allItemsAscAge[0]).toEqual(testData.map(x => x.data)[0]);
-          expect(allItemsDescAge[0]).toEqual(testData.map(x => x.data).slice(-1)[0]);
-        })
-      );
-      test(
         'orderBy: Should get all ordered items',
         runner(setupKeystone, async ({ context }) => {
           // Seed the db
@@ -221,7 +206,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
               returnFields,
               pageSize,
               first,
-              sortBy: ['age_ASC'],
+              orderBy: [{ age: 'asc' }],
             });
           expect(await getFirstItems(9, 5)).toEqual(testData.slice(0, 9).map(d => d.data));
           expect(await getFirstItems(5, 9)).toEqual(testData.slice(0, 5).map(d => d.data));
@@ -250,13 +235,13 @@ multiAdapterRunners().map(({ runner, provider }) =>
         runner(setupKeystone, async ({ context }) => {
           await seedDb({ context });
           const first = 4;
-          const getSortItems = (sortBy: string) =>
-            getItems({ context, listKey, returnFields, skip: 3, first, sortBy: [sortBy] });
-          const itemsDESC = await getSortItems('age_DESC');
+          const getOrderItems = (orderBy: Record<string, 'asc' | 'desc'>) =>
+            getItems({ context, listKey, returnFields, skip: 3, first, orderBy: [orderBy] });
+          const itemsDESC = await getOrderItems({ age: 'desc' });
           expect(itemsDESC.length).toEqual(first);
           expect(itemsDESC[0]).toEqual({ name: 'test46', age: 460 });
 
-          const itemsASC = await getSortItems('age_ASC');
+          const itemsASC = await getOrderItems({ age: 'asc' });
           expect(itemsASC.length).toEqual(4);
           expect(itemsASC[0]).toEqual({ name: 'test03', age: 30 });
         })


### PR DESCRIPTION
This updates the tests to no longer use the deprecated `sortBy` argument.