### PR TITLE
Fix pageMiddleware args

### DIFF
--- a/.changeset/wet-islands-buy.md
+++ b/.changeset/wet-islands-buy.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/auth': major
+'@keystone-next/keystone': major
+'@keystone-next/types': patch
+---
+
+Replaced `req, session, createContext` args to `config.ui.pageMiddleware` with a `context` arg.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -91,13 +91,9 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
    *  - to the init page when initFirstItem is configured, and there are no user in the database
    *  - to the signin page when no valid session is present
    */
-  const pageMiddleware: AdminUIConfig['pageMiddleware'] = async ({
-    req,
-    isValidSession,
-    createContext,
-    session,
-  }) => {
-    const pathname = url.parse(req.url!).pathname!;
+  const pageMiddleware: AdminUIConfig['pageMiddleware'] = async ({ context, isValidSession }) => {
+    const { req, session } = context;
+    const pathname = url.parse(req!.url!).pathname!;
 
     if (isValidSession) {
       if (pathname === '/signin' || (initFirstItem && pathname === '/init')) {
@@ -107,7 +103,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
 
     if (!session && initFirstItem) {
-      const count = await createContext({}).sudo().lists[listKey].count({});
+      const count = await context.sudo().lists[listKey].count({});
       if (count === 0) {
         if (pathname !== '/init') {
           return { kind: 'redirect', to: '/init' };
@@ -117,7 +113,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
 
     if (!session && pathname !== '/signin') {
-      return { kind: 'redirect', to: `/signin?from=${encodeURIComponent(req.url!)}` };
+      return { kind: 'redirect', to: `/signin?from=${encodeURIComponent(req!.url!)}` };
     }
   };
 

--- a/packages-next/keystone/src/admin-ui/system/createAdminUIServer.ts
+++ b/packages-next/keystone/src/admin-ui/system/createAdminUIServer.ts
@@ -28,18 +28,14 @@ export const createAdminUIServer = async (
       sessionContext: sessionStrategy
         ? await createSessionContext(sessionStrategy, req, res, createContext)
         : undefined,
+      req,
     });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
       : sessionStrategy
       ? context.session !== undefined
       : true;
-    const maybeRedirect = await ui?.pageMiddleware?.({
-      req,
-      session: context.session,
-      isValidSession,
-      createContext,
-    });
+    const maybeRedirect = await ui?.pageMiddleware?.({ context, isValidSession });
     if (maybeRedirect) {
       res.redirect(maybeRedirect.to);
       return;

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -1,11 +1,9 @@
-import { IncomingMessage } from 'http';
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import type { Config } from 'apollo-server-express';
 
 import type { ImageMode, FileMode, KeystoneContext } from '..';
 
-import { CreateContext } from '../core';
 import type { BaseKeystone } from '../base';
 import { SessionStrategy } from '../session';
 import type { MaybePromise } from '../utils';
@@ -104,10 +102,8 @@ export type AdminUIConfig = {
   // path?: string;
   getAdditionalFiles?: ((config: KeystoneConfig) => MaybePromise<AdminFileToWrite[]>)[];
   pageMiddleware?: (args: {
-    req: IncomingMessage;
-    session: any;
+    context: KeystoneContext;
     isValidSession: boolean;
-    createContext: CreateContext;
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 


### PR DESCRIPTION
Pass in a context object which includes the session context methods, which are otherwise inaccessible here. More generally this is just a simpler API to use.