### PR TITLE
Don't let withItemData clear session data

### DIFF
--- a/.changeset/shaggy-mayflies-fry.md
+++ b/.changeset/shaggy-mayflies-fry.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated `withItemData` to retain the original session data, even if item data was not found.

--- a/packages-next/keystone/src/session/index.ts
+++ b/packages-next/keystone/src/session/index.ts
@@ -97,7 +97,7 @@ export function withItemData(
           !session.itemId ||
           !sudoContext.lists[session.listKey]
         ) {
-          return;
+          return session;
         }
 
         // NOTE: This is wrapped in a try-catch block because a "not found" result will currently
@@ -114,7 +114,7 @@ export function withItemData(
         } catch (e) {
           // TODO: This swallows all errors, we need a way to differentiate between "not found" and
           // actual exceptions that should be thrown
-          return;
+          return session;
         }
       },
     };


### PR DESCRIPTION
At the moment if the `withItemData` wrapper can't find an item based on `listKey` and `itemId` it completely clears the session data by returning `undefined`. This makes it impossible to use `withItemData` in conjunction with code which might be setting values on the session independently from the auth package. This PR changes the behaviour to always return the original session from the wrapped `get` function, and only ever augment it with `data` where appropriate.