### PR TITLE
Fix images and files baseUrl bug

### DIFF
--- a/.changeset/curvy-stingrays-smell.md
+++ b/.changeset/curvy-stingrays-smell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed baseUrl bug for files and images config. BaseUrl now correctly referenced in uploaded image and file paths.

--- a/packages-next/keystone/src/admin-ui/system/generateAdminUI.ts
+++ b/packages-next/keystone/src/admin-ui/system/generateAdminUI.ts
@@ -61,13 +61,21 @@ export const generateAdminUI = async (
   if (config.images) {
     const storagePath = Path.resolve(config.images.local?.storagePath ?? './public/images');
     await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(storagePath, Path.join(publicDirectory, config.images.local?.baseUrl || 'images'), 'junction');
+    await fs.symlink(
+      storagePath,
+      Path.join(publicDirectory, config.images.local?.baseUrl || 'images'),
+      'junction'
+    );
   }
 
   if (config.files) {
     const storagePath = Path.resolve(config.files.local?.storagePath ?? './public/files');
     await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(storagePath, Path.join(publicDirectory, config.files.local?.baseUrl || 'files'), 'junction');
+    await fs.symlink(
+      storagePath,
+      Path.join(publicDirectory, config.files.local?.baseUrl || 'files'),
+      'junction'
+    );
   }
 
   // Write out the files configured by the user

--- a/packages-next/keystone/src/admin-ui/system/generateAdminUI.ts
+++ b/packages-next/keystone/src/admin-ui/system/generateAdminUI.ts
@@ -61,13 +61,13 @@ export const generateAdminUI = async (
   if (config.images) {
     const storagePath = Path.resolve(config.images.local?.storagePath ?? './public/images');
     await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(storagePath, Path.join(publicDirectory, 'images'), 'junction');
+    await fs.symlink(storagePath, Path.join(publicDirectory, config.images.local?.baseUrl || 'images'), 'junction');
   }
 
   if (config.files) {
     const storagePath = Path.resolve(config.files.local?.storagePath ?? './public/files');
     await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(storagePath, Path.join(publicDirectory, 'files'), 'junction');
+    await fs.symlink(storagePath, Path.join(publicDirectory, config.files.local?.baseUrl || 'files'), 'junction');
   }
 
   // Write out the files configured by the user


### PR DESCRIPTION
Thanks @bladey  for the fix. 
Uses the `baseUrl` specified in the images/files config in the symlink to the storage directory for both images and files. 