### PR TITLE
Add sessionData option to createAuth

### DIFF
--- a/.changeset/afraid-chefs-thank.md
+++ b/.changeset/afraid-chefs-thank.md
@@ -1,0 +1,78 @@
+---
+'@keystone-next/auth': major
+'@keystone-next/keystone': major
+'@keystone-next/website': patch
+'@keystone-next/example-auth': patch
+'@keystone-next/app-basic': patch
+'@keystone-next/example-ecommerce': patch
+'keystone-next-app': patch
+'@keystone-next/example-roles': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Removed `withItemData` in favour of a `sessionData` option to the `createAuth()` function.
+
+Previously, `withItemData` would be used to wrap the `config.session` argument:
+
+```typescript
+import { config, createSchema, list } from '@keystone-next/keystone/schema';
+import { statelessSessions, withAuthData } from '@keystone-next/keystone/session';
+import { text, password, checkbox } from '@keystone-next/fields';
+import { createAuth } from '@keystone-next/auth';
+
+const { withAuth } = createAuth({
+  listKey: 'User',
+  identityField: 'email',
+  secretField: 'password',
+});
+
+const session = statelessSessions({ secret: '-- EXAMPLE COOKIE SECRET; CHANGE ME --' });
+
+export default withAuth(
+  config({
+    lists: createSchema({
+      User: list({
+        fields: {
+          email: text({ isUnique: true }),
+          password: password(),
+          isAdmin: checkbox(),
+        },
+      }),
+      session: withItemData(session, { User: 'id isAdmin' }),
+    }),
+  })
+);
+```
+
+Now, the fields to populate are configured on `sessionData` in `createAuth`, and `withItemData` is completely removed.
+
+```typescript
+import { config, createSchema, list } from '@keystone-next/keystone/schema';
+import { statelessSessions } from '@keystone-next/keystone/session';
+import { text, password, checkbox } from '@keystone-next/fields';
+import { createAuth } from '@keystone-next/auth';
+
+const { withAuth } = createAuth({
+  listKey: 'User',
+  identityField: 'email',
+  secretField: 'password',
+  sessionData: 'id isAdmin',
+});
+
+const session = statelessSessions({ secret: '-- EXAMPLE COOKIE SECRET; CHANGE ME --' });
+
+export default withAuth(
+  config({
+    lists: createSchema({
+      User: list({
+        fields: {
+          email: text({ isUnique: true }),
+          password: password(),
+          isAdmin: checkbox(),
+        },
+      }),
+      session,
+    }),
+  })
+);
+```

--- a/docs/pages/apis/auth.mdx
+++ b/docs/pages/apis/auth.mdx
@@ -19,7 +19,7 @@ const { withAuth } = createAuth({
   secretField: 'password',
 
   // Additional options
-  sessionData: { query: 'id name email` }
+  sessionData: 'id name email`,
   initFirstItem: {
     fields: ['email', 'password'],
     itemData: { isAdmin: true },
@@ -142,9 +142,7 @@ The authentication mutations will set the values `{ listKey, itemId }` on the `c
 You will often need to know more than just the `itemId` of the authenticated user, such as when performing [access-control](../guides/access-control) or using [hooks](../guides/hooks).
 Configuring `sessionData` will add an `session.data` based on the `itemId`, populated by the fields given in `sessionData.query`.
 
-#### Options
-
-- `query` (required): A GraphQL query string which indicates which fields should be populated on the `session.data` object
+The value is a GraphQL query string which indicates which fields should be populated on the `session.data` object
 
 ```typescript
 import { createAuth } from '@keystone-next/auth';
@@ -153,7 +151,7 @@ const { withAuth } = createAuth({
   listKey: 'User',
   identityField: 'email',
   secretField: 'password',
-  sessionData: { query: 'id name isAdmin' },
+  sessionData: 'id name isAdmin',
 });
 ```
 

--- a/docs/pages/apis/auth.mdx
+++ b/docs/pages/apis/auth.mdx
@@ -19,6 +19,7 @@ const { withAuth } = createAuth({
   secretField: 'password',
 
   // Additional options
+  sessionData: { query: 'id name email` }
   initFirstItem: {
     fields: ['email', 'password'],
     itemData: { isAdmin: true },
@@ -132,6 +133,29 @@ This page uses the `authenticateUserWithPassword` mutation to let users sign in 
 
 The following options add extra functionality to your Keystone authentication system.
 By default they are disabled.
+
+### sessionData
+
+This option adds support for setting a custom `session.data` value based on the authenticated user.
+
+The authentication mutations will set the values `{ listKey, itemId }` on the `context.session` object.
+You will often need to know more than just the `itemId` of the authenticated user, such as when performing [access-control](../guides/access-control) or using [hooks](../guides/hooks).
+Configuring `sessionData` will add an `session.data` based on the `itemId`, populated by the fields given in `sessionData.query`.
+
+#### Options
+
+- `query` (required): A GraphQL query string which indicates which fields should be populated on the `session.data` object
+
+```typescript
+import { createAuth } from '@keystone-next/auth';
+
+const { withAuth } = createAuth({
+  listKey: 'User',
+  identityField: 'email',
+  secretField: 'password',
+  sessionData: { query: 'id name isAdmin' },
+});
+```
 
 ### initFirstItem
 

--- a/docs/pages/apis/config.mdx
+++ b/docs/pages/apis/config.mdx
@@ -209,18 +209,15 @@ import type { SessionStrategy } from '@keystone-next/types';
 ```
 
 The `session` config option allows you to configure session management of your Keystone system.
-It has a TypeScript type of `() => SessionStrategy<any>`.
+It has a TypeScript type of `SessionStrategy<any>`.
 
-In general you will use functions from the `@keystone-next/keystone/session` package, rather than writing this function yourself.
+In general you will use `SessionStrategy` objects from the `@keystone-next/keystone/session` package, rather than writing this yourself.
 
 ```typescript
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 
 export default config({
-  session: withItemData(
-    statelessSessions({ /* ... */ }),
-    { /* ... */ }
-  ),
+  session: statelessSessions({ /* ... */ }),
   /* ... */
 });
 ```

--- a/docs/pages/apis/session.mdx
+++ b/docs/pages/apis/session.mdx
@@ -8,21 +8,18 @@ In general you will use `SessionStrategy` objects from the `@keystone-next/keyst
 
 ```typescript
 import { config } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 
 export default config({
-  session: withItemData(
-    statelessSessions({
-      secret: 'ABCDEFGH1234567887654321HGFEDCBA',
-      ironOptions: { /* ... */ },
-      maxAge: 60 * 60 * 24,
-      secure: true,
-      path: '/',
-      domain: 'localhost',
-      sameSite: 'lax',
-    }),
-    { User: 'name isAdmin' }
-  ),
+  session: statelessSessions({
+    secret: 'ABCDEFGH1234567887654321HGFEDCBA',
+    ironOptions: { /* ... */ },
+    maxAge: 60 * 60 * 24,
+    secure: true,
+    path: '/',
+    domain: 'localhost',
+    sameSite: 'lax',
+  }),
   /* ... */
 });
 ```
@@ -124,31 +121,5 @@ If you configure your Keystone session with session management then the [`Keysto
 
 The `startSession` and `endSession` functions will be used by [authentication mutations](./auth) to start and end authenticated sessions.
 These mutations will set the value of `session` to include the values `{ listKey, itemId }`.
-
-## Authenticated item data
-
-The [authentication mutations](./auth) provide values `{ listKey, itemId }` for the `context.session` object.
-You will often need to know more than just the `itemId` of the authenticated user, such as when performing [access-control](../guides/access-control) or using [hooks](../guides/hooks).
-
-Keystone provides the wrapper function `withItemData()`, which will inject an additional value `data` onto the `context.session` object.
-This `data` value will be populated based on the value of `listKey` and `itemId` from the wrapped session strategy, and the configuration options passed to `withItemData()`.
-
-`withItemData()` accepts two arguments. The first is the session strategy to be wrapped, such as `statelessSessions()` or `storedSessions()`.
-The second argument is an object of the form `{ [listKey]: query }`.
-When the session data is created, the wrapper function will look up the item in the list `listKey`, performing a GraphQL query filtering on `itemId` and returning the fields in `query`.
-The returned item will be available as `context.session.data`.
-
-```typescript
-import { config } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
-
-export default config({
-  session: withItemData(
-    statelessSessions({ /* ... */ }),
-    { User: 'name isAdmin' }
-  ),
-  /* ... */
-});
-```
 
 export default ({ children }) => <Markdown>{children}</Markdown>;

--- a/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
@@ -92,7 +92,6 @@ To create and edit blog records in Keystone’s Admin UI, add a `keystone.ts` [c
 
 ?> **Note:** We're enabling experimental features to generate the APIs that make embedded mode work. These may change in future versions.
 
-
 ```tsx
 // keystone.ts
 
@@ -117,8 +116,7 @@ export default config({
 });
 ```
 
-!> For simplicity we set all Post fields as [`text`](/apis/fields#text) above. For a highly customizable rich text editor use the [`document`](/guides/document-fields) field type. 
-
+!> For simplicity we set all Post fields as [`text`](/apis/fields#text) above. For a highly customizable rich text editor use the [`document`](/guides/document-fields) field type.
 
 ### Add Keystone to Next.js config
 

--- a/examples-staging/auth/keystone.ts
+++ b/examples-staging/auth/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import { lists } from './schema';
 
@@ -40,6 +40,8 @@ const { withAuth } = createAuth({
       // isEnabled: true,
     },
   },
+  // Populate session.data based on the authed user
+  sessionData: { query: 'name isAdmin' },
   /* TODO -- complete the UI for these features and enable them
   passwordResetLink: {
     sendToken(args) {
@@ -63,7 +65,7 @@ export default withAuth(
     },
     lists,
     ui: {},
-    session: withItemData(
+    session:
       // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie
       statelessSessions({
         // The maxAge option controls how long session cookies are valid for before they expire
@@ -71,8 +73,5 @@ export default withAuth(
         // The session secret is used to encrypt cookie data (should be an environment variable)
         secret: sessionSecret,
       }),
-      // withItemData will fetch these fields for signed-in User items to populate session.data
-      { User: 'name isAdmin' }
-    ),
   })
 );

--- a/examples-staging/auth/keystone.ts
+++ b/examples-staging/auth/keystone.ts
@@ -41,7 +41,7 @@ const { withAuth } = createAuth({
     },
   },
   // Populate session.data based on the authed user
-  sessionData: { query: 'name isAdmin' },
+  sessionData: 'name isAdmin',
   /* TODO -- complete the UI for these features and enable them
   passwordResetLink: {
     sendToken(args) {

--- a/examples-staging/basic/keystone.ts
+++ b/examples-staging/basic/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 
 import { lists, extendGraphqlSchema } from './schema';
@@ -17,6 +17,7 @@ const auth = createAuth({
       isAdmin: true,
     },
   },
+  sessionData: { query: 'name isAdmin' },
 });
 
 // TODO -- Create a separate example for access control in the Admin UI
@@ -41,13 +42,7 @@ export default auth.withAuth(
     files: { upload: 'local' },
     lists,
     extendGraphqlSchema,
-    session: withItemData(
-      statelessSessions({
-        maxAge: sessionMaxAge,
-        secret: sessionSecret,
-      }),
-      { User: 'name isAdmin' }
-    ),
+    session: statelessSessions({ maxAge: sessionMaxAge, secret: sessionSecret }),
     // TODO -- Create a separate example for stored/redis sessions
     // session: storedSessions({
     //   store: new Map(),

--- a/examples-staging/basic/keystone.ts
+++ b/examples-staging/basic/keystone.ts
@@ -17,7 +17,7 @@ const auth = createAuth({
       isAdmin: true,
     },
   },
-  sessionData: { query: 'name isAdmin' },
+  sessionData: 'name isAdmin',
 });
 
 // TODO -- Create a separate example for access control in the Admin UI

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -14,7 +14,7 @@ import { document } from '@keystone-next/fields-document';
 // import { cloudinaryImage } from '@keystone-next/cloudinary';
 import { componentBlocks } from './admin/fieldViews/Content';
 
-// TODO: Can we generate this type based on withItemData in the main config?
+// TODO: Can we generate this type based on sessionData in the main config?
 type AccessArgs = {
   session?: {
     itemId?: string;

--- a/examples-staging/ecommerce/keystone.ts
+++ b/examples-staging/ecommerce/keystone.ts
@@ -1,6 +1,6 @@
 import { createAuth } from '@keystone-next/auth';
 import { config, createSchema } from '@keystone-next/keystone/schema';
-import { withItemData, statelessSessions } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { permissionsList } from './schemas/fields';
 import { Role } from './schemas/Role';
 import { OrderItem } from './schemas/OrderItem';
@@ -35,6 +35,7 @@ const { withAuth } = createAuth({
       await sendPasswordResetEmail(args.token, args.identity);
     },
   },
+  sessionData: { query: `id name email role { ${permissionsList.join(' ')} }` },
 });
 
 export default withAuth(
@@ -75,9 +76,6 @@ export default withAuth(
         // console.log(session);
         !!session?.data,
     },
-    session: withItemData(statelessSessions(sessionConfig), {
-      // GraphQL Query
-      User: `id name email role { ${permissionsList.join(' ')} }`,
-    }),
+    session: statelessSessions(sessionConfig),
   })
 );

--- a/examples-staging/ecommerce/keystone.ts
+++ b/examples-staging/ecommerce/keystone.ts
@@ -35,7 +35,7 @@ const { withAuth } = createAuth({
       await sendPasswordResetEmail(args.token, args.identity);
     },
   },
-  sessionData: { query: `id name email role { ${permissionsList.join(' ')} }` },
+  sessionData: `id name email role { ${permissionsList.join(' ')} }`,
 });
 
 export default withAuth(

--- a/examples-staging/graphql-api-endpoint/keystone.ts
+++ b/examples-staging/graphql-api-endpoint/keystone.ts
@@ -1,4 +1,4 @@
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 
 import { config } from '@keystone-next/keystone/schema';
 import { createAuth } from '@keystone-next/auth';
@@ -23,6 +23,7 @@ const auth = createAuth({
   initFirstItem: {
     fields: ['name', 'email', 'password'],
   },
+  sessionData: { query: 'name' },
 });
 
 export default auth.withAuth(
@@ -39,12 +40,6 @@ export default auth.withAuth(
       isAccessAllowed: context => !!context.session?.data,
     },
     lists,
-    session: withItemData(
-      statelessSessions({
-        maxAge: sessionMaxAge,
-        secret: sessionSecret,
-      }),
-      { User: 'name' }
-    ),
+    session: statelessSessions({ maxAge: sessionMaxAge, secret: sessionSecret }),
   })
 );

--- a/examples-staging/graphql-api-endpoint/keystone.ts
+++ b/examples-staging/graphql-api-endpoint/keystone.ts
@@ -23,7 +23,7 @@ const auth = createAuth({
   initFirstItem: {
     fields: ['name', 'email', 'password'],
   },
-  sessionData: { query: 'name' },
+  sessionData: 'name',
 });
 
 export default auth.withAuth(

--- a/examples-staging/roles/keystone.ts
+++ b/examples-staging/roles/keystone.ts
@@ -37,8 +37,8 @@ const { withAuth } = createAuth({
     },
   },
   /* This loads the related role for the current user, including all permissions */
-  sessionData: {
-    query: `name role {
+  sessionData: `
+    name role {
       id
       name
       canCreateTodos
@@ -48,7 +48,6 @@ const { withAuth } = createAuth({
       canManagePeople
       canManageRoles
     }`,
-  },
 });
 
 export default withAuth(

--- a/examples-staging/roles/keystone.ts
+++ b/examples-staging/roles/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import { lists } from './schema';
 
@@ -36,6 +36,19 @@ const { withAuth } = createAuth({
       },
     },
   },
+  /* This loads the related role for the current user, including all permissions */
+  sessionData: {
+    query: `name role {
+      id
+      name
+      canCreateTodos
+      canManageAllTodos
+      canSeeOtherPeople
+      canEditOtherPeople
+      canManagePeople
+      canManageRoles
+    }`,
+  },
 });
 
 export default withAuth(
@@ -49,18 +62,6 @@ export default withAuth(
       /* Everyone who is signed in can access the Admin UI */
       isAccessAllowed: isSignedIn,
     },
-    session: withItemData(statelessSessions(sessionConfig), {
-      /* This loads the related role for the current user, including all permissions */
-      Person: `name role {
-        id
-        name
-        canCreateTodos
-        canManageAllTodos
-        canSeeOtherPeople
-        canEditOtherPeople
-        canManagePeople
-        canManageRoles
-      }`,
-    }),
+    session: statelessSessions(sessionConfig),
   })
 );

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -271,7 +271,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
           // because doing so validates that it exists in the database
           const data = await sudoContext.lists[listKey].findOne({
             where: { id: session.itemId },
-            query: sessionData?.query || 'id',
+            query: sessionData? || 'id',
           });
           return { ...session, itemId: session.itemId, listKey, data };
         } catch (e) {

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -271,7 +271,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
           // because doing so validates that it exists in the database
           const data = await sudoContext.lists[listKey].findOne({
             where: { id: session.itemId },
-            query: sessionData? || 'id',
+            query: sessionData || 'id',
           });
           return { ...session, itemId: session.itemId, listKey, data };
         } catch (e) {

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -5,6 +5,7 @@ import {
   KeystoneConfig,
   KeystoneContext,
   AdminUIConfig,
+  SessionStrategy,
 } from '@keystone-next/types';
 import { password, timestamp } from '@keystone-next/fields';
 
@@ -25,6 +26,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   identityField,
   magicAuthLink,
   passwordResetLink,
+  sessionData,
 }: AuthConfig<GeneratedListTypes>) {
   // The protectIdentities flag is currently under review to see whether it should be
   // part of the createAuth API (in which case its use cases need to be documented and tested)
@@ -235,6 +237,53 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   };
 
   /**
+   * withItemData
+   *
+   * Automatically injects a session.data value with the authenticated item
+   */
+  /* TODO:
+    - [ ] We could support additional where input to validate item sessions (e.g an isEnabled boolean)
+  */
+  const withItemData = (
+    _sessionStrategy: SessionStrategy<Record<string, any>>
+  ): SessionStrategy<{ listKey: string; itemId: string; data: any }> => {
+    const { get, ...sessionStrategy } = _sessionStrategy;
+    return {
+      ...sessionStrategy,
+      get: async ({ req, createContext }) => {
+        const session = await get({ req, createContext });
+        const sudoContext = createContext({}).sudo();
+        if (
+          !session ||
+          !session.listKey ||
+          session.listKey !== listKey ||
+          !session.itemId ||
+          !sudoContext.lists[session.listKey]
+        ) {
+          return;
+        }
+
+        // NOTE: This is wrapped in a try-catch block because a "not found" result will currently
+        // throw; I think this needs to be reviewed, but for now this prevents a system crash when
+        // the session item is invalid
+        try {
+          // If no field selection is specified, just load the id. We still load the item,
+          // because doing so validates that it exists in the database
+          const data = await sudoContext.lists[listKey].findOne({
+            where: { id: session.itemId },
+            query: sessionData?.query || 'id',
+          });
+          return { ...session, itemId: session.itemId, listKey, data };
+        } catch (e) {
+          // TODO: This swallows all errors, we need a way to differentiate between "not found" and
+          // actual exceptions that should be thrown
+          return;
+        }
+      },
+    };
+  };
+
+  /**
    * withAuth
    *
    * Automatically extends config with the correct auth functionality. This is the easiest way to
@@ -274,11 +323,16 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
         },
       };
     }
+    let session = keystoneConfig.session;
+    if (session && sessionData) {
+      session = withItemData(session);
+    }
     const existingExtendGraphQLSchema = keystoneConfig.extendGraphqlSchema;
     const listConfig = keystoneConfig.lists[listKey];
     return {
       ...keystoneConfig,
       ui,
+      session,
       // Add the additional fields to the references lists fields object
       // TODO: The fields we're adding here shouldn't naively replace existing fields with the same key
       // Leaving existing fields in place would allow solution devs to customise these field defs (eg. access control,

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -48,6 +48,8 @@ export type AuthConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {
   passwordResetLink?: AuthTokenTypeConfig;
   /** "Magic link" functionality */
   magicAuthLink?: AuthTokenTypeConfig;
+  /** Session data population */
+  sessionData?: { query: string };
 };
 
 export type InitFirstItemConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {

--- a/packages-next/auth/src/types.ts
+++ b/packages-next/auth/src/types.ts
@@ -49,7 +49,7 @@ export type AuthConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {
   /** "Magic link" functionality */
   magicAuthLink?: AuthTokenTypeConfig;
   /** Session data population */
-  sessionData?: { query: string };
+  sessionData?: string;
 };
 
 export type InitFirstItemConfig<GeneratedListTypes extends BaseGeneratedListTypes> = {

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -1,6 +1,6 @@
 import { text, password } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { ProviderName, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createAuth } from '@keystone-next/auth';
 import { objMerge } from '@keystone-next/utils-legacy';
@@ -133,14 +133,16 @@ function setupKeystone(provider: ProviderName) {
       },
     });
   });
-  const auth = createAuth({ listKey: 'User', identityField: 'email', secretField: 'password' });
+  const auth = createAuth({
+    listKey: 'User',
+    identityField: 'email',
+    secretField: 'password',
+    sessionData: { query: 'id' },
+  });
   return setupFromConfig({
     provider,
     config: auth.withAuth(
-      testConfig({
-        lists,
-        session: withItemData(statelessSessions({ secret: COOKIE_SECRET }), { User: 'id' }),
-      }) as KeystoneConfig
+      testConfig({ lists, session: statelessSessions({ secret: COOKIE_SECRET }) }) as KeystoneConfig
     ),
   });
 }

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -137,7 +137,7 @@ function setupKeystone(provider: ProviderName) {
     listKey: 'User',
     identityField: 'email',
     secretField: 'password',
-    sessionData: { query: 'id' },
+    sessionData: 'id',
   });
   return setupFromConfig({
     provider,

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { text, timestamp, password } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import { statelessSessions, withItemData } from '@keystone-next/keystone/session';
+import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import {
   multiAdapterRunners,
@@ -34,7 +34,12 @@ const initialData = {
 const COOKIE_SECRET = 'qwertyuiopasdfghjlkzxcvbmnm1234567890';
 const defaultAccess = ({ context }: { context: KeystoneContext }) => !!context.session?.data;
 
-const auth = createAuth({ listKey: 'User', identityField: 'email', secretField: 'password' });
+const auth = createAuth({
+  listKey: 'User',
+  identityField: 'email',
+  secretField: 'password',
+  sessionData: { query: 'id' },
+});
 
 function setupKeystone(provider: ProviderName) {
   return setupFromConfig({
@@ -62,7 +67,7 @@ function setupKeystone(provider: ProviderName) {
             },
           }),
         }),
-        session: withItemData(statelessSessions({ secret: COOKIE_SECRET }), { User: 'id' }),
+        session: statelessSessions({ secret: COOKIE_SECRET }),
       }) as KeystoneConfig
     ),
   });

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -38,7 +38,7 @@ const auth = createAuth({
   listKey: 'User',
   identityField: 'email',
   secretField: 'password',
-  sessionData: { query: 'id' },
+  sessionData: 'id',
 });
 
 function setupKeystone(provider: ProviderName) {


### PR DESCRIPTION
This makes the common case of wanting to populate session data based on the authentication mutations generated by `createAuth()` much simpler. Most users will no longer need to extend the session strategies used 👍 