### PR TITLE
Added link to document field from embedded mode tutorial

### DIFF
--- a/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
@@ -88,6 +88,7 @@ Add the `.keystone` directory to your `.gitignore` file. The contents of `.keyst
 
 ### Create your Keystone config
 
+To create and edit blog records in Keystone’s Admin UI, add a `keystone.ts` [configuration file](/apis/config) to your project root with a simple `Post` [list](/apis/schema) containing fields for a Title, Slug, and some Content.
 
 ?> **Note:** We're enabling experimental features to generate the APIs that make embedded mode work. These may change in future versions.
 

--- a/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
@@ -88,7 +88,9 @@ Add the `.keystone` directory to your `.gitignore` file. The contents of `.keyst
 
 ### Create your Keystone config
 
-Now add a `keystone.ts` [configuration file](/apis/config) to your project root with a simple `Post` [list](/apis/schema). This will give us the ability to create and edit blog records in Keystone’s Admin UI:
+
+?> **Note:** We're enabling experimental features to generate the APIs that make embedded mode work. These may change in future versions.
+
 
 ```tsx
 // keystone.ts
@@ -114,7 +116,8 @@ export default config({
 });
 ```
 
-?> **Note:** We're enabling experimental features to generate the APIs that make embedded mode work. These may change in future versions.
+!> For simplicity we set all Post fields as [`text`](/apis/fields#text) above. For a highly customizable rich text editor use the [`document`](/guides/document-fields) field type. 
+
 
 ### Add Keystone to Next.js config
 


### PR DESCRIPTION
This qualifies the simplistic use of the `text` field for long-form content in the tut, and promotes the document field for real-world use case.