### PR TITLE
Fix typo in db items api docs

### DIFF
--- a/.changeset/shiny-lizards-mate.md
+++ b/.changeset/shiny-lizards-mate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/website': patch
+---
+
+Fixed a typo in the db items api sample code.

--- a/docs/pages/apis/db-items.mdx
+++ b/docs/pages/apis/db-items.mdx
@@ -77,7 +77,7 @@ const user = await context.db.lists.User.createOne({
 ### createMany
 
 ```typescript
-const users = await context.db.lists.User.createOne({
+const users = await context.db.lists.User.createMany({
   data: [
     {
       data: {


### PR DESCRIPTION
The sample code for `createMany` is using `createOne` instead of `createMany`.