### PR TITLE
Remove BaseKeystone dependency from auth schema extension

### DIFF
--- a/.changeset/smooth-impalas-provide.md
+++ b/.changeset/smooth-impalas-provide.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Updated schema extension code to not depend on the `BaseKeystone` object.

--- a/packages-next/auth/src/schema.ts
+++ b/packages-next/auth/src/schema.ts
@@ -27,7 +27,7 @@ export const getSchemaExtension =
     passwordResetLink?: AuthTokenTypeConfig;
     magicAuthLink?: AuthTokenTypeConfig;
   }): ExtendGraphqlSchema =>
-  (schema, keystone) =>
+  schema =>
     [
       getBaseAuthSchema({
         identityField,
@@ -42,7 +42,7 @@ export const getSchemaExtension =
           fields: initFirstItem.fields,
           itemData: initFirstItem.itemData,
           gqlNames,
-          keystone,
+          graphQLSchema: schema,
         }),
       passwordResetLink &&
         getPasswordResetSchema({


### PR DESCRIPTION
This sets us up for the breaking change of removing `keystone` from the `ExtendGraphqlSchema` type.