### PR TITLE
Remove the keystone argument from the ExtendGraphqlSchema type

### DIFF
--- a/.changeset/two-bees-watch.md
+++ b/.changeset/two-bees-watch.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/keystone': major
+'@keystone-next/types': major
+'@keystone-next/auth': patch
+---
+
+Removed the `keystone` argument from the `ExtendGraphqlSchema` type. This will only impact you if you were directly constructing this function. Users of the `graphQLSchemaExtension` function will not be impacted.

--- a/packages-next/auth/src/index.ts
+++ b/packages-next/auth/src/index.ts
@@ -288,8 +288,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
         [listKey]: { ...listConfig, fields: { ...listConfig.fields, ...fields } },
       },
       extendGraphqlSchema: existingExtendGraphQLSchema
-        ? (schema, keystone) =>
-            existingExtendGraphQLSchema(extendGraphqlSchema(schema, keystone), keystone)
+        ? schema => existingExtendGraphQLSchema(extendGraphqlSchema(schema))
         : extendGraphqlSchema,
     };
   };

--- a/packages-next/keystone/src/lib/createGraphQLSchema.ts
+++ b/packages-next/keystone/src/lib/createGraphQLSchema.ts
@@ -14,11 +14,9 @@ export function createGraphQLSchema(
     resolvers: keystone.getResolvers({ schemaName }),
   });
 
-  // TODO: find a way to not pass keystone in here, if we can - it's too broad and makes
-  // everything in the keystone instance public API
   // Merge in the user defined graphQL API
   if (config.extendGraphqlSchema) {
-    graphQLSchema = config.extendGraphqlSchema(graphQLSchema, keystone);
+    graphQLSchema = config.extendGraphqlSchema(graphQLSchema);
   }
 
   // Merge in session graphQL API

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -4,7 +4,6 @@ import type { Config } from 'apollo-server-express';
 
 import type { ImageMode, FileMode, KeystoneContext } from '..';
 
-import type { BaseKeystone } from '../base';
 import { SessionStrategy } from '../session';
 import type { MaybePromise } from '../utils';
 import type {
@@ -140,7 +139,7 @@ export type GraphQLConfig = {
 
 // config.extendGraphqlSchema
 
-export type ExtendGraphqlSchema = (schema: GraphQLSchema, keystone: BaseKeystone) => GraphQLSchema;
+export type ExtendGraphqlSchema = (schema: GraphQLSchema) => GraphQLSchema;
 
 // config.files
 


### PR DESCRIPTION
The new fields implementation does not use a Keystone object, so we need to remove it from our public APIs.