### PR TITLE
Directly access context.prisma in ecommerce example

### DIFF
--- a/.changeset/purple-pugs-develop.md
+++ b/.changeset/purple-pugs-develop.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/example-ecommerce': patch
+---
+
+Updated `insertSeedData` to directly access `context.prisma`.

--- a/examples-staging/ecommerce/keystone.ts
+++ b/examples-staging/ecommerce/keystone.ts
@@ -51,10 +51,10 @@ export default withAuth(
       : {
           provider: 'sqlite',
           url: databaseURL,
-          async onConnect(keystone) {
+          async onConnect(context) {
             console.log('Connected to the database!');
             if (process.argv.includes('--seed-data')) {
-              await insertSeedData(keystone);
+              await insertSeedData(context);
             }
           },
         },

--- a/examples-staging/ecommerce/seed-data/index.ts
+++ b/examples-staging/ecommerce/seed-data/index.ts
@@ -1,9 +1,8 @@
 import { KeystoneContext } from '@keystone-next/types';
 import { products } from './data';
 
-export async function insertSeedData(context: KeystoneContext) {
+export async function insertSeedData({ prisma }: KeystoneContext) {
   console.log(`🌱 Inserting Seed Data: ${products.length} Products`);
-  const { prisma } = context.keystone.adapter;
   for (const product of products) {
     console.log(`  🛍️ Adding Product: ${product.name}`);
     const { id } = await prisma.productImage.create({


### PR DESCRIPTION
Stop using the deprecated `context.keystone` here.