### PR TITLE
Move getGqlNames out of the types package

### DIFF
--- a/.changeset/slimy-beans-film.md
+++ b/.changeset/slimy-beans-film.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/types': major
+'@keystone-next/keystone': patch
+---
+
+Removed the function `getGqlNames` from `@keystone-next/types`.

--- a/packages-next/keystone/src/admin-ui/utils/useAdminMeta.tsx
+++ b/packages-next/keystone/src/admin-ui/utils/useAdminMeta.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import hashString from '@emotion/hash';
-import { AdminMeta, FieldViews, getGqlNames } from '@keystone-next/types';
+import { AdminMeta, FieldViews } from '@keystone-next/types';
 import { useLazyQuery } from '../apollo';
 import { StaticAdminMetaQuery, staticAdminMetaQuery } from '../admin-meta-graphql';
+import { getGqlNames } from '../../lib/gqlNames';
 
 const expectedExports = new Set(['Cell', 'Field', 'controller', 'CardValue']);
 
@@ -71,11 +72,7 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
     adminMeta.lists.forEach(list => {
       runtimeAdminMeta.lists[list.key] = {
         ...list,
-        gqlNames: getGqlNames({
-          listKey: list.key,
-          itemQueryName: list.itemQueryName,
-          listQueryName: list.listQueryName,
-        }),
+        gqlNames: getGqlNames({ listKey: list.key, pluralGraphQLName: list.listQueryName }),
         fields: {},
       };
       list.fields.forEach(field => {

--- a/packages-next/keystone/src/lib/createSystem.ts
+++ b/packages-next/keystone/src/lib/createSystem.ts
@@ -1,8 +1,9 @@
-import { KeystoneConfig, DatabaseProvider, getGqlNames } from '@keystone-next/types';
+import { KeystoneConfig, DatabaseProvider } from '@keystone-next/types';
 
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { makeCreateContext } from './context/createContext';
 import { createKeystone } from './createKeystone';
+import { getGqlNames } from './gqlNames';
 
 export function getDBProvider(db: KeystoneConfig['db']): DatabaseProvider {
   if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
@@ -29,8 +30,7 @@ export function createSystem(config: KeystoneConfig, prismaClient?: any) {
         listKey,
         getGqlNames({
           listKey,
-          itemQueryName: list.gqlNames.itemQueryName,
-          listQueryName: list.gqlNames.listQueryName.slice(3),
+          pluralGraphQLName: list.gqlNames.listQueryName.slice(3),
         }),
       ];
     })

--- a/packages-next/keystone/src/lib/gqlNames.ts
+++ b/packages-next/keystone/src/lib/gqlNames.ts
@@ -1,0 +1,34 @@
+import { GqlNames } from '@keystone-next/types';
+
+export function getGqlNames({
+  listKey,
+  pluralGraphQLName,
+}: {
+  listKey: string;
+  pluralGraphQLName: string;
+}): GqlNames {
+  const _lowerListName = pluralGraphQLName.slice(0, 1).toLowerCase() + pluralGraphQLName.slice(1);
+  return {
+    outputTypeName: listKey,
+    itemQueryName: listKey,
+    listQueryName: `all${pluralGraphQLName}`,
+    listQueryMetaName: `_all${pluralGraphQLName}Meta`,
+    listQueryCountName: `${_lowerListName}Count`,
+    listSortName: `Sort${pluralGraphQLName}By`,
+    listOrderName: `${listKey}OrderByInput`,
+    deleteMutationName: `delete${listKey}`,
+    updateMutationName: `update${listKey}`,
+    createMutationName: `create${listKey}`,
+    deleteManyMutationName: `delete${pluralGraphQLName}`,
+    updateManyMutationName: `update${pluralGraphQLName}`,
+    createManyMutationName: `create${pluralGraphQLName}`,
+    whereInputName: `${listKey}WhereInput`,
+    whereUniqueInputName: `${listKey}WhereUniqueInput`,
+    updateInputName: `${listKey}UpdateInput`,
+    createInputName: `${listKey}CreateInput`,
+    updateManyInputName: `${pluralGraphQLName}UpdateInput`,
+    createManyInputName: `${pluralGraphQLName}CreateInput`,
+    relateToManyInputName: `${listKey}RelateToManyInput`,
+    relateToOneInputName: `${listKey}RelateToOneInput`,
+  };
+}

--- a/packages-next/types/src/core.ts
+++ b/packages-next/types/src/core.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import type { GraphQLResolveInfo } from 'graphql';
-import type { BaseGeneratedListTypes, GqlNames, MaybePromise } from './utils';
+import type { BaseGeneratedListTypes, MaybePromise } from './utils';
 import type { KeystoneContext, SessionContext } from './context';
 
 type FieldDefaultValueArgs<TGeneratedListTypes extends BaseGeneratedListTypes> = {
@@ -40,39 +40,3 @@ export type GraphQLSchemaExtension = {
   typeDefs: string;
   resolvers: Record<string, Record<string, GraphQLResolver>>;
 };
-
-// TODO: don't duplicate this between here and packages/keystone/ListTypes/list.js
-export function getGqlNames({
-  listKey,
-  itemQueryName: _itemQueryName,
-  listQueryName: _listQueryName,
-}: {
-  listKey: string;
-  itemQueryName: string;
-  listQueryName: string;
-}): GqlNames {
-  const _lowerListName = _listQueryName.slice(0, 1).toLowerCase() + _listQueryName.slice(1);
-  return {
-    outputTypeName: listKey,
-    itemQueryName: _itemQueryName,
-    listQueryName: `all${_listQueryName}`,
-    listQueryMetaName: `_all${_listQueryName}Meta`,
-    listQueryCountName: `${_lowerListName}Count`,
-    listSortName: `Sort${_listQueryName}By`,
-    listOrderName: `${_itemQueryName}OrderByInput`,
-    deleteMutationName: `delete${_itemQueryName}`,
-    updateMutationName: `update${_itemQueryName}`,
-    createMutationName: `create${_itemQueryName}`,
-    deleteManyMutationName: `delete${_listQueryName}`,
-    updateManyMutationName: `update${_listQueryName}`,
-    createManyMutationName: `create${_listQueryName}`,
-    whereInputName: `${_itemQueryName}WhereInput`,
-    whereUniqueInputName: `${_itemQueryName}WhereUniqueInput`,
-    updateInputName: `${_itemQueryName}UpdateInput`,
-    createInputName: `${_itemQueryName}CreateInput`,
-    updateManyInputName: `${_listQueryName}UpdateInput`,
-    createManyInputName: `${_listQueryName}CreateInput`,
-    relateToManyInputName: `${_itemQueryName}RelateToManyInput`,
-    relateToOneInputName: `${_itemQueryName}RelateToOneInput`,
-  };
-}


### PR DESCRIPTION
This function doesn't belong in the `types` package. Also updates its signature to what's in the `next-fields` branch.