### PR TITLE
Display image in relationship UI

### DIFF
--- a/.changeset/rotten-keys-check.md
+++ b/.changeset/rotten-keys-check.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': patch
+---
+
+Fixed image not displaying when rendered in card format.

--- a/packages-next/fields/src/types/image/views/Field.tsx
+++ b/packages-next/fields/src/types/image/views/Field.tsx
@@ -385,7 +385,7 @@ export function validateImage({
 // Styled Components
 // ==============================
 
-const ImageWrapper = ({ children }: { children: ReactNode }) => {
+export const ImageWrapper = ({ children }: { children: ReactNode }) => {
   const theme = useTheme();
 
   return (

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -37,11 +37,7 @@ export const CardValue: CardValueComponent = ({ item, field }) => {
       <FieldLabel>{field.label}</FieldLabel>
       {data && (
         <ImageWrapper>
-          <img
-            css={{ width: '100%' }}
-            alt={data.filename}
-            src={data.src}
-          />
+          <img css={{ width: '100%' }} alt={data.filename} src={data.src} />
         </ImageWrapper>
       )}
     </FieldContainer>

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -8,9 +8,9 @@ import {
   FieldControllerConfig,
 } from '@keystone-next/types';
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
-import { validateImage, validateRef } from './Field';
+import { validateImage, validateRef, ImageWrapper } from './Field';
 
-export { Field, ImageWrapper } from './Field';
+export { Field } from './Field';=
 
 export const Cell: CellComponent = ({ item, field }) => {
   const data = item[field.path];

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -1,8 +1,6 @@
 /* @jsx jsx */
 
-import { ReactNode } from 'react';
-
-import { jsx, useTheme } from '@keystone-ui/core';
+import { jsx } from '@keystone-ui/core';
 import {
   CardValueComponent,
   CellComponent,
@@ -12,7 +10,7 @@ import {
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
 import { validateImage, validateRef } from './Field';
 
-export { Field } from './Field';
+export { Field, ImageWrapper } from './Field';
 
 export const Cell: CellComponent = ({ item, field }) => {
   const data = item[field.path];
@@ -130,30 +128,4 @@ export const controller = (config: FieldControllerConfig): ImageController => {
       return {};
     },
   };
-};
-
-// ==============================
-// Styled Components
-// ==============================
-
-const ImageWrapper = ({ children }: { children: ReactNode }) => {
-  const theme = useTheme();
-
-  return (
-    <div
-      css={{
-        backgroundColor: 'white',
-        borderRadius: theme.radii.medium,
-        border: `1px solid ${theme.colors.border}`,
-        flexShrink: 0,
-        lineHeight: 0,
-        padding: 4,
-        position: 'relative',
-        textAlign: 'center',
-        width: '130px', // 120px image + chrome
-      }}
-    >
-      {children}
-    </div>
-  );
 };

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@keystone-ui/core';
+import { jsx, useTheme } from '@keystone-ui/core';
 import {
   CardValueComponent,
   CellComponent,
@@ -35,7 +35,15 @@ export const CardValue: CardValueComponent = ({ item, field }) => {
   return (
     <FieldContainer>
       <FieldLabel>{field.label}</FieldLabel>
-      {data && <img alt={data.filename} src={data.publicUrlTransformed} />}
+      {data && (
+        <ImageWrapper>
+          <img
+            css={{ width: '100%' }}
+            alt={data.filename}
+            src={data.src || data.publicUrlTransformed}
+          />
+        </ImageWrapper>
+      )}
     </FieldContainer>
   );
 };
@@ -124,4 +132,30 @@ export const controller = (config: FieldControllerConfig): ImageController => {
       return {};
     },
   };
+};
+
+// ==============================
+// Styled Components
+// ==============================
+
+const ImageWrapper = ({ children }: { children: ReactNode }) => {
+  const theme = useTheme();
+
+  return (
+    <div
+      css={{
+        backgroundColor: 'white',
+        borderRadius: theme.radii.medium,
+        border: `1px solid ${theme.colors.border}`,
+        flexShrink: 0,
+        lineHeight: 0,
+        padding: 4,
+        position: 'relative',
+        textAlign: 'center',
+        width: '130px', // 120px image + chrome
+      }}
+    >
+      {children}
+    </div>
+  );
 };

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -1,5 +1,7 @@
 /* @jsx jsx */
 
+import { ReactNode } from 'react';
+
 import { jsx, useTheme } from '@keystone-ui/core';
 import {
   CardValueComponent,

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -40,7 +40,7 @@ export const CardValue: CardValueComponent = ({ item, field }) => {
           <img
             css={{ width: '100%' }}
             alt={data.filename}
-            src={data.src || data.publicUrlTransformed}
+            src={data.src}
           />
         </ImageWrapper>
       )}

--- a/packages-next/fields/src/types/image/views/index.tsx
+++ b/packages-next/fields/src/types/image/views/index.tsx
@@ -10,7 +10,7 @@ import {
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
 import { validateImage, validateRef, ImageWrapper } from './Field';
 
-export { Field } from './Field';=
+export { Field } from './Field';
 
 export const Cell: CellComponent = ({ item, field }) => {
   const data = item[field.path];


### PR DESCRIPTION
Local images aren't showing up when displayed as part of a relationship preview, only when you edit that item.

It seems to only expect a Cloudinary (?) `publicUrlTransformed`.

Example of issue:

![Kapture 2021-06-04 at 14 43 52](https://user-images.githubusercontent.com/737821/120747015-a7956a80-c543-11eb-8afb-a8532224253d.gif)

Changing it to `src` OR `publicUrlTransformed` fixes the issue, but it also needed a styled container as well that exists in `packages-next/fields/src/types/image/views/Field.tsx`, which has been copied, otherwise the image is full width with no styling or size restrictions.

Preview of changes:

![Kapture 2021-06-04 at 14 42 53](https://user-images.githubusercontent.com/737821/120746964-92b8d700-c543-11eb-828a-b0179d8748c6.gif)
