### PR TITLE
Minor addition to Stack

### DIFF
--- a/.changeset/sweet-donuts-dream.md
+++ b/.changeset/sweet-donuts-dream.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/core': minor
+---
+
+Added functionality to ensure that Stack elements that are 'ul' or 'ol' automaticaly wrap children in 'li' rather than 'div'.

--- a/design-system/packages/core/src/components/Stack.tsx
+++ b/design-system/packages/core/src/components/Stack.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { Children, Fragment, ReactNode, isValidElement } from 'react';
+import { ElementType, Children, Fragment, ReactNode, isValidElement } from 'react';
 
 import { jsx } from '../emotion';
 import { useMediaQuery } from '../hooks/useMediaQuery';
@@ -44,6 +44,16 @@ export type StackProps = {
   gap?: keyof Theme['spacing'];
 } & BoxProps;
 
+const getChildTag = (parentTag?: ElementType<any>) => {
+  switch (parentTag) {
+    case 'ul':
+    case 'ol':
+      return 'li';
+    default:
+      return 'div';
+  }
+};
+
 export const Stack = forwardRefWithAs<'div', StackProps>(
   ({ across, align = 'stretch', children, dividers = 'none', gap = 'none', ...props }, ref) => {
     const { spacing } = useTheme();
@@ -51,6 +61,7 @@ export const Stack = forwardRefWithAs<'div', StackProps>(
 
     const orientation = across ? 'horizontal' : 'vertical';
     const { dimension, flexDirection, marginProperty } = orientationMap[orientation];
+    const Child = getChildTag(props.as);
 
     return (
       <Box
@@ -76,7 +87,7 @@ export const Stack = forwardRefWithAs<'div', StackProps>(
                 {dividers !== 'none' && index ? <Divider orientation={orientation} /> : null}
 
                 {/* wrap the child to avoid unwanted or unexpected "stretch" on things like buttons */}
-                <div css={{ ':empty': { display: 'none' } }}>{child}</div>
+                <Child css={{ ':empty': { display: 'none' } }}>{child}</Child>
               </Fragment>
             );
           })}

--- a/design-system/packages/core/src/components/Stack.tsx
+++ b/design-system/packages/core/src/components/Stack.tsx
@@ -61,7 +61,7 @@ export const Stack = forwardRefWithAs<'div', StackProps>(
 
     const orientation = across ? 'horizontal' : 'vertical';
     const { dimension, flexDirection, marginProperty } = orientationMap[orientation];
-    const Child = getChildTag(props.as);
+    const ChildWrapper = getChildTag(props.as);
 
     return (
       <Box
@@ -87,7 +87,7 @@ export const Stack = forwardRefWithAs<'div', StackProps>(
                 {dividers !== 'none' && index ? <Divider orientation={orientation} /> : null}
 
                 {/* wrap the child to avoid unwanted or unexpected "stretch" on things like buttons */}
-                <Child css={{ ':empty': { display: 'none' } }}>{child}</Child>
+                <ChildWrapper css={{ ':empty': { display: 'none' } }}>{child}</ChildWrapper>
               </Fragment>
             );
           })}


### PR DESCRIPTION
If the Stack element is changed to an `ol` or `ul` via the `as` prop, the component now automatically wraps children in `li` as opposed to a `div`. 

All other tags fallback to the `div` behaviour. 

QOL fix to reduce div soup in situations where we want to use the Stack component for lists.