### PR TITLE
Update Embed Keystone + SQLite Next.js app tutorial

### DIFF
--- a/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
@@ -168,13 +168,16 @@ In order to query Keystone content we need to use the [`getStaticProps`](https:/
 ```tsx
 // pages/index.tsx
 
+import { InferGetStaticPropsType } from "next";
 import Link from 'next/link';
 
 // Import the generated Lists API from Keystone
 import { lists } from '.keystone/api';
 
 // Home receives a `posts` prop from `getStaticProps` below
-export default function Home({ posts }) {
+export default function Home({
+  posts,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <div>
       <main style={{margin: "3rem"}}>
@@ -207,10 +210,17 @@ Now add a `/post` subdirectory in `/pages` and include the code below in `[slug]
 ```tsx
 // pages/post/[slug].tsx
 
+import {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  InferGetStaticPropsType,
+} from "next";
 import Link from 'next/link';
 import { lists } from '.keystone/api';
 
-export default function Home({ post }) {
+export default function PostPage({
+  post,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
     <div>
       <main style={{margin: "3rem"}}>
@@ -226,7 +236,7 @@ export default function Home({ post }) {
   );
 }
 
-export async function getStaticPaths() {
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   const posts = await lists.Post.findMany({
     query: `slug`,
   });
@@ -242,9 +252,11 @@ export async function getStaticPaths() {
   };
 }
 
-export async function getStaticProps({ params: { slug } }) {
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext) {
   const [post] = await lists.Post.findMany({
-    where: { slug },
+    where: { slug: params!.slug as string },
     query: 'id title content',
   });
   return { props: { post } };

--- a/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/tutorials/embedded-mode-with-sqlite-nextjs.mdx
@@ -168,7 +168,7 @@ In order to query Keystone content we need to use the [`getStaticProps`](https:/
 ```tsx
 // pages/index.tsx
 
-import { InferGetStaticPropsType } from "next";
+import { InferGetStaticPropsType } from 'next';
 import Link from 'next/link';
 
 // Import the generated Lists API from Keystone
@@ -214,7 +214,7 @@ import {
   GetStaticPathsResult,
   GetStaticPropsContext,
   InferGetStaticPropsType,
-} from "next";
+} from 'next';
 import Link from 'next/link';
 import { lists } from '.keystone/api';
 


### PR DESCRIPTION
The current tutorial fails when it builds on the server due to `strict` mode in `tsconfig.json`, the changes in this PR resolve it.