### PR TITLE
Update changeset

### DIFF
--- a/.changeset/brown-rings-suffer.md
+++ b/.changeset/brown-rings-suffer.md
@@ -5,6 +5,6 @@
 '@keystone-next/utils-legacy': minor
 ---
 
-Added Keystone Cloud integration capabilities for images.
-
 Replaced the types `FileMode` and `ImageMode` with `AssetMode`.
+
+Added internal experimental Keystone Cloud integration capabilities for images.


### PR DESCRIPTION
Updates the cloud images changeset to downplay the cloud images support, since it's really only experimental at this stage, and not something regular keystone users will be able to use just yet.