### PR TITLE
Move more code out of legacy utils package

### DIFF
--- a/.changeset/quick-emus-count.md
+++ b/.changeset/quick-emus-count.md
@@ -24,3 +24,5 @@ Removed the following exports as they're no longer used by Keystone:
 - `mergeWhereClause`
 - `createLazyDeferred`
 - `versionGreaterOrEqualTo`
+- `upcase`
+- `humanize`

--- a/packages-next/keystone/src/admin-ui/system/createAdminMeta.ts
+++ b/packages-next/keystone/src/admin-ui/system/createAdminMeta.ts
@@ -1,5 +1,5 @@
 import type { KeystoneConfig, AdminMetaRootVal } from '@keystone-next/types';
-import { humanize } from '@keystone-next/utils-legacy';
+import { humanize } from '../../lib/utils';
 import { InitialisedList } from '../../lib/core/types-for-lists';
 
 export function createAdminMeta(

--- a/packages-next/keystone/src/lib/core/utils.ts
+++ b/packages-next/keystone/src/lib/core/utils.ts
@@ -1,6 +1,6 @@
 import { ItemRootValue, KeystoneConfig } from '@keystone-next/types';
 import pluralize from 'pluralize';
-import { humanize } from '@keystone-next/utils-legacy';
+import { humanize } from '../utils';
 import { PrismaFilter, UniquePrismaFilter } from './where-inputs';
 
 declare const prisma: unique symbol;

--- a/packages-next/keystone/src/lib/utils.ts
+++ b/packages-next/keystone/src/lib/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Converts the first character of a string to uppercase.
+ * @param {String} str The string to convert.
+ * @returns The new string
+ */
+export const upcase = (str: string) => str.substr(0, 1).toUpperCase() + str.substr(1);
+
+/**
+ * Turns a passed in string into
+ * a human readable label
+ * @param {String} str The string to convert.
+ * @returns The new string
+ */
+export const humanize = (str: string) => {
+  return str
+    .replace(/([a-z])([A-Z]+)/g, '$1 $2')
+    .split(/\s|_|\-/)
+    .filter(i => i)
+    .map(upcase)
+    .join(' ');
+};

--- a/packages-next/keystone/tests/utils.test.ts
+++ b/packages-next/keystone/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { upcase, humanize } from '../src';
+import { upcase, humanize } from '../src/lib/utils';
 
 describe('utils', () => {
   test('humanize()', () => {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,27 +1,5 @@
 import { AssetMode, ImageExtension } from '@keystone-next/types';
 
-/**
- * Converts the first character of a string to uppercase.
- * @param {String} str The string to convert.
- * @returns The new string
- */
-export const upcase = (str: string) => str.substr(0, 1).toUpperCase() + str.substr(1);
-
-/**
- * Turns a passed in string into
- * a human readable label
- * @param {String} str The string to convert.
- * @returns The new string
- */
-export const humanize = (str: string) => {
-  return str
-    .replace(/([a-z])([A-Z]+)/g, '$1 $2')
-    .split(/\s|_|\-/)
-    .filter(i => i)
-    .map(upcase)
-    .join(' ');
-};
-
 const IMAGEREGEX = /^(local|keystone-cloud):image:([^\\\/:\n]+)\.(gif|jpg|png|webp)$/;
 const FILEREGEX = /^(local):file:([^\\\/:\n]+)/;
 


### PR DESCRIPTION
This moves the code into a relatively arbitrary location. Not too fussed about finding the "best" place for these bit and pieces until the dust settles a bit more on the core changes.