### PR TITLE
Cleanup the test-utils package code

### DIFF
--- a/.changeset/three-lemons-invent.md
+++ b/.changeset/three-lemons-invent.md
@@ -1,5 +1,6 @@
 ---
-'@keystone-next/test-utils-legacy': minor
+'@keystone-next/test-utils-legacy': major
 ---
 
+Removed the `ProviderName` type, which is identical to the `DatabaseProvider` type in `@keystone-next/types`.
 Added exports for the `TestKeystoneConfig` and `Setup` types.

--- a/.changeset/three-lemons-invent.md
+++ b/.changeset/three-lemons-invent.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/test-utils-legacy': minor
+---
+
+Added exports for the `TestKeystoneConfig` and `Setup` types.

--- a/examples-staging/ecommerce/tests/mutations.test.ts
+++ b/examples-staging/ecommerce/tests/mutations.test.ts
@@ -1,13 +1,8 @@
-import { KeystoneContext } from '@keystone-next/types';
-import {
-  multiAdapterRunners,
-  setupFromConfig,
-  ProviderName,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import config from '../keystone';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/packages-next/cloudinary/src/test-fixtures.skip.ts
+++ b/packages-next/cloudinary/src/test-fixtures.skip.ts
@@ -4,8 +4,8 @@ import mime from 'mime';
 import { Upload } from 'graphql-upload';
 import cloudinary from 'cloudinary';
 import { text } from '@keystone-next/fields';
-import { ProviderName } from '@keystone-next/test-utils-legacy';
 import { cloudinaryImage } from './index';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const path = require('path');
 
@@ -83,7 +83,7 @@ export const storedValues = () => [
   { image: null, name: 'file6' },
 ];
 
-export const supportedFilters = (provider: ProviderName) => [
+export const supportedFilters = (provider: DatabaseProvider) => [
   'null_equality',
   !['postgresql', 'sqlite'].includes(provider) && 'in_empty_null',
 ];

--- a/packages-next/cloudinary/src/test-fixtures.skip.ts
+++ b/packages-next/cloudinary/src/test-fixtures.skip.ts
@@ -4,8 +4,8 @@ import mime from 'mime';
 import { Upload } from 'graphql-upload';
 import cloudinary from 'cloudinary';
 import { text } from '@keystone-next/fields';
-import { cloudinaryImage } from './index';
 import { DatabaseProvider } from '@keystone-next/types';
+import { cloudinaryImage } from './index';
 
 const path = require('path');
 

--- a/packages-next/fields/src/types/decimal/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/decimal/tests/test-fixtures.ts
@@ -1,4 +1,4 @@
-import { ProviderName } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 import { decimal } from '..';
 import { text } from '../../text';
 
@@ -37,7 +37,7 @@ export const storedValues = () => [
   { name: 'price7', price: null },
 ];
 
-export const supportedFilters = (provider: ProviderName) => [
+export const supportedFilters = (provider: DatabaseProvider) => [
   'null_equality',
   'equality',
   'ordering',

--- a/packages-next/fields/src/types/text/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/text/tests/test-fixtures.ts
@@ -1,4 +1,4 @@
-import { ProviderName } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 import { text } from '..';
 
 export const name = 'Text';
@@ -32,7 +32,7 @@ export const storedValues = () => [
   { name: 'g', testField: null },
 ];
 
-export const supportedFilters = (provider: ProviderName) => [
+export const supportedFilters = (provider: DatabaseProvider) => [
   'null_equality',
   'equality',
   provider !== 'sqlite' && 'equality_case_insensitive',

--- a/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/timestamp/tests/test-fixtures.ts
@@ -1,5 +1,4 @@
-import { ProviderName } from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 import { text } from '../../text';
 import { timestamp } from '..';
 
@@ -55,61 +54,63 @@ export const filterTests = (withKeystone: (args: any) => any) => {
 
   test(
     'Ordering: orderBy: { lastOnline: asc }',
-    withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
-      match(
-        context,
-        undefined,
-        provider === 'sqlite'
-          ? [
-              { name: 'person6', lastOnline: null },
-              { name: 'person7', lastOnline: null },
-              { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
-              { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
-              { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
-              { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
-              { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
-            ]
-          : [
-              { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
-              { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
-              { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
-              { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
-              { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
-              { name: 'person6', lastOnline: null },
-              { name: 'person7', lastOnline: null },
-            ],
-        { lastOnline: 'asc' }
-      )
+    withKeystone(
+      ({ context, provider }: { context: KeystoneContext; provider: DatabaseProvider }) =>
+        match(
+          context,
+          undefined,
+          provider === 'sqlite'
+            ? [
+                { name: 'person6', lastOnline: null },
+                { name: 'person7', lastOnline: null },
+                { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
+                { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
+                { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
+                { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
+                { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
+              ]
+            : [
+                { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
+                { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
+                { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
+                { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
+                { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
+                { name: 'person6', lastOnline: null },
+                { name: 'person7', lastOnline: null },
+              ],
+          { lastOnline: 'asc' }
+        )
     )
   );
 
   test(
     'Ordering: orderBy: { lastOnline: desc }',
-    withKeystone(({ context, provider }: { context: KeystoneContext; provider: ProviderName }) =>
-      match(
-        context,
-        undefined,
-        provider === 'sqlite'
-          ? [
-              { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
-              { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
-              { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
-              { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
-              { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
-              { name: 'person6', lastOnline: null },
-              { name: 'person7', lastOnline: null },
-            ]
-          : [
-              { name: 'person7', lastOnline: null },
-              { name: 'person6', lastOnline: null },
-              { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
-              { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
-              { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
-              { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
-              { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
-            ],
-        { lastOnline: 'desc' }
-      )
+    withKeystone(
+      ({ context, provider }: { context: KeystoneContext; provider: DatabaseProvider }) =>
+        match(
+          context,
+          undefined,
+          provider === 'sqlite'
+            ? [
+                { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
+                { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
+                { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
+                { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
+                { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
+                { name: 'person6', lastOnline: null },
+                { name: 'person7', lastOnline: null },
+              ]
+            : [
+                { name: 'person7', lastOnline: null },
+                { name: 'person6', lastOnline: null },
+                { name: 'person5', lastOnline: '2020-06-10T10:20:30.456Z' },
+                { name: 'person4', lastOnline: '2000-01-20T00:08:00.000Z' },
+                { name: 'person3', lastOnline: '1990-12-31T12:34:56.789Z' },
+                { name: 'person2', lastOnline: '1980-10-01T23:59:59.999Z' },
+                { name: 'person1', lastOnline: '1979-04-12T00:08:00.000Z' },
+              ],
+          { lastOnline: 'desc' }
+        )
     )
   );
 };

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -13,37 +13,34 @@ import {
   requirePrismaClient,
   generateNodeModulesArtifacts,
 } from '@keystone-next/keystone/artifacts';
-import type { KeystoneConfig, KeystoneContext } from '@keystone-next/types';
+import type { DatabaseConfig, KeystoneConfig, KeystoneContext } from '@keystone-next/types';
 import memoizeOne from 'memoize-one';
 
-export type ProviderName = 'postgresql' | 'sqlite';
+export type ProviderName = NonNullable<DatabaseConfig['provider']>;
 
-const hashPrismaSchema = memoizeOne(prismaSchema =>
+const _hashPrismaSchema = memoizeOne(prismaSchema =>
   crypto.createHash('md5').update(prismaSchema).digest('hex')
 );
 
 // Users should use testConfig({ ... }) in place of config({ ... }) when setting up
 // their system for test. We explicitly don't allow them to control the 'db' or 'ui'
 // properties as we're going to set that up as part of setupFromConfig.
-type TestKeystoneConfig = Omit<KeystoneConfig, 'db' | 'ui'>;
+export type TestKeystoneConfig = Omit<KeystoneConfig, 'db' | 'ui'>;
 export const testConfig = (config: TestKeystoneConfig) => config;
 
-const alreadyGeneratedProjects = new Set<string>();
+const _alreadyGeneratedProjects = new Set<string>();
 
-async function setupFromConfig({
+export async function setupFromConfig({
   provider,
   config: _config,
 }: {
   provider: ProviderName;
   config: TestKeystoneConfig;
 }) {
+  const enableLogging = false; // Turn this on if you need verbose debug info
   const config = initConfig({
     ..._config,
-    db: {
-      url: process.env.DATABASE_URL!,
-      provider,
-      enableLogging: false, // Turn this on if you need verbose debug info
-    },
+    db: { url: process.env.DATABASE_URL!, provider, enableLogging },
     ui: { isDisabled: true },
   });
 
@@ -51,13 +48,13 @@ async function setupFromConfig({
 
   const prismaClient = await (async () => {
     const artifacts = await getCommittedArtifacts(graphQLSchema, config);
-    const hash = hashPrismaSchema(artifacts.prisma);
+    const hash = _hashPrismaSchema(artifacts.prisma);
     if (provider === 'postgresql') {
       config.db.url = `${config.db.url}?schema=${hash.toString()}`;
     }
     const cwd = path.resolve('.api-test-prisma-clients', hash);
-    if (!alreadyGeneratedProjects.has(hash)) {
-      alreadyGeneratedProjects.add(hash);
+    if (!_alreadyGeneratedProjects.has(hash)) {
+      _alreadyGeneratedProjects.add(hash);
       fs.mkdirSync(cwd, { recursive: true });
       await writeCommittedArtifacts(artifacts, cwd);
       await generateNodeModulesArtifacts(graphQLSchema, config, cwd);
@@ -71,26 +68,15 @@ async function setupFromConfig({
     return requirePrismaClient(cwd);
   })();
 
-  const keystone = getKeystone(prismaClient);
+  const { connect, disconnect, createContext } = getKeystone(prismaClient);
 
-  const app = await createExpressServer(
-    config,
-    graphQLSchema,
-    keystone.createContext,
-    true,
-    '',
-    false
-  );
+  // (config, graphQLSchema, createContext, dev, projectAdminPath, isVerbose)
+  const app = await createExpressServer(config, graphQLSchema, createContext, true, '', false);
 
-  return {
-    connect: () => keystone.connect(),
-    disconnect: () => keystone.disconnect(),
-    context: keystone.createContext().sudo(),
-    app,
-  };
+  return { connect, disconnect, context: createContext().sudo(), app };
 }
 
-function networkedGraphqlRequest({
+export function networkedGraphqlRequest({
   app,
   query,
   variables = undefined,
@@ -115,12 +101,10 @@ function networkedGraphqlRequest({
       expect(res.statusCode).toBe(expectedStatusCode);
       return { ...JSON.parse(res.text), res };
     })
-    .catch((error: Error) => ({
-      errors: [error],
-    }));
+    .catch((error: Error) => ({ errors: [error] }));
 }
 
-type Setup = {
+export type Setup = {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   context: KeystoneContext;
@@ -173,7 +157,7 @@ function _after(tearDownFunction: () => Promise<void> | void) {
   };
 }
 
-function multiAdapterRunners(only = process.env.TEST_ADAPTER) {
+export function multiAdapterRunners(only = process.env.TEST_ADAPTER) {
   return (['postgresql', 'sqlite'] as const)
     .filter(provider => typeof only === 'undefined' || provider === only)
     .map(provider => ({
@@ -183,5 +167,3 @@ function multiAdapterRunners(only = process.env.TEST_ADAPTER) {
       after: _after(() => {}),
     }));
 }
-
-export { setupFromConfig, multiAdapterRunners, networkedGraphqlRequest };

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -13,10 +13,8 @@ import {
   requirePrismaClient,
   generateNodeModulesArtifacts,
 } from '@keystone-next/keystone/artifacts';
-import type { DatabaseConfig, KeystoneConfig, KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneConfig, KeystoneContext } from '@keystone-next/types';
 import memoizeOne from 'memoize-one';
-
-export type ProviderName = NonNullable<DatabaseConfig['provider']>;
 
 const _hashPrismaSchema = memoizeOne(prismaSchema =>
   crypto.createHash('md5').update(prismaSchema).digest('hex')
@@ -34,7 +32,7 @@ export async function setupFromConfig({
   provider,
   config: _config,
 }: {
-  provider: ProviderName;
+  provider: DatabaseProvider;
   config: TestKeystoneConfig;
 }) {
   const enableLogging = false; // Turn this on if you need verbose debug info
@@ -111,9 +109,9 @@ export type Setup = {
   app: express.Application;
 };
 
-function _keystoneRunner(provider: ProviderName, tearDownFunction: () => Promise<void> | void) {
+function _keystoneRunner(provider: DatabaseProvider, tearDownFunction: () => Promise<void> | void) {
   return function (
-    setupKeystoneFn: (provider: ProviderName) => Promise<Setup>,
+    setupKeystoneFn: (provider: DatabaseProvider) => Promise<Setup>,
     testFn?: (setup: Setup) => Promise<void>
   ) {
     return async function () {
@@ -142,8 +140,8 @@ function _keystoneRunner(provider: ProviderName, tearDownFunction: () => Promise
   };
 }
 
-function _before(provider: ProviderName) {
-  return async function (setupKeystone: (provider: ProviderName) => Promise<Setup>) {
+function _before(provider: DatabaseProvider) {
+  return async function (setupKeystone: (provider: DatabaseProvider) => Promise<Setup>) {
     const setup = await setupKeystone(provider);
     await setup.connect();
     return setup;

--- a/tests/api-tests/access-control/mutations-field-static.test.ts
+++ b/tests/api-tests/access-control/mutations-field-static.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/access-control/mutations-list-declarative.test.ts
+++ b/tests/api-tests/access-control/mutations-list-declarative.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/access-control/mutations-list-static.test.ts
+++ b/tests/api-tests/access-control/mutations-list-static.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -1,9 +1,9 @@
 import { text, password } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { statelessSessions } from '@keystone-next/keystone/session';
-import { ProviderName, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createAuth } from '@keystone-next/auth';
-import type { KeystoneConfig } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneConfig } from '@keystone-next/types';
 
 const FAKE_ID = { postgresql: 137, sqlite: 137 } as const;
 const FAKE_ID_2 = { postgresql: 138, sqlite: 138 } as const;
@@ -88,7 +88,7 @@ const createFieldImperative = (fieldAccess: BooleanAccess) => ({
     },
   }),
 });
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   const lists = createSchema({
     User: list({
       fields: {

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -7,10 +7,9 @@ import {
   multiAdapterRunners,
   setupFromConfig,
   networkedGraphqlRequest,
-  ProviderName,
   testConfig,
 } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext, KeystoneConfig } from '@keystone-next/types';
+import type { KeystoneContext, KeystoneConfig, DatabaseProvider } from '@keystone-next/types';
 
 const initialData = {
   User: [
@@ -41,7 +40,7 @@ const auth = createAuth({
   sessionData: 'id',
 });
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: auth.withAuth(

--- a/tests/api-tests/default-value/defaults.test.ts
+++ b/tests/api-tests/default-value/defaults.test.ts
@@ -1,10 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
-import type { BaseFields } from '@keystone-next/types';
+import type { BaseFields, DatabaseProvider } from '@keystone-next/types';
 
-const setupList = (provider: ProviderName, fields: BaseFields<any>) => () =>
+const setupList = (provider: DatabaseProvider, fields: BaseFields<any>) => () =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -1,11 +1,7 @@
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createSchema, list, graphQLSchemaExtension, gql } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const falseFn: (...args: any) => boolean = () => false;
 
@@ -25,7 +21,7 @@ const withAccessCheck = <T, Args extends unknown[]>(
   };
 };
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -1,15 +1,10 @@
 import { integer, relationship, text, virtual } from '@keystone-next/fields';
 import { BaseFields, createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
-import { schema } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, schema } from '@keystone-next/types';
 
 function makeSetupKeystone(fields: BaseFields<any>) {
-  return function setupKeystone(provider: ProviderName) {
+  return function setupKeystone(provider: DatabaseProvider) {
     return setupFromConfig({
       provider,
       config: testConfig({
@@ -108,7 +103,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
       test(
         'referencing other list type',
         runner(
-          function setupKeystone(provider: ProviderName) {
+          function setupKeystone(provider: DatabaseProvider) {
             return setupFromConfig({
               provider,
               config: testConfig({

--- a/tests/api-tests/hooks/auth-hooks.test.skip.ts
+++ b/tests/api-tests/hooks/auth-hooks.test.skip.ts
@@ -1,17 +1,13 @@
 import { AddressInfo } from 'net';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  testConfig,
-  setupFromConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, testConfig, setupFromConfig } from '@keystone-next/test-utils-legacy';
 // @ts-ignore
 import superagent from 'superagent';
 import express from 'express';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text, password } from '@keystone-next/fields';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/new-interfaces.test.ts
+++ b/tests/api-tests/new-interfaces.test.ts
@@ -1,9 +1,9 @@
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -5,12 +5,11 @@ import {
   setupFromConfig,
   networkedGraphqlRequest,
   testConfig,
-  ProviderName,
 } from '@keystone-next/test-utils-legacy';
 import { list, createSchema, graphQLSchemaExtension } from '@keystone-next/keystone/schema';
-import { KeystoneContext } from '@keystone-next/types';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -1,13 +1,9 @@
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -5,11 +5,11 @@ import {
   setupFromConfig,
   networkedGraphqlRequest,
   testConfig,
-  ProviderName,
 } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 import { depthLimit, definitionLimit, fieldLimit } from './validation';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -1,14 +1,9 @@
 import { integer } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -2,16 +2,12 @@ import { gen, sampleOne } from 'testcheck';
 
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/search.test.ts
+++ b/tests/api-tests/queries/search.test.ts
@@ -1,13 +1,9 @@
 import { text, integer } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/queries/sortBy.test.ts
+++ b/tests/api-tests/queries/sortBy.test.ts
@@ -1,14 +1,9 @@
 import { integer } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -77,7 +76,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -82,7 +81,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -79,7 +78,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
   return data;
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -77,7 +76,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -57,7 +56,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
   return data;
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -86,7 +85,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -92,7 +91,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -98,7 +97,7 @@ const getCompanyAndLocation = async (
   return data;
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -85,7 +84,7 @@ const createReadData = async (context: KeystoneContext) => {
   );
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -2,8 +2,7 @@ import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
-import type { ProviderName } from '@keystone-next/test-utils-legacy';
-import type { KeystoneContext } from '@keystone-next/types';
+import type { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -91,7 +90,7 @@ const getCompanyAndLocation = async (
   return data;
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/filtering/access-control.test.ts
+++ b/tests/api-tests/relationships/filtering/access-control.test.ts
@@ -1,18 +1,14 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const postNames = ['Post 1', 'Post 2', 'Post 3'];
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/filtering/filtering.test.ts
+++ b/tests/api-tests/relationships/filtering/filtering.test.ts
@@ -1,15 +1,11 @@
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 type IdType = any;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -1,11 +1,11 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
 
 type IdType = any;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -2,6 +2,7 @@ import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 type IdType = any;
 

--- a/tests/api-tests/relationships/many-to-one-to-one.test.ts
+++ b/tests/api-tests/relationships/many-to-one-to-one.test.ts
@@ -1,5 +1,5 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
@@ -85,7 +85,7 @@ const createCompanyAndLocation = async (context: KeystoneContext) => {
   });
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -1,12 +1,13 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -1,10 +1,11 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -1,14 +1,15 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 type IdType = any;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
@@ -1,9 +1,10 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -1,18 +1,14 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 type IdType = any;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({
@@ -68,7 +64,7 @@ multiAdapterRunners().map(({ runner, provider }) =>
     test(
       'afterChange is called for nested creates',
       runner(
-        function setupKeystone(provider: ProviderName) {
+        function setupKeystone(provider: DatabaseProvider) {
           return setupFromConfig({
             provider,
             config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -1,14 +1,10 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-all-many.test.ts
@@ -1,16 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/disconnect-all-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-all-singular.test.ts
@@ -1,16 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -1,16 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -1,16 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -1,15 +1,11 @@
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 type IdType = any;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -1,9 +1,9 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -11,7 +11,7 @@ type IdType = any;
 
 const toStr = (items: any[]) => items.map(item => item.toString());
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
@@ -1,12 +1,13 @@
-import { ProviderName, testConfig } from '@keystone-next/test-utils-legacy';
+import { testConfig } from '@keystone-next/test-utils-legacy';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { multiAdapterRunners, setupFromConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider } from '@keystone-next/types';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/relationships/shared-names.test.ts
+++ b/tests/api-tests/relationships/shared-names.test.ts
@@ -1,12 +1,7 @@
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 
 type IdType = any;
 
@@ -111,7 +106,7 @@ const createInitialData = async (context: KeystoneContext) => {
   });
 };
 
-const setupKeystone = (provider: ProviderName) =>
+const setupKeystone = (provider: DatabaseProvider) =>
   setupFromConfig({
     provider,
     config: testConfig({

--- a/tests/api-tests/server-side-graphql-client.test.ts
+++ b/tests/api-tests/server-side-graphql-client.test.ts
@@ -1,12 +1,7 @@
 import { text, integer } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
-import {
-  ProviderName,
-  multiAdapterRunners,
-  setupFromConfig,
-  testConfig,
-} from '@keystone-next/test-utils-legacy';
-import { KeystoneContext } from '@keystone-next/types';
+import { multiAdapterRunners, setupFromConfig, testConfig } from '@keystone-next/test-utils-legacy';
+import { DatabaseProvider, KeystoneContext } from '@keystone-next/types';
 import {
   createItems,
   createItem,
@@ -30,7 +25,7 @@ type IdType = any;
 const seedDb = ({ context }: { context: KeystoneContext }): Promise<{ id: IdType }[]> =>
   createItems({ context, listKey, items: testData }) as Promise<{ id: IdType }[]>;
 
-function setupKeystone(provider: ProviderName) {
+function setupKeystone(provider: DatabaseProvider) {
   return setupFromConfig({
     provider,
     config: testConfig({


### PR DESCRIPTION
Mostly cosmetic changes inside the `test-utils` package. I'd like to get this ready to have a bit of a face-lift and for us to give a bit of consideration to the desired API here so that we can promote it from a `legacy` package to a fully documented feature that people can use to test their own keystone systems.