### PR TITLE
Fix orderBy in generated TS types

### DIFF
--- a/.changeset/heavy-waves-peel.md
+++ b/.changeset/heavy-waves-peel.md
@@ -1,5 +1,6 @@
 ---
 '@keystone-next/types': patch
+'@keystone-next/keystone': patch
 ---
 
 Fixed `BaseGeneratedListTypes` to have `orderBy` be readonly like the generated types

--- a/.changeset/heavy-waves-peel.md
+++ b/.changeset/heavy-waves-peel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/types': patch
+---
+
+Fixed `BaseGeneratedListTypes` to have `orderBy` be readonly like the generated types

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -12,8 +12,9 @@ import {
 } from '@keystone-next/fields';
 import { document } from '@keystone-next/fields-document';
 // import { cloudinaryImage } from '@keystone-next/cloudinary';
-import { schema } from '@keystone-next/types';
+import { KeystoneListsAPI, schema } from '@keystone-next/types';
 import { componentBlocks } from './admin/fieldViews/Content';
+import { KeystoneListsTypeInfo } from '.keystone/types';
 
 // TODO: Can we generate this type based on sessionData in the main config?
 type AccessArgs = {
@@ -211,7 +212,10 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
         // TODO: add a way to verify access control here, e.g
         // await context.verifyAccessControl(userIsAdmin);
         const data = Array.from({ length: 238 }).map((x, i) => ({ data: { title: `Post ${i}` } }));
-        return context.lists.Post.createMany({ data });
+        // note this usage of the type is important because it tests that the generated
+        // KeystoneListsTypeInfo extends Record<string, BaseGeneratedListTypes>
+        const lists: KeystoneListsAPI<KeystoneListsTypeInfo> = context.lists;
+        return lists.Post.createMany({ data });
       },
     },
     Query: {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish-changed": "yarn build && changeset publish --public",
     "version-packages": "changeset version",
     "build": "preconstruct build",
-    "prepare": "manypkg check && preconstruct dev && yarn run --silent contributing-guide",
+    "prepare": "manypkg check && preconstruct dev && yarn run --silent contributing-guide && cd examples-staging/basic && yarn keystone-next postinstall",
     "contributing-guide": "is-ci && exit 0 || chalk -t \"{bold 📝 Contributing to KeystoneJS?}\" && terminal-link \"🔗 Read the full Contributing Guide\" \"https://github.com/keystonejs/keystone/blob/master/CONTRIBUTING.md\"",
     "npm-tag": "manypkg npm-tag",
     "update": "manypkg upgrade",

--- a/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
+++ b/packages-next/keystone/src/lib/context/server-side-graphql-client.ts
@@ -121,7 +121,7 @@ const getItems = async ({
   listKey: string;
   where?: Record<string, any> | null;
   sortBy?: readonly string[] | null;
-  orderBy?: Record<string, 'asc' | 'desc'>[];
+  orderBy?: readonly Record<string, 'asc' | 'desc' | null>[];
   first?: number | null;
   skip?: number | null;
   pageSize?: number;

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -9,7 +9,7 @@ export type BaseGeneratedListTypes = {
       readonly search?: string | null;
       readonly first?: number | null;
       readonly skip?: number | null;
-      readonly orderBy?: Record<string, 'asc' | 'desc'>[];
+      readonly orderBy?: readonly Record<string, 'asc' | 'desc'>[];
       readonly sortBy?: ReadonlyArray<string> | null;
     };
   };

--- a/packages-next/types/src/utils.ts
+++ b/packages-next/types/src/utils.ts
@@ -9,7 +9,7 @@ export type BaseGeneratedListTypes = {
       readonly search?: string | null;
       readonly first?: number | null;
       readonly skip?: number | null;
-      readonly orderBy?: readonly Record<string, 'asc' | 'desc'>[];
+      readonly orderBy?: readonly Record<string, 'asc' | 'desc' | null>[];
       readonly sortBy?: ReadonlyArray<string> | null;
     };
   };


### PR DESCRIPTION
Also made one of the things in examples-staging use it so that it's tested and we don't break it again (which requires we run keystone-next postinstall for that example so tsc passes)