### PR TITLE
Fix error in document guide

### DIFF
--- a/docs/pages/guides/document-fields.mdx
+++ b/docs/pages/guides/document-fields.mdx
@@ -76,7 +76,7 @@ To add component blocks, you need to create a file somewhere and export componen
 
 ```tsx
 import React from 'react';
-import { component, fields } from '@keystone-next/fields-document/component-blocks';
+import { NotEditable, component, fields } from '@keystone-next/fields-document/component-blocks';
 
 // naming the export componentBlocks is important because the Admin UI
 // expects to find the components like on the componentBlocks export


### PR DESCRIPTION
Add `NotEditable` import to component-blocks.tsx in document guide to fix "NotEditable" not found when following document guide