### PR TITLE
[WIP] Add support for passing args to virtual fields from the Admin UI

### DIFF
--- a/docs/pages/apis/fields.mdx
+++ b/docs/pages/apis/fields.mdx
@@ -561,6 +561,7 @@ Options:
 
 - `field` (required):
 - `graphQLReturnFragment` (default: `undefined` ):
+- `graphQLArgs` (default: `{}`):
 
 ```typescript
 import { config, createSchema, list } from '@keystone-next/keystone/schema';
@@ -576,10 +577,11 @@ export default config({
             type: schema.String,
             args: { something: schema.arg({ type: schema.Int }) },
             resolve(item, args, context, info) {
-
+              return (args.something || 0).toString();
             }
           })
           graphQLReturnFragment: '...',
+	  graphQLArgs: { something: 100 },
         }),
         /* ... */
       },

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -66,9 +66,15 @@ export const lists = createSchema({
             if (!item.content) {
               return null;
             }
-            return (item.content as string).slice(0, length - 3) + '...';
+            const content = item.content as string;
+            if (content.length <= length) {
+              return content;
+            } else {
+              return content.slice(0, length - 3) + '...';
+            }
           },
         }),
+        graphQLArgs: { length: 10 },
       }),
       // A virtual field which returns a type derived from a Keystone list.
       relatedPosts: virtual({

--- a/packages-next/fields/src/types/virtual/index.ts
+++ b/packages-next/fields/src/types/virtual/index.ts
@@ -6,6 +6,7 @@ import {
   FieldTypeFunc,
   fieldType,
   ListInfo,
+  JSONValue,
 } from '@keystone-next/types';
 import { resolveView } from '../../resolve-view';
 
@@ -18,11 +19,13 @@ export type VirtualFieldConfig<TGeneratedListTypes extends BaseGeneratedListType
       | ((lists: Record<string, ListInfo>) => VirtualFieldGraphQLField);
     unreferencedConcreteInterfaceImplementations?: schema.ObjectType<any>[];
     graphQLReturnFragment?: string;
+    graphQLArgs?: JSONValue;
   };
 
 export const virtual =
   <TGeneratedListTypes extends BaseGeneratedListTypes>({
     graphQLReturnFragment = '',
+    graphQLArgs = {},
     field,
     ...config
   }: VirtualFieldConfig<TGeneratedListTypes>): FieldTypeFunc =>
@@ -40,6 +43,6 @@ export const virtual =
         },
       }),
       views: resolveView('virtual/views'),
-      getAdminMeta: () => ({ graphQLReturnFragment }),
+      getAdminMeta: () => ({ graphQLReturnFragment, graphQLArgs }),
     });
   };

--- a/packages-next/fields/src/types/virtual/views/index.tsx
+++ b/packages-next/fields/src/types/virtual/views/index.tsx
@@ -36,12 +36,18 @@ export const CardValue: CardValueComponent = ({ item, field }) => {
 const createViewValue = Symbol('create view virtual field value');
 
 export const controller = (
-  config: FieldControllerConfig<{ graphQLReturnFragment: string }>
+  config: FieldControllerConfig<{ graphQLReturnFragment: string; graphQLArgs: Record<string, any> }>
 ): FieldController<any> => {
+  // FIXME: There's gotta be a better way to do this
+  const args = Object.keys(config.fieldMeta.graphQLArgs).length
+    ? `(${Object.entries(config.fieldMeta.graphQLArgs)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(' ')})`
+    : '';
   return {
     path: config.path,
     label: config.label,
-    graphqlSelection: `${config.path}${config.fieldMeta.graphQLReturnFragment}`,
+    graphqlSelection: `${config.path}${args}${config.fieldMeta.graphQLReturnFragment}`,
     defaultValue: createViewValue,
     deserialize: data => {
       return data[config.path];


### PR DESCRIPTION
Adds a `graphQLArgs` option to virtual fields, which allows you to set the field arguments passed to the query in the Admin UI. This option is **required** if using `args` that don't have a `defaultValue`.