### PR TITLE
fixed the arrow in the dialog appearing in the wrong place

### DIFF
--- a/.changeset/pink-wasps-learn.md
+++ b/.changeset/pink-wasps-learn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/popover': patch
+---
+
+Fixed popover arrow misalignment.

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -230,14 +230,8 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
           }}
           {...props}
         >
-          <div ref={focusTrapRef}>
-            {isVisible && (
-              <Fragment>
-                <div data-popper-arrow ref={arrow.ref} className="tooltipArrow" {...arrow.props} />
-                {children}
-              </Fragment>
-            )}
-          </div>
+          <div data-popper-arrow ref={arrow.ref} className="tooltipArrow" {...arrow.props} />
+          <div ref={focusTrapRef}>{isVisible && <Fragment>{children}</Fragment>}</div>
         </div>
       </Portal>
     );

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -231,7 +231,7 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
           {...props}
         >
           <div data-popper-arrow ref={arrow.ref} className="tooltipArrow" {...arrow.props} />
-          <div ref={focusTrapRef}>{isVisible && <Fragment>{children}</Fragment>}</div>
+          <div ref={focusTrapRef}>{isVisible && children}</div>
         </div>
       </Portal>
     );


### PR DESCRIPTION
On the tin, arrow was wrapped in our focus lock div, which was what was causing grief. 
Now moved back to its original location.