### PR TITLE
Update @types/graphql-upload

### DIFF
--- a/packages-next/cloudinary/src/test-fixtures.skip.ts
+++ b/packages-next/cloudinary/src/test-fixtures.skip.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import mime from 'mime';
-// @ts-ignore
-import { Upload } from 'graphql-upload';
+import { FileUpload, Upload } from 'graphql-upload';
 import cloudinary from 'cloudinary';
 import { text } from '@keystone-next/fields';
 import { DatabaseProvider } from '@keystone-next/types';
@@ -25,7 +24,7 @@ const prepareFile = (_filePath: string) => {
     mimetype: mime.getType(filePath),
     encoding: 'utf-8',
   });
-  return upload;
+  return upload as Upload & { file: FileUpload };
 };
 
 // Configurations

--- a/packages-next/fields/src/types/file/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/file/tests/test-fixtures.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs-extra';
-// @ts-ignore
 import { Upload } from 'graphql-upload';
 import mime from 'mime';
 import { text } from '../../text';

--- a/packages-next/fields/src/types/image/tests/test-fixtures.ts
+++ b/packages-next/fields/src/types/image/tests/test-fixtures.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs-extra';
-// @ts-ignore
 import { Upload } from 'graphql-upload';
 import mime from 'mime';
 import { KeystoneContext } from '@keystone-next/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,9 +2696,9 @@
     "@types/node" "*"
 
 "@types/graphql-upload@^8.0.4":
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql-upload/-/graphql-upload-8.0.4.tgz#23a8ffb3d2fe6e0ee07e6f16ee9d9d5e995a2f4f"
-  integrity sha512-0TRyJD2o8vbkmJF8InppFcPVcXKk+Rvlg/xvpHBIndSJYpmDWfmtx/ZAtl4f3jR2vfarpTqYgj8MZuJssSoU7Q==
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@types/graphql-upload/-/graphql-upload-8.0.5.tgz#d6adce53f82630e59dca8900c2285877ae61b9eb"
+  integrity sha512-h01wGd+0wzEGZhTi5609xTRheTtHaDOIG21NEb6UP2O9FcyU6FeMiTq2rLzjtN3JL2b0HKhwYhIzEe8XLTPerw==
   dependencies:
     "@types/express" "*"
     "@types/fs-capacitor" "*"


### PR DESCRIPTION
The latest version of this package now exports the `Upload` type, so we can remove the `@ts-ignore`, however the type misses the `file` property, so we add that to the type ourself in the one place we need it.