### PR TITLE
Fix readonly property set in format-error of createApolloServer

### DIFF
--- a/.changeset/clean-countries-drop.md
+++ b/.changeset/clean-countries-drop.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Fixed readonly property set in `format-error` of `createApolloServer`.

--- a/packages-next/keystone/src/lib/server/format-error.ts
+++ b/packages-next/keystone/src/lib/server/format-error.ts
@@ -63,9 +63,7 @@ const flattenNestedErrors = (error: any) =>
 
 export const formatError = (error: GraphQLError) => {
   const { originalError }: { originalError: any } = error;
-  if (originalError && !originalError.path) {
-    originalError.path = error.path;
-  }
+
   // For correlating user error reports with logs
   // @ts-ignore
   error.uid = cuid();


### PR DESCRIPTION
Fixes #5898 - simply removed the setting of a readonly property on the ApolloError object since I couldn't ascertain what its purpose was.