### PR TITLE
Add a basic document field example project

### DIFF
--- a/.changeset/few-socks-visit.md
+++ b/.changeset/few-socks-visit.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/example-document-field': major
+---
+
+Initial version of the document field example project.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,6 +251,7 @@ jobs:
             'auth.test.ts',
             'basic.test.ts',
             'blog.test.ts',
+            'document-field.test.ts',
             'default-values.test.ts',
             'extend-graphql-schema.test.ts',
             'json.test.ts',

--- a/examples/NEW-EXAMPLES.md
+++ b/examples/NEW-EXAMPLES.md
@@ -27,6 +27,7 @@ There are three types of example project:
 7. Make sure your base example runs. `cd <example-name>; yarn dev`.
 8. Add a changeset with the initial major version of the example. `cd ../..; yarn changeset - major “Initial version of the <example-name> example.”`
 9. [Draw the rest of the owl](https://knowyourmeme.com/memes/how-to-draw-an-owl). Write and test your example, making sure that it's clearly commented.
-10. Add a smoke test to ensure your example is executed on CI.
+10. Add a smoke test to ensure your example is executed on CI. You will need to edit the `examples_smoke_tests` block in `tests.yml`
 11. Update the `examples/README.md` with a link to your new example.
 12. Submit a PR for review.
+13. Once your PR is merged, update the branch protection rules on `master` to require the new smoke test.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,10 +18,11 @@ They have very simple schemas and none of the bells or whistles you'd expect in 
 Each project below demonstrates a Keystone feature you can learn about and experiment with.
 
 - [`withAuth()`](./with-auth): Adds password-based authentication to the Task Manager base.
-- [`JSON field`](./json): Adds a JSON field to the Task Manager base.
+- [JSON field](./json): Adds a JSON field to the Task Manager base.
 - [`defaultValue`](./default-values): Adds default values to the Blog base.
 - [`extendGraphqlSchema`](./extend-graphql-schema): Extends the GraphQL API of the Task Manager base.
-- [`virtual field`](./virtual-field): Adds virtual fields to the Blog base.
+- [Virtual field](./virtual-field): Adds virtual fields to the Blog base.
+- [Document field](./document-field): Adds document fields to the Blog base.
 - [Testing](./testing): Adds tests with `@keystone-next/testing` to the `withAuth()` example.
 
 ## Running examples

--- a/examples/document-field/CHANGELOG.md
+++ b/examples/document-field/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @keystone-next/example-document-field

--- a/examples/document-field/README.md
+++ b/examples/document-field/README.md
@@ -1,0 +1,96 @@
+## Feature Example - Document Field
+
+This project demonstrates how to configure [document fields](https://next.keystonejs.com/docs/guides/document-fields) in your Keystone system and render their data in a frontend application.
+It builds on the [Blog](../blog) starter project.
+
+## Instructions
+
+To run this project, clone the Keystone repository locally then navigate to this directory and run:
+
+```shell
+yarn dev
+```
+
+This will start the Admin UI at [localhost:3000](http://localhost:3000).
+You can use the Admin UI to create items in your database.
+
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+
+In a separate terminal, start the frontend dev server:
+
+```
+yarn dev:site
+```
+
+This will start the frontend at [localhost:3001](http://localhost:3001).
+
+
+## Configuring fields
+
+The project contains two `document` fields which show how to use the field configuration options to customise the document editor in the Admin UI.
+
+### `Post.content`
+
+For the blog post content we want the user to have the full complement of formatting and editor options available, including multi-column layouts.
+To do this we use the short-hand notation of `formatting: true`, which enables all formatting features. We also enable `dividers`, `links`, and specify two additional column layouts.
+
+```ts
+content: document({
+  formatting: true,
+  dividers: true,
+  links: true,
+  layouts: [
+    [1, 1],
+    [1, 1, 1],
+  ],
+}),
+```
+
+### `Author.bio`
+
+For the author bios we only want to allow bold and italics text, unordered lists, and linked text.
+We use fine-grained configuration options to customise which `formatting` options are enabled.
+
+```ts
+bio: document({
+  formatting: {
+    inlineMarks: {
+      bold: true,
+      italic: true,
+    },
+    listTypes: { unordered: true },
+  },
+  links: true,
+}),
+```
+
+## Frontend Rendering
+
+In the `src` directory there is a Next.js frontend which uses the `DocumentRenderer` component from `@keystone-next/document-renderer` to render the document data.
+
+We render the `Author.bio` field using the default document renderer.
+This renders the content with minimal styling.
+
+```tsx
+import { DocumentRenderer } from '@keystone-next/document-renderer';
+
+<DocumentRenderer document={author.bio.document} />;
+```
+
+For the `Post.content` field we provide a custom renderer for headings, which allows us to add our own styling.
+In this case we apply `textTransform: 'uppercase'` to all of our headings, while using the default styling for all other elements.
+
+```tsx
+import { DocumentRenderer, DocumentRendererProps } from '@keystone-next/document-renderer';
+
+const renderers: DocumentRendererProps['renderers'] = {
+  block: {
+    heading({ level, children, textAlign }) {
+      const Comp = `h${level}` as const;
+      return <Comp style={{ textAlign, textTransform: 'uppercase' }}>{children}</Comp>;
+    },
+  },
+};
+
+<DocumentRenderer document={post.content.document} renderers={renderers} />;
+```

--- a/examples/document-field/keystone.ts
+++ b/examples/document-field/keystone.ts
@@ -1,0 +1,10 @@
+import { config } from '@keystone-next/keystone/schema';
+import { lists } from './schema';
+
+export default config({
+  db: {
+    provider: 'sqlite',
+    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+  },
+  lists,
+});

--- a/examples/document-field/next-env.d.ts
+++ b/examples/document-field/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />

--- a/examples/document-field/next.config.js
+++ b/examples/document-field/next.config.js
@@ -1,0 +1,5 @@
+// you don't need this if you're building something outside of the Keystone repo
+
+const withPreconstruct = require('@preconstruct/next');
+
+module.exports = withPreconstruct();

--- a/examples/document-field/package.json
+++ b/examples/document-field/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@keystone-next/example-document-field",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "dev": "keystone-next dev",
+    "dev:site": "next dev -p 3001",
+    "start": "keystone-next start",
+    "build": "keystone-next build"
+  },
+  "dependencies": {
+    "@keystone-next/document-renderer": "^3.0.0",
+    "@keystone-next/fields": "^11.0.0",
+    "@keystone-next/fields-document": "^7.0.0",
+    "@keystone-next/keystone": "^20.0.0",
+    "@preconstruct/next": "^3.0.0",
+    "next": "^10.2.3",
+    "react": "^17.0.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20 || >= 14.13"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/master/examples/document-field"
+}

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -1,0 +1,478 @@
+"""
+ A keystone list
+"""
+type Post {
+  id: ID!
+  title: String
+  slug: String
+  status: PostStatusType
+  content: Post_content_DocumentField
+  publishDate: String
+  author: Author
+}
+
+enum PostStatusType {
+  draft
+  published
+}
+
+type Post_content_DocumentField {
+  document(hydrateRelationships: Boolean! = false): JSON!
+}
+
+input PostWhereInput {
+  AND: [PostWhereInput!]
+  OR: [PostWhereInput!]
+  id: ID
+  id_not: ID
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  title: String
+  title_not: String
+  title_contains: String
+  title_not_contains: String
+  title_in: [String]
+  title_not_in: [String]
+  slug: String
+  slug_not: String
+  slug_contains: String
+  slug_not_contains: String
+  slug_in: [String]
+  slug_not_in: [String]
+  status: PostStatusType
+  status_not: PostStatusType
+  status_in: [PostStatusType]
+  status_not_in: [PostStatusType]
+  publishDate: String
+  publishDate_not: String
+  publishDate_lt: String
+  publishDate_lte: String
+  publishDate_gt: String
+  publishDate_gte: String
+  publishDate_in: [String]
+  publishDate_not_in: [String]
+  author: AuthorWhereInput
+  author_is_null: Boolean
+}
+
+input PostWhereUniqueInput {
+  id: ID
+  slug: String
+}
+
+enum SortPostsBy {
+  id_ASC
+  id_DESC
+  title_ASC
+  title_DESC
+  slug_ASC
+  slug_DESC
+  status_ASC
+  status_DESC
+  publishDate_ASC
+  publishDate_DESC
+}
+
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  slug: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+input PostUpdateInput {
+  title: String
+  slug: String
+  status: PostStatusType
+  content: JSON
+  publishDate: String
+  author: AuthorRelateToOneInput
+}
+
+input AuthorRelateToOneInput {
+  create: AuthorCreateInput
+  connect: AuthorWhereUniqueInput
+  disconnect: AuthorWhereUniqueInput
+  disconnectAll: Boolean
+}
+
+input PostsUpdateInput {
+  id: ID!
+  data: PostUpdateInput
+}
+
+input PostCreateInput {
+  title: String
+  slug: String
+  status: PostStatusType
+  content: JSON
+  publishDate: String
+  author: AuthorRelateToOneInput
+}
+
+input PostsCreateInput {
+  data: PostCreateInput
+}
+
+"""
+ A keystone list
+"""
+type Author {
+  id: ID!
+  name: String
+  email: String
+  posts(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Post!]
+  _postsMeta(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int
+  bio: Author_bio_DocumentField
+}
+
+type _QueryMeta {
+  count: Int
+}
+
+type Author_bio_DocumentField {
+  document(hydrateRelationships: Boolean! = false): JSON!
+}
+
+input AuthorWhereInput {
+  AND: [AuthorWhereInput!]
+  OR: [AuthorWhereInput!]
+  id: ID
+  id_not: ID
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  name: String
+  name_not: String
+  name_contains: String
+  name_not_contains: String
+  name_in: [String]
+  name_not_in: [String]
+  email: String
+  email_not: String
+  email_contains: String
+  email_not_contains: String
+  email_in: [String]
+  email_not_in: [String]
+
+  """
+   condition must be true for all nodes
+  """
+  posts_every: PostWhereInput
+
+  """
+   condition must be true for at least 1 node
+  """
+  posts_some: PostWhereInput
+
+  """
+   condition must be false for all nodes
+  """
+  posts_none: PostWhereInput
+}
+
+input AuthorWhereUniqueInput {
+  id: ID
+  email: String
+}
+
+enum SortAuthorsBy {
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  email_ASC
+  email_DESC
+}
+
+input AuthorOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+}
+
+input AuthorUpdateInput {
+  name: String
+  email: String
+  posts: PostRelateToManyInput
+  bio: JSON
+}
+
+input PostRelateToManyInput {
+  create: [PostCreateInput]
+  connect: [PostWhereUniqueInput]
+  disconnect: [PostWhereUniqueInput]
+  disconnectAll: Boolean
+}
+
+input AuthorsUpdateInput {
+  id: ID!
+  data: AuthorUpdateInput
+}
+
+input AuthorCreateInput {
+  name: String
+  email: String
+  posts: PostRelateToManyInput
+  bio: JSON
+}
+
+input AuthorsCreateInput {
+  data: AuthorCreateInput
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+type Mutation {
+  """
+   Create a single Post item.
+  """
+  createPost(data: PostCreateInput): Post
+
+  """
+   Create multiple Post items.
+  """
+  createPosts(data: [PostsCreateInput]): [Post]
+
+  """
+   Update a single Post item by ID.
+  """
+  updatePost(id: ID!, data: PostUpdateInput): Post
+
+  """
+   Update multiple Post items by ID.
+  """
+  updatePosts(data: [PostsUpdateInput]): [Post]
+
+  """
+   Delete a single Post item by ID.
+  """
+  deletePost(id: ID!): Post
+
+  """
+   Delete multiple Post items by ID.
+  """
+  deletePosts(ids: [ID!]): [Post]
+
+  """
+   Create a single Author item.
+  """
+  createAuthor(data: AuthorCreateInput): Author
+
+  """
+   Create multiple Author items.
+  """
+  createAuthors(data: [AuthorsCreateInput]): [Author]
+
+  """
+   Update a single Author item by ID.
+  """
+  updateAuthor(id: ID!, data: AuthorUpdateInput): Author
+
+  """
+   Update multiple Author items by ID.
+  """
+  updateAuthors(data: [AuthorsUpdateInput]): [Author]
+
+  """
+   Delete a single Author item by ID.
+  """
+  deleteAuthor(id: ID!): Author
+
+  """
+   Delete multiple Author items by ID.
+  """
+  deleteAuthors(ids: [ID!]): [Author]
+}
+
+type Query {
+  """
+   Search for all Post items which match the where clause.
+  """
+  allPosts(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Post!]
+
+  """
+   Search for the Post item with the matching ID.
+  """
+  Post(where: PostWhereUniqueInput!): Post
+
+  """
+   Perform a meta-query on all Post items which match the where clause.
+  """
+  _allPostsMeta(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int
+
+  """
+   Search for all Author items which match the where clause.
+  """
+  allAuthors(
+    where: AuthorWhereInput! = {}
+    search: String
+    sortBy: [SortAuthorsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Author!]
+
+  """
+   Search for the Author item with the matching ID.
+  """
+  Author(where: AuthorWhereUniqueInput!): Author
+
+  """
+   Perform a meta-query on all Author items which match the where clause.
+  """
+  _allAuthorsMeta(
+    where: AuthorWhereInput! = {}
+    search: String
+    sortBy: [SortAuthorsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use authorsCount instead."
+    )
+  authorsCount(where: AuthorWhereInput! = {}): Int
+  keystone: KeystoneMeta!
+}
+
+type KeystoneMeta {
+  adminMeta: KeystoneAdminMeta!
+}
+
+type KeystoneAdminMeta {
+  enableSignout: Boolean!
+  enableSessionItem: Boolean!
+  lists: [KeystoneAdminUIListMeta!]!
+  list(key: String!): KeystoneAdminUIListMeta
+}
+
+type KeystoneAdminUIListMeta {
+  key: String!
+  itemQueryName: String!
+  listQueryName: String!
+  hideCreate: Boolean!
+  hideDelete: Boolean!
+  path: String!
+  label: String!
+  singular: String!
+  plural: String!
+  description: String
+  initialColumns: [String!]!
+  pageSize: Int!
+  labelField: String!
+  fields: [KeystoneAdminUIFieldMeta!]!
+  initialSort: KeystoneAdminUISort
+  isHidden: Boolean!
+}
+
+type KeystoneAdminUIFieldMeta {
+  path: String!
+  label: String!
+  isOrderable: Boolean!
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  createView: KeystoneAdminUIFieldMetaCreateView!
+  listView: KeystoneAdminUIFieldMetaListView!
+  itemView(id: ID!): KeystoneAdminUIFieldMetaItemView
+}
+
+type KeystoneAdminUIFieldMetaCreateView {
+  fieldMode: KeystoneAdminUIFieldMetaCreateViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaCreateViewFieldMode {
+  edit
+  hidden
+}
+
+type KeystoneAdminUIFieldMetaListView {
+  fieldMode: KeystoneAdminUIFieldMetaListViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaListViewFieldMode {
+  read
+  hidden
+}
+
+type KeystoneAdminUIFieldMetaItemView {
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldMode {
+  edit
+  read
+  hidden
+}
+
+type KeystoneAdminUISort {
+  field: String!
+  direction: KeystoneAdminUISortDirection!
+}
+
+enum KeystoneAdminUISortDirection {
+  ASC
+  DESC
+}

--- a/examples/document-field/schema.prisma
+++ b/examples/document-field/schema.prisma
@@ -1,0 +1,30 @@
+datasource sqlite {
+  url      = env("DATABASE_URL")
+  provider = "sqlite"
+}
+
+generator client {
+  provider = "prisma-client-js"
+  output   = "node_modules/.prisma/client"
+}
+
+model Post {
+  id          Int       @id @default(autoincrement())
+  title       String?
+  slug        String?   @unique
+  status      String?
+  content     String?
+  publishDate DateTime?
+  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId    Int?      @map("author")
+
+  @@index([authorId])
+}
+
+model Author {
+  id    Int     @id @default(autoincrement())
+  name  String?
+  email String? @unique
+  posts Post[]  @relation("Post_author")
+  bio   String?
+}

--- a/examples/document-field/schema.ts
+++ b/examples/document-field/schema.ts
@@ -1,0 +1,53 @@
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { select, relationship, text, timestamp } from '@keystone-next/fields';
+import { document } from '@keystone-next/fields-document';
+
+export const lists = createSchema({
+  Post: list({
+    fields: {
+      title: text({ isRequired: true }),
+      slug: text({ isRequired: true, isUnique: true }),
+      status: select({
+        dataType: 'enum',
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+      }),
+      content: document({
+        // We want to have support a fully featured document editor for our
+        // authors, so we're enabling all of the formatting abilities and
+        // providing 1, 2 or 3 column layouts.
+        formatting: true,
+        dividers: true,
+        links: true,
+        layouts: [
+          [1, 1],
+          [1, 1, 1],
+        ],
+      }),
+      publishDate: timestamp(),
+      author: relationship({ ref: 'Author.posts', many: false }),
+    },
+  }),
+  Author: list({
+    fields: {
+      name: text({ isRequired: true }),
+      email: text({ isRequired: true, isUnique: true }),
+      posts: relationship({ ref: 'Post.author', many: true }),
+      bio: document({
+        // We want to constrain the formatting in Author bios to a limited set of options.
+        // We will allow bold, italics, unordered lists, and links.
+        // See the document field guide for a complete list of configurable options
+        formatting: {
+          inlineMarks: {
+            bold: true,
+            italic: true,
+          },
+          listTypes: { unordered: true },
+        },
+        links: true,
+      }),
+    },
+  }),
+});

--- a/examples/document-field/src/pages/author/[id].tsx
+++ b/examples/document-field/src/pages/author/[id].tsx
@@ -1,0 +1,61 @@
+import { GetStaticPathsResult, GetStaticPropsContext } from 'next';
+import Link from 'next/link';
+import React from 'react';
+import { DocumentRenderer } from '@keystone-next/document-renderer';
+import { fetchGraphQL, gql } from '../../utils';
+
+export default function Post({ author }: { author: any }) {
+  return (
+    <article>
+      <h1>{author.name}</h1>
+
+      <h2>Bio</h2>
+      {author.bio?.document && <DocumentRenderer document={author.bio.document} />}
+
+      <h2>Posts</h2>
+      {author.posts.map((post: any) => (
+        <li key={post.id}>
+          <Link href={`/post/${post.slug}`}>
+            <a>{post.title}</a>
+          </Link>
+        </li>
+      ))}
+    </article>
+  );
+}
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  const data = await fetchGraphQL(gql`
+    query {
+      allAuthors {
+        id
+      }
+    }
+  `);
+  return {
+    paths: data.allAuthors.map((post: any) => ({ params: { id: post.id } })),
+    fallback: 'blocking',
+  };
+}
+
+export async function getStaticProps({ params }: GetStaticPropsContext) {
+  const data = await fetchGraphQL(
+    gql`
+      query ($id: ID!) {
+        Author(where: { id: $id }) {
+          name
+          bio {
+            document
+          }
+          posts {
+            id
+            title
+            slug
+          }
+        }
+      }
+    `,
+    { id: params!.id }
+  );
+  return { props: { author: data.Author }, revalidate: 60 };
+}

--- a/examples/document-field/src/pages/index.tsx
+++ b/examples/document-field/src/pages/index.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import React from 'react';
+import { fetchGraphQL, gql } from '../utils';
+
+type Author = { id: string; name: string; posts: { id: string; slug: string; title: string }[] };
+
+export default function Index({ authors }: { authors: Author[] }) {
+  <h1>Keystone Blog Project - Home</h1>;
+  return (
+    <ul>
+      {authors.map(author => (
+        <li key={author.id}>
+          <h2>
+            <Link href={`/author/${author.id}`}>
+              <a>{author.name}</a>
+            </Link>
+          </h2>
+          <ul>
+            {author.posts.map(post => (
+              <li key={post.id}>
+                <Link href={`/post/${post.slug}`}>
+                  <a>{post.title}</a>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export async function getStaticProps() {
+  const data = await fetchGraphQL(gql`
+    query {
+      allAuthors {
+        id
+        name
+        posts(where: { status: published }, orderBy: { publishDate: desc }) {
+          id
+          slug
+          title
+        }
+      }
+    }
+  `);
+  return { props: { authors: data.allAuthors }, revalidate: 30 };
+}

--- a/examples/document-field/src/pages/post/[slug].tsx
+++ b/examples/document-field/src/pages/post/[slug].tsx
@@ -1,0 +1,76 @@
+import { GetStaticPathsResult, GetStaticPropsContext } from 'next';
+import Link from 'next/link';
+import React from 'react';
+import { DocumentRenderer, DocumentRendererProps } from '@keystone-next/document-renderer';
+import { fetchGraphQL, gql } from '../../utils';
+
+// by default the DocumentRenderer will render unstyled html elements
+// we're customising how headings are rendered here but you can customise any of the renderers that the DocumentRenderer uses
+const renderers: DocumentRendererProps['renderers'] = {
+  block: {
+    heading({ level, children, textAlign }) {
+      const Comp = `h${level}` as const;
+      return <Comp style={{ textAlign, textTransform: 'uppercase' }}>{children}</Comp>;
+    },
+  },
+};
+
+export default function Post({ post }: { post: any }) {
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      {post.author?.name && (
+        <address>
+          By{' '}
+          <Link href={`/author/${post.author.id}`}>
+            <a>{post.author.name}</a>
+          </Link>
+        </address>
+      )}
+      {post.publishDate && (
+        <span>
+          on <time dateTime={post.publishDate}>{post.publishDate}</time>
+        </span>
+      )}
+      {post.content?.document && (
+        <DocumentRenderer document={post.content.document} renderers={renderers} />
+      )}
+    </article>
+  );
+}
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  const data = await fetchGraphQL(gql`
+    query {
+      allPosts {
+        slug
+      }
+    }
+  `);
+  return {
+    paths: data.allPosts.map((post: any) => ({ params: { slug: post.slug } })),
+    fallback: 'blocking',
+  };
+}
+
+export async function getStaticProps({ params }: GetStaticPropsContext) {
+  const data = await fetchGraphQL(
+    gql`
+      query ($slug: String!) {
+        Post(where: { slug: $slug }) {
+          title
+          content {
+            document
+          }
+          publishDate
+          author {
+            id
+            name
+          }
+        }
+      }
+    `,
+    { slug: params!.slug }
+  );
+  return { props: { post: data.Post }, revalidate: 60 };
+}

--- a/examples/document-field/src/utils.tsx
+++ b/examples/document-field/src/utils.tsx
@@ -1,0 +1,18 @@
+export const gql = ([content]: TemplateStringsArray) => content;
+
+export async function fetchGraphQL(query: string, variables?: Record<string, any>) {
+  return fetch('http://localhost:3000/api/graphql', {
+    method: 'POST',
+    body: JSON.stringify({ query, variables }),
+    headers: { 'Content-Type': 'application/json' },
+  })
+    .then(x => x.json())
+    .then(({ data, errors }) => {
+      if (errors) {
+        throw new Error(
+          `GraphQL errors occurred:\n${errors.map((x: any) => x.message).join('\n')}`
+        );
+      }
+      return data;
+    });
+}

--- a/examples/document-field/tsconfig.json
+++ b/examples/document-field/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": false,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tests/examples-smoke-tests/document-field.test.ts
+++ b/tests/examples-smoke-tests/document-field.test.ts
@@ -1,0 +1,19 @@
+import { Browser, Page } from 'playwright';
+import { exampleProjectTests } from './utils';
+
+exampleProjectTests('document-field', browserType => {
+  let browser: Browser = undefined as any;
+  let page: Page = undefined as any;
+  beforeAll(async () => {
+    browser = await browserType.launch();
+    page = await browser.newPage();
+    page.goto('http://localhost:3000');
+  });
+  test('Load list', async () => {
+    await Promise.all([page.waitForNavigation(), page.click('h3:has-text("Authors")')]);
+    await page.waitForSelector('button:has-text("Create Author")');
+  });
+  afterAll(async () => {
+    await browser.close();
+  });
+});


### PR DESCRIPTION
This PR adds an example project for the document field which covers the basic use case of configuring the toolbar, rendering the document field in a front end, and providing custom renderers for the built in data.

Out of scope are advanced use cases of custom component blocks and inline relationships, which will be covered in a separate example which is being worked on in #5940.