### PR TITLE
Update the document field guide

### DIFF
--- a/docs/components/docs/Navigation.tsx
+++ b/docs/components/docs/Navigation.tsx
@@ -129,6 +129,7 @@ export function DocsNavigation() {
         <NavItem href="/docs/guides/filters">Query Filters</NavItem>
         <NavItem href="/docs/guides/hooks">Hooks</NavItem>
         <NavItem href="/docs/guides/document-fields">Document Fields</NavItem>
+        <NavItem href="/docs/guides/document-field-demo">Document Field Demo</NavItem>
         <NavItem href="/docs/guides/virtual-fields">
           Virtual Fields <Badge look="success">New</Badge>
         </NavItem>

--- a/docs/lib/initialDocumentDemoContent.ts
+++ b/docs/lib/initialDocumentDemoContent.ts
@@ -165,7 +165,7 @@ export const initialContent = [
                 bold: true,
               },
               {
-                text: ', but you can build your own by just defining their prop types (like you do your Keystone schema) and providing a React Component to render the preview.',
+                text: ', but you can build your own by defining their data schema (like you do your Keystone schema) and providing a React Component to render the preview.',
               },
             ],
           },
@@ -203,7 +203,7 @@ export const initialContent = [
             type: 'paragraph',
             children: [
               {
-                text: 'They can also have props that are edited with an inline form, for more complex use cases (including conditional fields)',
+                text: 'Custom components can also have props that are edited with an inline form, for more complex use cases (including conditional fields)',
               },
             ],
           },
@@ -230,7 +230,7 @@ export const initialContent = [
     type: 'paragraph',
     children: [
       {
-        text: 'This is the end of the editable document. Expand the block below to see how the data is stored ↓',
+        text: 'This is the end of the editable document. Expand the blocks below to see how the editor has been configured and how the data is stored ↓',
         bold: true,
       },
     ],

--- a/docs/pages/docs/guides/_doc-field-intro.mdx
+++ b/docs/pages/docs/guides/_doc-field-intro.mdx
@@ -1,12 +1,7 @@
 The [`document`](../apis/fields#document) field type is a highly customisable rich text editor that lets content creators quickly and easily edit content in your system.
 
-It's built with [Slate](https://docs.slatejs.org/), stores your content as JSON-structured data, and lets you do things like:
+You can experiment with different configuration settings to see how these impact the editor experience.
 
-- Embed multi-column layouts (that your front-end can decide how to render)
-- Insert relationships to other items in your Keystone database
-- Define your own custom blocks based on React Components
-- Choose between automatically generated forms for editing Component Props, or create your own custom Component UI and Toolbars
-
-## Try the demo ↓
+See the [document field guide](./document-fields) for details on how to configure and render the document field in your Keystone application.
 
 export default ({ children }) => children;

--- a/docs/pages/docs/guides/document-field-demo.mdx
+++ b/docs/pages/docs/guides/document-field-demo.mdx
@@ -1,0 +1,52 @@
+import { MDXProvider } from '@mdx-js/react';
+import { components } from '../../../components/Markdown';
+import { getHeadings } from '../../../lib/getHeadings';
+import { H1 } from '../../../components/docs/Heading';
+import { DocsPage } from '../../../components/Page';
+import {
+  DocumentEditorDemo,
+  DocumentFeaturesFormAndCode,
+  DocumentFeaturesProvider,
+} from '../../../components/docs/DocumentEditorDemo';
+import Intro from './_doc-field-intro.mdx';
+
+## Configure the demo
+
+The document field is highly configurable.
+The form below lets you control which features are enabled in the demo editor.
+You can see the changes both in the toolbar of the editor, and in the field configuration itself.
+
+<DocumentFeaturesFormAndCode />
+
+export default ({ children }) => {
+  const headings = getHeadings(children);
+  return (
+    <DocsPage
+      title={'Document Fields Demo'}
+      headings={[
+        {
+          label: 'Document Field Demo',
+          id: 'document-field-demo',
+          depth: 1,
+        },
+        {
+          label: 'Try the demo',
+          id: 'try-the-demo',
+          depth: 2,
+        },
+        ...headings,
+      ]}
+    >
+      <DocumentFeaturesProvider>
+        <div className="prose">
+          <H1>Document Fields Demo</H1>
+          <MDXProvider components={components}><Intro /></MDXProvider>
+        </div>
+        <DocumentEditorDemo />
+        <div className="prose">
+          <MDXProvider components={components}>{children}</MDXProvider>
+        </div>
+      </DocumentFeaturesProvider>
+    </DocsPage>
+  );
+};

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -1,24 +1,155 @@
-import { MDXProvider } from '@mdx-js/react';
-import { components } from '../../../components/Markdown';
-import { getHeadings } from '../../../lib/getHeadings';
-import { H1 } from '../../../components/docs/Heading';
-import { DocsPage } from '../../../components/Page';
-import {
-  DocumentEditorDemo,
-  DocumentFeaturesFormAndCode,
-  DocumentFeaturesProvider,
-} from '../../../components/docs/DocumentEditorDemo';
-import Intro from './_doc-field-intro.mdx';
+import { Markdown } from '../../../components/Markdown';
 
----
+# How To Use Document Fields
 
-## Configure the demo
+The [`document`](../apis/fields#document) field type is a highly customizable rich text editor that lets content creators quickly and easily edit content in your system.
 
-The document field is highly configurable.
-The form below lets you control which features are enabled in the demo editor.
-You can see the changes both in the toolbar of the editor, and in the field configuration itself.
+It's built with [Slate](https://docs.slatejs.org/), stores your content as JSON-structured data, and lets you do things like:
 
-<DocumentFeaturesFormAndCode />
+- Configure the types of formatting used in your documents
+- Easily render the document in your application
+- Insert relationships to other items in your Keystone database
+- Define your own custom editor blocks based on React Components
+
+To see the document field in action, try out the [demo](./document-field-demo).
+
+## Configuration
+
+The document field provides a number of different formatting options, all of which can be configured.
+To get started with a fully featured editor experience, you can turn on all of the built-in options.
+
+```typescript
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { document } from '@keystone-next/fields-document';
+
+export const lists = createSchema({
+  Post: list({
+    fields: {
+      content: document({
+        formatting: true,
+        dividers: true,
+        links: true,
+        layouts: [
+          [1, 1],
+          [1, 1, 1],
+        ],
+      }),
+    },
+  }),
+});
+```
+
+This has enabled all of the **formatting** options, enabled inline **links**, section **dividers**, and both 2 and 3 column **layouts**.
+
+We can disable any of these features by simply omitting the option from our configuration.
+
+### Formatting
+
+Setting `formatting: true` turns on all the formatting options for the document.
+If you need more fine-grained control over which options are enabled, you can explicitly list the features you want, e.g.
+
+```typescript
+content: document({
+  formatting: {
+    inlineMarks: {
+      bold: true,
+      italic: true,
+      underline: true,
+      strikethrough: true,
+      code: true,
+      superscript: true,
+      subscript: true,
+      keyboard: true,
+    },
+    listTypes: {
+      ordered: true,
+      unordered: true,
+    },
+    alignment: {
+      center: true,
+      unordered: true,
+    },
+    headingLevels: [1, 2, 3, 4, 5, 6],
+    blockTypes: {
+      blockquote: true,
+      code: true
+    },
+    softBreaks: true,
+  },
+}),
+```
+
+All the features set to `true` will be enabled in your document field.
+To disable a specific feature you can simply omit it from the configuration.
+
+If you want to enable all the options in a particular sub-group, you can set the group to `true`.
+For example, to enable all `listType` options you could set `listType: true`.
+
+You can experiment with the different configuration settings in the [document field demo](./document-field-demo).
+
+## Querying
+
+Each document field will generate a type within your GraphQL schema. The example above of a `content` field in the `Post` list would generate the type:
+
+```graphql
+type Post_content_DocumentField {
+  document(hydrateRelationships: Boolean! = false): JSON!
+}
+```
+
+To query the content we can run the following GraphQL query, which will return the JSON representation of the content in `allPosts.content.document`.
+
+```graphql
+query {
+  allPosts {
+    content {
+      document
+    }
+  }
+}
+```
+
+We will discuss the `hydrateRelationships` option [below](#inline-relationships).
+
+The document data is stored as JSON.
+You can use the [document field demo](./document-field-demo) to interactively explore how data is stored when you make changes in the document editor.
+
+## Rendering
+
+To render the document in a React app, use the `@keystone-next/document-renderer` package.
+
+```tsx
+import { DocumentRenderer } from '@keystone-next/document-renderer';
+
+<DocumentRenderer document={document} />;
+```
+
+The `DocumentRenderer` component accepts the `JSON` representation of the document returned by the GraphQL API.
+
+### Overriding the default renderers
+
+The `DocumentRenderer` has built in renderers for all the different types of data stored in the JSON formatted data.
+If you need to override these defaults, you can do so by providing your own renderers to `DocumentRenderer`.
+
+```tsx
+import { DocumentRenderer, DocumentRendererProps } from '@keystone-next/document-renderer';
+
+const renderers: DocumentRendererProps['renderers'] = {
+  // use your editor's autocomplete to see what other renderers you can override
+  inline: {
+    bold: ({ children }) => {
+      return <strong>{children}</strong>;
+    },
+  },
+  block: {
+    paragraph: ({ children, textAlign }) => {
+      return <p style={{ textAlign }}>{children}</p>;
+    },
+  },
+};
+
+<DocumentRenderer document={document} renderers={renderers} />;
+```
 
 ## Inline Relationships
 
@@ -31,15 +162,15 @@ import { document } from '@keystone-next/fields-document';
 
 export default config({
   lists: createSchema({
-    ListName: list({
+    Post: list({
       fields: {
-        fieldName: document({
+        content: document({
           relationships: {
             mention: {
               kind: 'inline',
               listKey: 'User',
               label: 'Mention',
-              selection: 'some GraphQL selection',
+              selection: 'name',
             },
           },
           /* ... */
@@ -47,26 +178,31 @@ export default config({
         /* ... */
       },
     }),
+    User: list({
+      fields: {
+        name: text(),
+      }
+    }),
     /* ... */
   }),
   /* ... */
 });
 ```
 
-By default, only the ids for relationships are sent in document.
-To include the label and extra data from the selection specified in the relationship, pass `hydrateRelationships: true` to the field.
+By default, only the ids for the relationships are returned when querying for the document.
+To include the `label` and extra data from the `selection` specified in the `relationship`, pass `hydrateRelationships: true` to the GraphQL query.
 
 ```graphql
 query {
   allPosts {
-    content(hydrateRelationships: true) {
-      document
+    content {
+      document(hydrateRelationships: true)
     }
   }
 }
 ```
 
-Whenever a value is saved to the document field, the extra data from the selection and the label on relationships are removed (if they exist) so only the id is stored.
+Whenever a value is saved to the document field, the extra data from the `selection` and the `label` on `relationships` are removed (if they exist) so only the `id` is stored.
 
 ## Component Blocks
 
@@ -428,38 +564,6 @@ component({
 });
 ```
 
-## Rendering
-
-To render the document in a React app, use the `@keystone-next/document-renderer` package.
-
-```tsx
-import { DocumentRenderer } from '@keystone-next/document-renderer';
-
-<DocumentRenderer document={document} />;
-```
-
-### Overriding the default renderers
-
-```tsx
-import { DocumentRenderer, DocumentRendererProps } from '@keystone-next/document-renderer';
-
-const renderers: DocumentRendererProps['renderers'] = {
-  // use your editor's autocomplete to see what other renderers you can override
-  inline: {
-    bold: ({ children }) => {
-      return <strong>{children}</strong>;
-    },
-  },
-  block: {
-    paragraph: ({ children, textAlign }) => {
-      return <p style={{ textAlign }}>{children}</p>;
-    },
-  },
-};
-
-<DocumentRenderer document={document} renderers={renderers} />;
-```
-
 ### Rendering Component blocks
 
 #### Typing props for rendering component blocks
@@ -479,35 +583,4 @@ const componentBlockRenderers: InferRenderersForComponentBlocks<typeof component
 <DocumentRenderer document={document} componentBlocks={componentBlockRenderers} />;
 ```
 
-export default ({ children }) => {
-  const headings = getHeadings(children);
-  return (
-    <DocsPage
-      title={'How To Use Document Fields'}
-      headings={[
-        {
-          label: 'How To Use Document Fields',
-          id: 'how-to-use-document-fields',
-          depth: 1,
-        },
-        {
-          label: 'Try the demo',
-          id: 'try-the-demo',
-          depth: 2,
-        },
-        ...headings,
-      ]}
-    >
-      <DocumentFeaturesProvider>
-        <div className="prose">
-          <H1>How To Use Document Fields</H1>
-          <MDXProvider components={components}><Intro /></MDXProvider>
-        </div>
-        <DocumentEditorDemo />
-        <div className="prose">
-          <MDXProvider components={components}>{children}</MDXProvider>
-        </div>
-      </DocumentFeaturesProvider>
-    </DocsPage>
-  );
-};
+export default ({ children }) => <Markdown>{children}</Markdown>;

--- a/docs/pages/for-developers.tsx
+++ b/docs/pages/for-developers.tsx
@@ -242,7 +242,7 @@ export default function ForDevelopers() {
                 </Type>
               </li>
             </ul>
-            <Link href="/docs/guides/document-fields">
+            <Link href="/docs/guides/document-field-demo">
               <a>Try the demo →</a>
             </Link>
           </div>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -709,7 +709,7 @@ export const lists = createSchema({
           <Type as="h2" look="heading30" margin="2rem auto" css={{ maxWidth: '41.875rem' }}>
             What makes Keystone a CMS for the Design System generation?
           </Type>
-          <Button as="a" href="/docs/guides/document-fields#try-the-demo" shadow>
+          <Button as="a" href="/docs/guides/document-field-demo" shadow>
             See our new document editor <ArrowR />
           </Button>
           <div

--- a/docs/pages/updates/whats-new-in-v6.mdx
+++ b/docs/pages/updates/whats-new-in-v6.mdx
@@ -25,7 +25,7 @@ users get the right field interfaces based on whether they can view or edit a fi
 You can now set up a visual editor that manages components you have created - with custom props, and
 WYSIWYG previews. Perfect for authoring content that works with a Design System on the front-end.
 
-Check out the [Live Demo and Docs](./guides/document-fields)
+Check out the [Live Demo](../docs/guides/document-field-demo) and [Docs](../docs/guides/document-fields)
 
 ## Extensible GraphQL Schema
 

--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -224,7 +224,7 @@ export default function WhyKeystonePage() {
                 Highly configurable. Design systems friendly. BYO custom React components.
                 Structured JSON output.
               </Type>
-              <Link href="/docs/guides/document-fields#try-the-demo">
+              <Link href="/docs/guides/document-field-demo">
                 <a>Try the editor →</a>
               </Link>
             </li>


### PR DESCRIPTION
Updates the document field guide to split out the demonstration from the guide itself, and improves the usability of both the demo and the guide.

Having the demo in a separate place lets us link directly to the demo itself, giving people a chance to play with it without being overwhelmed by all the details of the guide. We CTA to the demo in a lot of places, so we expect a very different audience mix to the readers of the guide who are going to be devs who are ready to start using the document field in their project.

I've updated the content of the guide up to the `Component Blocks` section. I'd like to separate that out into its own guide, since it's an advanced use case, but that can happen in subsequent PRs.