### PR TITLE
Docs: fixed why-keystone heading and first content block on small screen

### DIFF
--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -31,6 +31,7 @@ import { Shield } from '../components/icons/Shield';
 import { Watch } from '../components/icons/Watch';
 import { Cli } from '../components/icons/Cli';
 import { Page } from '../components/Page';
+import { IntroHeading } from '../components/content/Intro';
 
 import adminUi from '../public/assets/admin-ui.png';
 
@@ -40,10 +41,9 @@ export default function WhyKeystonePage() {
   return (
     <Page>
       <MWrapper>
-        <Type as="h1" look="heading92" fontSize={['4rem', '5.75rem']}>
+        <IntroHeading>
           Why <Highlight look="grad2">Keystone</Highlight>
-        </Type>
-
+        </IntroHeading>
         <div
           css={mq({
             display: 'grid',

--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -40,17 +40,17 @@ export default function WhyKeystonePage() {
   return (
     <Page>
       <MWrapper>
-        <Type as="h1" look="heading92">
+        <Type as="h1" look="heading92" fontSize={['4rem', '5.75rem']}>
           Why <Highlight look="grad2">Keystone</Highlight>
         </Type>
 
         <div
-          css={{
+          css={mq({
             display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
+            gridTemplateColumns: ['1fr', '1fr 1fr'],
             gap: '2rem',
             marginTop: '3.75rem',
-          }}
+          })}
         >
           <div>
             <Type as="p" look="body18" color="var(--muted)" margin="0 0 1rem 0">


### PR DESCRIPTION
On the "Why keystone" page the heading was being clipped and the first content block was in 2 very narrow columns on smaller screens.

| Before | After |
|:----|:----|
| ![image](https://user-images.githubusercontent.com/814227/123369742-afd04b00-d5c1-11eb-9533-d10e1da57e96.png) |![image](https://user-images.githubusercontent.com/814227/123369810-d42c2780-d5c1-11eb-963b-c1754bbec381.png)|

