### PR TITLE
Docs: responsive fixes on For Organisations page + grammar nits

### DIFF
--- a/docs/pages/for-organisations.tsx
+++ b/docs/pages/for-organisations.tsx
@@ -299,8 +299,8 @@ export default function ForOrganisations() {
               <Type as="p" look="body18" color="var(--muted)" margin="0 0 1rem 0">
                 When you're <strong>growing a project</strong>, solving for repetitive tasks can
                 mean the difference between success and failure. You can choose tools with strong
-                opinions to solve the what you know today, but you <strong>risk</strong> binding
-                your future to tools that <strong>can't adapt as you grow</strong>.
+                opinions to solve what you know today, but you <strong>risk</strong> binding your
+                future to tools that <strong>can't adapt as you grow</strong>.
               </Type>
               <Type as="p" look="body18" color="var(--muted)" margin="0 0 1rem 0">
                 Keystone bridges this gap. You get to <strong>work fast</strong> with features that
@@ -316,8 +316,8 @@ export default function ForOrganisations() {
                 software – you can.
               </Type>
               <Type as="p" look="body18" color="var(--muted)">
-                When your success demands you need to go 100% bespoke, Keystone engineers it's own
-                redundancy so you can move to your own thing gracefully,{' '}
+                When your success demands you need to go 100% bespoke, Keystone engineers its own
+                redundancy, so you can move to your own thing gracefully,{' '}
                 <strong>on your terms</strong>.
               </Type>
             </div>

--- a/docs/pages/for-organisations.tsx
+++ b/docs/pages/for-organisations.tsx
@@ -288,12 +288,12 @@ export default function ForOrganisations() {
             <Highlight look="grad4">We just make it easier to get there.</Highlight>
           </Type>
           <div
-            css={{
+            css={mq({
               display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
+              gridTemplateColumns: ['1fr', '1fr 1fr'],
               gap: '2rem',
               marginTop: '3.75rem',
-            }}
+            })}
           >
             <div>
               <Type as="p" look="body18" color="var(--muted)" margin="0 0 1rem 0">


### PR DESCRIPTION
Two columns of text here feels like too many on mobile (For Organisations page)
Also, I picked some grammar nits.

| Before | After |
|:---|:---|
| ![image](https://user-images.githubusercontent.com/814227/123373251-68998880-d5c8-11eb-86d4-783a7c26ed64.png) | ![image](https://user-images.githubusercontent.com/814227/123373292-8109a300-d5c8-11eb-9187-5c15e50d126e.png) |