### PR TITLE
Pin decimal.js version

### DIFF
--- a/.changeset/strong-tools-camp.md
+++ b/.changeset/strong-tools-camp.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/fields': patch
+'@keystone-next/types': patch
+---
+
+Pinned dependency `decimal.js` to `10.2.1` to be consistent with Prisma.

--- a/packages-next/fields/package.json
+++ b/packages-next/fields/package.json
@@ -32,7 +32,7 @@
     "bytes": "^3.1.0",
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.22.1",
-    "decimal.js": "^10.2.1",
+    "decimal.js": "10.2.1",
     "dumb-passwords": "^0.2.1",
     "fast-deep-equal": "^3.1.3",
     "graphql-upload": "^12.0.0",

--- a/packages-next/types/package.json
+++ b/packages-next/types/package.json
@@ -12,7 +12,7 @@
     "@keystone-next/fields": "^11.0.0",
     "apollo-server-types": "^0.9.0",
     "cors": "^2.8.5",
-    "decimal.js": "^10.2.1",
+    "decimal.js": "10.2.1",
     "graphql": "^15.5.1",
     "graphql-type-json": "^0.3.2",
     "graphql-upload": "^12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5455,7 +5455,7 @@ decamelize@^1.1.0, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-decimal.js@^10.2.1:
+decimal.js@10.2.1, decimal.js@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
   integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==


### PR DESCRIPTION
Upgrading to 10.3.1 causes Prisma `create` operations with decimal fields to fail. Until this is addressed, having a `^` version range causes Keystone to be broken.