### PR TITLE
removed "updates" links until content is differentiated from "releases

### DIFF
--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -157,11 +157,12 @@ export function Footer() {
               Updates
             </Type>
             <List>
-              <li>
+              {/* UPDATES COMING SOON */}
+              {/* <li>
                 <Link href="/updates">
                   <a>Latest News</a>
                 </Link>
-              </li>
+              </li> */}
               <li>
                 <Link href="/updates/roadmap">
                   <a>Roadmap</a>

--- a/docs/components/Header.tsx
+++ b/docs/components/Header.tsx
@@ -180,7 +180,7 @@ export function Header() {
         </div> */}
 
         <LinkItem href="/why-keystone">Why Keystone</LinkItem>
-        <LinkItem href="/updates">Updates</LinkItem>
+        <LinkItem href="/releases">Releases</LinkItem>
         <LinkItem href="/docs">Docs</LinkItem>
 
         {/* SEARCH COMING SOON */}

--- a/docs/components/MobileMenu.tsx
+++ b/docs/components/MobileMenu.tsx
@@ -55,7 +55,8 @@ export function MobileMenu({ handleClose }: MobileMenuProps) {
               borderBottom: '1px solid var(--border)',
             }}
           >
-            <PrimaryNavItem href="/updates">Updates</PrimaryNavItem>
+            {/* UPDATES COMING SOON */}
+            {/* <PrimaryNavItem href="/updates">Updates</PrimaryNavItem> */}
             <PrimaryNavItem href="/updates/roadmap">Roadmap</PrimaryNavItem>
             <PrimaryNavItem href="/releases">Release Notes</PrimaryNavItem>
           </div>

--- a/docs/components/docs/Navigation.tsx
+++ b/docs/components/docs/Navigation.tsx
@@ -182,7 +182,8 @@ export function UpdatesNavigation({ releases = [] }: { releases: string[] }) {
         fontWeight: 500,
       }}
     >
-      <PrimaryNavItem href="/updates">Latest News</PrimaryNavItem>
+      {/* UPDATES COMING SOON */}
+      {/* <PrimaryNavItem href="/updates">Latest News</PrimaryNavItem> */}
       <PrimaryNavItem href="/updates/roadmap">Roadmap</PrimaryNavItem>
       <PrimaryNavItem href="/releases">Release Notes</PrimaryNavItem>
       <Section label="Recent Releases">


### PR DESCRIPTION
Short term fix until we get the right content on `/updates`.

Roadmap is a child of /updates per breadcrumb and location in updates folder 👇 

![CleanShot 2021-06-28 at 12 30 27](https://user-images.githubusercontent.com/6447754/123571155-01204a80-d80d-11eb-8241-b74cef4c25ff.png)

Maybe we can live with this for a few days?