### PR TITLE
Add a suggestion for v5 to the new 404 page

### DIFF
--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -1,11 +1,39 @@
 /** @jsx jsx  */
 import { jsx } from '@emotion/react';
+import { useRouter } from 'next/router';
 
 import { Highlight } from '../components/primitives/Highlight';
 import { Type } from '../components/primitives/Type';
 import { Page } from '../components/Page';
 
-export default function WhatsNew() {
+function ConstructionIllustration() {
+  return (
+    <div
+      css={{
+        background: '#fff',
+        width: '100%',
+        maxWidth: '30rem',
+        margin: '2rem auto 0',
+        padding: '2rem',
+        borderRadius: '2rem',
+      }}
+    >
+      <img
+        src="/assets/404.svg"
+        alt="The Keystone logo under construction"
+        css={{
+          width: '100%',
+        }}
+      />
+    </div>
+  );
+}
+
+const v5PathList = ['/tutorials', '/guides', '/keystonejs', '/api', '/discussions'];
+
+export default function NotFoundPage() {
+  const { asPath } = useRouter();
+  const tryV5Link = v5PathList.some(i => asPath.startsWith(i));
   return (
     <Page>
       <div
@@ -16,36 +44,19 @@ export default function WhatsNew() {
           textAlign: 'center',
         }}
       >
-        <div
-          css={{
-            background: '#fff',
-            width: '90vw',
-            maxWidth: '41.875rem',
-            margin: '2rem auto',
-            padding: '2rem',
-            borderRadius: '2rem',
-          }}
-        >
-          <img
-            src="/assets/404.svg"
-            alt="The Keystone logo under construction"
-            css={{
-              width: '100%',
-              paddingLeft: '10vw',
-            }}
-          />
-        </div>
-        <Type as="p" look="body18bold" margin="0">
-          We're sorry but we were unable to find what you're looking for.
+        <Type as="h1" look="heading48" fontSize={['8vw', null, null, '5rem']}>
+          <Highlight look="grad4">404</Highlight> <Type color="var(--muted)">Page Not Found</Type>
         </Type>
-        <Type
-          as="h1"
-          look="heading92"
-          fontSize={['15vw', null, null, null, '15rem']}
-          css={{ lineHeight: 1 }}
-        >
-          <Highlight look="grad4">Error 404</Highlight>
+        <Type as="p" look="body18bold" margin="2rem 0 0">
+          We're sorry but we couldn't find what you're looking for.
         </Type>
+        {tryV5Link ? (
+          <Type as="p" look="body18bold" margin="2rem 0 0">
+            If you were looking for a page in the Keystone 5 docs, try{' '}
+            <a href="https://v5.keystonejs.com">v5.keystonejs.com{asPath}</a>.
+          </Type>
+        ) : null}
+        <ConstructionIllustration />
       </div>
     </Page>
   );


### PR DESCRIPTION
We now recognise what may have previously been a valid URL on the v5 site that we can't automatically redirect to (see #6000) and suggest a link to the v5.keystonejs.com domain

<img width="921" alt="image" src="https://user-images.githubusercontent.com/872310/123599892-74d84c80-d839-11eb-9386-4d047026f6ae.png">
