### PR TITLE
Redirecting old /documentation url

### DIFF
--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -26,6 +26,12 @@ const KEYSTONE_5 = [
     destination: '/updates/roadmap',
     permanent: true,
   },
+  // Linked to from google results (2021-06-28) and possibly elsewhere?
+  {
+    source: '/documentation',
+    destination: '/docs',
+    permanent: false,
+  },
 ];
 
 /* URLs from the original next.keystonejs.com website */


### PR DESCRIPTION
Found via search results but it's likely this url has been linked from elsewhere too. Redirected to current `/docs` ... not sure if should go to v5 docs as it's an old link..?

![Screen Shot 2021-06-28 at 6 42 24 pm](https://user-images.githubusercontent.com/2416367/123611652-f8e20280-d840-11eb-9d56-a4637cc9b26d.png)
