### PR TITLE
Update document field editor demo

### DIFF
--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -60,6 +60,7 @@ const documentFeaturesProp = fields.object({
     defaultValue: ['center', 'end'],
     label: 'Alignment',
   }),
+  softBreaks: fields.checkbox({ label: 'Soft Breaks', defaultValue: true }),
   links: fields.checkbox({
     label: 'Links',
     defaultValue: true,
@@ -68,7 +69,6 @@ const documentFeaturesProp = fields.object({
     label: 'Dividers',
     defaultValue: true,
   }),
-  softBreaks: fields.checkbox({ label: 'Soft Breaks', defaultValue: true }),
   layouts: fields.checkbox({ label: 'Layouts', defaultValue: true }),
   useShorthand: fields.checkbox({ label: 'Use shorthand in code example', defaultValue: true }),
 });
@@ -255,7 +255,7 @@ export function DocumentFeaturesProvider({ children }: { children: ReactNode }) 
 }
 
 export function DocumentFeaturesFormAndCode() {
-  const { documentFeatures, formValue, setFormValue } = useContext(DocumentFeaturesContext);
+  const { formValue, setFormValue } = useContext(DocumentFeaturesContext);
   return (
     <div>
       <FormValueContent
@@ -266,26 +266,13 @@ export function DocumentFeaturesFormAndCode() {
         value={formValue}
         onChange={setFormValue}
       />
-      <pre>
-        <Code className="language-tsx">
-          {useMemo(
-            () =>
-              documentFeaturesCodeExample(
-                formValue.useShorthand
-                  ? documentFeaturesToShorthand(documentFeatures)
-                  : documentFeatures
-              ),
-            [documentFeatures, formValue]
-          )}
-        </Code>
-      </pre>
     </div>
   );
 }
 
 export const DocumentEditorDemo = () => {
   const [value, setValue] = useState(initialContent as any);
-  const { documentFeatures } = useContext(DocumentFeaturesContext);
+  const { documentFeatures, formValue } = useContext(DocumentFeaturesContext);
 
   const isShiftPressedRef = useKeyDownRef('Shift');
   const editor = useMemo(
@@ -354,7 +341,30 @@ export const DocumentEditorDemo = () => {
         </DocumentEditorProvider>
       </div>
       <details css={{ marginBottom: 'var(--space-xlarge)' }}>
+        <summary>View the Field Config</summary>
+        <p>
+          This is the configuration which is being used for the editor. This will be updated when
+          you select options to configure the demo.
+        </p>
+        <div className="prose">
+          <pre>
+            <Code className="language-tsx">
+              {useMemo(
+                () =>
+                  documentFeaturesCodeExample(
+                    formValue.useShorthand
+                      ? documentFeaturesToShorthand(documentFeatures)
+                      : documentFeatures
+                  ),
+                [documentFeatures, formValue]
+              )}
+            </Code>
+          </pre>
+        </div>
+      </details>
+      <details css={{ marginBottom: 'var(--space-xlarge)' }}>
         <summary>View the Document Structure</summary>
+        <p>Document field data is stored as a JSON string in the database.</p>
         <pre>{JSON.stringify(value, null, 2)}</pre>
       </details>
     </div>

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -12,9 +12,11 @@ import Intro from './_doc-field-intro.mdx';
 
 ---
 
-## Customise the editor
+## Configure the demo
 
-You can configure which fields appear in the editor based on what your team needs. Try adding and removing features below ↓ to see them update in the editor above ↑.
+The document field is highly configurable.
+The form below lets you control which features are enabled in the demo editor.
+You can see the changes both in the toolbar of the editor, and in the field configuration itself.
 
 <DocumentFeaturesFormAndCode />
 


### PR DESCRIPTION
This PR moves the dynamically generated editor config from below the form to be a hide-able block similar to the document data block. We also move `softBreaks` up the list of checkboxes, since it's part of the `formatting` block, so makes more sense to live closer to the other formatting options.

The motivation for this is that the previous layout made it very hard to follow the impact of changes made in the form, as you'd have to scroll both up *and* down. This makes the movement around the demo more natural and also allows the user to completely hide the config block if it's not something that they're interested in.