### PR TITLE
Add missing examples

### DIFF
--- a/docs/components/docs/ExamplesList.tsx
+++ b/docs/components/docs/ExamplesList.tsx
@@ -3,6 +3,7 @@ import { jsx } from '@emotion/react';
 
 import { Well } from '../primitives/Well';
 import { useMediaQuery } from '../../lib/media';
+import { InlineCode } from '../../components/primitives/Code';
 
 export function Examples() {
   const mq = useMediaQuery();
@@ -51,8 +52,56 @@ export function Examples() {
         target="_blank"
         rel="noopener noreferrer"
       >
-        This project demonstrates how to use default values for fields. Builds upon the Task Manager
-        starter project.
+        Demonstrates how to use default values for fields. Builds upon the Task Manager starter
+        project.
+      </Well>
+      <Well
+        grad="grad3"
+        heading="Virtual fields"
+        href="https://github.com/keystonejs/keystone/tree/master/examples/virtual-field"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Implements virtual fields in a Keystone list. Builds on the Blog starter project.
+      </Well>
+      <Well
+        grad="grad3"
+        heading="Document field"
+        href="https://github.com/keystonejs/keystone/tree/master/examples/document-field"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Illustrates how to configure <InlineCode>document</InlineCode> fields in your Keystone
+        system and render their data in a frontend application. Builds on the Blog starter project.
+      </Well>
+      <Well
+        grad="grad3"
+        heading="Testing"
+        href="https://github.com/keystonejs/keystone/tree/master/examples/testing"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Shows you how to write tests against the GraphQL API to your Keystone system. Builds on the
+        Authentication example project.
+      </Well>
+      <Well
+        grad="grad3"
+        heading="Authentication"
+        href="https://github.com/keystonejs/keystone/tree/master/examples/with-auth"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Adds password-based authentication to the Task Manager starter project.
+      </Well>
+      <Well
+        grad="grad3"
+        heading="JSON Field"
+        href="https://github.com/keystonejs/keystone/tree/master/examples/json"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Illustrates how to use the <InlineCode>json</InlineCode> field type. Builds on the Task
+        Manager starter project.
       </Well>
     </div>
   );

--- a/docs/pages/docs/index.tsx
+++ b/docs/pages/docs/index.tsx
@@ -96,7 +96,7 @@ export default function Docs() {
           target="_blank"
           rel="noopener noreferrer"
         >
-          View all &rarr;
+          View on Github &rarr;
         </a>
       </Type>
 


### PR DESCRIPTION
adds the remaining examples cards to the docs site.