### PR TITLE
Fix behaviour of hydrateRelationships with dangling references

### DIFF
--- a/.changeset/great-bats-kneel.md
+++ b/.changeset/great-bats-kneel.md
@@ -4,3 +4,4 @@
 ---
 
 Fixed the behaviour of `document(hydrateRelationships: true)` when a related item no longer exists or read access is denied.
+The resolver will now set the relationship data to be `{ id }`, leaving the `label` and `data` properties undefined.

--- a/.changeset/great-bats-kneel.md
+++ b/.changeset/great-bats-kneel.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/fields-document': patch
+'@keystone-next/api-tests-legacy': patch
+---
+
+Fixed the behaviour of `document(hydrateRelationships: true)` when a related item no longer exists or read access is denied.

--- a/.changeset/rare-ducks-suffer.md
+++ b/.changeset/rare-ducks-suffer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/document-renderer': patch
+---
+
+Inline relationship data which is null or undefined is now explicitly set to `null`, rather than `{}`.

--- a/.changeset/rare-ducks-suffer.md
+++ b/.changeset/rare-ducks-suffer.md
@@ -1,5 +1,6 @@
 ---
-'@keystone-next/document-renderer': patch
+'@keystone-next/document-renderer': major
 ---
 
-Inline relationship data which is null or undefined is now explicitly set to `null`, rather than `{}`.
+The value of `data` passed to the inline relationship renderer now matches the data returned by the GraphQL query.
+Falsey values of `data.label` are no longer set to `data.id` and falsey values of `data.data` are no longer set to `{}`.

--- a/packages-next/document-renderer/src/index.tsx
+++ b/packages-next/document-renderer/src/index.tsx
@@ -33,7 +33,7 @@ interface Renderers {
     link: Component<{ children: ReactNode; href: string }> | 'a';
     relationship: Component<{
       relationship: string;
-      data: { id: string; label: string; data: Record<string, any> | null };
+      data: { id: string; label: string; data: Record<string, any> | null } | null;
     }>;
   } & MarkRenderers;
   block: {
@@ -64,7 +64,7 @@ export const defaultRenderers: Renderers = {
     superscript: 'sup',
     underline: 'u',
     relationship: ({ data }) => {
-      return <span>{data.label}</span>;
+      return <span>{data?.label}</span>;
     },
   },
   block: {
@@ -187,11 +187,7 @@ function DocumentNode({
       return (
         <renderers.inline.relationship
           relationship={node.relationship as string}
-          data={{
-            id: data.id,
-            label: data.label || data.id,
-            data: data.data || null,
-          }}
+          data={data ? { id: data.id, label: data.label, data: data.data } : null}
         />
       );
     }

--- a/packages-next/document-renderer/src/index.tsx
+++ b/packages-next/document-renderer/src/index.tsx
@@ -33,7 +33,7 @@ interface Renderers {
     link: Component<{ children: ReactNode; href: string }> | 'a';
     relationship: Component<{
       relationship: string;
-      data: { id: string; label: string; data: Record<string, any> } | null;
+      data: { id: string; label: string; data: Record<string, any> | null };
     }>;
   } & MarkRenderers;
   block: {
@@ -64,7 +64,7 @@ export const defaultRenderers: Renderers = {
     superscript: 'sup',
     underline: 'u',
     relationship: ({ data }) => {
-      return <span>{data?.label}</span>;
+      return <span>{data.label}</span>;
     },
   },
   block: {
@@ -187,15 +187,11 @@ function DocumentNode({
       return (
         <renderers.inline.relationship
           relationship={node.relationship as string}
-          data={
-            data
-              ? {
-                  id: data.id,
-                  label: data.label || data.id,
-                  data: data.data || null,
-                }
-              : null
-          }
+          data={{
+            id: data.id,
+            label: data.label || data.id,
+            data: data.data || null,
+          }}
         />
       );
     }

--- a/packages-next/document-renderer/src/index.tsx
+++ b/packages-next/document-renderer/src/index.tsx
@@ -192,7 +192,7 @@ function DocumentNode({
               ? {
                   id: data.id,
                   label: data.label || data.id,
-                  data: data.data || {},
+                  data: data.data || null,
                 }
               : null
           }

--- a/packages-next/document-renderer/src/index.tsx
+++ b/packages-next/document-renderer/src/index.tsx
@@ -64,7 +64,7 @@ export const defaultRenderers: Renderers = {
     superscript: 'sup',
     underline: 'u',
     relationship: ({ data }) => {
-      return <span>{data?.label}</span>;
+      return <span>{data?.label || data?.id}</span>;
     },
   },
   block: {

--- a/packages-next/document-renderer/src/index.tsx
+++ b/packages-next/document-renderer/src/index.tsx
@@ -33,7 +33,7 @@ interface Renderers {
     link: Component<{ children: ReactNode; href: string }> | 'a';
     relationship: Component<{
       relationship: string;
-      data: { id: string; label: string; data: Record<string, any> | null } | null;
+      data: { id: string; label: string | undefined; data: Record<string, any> | undefined } | null;
     }>;
   } & MarkRenderers;
   block: {

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -63,16 +63,14 @@ export function addRelationshipData(
           console.error(err);
           return { id, label: id, data: null };
         }
-        return val.item
-          ? {
-              id,
-              label: val.item[labelFieldAlias],
-              data: (() => {
-                const { [labelFieldAlias]: _ignore, ...otherData } = val.item;
-                return otherData;
-              })(),
-            }
-          : null;
+        return {
+          id,
+          label: val.item[labelFieldAlias],
+          data: (() => {
+            const { [labelFieldAlias]: _ignore, ...otherData } = val.item;
+            return otherData;
+          })(),
+        };
       }
     }
   };

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -61,7 +61,7 @@ export function addRelationshipData(
           const r = JSON.stringify(relationship);
           console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
           console.error(err);
-          return { id, label: id, data: null };
+          return { id, data: null };
         }
         return {
           id,

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -58,11 +58,11 @@ export function addRelationshipData(
         } catch (err) {
           if (err.message === 'You do not have access to this resource') {
             // If we're unable to find the item (e.g. we have a dangling reference), or access was denied
-            // then simply return null.
+            // then simply return { id } and leave `label` and `data` undefined.
             const r = JSON.stringify(relationship);
             console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
             console.error(err);
-            return { id, data: null };
+            return { id };
           } else {
             // Other types of errors indicate something wrong with either the system or the
             // configuration (e.g. a bad selection field) and they should be surfaced as a

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -64,7 +64,7 @@ export function addRelationshipData(
             )}, id: ${id} `
           );
           console.error(err);
-          return null;
+          return { id, label: id, data: null };
         }
         return val.item
           ? {

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -58,11 +58,8 @@ export function addRelationshipData(
         } catch (err) {
           // If we're unable to find the user (e.g. we have a dangling reference), or access was denied
           // then simply return null.
-          console.error(
-            `Unable to fetch relationship data: relationship: ${JSON.stringify(
-              relationship
-            )}, id: ${id} `
-          );
+          const r = JSON.stringify(relationship);
+          console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
           console.error(err);
           return { id, label: id, data: null };
         }
@@ -71,11 +68,7 @@ export function addRelationshipData(
               id,
               label: val.item[labelFieldAlias],
               data: (() => {
-                const {
-                  [labelFieldAlias]: _ignore,
-                  [idFieldAlias]: _ignore2,
-                  ...otherData
-                } = val.item;
+                const { [labelFieldAlias]: _ignore, ...otherData } = val.item;
                 return otherData;
               })(),
             }

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -56,12 +56,19 @@ export function addRelationshipData(
             variables: { id },
           });
         } catch (err) {
-          // If we're unable to find the user (e.g. we have a dangling reference), or access was denied
-          // then simply return null.
-          const r = JSON.stringify(relationship);
-          console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
-          console.error(err);
-          return { id, data: null };
+          if (err.message === 'You do not have access to this resource') {
+            // If we're unable to find the item (e.g. we have a dangling reference), or access was denied
+            // then simply return null.
+            const r = JSON.stringify(relationship);
+            console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
+            console.error(err);
+            return { id, data: null };
+          } else {
+            // Other types of errors indicate something wrong with either the system or the
+            // configuration (e.g. a bad selection field) and they should be surfaced as a
+            // GraphQL error.
+            throw err;
+          }
         }
         return {
           id,

--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -41,7 +41,7 @@ export function addRelationshipData(
       }
       return [];
     } else {
-      // Inline
+      // Single related item
       const id = data?.id;
       if (id != null) {
         const labelField = getLabelFieldsForLists(graphQLAPI.schema)[relationship.listKey];

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -1,0 +1,152 @@
+import { text } from '@keystone-next/fields';
+import { document } from '@keystone-next/fields-document';
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { setupTestRunner } from '@keystone-next/testing';
+import { KeystoneContext } from '../../../../packages-next/types/src';
+import { apiTestConfig } from '../../utils';
+
+const runner = setupTestRunner({
+  config: apiTestConfig({
+    lists: createSchema({
+      Post: list({
+        fields: {
+          content: document({
+            relationships: {
+              mention: {
+                kind: 'inline',
+                listKey: 'Author',
+                label: 'Mention',
+                selection: 'id name',
+              },
+            },
+          }),
+        },
+      }),
+      Author: list({
+        fields: { name: text() },
+        access: { read: { name_not: 'Charlie' } },
+      }),
+    }),
+  }),
+});
+
+const initData = async ({ context }: { context: KeystoneContext }) => {
+  const alice = await context.lists.Author.createOne({ data: { name: 'Alice' } });
+  const bob = await context.lists.Author.createOne({ data: { name: 'Bob' } });
+  const charlie = await context.lists.Author.createOne({ data: { name: 'Charlie' } });
+  type T = { id: string; label?: string; data?: Record<string, any> } | null;
+  const content = [
+    {
+      type: 'paragraph',
+      children: [
+        { text: '' },
+        {
+          type: 'relationship',
+          data: { id: alice.id } as T,
+          relationship: 'mention',
+          children: [{ text: '' }],
+        },
+        { text: '' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      children: [
+        { text: '' },
+        {
+          type: 'relationship',
+          data: { id: bob.id } as T,
+          relationship: 'mention',
+          children: [{ text: '' }],
+        },
+        { text: '' },
+      ],
+    },
+    {
+      type: 'paragraph',
+      children: [
+        { text: '' },
+        {
+          type: 'relationship',
+          data: { id: charlie.id } as T,
+          relationship: 'mention',
+          children: [{ text: '' }],
+        },
+        { text: '' },
+      ],
+    },
+  ];
+  const post = await context.lists.Post.createOne({ data: { content } });
+  return { alice, bob, charlie, post, content };
+};
+
+describe('Document field type', () => {
+  test(
+    'hydrateRelationships default',
+    runner(async ({ context }) => {
+      const { post, content } = await initData({ context });
+
+      const _post = await context.lists.Post.findOne({
+        where: { id: post.id },
+        query: 'content { document }',
+      });
+      expect(_post.content.document).toEqual(content);
+    })
+  );
+
+  test(
+    'hydrateRelationships: false',
+    runner(async ({ context }) => {
+      const { post, content } = await initData({ context });
+
+      const _post = await context.lists.Post.findOne({
+        where: { id: post.id },
+        query: 'content { document(hydrateRelationships: false) }',
+      });
+      expect(_post.content.document).toEqual(content);
+    })
+  );
+
+  test(
+    'hydrateRelationships: true',
+    runner(async ({ context }) => {
+      const { alice, bob, post, content } = await initData({ context });
+
+      const _post = await context.lists.Post.findOne({
+        where: { id: post.id },
+        query: 'content { document(hydrateRelationships: true) }',
+      });
+      content[0].children[1].data = {
+        id: alice.id,
+        label: 'Alice',
+        data: { id: alice.id, name: 'Alice' },
+      };
+      content[1].children[1].data = { id: bob.id, label: 'Bob', data: { id: bob.id, name: 'Bob' } };
+      // Access denied on charlie;
+      content[2].children[1].data = null;
+      expect(_post.content.document).toEqual(content);
+    })
+  );
+
+  test(
+    'hydrateRelationships: true - dangling reference',
+    runner(async ({ context }) => {
+      const { alice, bob, post, content } = await initData({ context });
+      await context.lists.Author.deleteOne({ id: bob.id });
+      const _post = await context.lists.Post.findOne({
+        where: { id: post.id },
+        query: 'content { document(hydrateRelationships: true) }',
+      });
+      content[0].children[1].data = {
+        id: alice.id,
+        label: 'Alice',
+        data: { id: alice.id, name: 'Alice' },
+      };
+      // We expect the `data` field of the relationship to be null
+      content[1].children[1].data = null;
+      // Access denied on charlie;
+      content[2].children[1].data = null;
+      expect(_post.content.document).toEqual(content);
+    })
+  );
+});

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -183,7 +183,7 @@ describe('Document field type', () => {
       };
       content[1].children[1].data = { id: bob.id, label: 'Bob', data: { id: bob.id, name: 'Bob' } };
       // Access denied on charlie;
-      content[2].children[1].data = { id: charlie.id, label: charlie.id, data: null };
+      content[2].children[1].data = { id: charlie.id, data: null };
       expect(_post.content.document).toEqual(content);
     })
   );
@@ -203,9 +203,9 @@ describe('Document field type', () => {
         data: { id: alice.id, name: 'Alice' },
       };
       // We expect the `data` field of the relationship to be null
-      content[1].children[1].data = { id: bob.id, label: bob.id, data: null };
+      content[1].children[1].data = { id: bob.id, data: null };
       // Access denied on charlie;
-      content[2].children[1].data = { id: charlie.id, label: charlie.id, data: null };
+      content[2].children[1].data = { id: charlie.id, data: null };
       expect(_post.content.document).toEqual(content);
     })
   );
@@ -223,7 +223,7 @@ describe('Document field type', () => {
       // With no selection, we expect data to be an empty object
       bio[0].children[1].data = { id: alice.id, label: 'Alice', data: {} };
       // But still, and access-denied user will return data: null
-      bio[1].children[1].data = { id: charlie.id, label: charlie.id, data: null };
+      bio[1].children[1].data = { id: charlie.id, data: null };
 
       expect(_dave.bio.document).toEqual(bio);
     })

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -193,7 +193,7 @@ describe('Document field type', () => {
       };
       content[1].children[1].data = { id: bob.id, label: 'Bob', data: { id: bob.id, name: 'Bob' } };
       // Access denied on charlie;
-      content[2].children[1].data = { id: charlie.id, data: null };
+      content[2].children[1].data = { id: charlie.id };
       expect(_post.content.document).toEqual(content);
     })
   );
@@ -212,10 +212,10 @@ describe('Document field type', () => {
         label: 'Alice',
         data: { id: alice.id, name: 'Alice' },
       };
-      // We expect the `data` field of the relationship to be null
-      content[1].children[1].data = { id: bob.id, data: null };
+      // We expect the `data` field of the relationship to be undefined
+      content[1].children[1].data = { id: bob.id };
       // Access denied on charlie;
-      content[2].children[1].data = { id: charlie.id, data: null };
+      content[2].children[1].data = { id: charlie.id };
       expect(_post.content.document).toEqual(content);
     })
   );
@@ -232,8 +232,8 @@ describe('Document field type', () => {
 
       // With no selection, we expect data to be an empty object
       bio[0].children[1].data = { id: alice.id, label: 'Alice', data: {} };
-      // But still, and access-denied user will return data: null
-      bio[1].children[1].data = { id: charlie.id, data: null };
+      // But still, and access-denied user will return data: undefined
+      bio[1].children[1].data = { id: charlie.id };
 
       expect(_dave.bio.document).toEqual(bio);
     })

--- a/tests/api-tests/package.json
+++ b/tests/api-tests/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@hapi/iron": "^6.0.0",
     "@keystone-next/auth": "*",
+    "@keystone-next/fields-document": "*",
     "@keystone-next/fields": "*",
     "@keystone-next/keystone": "*",
     "cookie-signature": "^1.1.0",

--- a/tests/api-tests/package.json
+++ b/tests/api-tests/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "@hapi/iron": "^6.0.0",
     "@keystone-next/auth": "*",
-    "@keystone-next/fields-document": "*",
     "@keystone-next/fields": "*",
+    "@keystone-next/fields-document": "*",
     "@keystone-next/keystone": "*",
     "cookie-signature": "^1.1.0",
     "cuid": "^2.1.8",


### PR DESCRIPTION
If an item referenced in a document field is deleted from Keystone, the document field should handle this gracefully. The current behaviour will return an error when querying the field, which prevents the user from being able to manage the issue. This PR fixes this to simply return `null` for the missing item. This also covers the behaviour for when a user doesn't have read access for an item.

We also need to make a distinction between `data.data === null` (object not found/access denied) and `data.data === {}` (no selection fields in the config) in the document renderer.