### PR TITLE
Change default of hydrateRelationships from false to true

### DIFF
--- a/.changeset/funny-oranges-rhyme.md
+++ b/.changeset/funny-oranges-rhyme.md
@@ -1,0 +1,8 @@
+---
+'@keystone-next/fields-document': major
+'@keystone-next/examples-app-basic': patch
+'keystone-next-app': patch
+'@keystone-next/example-document-field': patch
+---
+
+Changed the default of `hydrateRelationships` from `false` to `true` to make the common case of rendering inline relationships easier. This is only a breaking change if you explicily want the `hydrateRelationships: false` behaviour.

--- a/examples-staging/basic/admin/pages/post/[id].tsx
+++ b/examples-staging/basic/admin/pages/post/[id].tsx
@@ -177,7 +177,7 @@ export default function Post() {
             name
           }
           content {
-            document(hydrateRelationships: true)
+            document
           }
         }
       }

--- a/examples-staging/basic/schema.graphql
+++ b/examples-staging/basic/schema.graphql
@@ -359,7 +359,7 @@ type Post {
 }
 
 type Post_content_DocumentField {
-  document(hydrateRelationships: Boolean! = false): JSON!
+  document(hydrateRelationships: Boolean! = true): JSON!
 }
 
 input PostWhereInput {

--- a/examples-staging/graphql-api-endpoint/schema.graphql
+++ b/examples-staging/graphql-api-endpoint/schema.graphql
@@ -193,7 +193,7 @@ type Post {
 }
 
 type Post_content_DocumentField {
-  document(hydrateRelationships: Boolean! = false): JSON!
+  document(hydrateRelationships: Boolean! = true): JSON!
 }
 
 input PostWhereInput {

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -17,7 +17,7 @@ enum PostStatusType {
 }
 
 type Post_content_DocumentField {
-  document(hydrateRelationships: Boolean! = false): JSON!
+  document(hydrateRelationships: Boolean! = true): JSON!
 }
 
 input PostWhereInput {
@@ -161,7 +161,7 @@ type _QueryMeta {
 }
 
 type Author_bio_DocumentField {
-  document(hydrateRelationships: Boolean! = false): JSON!
+  document(hydrateRelationships: Boolean! = true): JSON!
 }
 
 input AuthorWhereInput {

--- a/packages-next/fields-document/src/index.ts
+++ b/packages-next/fields-document/src/index.ts
@@ -130,7 +130,7 @@ export const document =
               args: {
                 hydrateRelationships: schema.arg({
                   type: schema.nonNull(schema.Boolean),
-                  defaultValue: false,
+                  defaultValue: true,
                 }),
               },
               type: schema.nonNull(schema.JSON),

--- a/packages-next/fields-document/src/views.tsx
+++ b/packages-next/fields-document/src/views.tsx
@@ -152,7 +152,7 @@ export const controller = (
   return {
     path: config.path,
     label: config.label,
-    graphqlSelection: `${config.path} {document(hydrateRelationships: true)}`,
+    graphqlSelection: `${config.path} { document }`,
     componentBlocks: config.customViews.componentBlocks || {},
     documentFeatures: config.fieldMeta.documentFeatures,
     relationships: config.fieldMeta.relationships,


### PR DESCRIPTION
The common use case when querying a document field is to query the document and then hand it off to a `DocumentRenderer`. For inline relationships to work as expected with the document renderer we need to have `hydrateRelationships: true`. Having a default of `false` makes this more complicated than it needs to be. It also makes it more difficult to explain in the supporting documentation. Having a default of `true` makes the common case easy, and makes it easier to document how to use inline relationships in general. 