### PR TITLE
Preserve null in inline relationships

### DIFF
--- a/packages-next/fields-document/src/relationship-data.tsx
+++ b/packages-next/fields-document/src/relationship-data.tsx
@@ -78,6 +78,8 @@ export function addRelationshipData(
             return otherData;
           })(),
         };
+      } else {
+        return null;
       }
     }
   };

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -145,6 +145,19 @@ const initData = async ({ context }: { context: KeystoneContext }) => {
         { text: '' },
       ],
     },
+    {
+      type: 'paragraph',
+      children: [
+        { text: '' },
+        {
+          type: 'relationship',
+          data: null,
+          relationship: 'mention',
+          children: [{ text: '' }],
+        },
+        { text: '' },
+      ],
+    },
   ];
   const post = await context.lists.Post.createOne({ data: { content } });
   return { alice, bob, charlie, dave, post, content, bio };


### PR DESCRIPTION
If a user doesn't select an item from the inline select when using an inline relationship in the document editor the data will be saved as `null`. The `hydrateRelationship: true` case needs to preserve this value rather than making it `undefined` or else the `RelationshipSelect` will have a bad time, since it checks for `element.data === null`.

No changeset since this falls under the broad category of changes in the previous PR.