### PR TITLE
 Allow access to Lists fields and other metadata from Backend API

### DIFF
--- a/.changeset/yellow-bees-know.md
+++ b/.changeset/yellow-bees-know.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': minor
+---
+
+Allow access to Lists fields and other metadata from Backend API

--- a/packages-next/keystone/src/lib/context/createContext.ts
+++ b/packages-next/keystone/src/lib/context/createContext.ts
@@ -12,6 +12,8 @@ import { PrismaClient } from '../core/utils';
 import { getDbAPIFactory, itemAPIForList } from './itemAPI';
 import { createImagesContext } from './createImagesContext';
 import { createFilesContext } from './createFilesContext';
+import { initialiseLists } from '../core/types-for-lists';
+import { getDBProvider } from '../createSystem';
 
 export function makeCreateContext({
   graphQLSchema,
@@ -45,6 +47,7 @@ export function makeCreateContext({
   for (const [listKey, gqlNames] of Object.entries(gqlNamesByList)) {
     internalDbApiFactories[listKey] = getDbAPIFactory(gqlNames, internalSchema);
   }
+  const initialisedLists = initialiseLists(config.lists, getDBProvider(config.db));
 
   const createContext = ({
     sessionContext,
@@ -98,6 +101,7 @@ export function makeCreateContext({
       gqlNames: (listKey: string) => gqlNamesByList[listKey],
       images,
       files,
+      initialisedLists,
     };
     const dbAPIFactories = schemaName === 'public' ? publicDbApiFactories : internalDbApiFactories;
     for (const listKey of Object.keys(gqlNamesByList)) {

--- a/packages-next/types/src/context.ts
+++ b/packages-next/types/src/context.ts
@@ -2,6 +2,7 @@ import { IncomingMessage } from 'http';
 import { Readable } from 'stream';
 import { GraphQLSchema, ExecutionResult, DocumentNode } from 'graphql';
 import type { BaseGeneratedListTypes, GqlNames } from './utils';
+import { InitialisedList } from '../../keystone/src/lib/core/types-for-lists';
 
 export type KeystoneContext = {
   req?: IncomingMessage;
@@ -20,6 +21,7 @@ export type KeystoneContext = {
   schemaName: 'public' | 'internal';
   /** @deprecated */
   gqlNames: (listKey: string) => GqlNames;
+  initialisedLists: Record<string, InitialisedList>;
 } & Partial<SessionContext<any>>;
 
 // List item API


### PR DESCRIPTION
After Keystone's core was reworked by #5665, we miss the ability to access Lists metadata at backend side. 

For example, earlier we can get list of fields from needed List via something like this:
```js
const myListFields = context.lists[listName].fieldsByPath;
const myListAuthorFieldType = context.lists[listName].fieldsByPath['author'].adapter.fieldName; // eg 'Relationship'
```

This PR is returns ability to get list of fields for all Lists, with all metadata such as field type (kind), access, hooks, views, etc:
```js
const myListAuthorFieldType = context.initialisedLists[listName].fields['author'].dbField.kind; // 'relation'
```

Please review id and describe if something wrong... Or if this info is already accessible at backend via some API call, please show some examples. Thanks!