### PR TITLE
Add abstractions for error checking to tests

### DIFF
--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { KeystoneContext } from '@keystone-next/types';
-import { setupTestEnv, TestEnv } from '@keystone-next/testing';
+import { GraphQLRequest, setupTestEnv, TestEnv } from '@keystone-next/testing';
+import { expectAccessDenied, expectGraphQLValidationError } from '../utils';
 import {
   FAKE_ID,
   nameFn,
@@ -19,22 +20,19 @@ const expectNoAccess = <N extends string>(
   name: N
 ) => {
   expect(data?.[name]).toBe(null);
-  expect(errors).toHaveLength(1);
-  const error = errors![0];
-  expect(error.message).toEqual('You do not have access to this resource');
-  expect(error.path).toHaveLength(1);
-  expect(error.path![0]).toEqual(name);
+  expectAccessDenied(errors, [{ path: [name] }]);
 };
 
 type IdType = any;
 
 describe(`Not authed`, () => {
-  let testEnv: TestEnv, context: KeystoneContext;
+  let testEnv: TestEnv, context: KeystoneContext, graphQLRequest: GraphQLRequest;
   let items: Record<string, { id: IdType; name: string }[]>;
   let provider = config.db.provider!;
   beforeAll(async () => {
     testEnv = await setupTestEnv({ config });
     context = testEnv.testArgs.context;
+    graphQLRequest = testEnv.testArgs.graphQLRequest;
 
     await testEnv.connect();
 
@@ -91,20 +89,32 @@ describe(`Not authed`, () => {
               const createMutationName = `create${nameFn[mode](listAccess)}`;
               const fieldName = getFieldName(access);
               const query = `mutation { ${createMutationName}(data: { ${fieldName}: "bar" }) { id ${fieldName} } }`;
-              const { data, errors } = await context.graphql.raw({ query });
+              const { body } = await graphQLRequest({ query });
               // If create is not allowed on a field then there will be a query validation error
-              expect(errors).toHaveLength(access.read ? 1 : 2);
-              expect(errors![0].message).toContain(
-                `Field "${fieldName}" is not defined by type "${nameFn[mode](
+              if (access.read) {
+                const message = `Field "${fieldName}" is not defined by type "${nameFn[mode](
                   listAccess
-                )}CreateInput".`
-              );
-              if (!access.read) {
-                expect(errors![1].message).toContain(
-                  `Cannot query field "${fieldName}" on type "${nameFn[mode](listAccess)}".`
-                );
+                )}CreateInput".`;
+                expectGraphQLValidationError(body.errors, [
+                  { message: expect.stringContaining(message) },
+                ]);
+              } else {
+                expectGraphQLValidationError(body.errors, [
+                  {
+                    message: expect.stringContaining(
+                      `Field "${fieldName}" is not defined by type "${nameFn[mode](
+                        listAccess
+                      )}CreateInput".`
+                    ),
+                  },
+                  {
+                    message: expect.stringContaining(
+                      `Cannot query field "${fieldName}" on type "${nameFn[mode](listAccess)}".`
+                    ),
+                  },
+                ]);
               }
-              expect(data).toBe(undefined);
+              expect(body.data).toBe(undefined);
             });
           });
       });
@@ -125,12 +135,8 @@ describe(`Not authed`, () => {
               const fieldName = getFieldName(access);
               const query = `mutation { ${createMutationName}(data: { ${fieldName}: "bar" }) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
-              expect(data?.[createMutationName]).toEqual(null);
-              expect(errors).not.toBe(undefined);
-              expect(errors).toHaveLength(1);
-              expect(errors![0].name).toEqual('GraphQLError');
-              expect(errors![0].message).toEqual('You do not have access to this resource');
-              expect(errors![0].path).toEqual([createMutationName]);
+              expect(data).toEqual({ [createMutationName]: null });
+              expectAccessDenied(errors, [{ path: [createMutationName] }]);
             });
           });
       });
@@ -156,12 +162,8 @@ describe(`Not authed`, () => {
               }sCount`;
               const query = `query { ${countName} }`;
               const { data, errors } = await context.graphql.raw({ query });
-              expect(data?.[countName]).toBe(null);
-              expect(errors).toHaveLength(1);
-              const error = errors![0];
-              expect(error.message).toEqual('You do not have access to this resource');
-              expect(error.path).toHaveLength(1);
-              expect(error.path![0]).toEqual(countName);
+              expect(data).toEqual({ [countName]: null });
+              expectAccessDenied(errors, [{ path: [countName] }]);
             });
 
             test(`single denied: ${JSON.stringify(access)}`, async () => {
@@ -194,14 +196,8 @@ describe(`Not authed`, () => {
                 .lists[listKey].updateOne({ id: item.id, data: { [fieldName]: 'hello' } });
               const query = `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`;
               const { data, errors } = await context.graphql.raw({ query });
-              expect(errors).not.toBe(null);
-              expect(errors).toHaveLength(1);
-              expect(errors![0].name).toEqual('GraphQLError');
-              expect(errors![0].message).toEqual('You do not have access to this resource');
-              expect(errors![0].path).toEqual([singleQueryName, fieldName]);
-              expect(data?.[singleQueryName]).not.toBe(null);
-              expect(data?.[singleQueryName].id).not.toBe(null);
-              expect(data?.[singleQueryName][fieldName]).toBe(null);
+              expectAccessDenied(errors, [{ path: [singleQueryName, fieldName] }]);
+              expect(data).toEqual({ [singleQueryName]: { id: item.id, [fieldName]: null } });
             });
             test(`field allowed - multi: ${JSON.stringify(access)}`, async () => {
               const listAccess = {
@@ -219,20 +215,16 @@ describe(`Not authed`, () => {
                 .lists[listKey].updateOne({ id: item.id, data: { [fieldName]: 'hello' } });
               const query = `query { ${allQueryName} { id ${fieldName} } }`;
               const { data, errors } = await context.graphql.raw({ query });
-              expect(errors).not.toBe(null);
-              expect(errors).toHaveLength(2);
-              expect(errors![0].name).toEqual('GraphQLError');
-              expect(errors![0].message).toEqual('You do not have access to this resource');
-              expect(errors![0].path).toEqual([allQueryName, 0, fieldName]);
-              expect(errors![1].name).toEqual('GraphQLError');
-              expect(errors![1].message).toEqual('You do not have access to this resource');
-              expect(errors![1].path).toEqual([allQueryName, 1, fieldName]);
-              expect(data?.[allQueryName]).not.toBe(null);
-              expect(data?.[allQueryName]).toHaveLength(2);
-              for (const _item of data?.[allQueryName]) {
-                expect(_item.id).not.toBe(null);
-                expect(_item[fieldName]).toEqual(null);
-              }
+              expectAccessDenied(errors, [
+                { path: [allQueryName, 0, fieldName] },
+                { path: [allQueryName, 1, fieldName] },
+              ]);
+              expect(data).toEqual({
+                [allQueryName]: [
+                  { id: expect.any(String), [fieldName]: null },
+                  { id: expect.any(String), [fieldName]: null },
+                ],
+              });
             });
           });
       });
@@ -252,12 +244,15 @@ describe(`Not authed`, () => {
                 .sudo()
                 .lists[listKey].updateOne({ id: item.id, data: { [fieldName]: 'hello' } });
               const query = `query { ${singleQueryName}(where: { id: "${item.id}" }) { id ${fieldName} } }`;
-              const { data, errors } = await context.graphql.raw({ query });
-              expect(errors).toHaveLength(1);
-              expect(errors![0].message).toContain(
-                `Cannot query field "${fieldName}" on type "${listKey}".`
-              );
-              expect(data).toBe(undefined);
+              const { body } = await graphQLRequest({ query });
+              expectGraphQLValidationError(body.errors, [
+                {
+                  message: expect.stringContaining(
+                    `Cannot query field "${fieldName}" on type "${listKey}".`
+                  ),
+                },
+              ]);
+              expect(body.data).toBe(undefined);
             });
             test(`field allowed - multi: ${JSON.stringify(access)}`, async () => {
               const listAccess = { create: true, read: true, update: true, delete: true };
@@ -269,12 +264,15 @@ describe(`Not authed`, () => {
                 .sudo()
                 .lists[listKey].updateOne({ id: item.id, data: { [fieldName]: 'hello' } });
               const query = `query { ${allQueryName} { id ${fieldName} } }`;
-              const { data, errors } = await context.graphql.raw({ query });
-              expect(errors).toHaveLength(1);
-              expect(errors![0].message).toContain(
-                `Cannot query field "${fieldName}" on type "${listKey}".`
-              );
-              expect(data).toBe(undefined);
+              const { body } = await graphQLRequest({ query });
+              expectGraphQLValidationError(body.errors, [
+                {
+                  message: expect.stringContaining(
+                    `Cannot query field "${fieldName}" on type "${listKey}".`
+                  ),
+                },
+              ]);
+              expect(body.data).toBe(undefined);
             });
           });
       });
@@ -316,13 +314,16 @@ describe(`Not authed`, () => {
               const query = `mutation { ${updateMutationName}(id: "${
                 item.id
               }", data: { ${fieldName}: "bar" }) { id ${access.read ? fieldName : ''} } }`;
-              const { data, errors } = await context.graphql.raw({ query });
+              const { body } = await graphQLRequest({ query });
               // If update is not allowed on a field then there will be a query validation error
-              expect(errors).toHaveLength(1);
-              expect(errors![0].message).toContain(
-                `Field "${fieldName}" is not defined by type "${listKey}UpdateInput".`
-              );
-              expect(data).toBe(undefined);
+              expectGraphQLValidationError(body.errors, [
+                {
+                  message: expect.stringContaining(
+                    `Field "${fieldName}" is not defined by type "${listKey}UpdateInput".`
+                  ),
+                },
+              ]);
+              expect(body.data).toBe(undefined);
             });
           });
       });
@@ -345,12 +346,8 @@ describe(`Not authed`, () => {
               const fieldName = getFieldName(access);
               const query = `mutation { ${updateMutationName}(id: "${item.id}", data: { ${fieldName}: "bar" }) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
-              expect(data?.[updateMutationName]).toEqual(null);
-              expect(errors).not.toBe(undefined);
-              expect(errors).toHaveLength(1);
-              expect(errors![0].name).toEqual('GraphQLError');
-              expect(errors![0].message).toEqual('You do not have access to this resource');
-              expect(errors![0].path).toEqual([updateMutationName]);
+              expect(data).toEqual({ [updateMutationName]: null });
+              expectAccessDenied(errors, [{ path: [updateMutationName] }]);
             });
           });
       });
@@ -375,12 +372,8 @@ describe(`Not authed`, () => {
               const query = `mutation { ${multiDeleteMutationName}(ids: ["${FAKE_ID[provider]}"]) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
 
-              expect(data?.[multiDeleteMutationName]).toEqual([null]);
-              expect(errors).not.toBe(undefined);
-              expect(errors).toHaveLength(1);
-              expect(errors![0].name).toEqual('GraphQLError');
-              expect(errors![0].message).toEqual('You do not have access to this resource');
-              expect(errors![0].path).toEqual([multiDeleteMutationName, 0]);
+              expect(data).toEqual({ [multiDeleteMutationName]: [null] });
+              expectAccessDenied(errors, [{ path: [multiDeleteMutationName, 0] }]);
             });
           });
       });

--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -1,7 +1,7 @@
 import { createSchema, list, graphQLSchemaExtension, gql } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig } from '../utils';
+import { apiTestConfig, expectInternalServerError } from '../utils';
 
 const falseFn: (...args: any) => boolean = () => false;
 
@@ -67,17 +67,16 @@ describe('extendGraphqlSchema', () => {
   );
   it(
     'Denies access acording to access control',
-    runner(async ({ context }) => {
-      const { data, errors } = await context.graphql.raw({
+    runner(async ({ graphQLRequest }) => {
+      const { body } = await graphQLRequest({
         query: `
               query {
                 quads(x: 10)
               }
             `,
       });
-      expect(data?.quads).toBe(null);
-      expect(errors).not.toBe(undefined);
-      expect(errors).toHaveLength(1);
+      expect(body.data).toEqual({ quads: null });
+      expectInternalServerError(body.errors, [{ path: ['quads'], message: 'Access denied' }]);
     })
   );
   it(

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -2,7 +2,7 @@ import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig } from '../utils';
+import { apiTestConfig, expectValidationFailure } from '../utils';
 
 const testModules = globby.sync(`{packages,packages-next}/**/src/**/test-fixtures.{js,ts}`, {
   absolute: true,
@@ -64,11 +64,8 @@ testModules
                     createTest(data: { name: "test entry" } ) { id }
                   }`,
             });
-            expect(data!.createTest).toBe(null);
-            expect(errors).not.toBe(null);
-            expect(errors!.length).toEqual(1);
-            expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-            expect(errors![0].path![0]).toEqual('createTest');
+            expect(data).toEqual({ createTest: null });
+            expectValidationFailure(errors, [{ path: ['createTest'] }]);
           })
         );
 
@@ -87,11 +84,8 @@ testModules
                     updateTest(id: "${data0.id}" data: { name: "updated test entry", testField: null } ) { id }
                   }`,
             });
-            expect(data!.updateTest).toBe(null);
-            expect(errors).not.toBe(undefined);
-            expect(errors!.length).toEqual(1);
-            expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-            expect(errors![0].path![0]).toEqual('updateTest');
+            expect(data).toEqual({ updateTest: null });
+            expectValidationFailure(errors, [{ path: ['updateTest'] }]);
           })
         );
 

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -1,7 +1,7 @@
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig } from '../utils';
+import { apiTestConfig, expectValidationFailure } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -39,10 +39,8 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Returns null and throws an error
-      expect(data!.createUser).toBe(null);
-      expect(errors).toHaveLength(1);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['createUser']);
+      expect(data).toEqual({ createUser: null });
+      expectValidationFailure(errors, [{ path: ['createUser'] }]);
 
       // Only the original user should exist
       const _users = await context.lists.User.findMany({ query: 'id name' });
@@ -64,10 +62,8 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Returns null and throws an error
-      expect(data!.updateUser).toBe(null);
-      expect(errors).toHaveLength(1);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['updateUser']);
+      expect(data).toEqual({ updateUser: null });
+      expectValidationFailure(errors, [{ path: ['updateUser'] }]);
 
       // User should have its original name
       const _users = await context.lists.User.findMany({ query: 'id name' });
@@ -90,10 +86,8 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Returns null and throws an error
-      expect(data!.deleteUser).toBe(null);
-      expect(errors).toHaveLength(1);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['deleteUser']);
+      expect(data).toEqual({ deleteUser: null });
+      expectValidationFailure(errors, [{ path: ['deleteUser'] }]);
 
       // Bad users should still be in the database.
       const _users = await context.lists.User.findMany({ query: 'id name' });
@@ -119,19 +113,17 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Valid users are returned, invalid come back as null
-      expect(data!.createUsers).toHaveLength(5);
-      expect(data!.createUsers[0].name).toEqual('good 1');
-      expect(data!.createUsers[1]).toBe(null);
-      expect(data!.createUsers[2].name).toEqual('good 2');
-      expect(data!.createUsers[3]).toBe(null);
-      expect(data!.createUsers[4].name).toEqual('good 3');
+      expect(data).toEqual({
+        createUsers: [
+          { id: expect.any(String), name: 'good 1' },
+          null,
+          { id: expect.any(String), name: 'good 2' },
+          null,
+          { id: expect.any(String), name: 'good 3' },
+        ],
+      });
       // The invalid creates should have errors which point to the nulls in their path
-      expect(errors).toHaveLength(2);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['createUsers', 1]);
-
-      expect(errors![1].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![1].path).toEqual(['createUsers', 3]);
+      expectValidationFailure(errors, [{ path: ['createUsers', 1] }, { path: ['createUsers', 3] }]);
 
       // Three users should exist in the database
       const users = await context.lists.User.findMany({
@@ -171,18 +163,16 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Valid users are returned, invalid come back as null
-      expect(data!.updateUsers).toHaveLength(4);
-      expect(data!.updateUsers[0].name).toEqual('still good 1');
-      expect(data!.updateUsers[1]).toBe(null);
-      expect(data!.updateUsers[2].name).toEqual('still good 3');
-      expect(data!.updateUsers[3]).toBe(null);
+      expect(data).toEqual({
+        updateUsers: [
+          { id: users[0].id, name: 'still good 1' },
+          null,
+          { id: users[2].id, name: 'still good 3' },
+          null,
+        ],
+      });
       // The invalid updates should have errors which point to the nulls in their path
-      expect(errors).toHaveLength(2);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['updateUsers', 1]);
-
-      expect(errors![1].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![1].path).toEqual(['updateUsers', 3]);
+      expectValidationFailure(errors, [{ path: ['updateUsers', 1] }, { path: ['updateUsers', 3] }]);
 
       // All users should still exist in the database
       const _users = await context.lists.User.findMany({
@@ -221,18 +211,16 @@ describe('List Hooks: #validateInput()', () => {
       });
 
       // Valid users are returned, invalid come back as null
-      expect(data!.deleteUsers).toHaveLength(4);
-      expect(data!.deleteUsers[0].name).toEqual('good 1');
-      expect(data!.deleteUsers[1]).toBe(null);
-      expect(data!.deleteUsers[2].name).toEqual('good 3');
-      expect(data!.deleteUsers[3]).toBe(null);
+      expect(data).toEqual({
+        deleteUsers: [
+          { id: users[0].id, name: 'good 1' },
+          null,
+          { id: users[2].id, name: 'good 3' },
+          null,
+        ],
+      });
       // The invalid deletes should have errors which point to the nulls in their path
-      expect(errors).toHaveLength(2);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![0].path).toEqual(['deleteUsers', 1]);
-
-      expect(errors![1].message).toEqual('You attempted to perform an invalid mutation');
-      expect(errors![1].path).toEqual(['deleteUsers', 3]);
+      expectValidationFailure(errors, [{ path: ['deleteUsers', 1] }, { path: ['deleteUsers', 3] }]);
 
       // Three users should still exist in the database
       const _users = await context.lists.User.findMany({

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -1,7 +1,7 @@
 import { text, integer, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig, expectGraphQLValidationError } from '../utils';
+import { apiTestConfig, expectGraphQLValidationError, expectLimitsExceededError } from '../utils';
 import { depthLimit, definitionLimit, fieldLimit } from './validation';
 
 const runner = setupTestRunner({
@@ -116,7 +116,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        limitsExceedError(errors, [{ path: ['allUsers'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allUsers'] }]);
 
         // The query results don't break the limits, but the "first" parameter does
         ({ errors } = await context.graphql.raw({
@@ -132,7 +132,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        limitsExceedError(errors, [{ path: ['allUsers'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allUsers'] }]);
       })
     );
   });
@@ -211,7 +211,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        limitsExceedError(errors, [{ path: ['allPosts', 0, 'author'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allPosts', 0, 'author'] }]);
 
         // Requesting the too-many-authors post is okay as long as the authors aren't returned
         // Reset the count for each query
@@ -239,7 +239,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        limitsExceedError(errors, [{ path: ['allPosts', 1, 'author'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allPosts', 1, 'author'] }]);
 
         // All subqueries are within limits, but the total isn't
         // Reset the count for each query
@@ -259,7 +259,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        limitsExceedError(errors, [{ path: ['allPosts', 0, 'author', 1, 'posts'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allPosts', 0, 'author', 1, 'posts'] }]);
       })
     );
   });

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -211,7 +211,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        expectLimitsExceededError(errors, [{ path: ['allPosts', 0, 'author'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allPosts', expect.any(Number), 'author'] }]);
 
         // Requesting the too-many-authors post is okay as long as the authors aren't returned
         // Reset the count for each query
@@ -239,7 +239,7 @@ describe('maxResults Limit', () => {
       `,
         }));
 
-        expectLimitsExceededError(errors, [{ path: ['allPosts', 1, 'author'] }]);
+        expectLimitsExceededError(errors, [{ path: ['allPosts', expect.any(Number), 'author'] }]);
 
         // All subqueries are within limits, but the total isn't
         // Reset the count for each query

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
@@ -1,7 +1,7 @@
 import { text, relationship } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig } from '../../utils';
+import { apiTestConfig, expectNestedError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -26,7 +26,7 @@ describe('errors on incomplete data', () => {
     'when neither id or create data passed',
     runner(async ({ context }) => {
       // Create an item that does the linking
-      const { errors } = await context.graphql.raw({
+      const { data, errors } = await context.graphql.raw({
         query: `
               mutation {
                 createEvent(data: { group: {} }) {
@@ -35,8 +35,12 @@ describe('errors on incomplete data', () => {
               }`,
       });
 
-      expect(errors).toMatchObject([
-        { message: 'Nested mutation operation invalid for Event.group<Group>' },
+      expect(data).toEqual({ createEvent: null });
+      expectNestedError(errors, [
+        {
+          path: ['createEvent'],
+          message: 'Nested mutation operation invalid for Event.group<Group>',
+        },
       ]);
     })
   );
@@ -57,9 +61,12 @@ describe('errors on incomplete data', () => {
               }`,
       });
 
-      expect(data?.createEvent).toBe(null);
-      expect(errors).toMatchObject([
-        { message: 'Nested mutation operation invalid for Event.group<Group>' },
+      expect(data).toEqual({ createEvent: null });
+      expectNestedError(errors, [
+        {
+          path: ['createEvent'],
+          message: 'Nested mutation operation invalid for Event.group<Group>',
+        },
       ]);
     })
   );

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -119,7 +119,6 @@ describe('non-matching filter', () => {
       });
 
       expect(user).toMatchObject({ id: expect.any(String), notes: [] });
-      expect(user).not.toHaveProperty('errors');
     })
   );
 

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -109,7 +109,6 @@ describe('no access control', () => {
       });
 
       expect(event).toMatchObject({ id: expect.any(String), group: null });
-      expect(event).not.toHaveProperty('errors');
     })
   );
 
@@ -133,7 +132,6 @@ describe('no access control', () => {
       });
 
       expect(event).toMatchObject({ id: expect.any(String), group: { id: createGroup.id } });
-      expect(event).not.toHaveProperty('errors');
     })
   );
 });

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -83,7 +83,7 @@ export const expectValidationFailure = (
   );
 };
 
-export const expectLimitsExceedError = (
+export const expectLimitsExceededError = (
   errors: readonly any[] | undefined,
   args: { path: (string | number)[] }[]
 ) => {

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -15,3 +15,95 @@ export const apiTestConfig = (
     url: process.env.DATABASE_URL as string,
   },
 });
+
+const unpackErrors = (errors: readonly any[] | undefined) =>
+  (errors || []).map(
+    ({ locations, uid, extensions: { exception, ...extensions }, ...unpacked }) => ({
+      extensions,
+      ...unpacked,
+    })
+  );
+
+export const expectInternalServerError = (
+  errors: readonly any[] | undefined,
+  args: { path: any[]; message: string }[]
+) => {
+  const unpackedErrors = unpackErrors(errors);
+  expect(unpackedErrors).toEqual(
+    args.map(({ path, message }) => ({
+      extensions: { code: 'INTERNAL_SERVER_ERROR' },
+      name: 'GraphQLError',
+      path,
+      message,
+    }))
+  );
+};
+
+export const expectGraphQLValidationError = (
+  errors: readonly any[] | undefined,
+  args: { message: string }[]
+) => {
+  const unpackedErrors = unpackErrors(errors);
+  expect(unpackedErrors).toEqual(
+    args.map(({ message }) => ({
+      extensions: { code: 'GRAPHQL_VALIDATION_FAILED' },
+      name: 'ValidationError',
+      message,
+    }))
+  );
+};
+
+export const expectAccessDenied = (
+  errors: readonly any[] | undefined,
+  args: { path: (string | number)[] }[]
+) => {
+  const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
+    ...unpacked,
+  }));
+  expect(unpackedErrors).toEqual(
+    args.map(({ path }) => ({
+      path,
+      message: 'You do not have access to this resource',
+    }))
+  );
+};
+
+export const expectValidationFailure = (
+  errors: readonly any[] | undefined,
+  args: { path: (string | number)[] }[]
+) => {
+  const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
+    ...unpacked,
+  }));
+  expect(unpackedErrors).toEqual(
+    args.map(({ path }) => ({
+      path,
+      message: 'You attempted to perform an invalid mutation',
+    }))
+  );
+};
+
+export const expectLimitsExceedError = (
+  errors: readonly any[] | undefined,
+  args: { path: (string | number)[] }[]
+) => {
+  const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
+    ...unpacked,
+  }));
+  expect(unpackedErrors).toEqual(
+    args.map(({ path }) => ({
+      path,
+      message: 'Your request exceeded server limits',
+    }))
+  );
+};
+
+export const expectNestedError = (
+  errors: readonly any[] | undefined,
+  args: { path: (string | number)[]; message: string }[]
+) => {
+  const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
+    ...unpacked,
+  }));
+  expect(unpackedErrors).toEqual(args.map(({ path, message }) => ({ path, message })));
+};


### PR DESCRIPTION
This PR adds some abstractions for checking the errors returned from our graphQL queries. This makes our error testing more consistent and also more comprehensive (checking more things in more places now). It will also let us refactor our error handling in general (e.g. #6050). I suspect these abstractions will be refined as we start addressing issues in our error handling in general.

These changes are purely to the tests, none of the system behaviour has changed in this PR.