### PR TITLE
Handle Keystone v4 redirects

### DIFF
--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -1,3 +1,37 @@
+/* URLs from v4.keystonejs.com */
+const KEYSTONE_4 = [
+  {
+    source: '/docs/configuration',
+    destination: 'https://v4.keystonejs.com/docs/configuration',
+    permanent: true,
+  },
+  {
+    source: '/docs/database',
+    destination: 'https://v4.keystonejs.com/api/field/options',
+    permanent: true,
+  },
+  {
+    source: '/docs/getting-started',
+    destination: 'https://v4.keystonejs.com/getting-started',
+    permanent: true,
+  },
+  {
+    source: '/documentation/configuration/project-options',
+    destination: 'https://v4.keystonejs.com/documentation/configuration/project-options',
+    permanent: true,
+  },
+  {
+    source: '/documentation/database',
+    destination: 'https://v4.keystonejs.com/documentation/database',
+    permanent: true,
+  },
+  {
+    source: '/getting-started',
+    destination: 'https://v4.keystonejs.com/getting-started',
+    permanent: true,
+  },
+];
+
 /* URLs from v5.keystonejs.com */
 const KEYSTONE_5 = [
   {
@@ -68,4 +102,4 @@ const ORIGINAL_NEXT = [
   { source: '/whats-new', destination: '/updates/whats-new-in-v6', permanent: true },
 ];
 
-module.exports = [...ORIGINAL_NEXT, ...KEYSTONE_5];
+module.exports = [...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];


### PR DESCRIPTION
We need to handle Keystone v4 URL redirects.

Analysing all Stack Overflow content referencing `keystonejs.com` I built up a list of broken URLs then de-duplicated, then made sure:

- [x] The unique url doesn't exist on the `keystonejs.com` website
- [x] The unique  url doesn't exist on the `v5.keystonejs.com` website

Then set up a redirect for it to the most appropriate page on the `v4.keystonejs.com` website, this was difficult in some cases as the `v4.keystonejs.com` site itself evolved at a point in the past, breaking it's own URLs in the process, so we're working with the _latest_ `v4.keystonejs.com` site.

Thus the best page has been selected for the redirects.