### PR TITLE
Refactor nested mutation handling

### DIFF
--- a/.changeset/few-poets-happen.md
+++ b/.changeset/few-poets-happen.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Refactored internal nested mutation input handler code.

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -1,36 +1,10 @@
 import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
 import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
-import {
-  isRejected,
-  isFulfilled,
-  getPrismaModelForList,
-  promiseAllRejectWithAllErrors,
-  IdType,
-} from '../utils';
-import { createOneState } from './create-update';
+import { isRejected, isFulfilled } from '../utils';
+import { NestedMutationState } from './create-update';
 
 const isNotNull = <T>(arg: T): arg is Exclude<T, null> => arg !== null;
-
-export class NestedMutationState {
-  #afterChanges: (() => void | Promise<void>)[] = [];
-  #context: KeystoneContext;
-  constructor(context: KeystoneContext) {
-    this.#context = context;
-  }
-  async create(
-    input: Record<string, any>,
-    list: InitialisedList
-  ): Promise<{ kind: 'connect'; id: IdType } | { kind: 'create'; data: Record<string, any> }> {
-    const { afterChange, data } = await createOneState({ data: input }, list, this.#context);
-    const item = await getPrismaModelForList(this.#context.prisma, list.listKey).create({ data });
-    this.#afterChanges.push(() => afterChange(item));
-    return { kind: 'connect' as const, id: item.id as any };
-  }
-  async afterChange() {
-    await promiseAllRejectWithAllErrors(this.#afterChanges.map(async x => x()));
-  }
-}
 
 export function resolveRelateToManyForCreateInput(
   nestedMutationState: NestedMutationState,
@@ -169,98 +143,5 @@ export function resolveRelateToManyForUpdateInput(
       disconnect,
       ...connectAndCreates,
     };
-  };
-}
-
-async function handleCreateAndUpdate(
-  value: Exclude<
-    schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['one']['create']>>,
-    null | undefined
-  >,
-  nestedMutationState: NestedMutationState,
-  context: KeystoneContext,
-  foreignList: InitialisedList,
-  target: string
-) {
-  if (value.connect) {
-    try {
-      await context.db.lists[foreignList.listKey].findOne({ where: value.connect as any });
-    } catch (err) {
-      throw new Error(`Unable to connect a ${target}`);
-    }
-    return {
-      connect: await resolveUniqueWhereInput(value.connect, foreignList.fields, context),
-    };
-  }
-  if (value.create) {
-    const createInput = value.create;
-    let create = await (async () => {
-      try {
-        return await nestedMutationState.create(createInput, foreignList);
-      } catch (err) {
-        throw new Error(`Unable to create a ${target}`);
-      }
-    })();
-
-    if (create.kind === 'connect') {
-      return { connect: { id: create.id } };
-    }
-    return { create: create.data };
-  }
-}
-
-export function resolveRelateToOneForCreateInput(
-  nestedMutationState: NestedMutationState,
-  context: KeystoneContext,
-  foreignList: InitialisedList,
-  target: string
-) {
-  return async (
-    value: schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['one']['create']>>
-  ) => {
-    if (value == null) {
-      return undefined;
-    }
-    const numOfKeys = Object.keys(value).length;
-    if (numOfKeys !== 1) {
-      throw new Error(`Nested mutation operation invalid for ${target}`);
-    }
-    return handleCreateAndUpdate(value, nestedMutationState, context, foreignList, target);
-  };
-}
-
-export function resolveRelateToOneForUpdateInput(
-  nestedMutationState: NestedMutationState,
-  context: KeystoneContext,
-  foreignList: InitialisedList,
-  target: string
-) {
-  return async (
-    value: schema.InferValueFromArg<
-      schema.Arg<schema.NonNullType<TypesForList['relateTo']['one']['update']>>
-    >
-  ) => {
-    if (value == null) {
-      return undefined;
-    }
-    if (value.connect && value.create) {
-      throw new Error(`Nested mutation operation invalid for ${target}`);
-    }
-    if (value.connect || value.create) {
-      return handleCreateAndUpdate(value, nestedMutationState, context, foreignList, target);
-    }
-    if (value.disconnect) {
-      try {
-        await context
-          .sudo()
-          .db.lists[foreignList.listKey].findOne({ where: value.disconnect as any });
-      } catch (err) {
-        return;
-      }
-      return { disconnect: true };
-    }
-    if (value.disconnectAll) {
-      return { disconnect: true };
-    }
   };
 }

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -1,0 +1,97 @@
+import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
+import { resolveUniqueWhereInput } from '../where-inputs';
+import { InitialisedList } from '../types-for-lists';
+import { NestedMutationState } from './create-update';
+
+async function handleCreateAndUpdate(
+  value: Exclude<
+    schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['one']['create']>>,
+    null | undefined
+  >,
+  nestedMutationState: NestedMutationState,
+  context: KeystoneContext,
+  foreignList: InitialisedList,
+  target: string
+) {
+  if (value.connect) {
+    try {
+      await context.db.lists[foreignList.listKey].findOne({ where: value.connect as any });
+    } catch (err) {
+      throw new Error(`Unable to connect a ${target}`);
+    }
+    return {
+      connect: await resolveUniqueWhereInput(value.connect, foreignList.fields, context),
+    };
+  }
+  if (value.create) {
+    const createInput = value.create;
+    let create = await (async () => {
+      try {
+        return await nestedMutationState.create(createInput, foreignList);
+      } catch (err) {
+        throw new Error(`Unable to create a ${target}`);
+      }
+    })();
+
+    if (create.kind === 'connect') {
+      return { connect: { id: create.id } };
+    }
+    return { create: create.data };
+  }
+}
+
+export function resolveRelateToOneForCreateInput(
+  nestedMutationState: NestedMutationState,
+  context: KeystoneContext,
+  foreignList: InitialisedList,
+  target: string
+) {
+  return async (
+    value: schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['one']['create']>>
+  ) => {
+    if (value == null) {
+      return undefined;
+    }
+    const numOfKeys = Object.keys(value).length;
+    if (numOfKeys !== 1) {
+      throw new Error(`Nested mutation operation invalid for ${target}`);
+    }
+    return handleCreateAndUpdate(value, nestedMutationState, context, foreignList, target);
+  };
+}
+
+export function resolveRelateToOneForUpdateInput(
+  nestedMutationState: NestedMutationState,
+  context: KeystoneContext,
+  foreignList: InitialisedList,
+  target: string
+) {
+  return async (
+    value: schema.InferValueFromArg<
+      schema.Arg<schema.NonNullType<TypesForList['relateTo']['one']['update']>>
+    >
+  ) => {
+    if (value == null) {
+      return undefined;
+    }
+    if (value.connect && value.create) {
+      throw new Error(`Nested mutation operation invalid for ${target}`);
+    }
+    if (value.connect || value.create) {
+      return handleCreateAndUpdate(value, nestedMutationState, context, foreignList, target);
+    }
+    if (value.disconnect) {
+      try {
+        await context
+          .sudo()
+          .db.lists[foreignList.listKey].findOne({ where: value.disconnect as any });
+      } catch (err) {
+        return;
+      }
+      return { disconnect: true };
+    }
+    if (value.disconnectAll) {
+      return { disconnect: true };
+    }
+  };
+}


### PR DESCRIPTION
A small refactoring to separate out the `many` from the `one` case when handling nested mutations. This is purely to help my brain think about one thing at a time, no functional changes here.