### PR TITLE
Remove unnecessary GraphQL descriptions

### DIFF
--- a/.changeset/odd-windows-explode.md
+++ b/.changeset/odd-windows-explode.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/fields': major
+'@keystone-next/keystone': major
+---
+
+Removed unnecessary descriptions on GraphQL types. 

--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -24,37 +24,20 @@ This system will generate the following GraphQL API.
 
 ```graphql
 type Query {
-  """ Search for the User item with the matching ID. """
   User(where: UserWhereUniqueInput!): User
-
-  """ Search for all User items which match the where clause. """
   allUsers(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): [User]
-
-  """ Perform a meta-query on all User items which match the where clause. """
   _allUsersMeta(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta
 }
 
 type Mutation {
-  """ Create a single User item. """
   createUser(data: UserCreateInput): User
-
-  """ Create multiple User items. """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """ Update a single User item by ID. """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """ Update multiple User items by ID. """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """ Delete a single User item by ID. """
   deleteUser(id: ID!): User
-
-  """ Delete multiple User items by ID. """
   deleteUsers(ids: [ID!]): [User]
 }
 
-""" A keystone list """
 type User {
   id: ID!
   name: String
@@ -133,7 +116,6 @@ type _QueryMeta {
 
 ```graphql
 type Query {
-  """ Search for the User item with the matching ID. """
   User(where: UserWhereUniqueInput!): User
 }
 
@@ -151,7 +133,6 @@ type User {
 
 ```graphql
 type Query {
-  """ Search for all User items which match the where clause. """
   allUsers(where: UserWhereInput, search: String, orderBy: [UserOrderByInput!]! = [], first: Int, skip: Int! = 0): [User]
 }
 
@@ -261,7 +242,6 @@ type _QueryMeta {
 
 ```graphql
 type Mutation {
-  """ Create a single User item. """
   createUser(data: UserCreateInput): User
 }
 
@@ -279,7 +259,6 @@ type User {
 
 ```graphql
 type Mutation {
-  """ Create multiple User items. """
   createUsers(data: [UsersCreateInput]): [User]
 }
 
@@ -301,7 +280,6 @@ type User {
 
 ```graphql
 type Mutation {
-  """ Update a single User item by ID. """
   updateUser(id: ID!, data: UserUpdateInput): User
 }
 
@@ -319,7 +297,6 @@ type User {
 
 ```graphql
 type Mutation {
-  """ Update multiple User items by ID. """
   updateUsers(data: [UsersUpdateInput]): [User]
 }
 
@@ -342,7 +319,6 @@ type User {
 
 ```graphql
 type Mutation {
-  """ Delete a single User item by ID. """
   deleteUser(id: ID!): User
 }
 
@@ -356,7 +332,6 @@ type User {
 
 ```graphql
 type Mutation {
-  """ Delete multiple User items by ID. """
   deleteUsers(ids: [ID!]): [User]
 }
 

--- a/examples-staging/assets-cloud/schema.graphql
+++ b/examples-staging/assets-cloud/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -178,9 +175,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -236,20 +230,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -310,71 +292,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -384,15 +316,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -406,10 +330,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -419,15 +339,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples-staging/assets-local/schema.graphql
+++ b/examples-staging/assets-local/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -156,9 +153,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -214,20 +208,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -288,71 +270,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -362,15 +294,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -384,10 +308,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -397,15 +317,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples-staging/auth/schema.graphql
+++ b/examples-staging/auth/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type User {
   id: ID!
   name: String
@@ -105,34 +102,11 @@ type _QueryMeta {
 }
 
 type Mutation {
-  """
-   Create a single User item.
-  """
   createUser(data: UserCreateInput): User
-
-  """
-   Create multiple User items.
-  """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """
-   Update a single User item by ID.
-  """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """
-   Update multiple User items by ID.
-  """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """
-   Delete a single User item by ID.
-  """
   deleteUser(id: ID!): User
-
-  """
-   Delete multiple User items by ID.
-  """
   deleteUsers(ids: [ID!]): [User]
   authenticateUserWithPassword(
     email: String!
@@ -175,9 +149,6 @@ input CreateInitialUserInput {
 }
 
 type Query {
-  """
-   Search for all User items which match the where clause.
-  """
   allUsers(
     where: UserWhereInput! = {}
     search: String
@@ -187,15 +158,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [User!]
-
-  """
-   Search for the User item with the matching ID.
-  """
   User(where: UserWhereUniqueInput!): User
-
-  """
-   Perform a meta-query on all User items which match the where clause.
-  """
   _allUsersMeta(
     where: UserWhereInput! = {}
     search: String

--- a/examples-staging/basic/schema.graphql
+++ b/examples-staging/basic/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type User {
   id: ID!
   name: String
@@ -138,35 +135,11 @@ input UserWhereInput {
   roles_not_contains: String
   roles_in: [String]
   roles_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   phoneNumbers_every: PhoneNumberWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   phoneNumbers_some: PhoneNumberWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   phoneNumbers_none: PhoneNumberWhereInput
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -263,9 +236,6 @@ input UsersCreateInput {
   data: UserCreateInput
 }
 
-"""
- A keystone list
-"""
 type PhoneNumber {
   id: ID!
   label: String
@@ -346,9 +316,6 @@ input PhoneNumbersCreateInput {
   data: PhoneNumberCreateInput
 }
 
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -451,94 +418,23 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single User item.
-  """
   createUser(data: UserCreateInput): User
-
-  """
-   Create multiple User items.
-  """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """
-   Update a single User item by ID.
-  """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """
-   Update multiple User items by ID.
-  """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """
-   Delete a single User item by ID.
-  """
   deleteUser(id: ID!): User
-
-  """
-   Delete multiple User items by ID.
-  """
   deleteUsers(ids: [ID!]): [User]
-
-  """
-   Create a single PhoneNumber item.
-  """
   createPhoneNumber(data: PhoneNumberCreateInput): PhoneNumber
-
-  """
-   Create multiple PhoneNumber items.
-  """
   createPhoneNumbers(data: [PhoneNumbersCreateInput]): [PhoneNumber]
-
-  """
-   Update a single PhoneNumber item by ID.
-  """
   updatePhoneNumber(id: ID!, data: PhoneNumberUpdateInput): PhoneNumber
-
-  """
-   Update multiple PhoneNumber items by ID.
-  """
   updatePhoneNumbers(data: [PhoneNumbersUpdateInput]): [PhoneNumber]
-
-  """
-   Delete a single PhoneNumber item by ID.
-  """
   deletePhoneNumber(id: ID!): PhoneNumber
-
-  """
-   Delete multiple PhoneNumber items by ID.
-  """
   deletePhoneNumbers(ids: [ID!]): [PhoneNumber]
-
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
   authenticateUserWithPassword(
     email: String!
@@ -587,9 +483,6 @@ type RandomNumber {
 }
 
 type Query {
-  """
-   Search for all User items which match the where clause.
-  """
   allUsers(
     where: UserWhereInput! = {}
     search: String
@@ -599,15 +492,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [User!]
-
-  """
-   Search for the User item with the matching ID.
-  """
   User(where: UserWhereUniqueInput!): User
-
-  """
-   Perform a meta-query on all User items which match the where clause.
-  """
   _allUsersMeta(
     where: UserWhereInput! = {}
     search: String
@@ -621,10 +506,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use usersCount instead."
     )
   usersCount(where: UserWhereInput! = {}): Int
-
-  """
-   Search for all PhoneNumber items which match the where clause.
-  """
   allPhoneNumbers(
     where: PhoneNumberWhereInput! = {}
     search: String
@@ -634,15 +515,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [PhoneNumber!]
-
-  """
-   Search for the PhoneNumber item with the matching ID.
-  """
   PhoneNumber(where: PhoneNumberWhereUniqueInput!): PhoneNumber
-
-  """
-   Perform a meta-query on all PhoneNumber items which match the where clause.
-  """
   _allPhoneNumbersMeta(
     where: PhoneNumberWhereInput! = {}
     search: String
@@ -656,10 +529,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use phoneNumbersCount instead."
     )
   phoneNumbersCount(where: PhoneNumberWhereInput! = {}): Int
-
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -669,15 +538,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String

--- a/examples-staging/ecommerce/schema.graphql
+++ b/examples-staging/ecommerce/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type User {
   id: ID!
   name: String
@@ -110,52 +107,16 @@ input UserWhereInput {
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   cart_every: CartItemWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   cart_some: CartItemWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   cart_none: CartItemWhereInput
-
-  """
-   condition must be true for all nodes
-  """
   orders_every: OrderWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   orders_some: OrderWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   orders_none: OrderWhereInput
   role: RoleWhereInput
   role_is_null: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   products_every: ProductWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   products_some: ProductWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   products_none: ProductWhereInput
   passwordResetToken_is_set: Boolean
   passwordResetIssuedAt: String
@@ -270,9 +231,6 @@ input UsersCreateInput {
   data: UserCreateInput
 }
 
-"""
- A keystone list
-"""
 type Product {
   id: ID!
   name: String
@@ -390,9 +348,6 @@ input ProductsCreateInput {
   data: ProductCreateInput
 }
 
-"""
- A keystone list
-"""
 type ProductImage {
   id: ID!
   image: CloudinaryImage_File
@@ -523,9 +478,6 @@ input ProductImagesCreateInput {
   data: ProductImageCreateInput
 }
 
-"""
- A keystone list
-"""
 type CartItem {
   id: ID!
   quantity: Int
@@ -595,9 +547,6 @@ input CartItemsCreateInput {
   data: CartItemCreateInput
 }
 
-"""
- A keystone list
-"""
 type OrderItem {
   id: ID!
   name: String
@@ -712,9 +661,6 @@ input OrderItemsCreateInput {
   data: OrderItemCreateInput
 }
 
-"""
- A keystone list
-"""
 type Order {
   id: ID!
   label: String
@@ -764,20 +710,8 @@ input OrderWhereInput {
   total_gte: Int
   total_in: [Int]
   total_not_in: [Int]
-
-  """
-   condition must be true for all nodes
-  """
   items_every: OrderItemWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   items_some: OrderItemWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   items_none: OrderItemWhereInput
   user: UserWhereInput
   user_is_null: Boolean
@@ -838,9 +772,6 @@ input OrdersCreateInput {
   data: OrderCreateInput
 }
 
-"""
- A keystone list
-"""
 type Role {
   id: ID!
   name: String
@@ -903,20 +834,8 @@ input RoleWhereInput {
   canManageCart_not: Boolean
   canManageOrders: Boolean
   canManageOrders_not: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   assignedTo_every: UserWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   assignedTo_some: UserWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   assignedTo_none: UserWhereInput
 }
 
@@ -1001,214 +920,47 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single User item.
-  """
   createUser(data: UserCreateInput): User
-
-  """
-   Create multiple User items.
-  """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """
-   Update a single User item by ID.
-  """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """
-   Update multiple User items by ID.
-  """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """
-   Delete a single User item by ID.
-  """
   deleteUser(id: ID!): User
-
-  """
-   Delete multiple User items by ID.
-  """
   deleteUsers(ids: [ID!]): [User]
-
-  """
-   Create a single Product item.
-  """
   createProduct(data: ProductCreateInput): Product
-
-  """
-   Create multiple Product items.
-  """
   createProducts(data: [ProductsCreateInput]): [Product]
-
-  """
-   Update a single Product item by ID.
-  """
   updateProduct(id: ID!, data: ProductUpdateInput): Product
-
-  """
-   Update multiple Product items by ID.
-  """
   updateProducts(data: [ProductsUpdateInput]): [Product]
-
-  """
-   Delete a single Product item by ID.
-  """
   deleteProduct(id: ID!): Product
-
-  """
-   Delete multiple Product items by ID.
-  """
   deleteProducts(ids: [ID!]): [Product]
-
-  """
-   Create a single ProductImage item.
-  """
   createProductImage(data: ProductImageCreateInput): ProductImage
-
-  """
-   Create multiple ProductImage items.
-  """
   createProductImages(data: [ProductImagesCreateInput]): [ProductImage]
-
-  """
-   Update a single ProductImage item by ID.
-  """
   updateProductImage(id: ID!, data: ProductImageUpdateInput): ProductImage
-
-  """
-   Update multiple ProductImage items by ID.
-  """
   updateProductImages(data: [ProductImagesUpdateInput]): [ProductImage]
-
-  """
-   Delete a single ProductImage item by ID.
-  """
   deleteProductImage(id: ID!): ProductImage
-
-  """
-   Delete multiple ProductImage items by ID.
-  """
   deleteProductImages(ids: [ID!]): [ProductImage]
-
-  """
-   Create a single CartItem item.
-  """
   createCartItem(data: CartItemCreateInput): CartItem
-
-  """
-   Create multiple CartItem items.
-  """
   createCartItems(data: [CartItemsCreateInput]): [CartItem]
-
-  """
-   Update a single CartItem item by ID.
-  """
   updateCartItem(id: ID!, data: CartItemUpdateInput): CartItem
-
-  """
-   Update multiple CartItem items by ID.
-  """
   updateCartItems(data: [CartItemsUpdateInput]): [CartItem]
-
-  """
-   Delete a single CartItem item by ID.
-  """
   deleteCartItem(id: ID!): CartItem
-
-  """
-   Delete multiple CartItem items by ID.
-  """
   deleteCartItems(ids: [ID!]): [CartItem]
-
-  """
-   Create a single OrderItem item.
-  """
   createOrderItem(data: OrderItemCreateInput): OrderItem
-
-  """
-   Create multiple OrderItem items.
-  """
   createOrderItems(data: [OrderItemsCreateInput]): [OrderItem]
-
-  """
-   Update a single OrderItem item by ID.
-  """
   updateOrderItem(id: ID!, data: OrderItemUpdateInput): OrderItem
-
-  """
-   Update multiple OrderItem items by ID.
-  """
   updateOrderItems(data: [OrderItemsUpdateInput]): [OrderItem]
-
-  """
-   Delete a single OrderItem item by ID.
-  """
   deleteOrderItem(id: ID!): OrderItem
-
-  """
-   Delete multiple OrderItem items by ID.
-  """
   deleteOrderItems(ids: [ID!]): [OrderItem]
-
-  """
-   Create a single Order item.
-  """
   createOrder(data: OrderCreateInput): Order
-
-  """
-   Create multiple Order items.
-  """
   createOrders(data: [OrdersCreateInput]): [Order]
-
-  """
-   Update a single Order item by ID.
-  """
   updateOrder(id: ID!, data: OrderUpdateInput): Order
-
-  """
-   Update multiple Order items by ID.
-  """
   updateOrders(data: [OrdersUpdateInput]): [Order]
-
-  """
-   Delete a single Order item by ID.
-  """
   deleteOrder(id: ID!): Order
-
-  """
-   Delete multiple Order items by ID.
-  """
   deleteOrders(ids: [ID!]): [Order]
-
-  """
-   Create a single Role item.
-  """
   createRole(data: RoleCreateInput): Role
-
-  """
-   Create multiple Role items.
-  """
   createRoles(data: [RolesCreateInput]): [Role]
-
-  """
-   Update a single Role item by ID.
-  """
   updateRole(id: ID!, data: RoleUpdateInput): Role
-
-  """
-   Update multiple Role items by ID.
-  """
   updateRoles(data: [RolesUpdateInput]): [Role]
-
-  """
-   Delete a single Role item by ID.
-  """
   deleteRole(id: ID!): Role
-
-  """
-   Delete multiple Role items by ID.
-  """
   deleteRoles(ids: [ID!]): [Role]
   authenticateUserWithPassword(
     email: String!
@@ -1289,9 +1041,6 @@ enum PasswordResetRedemptionErrorCode {
 }
 
 type Query {
-  """
-   Search for all User items which match the where clause.
-  """
   allUsers(
     where: UserWhereInput! = {}
     search: String
@@ -1301,15 +1050,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [User!]
-
-  """
-   Search for the User item with the matching ID.
-  """
   User(where: UserWhereUniqueInput!): User
-
-  """
-   Perform a meta-query on all User items which match the where clause.
-  """
   _allUsersMeta(
     where: UserWhereInput! = {}
     search: String
@@ -1323,10 +1064,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use usersCount instead."
     )
   usersCount(where: UserWhereInput! = {}): Int
-
-  """
-   Search for all Product items which match the where clause.
-  """
   allProducts(
     where: ProductWhereInput! = {}
     search: String
@@ -1336,15 +1073,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Product!]
-
-  """
-   Search for the Product item with the matching ID.
-  """
   Product(where: ProductWhereUniqueInput!): Product
-
-  """
-   Perform a meta-query on all Product items which match the where clause.
-  """
   _allProductsMeta(
     where: ProductWhereInput! = {}
     search: String
@@ -1358,10 +1087,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use productsCount instead."
     )
   productsCount(where: ProductWhereInput! = {}): Int
-
-  """
-   Search for all ProductImage items which match the where clause.
-  """
   allProductImages(
     where: ProductImageWhereInput! = {}
     search: String
@@ -1371,15 +1096,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [ProductImage!]
-
-  """
-   Search for the ProductImage item with the matching ID.
-  """
   ProductImage(where: ProductImageWhereUniqueInput!): ProductImage
-
-  """
-   Perform a meta-query on all ProductImage items which match the where clause.
-  """
   _allProductImagesMeta(
     where: ProductImageWhereInput! = {}
     search: String
@@ -1393,10 +1110,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use productImagesCount instead."
     )
   productImagesCount(where: ProductImageWhereInput! = {}): Int
-
-  """
-   Search for all CartItem items which match the where clause.
-  """
   allCartItems(
     where: CartItemWhereInput! = {}
     search: String
@@ -1406,15 +1119,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [CartItem!]
-
-  """
-   Search for the CartItem item with the matching ID.
-  """
   CartItem(where: CartItemWhereUniqueInput!): CartItem
-
-  """
-   Perform a meta-query on all CartItem items which match the where clause.
-  """
   _allCartItemsMeta(
     where: CartItemWhereInput! = {}
     search: String
@@ -1428,10 +1133,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use cartItemsCount instead."
     )
   cartItemsCount(where: CartItemWhereInput! = {}): Int
-
-  """
-   Search for all OrderItem items which match the where clause.
-  """
   allOrderItems(
     where: OrderItemWhereInput! = {}
     search: String
@@ -1441,15 +1142,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [OrderItem!]
-
-  """
-   Search for the OrderItem item with the matching ID.
-  """
   OrderItem(where: OrderItemWhereUniqueInput!): OrderItem
-
-  """
-   Perform a meta-query on all OrderItem items which match the where clause.
-  """
   _allOrderItemsMeta(
     where: OrderItemWhereInput! = {}
     search: String
@@ -1463,10 +1156,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use orderItemsCount instead."
     )
   orderItemsCount(where: OrderItemWhereInput! = {}): Int
-
-  """
-   Search for all Order items which match the where clause.
-  """
   allOrders(
     where: OrderWhereInput! = {}
     search: String
@@ -1476,15 +1165,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Order!]
-
-  """
-   Search for the Order item with the matching ID.
-  """
   Order(where: OrderWhereUniqueInput!): Order
-
-  """
-   Perform a meta-query on all Order items which match the where clause.
-  """
   _allOrdersMeta(
     where: OrderWhereInput! = {}
     search: String
@@ -1498,10 +1179,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use ordersCount instead."
     )
   ordersCount(where: OrderWhereInput! = {}): Int
-
-  """
-   Search for all Role items which match the where clause.
-  """
   allRoles(
     where: RoleWhereInput! = {}
     search: String
@@ -1511,15 +1188,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Role!]
-
-  """
-   Search for the Role item with the matching ID.
-  """
   Role(where: RoleWhereUniqueInput!): Role
-
-  """
-   Perform a meta-query on all Role items which match the where clause.
-  """
   _allRolesMeta(
     where: RoleWhereInput! = {}
     search: String

--- a/examples-staging/embedded-nextjs/schema.graphql
+++ b/examples-staging/embedded-nextjs/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -100,41 +97,15 @@ type _QueryMeta {
 }
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -144,15 +115,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String

--- a/examples-staging/graphql-api-endpoint/schema.graphql
+++ b/examples-staging/graphql-api-endpoint/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type User {
   id: ID!
   name: String
@@ -86,20 +83,8 @@ input UserWhereInput {
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -158,9 +143,6 @@ input UsersCreateInput {
   data: UserCreateInput
 }
 
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -239,20 +221,8 @@ input PostWhereInput {
   publishDate_not_in: [String]
   author: UserWhereInput
   author_is_null: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   tags_every: TagWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tags_some: TagWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tags_none: TagWhereInput
 }
 
@@ -319,9 +289,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Tag {
   id: ID!
   name: String
@@ -378,20 +345,8 @@ input TagWhereInput {
   name_not_ends_with_i: String
   name_in: [String]
   name_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -439,94 +394,23 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single User item.
-  """
   createUser(data: UserCreateInput): User
-
-  """
-   Create multiple User items.
-  """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """
-   Update a single User item by ID.
-  """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """
-   Update multiple User items by ID.
-  """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """
-   Delete a single User item by ID.
-  """
   deleteUser(id: ID!): User
-
-  """
-   Delete multiple User items by ID.
-  """
   deleteUsers(ids: [ID!]): [User]
-
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Tag item.
-  """
   createTag(data: TagCreateInput): Tag
-
-  """
-   Create multiple Tag items.
-  """
   createTags(data: [TagsCreateInput]): [Tag]
-
-  """
-   Update a single Tag item by ID.
-  """
   updateTag(id: ID!, data: TagUpdateInput): Tag
-
-  """
-   Update multiple Tag items by ID.
-  """
   updateTags(data: [TagsUpdateInput]): [Tag]
-
-  """
-   Delete a single Tag item by ID.
-  """
   deleteTag(id: ID!): Tag
-
-  """
-   Delete multiple Tag items by ID.
-  """
   deleteTags(ids: [ID!]): [Tag]
   authenticateUserWithPassword(
     email: String!
@@ -569,9 +453,6 @@ input CreateInitialUserInput {
 }
 
 type Query {
-  """
-   Search for all User items which match the where clause.
-  """
   allUsers(
     where: UserWhereInput! = {}
     search: String
@@ -581,15 +462,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [User!]
-
-  """
-   Search for the User item with the matching ID.
-  """
   User(where: UserWhereUniqueInput!): User
-
-  """
-   Perform a meta-query on all User items which match the where clause.
-  """
   _allUsersMeta(
     where: UserWhereInput! = {}
     search: String
@@ -603,10 +476,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use usersCount instead."
     )
   usersCount(where: UserWhereInput! = {}): Int
-
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -616,15 +485,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -638,10 +499,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Tag items which match the where clause.
-  """
   allTags(
     where: TagWhereInput! = {}
     search: String
@@ -651,15 +508,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Tag!]
-
-  """
-   Search for the Tag item with the matching ID.
-  """
   Tag(where: TagWhereUniqueInput!): Tag
-
-  """
-   Perform a meta-query on all Tag items which match the where clause.
-  """
   _allTagsMeta(
     where: TagWhereInput! = {}
     search: String

--- a/examples-staging/playground/schema.graphql
+++ b/examples-staging/playground/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Note {
   id: ID!
   label: String
@@ -76,41 +73,15 @@ type _QueryMeta {
 }
 
 type Mutation {
-  """
-   Create a single Note item.
-  """
   createNote(data: NoteCreateInput): Note
-
-  """
-   Create multiple Note items.
-  """
   createNotes(data: [NotesCreateInput]): [Note]
-
-  """
-   Update a single Note item by ID.
-  """
   updateNote(id: ID!, data: NoteUpdateInput): Note
-
-  """
-   Update multiple Note items by ID.
-  """
   updateNotes(data: [NotesUpdateInput]): [Note]
-
-  """
-   Delete a single Note item by ID.
-  """
   deleteNote(id: ID!): Note
-
-  """
-   Delete multiple Note items by ID.
-  """
   deleteNotes(ids: [ID!]): [Note]
 }
 
 type Query {
-  """
-   Search for all Note items which match the where clause.
-  """
   allNotes(
     where: NoteWhereInput! = {}
     search: String
@@ -120,15 +91,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Note!]
-
-  """
-   Search for the Note item with the matching ID.
-  """
   Note(where: NoteWhereUniqueInput!): Note
-
-  """
-   Perform a meta-query on all Note items which match the where clause.
-  """
   _allNotesMeta(
     where: NoteWhereInput! = {}
     search: String

--- a/examples-staging/roles/schema.graphql
+++ b/examples-staging/roles/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Todo {
   id: ID!
   label: String
@@ -91,9 +88,6 @@ input TodosCreateInput {
   data: TodoCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -158,20 +152,8 @@ input PersonWhereInput {
   password_is_set: Boolean
   role: RoleWhereInput
   role_is_null: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TodoWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TodoWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TodoWhereInput
 }
 
@@ -233,9 +215,6 @@ input PeopleCreateInput {
   data: PersonCreateInput
 }
 
-"""
- A keystone list
-"""
 type Role {
   id: ID!
   name: String
@@ -298,20 +277,8 @@ input RoleWhereInput {
   canManagePeople_not: Boolean
   canManageRoles: Boolean
   canManageRoles_not: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   assignedTo_every: PersonWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   assignedTo_some: PersonWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   assignedTo_none: PersonWhereInput
 }
 
@@ -396,94 +363,23 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Todo item.
-  """
   createTodo(data: TodoCreateInput): Todo
-
-  """
-   Create multiple Todo items.
-  """
   createTodos(data: [TodosCreateInput]): [Todo]
-
-  """
-   Update a single Todo item by ID.
-  """
   updateTodo(id: ID!, data: TodoUpdateInput): Todo
-
-  """
-   Update multiple Todo items by ID.
-  """
   updateTodos(data: [TodosUpdateInput]): [Todo]
-
-  """
-   Delete a single Todo item by ID.
-  """
   deleteTodo(id: ID!): Todo
-
-  """
-   Delete multiple Todo items by ID.
-  """
   deleteTodos(ids: [ID!]): [Todo]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
-
-  """
-   Create a single Role item.
-  """
   createRole(data: RoleCreateInput): Role
-
-  """
-   Create multiple Role items.
-  """
   createRoles(data: [RolesCreateInput]): [Role]
-
-  """
-   Update a single Role item by ID.
-  """
   updateRole(id: ID!, data: RoleUpdateInput): Role
-
-  """
-   Update multiple Role items by ID.
-  """
   updateRoles(data: [RolesUpdateInput]): [Role]
-
-  """
-   Delete a single Role item by ID.
-  """
   deleteRole(id: ID!): Role
-
-  """
-   Delete multiple Role items by ID.
-  """
   deleteRoles(ids: [ID!]): [Role]
   authenticatePersonWithPassword(
     email: String!
@@ -526,9 +422,6 @@ input CreateInitialPersonInput {
 }
 
 type Query {
-  """
-   Search for all Todo items which match the where clause.
-  """
   allTodos(
     where: TodoWhereInput! = {}
     search: String
@@ -538,15 +431,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Todo!]
-
-  """
-   Search for the Todo item with the matching ID.
-  """
   Todo(where: TodoWhereUniqueInput!): Todo
-
-  """
-   Perform a meta-query on all Todo items which match the where clause.
-  """
   _allTodosMeta(
     where: TodoWhereInput! = {}
     search: String
@@ -560,10 +445,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use todosCount instead."
     )
   todosCount(where: TodoWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -573,15 +454,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String
@@ -595,10 +468,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use peopleCount instead."
     )
   peopleCount(where: PersonWhereInput! = {}): Int
-
-  """
-   Search for all Role items which match the where clause.
-  """
   allRoles(
     where: RoleWhereInput! = {}
     search: String
@@ -608,15 +477,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Role!]
-
-  """
-   Search for the Role item with the matching ID.
-  """
   Role(where: RoleWhereUniqueInput!): Role
-
-  """
-   Perform a meta-query on all Role items which match the where clause.
-  """
   _allRolesMeta(
     where: RoleWhereInput! = {}
     search: String

--- a/examples-staging/sandbox/schema.graphql
+++ b/examples-staging/sandbox/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Todo {
   id: ID!
   label: String
@@ -121,9 +118,6 @@ input TodosCreateInput {
   data: TodoCreateInput
 }
 
-"""
- A keystone list
-"""
 type User {
   id: ID!
   name: String
@@ -187,20 +181,8 @@ input UserWhereInput {
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TodoWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TodoWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TodoWhereInput
   createdAt: String
   createdAt_not: String
@@ -284,71 +266,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Todo item.
-  """
   createTodo(data: TodoCreateInput): Todo
-
-  """
-   Create multiple Todo items.
-  """
   createTodos(data: [TodosCreateInput]): [Todo]
-
-  """
-   Update a single Todo item by ID.
-  """
   updateTodo(id: ID!, data: TodoUpdateInput): Todo
-
-  """
-   Update multiple Todo items by ID.
-  """
   updateTodos(data: [TodosUpdateInput]): [Todo]
-
-  """
-   Delete a single Todo item by ID.
-  """
   deleteTodo(id: ID!): Todo
-
-  """
-   Delete multiple Todo items by ID.
-  """
   deleteTodos(ids: [ID!]): [Todo]
-
-  """
-   Create a single User item.
-  """
   createUser(data: UserCreateInput): User
-
-  """
-   Create multiple User items.
-  """
   createUsers(data: [UsersCreateInput]): [User]
-
-  """
-   Update a single User item by ID.
-  """
   updateUser(id: ID!, data: UserUpdateInput): User
-
-  """
-   Update multiple User items by ID.
-  """
   updateUsers(data: [UsersUpdateInput]): [User]
-
-  """
-   Delete a single User item by ID.
-  """
   deleteUser(id: ID!): User
-
-  """
-   Delete multiple User items by ID.
-  """
   deleteUsers(ids: [ID!]): [User]
 }
 
 type Query {
-  """
-   Search for all Todo items which match the where clause.
-  """
   allTodos(
     where: TodoWhereInput! = {}
     search: String
@@ -358,15 +290,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Todo!]
-
-  """
-   Search for the Todo item with the matching ID.
-  """
   Todo(where: TodoWhereUniqueInput!): Todo
-
-  """
-   Perform a meta-query on all Todo items which match the where clause.
-  """
   _allTodosMeta(
     where: TodoWhereInput! = {}
     search: String
@@ -380,10 +304,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use todosCount instead."
     )
   todosCount(where: TodoWhereInput! = {}): Int
-
-  """
-   Search for all User items which match the where clause.
-  """
   allUsers(
     where: UserWhereInput! = {}
     search: String
@@ -393,15 +313,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [User!]
-
-  """
-   Search for the User item with the matching ID.
-  """
   User(where: UserWhereUniqueInput!): User
-
-  """
-   Perform a meta-query on all User items which match the where clause.
-  """
   _allUsersMeta(
     where: UserWhereInput! = {}
     search: String

--- a/examples/blog/schema.graphql
+++ b/examples/blog/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -116,9 +113,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -174,20 +168,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -248,71 +230,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -322,15 +254,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -344,10 +268,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -357,15 +277,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples/custom-field-view/schema.graphql
+++ b/examples/custom-field-view/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Task {
   id: ID!
   label: String
@@ -116,9 +113,6 @@ input TasksCreateInput {
   data: TaskCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -167,20 +161,8 @@ input PersonWhereInput {
   name_not_contains: String
   name_in: [String]
   name_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TaskWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TaskWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TaskWhereInput
 }
 
@@ -235,71 +217,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Task item.
-  """
   createTask(data: TaskCreateInput): Task
-
-  """
-   Create multiple Task items.
-  """
   createTasks(data: [TasksCreateInput]): [Task]
-
-  """
-   Update a single Task item by ID.
-  """
   updateTask(id: ID!, data: TaskUpdateInput): Task
-
-  """
-   Update multiple Task items by ID.
-  """
   updateTasks(data: [TasksUpdateInput]): [Task]
-
-  """
-   Delete a single Task item by ID.
-  """
   deleteTask(id: ID!): Task
-
-  """
-   Delete multiple Task items by ID.
-  """
   deleteTasks(ids: [ID!]): [Task]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
 }
 
 type Query {
-  """
-   Search for all Task items which match the where clause.
-  """
   allTasks(
     where: TaskWhereInput! = {}
     search: String
@@ -309,15 +241,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Task!]
-
-  """
-   Search for the Task item with the matching ID.
-  """
   Task(where: TaskWhereUniqueInput!): Task
-
-  """
-   Perform a meta-query on all Task items which match the where clause.
-  """
   _allTasksMeta(
     where: TaskWhereInput! = {}
     search: String
@@ -331,10 +255,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use tasksCount instead."
     )
   tasksCount(where: TaskWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -344,15 +264,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/examples/custom-field/schema.graphql
+++ b/examples/custom-field/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -130,9 +127,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -188,20 +182,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -262,71 +244,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -336,15 +268,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -358,10 +282,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -371,15 +291,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples/default-values/schema.graphql
+++ b/examples/default-values/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Task {
   id: ID!
   label: String
@@ -113,9 +110,6 @@ input TasksCreateInput {
   data: TaskCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -164,20 +158,8 @@ input PersonWhereInput {
   name_not_contains: String
   name_in: [String]
   name_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TaskWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TaskWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TaskWhereInput
 }
 
@@ -232,71 +214,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Task item.
-  """
   createTask(data: TaskCreateInput): Task
-
-  """
-   Create multiple Task items.
-  """
   createTasks(data: [TasksCreateInput]): [Task]
-
-  """
-   Update a single Task item by ID.
-  """
   updateTask(id: ID!, data: TaskUpdateInput): Task
-
-  """
-   Update multiple Task items by ID.
-  """
   updateTasks(data: [TasksUpdateInput]): [Task]
-
-  """
-   Delete a single Task item by ID.
-  """
   deleteTask(id: ID!): Task
-
-  """
-   Delete multiple Task items by ID.
-  """
   deleteTasks(ids: [ID!]): [Task]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
 }
 
 type Query {
-  """
-   Search for all Task items which match the where clause.
-  """
   allTasks(
     where: TaskWhereInput! = {}
     search: String
@@ -306,15 +238,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Task!]
-
-  """
-   Search for the Task item with the matching ID.
-  """
   Task(where: TaskWhereUniqueInput!): Task
-
-  """
-   Perform a meta-query on all Task items which match the where clause.
-  """
   _allTasksMeta(
     where: TaskWhereInput! = {}
     search: String
@@ -328,10 +252,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use tasksCount instead."
     )
   tasksCount(where: TaskWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -341,15 +261,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -124,9 +121,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -187,20 +181,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -263,71 +245,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -337,15 +269,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -359,10 +283,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -372,15 +292,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples/extend-graphql-schema/schema.graphql
+++ b/examples/extend-graphql-schema/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -116,9 +113,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -174,20 +168,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -248,64 +230,17 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 
   """
@@ -324,9 +259,6 @@ type Statistics {
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -336,15 +268,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -358,10 +282,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -371,15 +291,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples/json/schema.graphql
+++ b/examples/json/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Package {
   id: ID!
   label: String
@@ -86,9 +83,6 @@ input PackagesCreateInput {
   data: PackageCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -137,20 +131,8 @@ input PersonWhereInput {
   name_not_contains: String
   name_in: [String]
   name_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   packages_every: PackageWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   packages_some: PackageWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   packages_none: PackageWhereInput
 }
 
@@ -205,71 +187,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Package item.
-  """
   createPackage(data: PackageCreateInput): Package
-
-  """
-   Create multiple Package items.
-  """
   createPackages(data: [PackagesCreateInput]): [Package]
-
-  """
-   Update a single Package item by ID.
-  """
   updatePackage(id: ID!, data: PackageUpdateInput): Package
-
-  """
-   Update multiple Package items by ID.
-  """
   updatePackages(data: [PackagesUpdateInput]): [Package]
-
-  """
-   Delete a single Package item by ID.
-  """
   deletePackage(id: ID!): Package
-
-  """
-   Delete multiple Package items by ID.
-  """
   deletePackages(ids: [ID!]): [Package]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
 }
 
 type Query {
-  """
-   Search for all Package items which match the where clause.
-  """
   allPackages(
     where: PackageWhereInput! = {}
     search: String
@@ -279,15 +211,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Package!]
-
-  """
-   Search for the Package item with the matching ID.
-  """
   Package(where: PackageWhereUniqueInput!): Package
-
-  """
-   Perform a meta-query on all Package items which match the where clause.
-  """
   _allPackagesMeta(
     where: PackageWhereInput! = {}
     search: String
@@ -301,10 +225,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use packagesCount instead."
     )
   packagesCount(where: PackageWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -314,15 +234,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/examples/task-manager/schema.graphql
+++ b/examples/task-manager/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Task {
   id: ID!
   label: String
@@ -113,9 +110,6 @@ input TasksCreateInput {
   data: TaskCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -164,20 +158,8 @@ input PersonWhereInput {
   name_not_contains: String
   name_in: [String]
   name_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TaskWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TaskWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TaskWhereInput
 }
 
@@ -232,71 +214,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Task item.
-  """
   createTask(data: TaskCreateInput): Task
-
-  """
-   Create multiple Task items.
-  """
   createTasks(data: [TasksCreateInput]): [Task]
-
-  """
-   Update a single Task item by ID.
-  """
   updateTask(id: ID!, data: TaskUpdateInput): Task
-
-  """
-   Update multiple Task items by ID.
-  """
   updateTasks(data: [TasksUpdateInput]): [Task]
-
-  """
-   Delete a single Task item by ID.
-  """
   deleteTask(id: ID!): Task
-
-  """
-   Delete multiple Task items by ID.
-  """
   deleteTasks(ids: [ID!]): [Task]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
 }
 
 type Query {
-  """
-   Search for all Task items which match the where clause.
-  """
   allTasks(
     where: TaskWhereInput! = {}
     search: String
@@ -306,15 +238,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Task!]
-
-  """
-   Search for the Task item with the matching ID.
-  """
   Task(where: TaskWhereUniqueInput!): Task
-
-  """
-   Perform a meta-query on all Task items which match the where clause.
-  """
   _allTasksMeta(
     where: TaskWhereInput! = {}
     search: String
@@ -328,10 +252,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use tasksCount instead."
     )
   tasksCount(where: TaskWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -341,15 +261,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/examples/testing/schema.graphql
+++ b/examples/testing/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Task {
   id: ID!
   label: String
@@ -113,9 +110,6 @@ input TasksCreateInput {
   data: TaskCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -177,20 +171,8 @@ input PersonWhereInput {
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TaskWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TaskWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TaskWhereInput
 }
 
@@ -253,64 +235,17 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Task item.
-  """
   createTask(data: TaskCreateInput): Task
-
-  """
-   Create multiple Task items.
-  """
   createTasks(data: [TasksCreateInput]): [Task]
-
-  """
-   Update a single Task item by ID.
-  """
   updateTask(id: ID!, data: TaskUpdateInput): Task
-
-  """
-   Update multiple Task items by ID.
-  """
   updateTasks(data: [TasksUpdateInput]): [Task]
-
-  """
-   Delete a single Task item by ID.
-  """
   deleteTask(id: ID!): Task
-
-  """
-   Delete multiple Task items by ID.
-  """
   deleteTasks(ids: [ID!]): [Task]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
   authenticatePersonWithPassword(
     email: String!
@@ -353,9 +288,6 @@ input CreateInitialPersonInput {
 }
 
 type Query {
-  """
-   Search for all Task items which match the where clause.
-  """
   allTasks(
     where: TaskWhereInput! = {}
     search: String
@@ -365,15 +297,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Task!]
-
-  """
-   Search for the Task item with the matching ID.
-  """
   Task(where: TaskWhereUniqueInput!): Task
-
-  """
-   Perform a meta-query on all Task items which match the where clause.
-  """
   _allTasksMeta(
     where: TaskWhereInput! = {}
     search: String
@@ -387,10 +311,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use tasksCount instead."
     )
   tasksCount(where: TaskWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -400,15 +320,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/examples/virtual-field/schema.graphql
+++ b/examples/virtual-field/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Post {
   id: ID!
   title: String
@@ -126,9 +123,6 @@ input PostsCreateInput {
   data: PostCreateInput
 }
 
-"""
- A keystone list
-"""
 type Author {
   id: ID!
   name: String
@@ -185,20 +179,8 @@ input AuthorWhereInput {
   email_not_contains: String
   email_in: [String]
   email_not_in: [String]
-
-  """
-   condition must be true for all nodes
-  """
   posts_every: PostWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   posts_some: PostWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   posts_none: PostWhereInput
 }
 
@@ -259,71 +241,21 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Post item.
-  """
   createPost(data: PostCreateInput): Post
-
-  """
-   Create multiple Post items.
-  """
   createPosts(data: [PostsCreateInput]): [Post]
-
-  """
-   Update a single Post item by ID.
-  """
   updatePost(id: ID!, data: PostUpdateInput): Post
-
-  """
-   Update multiple Post items by ID.
-  """
   updatePosts(data: [PostsUpdateInput]): [Post]
-
-  """
-   Delete a single Post item by ID.
-  """
   deletePost(id: ID!): Post
-
-  """
-   Delete multiple Post items by ID.
-  """
   deletePosts(ids: [ID!]): [Post]
-
-  """
-   Create a single Author item.
-  """
   createAuthor(data: AuthorCreateInput): Author
-
-  """
-   Create multiple Author items.
-  """
   createAuthors(data: [AuthorsCreateInput]): [Author]
-
-  """
-   Update a single Author item by ID.
-  """
   updateAuthor(id: ID!, data: AuthorUpdateInput): Author
-
-  """
-   Update multiple Author items by ID.
-  """
   updateAuthors(data: [AuthorsUpdateInput]): [Author]
-
-  """
-   Delete a single Author item by ID.
-  """
   deleteAuthor(id: ID!): Author
-
-  """
-   Delete multiple Author items by ID.
-  """
   deleteAuthors(ids: [ID!]): [Author]
 }
 
 type Query {
-  """
-   Search for all Post items which match the where clause.
-  """
   allPosts(
     where: PostWhereInput! = {}
     search: String
@@ -333,15 +265,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Post!]
-
-  """
-   Search for the Post item with the matching ID.
-  """
   Post(where: PostWhereUniqueInput!): Post
-
-  """
-   Perform a meta-query on all Post items which match the where clause.
-  """
   _allPostsMeta(
     where: PostWhereInput! = {}
     search: String
@@ -355,10 +279,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use postsCount instead."
     )
   postsCount(where: PostWhereInput! = {}): Int
-
-  """
-   Search for all Author items which match the where clause.
-  """
   allAuthors(
     where: AuthorWhereInput! = {}
     search: String
@@ -368,15 +288,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Author!]
-
-  """
-   Search for the Author item with the matching ID.
-  """
   Author(where: AuthorWhereUniqueInput!): Author
-
-  """
-   Perform a meta-query on all Author items which match the where clause.
-  """
   _allAuthorsMeta(
     where: AuthorWhereInput! = {}
     search: String

--- a/examples/with-auth/schema.graphql
+++ b/examples/with-auth/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Task {
   id: ID!
   label: String
@@ -113,9 +110,6 @@ input TasksCreateInput {
   data: TaskCreateInput
 }
 
-"""
- A keystone list
-"""
 type Person {
   id: ID!
   name: String
@@ -177,20 +171,8 @@ input PersonWhereInput {
   email_in: [String]
   email_not_in: [String]
   password_is_set: Boolean
-
-  """
-   condition must be true for all nodes
-  """
   tasks_every: TaskWhereInput
-
-  """
-   condition must be true for at least 1 node
-  """
   tasks_some: TaskWhereInput
-
-  """
-   condition must be false for all nodes
-  """
   tasks_none: TaskWhereInput
 }
 
@@ -253,64 +235,17 @@ scalar JSON
   )
 
 type Mutation {
-  """
-   Create a single Task item.
-  """
   createTask(data: TaskCreateInput): Task
-
-  """
-   Create multiple Task items.
-  """
   createTasks(data: [TasksCreateInput]): [Task]
-
-  """
-   Update a single Task item by ID.
-  """
   updateTask(id: ID!, data: TaskUpdateInput): Task
-
-  """
-   Update multiple Task items by ID.
-  """
   updateTasks(data: [TasksUpdateInput]): [Task]
-
-  """
-   Delete a single Task item by ID.
-  """
   deleteTask(id: ID!): Task
-
-  """
-   Delete multiple Task items by ID.
-  """
   deleteTasks(ids: [ID!]): [Task]
-
-  """
-   Create a single Person item.
-  """
   createPerson(data: PersonCreateInput): Person
-
-  """
-   Create multiple Person items.
-  """
   createPeople(data: [PeopleCreateInput]): [Person]
-
-  """
-   Update a single Person item by ID.
-  """
   updatePerson(id: ID!, data: PersonUpdateInput): Person
-
-  """
-   Update multiple Person items by ID.
-  """
   updatePeople(data: [PeopleUpdateInput]): [Person]
-
-  """
-   Delete a single Person item by ID.
-  """
   deletePerson(id: ID!): Person
-
-  """
-   Delete multiple Person items by ID.
-  """
   deletePeople(ids: [ID!]): [Person]
   authenticatePersonWithPassword(
     email: String!
@@ -353,9 +288,6 @@ input CreateInitialPersonInput {
 }
 
 type Query {
-  """
-   Search for all Task items which match the where clause.
-  """
   allTasks(
     where: TaskWhereInput! = {}
     search: String
@@ -365,15 +297,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Task!]
-
-  """
-   Search for the Task item with the matching ID.
-  """
   Task(where: TaskWhereUniqueInput!): Task
-
-  """
-   Perform a meta-query on all Task items which match the where clause.
-  """
   _allTasksMeta(
     where: TaskWhereInput! = {}
     search: String
@@ -387,10 +311,6 @@ type Query {
       reason: "This query will be removed in a future version. Please use tasksCount instead."
     )
   tasksCount(where: TaskWhereInput! = {}): Int
-
-  """
-   Search for all Person items which match the where clause.
-  """
   allPeople(
     where: PersonWhereInput! = {}
     search: String
@@ -400,15 +320,7 @@ type Query {
     first: Int
     skip: Int! = 0
   ): [Person!]
-
-  """
-   Search for the Person item with the matching ID.
-  """
   Person(where: PersonWhereUniqueInput!): Person
-
-  """
-   Perform a meta-query on all Person items which match the where clause.
-  """
   _allPeopleMeta(
     where: PersonWhereInput! = {}
     search: String

--- a/packages/fields/src/types/relationship/index.ts
+++ b/packages/fields/src/types/relationship/index.ts
@@ -209,18 +209,9 @@ export const relationship =
         __legacy: {
           filters: {
             fields: {
-              [`${meta.fieldKey}_every`]: schema.arg({
-                type: listTypes.where,
-                description: ' condition must be true for all nodes',
-              }),
-              [`${meta.fieldKey}_some`]: schema.arg({
-                type: listTypes.where,
-                description: ' condition must be true for at least 1 node',
-              }),
-              [`${meta.fieldKey}_none`]: schema.arg({
-                type: listTypes.where,
-                description: ' condition must be false for all nodes',
-              }),
+              [`${meta.fieldKey}_every`]: schema.arg({ type: listTypes.where }),
+              [`${meta.fieldKey}_some`]: schema.arg({ type: listTypes.where }),
+              [`${meta.fieldKey}_none`]: schema.arg({ type: listTypes.where }),
             },
             impls: {
               [`${meta.fieldKey}_every`]: whereInputResolve('every'),

--- a/packages/fields/src/types/relationship/tests/implementation.test.ts
+++ b/packages/fields/src/types/relationship/tests/implementation.test.ts
@@ -199,26 +199,24 @@ describe('Type Generation', () => {
     const schema = getSchema(relationship({ many: true, ref: 'Zip' }));
 
     expect(printType(schema.getType('Test')!)).toMatchInlineSnapshot(`
-      "\\"\\"\\" A keystone list\\"\\"\\"
-      type Test {
-        id: ID!
-        foo(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): [Zip!]
-        _fooMeta(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta @deprecated(reason: \\"This query will be removed in a future version. Please use fooCount instead.\\")
-        fooCount(where: ZipWhereInput! = {}): Int
-      }"
-    `);
+"type Test {
+  id: ID!
+  foo(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): [Zip!]
+  _fooMeta(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): _QueryMeta @deprecated(reason: \\"This query will be removed in a future version. Please use fooCount instead.\\")
+  fooCount(where: ZipWhereInput! = {}): Int
+}"
+`);
   });
 
   test('to-many relationships can have meta disabled', () => {
     const schema = getSchema(relationship({ many: true, ref: 'Zip', withMeta: false }));
 
     expect(printType(schema.getType('Test')!)).toMatchInlineSnapshot(`
-      "\\"\\"\\" A keystone list\\"\\"\\"
-      type Test {
-        id: ID!
-        foo(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): [Zip!]
-      }"
-    `);
+"type Test {
+  id: ID!
+  foo(where: ZipWhereInput! = {}, search: String, sortBy: [SortZipsBy!] @deprecated(reason: \\"sortBy has been deprecated in favour of orderBy\\"), orderBy: [ZipOrderByInput!]! = [], first: Int, skip: Int! = 0): [Zip!]
+}"
+`);
   });
 });
 

--- a/packages/keystone/src/lib/core/mutations/index.ts
+++ b/packages/keystone/src/lib/core/mutations/index.ts
@@ -25,7 +25,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
   const createOne = schema.field({
     type: list.types.output,
     args: { data: schema.arg({ type: list.types.create }) },
-    description: ` Create a single ${list.listKey} item.`,
     resolve(_rootVal, { data }, context) {
       return createAndUpdate.createOne({ data: data ?? {} }, list, context);
     },
@@ -38,7 +37,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
   const createMany = schema.field({
     type: schema.list(list.types.output),
     args: { data: schema.arg({ type: schema.list(createManyInput) }) },
-    description: ` Create multiple ${list.listKey} items.`,
     resolve(_rootVal, args, context) {
       return promisesButSettledWhenAllSettledAndInOrder(
         createAndUpdate.createMany(
@@ -57,7 +55,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
       id: schema.arg({ type: schema.nonNull(schema.ID) }),
       data: schema.arg({ type: list.types.update }),
     },
-    description: ` Update a single ${list.listKey} item by ID.`,
     resolve(_rootVal, { data, id }, context) {
       return createAndUpdate.updateOne({ data: data ?? {}, where: { id } }, list, context);
     },
@@ -73,7 +70,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
   const updateMany = schema.field({
     type: schema.list(list.types.output),
     args: { data: schema.arg({ type: schema.list(updateManyInput) }) },
-    description: ` Update multiple ${list.listKey} items by ID.`,
     resolve(_rootVal, { data }, context) {
       return promisesButSettledWhenAllSettledAndInOrder(
         createAndUpdate.updateMany(
@@ -93,7 +89,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
   const deleteOne = schema.field({
     type: list.types.output,
     args: { id: schema.arg({ type: schema.nonNull(schema.ID) }) },
-    description: ` Delete a single ${list.listKey} item by ID.`,
     resolve(rootVal, { id }, context) {
       return deletes.deleteOne({ where: { id } }, list, context);
     },
@@ -102,7 +97,6 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
   const deleteMany = schema.field({
     type: schema.list(list.types.output),
     args: { ids: schema.arg({ type: schema.list(schema.nonNull(schema.ID)) }) },
-    description: ` Delete multiple ${list.listKey} items by ID.`,
     resolve(rootVal, { ids }, context) {
       return promisesButSettledWhenAllSettledAndInOrder(
         deletes.deleteMany({ where: (ids || []).map(id => ({ id })) }, list, context, provider)

--- a/packages/keystone/src/lib/core/queries/index.ts
+++ b/packages/keystone/src/lib/core/queries/index.ts
@@ -10,7 +10,6 @@ export function getQueriesForList(list: InitialisedList) {
   const findOne = schema.field({
     type: list.types.output,
     args: { where: schema.arg({ type: schema.nonNull(list.types.uniqueWhere) }) },
-    description: ` Search for the ${list.listKey} item with the matching ID.`,
     async resolve(_rootVal, args, context) {
       return queries.findOne(args, list, context);
     },
@@ -19,7 +18,6 @@ export function getQueriesForList(list: InitialisedList) {
   const findMany = schema.field({
     type: schema.list(schema.nonNull(list.types.output)),
     args: list.types.findManyArgs,
-    description: ` Search for all ${list.listKey} items which match the where clause.`,
     async resolve(_rootVal, args, context, info) {
       return queries.findMany(args, list, context, info);
     },
@@ -46,7 +44,6 @@ export function getQueriesForList(list: InitialisedList) {
   const metaQuery = schema.field({
     type: QueryMeta,
     args: list.types.findManyArgs,
-    description: ` Perform a meta-query on all ${list.listKey} items which match the where clause.`,
     resolve(_rootVal, { first, search, skip, where }, context, info) {
       return {
         getCount: async () => {

--- a/packages/keystone/src/lib/core/types-for-lists.ts
+++ b/packages/keystone/src/lib/core/types-for-lists.ts
@@ -64,7 +64,6 @@ export function initialiseLists(
 
     let output = schema.object<ItemRootValue>()({
       name: names.outputTypeName,
-      description: ' A keystone list',
       fields: () => {
         const { fields } = lists[listKey];
         return {

--- a/packages/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -1,6 +1,3 @@
-"""
- A keystone list
-"""
 type Todo {
   id: ID!
   title: String
@@ -67,73 +64,35 @@ input TodosCreateInput {
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
-  @specifiedBy(
-    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
-  )
+  @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type _QueryMeta {
   count: Int
 }
 
 type Mutation {
-  """
-   Create a single Todo item.
-  """
   createTodo(data: TodoCreateInput): Todo
-
-  """
-   Create multiple Todo items.
-  """
   createTodos(data: [TodosCreateInput]): [Todo]
-
-  """
-   Update a single Todo item by ID.
-  """
   updateTodo(id: ID!, data: TodoUpdateInput): Todo
-
-  """
-   Update multiple Todo items by ID.
-  """
   updateTodos(data: [TodosUpdateInput]): [Todo]
-
-  """
-   Delete a single Todo item by ID.
-  """
   deleteTodo(id: ID!): Todo
-
-  """
-   Delete multiple Todo items by ID.
-  """
   deleteTodos(ids: [ID!]): [Todo]
 }
 
 type Query {
-  """
-   Search for all Todo items which match the where clause.
-  """
   allTodos(
     where: TodoWhereInput! = {}
     search: String
-    sortBy: [SortTodosBy!]
-      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    sortBy: [SortTodosBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
     orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
   ): [Todo!]
-
-  """
-   Search for the Todo item with the matching ID.
-  """
   Todo(where: TodoWhereUniqueInput!): Todo
-
-  """
-   Perform a meta-query on all Todo items which match the where clause.
-  """
   _allTodosMeta(
     where: TodoWhereInput! = {}
     search: String
-    sortBy: [SortTodosBy!]
-      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    sortBy: [SortTodosBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
     orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0

--- a/packages/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages/keystone/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -64,7 +64,9 @@ input TodosCreateInput {
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
 scalar JSON
-  @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
 
 type _QueryMeta {
   count: Int
@@ -83,7 +85,8 @@ type Query {
   allTodos(
     where: TodoWhereInput! = {}
     search: String
-    sortBy: [SortTodosBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    sortBy: [SortTodosBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
     orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0
@@ -92,7 +95,8 @@ type Query {
   _allTodosMeta(
     where: TodoWhereInput! = {}
     search: String
-    sortBy: [SortTodosBy!] @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    sortBy: [SortTodosBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
     orderBy: [TodoOrderByInput!]! = []
     first: Int
     skip: Int! = 0


### PR DESCRIPTION
These descriptions just repeat what's in the name and don't actually add any new information so having a smaller schema that's easier to read at a glance is better imo

note: major because a build that would succeed with the current version would fail since the schema.graphql file would have to be updated.