### PR TITLE
Check unique input format before using it

### DIFF
--- a/.changeset/itchy-pets-work.md
+++ b/.changeset/itchy-pets-work.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated unique filter checking code to ensure it is always run before using the unique input filter.

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -50,7 +50,7 @@ async function processDelete(
   filter: UniqueInputFilter
 ) {
   // Access control
-  const existingItem = await getAccessControlledItemForDelete(list, context, filter, filter);
+  const existingItem = await getAccessControlledItemForDelete(list, context, filter);
 
   // Field validation
   const hookArgs = { operation: 'delete' as const, listKey: list.listKey, context, existingItem };

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -18,13 +18,13 @@ async function handleCreateAndUpdate(
   target: string
 ) {
   if (value.connect) {
+    const uniqueWhere = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
     try {
-      await context.db.lists[foreignList.listKey].findOne({ where: value.connect });
+      await context.db.lists[foreignList.listKey].findOne({ where: uniqueWhere });
     } catch (err) {
       throw new Error(`Unable to connect a ${target}`);
     }
-    const connect = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
-    return { connect };
+    return { connect: uniqueWhere };
   } else if (value.create) {
     const createInput = value.create;
     let create = await (async () => {

--- a/packages/keystone/src/lib/core/where-inputs.ts
+++ b/packages/keystone/src/lib/core/where-inputs.ts
@@ -26,18 +26,18 @@ export type UniquePrismaFilter = Record<string, any> & {
 };
 
 export async function resolveUniqueWhereInput(
-  input: UniqueInputFilter,
+  uniqueInput: UniqueInputFilter,
   fields: InitialisedList['fields'],
   context: KeystoneContext
 ): Promise<UniquePrismaFilter> {
-  const inputKeys = Object.keys(input);
+  const inputKeys = Object.keys(uniqueInput);
   if (inputKeys.length !== 1) {
     throw new Error(
       `Exactly one key must be passed in a unique where input but ${inputKeys.length} keys were passed`
     );
   }
   const key = inputKeys[0];
-  const val = input[key];
+  const val = uniqueInput[key];
   if (val === null) {
     throw new Error(`The unique value provided in a unique where input must not be null`);
   }

--- a/packages/keystone/src/lib/core/where-inputs.ts
+++ b/packages/keystone/src/lib/core/where-inputs.ts
@@ -41,6 +41,7 @@ export async function resolveUniqueWhereInput(
   if (val === null) {
     throw new Error(`The unique value provided in a unique where input must not be null`);
   }
+
   const resolver = fields[key].input!.uniqueWhere!.resolve;
   return { [key]: resolver ? await resolver(val, context) : val };
 }

--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -168,7 +168,7 @@ describe(`Not authed`, () => {
 
             test(`single denied: ${JSON.stringify(access)}`, async () => {
               const singleQueryName = nameFn[mode](access);
-              const query = `query { ${singleQueryName}(where: { id: "abc123" }) { id } }`;
+              const query = `query { ${singleQueryName}(where: { id: "cabc123" }) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
               expectNoAccess(data, errors, singleQueryName);
             });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -138,7 +138,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during creating',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -164,7 +164,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during update',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item to link against
       const createEvent = await context.lists.Event.createOne({ data: {} });


### PR DESCRIPTION
The function `resolveUniqueWhereInput` is used to check that the user hasn't provided an invalid unique filter, e.g. providing two different keys, or trying to filter on `null`. This PR ensures that this function is always called before we attempt to use the filter itself.