### PR TITLE
Validate unique inputs before use

### DIFF
--- a/.changeset/popular-dodos-rest.md
+++ b/.changeset/popular-dodos-rest.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated unique filter checking code to ensure it is always run before using the unique input filter.

--- a/packages/keystone/src/lib/core/mutations/create-update.ts
+++ b/packages/keystone/src/lib/core/mutations/create-update.ts
@@ -8,6 +8,7 @@ import {
   getDBFieldKeyForFieldOnMultiField,
   IdType,
 } from '../utils';
+import { validateUniqueWhereInput } from '../where-inputs';
 import {
   resolveRelateToManyForCreateInput,
   resolveRelateToManyForUpdateInput,
@@ -18,7 +19,6 @@ import {
 } from './nested-mutation-one-input-resolvers';
 import { applyAccessControlForCreate, getAccessControlledItemForUpdate } from './access-control';
 import { runSideEffectOnlyHook, validationHook } from './hooks';
-import { validateUniqueWhereInput } from '../where-inputs';
 
 export class NestedMutationState {
   #afterChanges: (() => void | Promise<void>)[] = [];

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -2,7 +2,7 @@ import { KeystoneContext, DatabaseProvider } from '@keystone-next/types';
 import pLimit from 'p-limit';
 import { InitialisedList } from '../types-for-lists';
 import { getPrismaModelForList, promiseAllRejectWithAllErrors } from '../utils';
-import { UniqueInputFilter } from '../where-inputs';
+import { UniqueInputFilter, validateUniqueWhereInput } from '../where-inputs';
 import { getAccessControlledItemForDelete } from './access-control';
 import { runSideEffectOnlyHook, validationHook } from './hooks';
 
@@ -47,10 +47,12 @@ export async function deleteOne(
 async function processDelete(
   list: InitialisedList,
   context: KeystoneContext,
-  filter: UniqueInputFilter
+  uniqueInput: UniqueInputFilter
 ) {
+  validateUniqueWhereInput(uniqueInput);
+
   // Access control
-  const existingItem = await getAccessControlledItemForDelete(list, context, filter, filter);
+  const existingItem = await getAccessControlledItemForDelete(list, context, uniqueInput);
 
   // Field validation
   const hookArgs = { operation: 'delete' as const, listKey: list.listKey, context, existingItem };

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -1,5 +1,10 @@
 import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
-import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter, validateUniqueWhereInput } from '../where-inputs';
+import {
+  resolveUniqueWhereInput,
+  UniqueInputFilter,
+  UniquePrismaFilter,
+  validateUniqueWhereInput,
+} from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { isRejected, isFulfilled } from '../utils';
 import { NestedMutationState } from './create-update';

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -1,5 +1,5 @@
 import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
-import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter } from '../where-inputs';
+import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter, validateUniqueWhereInput } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { isRejected, isFulfilled } from '../utils';
 import { NestedMutationState } from './create-update';
@@ -35,13 +35,14 @@ async function getDisconnects(
 }
 
 function getConnects(
-  uniqueWhere: UniqueInputFilter[],
+  uniqueInputs: UniqueInputFilter[],
   context: KeystoneContext,
   foreignList: InitialisedList
 ): Promise<UniquePrismaFilter>[] {
-  return uniqueWhere.map(async filter => {
-    await context.db.lists[foreignList.listKey].findOne({ where: filter });
-    return resolveUniqueWhereInput(filter, foreignList.fields, context);
+  return uniqueInputs.map(async uniqueInput => {
+    validateUniqueWhereInput(uniqueInput);
+    await context.db.lists[foreignList.listKey].findOne({ where: uniqueInput });
+    return resolveUniqueWhereInput(uniqueInput, foreignList.fields, context);
   });
 }
 

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -1,5 +1,5 @@
 import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
-import { resolveUniqueWhereInput } from '../where-inputs';
+import { resolveUniqueWhereInput, validateUniqueWhereInput } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { NestedMutationState } from './create-update';
 
@@ -18,13 +18,13 @@ async function handleCreateAndUpdate(
   target: string
 ) {
   if (value.connect) {
+    validateUniqueWhereInput(value.connect);
     try {
       await context.db.lists[foreignList.listKey].findOne({ where: value.connect });
     } catch (err) {
       throw new Error(`Unable to connect a ${target}`);
     }
-    const connect = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
-    return { connect };
+    return { connect: await resolveUniqueWhereInput(value.connect, foreignList.fields, context) };
   } else if (value.create) {
     const createInput = value.create;
     let create = await (async () => {

--- a/packages/keystone/src/lib/core/where-inputs.ts
+++ b/packages/keystone/src/lib/core/where-inputs.ts
@@ -25,24 +25,29 @@ export type UniquePrismaFilter = Record<string, any> & {
   then?: undefined;
 };
 
-export async function resolveUniqueWhereInput(
-  input: UniqueInputFilter,
-  fields: InitialisedList['fields'],
-  context: KeystoneContext
-): Promise<UniquePrismaFilter> {
-  const inputKeys = Object.keys(input);
+export function validateUniqueWhereInput(uniqueInput: UniqueInputFilter) {
+  const inputKeys = Object.keys(uniqueInput);
   if (inputKeys.length !== 1) {
     throw new Error(
       `Exactly one key must be passed in a unique where input but ${inputKeys.length} keys were passed`
     );
   }
-  const key = inputKeys[0];
-  const val = input[key];
+  const fieldPath = inputKeys[0];
+  const val = uniqueInput[fieldPath];
   if (val === null) {
     throw new Error(`The unique value provided in a unique where input must not be null`);
   }
-  const resolver = fields[key].input!.uniqueWhere!.resolve;
-  return { [key]: resolver ? await resolver(val, context) : val };
+}
+
+export async function resolveUniqueWhereInput(
+  uniqueInput: UniqueInputFilter,
+  fields: InitialisedList['fields'],
+  context: KeystoneContext
+): Promise<UniquePrismaFilter> {
+  const fieldPath = Object.keys(uniqueInput)[0];
+  const val = uniqueInput[fieldPath];
+  const resolver = fields[fieldPath].input!.uniqueWhere!.resolve;
+  return { [fieldPath]: resolver ? await resolver(val, context) : val };
 }
 
 export async function resolveWhereInput(

--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -168,7 +168,7 @@ describe(`Not authed`, () => {
 
             test(`single denied: ${JSON.stringify(access)}`, async () => {
               const singleQueryName = nameFn[mode](access);
-              const query = `query { ${singleQueryName}(where: { id: "abc123" }) { id } }`;
+              const query = `query { ${singleQueryName}(where: { id: "cabc123" }) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
               expectNoAccess(data, errors, singleQueryName);
             });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -138,7 +138,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during creating',
     runner(async ({ context }) => {
-      const FAKE_ID = "cabc123";
+      const FAKE_ID = 'cabc123';
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -164,7 +164,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during update',
     runner(async ({ context }) => {
-      const FAKE_ID = "cabc123";
+      const FAKE_ID = 'cabc123';
 
       // Create an item to link against
       const createEvent = await context.lists.Event.createOne({ data: {} });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -138,7 +138,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during creating',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -164,7 +164,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during update',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item to link against
       const createEvent = await context.lists.Event.createOne({ data: {} });


### PR DESCRIPTION
This replaces #6106 with an explicit decoupling of the validation step from the resolver step.