### PR TITLE
Alternative uniqueWhere resolving changes

### DIFF
--- a/.changeset/famous-vans-sniff.md
+++ b/.changeset/famous-vans-sniff.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Changed the way errors from resolving unique where inputs are thrown.

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -50,7 +50,7 @@ async function processDelete(
   filter: UniqueInputFilter
 ) {
   // Access control
-  const existingItem = await getAccessControlledItemForDelete(list, context, filter, filter);
+  const existingItem = await getAccessControlledItemForDelete(list, context, filter);
 
   // Field validation
   const hookArgs = { operation: 'delete' as const, listKey: list.listKey, context, existingItem };

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -2,6 +2,7 @@ import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
 import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { isRejected, isFulfilled } from '../utils';
+import { findOne } from '../queries/resolvers';
 import { NestedMutationState } from './create-update';
 
 const isNotNull = <T>(arg: T): arg is Exclude<T, null> => arg !== null;
@@ -24,7 +25,7 @@ async function getDisconnects(
       uniqueWheres.map(async filter => {
         if (filter === null) return [];
         try {
-          await context.sudo().db.lists[foreignList.listKey].findOne({ where: filter });
+          await findOne({ where: filter }, foreignList, context);
         } catch (err) {
           return [];
         }
@@ -40,7 +41,7 @@ function getConnects(
   foreignList: InitialisedList
 ): Promise<UniquePrismaFilter>[] {
   return uniqueWhere.map(async filter => {
-    await context.db.lists[foreignList.listKey].findOne({ where: filter });
+    await findOne({ where: filter }, foreignList, context);
     return resolveUniqueWhereInput(filter, foreignList.fields, context);
   });
 }

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -1,6 +1,7 @@
 import { KeystoneContext, TypesForList, schema } from '@keystone-next/types';
 import { resolveUniqueWhereInput } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
+import { findOne } from '../queries/resolvers';
 import { NestedMutationState } from './create-update';
 
 type _CreateValueType = schema.InferValueFromArg<
@@ -19,7 +20,7 @@ async function handleCreateAndUpdate(
 ) {
   if (value.connect) {
     try {
-      await context.db.lists[foreignList.listKey].findOne({ where: value.connect });
+      await findOne({ where: value.connect }, foreignList, context);
     } catch (err) {
       throw new Error(`Unable to connect a ${target}`);
     }
@@ -81,7 +82,7 @@ export function resolveRelateToOneForUpdateInput(
       return handleCreateAndUpdate(value, nestedMutationState, context, foreignList, target);
     } else if (value.disconnect) {
       try {
-        await context.sudo().db.lists[foreignList.listKey].findOne({ where: value.disconnect });
+        await findOne({ where: value.disconnect }, foreignList, context);
       } catch (err) {
         return;
       }


### PR DESCRIPTION
@timleslie I'm assuming the reason behind the changes was that you didn't want the errors to be wrapped in another `GraphQLError`, this will achieve the same thing.