### PR TITLE
[POC] input resolver errors

### DIFF
--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -28,6 +28,7 @@
     "@keystone-ui/tooltip": "^4.0.0",
     "@types/bcryptjs": "^2.4.2",
     "@types/react": "^17.0.14",
+    "apollo-server-errors": "^2.5.0",
     "bcryptjs": "^2.4.3",
     "bytes": "^3.1.0",
     "copy-to-clipboard": "^3.3.1",

--- a/packages/fields/src/types/password/index.ts
+++ b/packages/fields/src/types/password/index.ts
@@ -9,6 +9,7 @@ import {
 import bcryptjs from 'bcryptjs';
 // @ts-ignore
 import dumbPasswords from 'dumb-passwords';
+import { UserInputError } from 'apollo-server-errors';
 import { resolveView } from '../../resolve-view';
 
 type PasswordFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
@@ -63,12 +64,14 @@ export const password =
       }
       if (typeof val === 'string') {
         if (rejectCommon && dumbPasswords.check(val)) {
-          throw new Error(
+          // Would use a custom validation error here in reality, but this demonstrates the issue.
+          // I have examples of using this function and the associated
+          throw new UserInputError(
             `[password:rejectCommon:${meta.listKey}:${meta.fieldKey}] Common and frequently-used passwords are not allowed.`
           );
         }
         if (val.length < minLength) {
-          throw new Error(
+          throw new UserInputError(
             `[password:minLength:${meta.listKey}:${meta.fieldKey}] Value must be at least ${minLength} characters long.`
           );
         }

--- a/packages/fields/src/types/password/index.ts
+++ b/packages/fields/src/types/password/index.ts
@@ -72,7 +72,8 @@ export const password =
         }
         if (val.length < minLength) {
           throw new UserInputError(
-            `[password:minLength:${meta.listKey}:${meta.fieldKey}] Value must be at least ${minLength} characters long.`
+            `[password:minLength:${meta.listKey}:${meta.fieldKey}] Value must be at least ${minLength} characters long.`,
+            { listKey: meta.listKey, fieldKey: meta.fieldKey }
           );
         }
 

--- a/packages/fields/src/types/password/tests/test-fixtures.ts
+++ b/packages/fields/src/types/password/tests/test-fixtures.ts
@@ -1,4 +1,5 @@
 import { password } from '..';
+import { GraphQLRequest } from '../../../../../testing/src';
 import { text } from '../../text';
 
 export const name = 'Password';
@@ -41,35 +42,76 @@ export const storedValues = () => [
 
 export const supportedFilters = () => ['isSet'];
 
+const unpackErrors = (errors: readonly any[] | undefined) =>
+  (errors || []).map(({ locations, extensions: { exception, ...extensions }, ...unpacked }) => ({
+    extensions,
+    ...unpacked,
+  }));
+
+export const expectBadUserInput = (
+  errors: readonly any[] | undefined,
+  args: { path: any[]; message: string }[]
+) => {
+  const unpackedErrors = unpackErrors(errors);
+  expect(unpackedErrors).toEqual(
+    args.map(({ path, message }) => ({ extensions: { code: 'BAD_USER_INPUT' }, path, message }))
+  );
+};
+
 export const crudTests = (keystoneTestWrapper: any) => {
   test(
     'setting a password below the minLength fails',
-    keystoneTestWrapper(async ({ context }: { context: any }) => {
-      await expect(
-        context.lists.Test.createOne({
-          data: { password: '123' },
-        })
-      ).rejects.toMatchInlineSnapshot(
-        `[GraphQLError: [password:minLength:Test:password] Value must be at least 4 characters long.]`
-      );
+    keystoneTestWrapper(async ({ graphQLRequest }: { graphQLRequest: GraphQLRequest }) => {
+      const { body } = await graphQLRequest({
+        query: `mutation {
+          createTest(data: { password: "123" }) {
+            id
+          }
+        }`,
+      });
+      expect(body.data).toEqual({ createTest: null });
+      // We throw an apollo error during the input resolver, which gets
+      // converted to an internal server error when returned to the client.
+      // We may want to look into ways to do this in a nicer way.
+      console.log(JSON.stringify(body.errors[0]));
+      console.log(body.errors[0].extensions.exception.errors);
+      expectBadUserInput(body.errors, [
+        {
+          path: ['createTest'],
+          message: '[password:minLength:Test:password] Value must be at least 4 characters long.',
+        },
+      ]);
     })
   );
   test(
     'setting a common password fails',
-    keystoneTestWrapper(async ({ context }: { context: any }) => {
-      await expect(
-        context.lists.Test.createOne({
-          data: { passwordRejectCommon: 'password' },
-          query: ``,
-        })
-      ).rejects.toMatchInlineSnapshot(
-        `[GraphQLError: [password:rejectCommon:Test:passwordRejectCommon] Common and frequently-used passwords are not allowed.]`
-      );
-      const data = await context.lists.Test.createOne({
-        data: { passwordRejectCommon: 'sdfinwedvhweqfoiuwdfnvjiewrijnf' },
-        query: `passwordRejectCommon {isSet}`,
-      });
-      expect(data.passwordRejectCommon.isSet).toBe(true);
-    })
+    keystoneTestWrapper(
+      async ({ context, graphQLRequest }: { context: any; graphQLRequest: GraphQLRequest }) => {
+        const { body } = await graphQLRequest({
+          query: `mutation {
+            createTest(data: { passwordRejectCommon: "password" }) {
+              id
+            }
+          }`,
+        });
+        expect(body.data).toEqual({ createTest: null });
+        // We throw an apollo error during the input resolver, which gets
+        // converted to an internal server error when returned to the client.
+        // We may want to look into ways to do this in a nicer way.
+        expectBadUserInput(body.errors, [
+          {
+            path: ['createTest'],
+            message:
+              '[password:rejectCommon:Test:passwordRejectCommon] Common and frequently-used passwords are not allowed.',
+          },
+        ]);
+
+        const item = await context.lists.Test.createOne({
+          data: { passwordRejectCommon: 'sdfinwedvhweqfoiuwdfnvjiewrijnf' },
+          query: `passwordRejectCommon {isSet}`,
+        });
+        expect(item.passwordRejectCommon.isSet).toBe(true);
+      }
+    )
   );
 };

--- a/packages/keystone/src/lib/server/createApolloServer.ts
+++ b/packages/keystone/src/lib/server/createApolloServer.ts
@@ -5,7 +5,7 @@ import { ApolloServer as ApolloServerExpress } from 'apollo-server-express';
 import type { Config } from 'apollo-server-express';
 import type { CreateContext, SessionStrategy } from '@keystone-next/types';
 import { createSessionContext } from '../../session';
-import { formatError } from './format-error';
+// import { formatError } from './format-error';
 
 export const createApolloServerMicro = ({
   graphQLSchema,
@@ -87,7 +87,7 @@ const _createApolloServerConfig = ({
   return {
     uploads: false,
     schema: graphQLSchema,
-    formatError, // TODO: this needs to be discussed
+    // formatError, // TODO: this needs to be discussed
     // FIXME: support for apollo studio tracing
     // ...(process.env.ENGINE_API_KEY || process.env.APOLLO_KEY
     //   ? { tracing: true }

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -16,6 +16,7 @@ testModules
     ({ skipCrudTest, unSupportedAdapterList = [] }) =>
       !skipCrudTest && !unSupportedAdapterList.includes(process.env.TEST_ADAPTER)
   )
+  .filter(mod => mod.name === 'Password')
   .forEach(mod => {
     (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
       const listKey = 'Test';


### PR DESCRIPTION
@mitchellhamilton This is the error we get when we throw a `UserInputError` in the password field input resolver. Note that the `BAD_USER_INPUT` code is actually available here as a nested error. This makes sense, as there could easily be multiple `input resolver` errors, but it highlights that we don't currently have complete over the way input resolver errors are surfaced to users.

```
{
  message: '[password:minLength:Test:password] Value must be at least 4 characters long.',
  locations: [{ line: 2, column: 11 }],
  path: ['createTest'],
  extensions: {
    code: 'INTERNAL_SERVER_ERROR',
    exception: {
      errors: [
        {
          listKey: 'Test',
          fieldKey: 'password',
          extensions: { listKey: 'Test', fieldKey: 'password', code: 'BAD_USER_INPUT' },
        },
      ],
    },
  },
}
```