### PR TITLE
Fix virtual field rendering of false & 0

### DIFF
--- a/.changeset/shy-bobcats-float.md
+++ b/.changeset/shy-bobcats-float.md
@@ -2,4 +2,4 @@
 '@keystone-next/fields': patch
 ---
 
-Fix virtual field rendering of false & 0 values
+Fixed virtual field rendering of false & 0 values.

--- a/.changeset/shy-bobcats-float.md
+++ b/.changeset/shy-bobcats-float.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields': patch
+---
+
+Fix virtual field rendering of false & 0 values

--- a/packages/fields/src/types/virtual/views/PrettyData.tsx
+++ b/packages/fields/src/types/virtual/views/PrettyData.tsx
@@ -10,7 +10,7 @@ const stringify = (data: any) => {
   return JSON.stringify(dataWithoutTypename, null, 2);
 };
 export function PrettyData({ data }: { data: any }) {
-  if (!data) return null;
+  if (data === undefined || data === null) return null;
 
   let prettyData: ReactNode = '';
   if (typeof data === 'string') prettyData = data;


### PR DESCRIPTION
`0` and `false` currently don't render when they are returned by virtual fields.  Seems like this component could be more "aware" if we were passing in the `schema.field type`.
