### PR TITLE
Take 3 of refactoring unique where resolver

### DIFF
--- a/.changeset/six-kids-cough.md
+++ b/.changeset/six-kids-cough.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated unique filter checking code to ensure it is always run before using the unique input filter.

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -2,7 +2,7 @@ import { KeystoneContext, DatabaseProvider } from '@keystone-next/types';
 import pLimit from 'p-limit';
 import { InitialisedList } from '../types-for-lists';
 import { getPrismaModelForList, promiseAllRejectWithAllErrors } from '../utils';
-import { UniqueInputFilter } from '../where-inputs';
+import { resolveUniqueWhereInput, UniqueInputFilter } from '../where-inputs';
 import { getAccessControlledItemForDelete } from './access-control';
 import { runSideEffectOnlyHook, validationHook } from './hooks';
 
@@ -47,10 +47,17 @@ export async function deleteOne(
 async function processDelete(
   list: InitialisedList,
   context: KeystoneContext,
-  filter: UniqueInputFilter
+  uniqueInput: UniqueInputFilter
 ) {
+  // Validate and resolve the input filter
+  const uniqueWhere = await resolveUniqueWhereInput(uniqueInput, list.fields, context);
   // Access control
-  const existingItem = await getAccessControlledItemForDelete(list, context, filter, filter);
+  const existingItem = await getAccessControlledItemForDelete(
+    list,
+    context,
+    uniqueInput,
+    uniqueWhere
+  );
 
   // Field validation
   const hookArgs = { operation: 'delete' as const, listKey: list.listKey, context, existingItem };

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -18,13 +18,15 @@ async function handleCreateAndUpdate(
   target: string
 ) {
   if (value.connect) {
+    // Validate and resolve the input filter
+    const uniqueWhere = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
+    // Check whether the item exists
     try {
       await context.db.lists[foreignList.listKey].findOne({ where: value.connect });
     } catch (err) {
       throw new Error(`Unable to connect a ${target}`);
     }
-    const connect = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
-    return { connect };
+    return { connect: uniqueWhere };
   } else if (value.create) {
     const createInput = value.create;
     let create = await (async () => {

--- a/tests/api-tests/access-control/not-authed.test.ts
+++ b/tests/api-tests/access-control/not-authed.test.ts
@@ -168,7 +168,7 @@ describe(`Not authed`, () => {
 
             test(`single denied: ${JSON.stringify(access)}`, async () => {
               const singleQueryName = nameFn[mode](access);
-              const query = `query { ${singleQueryName}(where: { id: "abc123" }) { id } }`;
+              const query = `query { ${singleQueryName}(where: { id: "cabc123" }) { id } }`;
               const { data, errors } = await context.graphql.raw({ query });
               expectNoAccess(data, errors, singleQueryName);
             });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -138,7 +138,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during creating',
     runner(async ({ context }) => {
-      const FAKE_ID = "cabc123";
+      const FAKE_ID = 'cabc123';
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -164,7 +164,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during update',
     runner(async ({ context }) => {
-      const FAKE_ID = "cabc123";
+      const FAKE_ID = 'cabc123';
 
       // Create an item to link against
       const createEvent = await context.lists.Event.createOne({ data: {} });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -138,7 +138,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during creating',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -164,7 +164,7 @@ describe('non-matching filter', () => {
   test(
     'errors if connecting an item which cannot be found during update',
     runner(async ({ context }) => {
-      const FAKE_ID = 100;
+      const FAKE_ID = "cabc123";
 
       // Create an item to link against
       const createEvent = await context.lists.Event.createOne({ data: {} });


### PR DESCRIPTION
These changes make it clear where in the lifecycle this check happens, while making sure that the right data is passed into e.g. `.findOne()`, etc.