### PR TITLE
Split default value loop from field-type resolver loop

### DIFF
--- a/.changeset/ten-ducks-work.md
+++ b/.changeset/ten-ducks-work.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Split the default value loop from the field-type input resolver loop to allow for more fine-grained error handling.

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -6,12 +6,14 @@ import { NestedMutationState } from './create-update';
 
 const isNotNull = <T>(arg: T): arg is Exclude<T, null> => arg !== null;
 
-type _CreateValueType = schema.InferValueFromArg<
-  schema.Arg<TypesForList['relateTo']['many']['create']>
+type _CreateValueType = Exclude<
+  schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['many']['create']>>,
+  null | undefined
 >;
 
-type _UpdateValueType = schema.InferValueFromArg<
-  schema.Arg<TypesForList['relateTo']['many']['update']>
+type _UpdateValueType = Exclude<
+  schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['many']['update']>>,
+  null | undefined
 >;
 
 async function getDisconnects(
@@ -53,7 +55,7 @@ function getConnects(
 }
 
 async function resolveCreateAndConnect(
-  value: Exclude<_UpdateValueType, null | undefined>,
+  value: _UpdateValueType,
   nestedMutationState: NestedMutationState,
   context: KeystoneContext,
   foreignList: InitialisedList,
@@ -96,10 +98,7 @@ async function resolveCreateAndConnect(
   return result;
 }
 
-function assertValidManyOperation(
-  val: Exclude<_UpdateValueType, undefined | null>,
-  target: string
-) {
+function assertValidManyOperation(val: _UpdateValueType, target: string) {
   if (
     !Array.isArray(val.connect) &&
     !Array.isArray(val.create) &&
@@ -117,9 +116,6 @@ export function resolveRelateToManyForCreateInput(
   target: string
 ) {
   return async (value: _CreateValueType) => {
-    if (value == null) {
-      return undefined;
-    }
     assertValidManyOperation(value, target);
     return resolveCreateAndConnect(value, nestedMutationState, context, foreignList, target);
   };
@@ -132,9 +128,6 @@ export function resolveRelateToManyForUpdateInput(
   target: string
 ) {
   return async (value: _UpdateValueType) => {
-    if (value == null) {
-      return undefined;
-    }
     assertValidManyOperation(value, target);
     const disconnects = getDisconnects(
       value.disconnectAll ? [] : value.disconnect || [],

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -3,15 +3,19 @@ import { resolveUniqueWhereInput } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { NestedMutationState } from './create-update';
 
-type _CreateValueType = schema.InferValueFromArg<
-  schema.Arg<TypesForList['relateTo']['one']['create']>
+type _CreateValueType = Exclude<
+  schema.InferValueFromArg<schema.Arg<TypesForList['relateTo']['one']['create']>>,
+  null | undefined
 >;
-type _UpdateValueType = schema.InferValueFromArg<
-  schema.Arg<schema.NonNullType<TypesForList['relateTo']['one']['update']>>
+type _UpdateValueType = Exclude<
+  schema.InferValueFromArg<
+    schema.Arg<schema.NonNullType<TypesForList['relateTo']['one']['update']>>
+  >,
+  null | undefined
 >;
 
 async function handleCreateAndUpdate(
-  value: Exclude<_CreateValueType, null | undefined>,
+  value: _CreateValueType,
   nestedMutationState: NestedMutationState,
   context: KeystoneContext,
   foreignList: InitialisedList,
@@ -53,9 +57,6 @@ export function resolveRelateToOneForCreateInput(
   target: string
 ) {
   return async (value: _CreateValueType) => {
-    if (value == null) {
-      return undefined;
-    }
     const numOfKeys = Object.keys(value).length;
     if (numOfKeys !== 1) {
       throw new Error(`Nested mutation operation invalid for ${target}`);
@@ -71,10 +72,6 @@ export function resolveRelateToOneForUpdateInput(
   target: string
 ) {
   return async (value: _UpdateValueType) => {
-    if (value == null) {
-      return undefined;
-    }
-
     if (value.connect && value.create) {
       throw new Error(`Nested mutation operation invalid for ${target}`);
     }


### PR DESCRIPTION
Decouples these two loops so that we can provide better error messages moving forward.

This also lifts the `null` input case out of the individual relationship resolver functions so we can have the discussion around what the correct behaviour for this input should be (currently a no-op).