### PR TITLE
Add / to list.path on HomePage ListCard to better allow custom basePath

### DIFF
--- a/.changeset/clever-pens-pretend.md
+++ b/.changeset/clever-pens-pretend.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': patch
 ---
 
-Add / to list.path on HomePage ListCard to better allow custom basePath
+Added `/` to `list.path` on HomePage ListCard to better allow custom `basePath`.

--- a/.changeset/clever-pens-pretend.md
+++ b/.changeset/clever-pens-pretend.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Add / to list.path on HomePage ListCard to better allow custom basePath

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
@@ -34,7 +34,7 @@ const ListCard = ({ listKey, count }: ListCardProps) => {
   return (
     <div css={{ position: 'relative' }}>
       <Link
-        href={list.path}
+        href={`/${list.path}`}
         css={{
           backgroundColor: colors.background,
           borderColor: colors.border,


### PR DESCRIPTION
Fix for #6125 - Added `/` to `href` in `ListCard` on `HomePage` so it doesn't mess up with a custom `basePath`