### PR TITLE
Move logic for running field-level hooks into runSideEffectOnlyHook

### DIFF
--- a/packages/keystone/src/lib/core/mutations/create-update.ts
+++ b/packages/keystone/src/lib/core/mutations/create-update.ts
@@ -232,9 +232,7 @@ async function resolveInputForCreateOrUpdate(
   await validateUpdateCreate({ list, hookArgs });
 
   // Run beforeChange hooks
-  const originalInputKeys = new Set(Object.keys(originalInput));
-  const shouldCallFieldLevelSideEffectHook = (fieldKey: string) => originalInputKeys.has(fieldKey);
-  await runSideEffectOnlyHook(list, 'beforeChange', hookArgs, shouldCallFieldLevelSideEffectHook);
+  await runSideEffectOnlyHook(list, 'beforeChange', hookArgs);
 
   // Return the full resolved input (ready for prisma level operation),
   // and the afterChange hook to be applied
@@ -242,12 +240,7 @@ async function resolveInputForCreateOrUpdate(
     data: flattenMultiDbFields(list.fields, resolvedData),
     afterChange: async (updatedItem: ItemRootValue) => {
       await nestedMutationState.afterChange();
-      await runSideEffectOnlyHook(
-        list,
-        'afterChange',
-        { ...hookArgs, updatedItem, existingItem },
-        shouldCallFieldLevelSideEffectHook
-      );
+      await runSideEffectOnlyHook(list, 'afterChange', { ...hookArgs, updatedItem, existingItem });
     },
   };
 }

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -23,7 +23,7 @@ export function deleteMany(
       })
     );
 
-    afterDelete();
+    await afterDelete();
 
     return existingItem;
   });
@@ -52,6 +52,7 @@ async function processDelete(
 ) {
   // Validate and resolve the input filter
   const uniqueWhere = await resolveUniqueWhereInput(uniqueInput, list.fields, context);
+
   // Access control
   const existingItem = await getAccessControlledItemForDelete(
     list,
@@ -66,12 +67,12 @@ async function processDelete(
   await validateDelete({ list, hookArgs });
 
   // Before delete
-  await runSideEffectOnlyHook(list, 'beforeDelete', hookArgs, () => true);
+  await runSideEffectOnlyHook(list, 'beforeDelete', hookArgs);
 
   return {
     existingItem,
     afterDelete: async () => {
-      await runSideEffectOnlyHook(list, 'afterDelete', hookArgs, () => true);
+      await runSideEffectOnlyHook(list, 'afterDelete', hookArgs);
     },
   };
 }


### PR DESCRIPTION
Groups the pre/post hook logic for all mutations in the one function. No functional changes.

Also adds a missing `await`.