### PR TITLE
Consolidate delete operation into a single function

### DIFF
--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -1,5 +1,5 @@
 import { KeystoneContext, DatabaseProvider } from '@keystone-next/types';
-import pLimit from 'p-limit';
+import pLimit, { Limit } from 'p-limit';
 import { InitialisedList } from '../types-for-lists';
 import { getPrismaModelForList } from '../utils';
 import { resolveUniqueWhereInput, UniqueInputFilter } from '../where-inputs';
@@ -7,48 +7,11 @@ import { getAccessControlledItemForDelete } from './access-control';
 import { runSideEffectOnlyHook } from './hooks';
 import { validateDelete } from './validation';
 
-export function deleteMany(
-  { where }: { where: UniqueInputFilter[] },
+async function deleteSingle(
+  uniqueInput: UniqueInputFilter,
   list: InitialisedList,
   context: KeystoneContext,
-  provider: DatabaseProvider
-) {
-  const writeLimit = pLimit(provider === 'sqlite' ? 1 : Infinity);
-  return where.map(async where => {
-    const { afterDelete, existingItem } = await processDelete(list, context, where);
-
-    await writeLimit(() =>
-      getPrismaModelForList(context.prisma, list.listKey).delete({
-        where: { id: existingItem.id },
-      })
-    );
-
-    await afterDelete();
-
-    return existingItem;
-  });
-}
-
-export async function deleteOne(
-  { where }: { where: UniqueInputFilter },
-  list: InitialisedList,
-  context: KeystoneContext
-) {
-  const { afterDelete, existingItem } = await processDelete(list, context, where);
-
-  const item = await getPrismaModelForList(context.prisma, list.listKey).delete({
-    where: { id: existingItem.id },
-  });
-
-  await afterDelete();
-
-  return item;
-}
-
-async function processDelete(
-  list: InitialisedList,
-  context: KeystoneContext,
-  uniqueInput: UniqueInputFilter
+  writeLimit: Limit
 ) {
   // Validate and resolve the input filter
   const uniqueWhere = await resolveUniqueWhereInput(uniqueInput, list.fields, context);
@@ -69,10 +32,33 @@ async function processDelete(
   // Before delete
   await runSideEffectOnlyHook(list, 'beforeDelete', hookArgs);
 
-  return {
-    existingItem,
-    afterDelete: async () => {
-      await runSideEffectOnlyHook(list, 'afterDelete', hookArgs);
-    },
-  };
+  const item = await writeLimit(() =>
+    getPrismaModelForList(context.prisma, list.listKey).delete({
+      where: { id: existingItem.id },
+    })
+  );
+
+  await runSideEffectOnlyHook(list, 'afterDelete', hookArgs);
+
+  return item;
+}
+
+export function deleteMany(
+  uniqueInputs: UniqueInputFilter[],
+  list: InitialisedList,
+  context: KeystoneContext,
+  provider: DatabaseProvider
+) {
+  const writeLimit = pLimit(provider === 'sqlite' ? 1 : Infinity);
+  return uniqueInputs.map(async uniqueInput =>
+    deleteSingle(uniqueInput, list, context, writeLimit)
+  );
+}
+
+export async function deleteOne(
+  uniqueInput: UniqueInputFilter,
+  list: InitialisedList,
+  context: KeystoneContext
+) {
+  return deleteSingle(uniqueInput, list, context, pLimit(1));
 }

--- a/packages/keystone/src/lib/core/mutations/index.ts
+++ b/packages/keystone/src/lib/core/mutations/index.ts
@@ -90,7 +90,7 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
     type: list.types.output,
     args: { id: schema.arg({ type: schema.nonNull(schema.ID) }) },
     resolve(rootVal, { id }, context) {
-      return deletes.deleteOne({ where: { id } }, list, context);
+      return deletes.deleteOne({ id }, list, context);
     },
   });
 
@@ -99,7 +99,12 @@ export function getMutationsForList(list: InitialisedList, provider: DatabasePro
     args: { ids: schema.arg({ type: schema.list(schema.nonNull(schema.ID)) }) },
     resolve(rootVal, { ids }, context) {
       return promisesButSettledWhenAllSettledAndInOrder(
-        deletes.deleteMany({ where: (ids || []).map(id => ({ id })) }, list, context, provider)
+        deletes.deleteMany(
+          (ids || []).map(id => ({ id })),
+          list,
+          context,
+          provider
+        )
       );
     },
   });


### PR DESCRIPTION
Simplifies the delete mutation code a bit and makes it explicit that `deleteMany` is identical to `deleteOne` in its behaviour.