### PR TITLE
Move run-time checks to startup for unique fields

### DIFF
--- a/.changeset/thirty-windows-dance.md
+++ b/.changeset/thirty-windows-dance.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Added check at startup to ensure field types which defined uniqueWhere have a supported `dbField` type of `String` or `Int`.

--- a/packages/keystone/src/lib/core/queries/resolvers.ts
+++ b/packages/keystone/src/lib/core/queries/resolvers.ts
@@ -27,20 +27,7 @@ export function mapUniqueWhereToWhere(
 ): PrismaFilter {
   // inputResolvers.uniqueWhere validates that there is only one key
   const key = Object.keys(uniqueWhere)[0];
-  const dbField = list.fields[key].dbField;
-  if (dbField.kind !== 'scalar' || (dbField.scalar !== 'String' && dbField.scalar !== 'Int')) {
-    throw new Error(
-      'Currently only String and Int scalar db fields can provide a uniqueWhere input'
-    );
-  }
-  const val = uniqueWhere[key];
-  if (dbField.scalar === 'Int' && typeof val !== 'number') {
-    throw new Error('uniqueWhere inputs must return an integer for Int db fields');
-  }
-  if (dbField.scalar === 'String' && typeof val !== 'string') {
-    throw new Error('uniqueWhere inputs must return an string for String db fields');
-  }
-  return { [key]: val };
+  return { [key]: uniqueWhere[key] };
 }
 
 export async function accessControlledFilter(

--- a/packages/keystone/src/lib/core/types-for-lists.ts
+++ b/packages/keystone/src/lib/core/types-for-lists.ts
@@ -100,6 +100,15 @@ export function initialiseLists(
         return Object.fromEntries(
           Object.entries(fields).flatMap(([key, field]) => {
             if (!field.input?.uniqueWhere?.arg || field.access.read === false) return [];
+            const { dbField } = field;
+            if (
+              dbField.kind !== 'scalar' ||
+              (dbField.scalar !== 'String' && dbField.scalar !== 'Int')
+            ) {
+              throw new Error(
+                'Currently only String and Int scalar db fields can provide a uniqueWhere input'
+              );
+            }
             return [[key, field.input.uniqueWhere.arg]] as const;
           })
         );


### PR DESCRIPTION
Moves run time check of types from query time to startup time. Removes run time checks for input values, which will be surface as errors when running queries if there's a problem.