### PR TITLE
Replace getPrismaModelForList with runWithPrisma

### DIFF
--- a/packages/keystone/src/lib/core/mutations/create-update.ts
+++ b/packages/keystone/src/lib/core/mutations/create-update.ts
@@ -3,10 +3,10 @@ import pLimit, { Limit } from 'p-limit';
 import { ResolvedDBField } from '../resolve-relationships';
 import { InitialisedList } from '../types-for-lists';
 import {
-  getPrismaModelForList,
   promiseAllRejectWithAllErrors,
   getDBFieldKeyForFieldOnMultiField,
   IdType,
+  runWithPrisma,
 } from '../utils';
 import { resolveUniqueWhereInput, UniqueInputFilter } from '../where-inputs';
 import {
@@ -37,7 +37,7 @@ async function createSingle(
   );
 
   const item = await writeLimit(() =>
-    getPrismaModelForList(context.prisma, list.listKey).create({ data })
+    runWithPrisma(context, list, model => model.create({ data }))
   );
 
   return { item, afterChange };
@@ -116,7 +116,7 @@ async function updateSingle(
   const { afterChange, data } = await resolveInputForCreateOrUpdate(list, context, rawData, item);
 
   const updatedItem = await writeLimit(() =>
-    getPrismaModelForList(context.prisma, list.listKey).update({ where: { id: item.id }, data })
+    runWithPrisma(context, list, model => model.update({ where: { id: item.id }, data }))
   );
 
   await afterChange(updatedItem);

--- a/packages/keystone/src/lib/core/mutations/delete.ts
+++ b/packages/keystone/src/lib/core/mutations/delete.ts
@@ -1,7 +1,7 @@
 import { KeystoneContext, DatabaseProvider } from '@keystone-next/types';
 import pLimit, { Limit } from 'p-limit';
 import { InitialisedList } from '../types-for-lists';
-import { getPrismaModelForList } from '../utils';
+import { runWithPrisma } from '../utils';
 import { resolveUniqueWhereInput, UniqueInputFilter } from '../where-inputs';
 import { getAccessControlledItemForDelete } from './access-control';
 import { runSideEffectOnlyHook } from './hooks';
@@ -33,9 +33,7 @@ async function deleteSingle(
   await runSideEffectOnlyHook(list, 'beforeDelete', hookArgs);
 
   const item = await writeLimit(() =>
-    getPrismaModelForList(context.prisma, list.listKey).delete({
-      where: { id: existingItem.id },
-    })
+    runWithPrisma(context, list, model => model.delete({ where: { id: existingItem.id } }))
   );
 
   await runSideEffectOnlyHook(list, 'afterDelete', hookArgs);

--- a/packages/keystone/src/lib/core/queries/output-field.ts
+++ b/packages/keystone/src/lib/core/queries/output-field.ts
@@ -16,9 +16,9 @@ import { ResolvedDBField, ResolvedRelationDBField } from '../resolve-relationshi
 import { InitialisedList } from '../types-for-lists';
 import {
   applyFirstSkipToCount,
-  getPrismaModelForList,
   IdType,
   getDBFieldKeyForFieldOnMultiField,
+  runWithPrisma,
 } from '../utils';
 import { accessControlledFilter } from './resolvers';
 import * as queries from './resolvers';
@@ -62,9 +62,9 @@ function getRelationVal(
     return async () => {
       const resolvedWhere = await accessControlledFilter(foreignList, context, relationFilter);
 
-      return getPrismaModelForList(context.prisma, dbField.list).findFirst({
-        where: resolvedWhere,
-      });
+      return runWithPrisma(context, foreignList, model =>
+        model.findFirst({ where: resolvedWhere })
+      );
     };
   }
 }

--- a/packages/keystone/src/lib/core/queries/resolvers.ts
+++ b/packages/keystone/src/lib/core/queries/resolvers.ts
@@ -15,7 +15,7 @@ import {
 } from '../where-inputs';
 import { accessDeniedError, LimitsExceededError } from '../graphql-errors';
 import { InitialisedList } from '../types-for-lists';
-import { getPrismaModelForList, getDBFieldKeyForFieldOnMultiField } from '../utils';
+import { getDBFieldKeyForFieldOnMultiField, runWithPrisma } from '../utils';
 
 // doing this is a result of an optimisation to skip doing a findUnique and then a findFirst(where the second one is done with access control)
 // we want to do this explicit mapping because:
@@ -83,9 +83,8 @@ export async function findOne(
   // Apply access control
   const filter = await accessControlledFilter(list, context, resolvedWhere);
 
-  const item = await getPrismaModelForList(context.prisma, list.listKey).findFirst({
-    where: filter,
-  });
+  const item = await runWithPrisma(context, list, model => model.findFirst({ where: filter }));
+
   if (item === null) {
     throw accessDeniedError('query');
   }
@@ -106,12 +105,14 @@ export async function findMany(
   let resolvedWhere = await resolveWhereInput(where || {}, list);
   resolvedWhere = await accessControlledFilter(list, context, resolvedWhere, search);
 
-  const results = await getPrismaModelForList(context.prisma, list.listKey).findMany({
-    where: extraFilter === undefined ? resolvedWhere : { AND: [resolvedWhere, extraFilter] },
-    orderBy,
-    take: first ?? undefined,
-    skip,
-  });
+  const results = await runWithPrisma(context, list, model =>
+    model.findMany({
+      where: extraFilter === undefined ? resolvedWhere : { AND: [resolvedWhere, extraFilter] },
+      orderBy,
+      take: first ?? undefined,
+      skip,
+    })
+  );
 
   applyMaxResults(results, list, context);
 
@@ -182,9 +183,11 @@ export async function count(
   let resolvedWhere = await resolveWhereInput(where || {}, list);
   resolvedWhere = await accessControlledFilter(list, context, resolvedWhere, search);
 
-  return getPrismaModelForList(context.prisma, list.listKey).count({
-    where: extraFilter === undefined ? resolvedWhere : { AND: [resolvedWhere, extraFilter] },
-  });
+  return runWithPrisma(context, list, model =>
+    model.count({
+      where: extraFilter === undefined ? resolvedWhere : { AND: [resolvedWhere, extraFilter] },
+    })
+  );
 }
 
 const limitsExceedError = (args: { type: string; limit: number; list: string }) =>

--- a/packages/keystone/src/lib/core/utils.ts
+++ b/packages/keystone/src/lib/core/utils.ts
@@ -1,6 +1,7 @@
-import { ItemRootValue, KeystoneConfig } from '@keystone-next/types';
+import { ItemRootValue, KeystoneConfig, KeystoneContext } from '@keystone-next/types';
 import pluralize from 'pluralize';
 import { humanize } from '../utils';
+import { InitialisedList } from './types-for-lists';
 import { PrismaFilter, UniquePrismaFilter } from './where-inputs';
 
 declare const prisma: unique symbol;
@@ -70,8 +71,15 @@ export type PrismaClient = {
   $transaction<T extends PrismaPromise<any>[]>(promises: [...T]): UnwrapPromises<T>;
 } & Record<string, PrismaModel>;
 
-export function getPrismaModelForList(prismaClient: PrismaClient, listKey: string) {
-  return prismaClient[listKey[0].toLowerCase() + listKey.slice(1)];
+// Run prisma operations as part of a resolver
+export async function runWithPrisma<T>(
+  context: KeystoneContext,
+  { listKey }: InitialisedList,
+  fn: (model: PrismaModel) => Promise<T>
+) {
+  const model = context.prisma[listKey[0].toLowerCase() + listKey.slice(1)];
+  // FIXME: We will capture errors here and return them with a custom error code
+  return await fn(model);
 }
 
 // this is wrong


### PR DESCRIPTION
Consolidates the executing of `model.*` operations within this wrapper function so that in a future PR we can capture errors and surface them with a custom error code. At this PR there are no functional changes.