### PR TITLE
Throw NotFoundError when findOne failed to find an item

### DIFF
--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -4,6 +4,10 @@ export const AccessDeniedError = createError('AccessDeniedError', {
   message: 'You do not have access to this resource',
   options: { showPath: true },
 });
+export const NotFoundError = createError('NotFoundError', {
+  message: 'Your requested resource could not be found',
+  options: { showPath: true },
+});
 export const ValidationFailureError = createError('ValidationFailureError', {
   message: 'You attempted to perform an invalid mutation',
   options: { showPath: true },
@@ -20,4 +24,13 @@ export const accessDeniedError = (
   extraData = {}
 ) => {
   return new AccessDeniedError({ data: { type, target, ...extraData }, internalData });
+};
+
+export const notFoundError = (
+  type: 'query' | 'mutation',
+  target?: string,
+  internalData = {},
+  extraData = {}
+) => {
+  return new NotFoundError({ data: { type, target, ...extraData }, internalData });
 };

--- a/packages/keystone/src/lib/core/queries/resolvers.ts
+++ b/packages/keystone/src/lib/core/queries/resolvers.ts
@@ -13,7 +13,7 @@ import {
   resolveWhereInput,
   UniqueInputFilter,
 } from '../where-inputs';
-import { accessDeniedError, LimitsExceededError } from '../graphql-errors';
+import { accessDeniedError, notFoundError, LimitsExceededError } from '../graphql-errors';
 import { InitialisedList } from '../types-for-lists';
 import { getDBFieldKeyForFieldOnMultiField, runWithPrisma } from '../utils';
 
@@ -86,7 +86,7 @@ export async function findOne(
   const item = await runWithPrisma(context, list, model => model.findFirst({ where: filter }));
 
   if (item === null) {
-    throw accessDeniedError('query');
+    throw notFoundError('query');
   }
   return item;
 }


### PR DESCRIPTION
The following query (obviously an ID shouldn't ever be zero):

```gql
{
  User(where: {id: 0}) {
    id
  }
}
```

misleadingly throws an AccessDeniedError when it fails to locate a relevant entry. This pull request creates a differently-named NotFoundError so that this can be differentiated from a true access denial in a try/catch block.

Happy to create a changeset in accordance with guidelines and fix tests if this patch is wanted (not sure if it's an access denial by design and I'm missing something).

Incidentally this ~~is likely~~ might be a fix for #1047.