### PR TITLE
Switch from apollo-errors to apollo-server-errors

### DIFF
--- a/.changeset/tidy-suits-refuse.md
+++ b/.changeset/tidy-suits-refuse.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': patch
 ---
 
-Updated internal error handling to use the `apollo-server-errors` instead of `apollo-errors`.
+Updated internal error handling to use the `apollo-server-errors` package instead of `apollo-errors`.

--- a/.changeset/tidy-suits-refuse.md
+++ b/.changeset/tidy-suits-refuse.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated internal error handling to use the `apollo-server-errors` instead of `apollo-errors`.

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -65,7 +65,7 @@
     "@types/source-map-support": "^0.5.4",
     "@types/uid-safe": "^2.1.2",
     "@types/uuid": "^8.3.1",
-    "apollo-errors": "^1.9.0",
+    "apollo-server-errors": "^2.5.0",
     "apollo-server-express": "^2.25.2",
     "apollo-server-micro": "^2.25.2",
     "apollo-server-types": "^0.9.0",

--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -1,12 +1,12 @@
 import { ApolloError } from 'apollo-server-errors';
 
-export const AccessDeniedError = () => new ApolloError('You do not have access to this resource');
+export const accessDeniedError = () => new ApolloError('You do not have access to this resource');
 
-export const ValidationFailureError = () =>
+export const validationFailureError = () =>
   new ApolloError('You attempted to perform an invalid mutation');
 
 // FIXME: In an upcoming PR we will use these args to construct a better
 // error message, so leaving the, here for now. - TL
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const LimitsExceededError = (args: { type: string; limit: number; list: string }) =>
+export const limitsExceededError = (args: { type: string; limit: number; list: string }) =>
   new ApolloError('Your request exceeded server limits');

--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -1,23 +1,12 @@
-import { createError } from 'apollo-errors';
+import { ApolloError } from 'apollo-server-errors';
 
-export const AccessDeniedError = createError('AccessDeniedError', {
-  message: 'You do not have access to this resource',
-  options: { showPath: true },
-});
-export const ValidationFailureError = createError('ValidationFailureError', {
-  message: 'You attempted to perform an invalid mutation',
-  options: { showPath: true },
-});
-export const LimitsExceededError = createError('LimitsExceededError', {
-  message: 'Your request exceeded server limits',
-  options: { showPath: true },
-});
+export const AccessDeniedError = () => new ApolloError('You do not have access to this resource');
 
-export const accessDeniedError = (
-  type: 'query' | 'mutation',
-  target?: string,
-  internalData = {},
-  extraData = {}
-) => {
-  return new AccessDeniedError({ data: { type, target, ...extraData }, internalData });
-};
+export const ValidationFailureError = () =>
+  new ApolloError('You attempted to perform an invalid mutation');
+
+// FIXME: In an upcoming PR we will use these args to construct a better
+// error message, so leaving the, here for now. - TL
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const LimitsExceededError = (args: { type: string; limit: number; list: string }) =>
+  new ApolloError('Your request exceeded server limits');

--- a/packages/keystone/src/lib/core/mutations/access-control.ts
+++ b/packages/keystone/src/lib/core/mutations/access-control.ts
@@ -4,7 +4,7 @@ import {
   validateFieldAccessControl,
   validateNonCreateListAccessControl,
 } from '../access-control';
-import { AccessDeniedError } from '../graphql-errors';
+import { accessDeniedError } from '../graphql-errors';
 import { mapUniqueWhereToWhere } from '../queries/resolvers';
 import { InitialisedList } from '../types-for-lists';
 import { runWithPrisma } from '../utils';
@@ -29,7 +29,7 @@ export async function getAccessControlledItemForDelete(
     args: { context, listKey: list.listKey, operation: 'delete', session: context.session, itemId },
   });
   if (access === false) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   // List access: pass 2
@@ -39,7 +39,7 @@ export async function getAccessControlledItemForDelete(
   }
   const item = await runWithPrisma(context, list, model => model.findFirst({ where }));
   if (item === null) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   return item;
@@ -68,7 +68,7 @@ export async function getAccessControlledItemForUpdate(
     args,
   });
   if (accessControl === false) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   // List access: pass 2
@@ -82,7 +82,7 @@ export async function getAccessControlledItemForUpdate(
     })
   );
   if (!item) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   // Field access
@@ -97,7 +97,7 @@ export async function getAccessControlledItemForUpdate(
   );
 
   if (results.some(canAccess => !canAccess)) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   return item;
@@ -119,7 +119,7 @@ export async function applyAccessControlForCreate(
   // List access
   const result = await validateCreateListAccessControl({ access: list.access.create, args });
   if (!result) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   // Field access
@@ -134,7 +134,7 @@ export async function applyAccessControlForCreate(
   );
 
   if (results.some(canAccess => !canAccess)) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 }
 
@@ -150,6 +150,6 @@ async function getStringifiedItemIdFromUniqueWhereInput(
     const item = await context.sudo().lists[listKey].findOne({ where: uniqueInput });
     return item.id;
   } catch (err) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 }

--- a/packages/keystone/src/lib/core/mutations/access-control.ts
+++ b/packages/keystone/src/lib/core/mutations/access-control.ts
@@ -4,7 +4,7 @@ import {
   validateFieldAccessControl,
   validateNonCreateListAccessControl,
 } from '../access-control';
-import { accessDeniedError } from '../graphql-errors';
+import { AccessDeniedError } from '../graphql-errors';
 import { mapUniqueWhereToWhere } from '../queries/resolvers';
 import { InitialisedList } from '../types-for-lists';
 import { runWithPrisma } from '../utils';
@@ -29,7 +29,7 @@ export async function getAccessControlledItemForDelete(
     args: { context, listKey: list.listKey, operation: 'delete', session: context.session, itemId },
   });
   if (access === false) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   // List access: pass 2
@@ -39,7 +39,7 @@ export async function getAccessControlledItemForDelete(
   }
   const item = await runWithPrisma(context, list, model => model.findFirst({ where }));
   if (item === null) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   return item;
@@ -68,7 +68,7 @@ export async function getAccessControlledItemForUpdate(
     args,
   });
   if (accessControl === false) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   // List access: pass 2
@@ -82,7 +82,7 @@ export async function getAccessControlledItemForUpdate(
     })
   );
   if (!item) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   // Field access
@@ -97,7 +97,7 @@ export async function getAccessControlledItemForUpdate(
   );
 
   if (results.some(canAccess => !canAccess)) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   return item;
@@ -119,7 +119,7 @@ export async function applyAccessControlForCreate(
   // List access
   const result = await validateCreateListAccessControl({ access: list.access.create, args });
   if (!result) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 
   // Field access
@@ -134,7 +134,7 @@ export async function applyAccessControlForCreate(
   );
 
   if (results.some(canAccess => !canAccess)) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 }
 
@@ -150,6 +150,6 @@ async function getStringifiedItemIdFromUniqueWhereInput(
     const item = await context.sudo().lists[listKey].findOne({ where: uniqueInput });
     return item.id;
   } catch (err) {
-    throw accessDeniedError('mutation');
+    throw AccessDeniedError();
   }
 }

--- a/packages/keystone/src/lib/core/mutations/validation.ts
+++ b/packages/keystone/src/lib/core/mutations/validation.ts
@@ -19,15 +19,9 @@ export async function validationHook(
   });
 
   if (errors.length) {
-    throw new ValidationFailureError({
-      data: {
-        messages: errors.map(e => e.msg),
-        errors: errors.map(e => e.data),
-        listKey,
-        operation,
-      },
-      internalData: { errors: errors.map(e => e.internalData), data: originalInput },
-    });
+    // FIXME: We will incorporate the `msg` values, which are currently being lost
+    // into the error message in an upcoming change. -TL
+    throw ValidationFailureError();
   }
 }
 

--- a/packages/keystone/src/lib/core/mutations/validation.ts
+++ b/packages/keystone/src/lib/core/mutations/validation.ts
@@ -1,4 +1,4 @@
-import { ValidationFailureError } from '../graphql-errors';
+import { validationFailureError } from '../graphql-errors';
 import { InitialisedList } from '../types-for-lists';
 import { promiseAllRejectWithAllErrors } from '../utils';
 
@@ -21,7 +21,7 @@ export async function validationHook(
   if (errors.length) {
     // FIXME: We will incorporate the `msg` values, which are currently being lost
     // into the error message in an upcoming change. -TL
-    throw ValidationFailureError();
+    throw validationFailureError();
   }
 }
 

--- a/packages/keystone/src/lib/core/queries/output-field.ts
+++ b/packages/keystone/src/lib/core/queries/output-field.ts
@@ -12,7 +12,7 @@ import {
 } from '@keystone-next/types';
 import { GraphQLResolveInfo } from 'graphql';
 import { validateFieldAccessControl } from '../access-control';
-import { accessDeniedError } from '../graphql-errors';
+import { AccessDeniedError } from '../graphql-errors';
 import { ResolvedDBField, ResolvedRelationDBField } from '../resolve-relationships';
 import { InitialisedList } from '../types-for-lists';
 import { IdType, getDBFieldKeyForFieldOnMultiField, runWithPrisma } from '../utils';
@@ -107,7 +107,7 @@ export function outputTypeField(
         // If the client handles errors correctly, it should be able to
         // receive partial data (for the fields the user has access to),
         // and then an `errors` array of AccessDeniedError's
-        throw accessDeniedError('query', fieldKey, { itemId: rootVal.id });
+        throw AccessDeniedError();
       }
 
       // Only static cache hints are supported at the field level until a use-case makes it clear what parameters a dynamic hint would take

--- a/packages/keystone/src/lib/core/queries/output-field.ts
+++ b/packages/keystone/src/lib/core/queries/output-field.ts
@@ -12,7 +12,7 @@ import {
 } from '@keystone-next/types';
 import { GraphQLResolveInfo } from 'graphql';
 import { validateFieldAccessControl } from '../access-control';
-import { AccessDeniedError } from '../graphql-errors';
+import { accessDeniedError } from '../graphql-errors';
 import { ResolvedDBField, ResolvedRelationDBField } from '../resolve-relationships';
 import { InitialisedList } from '../types-for-lists';
 import { IdType, getDBFieldKeyForFieldOnMultiField, runWithPrisma } from '../utils';
@@ -107,7 +107,7 @@ export function outputTypeField(
         // If the client handles errors correctly, it should be able to
         // receive partial data (for the fields the user has access to),
         // and then an `errors` array of AccessDeniedError's
-        throw AccessDeniedError();
+        throw accessDeniedError();
       }
 
       // Only static cache hints are supported at the field level until a use-case makes it clear what parameters a dynamic hint would take

--- a/packages/keystone/src/lib/core/queries/resolvers.ts
+++ b/packages/keystone/src/lib/core/queries/resolvers.ts
@@ -13,7 +13,7 @@ import {
   resolveWhereInput,
   UniqueInputFilter,
 } from '../where-inputs';
-import { AccessDeniedError, LimitsExceededError } from '../graphql-errors';
+import { accessDeniedError, limitsExceededError } from '../graphql-errors';
 import { InitialisedList } from '../types-for-lists';
 import { getDBFieldKeyForFieldOnMultiField, runWithPrisma } from '../utils';
 
@@ -54,7 +54,7 @@ export async function accessControlledFilter(
     args: { context, listKey: list.listKey, operation: 'read', session: context.session },
   });
   if (access === false) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
 
   // Merge declarative access control
@@ -80,7 +80,7 @@ export async function findOne(
   const item = await runWithPrisma(context, list, model => model.findFirst({ where: filter }));
 
   if (item === null) {
-    throw AccessDeniedError();
+    throw accessDeniedError();
   }
   return item;
 }
@@ -196,18 +196,18 @@ function applyEarlyMaxResults(_first: number | null | undefined, list: Initialis
   // * The query explicitly has a "first" that exceeds the limit
   // * The query has no "first", and has more results than the limit
   if (first < Infinity && first > list.maxResults) {
-    throw LimitsExceededError({ list: list.listKey, type: 'maxResults', limit: list.maxResults });
+    throw limitsExceededError({ list: list.listKey, type: 'maxResults', limit: list.maxResults });
   }
 }
 
 function applyMaxResults(results: unknown[], list: InitialisedList, context: KeystoneContext) {
   if (results.length > list.maxResults) {
-    throw LimitsExceededError({ list: list.listKey, type: 'maxResults', limit: list.maxResults });
+    throw limitsExceededError({ list: list.listKey, type: 'maxResults', limit: list.maxResults });
   }
   if (context) {
     context.totalResults += Array.isArray(results) ? results.length : 1;
     if (context.totalResults > context.maxTotalResults) {
-      throw LimitsExceededError({
+      throw limitsExceededError({
         list: list.listKey,
         type: 'maxTotalResults',
         limit: context.maxTotalResults,

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -58,6 +58,7 @@ export const expectAccessDenied = (
   }));
   expect(unpackedErrors).toEqual(
     args.map(({ path }) => ({
+      extensions: { code: undefined },
       path,
       message: 'You do not have access to this resource',
     }))
@@ -73,6 +74,7 @@ export const expectValidationError = (
   }));
   expect(unpackedErrors).toEqual(
     args.map(({ path }) => ({
+      extensions: { code: undefined },
       path,
       message: 'You attempted to perform an invalid mutation',
     }))
@@ -102,6 +104,7 @@ export const expectLimitsExceededError = (
   }));
   expect(unpackedErrors).toEqual(
     args.map(({ path }) => ({
+      extensions: { code: undefined },
       path,
       message: 'Your request exceeded server limits',
     }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,14 +3551,6 @@ apollo-env@^0.10.0:
     node-fetch "^2.6.1"
     sha.js "^2.4.11"
 
-apollo-errors@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/apollo-errors/-/apollo-errors-1.9.0.tgz#f1ed0ca0a6be5cd2f24e2eaa7b0860a10146ff51"
-  integrity sha512-XVukHd0KLvgY6tNjsPS3/Re3U6RQlTKrTbIpqqeTMo2N34uQMr+H1UheV21o8hOZBAFosvBORVricJiP5vfmrw==
-  dependencies:
-    assert "^1.4.1"
-    extendable-error "^0.1.5"
-
 apollo-graphql@^0.9.0:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.9.3.tgz#1ca6f625322ae10a66f57a39642849a07a7a5dc9"


### PR DESCRIPTION
The only functional difference is that `apollo-server-errors` injects `extensions: { code: undefined }` into the error, but we're not using this field just yet. This change highlights that our error functions were passing through a bunch of extra data which was never being surfaced in our errors. That's fine, since we want re-assess what we're exposing to people anyway. This gives us a nice clean slate to work from.