### PR TITLE
Improve error messages for validation failures

### DIFF
--- a/.changeset/fluffy-coins-argue.md
+++ b/.changeset/fluffy-coins-argue.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/example-testing': patch
+'@keystone-next/keystone': patch
+---
+
+Added more details to validation failure error messages.

--- a/docs/pages/docs/guides/testing.mdx
+++ b/docs/pages/docs/guides/testing.mdx
@@ -94,7 +94,9 @@ runner(async ({ context }) => {
   expect(data.createPerson).toBe(null);
   expect(errors).toHaveLength(1);
   expect(errors[0].path).toEqual(['createPerson']);
-  expect(errors[0].message).toEqual('You attempted to perform an invalid mutation');
+  expect(errors[0].message).toEqual(
+    'You provided invalid data for this operation.\n  - Person.name: Required field "name" is null or undefined.'
+  );
 })
 ```
 

--- a/examples/testing/example.test.ts
+++ b/examples/testing/example.test.ts
@@ -57,7 +57,9 @@ describe('Example tests using test runner', () => {
       expect(data!.createPerson).toBe(null);
       expect(errors).toHaveLength(1);
       expect(errors![0].path).toEqual(['createPerson']);
-      expect(errors![0].message).toEqual('You attempted to perform an invalid mutation');
+      expect(errors![0].message).toEqual(
+        'You provided invalid data for this operation.\n  - Person.name: Required field "name" is null or undefined.'
+      );
     })
   );
 

--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -2,8 +2,10 @@ import { ApolloError } from 'apollo-server-errors';
 
 export const accessDeniedError = () => new ApolloError('You do not have access to this resource');
 
-export const validationFailureError = () =>
-  new ApolloError('You attempted to perform an invalid mutation');
+export const validationFailureError = (messages: string[]) => {
+  const s = messages.map(m => `  - ${m}`).join('\n');
+  return new ApolloError(`You provided invalid data for this operation.\n${s}`);
+};
 
 // FIXME: In an upcoming PR we will use these args to construct a better
 // error message, so leaving the, here for now. - TL

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -65,7 +65,12 @@ testModules
                   }`,
             });
             expect(data).toEqual({ createTest: null });
-            expectValidationError(errors, [{ path: ['createTest'] }]);
+            expectValidationError(errors, [
+              {
+                path: ['createTest'],
+                messages: ['Test.testField: Required field "testField" is null or undefined.'],
+              },
+            ]);
           })
         );
 
@@ -85,7 +90,12 @@ testModules
                   }`,
             });
             expect(data).toEqual({ updateTest: null });
-            expectValidationError(errors, [{ path: ['updateTest'] }]);
+            expectValidationError(errors, [
+              {
+                path: ['updateTest'],
+                messages: ['Test.testField: Required field "testField" is null or undefined.'],
+              },
+            ]);
           })
         );
 

--- a/tests/api-tests/hooks/auth-hooks.test.skip.ts
+++ b/tests/api-tests/hooks/auth-hooks.test.skip.ts
@@ -246,7 +246,7 @@ describe('Auth Hooks', () => {
         expect(authenticateUserWithPassword).toBe(null);
         expect(errors).not.toBe(undefined);
         expect(errors).toHaveLength(1);
-        expect(errors[0].message).toEqual('You attempted to perform an invalid mutation');
+        expect(errors[0].message).toEqual('You provided invalid data for this operation.');
         expect(errors[0].path).toEqual(['authenticateUserWithPassword']);
       });
     })

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -22,6 +22,8 @@ const unpackErrors = (errors: readonly any[] | undefined) =>
     ...unpacked,
   }));
 
+const j = (messages: string[]) => messages.map(m => `  - ${m}`).join('\n');
+
 export const expectInternalServerError = (
   errors: readonly any[] | undefined,
   args: { path: any[]; message: string }[]
@@ -67,16 +69,16 @@ export const expectAccessDenied = (
 
 export const expectValidationError = (
   errors: readonly any[] | undefined,
-  args: { path: (string | number)[] }[]
+  args: { path: (string | number)[]; messages: string[] }[]
 ) => {
   const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
     ...unpacked,
   }));
   expect(unpackedErrors).toEqual(
-    args.map(({ path }) => ({
+    args.map(({ path, messages }) => ({
       extensions: { code: undefined },
       path,
-      message: 'You attempted to perform an invalid mutation',
+      message: `You provided invalid data for this operation.\n${j(messages)}`,
     }))
   );
 };


### PR DESCRIPTION
This PR updates the error message provided during the `validation` phase of our CRUD mutations. The changes are:

 * Changed the top level message to something a bit more specific
 * Include the individual error messages in a list below the top level message
 * Include the list/field name in the individual error messages for context.
 * All phases of validation (`isRequired`, field hooks, list hooks) are now run to completion before returning the errors, so as to provide as much feedback as possible to the user.

## Config

```
...
      label: text({
        isRequired: true,
        hooks: {
          validateInput: ({ resolvedData, addValidationError }) => {
            if (resolvedData.label === 'bad') {
              addValidationError(`"${resolvedData.label}" is not allowed.`);
            }
          },
        },
      }),
      priority: select({
        dataType: 'enum',
        options: [
          { label: 'Low', value: 'low' },
          { label: 'Medium', value: 'medium' },
          { label: 'High', value: 'high' },
        ],
        isRequired: true,
      }),
...
```

## Before

<img width="710" alt="Screen Shot 2021-07-30 at 9 10 06 am" src="https://user-images.githubusercontent.com/616382/127576852-997a3028-5662-4322-b0a3-de918f969b33.png">

## After

<img width="707" alt="Screen Shot 2021-07-30 at 9 06 18 am" src="https://user-images.githubusercontent.com/616382/127576594-826c8ab6-5dae-45fb-b28b-a97bce559359.png">
