### PR TITLE
Remove unused code path

### DIFF
--- a/.changeset/empty-baboons-unite.md
+++ b/.changeset/empty-baboons-unite.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Removed unused code path in Admin UI error display.

--- a/packages/keystone/src/admin-ui/components/GraphQLErrorNotice.tsx
+++ b/packages/keystone/src/admin-ui/components/GraphQLErrorNotice.tsx
@@ -15,18 +15,9 @@ export function GraphQLErrorNotice({ errors, networkError }: GraphQLErrorNoticeP
   if (errors?.length) {
     return (
       <Stack gap="small">
-        {errors.map(err => {
-          const errButAny: any = err;
-          if (
-            err.message === 'You attempted to perform an invalid mutation' &&
-            errButAny.data?.messages?.length
-          ) {
-            return errButAny.data.messages.map((message: string) => (
-              <Notice tone="negative">{message}</Notice>
-            ));
-          }
-          return <Notice tone="negative">{err.message}</Notice>;
-        })}
+        {errors.map(err => (
+          <Notice tone="negative">{err.message}</Notice>
+        ))}
       </Stack>
     );
   }


### PR DESCRIPTION
Our validation errors don't contain the kind of data that was being checked for here. They probably will at some point in the future, but for now let's get rid of this dead code.