### PR TITLE
Preserve whitespace in errors

### DIFF
--- a/.changeset/eleven-mayflies-kneel.md
+++ b/.changeset/eleven-mayflies-kneel.md
@@ -1,0 +1,6 @@
+---
+'@keystone-ui/notice': patch
+'@keystone-ui/toast': patch
+---
+
+Updated css to preserve whitespace formatting of error messages.

--- a/design-system/packages/notice/src/Notice.tsx
+++ b/design-system/packages/notice/src/Notice.tsx
@@ -65,6 +65,7 @@ export const Notice = ({
           flex: 1,
           flexDirection: 'row',
           outline: 0,
+          'white-space': 'pre-wrap',
           ...styles.box,
         }}
         tabIndex={0}

--- a/design-system/packages/toast/src/Toast.tsx
+++ b/design-system/packages/toast/src/Toast.tsx
@@ -165,6 +165,7 @@ export const ToastElement = forwardRef<HTMLDivElement, ToastElementProps>((props
         width: 380, // less than desirable magic number, but not sure if this needs to be in theme...
         maxWidth: '100%',
         padding: spacing.large,
+        'white-space': 'pre-wrap',
       }}
       {...rest}
     >


### PR DESCRIPTION
The aim here is to preserve white-space from the error messages returned by the GraphQL API.

@gwyneplaine Is this the right approach? Are there are places these errors are surfaced that might also need this change?