### PR TITLE
Update hooks error handling

### DIFF
--- a/.changeset/olive-maps-serve.md
+++ b/.changeset/olive-maps-serve.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Added more details to before/after change/delete hook error messages.

--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -7,6 +7,11 @@ export const validationFailureError = (messages: string[]) => {
   return new ApolloError(`You provided invalid data for this operation.\n${s}`);
 };
 
+export const extensionError = (extension: string, messages: string[]) => {
+  const s = messages.map(m => `  - ${m}`).join('\n');
+  return new ApolloError(`An error occured while running "${extension}".\n${s}`);
+};
+
 // FIXME: In an upcoming PR we will use these args to construct a better
 // error message, so leaving the, here for now. - TL
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -103,8 +103,8 @@ const runner = setupTestRunner({
 
         // Returns null and throws an error
         expect(data).toEqual({ createUser: null });
-        expectExtensionError(errors, [
-          { path: ['createUser'], message: `Simulated error: ${phase}Change` },
+        expectExtensionError(errors, `${phase}Change`, [
+          { path: ['createUser'], messages: [`User: Simulated error: ${phase}Change`] },
         ]);
 
         // Only the original user should exist for 'before', both exist for 'after'
@@ -130,8 +130,8 @@ const runner = setupTestRunner({
 
         // Returns null and throws an error
         expect(data).toEqual({ updateUser: null });
-        expectExtensionError(errors, [
-          { path: ['updateUser'], message: `Simulated error: ${phase}Change` },
+        expectExtensionError(errors, `${phase}Change`, [
+          { path: ['updateUser'], messages: [`User: Simulated error: ${phase}Change`] },
         ]);
 
         // User should have its original name for 'before', and the new name for 'after'.
@@ -160,8 +160,8 @@ const runner = setupTestRunner({
 
         // Returns null and throws an error
         expect(data).toEqual({ deleteUser: null });
-        expectExtensionError(errors, [
-          { path: ['deleteUser'], message: `Simulated error: ${phase}Delete` },
+        expectExtensionError(errors, `${phase}Delete`, [
+          { path: ['deleteUser'], messages: [`User: Simulated error: ${phase}Delete`] },
         ]);
 
         // Bad users should still be in the database for 'before', deleted for 'after'.
@@ -200,9 +200,9 @@ const runner = setupTestRunner({
           ],
         });
         // The invalid creates should have errors which point to the nulls in their path
-        expectExtensionError(errors, [
-          { path: ['createUsers', 1], message: `Simulated error: ${phase}Change` },
-          { path: ['createUsers', 3], message: `Simulated error: ${phase}Change` },
+        expectExtensionError(errors, `${phase}Change`, [
+          { path: ['createUsers', 1], messages: [`User: Simulated error: ${phase}Change`] },
+          { path: ['createUsers', 3], messages: [`User: Simulated error: ${phase}Change`] },
         ]);
 
         // Three users should exist in the database for 'before,' five for 'after'.
@@ -256,9 +256,9 @@ const runner = setupTestRunner({
           ],
         });
         // The invalid updates should have errors which point to the nulls in their path
-        expectExtensionError(errors, [
-          { path: ['updateUsers', 1], message: `Simulated error: ${phase}Change` },
-          { path: ['updateUsers', 3], message: `Simulated error: ${phase}Change` },
+        expectExtensionError(errors, `${phase}Change`, [
+          { path: ['updateUsers', 1], messages: [`User: Simulated error: ${phase}Change`] },
+          { path: ['updateUsers', 3], messages: [`User: Simulated error: ${phase}Change`] },
         ]);
 
         // All users should still exist in the database, un-changed for `before`, changed for `after`.
@@ -307,9 +307,9 @@ const runner = setupTestRunner({
           ],
         });
         // The invalid deletes should have errors which point to the nulls in their path
-        expectExtensionError(errors, [
-          { path: ['deleteUsers', 1], message: `Simulated error: ${phase}Delete` },
-          { path: ['deleteUsers', 3], message: `Simulated error: ${phase}Delete` },
+        expectExtensionError(errors, `${phase}Delete`, [
+          { path: ['deleteUsers', 1], messages: [`User: Simulated error: ${phase}Delete`] },
+          { path: ['deleteUsers', 3], messages: [`User: Simulated error: ${phase}Delete`] },
         ]);
 
         // Three users should still exist in the database for `before`, only 1 for `after`.
@@ -343,8 +343,14 @@ const runner = setupTestRunner({
             data: { title: `trigger ${phase}`, content: `trigger ${phase}` },
           },
         });
-        expectExtensionError(errors, [
-          { path: ['updatePost'], message: `Simulated error: title: ${phase}Change` },
+        expectExtensionError(errors, `${phase}Change`, [
+          {
+            path: ['updatePost'],
+            messages: [
+              `Post.title: Simulated error: title: ${phase}Change`,
+              `Post.content: Simulated error: content: ${phase}Change`,
+            ],
+          },
         ]);
         expect(data).toEqual({ updatePost: null });
 
@@ -371,8 +377,14 @@ const runner = setupTestRunner({
           query: `mutation ($id: ID!) { deletePost(where: { id: $id }) { id } }`,
           variables: { id: post.id },
         });
-        expectExtensionError(errors, [
-          { path: ['deletePost'], message: `Simulated error: title: ${phase}Delete` },
+        expectExtensionError(errors, `${phase}Delete`, [
+          {
+            path: ['deletePost'],
+            messages: [
+              `Post.title: Simulated error: title: ${phase}Delete`,
+              `Post.content: Simulated error: content: ${phase}Delete`,
+            ],
+          },
         ]);
         expect(data).toEqual({ deletePost: null });
 

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -85,12 +85,17 @@ export const expectValidationError = (
 
 export const expectExtensionError = (
   errors: readonly any[] | undefined,
-  args: { path: (string | number)[]; message: string }[]
+  extensionName: string,
+  args: { path: (string | number)[]; messages: string[] }[]
 ) => {
-  const unpackedErrors = (errors || []).map(({ locations, ...unpacked }) => ({
-    ...unpacked,
-  }));
-  expect(unpackedErrors).toEqual(args.map(({ path, message }) => ({ path, message })));
+  const unpackedErrors = unpackErrors(errors);
+  expect(unpackedErrors).toEqual(
+    args.map(({ path, messages }) => ({
+      extensions: { code: undefined },
+      path,
+      message: `An error occured while running "${extensionName}".\n${j(messages)}`,
+    }))
+  );
 };
 
 export const expectPrismaError = (


### PR DESCRIPTION
Updates error messages returned from before/after change/delete hooks to include more context about where the error occurred. Also properly captures the case where multiple field hooks fail.

## Before
<img width="713" alt="Screen Shot 2021-08-02 at 1 32 26 pm" src="https://user-images.githubusercontent.com/616382/127801018-6fd2cd92-6dfb-4ab1-a666-6cb303758faf.png">

## After

<img width="717" alt="Screen Shot 2021-08-02 at 1 31 12 pm" src="https://user-images.githubusercontent.com/616382/127801026-962325eb-7f2d-494c-8ea1-57db86742cfc.png">

