### PR TITLE
Updated apollo package and fix types

### DIFF
--- a/.changeset/chilled-grapes-cry.md
+++ b/.changeset/chilled-grapes-cry.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/example-ecommerce': patch
+'@keystone-next/fields-document': patch
+'@keystone-next/keystone': patch
+---
+
+Updated internal type definitions.

--- a/examples-staging/ecommerce/access.ts
+++ b/examples-staging/ecommerce/access.ts
@@ -1,4 +1,4 @@
-import { permissionsList } from './schemas/fields';
+import { Permission, permissionsList } from './schemas/fields';
 import { ListAccessArgs } from './types';
 // At it's simplest, the access control returns a yes or no value depending on the users session
 
@@ -13,7 +13,7 @@ const generatedPermissions = Object.fromEntries(
       return !!session?.data.role?.[permission];
     },
   ])
-);
+) as Record<Permission, ({ session }: ListAccessArgs) => boolean>;
 
 // Permissions check if someone meets a criteria - yes or no.
 export const permissions = {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/utils.ts
@@ -103,11 +103,11 @@ export function getDocumentFeaturesForChildField(
   const inlineMarks =
     inlineMarksFromOptions === 'inherit'
       ? 'inherit'
-      : Object.fromEntries(
+      : (Object.fromEntries(
           Object.keys(editorDocumentFeatures.formatting.inlineMarks).map(mark => {
             return [mark as Mark, !!(inlineMarksFromOptions || {})[mark as Mark]];
           })
-        );
+        ) as Record<Mark, boolean>);
   if (options.kind === 'inline') {
     return {
       kind: 'inline',

--- a/packages/fields-document/src/DocumentEditor/toolbar-state.tsx
+++ b/packages/fields-document/src/DocumentEditor/toolbar-state.tsx
@@ -121,7 +121,7 @@ export const createToolbarState = (
     match: node => node.type !== 'code' && Editor.isBlock(editor, node),
   });
   const editorMarks = Editor.marks(editor) || {};
-  const marks: ToolbarState['marks'] = Object.fromEntries(
+  const marks = Object.fromEntries(
     allMarks.map(mark => [
       mark,
       {
@@ -132,7 +132,7 @@ export const createToolbarState = (
         isSelected: !!editorMarks[mark],
       },
     ])
-  );
+  ) as ToolbarState['marks'];
 
   // Editor.marks is "what are the marks that would be applied if text was inserted now"
   // that's not really the UX we want, if we have some a document like this

--- a/packages/keystone/src/lib/context/itemAPI.ts
+++ b/packages/keystone/src/lib/context/itemAPI.ts
@@ -40,15 +40,13 @@ export function getDbAPIFactory(
     deleteOne: f(mutationFields[gqlNames.deleteMutationName]),
     deleteMany: f(mutationFields[gqlNames.deleteManyMutationName]),
   };
-  return (context: KeystoneContext) => {
-    let obj = Object.fromEntries(
+  return (context: KeystoneContext) =>
+    Object.fromEntries(
       objectEntriesButUsingKeyof(api).map(([key, impl]) => [
         key,
         (args: Record<string, any>) => impl(args, context),
       ])
-    );
-    return obj;
-  };
+    ) as Record<keyof typeof api, any>;
 }
 
 function defaultQueryParam(query?: string, resolveFields?: string | false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,11 +41,9 @@
     long "^4.0.0"
 
 "@apollographql/apollo-tools@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.5.0.tgz#81aadcabb35eeab6ef7e0d3d6c592a6fe15e66d9"
-  integrity sha512-7IOZHVaKjBq44StXFJEITl4rxgZCsZFSWogAvIErKR9DYV20rt9bJ2mY5lCn+zghfGrweykjLb9g4TDxLg750w==
-  dependencies:
-    apollo-env "^0.10.0"
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.5.1.tgz#f0baef739ff7e2fafcb8b98ad29f6ac817e53e32"
+  integrity sha512-ZII+/xUFfb9ezDU2gad114+zScxVFMVlZ91f8fGApMzlS1kkqoyLnC4AJaQ1Ya/X+b63I20B4Gd+eCL8QuB4sA==
 
 "@apollographql/graphql-playground-html@1.6.27":
   version "1.6.27"
@@ -2881,7 +2879,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-fetch@^2.5.10", "@types/node-fetch@^2.5.12":
+"@types/node-fetch@^2.5.12":
   version "2.5.12"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
   integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
@@ -3486,16 +3484,6 @@ apollo-datasource@^0.9.0:
   dependencies:
     apollo-server-caching "^0.7.0"
     apollo-server-env "^3.1.0"
-
-apollo-env@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/apollo-env/-/apollo-env-0.10.0.tgz#8dd51bf974253a760ea15c81e870ff2c0d6e6820"
-  integrity sha512-7Geot+eyOl4jzPi9beiszeDmEEVZOVT11LSlkQluF5eaCNaIvld+xklZxITZGI/Wr+PQX380YJgQt1ndR2GtOg==
-  dependencies:
-    "@types/node-fetch" "^2.5.10"
-    core-js "^3.0.1"
-    node-fetch "^2.6.1"
-    sha.js "^2.4.11"
 
 apollo-graphql@^0.9.0:
   version "0.9.3"
@@ -5022,7 +5010,7 @@ core-js@3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
-core-js@^3.0.1, core-js@^3.1.3:
+core-js@^3.1.3:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.16.0.tgz#1d46fb33720bc1fa7f90d20431f36a5540858986"
   integrity sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g==


### PR DESCRIPTION
Updating this package removes the `apollo-env` dependency which means we no longer get the following polyfill injected:

https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo-env/src/polyfills/object.ts

As such we have to update some types throughout the code.