### PR TITLE
Update website search config to match new DocSearch config

### DIFF
--- a/docs/components/Header.tsx
+++ b/docs/components/Header.tsx
@@ -128,6 +128,9 @@ export function Header() {
           apiKey: '211e94c001e6b4c6744ae72fb252eaba',
           indexName: 'keystonejs',
           inputSelector: '#search-field',
+          algoliaOptions: {
+            facetFilters: ['tags:stable'],
+          },
         });
       } else if (searchAttempt >= 10) {
         // @ts-ignore


### PR DESCRIPTION
Allows DocSearch to be used on both `v5` and `v6` websites.

Waiting for https://github.com/algolia/docsearch-configs/pull/4441 to be merged, when it is this needs to be merged ASAP.