### PR TITLE
Integration tests admin UI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -314,7 +314,7 @@ jobs:
       DATABASE_URL: 'file:./test.db'
     strategy:
       matrix:
-        test: ['init.test.ts', 'list-view-crud.test.ts']
+        test: ['init.test.ts', 'list-view-crud.test.ts', 'navigation.test.ts']
       fail-fast: false
     steps:
       - name: Checkout Repo

--- a/tests/admin-ui-tests/init.test.ts
+++ b/tests/admin-ui-tests/init.test.ts
@@ -10,19 +10,25 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
     await page.goto('http://localhost:3000');
   });
-  test('Task List card should be visible', async () => {
-    await page.waitForSelector('h3:has-text("Task")');
+  // test('Task List card should be visible', async () => {
+  //   await page.waitForSelector('h3:has-text("Task")');
+  // });
+  test('Clicking on the logo should return you to the Dashboard route', async () => {
+    await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
+    expect(page.url()).toBe('http://localhost:3000/tasks');
+    await Promise.all([page.waitForNavigation(), page.click('h3 a:has-text("Keystone 6")')]);
+    expect(page.url()).toBe('http://localhost:3000/');
   });
-  test('Should see a 404 on request of the /init route', async () => {
-    await page.goto('http://localhost:3000/init');
-    const content = await page.textContent('body h1');
-    expect(content).toBe('404');
-  });
-  test('Should see a 404 on request of the /signin route', async () => {
-    await page.goto('http://localhost:3000/signin');
-    const content = await page.textContent('body h1');
-    expect(content).toBe('404');
-  });
+  // test('Should see a 404 on request of the /init route', async () => {
+  //   await page.goto('http://localhost:3000/init');
+  //   const content = await page.textContent('body h1');
+  //   expect(content).toBe('404');
+  // });
+  // test('Should see a 404 on request of the /signin route', async () => {
+  //   await page.goto('http://localhost:3000/signin');
+  //   const content = await page.textContent('body h1');
+  //   expect(content).toBe('404');
+  // });
   afterAll(async () => {
     await browser.close();
   });

--- a/tests/admin-ui-tests/init.test.ts
+++ b/tests/admin-ui-tests/init.test.ts
@@ -14,11 +14,14 @@ adminUITests('./tests/test-projects/basic', browserType => {
     await page.waitForSelector('h3:has-text("Task")');
   });
   test('Clicking on the logo should return you to the Dashboard route', async () => {
-    await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
-    expect(page.url()).toBe('http://localhost:3000/tasks');
+    await page.goto('http://localhost:3000/tasks');
     await page.waitForSelector('h3 a:has-text("Keystone 6")');
-    await Promise.all([page.waitForNavigation(), page.click('h3 a:has-text("Keystone 6")')]);
-    expect(page.url()).toBe('http://localhost:3000/');
+    await Promise.all([
+      page.waitForNavigation({
+        url: 'http://localhost:3000',
+      }),
+      page.click('h3 a:has-text("Keystone 6")'),
+    ]);
   });
   test('Should see a 404 on request of the /init route', async () => {
     await page.goto('http://localhost:3000/init');

--- a/tests/admin-ui-tests/init.test.ts
+++ b/tests/admin-ui-tests/init.test.ts
@@ -16,6 +16,7 @@ adminUITests('./tests/test-projects/basic', browserType => {
   test('Clicking on the logo should return you to the Dashboard route', async () => {
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
     expect(page.url()).toBe('http://localhost:3000/tasks');
+    await page.waitForSelector('h3 a:has-text("Keystone 6")');
     await Promise.all([page.waitForNavigation(), page.click('h3 a:has-text("Keystone 6")')]);
     expect(page.url()).toBe('http://localhost:3000/');
   });

--- a/tests/admin-ui-tests/init.test.ts
+++ b/tests/admin-ui-tests/init.test.ts
@@ -10,25 +10,25 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
     await page.goto('http://localhost:3000');
   });
-  // test('Task List card should be visible', async () => {
-  //   await page.waitForSelector('h3:has-text("Task")');
-  // });
+  test('Task List card should be visible', async () => {
+    await page.waitForSelector('h3:has-text("Task")');
+  });
   test('Clicking on the logo should return you to the Dashboard route', async () => {
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
     expect(page.url()).toBe('http://localhost:3000/tasks');
     await Promise.all([page.waitForNavigation(), page.click('h3 a:has-text("Keystone 6")')]);
     expect(page.url()).toBe('http://localhost:3000/');
   });
-  // test('Should see a 404 on request of the /init route', async () => {
-  //   await page.goto('http://localhost:3000/init');
-  //   const content = await page.textContent('body h1');
-  //   expect(content).toBe('404');
-  // });
-  // test('Should see a 404 on request of the /signin route', async () => {
-  //   await page.goto('http://localhost:3000/signin');
-  //   const content = await page.textContent('body h1');
-  //   expect(content).toBe('404');
-  // });
+  test('Should see a 404 on request of the /init route', async () => {
+    await page.goto('http://localhost:3000/init');
+    const content = await page.textContent('body h1');
+    expect(content).toBe('404');
+  });
+  test('Should see a 404 on request of the /signin route', async () => {
+    await page.goto('http://localhost:3000/signin');
+    const content = await page.textContent('body h1');
+    expect(content).toBe('404');
+  });
   afterAll(async () => {
     await browser.close();
   });

--- a/tests/admin-ui-tests/list-view-crud.test.ts
+++ b/tests/admin-ui-tests/list-view-crud.test.ts
@@ -1,30 +1,10 @@
 import { Browser, Page } from 'playwright';
-import fetch from 'node-fetch';
-import { adminUITests, deleteAllData } from './utils';
+
+import { makeGqlRequest, adminUITests, deleteAllData } from './utils';
 
 adminUITests('./tests/test-projects/crud-notifications', browserType => {
   let browser: Browser = undefined as any;
   let page: Page = undefined as any;
-  const seedData = async (query: string, variables?: Record<string, any>) => {
-    try {
-      const { errors } = await fetch('http://localhost:3000/api/graphql', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          query,
-          variables,
-        }),
-      }).then(res => res.json());
-      if (errors) {
-        throw errors;
-      }
-    } catch (e) {
-      console.log(e);
-      throw e;
-    }
-  };
 
   beforeAll(async () => {
     browser = await browserType.launch();
@@ -46,7 +26,7 @@ adminUITests('./tests/test-projects/crud-notifications', browserType => {
         }
       }
     `;
-    await seedData(query);
+    await makeGqlRequest(query);
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
     await page.waitForSelector('tbody tr:first-of-type td:first-of-type label');
     await page.click('tbody tr:first-of-type td:first-of-type label');
@@ -71,7 +51,7 @@ adminUITests('./tests/test-projects/crud-notifications', browserType => {
         }
       }
     `;
-    await seedData(query);
+    await makeGqlRequest(query);
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000/tasks')]);
     await page.click('tbody tr:first-of-type td:first-of-type label');
     await page.click('button:has-text("Delete")');
@@ -105,7 +85,7 @@ adminUITests('./tests/test-projects/crud-notifications', browserType => {
         }
       }),
     };
-    await seedData(query, variables);
+    await makeGqlRequest(query, variables);
     await Promise.all([
       page.waitForNavigation(),
       page.goto('http://localhost:3000/tasks?sortBy=label&page=1'),

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -33,6 +33,7 @@ adminUITests('./tests/test-projects/basic', browserType => {
   });
   test('Can not access hidden lists via the navigation', async () => {
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000')]);
+    await page.waitForSelector('nav');
     const navItems = await page.$$('nav li a');
     const navLinks = await Promise.all(
       navItems.map(navItem => {

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -10,20 +10,20 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
     await page.goto('http://localhost:3000');
   });
-  // test('Nav contains a Dashboard route by default', async () => {
-  //   await page.waitForSelector('nav a:has-text("Dashboard")');
-  // });
-  // test('When at the index, the Dashboard NavItem is selected', async () => {
-  //   const element = await page.waitForSelector('nav a:has-text("Dashboard")');
-  //   const ariaCurrent = await element?.getAttribute('aria-current');
-  //   expect(ariaCurrent).toBe('location');
-  // });
-  // test('When navigated to a List route, the representative list NavItem is selected', async () => {
-  //   await page.goto('http://localhost:3000/tasks');
-  //   const element = await page.waitForSelector('nav a:has-text("Tasks")');
-  //   const ariaCurrent = await element?.getAttribute('aria-current');
-  //   expect(ariaCurrent).toBe('location');
-  // });
+  test('Nav contains a Dashboard route by default', async () => {
+    await page.waitForSelector('nav a:has-text("Dashboard")');
+  });
+  test('When at the index, the Dashboard NavItem is selected', async () => {
+    const element = await page.waitForSelector('nav a:has-text("Dashboard")');
+    const ariaCurrent = await element?.getAttribute('aria-current');
+    expect(ariaCurrent).toBe('location');
+  });
+  test('When navigated to a List route, the representative list NavItem is selected', async () => {
+    await page.goto('http://localhost:3000/tasks');
+    const element = await page.waitForSelector('nav a:has-text("Tasks")');
+    const ariaCurrent = await element?.getAttribute('aria-current');
+    expect(ariaCurrent).toBe('location');
+  });
   test('Can access all list pages via the navigation', async () => {
     await page.goto('http://localhost:3000');
     await Promise.all([

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -10,26 +10,34 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
     await page.goto('http://localhost:3000');
   });
-  test('Nav contains a Dashboard route by default', async () => {
-    await page.waitForSelector('nav a:has-text("Dashboard")');
-  });
-  test('When at the index, the Dashboard NavItem is selected', async () => {
-    const element = await page.waitForSelector('nav a:has-text("Dashboard")');
-    const ariaCurrent = await element?.getAttribute('aria-current');
-    expect(ariaCurrent).toBe('location');
-  });
-  test('When navigated to a List route, the representative list NavItem is selected', async () => {
-    await page.goto('http://localhost:3000/tasks');
-    const element = await page.waitForSelector('nav a:has-text("Tasks")');
-    const ariaCurrent = await element?.getAttribute('aria-current');
-    expect(ariaCurrent).toBe('location');
-  });
+  // test('Nav contains a Dashboard route by default', async () => {
+  //   await page.waitForSelector('nav a:has-text("Dashboard")');
+  // });
+  // test('When at the index, the Dashboard NavItem is selected', async () => {
+  //   const element = await page.waitForSelector('nav a:has-text("Dashboard")');
+  //   const ariaCurrent = await element?.getAttribute('aria-current');
+  //   expect(ariaCurrent).toBe('location');
+  // });
+  // test('When navigated to a List route, the representative list NavItem is selected', async () => {
+  //   await page.goto('http://localhost:3000/tasks');
+  //   const element = await page.waitForSelector('nav a:has-text("Tasks")');
+  //   const ariaCurrent = await element?.getAttribute('aria-current');
+  //   expect(ariaCurrent).toBe('location');
+  // });
   test('Can access all list pages via the navigation', async () => {
     await page.goto('http://localhost:3000');
-    await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("Tasks")')]);
-    expect(page.url()).toBe('http://localhost:3000/tasks');
-    await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("People")')]);
-    expect(page.url()).toBe('http://localhost:3000/people');
+    await Promise.all([
+      page.waitForNavigation({
+        url: 'http://localhost:3000/tasks',
+      }),
+      page.click('nav a:has-text("Tasks")'),
+    ]);
+    await Promise.all([
+      page.waitForNavigation({
+        url: 'http://localhost:3000/people',
+      }),
+      page.click('nav a:has-text("People")'),
+    ]);
   });
   test('Can not access hidden lists via the navigation', async () => {
     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000')]);

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -31,13 +31,17 @@ adminUITests('./tests/test-projects/basic', browserType => {
     await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("People")')]);
     expect(page.url()).toBe('http://localhost:3000/people');
   });
-  //   test('Can not access hidden lists via the navigation', async () => {
-  //     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000')]);
-  //     const nav = await page.waitForSelector('nav');
-  //     console.log('NAV ELEMENT', nav);
-  //     const navItems = await nav.$$eval('li', elements => elements);
-  //     console.log('NAVITEMS', navItems);
-  //   });
+  test('Can not access hidden lists via the navigation', async () => {
+    await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000')]);
+    const navItems = await page.$$('nav li a');
+    const navLinks = await Promise.all(
+      navItems.map(navItem => {
+        return navItem.getAttribute('href');
+      })
+    );
+    expect(navLinks.length).toBe(3);
+    expect(navLinks.includes('/secretplans')).toBe(false);
+  });
   test('When navigated to an Item view, the representative list NavItem is selected', async () => {
     await page.goto('http://localhost:3000');
     await page.click('button[title="Create Task"]');

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -31,10 +31,13 @@ adminUITests('./tests/test-projects/basic', browserType => {
     await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("People")')]);
     expect(page.url()).toBe('http://localhost:3000/people');
   });
-  test('Can not access hidden lists via the navigation', async () => {
-    await page.goto('http://localhost:3000');
-    await page.waitForSelector('nav a:has-text("Tasks")', { state: 'detached' });
-  });
+  //   test('Can not access hidden lists via the navigation', async () => {
+  //     await Promise.all([page.waitForNavigation(), page.goto('http://localhost:3000')]);
+  //     const nav = await page.waitForSelector('nav');
+  //     console.log('NAV ELEMENT', nav);
+  //     const navItems = await nav.$$eval('li', elements => elements);
+  //     console.log('NAVITEMS', navItems);
+  //   });
   test('When navigated to an Item view, the representative list NavItem is selected', async () => {
     await page.goto('http://localhost:3000');
     await page.click('button[title="Create Task"]');

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -24,6 +24,17 @@ adminUITests('./tests/test-projects/basic', browserType => {
     const ariaCurrent = await element?.getAttribute('aria-current');
     expect(ariaCurrent).toBe('location');
   });
+  test('Can access all list pages via the navigation', async () => {
+    await page.goto('http://localhost:3000');
+    await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("Tasks")')]);
+    expect(page.url()).toBe('http://localhost:3000/tasks');
+    await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("People")')]);
+    expect(page.url()).toBe('http://localhost:3000/people');
+  });
+  test('Can not access hidden lists via the navigation', async () => {
+    await page.goto('http://localhost:3000');
+    await page.waitForSelector('nav a:has-text("Tasks")', { state: 'detached' });
+  });
   test('When navigated to an Item view, the representative list NavItem is selected', async () => {
     await page.goto('http://localhost:3000');
     await page.click('button[title="Create Task"]');

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -1,0 +1,48 @@
+import { Browser, Page } from 'playwright';
+import { adminUITests } from './utils';
+
+adminUITests('./tests/test-projects/basic', browserType => {
+  let browser: Browser = undefined as any;
+  let page: Page = undefined as any;
+
+  beforeAll(async () => {
+    browser = await browserType.launch();
+    page = await browser.newPage();
+    await page.goto('http://localhost:3000');
+  });
+  test('Nav contains a Dashboard route by default', async () => {
+    await page.waitForSelector('nav a:has-text("Dashboard")');
+  });
+  test('When at the index, the Dashboard NavItem is selected', async () => {
+    const element = await page.waitForSelector('nav a:has-text("Dashboard")');
+    const ariaCurrent = await element?.getAttribute('aria-current');
+    expect(ariaCurrent).toBe('location');
+  });
+  test('When navigated to a List route, the representative list NavItem is selected', async () => {
+    await page.goto('http://localhost:3000/tasks');
+    const element = await page.waitForSelector('nav a:has-text("Tasks")');
+    const ariaCurrent = await element?.getAttribute('aria-current');
+    expect(ariaCurrent).toBe('location');
+  });
+  test('When navigated to an Item view, the representative list NavItem is selected', async () => {
+    await page.goto('http://localhost:3000');
+    await page.click('button[title="Create Task"]');
+    await page.fill('id=label', 'Test Task');
+    await Promise.all([page.waitForNavigation(), page.click('button[type="submit"]')]);
+    const element = await page.waitForSelector('nav a:has-text("Tasks")');
+    const ariaCurrent = await element?.getAttribute('aria-current');
+    expect(ariaCurrent).toBe('location');
+  });
+  test('When pressing a list view nav item from an item view, the correct route should be reached', async () => {
+    await page.goto('http://localhost:3000');
+    await page.click('button[title="Create Task"]');
+    await page.fill('id=label', 'Test Task');
+    await Promise.all([page.waitForNavigation(), page.click('button[type="submit"]')]);
+    await Promise.all([page.waitForNavigation(), page.click('nav a:has-text("Tasks")')]);
+
+    expect(page.url()).toBe('http://localhost:3000/tasks');
+  });
+  afterAll(async () => {
+    await browser.close();
+  });
+});

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { promisify } from 'util';
+import fetch from 'node-fetch';
 import execa from 'execa';
 import _treeKill from 'tree-kill';
 import * as playwright from 'playwright';
@@ -20,6 +21,27 @@ const promiseSignal = (): Promise<void> & { resolve: () => void } => {
   return Object.assign(promise, { resolve: resolve as any });
 };
 const projectRoot = findRootSync(process.cwd());
+
+export const makeGqlRequest = async (query: string, variables?: Record<string, any>) => {
+  try {
+    const { errors } = await fetch('http://localhost:3000/api/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    }).then(res => res.json());
+    if (errors) {
+      throw errors;
+    }
+  } catch (e) {
+    console.log(e);
+    throw e;
+  }
+};
 
 export const deleteAllData: (projectDir: string) => Promise<void> = async (projectDir: string) => {
   const { PrismaClient } = require(path.resolve(

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -38,7 +38,6 @@ export const makeGqlRequest = async (query: string, variables?: Record<string, a
       throw errors;
     }
   } catch (e) {
-    console.log(e);
     throw e;
   }
 };

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -23,22 +23,19 @@ const promiseSignal = (): Promise<void> & { resolve: () => void } => {
 const projectRoot = findRootSync(process.cwd());
 
 export const makeGqlRequest = async (query: string, variables?: Record<string, any>) => {
-  try {
-    const { errors } = await fetch('http://localhost:3000/api/graphql', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        query,
-        variables,
-      }),
-    }).then(res => res.json());
-    if (errors) {
-      throw new Error(`graphql errors: ${errors.map((x: Error) => x.message).join('\n')}`);
-    }
-  } catch (e) {
-    throw e;
+  const { errors } = await fetch('http://localhost:3000/api/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  }).then(res => res.json());
+
+  if (errors) {
+    throw new Error(`graphql errors: ${errors.map((x: Error) => x.message).join('\n')}`);
   }
 };
 

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -35,7 +35,7 @@ export const makeGqlRequest = async (query: string, variables?: Record<string, a
       }),
     }).then(res => res.json());
     if (errors) {
-      throw errors;
+      throw new Error(`graphql errors: ${errors.map((x: Error) => x.message).join('\n')}`);
     }
   } catch (e) {
     throw e;

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -208,23 +208,19 @@ type SecretPlan {
   description: String
 }
 
+input SecretPlanWhereUniqueInput {
+  id: ID
+}
+
 input SecretPlanWhereInput {
   AND: [SecretPlanWhereInput!]
   OR: [SecretPlanWhereInput!]
   NOT: [SecretPlanWhereInput!]
   id: IDFilter
-  label: StringNullableFilter
-  description: StringNullableFilter
-}
-
-input SecretPlanWhereUniqueInput {
-  id: ID
 }
 
 input SecretPlanOrderByInput {
   id: OrderDirection
-  label: OrderDirection
-  description: OrderDirection
 }
 
 input SecretPlanUpdateInput {

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -310,7 +310,7 @@ type Query {
   secretPlans(
     where: SecretPlanWhereInput! = {}
     orderBy: [SecretPlanOrderByInput!]! = []
-    first: Int
+    take: Int
     skip: Int! = 0
   ): [SecretPlan!]
   secretPlan(where: SecretPlanWhereUniqueInput!): SecretPlan

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -211,26 +211,10 @@ type SecretPlan {
 input SecretPlanWhereInput {
   AND: [SecretPlanWhereInput!]
   OR: [SecretPlanWhereInput!]
-  id: ID
-  id_not: ID
-  id_lt: ID
-  id_lte: ID
-  id_gt: ID
-  id_gte: ID
-  id_in: [ID!]
-  id_not_in: [ID!]
-  label: String
-  label_not: String
-  label_contains: String
-  label_not_contains: String
-  label_in: [String]
-  label_not_in: [String]
-  description: String
-  description_not: String
-  description_contains: String
-  description_not_contains: String
-  description_in: [String]
-  description_not_in: [String]
+  NOT: [SecretPlanWhereInput!]
+  id: IDFilter
+  label: StringNullableFilter
+  description: StringNullableFilter
 }
 
 input SecretPlanWhereUniqueInput {

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -202,6 +202,62 @@ input TaskRelateToManyForCreateInput {
   connect: [TaskWhereUniqueInput!]
 }
 
+type SecretPlan {
+  id: ID!
+  label: String
+  description: String
+}
+
+input SecretPlanWhereInput {
+  AND: [SecretPlanWhereInput!]
+  OR: [SecretPlanWhereInput!]
+  id: ID
+  id_not: ID
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID!]
+  id_not_in: [ID!]
+  label: String
+  label_not: String
+  label_contains: String
+  label_not_contains: String
+  label_in: [String]
+  label_not_in: [String]
+  description: String
+  description_not: String
+  description_contains: String
+  description_not_contains: String
+  description_in: [String]
+  description_not_in: [String]
+}
+
+input SecretPlanWhereUniqueInput {
+  id: ID
+}
+
+input SecretPlanOrderByInput {
+  id: OrderDirection
+  label: OrderDirection
+  description: OrderDirection
+}
+
+input SecretPlanUpdateInput {
+  label: String
+  description: String
+}
+
+input SecretPlanUpdateArgs {
+  where: SecretPlanWhereUniqueInput!
+  data: SecretPlanUpdateInput!
+}
+
+input SecretPlanCreateInput {
+  label: String
+  description: String
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -223,6 +279,15 @@ type Mutation {
   updatePeople(data: [PersonUpdateArgs!]!): [Person]
   deletePerson(where: PersonWhereUniqueInput!): Person
   deletePeople(where: [PersonWhereUniqueInput!]!): [Person]
+  createSecretPlan(data: SecretPlanCreateInput!): SecretPlan
+  createSecretPlans(data: [SecretPlanCreateInput!]!): [SecretPlan]
+  updateSecretPlan(
+    where: SecretPlanWhereUniqueInput!
+    data: SecretPlanUpdateInput!
+  ): SecretPlan
+  updateSecretPlans(data: [SecretPlanUpdateArgs!]!): [SecretPlan]
+  deleteSecretPlan(where: SecretPlanWhereUniqueInput!): SecretPlan
+  deleteSecretPlans(where: [SecretPlanWhereUniqueInput!]!): [SecretPlan]
 }
 
 type Query {
@@ -242,6 +307,14 @@ type Query {
   ): [Person!]
   person(where: PersonWhereUniqueInput!): Person
   peopleCount(where: PersonWhereInput! = {}): Int
+  secretPlans(
+    where: SecretPlanWhereInput! = {}
+    orderBy: [SecretPlanOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [SecretPlan!]
+  secretPlan(where: SecretPlanWhereUniqueInput!): SecretPlan
+  secretPlansCount(where: SecretPlanWhereInput! = {}): Int
   keystone: KeystoneMeta!
 }
 

--- a/tests/test-projects/basic/schema.prisma
+++ b/tests/test-projects/basic/schema.prisma
@@ -28,3 +28,9 @@ model Person {
   name  String?
   tasks Task[]  @relation("Task_assignedTo")
 }
+
+model SecretPlan {
+  id          String  @id @default(cuid())
+  label       String?
+  description String?
+}

--- a/tests/test-projects/basic/schema.ts
+++ b/tests/test-projects/basic/schema.ts
@@ -29,4 +29,13 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
+  SecretPlan: list({
+    fields: {
+      label: text(),
+      description: text(),
+    },
+    ui: {
+      isHidden: true,
+    },
+  }),
 });


### PR DESCRIPTION
This PR contains:
* Integration tests for admin-ui, centred mostly around Navigation
* Name change to the `seedData` helper, and moving it into the `utils` file 