### PR TITLE
Check exceptions returned from GraphQL

### DIFF
--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -70,13 +70,15 @@ describe('extendGraphqlSchema', () => {
     runner(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: `
-              query {
-                quads(x: 10)
-              }
-            `,
+          query {
+            quads(x: 10)
+          }
+        `,
       });
       expect(body.data).toEqual({ quads: null });
-      expectInternalServerError(body.errors, [{ path: ['quads'], message: 'Access denied' }]);
+      expectInternalServerError(body.errors, false, [
+        { path: ['quads'], message: 'Access denied' },
+      ]);
     })
   );
   it(

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -284,7 +284,7 @@ describe('Document field type', () => {
       });
       // FIXME: The path doesn't match the null field here!
       expect(body.data).toEqual({ author: { badBio: null } });
-      expectInternalServerError(body.errors, [
+      expectInternalServerError(body.errors, true, [
         {
           path: ['author', 'badBio', 'document'],
           message: 'Cannot query field "bad" on type "Author". Did you mean "bio" or "id"?',

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -76,6 +76,8 @@ testModules
                 message: expect.stringMatching(
                   /\nInvalid `prisma\.test\.create\(\)` invocation:\n(.*\n){2}  Unique constraint failed on the fields: \(`testField`\)/
                 ),
+                code: 'P2002',
+                target: ['testField'],
               },
             ]);
           })
@@ -104,6 +106,8 @@ testModules
                 message: expect.stringMatching(
                   /\nInvalid `prisma\.test\.create\(\)` invocation:\n(.*\n){2}  Unique constraint failed on the fields: \(`testField`\)/
                 ),
+                code: 'P2002',
+                target: ['testField'],
               },
             ]);
           })

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -115,7 +115,7 @@ const runner = setupTestRunner({
             // Returns null and throws an error
             expect(data).toEqual({ createUser: null });
             const message = `Simulated error: ${phase}Change`;
-            expectExtensionError(mode, errors, `${phase}Change`, [
+            expectExtensionError(mode, false, errors, `${phase}Change`, [
               {
                 path: ['createUser'],
                 messages: [`User: Simulated error: ${phase}Change`],
@@ -157,7 +157,7 @@ const runner = setupTestRunner({
             // Returns null and throws an error
             expect(data).toEqual({ updateUser: null });
             const message = `Simulated error: ${phase}Change`;
-            expectExtensionError(mode, errors, `${phase}Change`, [
+            expectExtensionError(mode, false, errors, `${phase}Change`, [
               {
                 path: ['updateUser'],
                 messages: [`User: ${message}`],
@@ -199,7 +199,7 @@ const runner = setupTestRunner({
             // Returns null and throws an error
             expect(data).toEqual({ deleteUser: null });
             const message = `Simulated error: ${phase}Delete`;
-            expectExtensionError(mode, errors, `${phase}Delete`, [
+            expectExtensionError(mode, false, errors, `${phase}Delete`, [
               {
                 path: ['deleteUser'],
                 messages: [`User: ${message}`],
@@ -251,7 +251,7 @@ const runner = setupTestRunner({
             });
             // The invalid creates should have errors which point to the nulls in their path
             const message = `Simulated error: ${phase}Change`;
-            expectExtensionError(mode, errors, `${phase}Change`, [
+            expectExtensionError(mode, false, errors, `${phase}Change`, [
               {
                 path: ['createUsers', 1],
                 messages: [`User: ${message}`],
@@ -330,7 +330,7 @@ const runner = setupTestRunner({
             });
             // The invalid updates should have errors which point to the nulls in their path
             const message = `Simulated error: ${phase}Change`;
-            expectExtensionError(mode, errors, `${phase}Change`, [
+            expectExtensionError(mode, false, errors, `${phase}Change`, [
               {
                 path: ['updateUsers', 1],
                 messages: [`User: ${message}`],
@@ -404,7 +404,7 @@ const runner = setupTestRunner({
             });
             // The invalid deletes should have errors which point to the nulls in their path
             const message = `Simulated error: ${phase}Delete`;
-            expectExtensionError(mode, errors, `${phase}Delete`, [
+            expectExtensionError(mode, false, errors, `${phase}Delete`, [
               {
                 path: ['deleteUsers', 1],
                 messages: [`User: ${message}`],
@@ -464,7 +464,7 @@ const runner = setupTestRunner({
             });
             const message1 = `Simulated error: title: ${phase}Change`;
             const message2 = `Simulated error: content: ${phase}Change`;
-            expectExtensionError(mode, errors, `${phase}Change`, [
+            expectExtensionError(mode, false, errors, `${phase}Change`, [
               {
                 path: ['updatePost'],
                 messages: [`Post.title: ${message1}`, `Post.content: ${message2}`],
@@ -512,7 +512,7 @@ const runner = setupTestRunner({
             const { data, errors } = body;
             const message1 = `Simulated error: title: ${phase}Delete`;
             const message2 = `Simulated error: content: ${phase}Delete`;
-            expectExtensionError(mode, errors, `${phase}Delete`, [
+            expectExtensionError(mode, true, errors, `${phase}Delete`, [
               {
                 path: ['deletePost'],
                 messages: [`Post.title: ${message1}`, `Post.content: ${message2}`],

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -123,11 +123,7 @@ export const expectPrismaError = (
     args.map(({ path, message, code, target }) => ({
       extensions: {
         code: 'INTERNAL_SERVER_ERROR',
-        exception: {
-          clientVersion: '2.28.0',
-          code,
-          meta: { target },
-        },
+        exception: { clientVersion: '2.28.0', code, meta: { target } },
       },
       path,
       message,


### PR DESCRIPTION
Stop throwing away `extensions.exception` and actually check its value. This becomes relevant now that we're trying to provide more control over precisely when stacktrace information is exposed to the GraphQL API.