### PR TITLE
Updates page update

### DIFF
--- a/docs/pages/updates/index.tsx
+++ b/docs/pages/updates/index.tsx
@@ -165,7 +165,32 @@ export default function WhatsNew() {
           gap: 0,
         })}
       >
-        <Timeline date="10th July 2021" isLatest />
+        <Timeline date="29th July 2021" isLatest />
+        <Box heading="Admin UI Customizations">
+          We're opening Admin UI up to support a more personal content experience. Now you can:
+          <ul>
+            <li>
+              embed your own <a href="/docs/guides/custom-admin-ui-logo">custom logo</a>,
+            </li>
+            <li>
+              add <a href="/docs/guides/custom-admin-ui-pages">custom pages</a> with Admin UI
+              routes, and
+            </li>
+            <li>
+              link to them (and elsewhere) with{' '}
+              <a href="/docs/guides/custom-admin-ui-navigation">custom navigation</a>.
+            </li>
+          </ul>
+          To deliver a more productive editor experience that's aligned with the needs and brand of
+          your organisation.
+        </Box>
+        <Timeline date="29th July 2021" />
+        <Box link="/docs/apis/config#health-check" heading="New Health Check endpoint">
+          We've added an optional <InlineCode>/_healthcheck</InlineCode> endpoint to Keystone's
+          express server. Use it to ensure your Keystone instance is up and running with website
+          monitoring solutions.
+        </Box>
+        <Timeline date="10th July 2021" />
         <Box heading="Watch Jed's Prisma Day workshop">
           <div
             css={{


### PR DESCRIPTION
Fixes #6272 which didn't land. Presumably due to the transition to `website_live` earlier this week.