### PR TITLE
[RFC] config.graphql.extendContext

### DIFF
--- a/examples/blog/keystone.ts
+++ b/examples/blog/keystone.ts
@@ -1,6 +1,9 @@
 import { config } from '@keystone-next/keystone';
+import { KeystoneContext } from '../../packages/types/src';
 import { lists } from './schema';
 import { insertSeedData } from './seed-data';
+
+type Context = KeystoneContext & { foo: string };
 
 export default config({
   db: {
@@ -13,4 +16,14 @@ export default config({
     },
   },
   lists,
+  graphql: {
+    // Example usage for RFC, will document/exemplify this elsewhere before merging.
+    extendContext: _context => {
+      // We need to return the same object, but we need to tell typescript its new type,
+      // so we reassign the input and use an 'as' statement to set the type
+      const context = _context as Context;
+      context.foo = 'bar';
+      return context;
+    },
+  },
 });

--- a/examples/blog/schema.ts
+++ b/examples/blog/schema.ts
@@ -1,5 +1,8 @@
-import { list } from '@keystone-next/keystone';
-import { select, relationship, text, timestamp } from '@keystone-next/keystone/fields';
+import { list } from '@keystone-next/keystone/schema';
+import { select, relationship, text, timestamp } from '@keystone-next/fields';
+import { KeystoneContext } from '../../packages/types/src';
+
+type Context = KeystoneContext & { foo: string };
 
 export const lists = {
   Post: list({
@@ -15,6 +18,12 @@ export const lists = {
       content: text(),
       publishDate: timestamp(),
       author: relationship({ ref: 'Author.posts', many: false }),
+    },
+    access: {
+      read: true,
+      update: true,
+      create: true,
+      delete: ({ context }: { context: Context }) => context.foo === 'bar',
     },
   }),
   Author: list({

--- a/packages/keystone/src/lib/context/createContext.ts
+++ b/packages/keystone/src/lib/context/createContext.ts
@@ -107,6 +107,17 @@ export function makeCreateContext({
       dbAPI[listKey] = dbAPIFactories[listKey](contextToReturn);
       itemAPI[listKey] = itemAPIForList(listKey, contextToReturn, dbAPI[listKey]);
     }
+    if (config.graphql?.extendContext) {
+      const newContext = config.graphql.extendContext(contextToReturn);
+      // We have functions which are bound to the `contextToReturn` object, so we
+      // need to make sure that we're not creating a new object here, otherwise
+      // those functions won't behave as expected.
+      if (newContext !== contextToReturn) {
+        throw Error(
+          'config.graphql.extendContext must return the modified context object. You cannot return a new object.'
+        );
+      }
+    }
     return contextToReturn;
   };
 

--- a/packages/keystone/src/lib/server/createApolloServer.ts
+++ b/packages/keystone/src/lib/server/createApolloServer.ts
@@ -15,7 +15,7 @@ export const createApolloServerMicro = ({
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;
   sessionStrategy?: SessionStrategy<any>;
-  graphqlConfig?: GraphQLConfig;
+  graphqlConfig?: GraphQLConfig<any>;
   connectionPromise: Promise<any>;
 }) => {
   const context = async ({ req, res }: { req: IncomingMessage; res: ServerResponse }) => {
@@ -40,7 +40,7 @@ export const createApolloServerExpress = ({
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;
   sessionStrategy?: SessionStrategy<any>;
-  graphqlConfig?: GraphQLConfig;
+  graphqlConfig?: GraphQLConfig<any>;
 }) => {
   const context = async ({ req, res }: { req: IncomingMessage; res: ServerResponse }) =>
     createContext({
@@ -58,7 +58,7 @@ const _createApolloServerConfig = ({
   graphqlConfig,
 }: {
   graphQLSchema: GraphQLSchema;
-  graphqlConfig?: GraphQLConfig;
+  graphqlConfig?: GraphQLConfig<any>;
 }) => {
   const apolloConfig = graphqlConfig?.apolloConfig;
 
@@ -70,7 +70,7 @@ const _createApolloServerConfig = ({
   };
 };
 
-const formatError = (graphqlConfig: GraphQLConfig | undefined) => {
+const formatError = (graphqlConfig: GraphQLConfig<any> | undefined) => {
   return (err: GraphQLError) => {
     let debug = graphqlConfig?.debug;
     if (debug === undefined) {

--- a/packages/keystone/src/lib/server/createExpressServer.ts
+++ b/packages/keystone/src/lib/server/createExpressServer.ts
@@ -29,7 +29,7 @@ const addApolloServer = async ({
   graphQLSchema: GraphQLSchema;
   createContext: CreateContext;
   sessionStrategy?: SessionStrategy<any>;
-  graphqlConfig?: GraphQLConfig;
+  graphqlConfig?: GraphQLConfig<any>;
 }) => {
   const apolloServer = createApolloServerExpress({
     graphQLSchema,

--- a/packages/keystone/src/types/config/index.ts
+++ b/packages/keystone/src/types/config/index.ts
@@ -24,7 +24,7 @@ export type KeystoneConfig = {
   ui?: AdminUIConfig;
   server?: ServerConfig;
   session?: SessionStrategy<any>;
-  graphql?: GraphQLConfig;
+  graphql?: GraphQLConfig<any>;
   extendGraphqlSchema?: ExtendGraphqlSchema;
   files?: FilesConfig;
   images?: ImagesConfig;
@@ -108,7 +108,7 @@ export type ServerConfig = {
 
 // config.graphql
 
-export type GraphQLConfig = {
+export type GraphQLConfig<T extends KeystoneContext> = {
   // The path of the GraphQL API endpoint. Default: '/api/graphql'.
   path?: string;
   // The CORS configuration to use on the GraphQL API endpoint.
@@ -156,6 +156,7 @@ export type GraphQLConfig = {
    * Default: process.env.NODE_ENV !== 'production'
    */
   debug?: boolean;
+  extendContext?: (context: KeystoneContext) => T;
 };
 
 // config.extendGraphqlSchema


### PR DESCRIPTION
This config option provides a general escape hatch to let developers extend/modify the context object however they want. In general it should be used for extension purposes.