### PR TITLE
Added styles to table

### DIFF
--- a/docs/lib/prose-lite.ts
+++ b/docs/lib/prose-lite.ts
@@ -153,6 +153,21 @@ export const proseStyles = {
     marginBottom: '2rem',
     fontSize: 'var(--font-xsmall)',
     lineHeight: 1.7142857,
+    maxWidth: '100%',
+    overflowX: 'auto',
+    display: 'block',
+    // Visual help for overflow if we need it ↓
+    // Needs TLC
+    // position: 'relative',
+    // '::after': {
+    //   content: '""',
+    //   width: '1rem',
+    //   height: '100%',
+    //   background: 'linear-gradient(to right, rgba(255,255,255,0.0) 0%, rgba(255,255,255,1) 100%);',
+    //   position: 'absolute',
+    //   top: '0',
+    //   right: '0',
+    // }
   },
   thead: {
     color: 'var(--text)',
@@ -173,6 +188,9 @@ export const proseStyles = {
     paddingRight: '0.5714285714em',
     paddingBottom: '0.5714285714em',
     paddingLeft: '0.5714285714em',
+    '> code': {
+      whiteSpace: 'nowrap',
+    }
   },
   fontSize: 'var(--font-small)',
   lineHeight: 1.75,

--- a/docs/lib/prose-lite.ts
+++ b/docs/lib/prose-lite.ts
@@ -190,7 +190,7 @@ export const proseStyles = {
     paddingLeft: '0.5714285714em',
     '> code': {
       whiteSpace: 'nowrap',
-    }
+    },
   },
   fontSize: 'var(--font-small)',
   lineHeight: 1.75,

--- a/docs/lib/prose-lite.ts
+++ b/docs/lib/prose-lite.ts
@@ -156,18 +156,6 @@ export const proseStyles = {
     maxWidth: '100%',
     overflowX: 'auto' as const,
     display: 'block',
-    // Visual help for overflow if we need it ↓
-    // Needs TLC
-    // position: 'relative',
-    // '::after': {
-    //   content: '""',
-    //   width: '1rem',
-    //   height: '100%',
-    //   background: 'linear-gradient(to right, rgba(255,255,255,0.0) 0%, rgba(255,255,255,1) 100%);',
-    //   position: 'absolute',
-    //   top: '0',
-    //   right: '0',
-    // }
   },
   thead: {
     color: 'var(--text)',
@@ -189,7 +177,7 @@ export const proseStyles = {
     paddingBottom: '0.5714285714em',
     paddingLeft: '0.5714285714em',
     '> code': {
-      whiteSpace: 'nowrap',
+      whiteSpace: 'nowrap' as const,
     },
   },
   fontSize: 'var(--font-small)',

--- a/docs/lib/prose-lite.ts
+++ b/docs/lib/prose-lite.ts
@@ -154,7 +154,7 @@ export const proseStyles = {
     fontSize: 'var(--font-xsmall)',
     lineHeight: 1.7142857,
     maxWidth: '100%',
-    overflowX: 'auto',
+    overflowX: 'auto' as const,
     display: 'block',
     // Visual help for overflow if we need it ↓
     // Needs TLC


### PR DESCRIPTION
Attempts to make the visual appearance of  markdown generated `<table>` elements perform better. Comes with some tradeoffs. Let's discuss before merging this.

(may want to open the original for the image below in a separate tab)

![table-poc-branch](https://user-images.githubusercontent.com/6447754/129299667-4a00cfca-d5ff-440c-8fc5-c7d0780d8af3.png)
