### PR TITLE
Update resolveInput error handling

### DIFF
--- a/.changeset/grumpy-jobs-burn.md
+++ b/.changeset/grumpy-jobs-burn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Updated handling of errors in `resolveInput` hooks to provide developers with appropriate debug information.

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -1,7 +1,7 @@
 import { text } from '@keystone-next/fields';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { setupTestRunner } from '@keystone-next/testing';
-import { apiTestConfig } from '../utils';
+import { apiTestConfig, expectExtensionError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -11,6 +11,10 @@ const runner = setupTestRunner({
           name: text({
             hooks: {
               resolveInput: ({ resolvedData }) => {
+                if (resolvedData.name === 'trigger field error') {
+                  throw new Error('Field error triggered');
+                }
+
                 return `${resolvedData.name}-field`;
               },
             },
@@ -18,6 +22,9 @@ const runner = setupTestRunner({
         },
         hooks: {
           resolveInput: ({ resolvedData }) => {
+            if (resolvedData.name === 'trigger list error-field') {
+              throw new Error('List error triggered');
+            }
             return {
               name: `${resolvedData.name}-list`,
             };
@@ -29,18 +36,70 @@ const runner = setupTestRunner({
 });
 
 describe('List Hooks: #resolveInput()', () => {
-  it(
+  test(
     'resolves fields first, then passes them to the list',
     runner(async ({ context }) => {
-      const user = await context.lists.User.createOne({
-        data: { name: 'jess' },
-        query: 'name',
-      });
-
+      const user = await context.lists.User.createOne({ data: { name: 'jess' }, query: 'name' });
       // Field should be executed first, appending `-field`, then the list
       // should be executed which appends `-list`, and finally that total
       // result should be stored.
       expect(user.name).toBe('jess-field-list');
+    })
+  );
+
+  test(
+    'List error',
+    runner(async ({ context }) => {
+      // Trigger an error
+      const { data, errors } = await context.graphql.raw({
+        query: `mutation ($data: UserCreateInput!) { createUser(data: $data) { id } }`,
+        variables: { data: { name: `trigger list error` } },
+      });
+      // Returns null and throws an error
+      expect(data).toEqual({ createUser: null });
+      const message = `List error triggered`;
+      expectExtensionError('dev', false, undefined, errors, `resolveInput`, [
+        {
+          path: ['createUser'],
+          messages: [`User: ${message}`],
+          debug: [
+            {
+              message,
+              stacktrace: expect.stringMatching(
+                new RegExp(`Error: ${message}\n[^\n]*resolveInput .${__filename}`)
+              ),
+            },
+          ],
+        },
+      ]);
+    })
+  );
+
+  test(
+    'Field error',
+    runner(async ({ context }) => {
+      // Trigger an error
+      const { data, errors } = await context.graphql.raw({
+        query: `mutation ($data: UserCreateInput!) { createUser(data: $data) { id } }`,
+        variables: { data: { name: `trigger field error` } },
+      });
+      // Returns null and throws an error
+      expect(data).toEqual({ createUser: null });
+      const message = `Field error triggered`;
+      expectExtensionError('dev', false, undefined, errors, `resolveInput`, [
+        {
+          path: ['createUser'],
+          messages: [`User.name: ${message}`],
+          debug: [
+            {
+              message,
+              stacktrace: expect.stringMatching(
+                new RegExp(`Error: ${message}\n[^\n]*resolveInput .${__filename}`)
+              ),
+            },
+          ],
+        },
+      ]);
     })
   );
 });


### PR DESCRIPTION
This makes the error handling of `resolveInput` consistent with `beforeChange`, etc, making sure we don't lose debug stacktraces, especially in field hooks.