### PR TITLE
Tweaking for local dev using Docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Keystone",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "14"
+    }
+  },
+
+  "settings": {},
+
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "gamunu.vscode-yarn",
+    "prisma.prisma"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  "postCreateCommand": "yarn install",
+
+  "remoteUser": "node"
+}


### PR DESCRIPTION
I came to contribute to the repo only to find that I didn't have the right yarn installed, I needed to do some local env setup, etc. which just made it a little tricky to poke around in the codebase.

This PR adds a [VS Code remote containers](https://code.visualstudio.com/docs/remote/containers?WT.mc_id=javascript-00000-aapowell) definition file that, when used, will create a Dockerised dev environment that you can use from VS Code in a seamless fashion.

If you're not using VS Code, or not using the remote containers extension, these files will have no impact on you.