### PR TITLE
[WIP] File adapters

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,2 @@
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Keystone",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "14"
+    }
+  },
+
+  "settings": {},
+
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "gamunu.vscode-yarn",
+    "prisma.prisma"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  "postCreateCommand": "yarn install",
+
+  "remoteUser": "node"
+}

--- a/examples-staging/assets-cloud/keystone.ts
+++ b/examples-staging/assets-cloud/keystone.ts
@@ -1,4 +1,5 @@
 import { config } from '@keystone-next/keystone/schema';
+import { KeystoneCloudFileAdapter, KeystoneCloudImageAdapter } from '@keystone-next/keystone';
 import dotenv from 'dotenv';
 import { lists } from './schema';
 
@@ -18,17 +19,18 @@ export default config({
   },
   lists,
   images: {
-    upload: 'keystone-cloud',
-  },
-  files: {
-    upload: 'keystone-cloud',
-  },
-  experimental: {
-    keystoneCloud: {
+    adapter: new KeystoneCloudImageAdapter({
       apiKey: KEYSTONE_CLOUD_API_KEY,
       imagesDomain: KEYSTONE_CLOUD_IMAGES_DOMAIN,
       graphqlApiEndpoint: KEYSTONE_CLOUD_GRAPHQL_API_ENDPOINT,
       restApiEndpoint: KEYSTONE_CLOUD_REST_API_ENDPOINT,
-    },
+    }),
+  },
+  files: {
+    adapter: new KeystoneCloudFileAdapter({
+      apiKey: KEYSTONE_CLOUD_API_KEY,
+      graphqlApiEndpoint: KEYSTONE_CLOUD_GRAPHQL_API_ENDPOINT,
+      restApiEndpoint: KEYSTONE_CLOUD_REST_API_ENDPOINT,
+    }),
   },
 });

--- a/examples-staging/assets-cloud/schema.prisma
+++ b/examples-staging/assets-cloud/schema.prisma
@@ -20,10 +20,8 @@ model Post {
   hero_extension      String?
   hero_width          Int?
   hero_height         Int?
-  hero_mode           String?
   hero_id             String?
   attachment_filesize Int?
-  attachment_mode     String?
   attachment_filename String?
 
   @@index([authorId])

--- a/examples-staging/assets-local/keystone.ts
+++ b/examples-staging/assets-local/keystone.ts
@@ -1,3 +1,4 @@
+import { LocalImageAdapter } from '@keystone-next/file-adapters';
 import { config } from '@keystone-next/keystone/schema';
 import { lists } from './schema';
 
@@ -8,6 +9,6 @@ export default config({
   },
   lists,
   images: {
-    upload: 'local',
+    adapter: new LocalImageAdapter(),
   },
 });

--- a/examples-staging/assets-local/package.json
+++ b/examples-staging/assets-local/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@keystone-next/fields": "^14.0.0",
+    "@keystone-next/file-adapters": "^0.1.0",
     "@keystone-next/keystone": "^24.0.0"
   },
   "devDependencies": {

--- a/examples-staging/assets-local/schema.prisma
+++ b/examples-staging/assets-local/schema.prisma
@@ -20,7 +20,6 @@ model Post {
   hero_extension String?
   hero_width     Int?
   hero_height    Int?
-  hero_mode      String?
   hero_id        String?
 
   @@index([authorId])

--- a/examples-staging/basic/keystone.ts
+++ b/examples-staging/basic/keystone.ts
@@ -1,6 +1,7 @@
 import { config } from '@keystone-next/keystone/schema';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
+import { LocalFileAdapter, LocalImageAdapter } from '@keystone-next/file-adapters';
 
 import { lists, extendGraphqlSchema } from './schema';
 
@@ -38,8 +39,8 @@ export default auth.withAuth(
       // path: '/admin',
       // isAccessAllowed,
     },
-    images: { upload: 'local' },
-    files: { upload: 'local' },
+    images: { adapter: new LocalImageAdapter() },
+    files: { adapter: new LocalFileAdapter() },
     lists,
     extendGraphqlSchema,
     session: statelessSessions({ maxAge: sessionMaxAge, secret: sessionSecret }),

--- a/examples-staging/basic/package.json
+++ b/examples-staging/basic/package.json
@@ -14,6 +14,7 @@
     "@keystone-next/document-renderer": "^4.0.0",
     "@keystone-next/fields": "^14.0.0",
     "@keystone-next/fields-document": "^8.0.0",
+    "@keystone-next/file-adapters": "^0.1.0",
     "@keystone-next/keystone": "^24.0.0",
     "@keystone-next/types": "^24.0.0",
     "@keystone-ui/core": "^3.1.1",

--- a/examples-staging/basic/schema.prisma
+++ b/examples-staging/basic/schema.prisma
@@ -16,10 +16,8 @@ model User {
   avatar_extension    String?
   avatar_width        Int?
   avatar_height       Int?
-  avatar_mode         String?
   avatar_id           String?
   attachment_filesize Int?
-  attachment_mode     String?
   attachment_filename String?
   password            String?
   isAdmin             Boolean?

--- a/packages/fields/src/types/file/index.ts
+++ b/packages/fields/src/types/file/index.ts
@@ -34,7 +34,7 @@ const fileFields = schema.fields<FileData>()({
   ref: schema.field({
     type: schema.nonNull(schema.String),
     resolve(data) {
-      return getFileRef(data.mode, data.filename);
+      return getFileRef(data.filename);
     },
   }),
   src: schema.field({
@@ -45,7 +45,7 @@ const fileFields = schema.fields<FileData>()({
           'File context is undefined, this most likely means that you havent configurd keystone with a file config, see https://keystonejs.com/docs/apis/config#files for details'
         );
       }
-      return context.files.getSrc(data.mode, data.filename);
+      return context.files.getSrc(data.filename);
     },
   }),
 });
@@ -64,7 +64,7 @@ const LocalFileFieldOutput = schema.object<FileData>()({
 
 async function inputResolver(data: FileFieldInputType, context: KeystoneContext) {
   if (data === null || data === undefined) {
-    return { mode: data, filename: data, filesize: data };
+    return { filename: data, filesize: data };
   }
 
   if (data.ref) {
@@ -95,7 +95,6 @@ export const file =
       kind: 'multi',
       fields: {
         filesize: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-        mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
         filename: { kind: 'scalar', scalar: 'String', mode: 'optional' },
       },
     })({
@@ -106,16 +105,11 @@ export const file =
       },
       output: schema.field({
         type: FileFieldOutput,
-        resolve({ value: { filesize, filename, mode } }) {
-          if (
-            filesize === null ||
-            filename === null ||
-            mode === null ||
-            (mode !== 'local' && mode !== 'keystone-cloud')
-          ) {
+        resolve({ value: { filesize, filename } }) {
+          if (filesize === null || filename === null) {
             return null;
           }
-          return { mode, filename, filesize };
+          return { filename, filesize };
         },
       }),
       unreferencedConcreteInterfaceImplementations: [LocalFileFieldOutput],

--- a/packages/fields/src/types/image/index.ts
+++ b/packages/fields/src/types/image/index.ts
@@ -38,7 +38,7 @@ const imageOutputFields = schema.fields<ImageData>()({
   ref: schema.field({
     type: schema.nonNull(schema.String),
     resolve(data) {
-      return getImageRef(data.mode, data.id, data.extension);
+      return getImageRef( data.id, data.extension);
     },
   }),
   src: schema.field({
@@ -47,7 +47,7 @@ const imageOutputFields = schema.fields<ImageData>()({
       if (!context.images) {
         throw new Error('Image context is undefined');
       }
-      return context.images.getSrc(data.mode, data.id, data.extension);
+      return context.images.getSrc(data.id, data.extension);
     },
   }),
 });
@@ -71,7 +71,7 @@ type ImageFieldInputType =
 
 async function inputResolver(data: ImageFieldInputType, context: KeystoneContext) {
   if (data === null || data === undefined) {
-    return { extension: data, filesize: data, height: data, id: data, mode: data, width: data };
+    return { extension: data, filesize: data, height: data, id: data, width: data };
   }
 
   if (data.ref) {
@@ -110,7 +110,6 @@ export const image =
         extension: { kind: 'scalar', scalar: 'String', mode: 'optional' },
         width: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
         height: { kind: 'scalar', scalar: 'Int', mode: 'optional' },
-        mode: { kind: 'scalar', scalar: 'String', mode: 'optional' },
         id: { kind: 'scalar', scalar: 'String', mode: 'optional' },
       },
     })({
@@ -121,20 +120,18 @@ export const image =
       },
       output: schema.field({
         type: ImageFieldOutput,
-        resolve({ value: { extension, filesize, height, id, mode, width } }) {
+        resolve({ value: { extension, filesize, height, id, width } }) {
           if (
             extension === null ||
             !isValidImageExtension(extension) ||
             filesize === null ||
             height === null ||
             width === null ||
-            id === null ||
-            mode === null ||
-            (mode !== 'local' && mode !== 'keystone-cloud')
+            id === null
           ) {
             return null;
           }
-          return { mode, extension, filesize, height, width, id };
+          return { extension, filesize, height, width, id };
         },
       }),
       unreferencedConcreteInterfaceImplementations: [LocalImageFieldOutput],

--- a/packages/fields/src/types/image/index.ts
+++ b/packages/fields/src/types/image/index.ts
@@ -38,7 +38,7 @@ const imageOutputFields = schema.fields<ImageData>()({
   ref: schema.field({
     type: schema.nonNull(schema.String),
     resolve(data) {
-      return getImageRef( data.id, data.extension);
+      return getImageRef(data.id, data.extension);
     },
   }),
   src: schema.field({

--- a/packages/file-adapters/package.json
+++ b/packages/file-adapters/package.json
@@ -8,6 +8,7 @@
     "node": "^12.20 || >= 14.13"
   },
   "dependencies": {
+    "@babel/runtime": "^7.15.3",
     "@keystone-next/types": "^24.0.0",
     "@keystone-next/utils": "^1.0.4",
     "@sindresorhus/slugify": "^1.1.2",

--- a/packages/file-adapters/package.json
+++ b/packages/file-adapters/package.json
@@ -12,8 +12,12 @@
     "@keystone-next/utils": "^1.0.4",
     "@sindresorhus/slugify": "^1.1.2",
     "@types/fs-extra": "^9.0.12",
+    "@types/uuid": "^8.3.1",
     "filenamify": "^4.3.0",
-    "fs-extra": "^10.0.0"
+    "fs-extra": "^10.0.0",
+    "image-size": "^1.0.0",
+    "image-type": "^4.1.0",
+    "uuid": "^8.3.2"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/master/packages/file-adapters"
 }

--- a/packages/file-adapters/package.json
+++ b/packages/file-adapters/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@keystone-next/file-adapters",
+  "description": "KeystoneJS File Adapters",
+  "version": "0.1.0",
+  "main": "dist/file-adapters.cjs.js",
+  "module": "dist/file-adapters.esm.js",
+  "engines": {
+    "node": "^12.20 || >= 14.13"
+  },
+  "dependencies": {
+    "@keystone-next/types": "^24.0.0",
+    "@keystone-next/utils": "^1.0.4",
+    "@sindresorhus/slugify": "^1.1.2",
+    "@types/fs-extra": "^9.0.12",
+    "filenamify": "^4.3.0",
+    "fs-extra": "^10.0.0"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/master/packages/file-adapters"
+}

--- a/packages/file-adapters/src/FileAdapter.ts
+++ b/packages/file-adapters/src/FileAdapter.ts
@@ -1,0 +1,15 @@
+import { Readable } from 'stream';
+import { FileData } from '@keystone-next/types';
+
+abstract class FileAdapter {
+  abstract getSrc(filename: string): Promise<string>;
+  abstract getDataFromRef(ref: string): Promise<FileData>;
+  abstract getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData>;
+  // Called when the adapter is being provisioned for use in the context
+  // or when the admin ui is being built
+  bootstrap(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export { FileAdapter };

--- a/packages/file-adapters/src/ImageAdapter.ts
+++ b/packages/file-adapters/src/ImageAdapter.ts
@@ -1,0 +1,15 @@
+import { Readable } from 'stream';
+import { ImageExtension, ImageData } from '@keystone-next/types';
+
+abstract class ImageAdapter {
+  abstract getSrc(id: string, extension: ImageExtension): Promise<string>;
+  abstract getDataFromRef(ref: string): Promise<ImageData>;
+  abstract getDataFromStream(stream: Readable): Promise<ImageData>;
+  // Called when the adapter is being provisioned for use in the context
+  // or when the admin ui is being built
+  bootstrap(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export { ImageAdapter };

--- a/packages/file-adapters/src/adapters/LocalFileAdapter.ts
+++ b/packages/file-adapters/src/adapters/LocalFileAdapter.ts
@@ -4,7 +4,7 @@ import { FileData } from '@keystone-next/types';
 import { parseFileRef } from '@keystone-next/utils';
 
 import fs from 'fs-extra';
-import { FileAdapter } from '..';
+import { FileAdapter } from '../FileAdapter';
 import { generateSafeFilename } from '../utils';
 
 export type LocalFileAdapterConfig = {
@@ -60,10 +60,13 @@ export class LocalFileAdapter extends FileAdapter {
     try {
       await pipeStreams;
       const { size: filesize } = await fs.stat(path.join(this.storagePath, filename));
-      return { mode: 'local', filesize, filename };
+      return { filesize, filename };
     } catch (e) {
       await fs.remove(path.join(this.storagePath, filename));
       throw e;
     }
+  }
+  override bootstrap() {
+    return fs.mkdir(this.storagePath, { recursive: true });
   }
 }

--- a/packages/file-adapters/src/adapters/LocalFileAdapter.ts
+++ b/packages/file-adapters/src/adapters/LocalFileAdapter.ts
@@ -1,0 +1,69 @@
+import path from 'path';
+import { Readable, pipeline } from 'stream';
+import { FileData } from '@keystone-next/types';
+import { parseFileRef } from '@keystone-next/utils';
+
+import fs from 'fs-extra';
+import { FileAdapter } from '..';
+import { generateSafeFilename } from '../utils';
+
+export type LocalFileAdapterConfig = {
+  baseUrl?: string;
+  storagePath?: string;
+  transformFilename?: (str: string) => string;
+};
+
+const DEFAULT_BASE_URL = '/files';
+const DEFAULT_STORAGE_PATH = './public/files';
+
+export class LocalFileAdapter extends FileAdapter {
+  private baseUrl: string;
+  private storagePath: string;
+  private transformFilename?: (str: string) => string;
+  constructor(config: LocalFileAdapterConfig = {}) {
+    super();
+    this.baseUrl = config.baseUrl || DEFAULT_BASE_URL;
+    this.storagePath = config.storagePath || DEFAULT_STORAGE_PATH;
+    this.transformFilename = config.transformFilename;
+
+    fs.mkdirSync(this.storagePath, { recursive: true });
+  }
+  getSrc(filename: string): Promise<string> {
+    return Promise.resolve(`${this.baseUrl}/${filename}`);
+  }
+  async getDataFromRef(ref: string): Promise<FileData> {
+    const fileRef = parseFileRef(ref);
+
+    if (!fileRef) {
+      throw new Error('Invalid file reference');
+    }
+
+    const { filename } = fileRef;
+    const { size: filesize } = await fs.stat(path.join(this.storagePath, filename));
+
+    return { filesize, ...fileRef };
+  }
+  async getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData> {
+    const filename = generateSafeFilename(originalFilename, this.transformFilename);
+
+    const writeStream = fs.createWriteStream(path.join(this.storagePath, filename));
+    const pipeStreams: Promise<void> = new Promise((resolve, reject) => {
+      pipeline(stream, writeStream, err => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    try {
+      await pipeStreams;
+      const { size: filesize } = await fs.stat(path.join(this.storagePath, filename));
+      return { mode: 'local', filesize, filename };
+    } catch (e) {
+      await fs.remove(path.join(this.storagePath, filename));
+      throw e;
+    }
+  }
+}

--- a/packages/file-adapters/src/adapters/LocalImageAdapter.ts
+++ b/packages/file-adapters/src/adapters/LocalImageAdapter.ts
@@ -1,0 +1,62 @@
+import path from 'path';
+import { Readable } from 'stream';
+import fs from 'fs-extra';
+import { v4 as uuid } from 'uuid';
+import { ImageExtension, ImageData } from '@keystone-next/types';
+import { parseImageRef } from '@keystone-next/utils';
+import { ImageAdapter } from '..';
+import { getImageMetadataFromBuffer } from '../utils';
+
+export type LocalImageAdapterConfig = {
+  baseUrl?: string;
+  storagePath?: string;
+};
+
+const DEFAULT_BASE_URL = '/images';
+const DEFAULT_STORAGE_PATH = './public/images';
+
+export class LocalImageAdapter extends ImageAdapter {
+  private baseUrl: string;
+  private storagePath: string;
+  constructor(config: LocalImageAdapterConfig = {}) {
+    super();
+    this.baseUrl = config.baseUrl || DEFAULT_BASE_URL;
+    this.storagePath = config.storagePath || DEFAULT_STORAGE_PATH;
+
+    fs.mkdirSync(this.storagePath, { recursive: true });
+  }
+  getSrc(id: string, extension: ImageExtension) {
+    const filename = `${id}.${extension}`;
+    return Promise.resolve(`${this.baseUrl}/${filename}`);
+  }
+  async getDataFromRef(ref: string): Promise<ImageData> {
+    const imageRef = parseImageRef(ref);
+
+    if (!imageRef) {
+      throw new Error('Invalid image reference');
+    }
+
+    const buffer = await fs.readFile(
+      path.join(this.storagePath, `${imageRef.id}.${imageRef.extension}`)
+    );
+    const metadata = await getImageMetadataFromBuffer(buffer);
+
+    return { ...imageRef, ...metadata };
+  }
+  async getDataFromStream(stream: Readable): Promise<ImageData> {
+    const id = uuid();
+
+    const chunks = [];
+
+    for await (let chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    const buffer = Buffer.concat(chunks);
+    const metadata = await getImageMetadataFromBuffer(buffer);
+
+    await fs.writeFile(path.join(this.storagePath, `${id}.${metadata.extension}`), buffer);
+
+    return { id, ...metadata };
+  }
+}

--- a/packages/file-adapters/src/adapters/LocalImageAdapter.ts
+++ b/packages/file-adapters/src/adapters/LocalImageAdapter.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import { v4 as uuid } from 'uuid';
 import { ImageExtension, ImageData } from '@keystone-next/types';
 import { parseImageRef } from '@keystone-next/utils';
-import { ImageAdapter } from '..';
+import { ImageAdapter } from '../ImageAdapter';
 import { getImageMetadataFromBuffer } from '../utils';
 
 export type LocalImageAdapterConfig = {
@@ -22,8 +22,6 @@ export class LocalImageAdapter extends ImageAdapter {
     super();
     this.baseUrl = config.baseUrl || DEFAULT_BASE_URL;
     this.storagePath = config.storagePath || DEFAULT_STORAGE_PATH;
-
-    fs.mkdirSync(this.storagePath, { recursive: true });
   }
   getSrc(id: string, extension: ImageExtension) {
     const filename = `${id}.${extension}`;
@@ -58,5 +56,8 @@ export class LocalImageAdapter extends ImageAdapter {
     await fs.writeFile(path.join(this.storagePath, `${id}.${metadata.extension}`), buffer);
 
     return { id, ...metadata };
+  }
+  override bootstrap() {
+    return fs.mkdir(this.storagePath, { recursive: true });
   }
 }

--- a/packages/file-adapters/src/index.ts
+++ b/packages/file-adapters/src/index.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { FileData } from '@keystone-next/types';
+import { FileData, ImageExtension, ImageData } from '@keystone-next/types';
 
 abstract class FileAdapter {
   abstract getSrc(filename: string): Promise<string>;
@@ -7,4 +7,10 @@ abstract class FileAdapter {
   abstract getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData>;
 }
 
-export { FileAdapter };
+abstract class ImageAdapter {
+  abstract getSrc(id: string, extension: ImageExtension): Promise<string>;
+  abstract getDataFromRef(ref: string): Promise<ImageData>;
+  abstract getDataFromStream(stream: Readable): Promise<ImageData>;
+}
+
+export { FileAdapter, ImageAdapter };

--- a/packages/file-adapters/src/index.ts
+++ b/packages/file-adapters/src/index.ts
@@ -1,0 +1,10 @@
+import { Readable } from 'stream';
+import { FileData } from '@keystone-next/types';
+
+abstract class FileAdapter {
+  abstract getSrc(filename: string): Promise<string>;
+  abstract getDataFromRef(ref: string): Promise<FileData>;
+  abstract getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData>;
+}
+
+export { FileAdapter };

--- a/packages/file-adapters/src/index.ts
+++ b/packages/file-adapters/src/index.ts
@@ -1,16 +1,4 @@
-import { Readable } from 'stream';
-import { FileData, ImageExtension, ImageData } from '@keystone-next/types';
-
-abstract class FileAdapter {
-  abstract getSrc(filename: string): Promise<string>;
-  abstract getDataFromRef(ref: string): Promise<FileData>;
-  abstract getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData>;
-}
-
-abstract class ImageAdapter {
-  abstract getSrc(id: string, extension: ImageExtension): Promise<string>;
-  abstract getDataFromRef(ref: string): Promise<ImageData>;
-  abstract getDataFromStream(stream: Readable): Promise<ImageData>;
-}
-
-export { FileAdapter, ImageAdapter };
+export { FileAdapter } from './FileAdapter';
+export { ImageAdapter } from './ImageAdapter';
+export { LocalFileAdapter } from './adapters/LocalFileAdapter';
+export { LocalImageAdapter } from './adapters/LocalImageAdapter';

--- a/packages/file-adapters/src/utils.ts
+++ b/packages/file-adapters/src/utils.ts
@@ -1,6 +1,9 @@
 import crypto from 'crypto';
 import slugify from '@sindresorhus/slugify';
 import filenamify from 'filenamify';
+import fromBuffer from 'image-type';
+import imageSize from 'image-size';
+import { ImageMetadata } from '@keystone-next/types';
 
 export const defaultTransformer = (str: string) => slugify(str);
 
@@ -30,4 +33,30 @@ export const generateSafeFilename = (
     return `${urlSafeName}-${id}${ext}`;
   }
   return `${urlSafeName}-${id}`;
+};
+
+export const getImageMetadataFromBuffer = async (buffer: Buffer): Promise<ImageMetadata> => {
+  const filesize = buffer.length;
+  const fileType = fromBuffer(buffer);
+  if (!fileType) {
+    throw new Error('File type not found');
+  }
+
+  if (
+    fileType.ext !== 'jpg' &&
+    fileType.ext !== 'png' &&
+    fileType.ext !== 'webp' &&
+    fileType.ext !== 'gif'
+  ) {
+    throw new Error(`${fileType.ext} is not a supported image type`);
+  }
+
+  const extension = fileType.ext;
+
+  const { height, width } = imageSize(buffer);
+
+  if (width === undefined || height === undefined) {
+    throw new Error('Height and width could not be found for image');
+  }
+  return { width, height, filesize, extension };
 };

--- a/packages/file-adapters/src/utils.ts
+++ b/packages/file-adapters/src/utils.ts
@@ -1,0 +1,33 @@
+import crypto from 'crypto';
+import slugify from '@sindresorhus/slugify';
+import filenamify from 'filenamify';
+
+export const defaultTransformer = (str: string) => slugify(str);
+
+export const generateSafeFilename = (
+  filename: string,
+  transformFilename: (str: string) => string = defaultTransformer
+) => {
+  // Appends a UUID to the filename so that people can't brute-force guess stored filenames
+  //
+  // This regex lazily matches for any characters that aren't a new line
+  // it then optionally matches the last instance of a "." symbol
+  // followed by any alphabetical character before the end of the string
+  const [, name, ext] = filename.match(/^([^:\n].*?)(\.[A-Za-z]+)?$/) as RegExpMatchArray;
+
+  const id = crypto
+    .randomBytes(24)
+    .toString('base64')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .slice(12);
+
+  // console.log(id, id.length, id.slice(12).length);
+  const urlSafeName = filenamify(transformFilename(name), {
+    maxLength: 100 - id.length,
+    replacement: '-',
+  });
+  if (ext) {
+    return `${urlSafeName}-${id}${ext}`;
+  }
+  return `${urlSafeName}-${id}`;
+};

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -31,6 +31,7 @@
     "@hapi/iron": "^6.0.0",
     "@keystone-next/admin-ui-utils": "^5.0.6",
     "@keystone-next/fields": "^14.0.0",
+    "@keystone-next/file-adapters": "^0.1.0",
     "@keystone-next/types": "^24.0.0",
     "@keystone-next/utils": "^1.0.4",
     "@keystone-ui/button": "^5.0.0",

--- a/packages/keystone/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/keystone/src/admin-ui/system/generateAdminUI.ts
@@ -59,23 +59,11 @@ export const generateAdminUI = async (
   }
 
   if (config.images) {
-    const storagePath = Path.resolve(config.images.local?.storagePath ?? './public/images');
-    await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(
-      Path.relative(publicDirectory, storagePath),
-      Path.join(publicDirectory, 'images'),
-      'junction'
-    );
+    await config.images.adapter.bootstrap();
   }
 
   if (config.files) {
-    const storagePath = Path.resolve(config.files.local?.storagePath ?? './public/files');
-    await fs.mkdir(storagePath, { recursive: true });
-    await fs.symlink(
-      Path.relative(publicDirectory, storagePath),
-      Path.join(publicDirectory, 'files'),
-      'junction'
-    );
+    await config.files.adapter.bootstrap();
   }
 
   // Write out the files configured by the user

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -2,3 +2,5 @@ export { createSystem } from './lib/createSystem';
 export { createExpressServer } from './lib/server/createExpressServer';
 export { initConfig } from './lib/config/initConfig';
 export { createApolloServerMicro } from './lib/server/createApolloServer';
+export { KeystoneCloudFileAdapter } from './lib/keystone-cloud/KeystoneCloudFileAdapter';
+export { KeystoneCloudImageAdapter } from './lib/keystone-cloud/KeystoneCloudImageAdapter';

--- a/packages/keystone/src/lib/context/createFilesContext.ts
+++ b/packages/keystone/src/lib/context/createFilesContext.ts
@@ -1,144 +1,22 @@
-import path from 'path';
-import crypto from 'crypto';
-import { pipeline } from 'stream';
-import filenamify from 'filenamify';
 import { KeystoneConfig, FilesContext } from '@keystone-next/types';
-import fs from 'fs-extra';
-
-import { parseFileRef, isLocalAsset, isKeystoneCloudAsset } from '@keystone-next/utils';
-import slugify from '@sindresorhus/slugify';
-import {
-  buildKeystoneCloudFileSrc,
-  uploadFileToKeystoneCloud,
-  getFileFromKeystoneCloud,
-} from '../keystone-cloud/assets';
-
-const DEFAULT_BASE_URL = '/files';
-const DEFAULT_STORAGE_PATH = './public/files';
-
-const defaultTransformer = (str: string) => slugify(str);
-
-const generateSafeFilename = (
-  filename: string,
-  transformFilename: (str: string) => string = defaultTransformer
-) => {
-  // Appends a UUID to the filename so that people can't brute-force guess stored filenames
-  //
-  // This regex lazily matches for any characters that aren't a new line
-  // it then optionally matches the last instance of a "." symbol
-  // followed by any alphabetical character before the end of the string
-  const [, name, ext] = filename.match(/^([^:\n].*?)(\.[A-Za-z]+)?$/) as RegExpMatchArray;
-
-  const id = crypto
-    .randomBytes(24)
-    .toString('base64')
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .slice(12);
-
-  // console.log(id, id.length, id.slice(12).length);
-  const urlSafeName = filenamify(transformFilename(name), {
-    maxLength: 100 - id.length,
-    replacement: '-',
-  });
-  if (ext) {
-    return `${urlSafeName}-${id}${ext}`;
-  }
-  return `${urlSafeName}-${id}`;
-};
 
 export function createFilesContext(config: KeystoneConfig): FilesContext | undefined {
   if (!config.files) {
     return;
   }
 
-  const { files, experimental } = config;
-  const { baseUrl = DEFAULT_BASE_URL, storagePath = DEFAULT_STORAGE_PATH } = files.local || {};
-  const {
-    apiKey = '',
-    graphqlApiEndpoint = '',
-    restApiEndpoint = '',
-  } = experimental?.keystoneCloud || {};
-
+  const { files } = config;
   const { adapter } = files;
-
-  if (isLocalAsset(files.upload)) {
-    fs.mkdirSync(storagePath, { recursive: true });
-  }
 
   return {
     getSrc: async (mode, filename) => {
-      if (adapter) {
-        return adapter.getSrc(filename);
-      }
-      if (isKeystoneCloudAsset(mode)) {
-        return await buildKeystoneCloudFileSrc({ apiKey, graphqlApiEndpoint, filename });
-      }
-
-      return `${baseUrl}/${filename}`;
+      return adapter.getSrc(filename);
     },
     getDataFromRef: async (ref: string) => {
-      if (adapter) {
-        return adapter.getDataFromRef(ref);
-      }
-      const fileRef = parseFileRef(ref);
-
-      if (!fileRef) {
-        throw new Error('Invalid file reference');
-      }
-
-      const { mode, filename } = fileRef;
-
-      if (isKeystoneCloudAsset(mode)) {
-        const { filesize } = await getFileFromKeystoneCloud({
-          apiKey,
-          filename,
-          restApiEndpoint,
-        });
-
-        return { filesize, ...fileRef };
-      }
-
-      const { size: filesize } = await fs.stat(path.join(storagePath, fileRef.filename));
-
-      return { filesize, ...fileRef };
+      return adapter.getDataFromRef(ref);
     },
     getDataFromStream: async (stream, originalFilename) => {
-      if (adapter) {
-        return adapter.getDataFromStream(stream, originalFilename);
-      }
-      const { upload: mode } = files;
-      const filename = generateSafeFilename(originalFilename, files.transformFilename);
-
-      if (isKeystoneCloudAsset(mode)) {
-        const { filesize } = await uploadFileToKeystoneCloud({
-          apiKey,
-          stream,
-          filename,
-          restApiEndpoint,
-        });
-
-        return { mode, filesize, filename };
-      }
-
-      const writeStream = fs.createWriteStream(path.join(storagePath, filename));
-      const pipeStreams: Promise<void> = new Promise((resolve, reject) => {
-        pipeline(stream, writeStream, err => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        });
-      });
-
-      try {
-        await pipeStreams;
-        const { size: filesize } = await fs.stat(path.join(storagePath, filename));
-        return { mode, filesize, filename };
-      } catch (e) {
-        await fs.remove(path.join(storagePath, filename));
-        throw e;
-      }
+      return adapter.getDataFromStream(stream, originalFilename);
     },
   };
 }

--- a/packages/keystone/src/lib/context/createFilesContext.ts
+++ b/packages/keystone/src/lib/context/createFilesContext.ts
@@ -8,6 +8,8 @@ export function createFilesContext(config: KeystoneConfig): FilesContext | undef
   const { files } = config;
   const { adapter } = files;
 
+  adapter.bootstrap();
+
   return {
     getSrc: adapter.getSrc,
     getDataFromRef: adapter.getDataFromRef,

--- a/packages/keystone/src/lib/context/createFilesContext.ts
+++ b/packages/keystone/src/lib/context/createFilesContext.ts
@@ -9,14 +9,8 @@ export function createFilesContext(config: KeystoneConfig): FilesContext | undef
   const { adapter } = files;
 
   return {
-    getSrc: async (mode, filename) => {
-      return adapter.getSrc(filename);
-    },
-    getDataFromRef: async (ref: string) => {
-      return adapter.getDataFromRef(ref);
-    },
-    getDataFromStream: async (stream, originalFilename) => {
-      return adapter.getDataFromStream(stream, originalFilename);
-    },
+    getSrc: adapter.getSrc,
+    getDataFromRef: adapter.getDataFromRef,
+    getDataFromStream: adapter.getDataFromStream,
   };
 }

--- a/packages/keystone/src/lib/context/createFilesContext.ts
+++ b/packages/keystone/src/lib/context/createFilesContext.ts
@@ -59,12 +59,17 @@ export function createFilesContext(config: KeystoneConfig): FilesContext | undef
     restApiEndpoint = '',
   } = experimental?.keystoneCloud || {};
 
+  const { adapter } = files;
+
   if (isLocalAsset(files.upload)) {
     fs.mkdirSync(storagePath, { recursive: true });
   }
 
   return {
     getSrc: async (mode, filename) => {
+      if (adapter) {
+        return adapter.getSrc(filename);
+      }
       if (isKeystoneCloudAsset(mode)) {
         return await buildKeystoneCloudFileSrc({ apiKey, graphqlApiEndpoint, filename });
       }
@@ -72,6 +77,9 @@ export function createFilesContext(config: KeystoneConfig): FilesContext | undef
       return `${baseUrl}/${filename}`;
     },
     getDataFromRef: async (ref: string) => {
+      if (adapter) {
+        return adapter.getDataFromRef(ref);
+      }
       const fileRef = parseFileRef(ref);
 
       if (!fileRef) {
@@ -95,6 +103,9 @@ export function createFilesContext(config: KeystoneConfig): FilesContext | undef
       return { filesize, ...fileRef };
     },
     getDataFromStream: async (stream, originalFilename) => {
+      if (adapter) {
+        return adapter.getDataFromStream(stream, originalFilename);
+      }
       const { upload: mode } = files;
       const filename = generateSafeFilename(originalFilename, files.transformFilename);
 

--- a/packages/keystone/src/lib/context/createImagesContext.ts
+++ b/packages/keystone/src/lib/context/createImagesContext.ts
@@ -7,6 +7,9 @@ export function createImagesContext(config: KeystoneConfig): ImagesContext | und
 
   const { images } = config;
   const { adapter } = images;
+
+  adapter.bootstrap();
+
   return {
     getSrc: adapter.getSrc,
     getDataFromRef: adapter.getDataFromRef,

--- a/packages/keystone/src/lib/context/createImagesContext.ts
+++ b/packages/keystone/src/lib/context/createImagesContext.ts
@@ -1,133 +1,15 @@
-import path from 'path';
-import { KeystoneConfig, ImagesContext, ImageMetadata } from '@keystone-next/types';
-import { v4 as uuid } from 'uuid';
-import fs from 'fs-extra';
-import fromBuffer from 'image-type';
-import imageSize from 'image-size';
-import { parseImageRef, isLocalAsset, isKeystoneCloudAsset } from '@keystone-next/utils';
-import {
-  buildKeystoneCloudImageSrc,
-  getImageMetadataFromKeystoneCloud,
-  uploadImageToKeystoneCloud,
-} from '../keystone-cloud/assets';
-
-const DEFAULT_BASE_URL = '/images';
-const DEFAULT_STORAGE_PATH = './public/images';
-
-const getImageMetadataFromBuffer = async (buffer: Buffer): Promise<ImageMetadata> => {
-  const filesize = buffer.length;
-  const fileType = fromBuffer(buffer);
-  if (!fileType) {
-    throw new Error('File type not found');
-  }
-
-  if (
-    fileType.ext !== 'jpg' &&
-    fileType.ext !== 'png' &&
-    fileType.ext !== 'webp' &&
-    fileType.ext !== 'gif'
-  ) {
-    throw new Error(`${fileType.ext} is not a supported image type`);
-  }
-
-  const extension = fileType.ext;
-
-  const { height, width } = imageSize(buffer);
-
-  if (width === undefined || height === undefined) {
-    throw new Error('Height and width could not be found for image');
-  }
-  return { width, height, filesize, extension };
-};
+import { KeystoneConfig, ImagesContext } from '@keystone-next/types';
 
 export function createImagesContext(config: KeystoneConfig): ImagesContext | undefined {
   if (!config.images) {
     return;
   }
 
-  const { images, experimental } = config;
-  const { baseUrl = DEFAULT_BASE_URL, storagePath = DEFAULT_STORAGE_PATH } = images.local || {};
-  const {
-    apiKey = '',
-    imagesDomain = '',
-    graphqlApiEndpoint = '',
-    restApiEndpoint = '',
-  } = experimental?.keystoneCloud || {};
-
-  if (isLocalAsset(images.upload)) {
-    fs.mkdirSync(storagePath, { recursive: true });
-  }
-
+  const { images } = config;
+  const { adapter } = images;
   return {
-    getSrc: async (mode, id, extension) => {
-      const filename = `${id}.${extension}`;
-
-      if (isKeystoneCloudAsset(mode)) {
-        return await buildKeystoneCloudImageSrc({
-          apiKey,
-          imagesDomain,
-          graphqlApiEndpoint,
-          filename,
-        });
-      }
-
-      return `${baseUrl}/${filename}`;
-    },
-    getDataFromRef: async ref => {
-      const imageRef = parseImageRef(ref);
-
-      if (!imageRef) {
-        throw new Error('Invalid image reference');
-      }
-
-      const { mode } = imageRef;
-
-      if (isKeystoneCloudAsset(mode)) {
-        const { id, extension } = imageRef;
-        const filename = `${id}.${extension}`;
-        const metadata = await getImageMetadataFromKeystoneCloud({
-          filename,
-          apiKey,
-          restApiEndpoint,
-        });
-
-        return { ...imageRef, ...metadata };
-      }
-
-      const buffer = await fs.readFile(
-        path.join(storagePath, `${imageRef.id}.${imageRef.extension}`)
-      );
-      const metadata = await getImageMetadataFromBuffer(buffer);
-
-      return { ...imageRef, ...metadata };
-    },
-    getDataFromStream: async stream => {
-      const { upload: mode } = images;
-      const id = uuid();
-
-      if (isKeystoneCloudAsset(mode)) {
-        const metadata = await uploadImageToKeystoneCloud({
-          apiKey,
-          stream,
-          restApiEndpoint,
-          filename: id,
-        });
-
-        return { mode, id, ...metadata };
-      }
-
-      const chunks = [];
-
-      for await (let chunk of stream) {
-        chunks.push(chunk);
-      }
-
-      const buffer = Buffer.concat(chunks);
-      const metadata = await getImageMetadataFromBuffer(buffer);
-
-      await fs.writeFile(path.join(storagePath, `${id}.${metadata.extension}`), buffer);
-
-      return { mode, id, ...metadata };
-    },
+    getSrc: adapter.getSrc,
+    getDataFromRef: adapter.getDataFromRef,
+    getDataFromStream: adapter.getDataFromStream,
   };
 }

--- a/packages/keystone/src/lib/keystone-cloud/KeystoneCloudFileAdapter.ts
+++ b/packages/keystone/src/lib/keystone-cloud/KeystoneCloudFileAdapter.ts
@@ -1,0 +1,57 @@
+import { Readable } from 'stream';
+import { FileData } from '@keystone-next/types';
+import { FileAdapter } from '@keystone-next/file-adapters';
+import { parseFileRef } from '@keystone-next/utils';
+import { generateSafeFilename } from '@keystone-next/file-adapters/src/utils';
+import {
+  buildKeystoneCloudFileSrc,
+  getFileFromKeystoneCloud,
+  uploadFileToKeystoneCloud,
+} from './assets';
+
+export type KeystoneCloudFileAdapterConfig = {
+  apiKey: string;
+  graphqlApiEndpoint: string;
+  restApiEndpoint: string;
+  transformFilename?: (str: string) => string;
+};
+
+export class KeystoneCloudFileAdapter extends FileAdapter {
+  constructor(private config: KeystoneCloudFileAdapterConfig) {
+    super();
+  }
+  getSrc(filename: string) {
+    return buildKeystoneCloudFileSrc({
+      apiKey: this.config.apiKey,
+      graphqlApiEndpoint: this.config.graphqlApiEndpoint,
+      filename,
+    });
+  }
+  async getDataFromRef(ref: string): Promise<FileData> {
+    const fileRef = parseFileRef(ref);
+
+    if (!fileRef) {
+      throw new Error('Invalid file reference');
+    }
+    const { filename } = fileRef;
+    const { filesize } = await getFileFromKeystoneCloud({
+      apiKey: this.config.apiKey,
+      restApiEndpoint: this.config.restApiEndpoint,
+      filename,
+    });
+
+    return { filesize, ...fileRef };
+  }
+  async getDataFromStream(stream: Readable, originalFilename: string): Promise<FileData> {
+    const filename = generateSafeFilename(originalFilename, this.config.transformFilename);
+
+    const { filesize } = await uploadFileToKeystoneCloud({
+      apiKey: this.config.apiKey,
+      restApiEndpoint: this.config.restApiEndpoint,
+      stream,
+      filename,
+    });
+
+    return { mode: 'keystone-cloud', filesize, filename };
+  }
+}

--- a/packages/keystone/src/lib/keystone-cloud/KeystoneCloudFileAdapter.ts
+++ b/packages/keystone/src/lib/keystone-cloud/KeystoneCloudFileAdapter.ts
@@ -52,6 +52,6 @@ export class KeystoneCloudFileAdapter extends FileAdapter {
       filename,
     });
 
-    return { mode: 'keystone-cloud', filesize, filename };
+    return { filesize, filename };
   }
 }

--- a/packages/keystone/src/lib/keystone-cloud/KeystoneCloudImageAdapter.ts
+++ b/packages/keystone/src/lib/keystone-cloud/KeystoneCloudImageAdapter.ts
@@ -1,0 +1,61 @@
+import { Readable } from 'stream';
+import { v4 as uuid } from 'uuid';
+import { ImageExtension, ImageData } from '@keystone-next/types';
+import { parseImageRef } from '@keystone-next/utils';
+import { ImageAdapter } from '@keystone-next/file-adapters';
+import {
+  buildKeystoneCloudImageSrc,
+  getImageMetadataFromKeystoneCloud,
+  uploadImageToKeystoneCloud,
+} from './assets';
+
+export type KeystoneCloudImageAdapterConfig = {
+  apiKey: string;
+  graphqlApiEndpoint: string;
+  restApiEndpoint: string;
+  imagesDomain: string;
+};
+
+export class KeystoneCloudImageAdapter extends ImageAdapter {
+  constructor(private config: KeystoneCloudImageAdapterConfig) {
+    super();
+  }
+  getSrc(id: string, extension: ImageExtension) {
+    const filename = `${id}.${extension}`;
+    return buildKeystoneCloudImageSrc({
+      apiKey: this.config.apiKey,
+      imagesDomain: this.config.imagesDomain,
+      graphqlApiEndpoint: this.config.graphqlApiEndpoint,
+      filename,
+    });
+  }
+  async getDataFromRef(ref: string): Promise<ImageData> {
+    const imageRef = parseImageRef(ref);
+
+    if (!imageRef) {
+      throw new Error('Invalid image reference');
+    }
+
+    const { id, extension } = imageRef;
+    const filename = `${id}.${extension}`;
+    const metadata = await getImageMetadataFromKeystoneCloud({
+      filename,
+      apiKey: this.config.apiKey,
+      restApiEndpoint: this.config.restApiEndpoint,
+    });
+
+    return { ...imageRef, ...metadata };
+  }
+  async getDataFromStream(stream: Readable): Promise<ImageData> {
+    const id = uuid();
+
+    const metadata = await uploadImageToKeystoneCloud({
+      apiKey: this.config.apiKey,
+      stream,
+      restApiEndpoint: this.config.restApiEndpoint,
+      filename: id,
+    });
+
+    return { id, ...metadata };
+  }
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,6 +11,7 @@
     "@babel/runtime": "^7.15.3",
     "@graphql-ts/schema": "0.2.0",
     "@keystone-next/fields": "^14.0.0",
+    "@keystone-next/file-adapters": "^0.1.0",
     "apollo-server-types": "^0.9.0",
     "cors": "^2.8.5",
     "decimal.js": "10.3.1",

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -187,21 +187,7 @@ export type ExtendGraphqlSchema = (schema: GraphQLSchema) => GraphQLSchema;
 // config.files
 
 export type FilesConfig = {
-  upload: AssetMode;
-  transformFilename?: (str: string) => string;
-  local?: {
-    /**
-     * The path local files are uploaded to.
-     * @default 'public/files'
-     */
-    storagePath?: string;
-    /**
-     * The base of the URL local files will be served from, outside of keystone.
-     * @default '/files'
-     */
-    baseUrl?: string;
-  };
-  adapter?: FileAdapter;
+  adapter: FileAdapter;
 };
 
 // config.images
@@ -220,7 +206,6 @@ export type ImagesConfig = {
      */
     baseUrl?: string;
   };
-  adapter?: FileAdapter;
 };
 
 // config.experimental.keystoneCloud

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -1,9 +1,9 @@
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import type { Config } from 'apollo-server-express';
-import { FileAdapter } from '@keystone-next/file-adapters';
+import { FileAdapter, ImageAdapter } from '@keystone-next/file-adapters';
 
-import type { AssetMode, KeystoneContext } from '..';
+import type { KeystoneContext } from '..';
 
 import { SessionStrategy } from '../session';
 import type { MaybePromise } from '../utils';
@@ -193,19 +193,7 @@ export type FilesConfig = {
 // config.images
 
 export type ImagesConfig = {
-  upload: AssetMode;
-  local?: {
-    /**
-     * The path local images are uploaded to.
-     * @default 'public/images'
-     */
-    storagePath?: string;
-    /**
-     * The base of the URL local images will be served from, outside of keystone.
-     * @default '/images'
-     */
-    baseUrl?: string;
-  };
+  adapter: ImageAdapter;
 };
 
 // config.experimental.keystoneCloud

--- a/packages/types/src/config/index.ts
+++ b/packages/types/src/config/index.ts
@@ -1,6 +1,7 @@
 import { CorsOptions } from 'cors';
 import type { GraphQLSchema } from 'graphql';
 import type { Config } from 'apollo-server-express';
+import { FileAdapter } from '@keystone-next/file-adapters';
 
 import type { AssetMode, KeystoneContext } from '..';
 
@@ -200,6 +201,7 @@ export type FilesConfig = {
      */
     baseUrl?: string;
   };
+  adapter?: FileAdapter;
 };
 
 // config.images
@@ -218,6 +220,7 @@ export type ImagesConfig = {
      */
     baseUrl?: string;
   };
+  adapter?: FileAdapter;
 };
 
 // config.experimental.keystoneCloud

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -154,8 +154,6 @@ export type SessionContext<T> = {
   endSession(): Promise<void>;
 };
 
-export type AssetMode = 'local' | 'keystone-cloud';
-
 // Files API
 
 export type FileData = {
@@ -181,12 +179,11 @@ export type ImageMetadata = {
 };
 
 export type ImageData = {
-  mode: AssetMode;
   id: string;
 } & ImageMetadata;
 
 export type ImagesContext = {
-  getSrc: (mode: AssetMode, id: string, extension: ImageExtension) => Promise<string>;
+  getSrc: (id: string, extension: ImageExtension) => Promise<string>;
   getDataFromRef: (ref: string) => Promise<ImageData>;
   getDataFromStream: (stream: Readable) => Promise<ImageData>;
 };

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -159,13 +159,12 @@ export type AssetMode = 'local' | 'keystone-cloud';
 // Files API
 
 export type FileData = {
-  mode: AssetMode;
   filename: string;
   filesize: number;
 };
 
 export type FilesContext = {
-  getSrc: (mode: AssetMode, filename: string) => Promise<string>;
+  getSrc: (filename: string) => Promise<string>;
   getDataFromRef: (ref: string) => Promise<FileData>;
   getDataFromStream: (stream: Readable, filename: string) => Promise<FileData>;
 };

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,18 +1,16 @@
-import { AssetMode, ImageExtension } from '@keystone-next/types';
+import { ImageExtension } from '@keystone-next/types';
 
-const IMAGEREGEX = /^(local|keystone-cloud):image:([^\\\/:\n]+)\.(gif|jpg|png|webp)$/;
-const FILEREGEX = /^(local|keystone-cloud):file:([^\\\/:\n]+)/;
+const IMAGEREGEX = /^image:([^\\\/:\n]+)\.(gif|jpg|png|webp)$/;
+const FILEREGEX = /^file:([^\\\/:\n]+)/;
 
-export const getImageRef = (mode: AssetMode, id: string, extension: ImageExtension) =>
-  `${mode}:image:${id}.${extension}`;
+export const getImageRef = (id: string, extension: ImageExtension) => `image:${id}.${extension}`;
 
 export const getFileRef = (name: string) => `file:${name}`;
 export const parseFileRef = (ref: string) => {
   const match = ref.match(FILEREGEX);
   if (match) {
-    const [, mode, filename] = match;
+    const [, filename] = match;
     return {
-      mode: mode as AssetMode,
       filename: filename as string,
     };
   }
@@ -23,19 +21,14 @@ export const SUPPORTED_IMAGE_EXTENSIONS = ['jpg', 'png', 'webp', 'gif'];
 
 export const parseImageRef = (
   ref: string
-): { mode: AssetMode; id: string; extension: ImageExtension } | undefined => {
+): { id: string; extension: ImageExtension } | undefined => {
   const match = ref.match(IMAGEREGEX);
   if (match) {
-    const [, mode, id, ext] = match;
+    const [, id, ext] = match;
     return {
-      mode: mode as AssetMode,
       id,
       extension: ext as ImageExtension,
     };
   }
   return undefined;
 };
-
-export const isLocalAsset = (mode: AssetMode) => mode === 'local';
-
-export const isKeystoneCloudAsset = (mode: AssetMode) => mode === 'keystone-cloud';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,7 +6,7 @@ const FILEREGEX = /^(local|keystone-cloud):file:([^\\\/:\n]+)/;
 export const getImageRef = (mode: AssetMode, id: string, extension: ImageExtension) =>
   `${mode}:image:${id}.${extension}`;
 
-export const getFileRef = (mode: AssetMode, name: string) => `${mode}:file:${name}`;
+export const getFileRef = (name: string) => `file:${name}`;
 export const parseFileRef = (ref: string) => {
   const match = ref.match(FILEREGEX);
   if (match) {

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -3,6 +3,7 @@ import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { KeystoneContext } from '@keystone-next/types';
 import { setupTestRunner } from '@keystone-next/testing';
+import { LocalImageAdapter, LocalFileAdapter } from '@keystone-next/file-adapters';
 import { apiTestConfig } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {
@@ -24,8 +25,8 @@ testModules
           lists: createSchema({
             [listKey]: list({ fields: mod.getTestFields(matrixValue) }),
           }),
-          images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-          files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+          images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+          files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
         }),
       });
       const keystoneTestWrapper = (testFn: (args: any) => void = () => {}) =>

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -3,6 +3,7 @@ import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { KeystoneContext } from '@keystone-next/types';
 import { setupTestRunner } from '@keystone-next/testing';
+import { LocalImageAdapter, LocalFileAdapter } from '@keystone-next/file-adapters';
 import { apiTestConfig } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {
@@ -23,8 +24,8 @@ testModules
           lists: createSchema({
             [listKey]: list({ fields: mod.getTestFields(matrixValue) }),
           }),
-          images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-          files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+          images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+          files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
         }),
       });
       const withKeystone = (testFn: (args: any) => void = () => {}) =>

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -2,6 +2,7 @@ import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
 import { setupTestRunner } from '@keystone-next/testing';
+import { LocalImageAdapter, LocalFileAdapter } from '@keystone-next/file-adapters';
 import { apiTestConfig, expectValidationError } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {
@@ -50,8 +51,8 @@ testModules
                 },
               }),
             }),
-            images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-            files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+            images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+            files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
           }),
         });
 

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -2,6 +2,7 @@ import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { text } from '@keystone-next/fields';
 import { setupTestEnv, setupTestRunner } from '@keystone-next/testing';
+import { LocalFileAdapter, LocalImageAdapter } from '@keystone-next/file-adapters';
 import { apiTestConfig, expectPrismaError } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {
@@ -50,8 +51,8 @@ testModules
                 },
               }),
             }),
-            images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-            files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+            images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+            files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
           }),
         });
         test(
@@ -158,8 +159,8 @@ testModules
                     },
                   }),
                 }),
-                images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-                files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+                images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+                  files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
               }),
             });
           } catch (error) {

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -160,7 +160,7 @@ testModules
                   }),
                 }),
                 images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
-                  files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
+                files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
               }),
             });
           } catch (error) {

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import globby from 'globby';
 import { createSchema, list } from '@keystone-next/keystone/schema';
 import { setupTestEnv } from '@keystone-next/testing';
+import { LocalFileAdapter, LocalImageAdapter } from '@keystone-next/file-adapters';
 import { apiTestConfig } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {
@@ -49,8 +50,8 @@ if (unsupportedModules.length > 0) {
                   lists: createSchema({
                     [listKey]: list({ fields: mod.getTestFields(matrixValue) }),
                   }),
-                  images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
-                  files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
+                  images: { adapter: new LocalImageAdapter({ storagePath: 'tmp_test_images' }) },
+                  files: { adapter: new LocalFileAdapter({ storagePath: 'tmp_test_files' }) },
                 }),
               })
           ).rejects.toThrow(Error);

--- a/tests/api-tests/package.json
+++ b/tests/api-tests/package.json
@@ -15,6 +15,7 @@
     "@keystone-next/auth": "*",
     "@keystone-next/fields": "*",
     "@keystone-next/fields-document": "*",
+    "@keystone-next/file-adapters": "*",
     "@keystone-next/keystone": "*",
     "cookie-signature": "^1.1.0",
     "cuid": "^2.1.8",


### PR DESCRIPTION
This is a prototype of how Keystone v6 could support File Adapters in an abstract way, allowing for custom adapters to be written to store files in cloud services like S3, Azure Storage, etc., rather than on local disk.

I've done the refactor to have the two existing types, local file and keystone-cloud, implemented in this pattern.

Edit - added image adapter too

Edit 2 - Linting/etc. all looks fixed. Test's are failing on the stuff I changed but I can't figure out how to run/debug tests locally to fix them