### PR TITLE
merge aria-description text into aria-label

### DIFF
--- a/.changeset/spotty-ducks-wonder.md
+++ b/.changeset/spotty-ducks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Merged aria-description text for dialogs on list view in Admin UI into their respective aria-labels.

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FieldSelection.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FieldSelection.tsx
@@ -71,8 +71,7 @@ export function FieldSelection({
 
   return (
     <Popover
-      aria-label="Columns options"
-      aria-description={`list of column options to apply to the ${list.key} list`}
+      aria-label={`Columns options, list of column options to apply to the ${list.key} list`}
       triggerRenderer={({ triggerProps }) => {
         return (
           <Button weight="link" css={{ padding: 4 }} {...triggerProps}>

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterAdd.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterAdd.tsx
@@ -75,8 +75,7 @@ export function FilterAdd({ listKey }: { listKey: string }) {
         <ChevronDownIcon size="small" />
       </Button>
       <PopoverDialog
-        aria-label="Filters options"
-        aria-description={`list of filters to apply to the ${listKey} list`}
+        aria-label={`Filters options, list of filters to apply to the ${listKey} list`}
         arrow={arrow}
         isVisible={isOpen}
         {...dialog.props}

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterList.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterList.tsx
@@ -43,9 +43,8 @@ function FilterPill({ filter, field }: { filter: Filter; field: FieldMeta }) {
     <Fragment>
       <Pill
         containerProps={{
-          'aria-label': `Filter item ${filter.field}`,
+          'aria-label': `Filter item ${filter.field}, press to edit filter`,
         }}
-        aria-description={'Press to edit filter'}
         {...trigger.props}
         ref={trigger.ref}
         onClick={() => setOpen(true)}
@@ -64,8 +63,7 @@ function FilterPill({ filter, field }: { filter: Filter; field: FieldMeta }) {
         />
       </Pill>
       <PopoverDialog
-        aria-label="filter item config"
-        aria-description={`dialog for configuring ${filter.field} filter`}
+        aria-label={`filter item config, dialog for configuring ${filter.field} filter`}
         arrow={arrow}
         {...dialog.props}
         isVisible={isOpen}

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
@@ -44,8 +44,7 @@ export function SortSelection({ list }: { list: ListMeta }) {
       </Button>
 
       <PopoverDialog
-        aria-label="Sort options"
-        aria-description={`list of sorting parameters to apply to the ${list.key} list`}
+        aria-label={`Sort options, list of sorting parameters to apply to the ${list.key} list`}
         arrow={arrow}
         isVisible={isOpen}
         {...dialog.props}


### PR DESCRIPTION
resolves #6274 
PR merges aria-description text into aria-label attribute for:
* Filter options dialog 
* Sort options dialog
* Column options dialog   

not leaning on `aria-describedby` here as we don't really want the description text to be visible in the DOM, just additional context for screen reader users. 