### PR TITLE
Fix styles on document field demo on website live

### DIFF
--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />

--- a/docs/pages/docs/guides/document-field-demo.mdx
+++ b/docs/pages/docs/guides/document-field-demo.mdx
@@ -25,6 +25,7 @@ export default ({ children }) => {
   const headings = getHeadings(children);
   return (
     <DocsPage
+      noProse
       title={'Document Fields Demo'}
       description={'Try Keystone’s powerful new Document field. Experiment with its config settings in real time to shape custom editing experiences.'}
       headings={[


### PR DESCRIPTION
~~Note the `docs/next-env.d.ts` change is unrelated but Next forces it and it's fine now that we use Next 11 in the Admin UI as well.~~ Next isn't up to date on this branch so that's been reverted.