### PR TITLE
Fix a process crash when createContext() fails for the Admin UI

### DIFF
--- a/.changeset/tidy-hairs-visit.md
+++ b/.changeset/tidy-hairs-visit.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Fixed crashing the process when createContext() fails for Admin UI requests

--- a/packages/keystone/static/admin-error.html
+++ b/packages/keystone/static/admin-error.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <title>KeystoneJS</title>
+    <style type="text/css">
+      html,
+      body {
+        height: 100vh;
+      }
+      body {
+        align-items: center;
+        background-color: #fafbfc;
+        color: #172b4d;
+        display: flex;
+        flex-direction: column;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial,
+          sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        font-size: 15px;
+        justify-content: center;
+        letter-spacing: -0.005em;
+        margin: 0;
+        padding: 0;
+        text-decoration-skip: ink;
+        text-rendering: optimizeLegibility;
+        -ms-overflow-style: -ms-autohiding-scrollbar;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      h1 {
+        font-weight: 300;
+        margin-bottom: 0.66em;
+        margin-top: 0;
+      }
+      p {
+        color: #6c798f;
+      }
+      .container {
+        margin-top: -4vh;
+        padding-left: 1em;
+        padding-right: 1em;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="status">Error</h1>
+      <p id="message">Something went wrong loading the Admin UI</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
If you've got a custom session `get` function, and it throws an error to return through the GraphQL API, because Admin UI's  context creation for the access check isn't in a `try/catch` block it causes the process to crash.

This PR wraps the entire Admin UI rendering block in a try/catch and adds a new static error html file to return if something goes wrong.