### PR TITLE
Fast Graphql API Startup in Dev

### DIFF
--- a/.changeset/ninety-books-glow.md
+++ b/.changeset/ninety-books-glow.md
@@ -1,5 +1,7 @@
 ---
-"@keystone-next/keystone": patch
+"@keystone-next/keystone": major
 ---
 
-Significantly faster Graphql API Startup in Dev
+The Graphql API endpoint now starts up significantly faster in Dev.
+
+To facilitate this, `createExpressServer` no longer includes the step of creating the Admin UI Middleware, which changes its signature. `createAdminUIMiddleware` is now also exported from `@keystone-next/keystone/system`.

--- a/.changeset/ninety-books-glow.md
+++ b/.changeset/ninety-books-glow.md
@@ -2,6 +2,6 @@
 "@keystone-next/keystone": major
 ---
 
-The Graphql API endpoint now starts up significantly faster in Dev.
+The GraphQL API endpoint now starts up significantly faster in Dev.
 
 To facilitate this, `createExpressServer` no longer includes the step of creating the Admin UI Middleware, which changes its signature. `createAdminUIMiddleware` is now also exported from `@keystone-next/keystone/system`.

--- a/.changeset/ninety-books-glow.md
+++ b/.changeset/ninety-books-glow.md
@@ -1,0 +1,5 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Significantly faster Graphql API Startup in Dev

--- a/packages/keystone/src/admin-ui/system/createAdminUIServer.ts
+++ b/packages/keystone/src/admin-ui/system/createAdminUIServer.ts
@@ -1,19 +1,18 @@
 import url from 'url';
 import express from 'express';
-import type { KeystoneConfig, SessionStrategy, CreateContext } from '../../types';
+import type { KeystoneConfig, CreateContext } from '../../types';
 import { createSessionContext } from '../../session';
 
 export const createAdminUIServer = async (
   config: KeystoneConfig,
   createContext: CreateContext,
   dev: boolean,
-  projectAdminPath: string,
-  sessionStrategy?: SessionStrategy<any>
+  projectAdminPath: string
 ) => {
   /** We do this to stop webpack from bundling next inside of next */
-  const { ui, graphql } = config;
-  const thing = 'next';
-  const next = require(thing);
+  const { ui, graphql, session } = config;
+  const _next = 'next';
+  const next = require(_next);
   const app = next({ dev, dir: projectAdminPath });
   const handle = app.getRequestHandler();
   await app.prepare();
@@ -26,14 +25,14 @@ export const createAdminUIServer = async (
       return;
     }
     const context = createContext({
-      sessionContext: sessionStrategy
-        ? await createSessionContext(sessionStrategy, req, res, createContext)
+      sessionContext: session
+        ? await createSessionContext(session, req, res, createContext)
         : undefined,
       req,
     });
     const isValidSession = ui?.isAccessAllowed
       ? await ui.isAccessAllowed(context)
-      : sessionStrategy
+      : session
       ? context.session !== undefined
       : true;
     const maybeRedirect = await ui?.pageMiddleware?.({ context, isValidSession });

--- a/packages/keystone/src/admin-ui/system/index.ts
+++ b/packages/keystone/src/admin-ui/system/index.ts
@@ -1,4 +1,4 @@
 export { generateAdminUI } from './generateAdminUI';
-export { createAdminUIServer } from './createAdminUIServer';
+export { createAdminUIMiddleware } from './createAdminUIMiddleware';
 export { getAdminMetaSchema } from './getAdminMetaSchema';
 export { buildAdminUI } from './buildAdminUI';

--- a/packages/keystone/src/admin-ui/system/index.ts
+++ b/packages/keystone/src/admin-ui/system/index.ts
@@ -1,4 +1,3 @@
 export { generateAdminUI } from './generateAdminUI';
-export { createAdminUIMiddleware } from './createAdminUIMiddleware';
 export { getAdminMetaSchema } from './getAdminMetaSchema';
 export { buildAdminUI } from './buildAdminUI';

--- a/packages/keystone/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/keystone/src/lib/server/createAdminUIMiddleware.ts
@@ -10,7 +10,7 @@ const adminErrorHTMLFilepath = path.join(
   'admin-error.html'
 );
 
-export const createAdminUIServer = async (
+export const createAdminUIMiddleware = async (
   config: KeystoneConfig,
   createContext: CreateContext,
   dev: boolean,

--- a/packages/keystone/src/lib/server/createExpressServer.ts
+++ b/packages/keystone/src/lib/server/createExpressServer.ts
@@ -3,9 +3,16 @@ import express from 'express';
 import { GraphQLSchema } from 'graphql';
 import { graphqlUploadExpress } from 'graphql-upload';
 import type { KeystoneConfig, CreateContext, SessionStrategy, GraphQLConfig } from '../../types';
-import { createAdminUIServer } from '../../admin-ui/system';
 import { createApolloServerExpress } from './createApolloServer';
 import { addHealthCheck } from './addHealthCheck';
+
+/*
+NOTE: This creates the main Keystone express server, including the
+GraphQL API, but does NOT add the Admin UI middleware.
+
+The Admin UI takes a while to build for dev, and is created separately
+so the CLI can bring up the dev server early to handle GraphQL requests.
+*/
 
 const DEFAULT_MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MiB
 
@@ -43,10 +50,7 @@ const addApolloServer = ({
 export const createExpressServer = async (
   config: KeystoneConfig,
   graphQLSchema: GraphQLSchema,
-  createContext: CreateContext,
-  dev: boolean,
-  projectAdminPath: string,
-  isVerbose: boolean = true
+  createContext: CreateContext
 ) => {
   const server = express();
 
@@ -62,7 +66,6 @@ export const createExpressServer = async (
 
   addHealthCheck({ config, server });
 
-  if (isVerbose) console.log('✨ Preparing GraphQL Server');
   addApolloServer({
     server,
     config,
@@ -71,15 +74,6 @@ export const createExpressServer = async (
     sessionStrategy: config.session,
     graphqlConfig: config.graphql,
   });
-
-  if (config.ui?.isDisabled) {
-    if (isVerbose) console.log('✨ Skipping Admin UI app');
-  } else {
-    if (isVerbose) console.log('✨ Preparing Admin UI Next.js app');
-    server.use(
-      await createAdminUIServer(config, createContext, dev, projectAdminPath, config.session)
-    );
-  }
 
   return server;
 };

--- a/packages/keystone/src/scripts/run/dev.ts
+++ b/packages/keystone/src/scripts/run/dev.ts
@@ -1,13 +1,14 @@
 import path from 'path';
 import url from 'url';
 import express from 'express';
-import { createAdminUIServer, generateAdminUI } from '../../admin-ui/system';
+import { generateAdminUI } from '../../admin-ui/system';
 import { devMigrations, pushPrismaSchemaToDatabase } from '../../lib/migrations';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
 import { requireSource } from '../../lib/config/requireSource';
 import { defaults } from '../../lib/config/defaults';
 import { createExpressServer } from '../../lib/server/createExpressServer';
+import { createAdminUIMiddleware } from '../../lib/server/createAdminUIMiddleware';
 import {
   generateCommittedArtifacts,
   generateNodeModulesArtifacts,
@@ -82,7 +83,12 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
       await generateAdminUI(config, graphQLSchema, adminMeta, getAdminPath(cwd));
 
       console.log('✨ Preparing Admin UI app');
-      adminUIMiddleware = await createAdminUIServer(config, createContext, true, getAdminPath(cwd));
+      adminUIMiddleware = await createAdminUIMiddleware(
+        config,
+        createContext,
+        true,
+        getAdminPath(cwd)
+      );
       expressServer.use(adminUIMiddleware);
       console.log(`✅ Admin UI ready`);
     }

--- a/packages/keystone/src/scripts/run/dev.ts
+++ b/packages/keystone/src/scripts/run/dev.ts
@@ -1,6 +1,7 @@
 import path from 'path';
+import url from 'url';
 import express from 'express';
-import { generateAdminUI } from '../../admin-ui/system';
+import { createAdminUIServer, generateAdminUI } from '../../admin-ui/system';
 import { devMigrations, pushPrismaSchemaToDatabase } from '../../lib/migrations';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
@@ -15,6 +16,9 @@ import {
 } from '../../artifacts';
 import { getAdminPath, getConfigPath } from '../utils';
 
+type ExpressServer = null | ReturnType<typeof express>;
+type AdminUIMiddleware = null | ((req: express.Request, res: express.Response) => Promise<void>);
+
 const devLoadingHTMLFilepath = path.join(
   path.dirname(require.resolve('@keystone-next/keystone/package.json')),
   'static',
@@ -25,7 +29,9 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   console.log('✨ Starting Keystone');
 
   const app = express();
-  let expressServer: null | ReturnType<typeof express> = null;
+  let expressServer: ExpressServer = null;
+  let adminUIMiddleware: AdminUIMiddleware = null;
+  const ready = () => !!(expressServer && adminUIMiddleware);
 
   let disconnect: null | (() => Promise<void>) = null;
 
@@ -34,10 +40,12 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const initKeystone = async () => {
     const { graphQLSchema, adminMeta, getKeystone } = createSystem(config);
 
+    // Generate the Artifacts
     console.log('✨ Generating GraphQL and Prisma schemas');
     const prismaSchema = (await generateCommittedArtifacts(graphQLSchema, config, cwd)).prisma;
     await generateNodeModulesArtifacts(graphQLSchema, config, cwd);
 
+    // Set up the Database
     if (config.db.useMigrations) {
       await devMigrations(
         config.db.url,
@@ -55,28 +63,29 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
     }
 
     const prismaClient = requirePrismaClient(cwd);
-
     const keystone = getKeystone(prismaClient);
+    const { createContext } = keystone;
 
+    // Connect to the Database
     console.log('✨ Connecting to the database');
     await keystone.connect();
     disconnect = () => keystone.disconnect();
-    if (config.ui?.isDisabled) {
-      console.log('✨ Skipping Admin UI code generation');
-    } else {
+
+    // Set up the Express Server
+    console.log('✨ Creating server');
+    expressServer = await createExpressServer(config, graphQLSchema, createContext);
+    console.log(`✅ GraphQL API ready`);
+
+    // Initialise the Admin UI
+    if (!config.ui?.isDisabled) {
       console.log('✨ Generating Admin UI code');
       await generateAdminUI(config, graphQLSchema, adminMeta, getAdminPath(cwd));
-    }
 
-    console.log('✨ Creating server');
-    expressServer = await createExpressServer(
-      config,
-      graphQLSchema,
-      keystone.createContext,
-      true,
-      getAdminPath(cwd)
-    );
-    console.log(`👋 Admin UI and GraphQL API ready`);
+      console.log('✨ Preparing Admin UI app');
+      adminUIMiddleware = await createAdminUIServer(config, createContext, true, getAdminPath(cwd));
+      expressServer.use(adminUIMiddleware);
+      console.log(`✅ Admin UI ready`);
+    }
   };
 
   // You shouldn't really be doing a healthcheck on the dev server, but we
@@ -94,13 +103,23 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
     });
   }
 
+  // Serve the dev status page for the Admin UI
   app.use('/__keystone_dev_status', (req, res) => {
-    res.json({ ready: expressServer ? true : false });
+    res.json({ ready: ready() ? true : false });
   });
+  // Pass the request the express server, or serve the loading page
   app.use((req, res, next) => {
-    if (expressServer) return expressServer(req, res, next);
+    // If both the express server and Admin UI Middleware are ready, we're go!
+    if (expressServer && adminUIMiddleware) return expressServer(req, res, next);
+    // Otherwise, we may be able to serve the GraphQL API
+    const { pathname } = url.parse(req.url);
+    if (expressServer && pathname === (config.graphql?.path || '/api/graphql')) {
+      return expressServer(req, res, next);
+    }
+    // Serve the loading page
     res.sendFile(devLoadingHTMLFilepath);
   });
+
   const port = config.server?.port || process.env.PORT || 3000;
   let initKeystonePromiseResolve: () => void | undefined;
   let initKeystonePromiseReject: (err: any) => void | undefined;
@@ -111,7 +130,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const server = app.listen(port, (err?: any) => {
     if (err) throw err;
     console.log(`⭐️ Dev Server Ready on http://localhost:${port}`);
-    // Don't start initialising Keystone until the dev server is ready,
+    // We start initialising Keystone after the dev server is ready,
     // otherwise it slows down the first response significantly
     initKeystone()
       .then(() => {

--- a/packages/keystone/src/scripts/run/start.ts
+++ b/packages/keystone/src/scripts/run/start.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs-extra';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
 import { createExpressServer } from '../../lib/server/createExpressServer';
-import { createAdminUIServer } from '../../admin-ui/system';
+import { createAdminUIMiddleware } from '../../lib/server/createAdminUIMiddleware';
 import { requirePrismaClient } from '../../artifacts';
 import { ExitError, getAdminPath } from '../utils';
 
@@ -32,7 +32,9 @@ export const start = async (cwd: string) => {
   console.log(`✅ GraphQL API ready`);
   if (!config.ui?.isDisabled) {
     console.log('✨ Preparing Admin UI Next.js app');
-    server.use(await createAdminUIServer(config, keystone.createContext, false, getAdminPath(cwd)));
+    server.use(
+      await createAdminUIMiddleware(config, keystone.createContext, false, getAdminPath(cwd))
+    );
     console.log(`✅ Admin UI ready`);
   }
 

--- a/packages/keystone/src/scripts/tests/migrations.test.ts
+++ b/packages/keystone/src/scripts/tests/migrations.test.ts
@@ -97,11 +97,8 @@ model Todo {
 ✨ sqlite database "app.db" created at file:./app.db
 ✨ Your database is now in sync with your schema. Done in 0ms
 ✨ Connecting to the database
-✨ Skipping Admin UI code generation
 ✨ Creating server
-✨ Preparing GraphQL Server
-✨ Skipping Admin UI app
-👋 Admin UI and GraphQL API ready`);
+✅ GraphQL API ready`);
   return tmp;
 }
 
@@ -116,17 +113,14 @@ describe('useMigrations: false', () => {
     await setupAndStopDevServerForMigrations(tmp);
 
     expect(recording()).toMatchInlineSnapshot(`
-      "✨ Starting Keystone
-      ⭐️ Dev Server Ready on http://localhost:3000
-      ✨ Generating GraphQL and Prisma schemas
-      ✨ The database is already in sync with the Prisma schema.
-      ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
-      ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
-    `);
+"✨ Starting Keystone
+⭐️ Dev Server Ready on http://localhost:3000
+✨ Generating GraphQL and Prisma schemas
+✨ The database is already in sync with the Prisma schema.
+✨ Connecting to the database
+✨ Creating server
+✅ GraphQL API ready"
+`);
   });
   test('warns when dropping field that has data in it', async () => {
     const prevCwd = await setupInitialProjectWithoutMigrations();
@@ -159,22 +153,19 @@ describe('useMigrations: false', () => {
       "
     `);
     expect(recording()).toMatchInlineSnapshot(`
-      "✨ Starting Keystone
-      ⭐️ Dev Server Ready on http://localhost:3000
-      ✨ Generating GraphQL and Prisma schemas
+"✨ Starting Keystone
+⭐️ Dev Server Ready on http://localhost:3000
+✨ Generating GraphQL and Prisma schemas
 
-      ⚠️  Warnings:
+⚠️  Warnings:
 
-        • You are about to drop the column \`title\` on the \`Todo\` table, which still contains 1 non-null values.
-      Prompt: Do you want to continue? Some data will be lost. true
-      ✨ Your database is now in sync with your schema. Done in 0ms
-      ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
-      ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
-    `);
+  • You are about to drop the column \`title\` on the \`Todo\` table, which still contains 1 non-null values.
+Prompt: Do you want to continue? Some data will be lost. true
+✨ Your database is now in sync with your schema. Done in 0ms
+✨ Connecting to the database
+✨ Creating server
+✅ GraphQL API ready"
+`);
   });
   test('exits when refusing data loss prompt', async () => {
     const prevCwd = await setupInitialProjectWithoutMigrations();
@@ -241,11 +232,8 @@ describe('useMigrations: false', () => {
       ✨ Your database has been reset
       ✨ Your database is now in sync with your schema. Done in 0ms
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
 });
@@ -292,11 +280,8 @@ Prompt: Name of migration init
 Prompt: Would you like to apply this migration? true
 ✅ The migration has been applied
 ✨ Connecting to the database
-✨ Skipping Admin UI code generation
 ✨ Creating server
-✨ Preparing GraphQL Server
-✨ Skipping Admin UI app
-👋 Admin UI and GraphQL API ready`);
+✅ GraphQL API ready`);
   return tmp;
 }
 
@@ -361,11 +346,8 @@ describe('useMigrations: true', () => {
       Prompt: Would you like to apply this migration? true
       ✅ The migration has been applied
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
   test('warns when dropping field that has data in it', async () => {
@@ -441,11 +423,8 @@ describe('useMigrations: true', () => {
       Prompt: Would you like to apply this migration? true
       ✅ The migration has been applied
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
   test('prompts to drop database when database is out of sync with migrations directory', async () => {
@@ -517,11 +496,8 @@ describe('useMigrations: true', () => {
       Prompt: Would you like to apply this migration? true
       ✅ The migration has been applied
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
   test("doesn't drop when prompt denied", async () => {
@@ -659,11 +635,8 @@ describe('useMigrations: true', () => {
           └─ migration.sql
       ✨ Your migrations are up to date, no new migrations need to be created
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
   test('--reset-db flag', async () => {
@@ -695,11 +668,8 @@ describe('useMigrations: true', () => {
           └─ migration.sql
       ✨ Your migrations are up to date, no new migrations need to be created
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
   test('logs correctly when no migrations need to be created or applied', async () => {
@@ -713,11 +683,8 @@ describe('useMigrations: true', () => {
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database is up to date, no migrations need to be created or applied
       ✨ Connecting to the database
-      ✨ Skipping Admin UI code generation
       ✨ Creating server
-      ✨ Preparing GraphQL Server
-      ✨ Skipping Admin UI app
-      👋 Admin UI and GraphQL API ready"
+      ✅ GraphQL API ready"
     `);
   });
 });

--- a/packages/keystone/src/system.ts
+++ b/packages/keystone/src/system.ts
@@ -1,4 +1,5 @@
 export { createSystem } from './lib/createSystem';
 export { createExpressServer } from './lib/server/createExpressServer';
+export { createAdminUIMiddleware } from './lib/server/createAdminUIMiddleware';
 export { initConfig } from './lib/config/initConfig';
 export { createApolloServerMicro } from './lib/server/createApolloServer';

--- a/packages/keystone/src/testing.ts
+++ b/packages/keystone/src/testing.ts
@@ -66,7 +66,7 @@ export async function setupTestEnv({
   const { connect, disconnect, createContext } = getKeystone(requirePrismaClient(artifactPath));
 
   // (config, graphQLSchema, createContext, dev, projectAdminPath, isVerbose)
-  const app = await createExpressServer(config, graphQLSchema, createContext, true, '', false);
+  const app = await createExpressServer(config, graphQLSchema, createContext);
 
   const graphQLRequest: GraphQLRequest = ({ query, variables = undefined, operationName }) =>
     supertest(app)

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -83,7 +83,7 @@ export const adminUITests = (
         if (process.env.VERBOSE) {
           console.log(stringified);
         }
-        if (stringified.includes('API ready')) {
+        if (stringified.includes('Admin UI ready')) {
           adminUIReady.resolve();
         }
       };
@@ -127,8 +127,8 @@ export const adminUITests = (
     }
 
     describe.each([
-      'firefox',
       'chromium',
+      'firefox',
       // we don't run the tests on webkit in production
       // because unlike chromium and firefox
       // webkit doesn't treat localhost as a secure context

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -127,8 +127,8 @@ export const adminUITests = (
     }
 
     describe.each([
-      // 'chromium',
       'firefox',
+      'chromium',
       // we don't run the tests on webkit in production
       // because unlike chromium and firefox
       // webkit doesn't treat localhost as a secure context

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -127,7 +127,7 @@ export const adminUITests = (
     }
 
     describe.each([
-      'chromium',
+      // 'chromium',
       'firefox',
       // we don't run the tests on webkit in production
       // because unlike chromium and firefox

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -65,7 +65,7 @@ export const exampleProjectTests = (
         if (process.env.VERBOSE) {
           console.log(stringified);
         }
-        if (stringified.includes('API ready')) {
+        if (stringified.includes('Admin UI ready')) {
           adminUIReady.resolve();
         }
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1941,26 +1941,6 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-11.1.0.tgz#60c3c7b127a5dab8b0a2889a7dcf8a90d2c4e592"
   integrity sha512-g5DtFTpLTGa36iy9DuZawtJeitI11gysFGKPQQqy+mNbSFazguArcJ10gAYFlbqpIi4boUamWNI5mAoSPx3kog==
 
-"@next/swc-darwin-arm64@11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz#93226c38db488c4b62b30a53b530e87c969b8251"
-  integrity sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==
-
-"@next/swc-darwin-x64@11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz#792003989f560c00677b5daeff360b35b510db83"
-  integrity sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==
-
-"@next/swc-linux-x64-gnu@11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz#8216b2ae1f21f0112958735c39dd861088108f37"
-  integrity sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==
-
-"@next/swc-win32-x64-msvc@11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz#e15824405df137129918205e43cb5e9339589745"
-  integrity sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==
-
 "@node-rs/helper@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@node-rs/helper/-/helper-1.2.1.tgz#e079b05f21ff4329d82c4e1f71c0290e4ecdc70c"
@@ -12423,10 +12403,10 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-jsx@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-4.0.1.tgz#ae3f716eacc0792f7050389de88add6d5245b9e9"
-  integrity sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==
+styled-jsx@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-4.0.0.tgz#f7b90e7889d0a4f4635f8d1ae9ac32f3acaedc57"
+  integrity sha512-2USeoWMoJ/Lx5s2y1PxuvLy/cz2Yrr8cTySV3ILHU1Vmaw1bnV7suKdblLPjnyhMD+qzN7B1SWyh4UZTARn/WA==
   dependencies:
     "@babel/plugin-syntax-jsx" "7.14.5"
     "@babel/types" "7.15.0"
@@ -13475,10 +13455,10 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-util@0.12.4, util@^0.12.0:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
-  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+util@0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.3.tgz#971bb0292d2cc0c892dab7c6a5d37c2bec707888"
+  integrity sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==
   dependencies:
     inherits "^2.0.3"
     is-arguments "^1.0.4"
@@ -13493,6 +13473,18 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+util@^0.12.0:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.4.tgz#66121a31420df8f01ca0c464be15dfa1d1850253"
+  integrity sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    safe-buffer "^5.1.2"
+    which-typed-array "^1.1.2"
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
It takes ... a while, to generate and start the Admin UI app.

In development, often you're working with the GraphQL API and don't need to wait for the Admin UI to be ready before hitting the server.

This PR splits out the creation of the Express Server + GraphQL API from the Admin UI, which significantly speeds up boot time for the GraphQL API in dev 🎉 