### PR TITLE
Make sure prisma error code isn't lost

### DIFF
--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -6,7 +6,7 @@ export const prismaError = (err: Error) => {
   return new ApolloError(
     `Prisma error: ${err.message.split('\n').slice(-1)[0].trim()}`,
     'INTERNAL_SERVER_ERROR',
-    { ...err }
+    { prisma: { ...err } }
   );
 };
 

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -156,9 +156,8 @@ export const expectPrismaError = (
     args.map(({ path, message, code, target }) => ({
       extensions: {
         code: 'INTERNAL_SERVER_ERROR',
-        exception: { clientVersion: '2.30.2', code, meta: { target } },
-        meta: { target },
-        clientVersion: '2.30.2',
+        exception: { prisma: { clientVersion: '2.30.2', code, meta: { target } } },
+        prisma: { clientVersion: '2.30.2', code, meta: { target } },
       },
       path,
       message,


### PR DESCRIPTION
This follows up from the previous PR and nests the prisma error under its own key. This prevents the `code` value from being lost. This will be important when we move to Apollo 3, as the `exception` is no longer reported in Apollo 3, which would mean we'd lost the prisma `code`.