### PR TITLE
Make all docs pages editable via Github

### DIFF
--- a/docs/components/Page.tsx
+++ b/docs/components/Page.tsx
@@ -131,9 +131,8 @@ export function DocsPage({
               css={{ justifyContent: 'space-between', alignItems: 'baseline' }}
             >
               <Breadcrumbs />
-              {!isUpdatesPage && (
-                <EditButton pathName={pathname} isIndexPage={isIndexPage} editPath={editPath} />
-              )}
+
+              <EditButton pathName={pathname} isIndexPage={isIndexPage} editPath={editPath} />
             </Stack>
             {children}
           </main>


### PR DESCRIPTION
Exposes `edit on github` functionality across all docs pages.

![CleanShot 2021-09-08 at 09 08 35](https://user-images.githubusercontent.com/6447754/132421547-d5b4e7c0-9ba3-4858-b080-d714fe6d9cc9.png)
![CleanShot 2021-09-08 at 09 08 24](https://user-images.githubusercontent.com/6447754/132421552-26481f97-8391-474a-a8b3-e185823ef07e.png)
