### PR TITLE
Remove unnecessary calls to context.exitSudo() from tests

### DIFF
--- a/tests/api-tests/access-control/mutations-field.test.ts
+++ b/tests/api-tests/access-control/mutations-field.test.ts
@@ -40,7 +40,6 @@ describe('Access control', () => {
   test(
     'createOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid name should pass
       await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
 
@@ -64,7 +63,6 @@ describe('Access control', () => {
   test(
     'updateOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid name should pass
       const user = await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
       await context.lists.User.updateOne({
@@ -92,7 +90,6 @@ describe('Access control', () => {
   test(
     'createMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Mix of good and bad names
       const { data, errors } = await context.graphql.raw({
         query: `mutation ($data: [UserCreateInput!]!) { createUsers(data: $data) { id name } }`,
@@ -139,7 +136,6 @@ describe('Access control', () => {
   test(
     'updateMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Start with some users
       const users = await context.lists.User.createMany({
         data: [

--- a/tests/api-tests/access-control/mutations-list-filter.test.ts
+++ b/tests/api-tests/access-control/mutations-list-filter.test.ts
@@ -25,7 +25,6 @@ describe('Access control - Filter', () => {
   test(
     'updateOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid name should pass
       const user = await context.lists.User.createOne({ data: { name: 'good' } });
       await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
@@ -52,7 +51,6 @@ describe('Access control - Filter', () => {
   test(
     'deleteOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid names should pass
       const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
       const user2 = await context.lists.User.createOne({ data: { name: 'no delete' } });
@@ -77,7 +75,6 @@ describe('Access control - Filter', () => {
   test(
     'updateMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Start with some users
       const users = await context.lists.User.createMany({
         data: [
@@ -144,7 +141,6 @@ describe('Access control - Filter', () => {
   test(
     'deleteMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Start with some users
       const users = await context.lists.User.createMany({
         data: [

--- a/tests/api-tests/access-control/mutations-list-item.test.ts
+++ b/tests/api-tests/access-control/mutations-list-item.test.ts
@@ -31,7 +31,6 @@ describe('Access control - Item', () => {
   test(
     'createOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid name should pass
       await context.lists.User.createOne({ data: { name: 'good' } });
 
@@ -54,7 +53,6 @@ describe('Access control - Item', () => {
   test(
     'updateOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid name should pass
       const user = await context.lists.User.createOne({ data: { name: 'good' } });
       await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
@@ -78,7 +76,6 @@ describe('Access control - Item', () => {
   test(
     'deleteOne',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Valid names should pass
       const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
       const user2 = await context.lists.User.createOne({ data: { name: 'no delete' } });
@@ -103,7 +100,6 @@ describe('Access control - Item', () => {
   test(
     'createMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Mix of good and bad names
       const { data, errors } = await context.graphql.raw({
         query: `mutation ($data: [UserCreateInput!]!) { createUsers(data: $data) { id name } }`,
@@ -147,7 +143,6 @@ describe('Access control - Item', () => {
   test(
     'updateMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Start with some users
       const users = await context.lists.User.createMany({
         data: [
@@ -205,7 +200,6 @@ describe('Access control - Item', () => {
   test(
     'deleteMany',
     runner(async ({ context }) => {
-      context = context.exitSudo();
       // Start with some users
       const users = await context.lists.User.createMany({
         data: [

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -217,7 +217,7 @@ describe('with access control', () => {
             expect(id).toBeTruthy();
 
             // Create an item that does the linking
-            const data = await context.exitSudo().lists[`EventTo${group.name}`].createOne({
+            const data = await context.lists[`EventTo${group.name}`].createOne({
               data: { title: 'A thing', group: { connect: { id } } },
               query: 'id group { id }',
             });
@@ -283,7 +283,7 @@ describe('with access control', () => {
             expect(eventModel.id).toBeTruthy();
 
             // Update the item and link the relationship field
-            const { data, errors } = await context.exitSudo().graphql.raw({
+            const { data, errors } = await context.graphql.raw({
               query: `
                     mutation {
                       updateEventTo${group.name}(
@@ -319,7 +319,7 @@ describe('with access control', () => {
             expect(id).toBeTruthy();
 
             // Create an item that does the linking
-            const { data, errors } = await context.exitSudo().graphql.raw({
+            const { data, errors } = await context.graphql.raw({
               query: `
                     mutation {
                       createEventTo${group.name}(data: {

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -174,7 +174,7 @@ describe('with access control', () => {
         });
 
         // Create an item that does the linking
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -216,7 +216,7 @@ describe('with access control', () => {
         });
 
         // Update the item and link the relationship field
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   updateUserToNotesNoRead(

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -202,7 +202,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item that does the nested create
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -228,7 +228,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item that does the nested create
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   createUserToNotesNoRead(data: {
@@ -256,7 +256,7 @@ describe('with access control', () => {
         });
 
         // Update an item that does the nested create
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   updateUserToNotesNoRead(
@@ -284,7 +284,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item that does the nested create
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   createUserToNotesNoCreate(data: {
@@ -328,7 +328,7 @@ describe('with access control', () => {
         });
 
         // Update an item that does the nested create
-        const { data, errors } = await context.exitSudo().graphql.raw({
+        const { data, errors } = await context.graphql.raw({
           query: `
                 mutation {
                   updateUserToNotesNoCreate(


### PR DESCRIPTION
These are remnants from when the test framework provided a `sudo` context by default.