### PR TITLE
Fix bug in DB API with null values

### DIFF
--- a/.changeset/popular-goats-juggle.md
+++ b/.changeset/popular-goats-juggle.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed a bug in `context.db.lists` API when finding items that don't exist.

--- a/packages/keystone/src/lib/context/executeGraphQLFieldToRootVal.ts
+++ b/packages/keystone/src/lib/context/executeGraphQLFieldToRootVal.ts
@@ -134,8 +134,8 @@ function getRootValGivenOutputType(originalType: OutputType, value: any): any {
   if (originalType instanceof GraphQLNonNull) {
     return getRootValGivenOutputType(originalType.ofType, value);
   }
+  if (value === null) return null;
   if (originalType instanceof GraphQLList) {
-    if (value === null) return null;
     return value.map((x: any) => getRootValGivenOutputType(originalType.ofType, x));
   }
   return value[rawField];


### PR DESCRIPTION
I don't have an explicit reproduction for this, but I was able to trigger it while working on tests and calling `context.db.lists.Foo.findOne()` on an item which didn't exist in the database. This fixes it to simply return `null` if the value is `null` as expected.