### PR TITLE
fix: the tabbable error when you click the popover in the keystone-ui website

### DIFF
--- a/design-system/website/pages/components/popover.tsx
+++ b/design-system/website/pages/components/popover.tsx
@@ -1,8 +1,8 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-import { jsx, Box } from '@keystone-ui/core';
 import { Button } from '@keystone-ui/button';
+import { Box, jsx } from '@keystone-ui/core';
 import { Popover } from '@keystone-ui/popover';
 import { Page } from '../../components/Page';
 
@@ -20,7 +20,7 @@ export default function PopoverPage() {
         styles for height and width.
       </p>
       <Popover triggerRenderer={({ triggerProps }) => <Button {...triggerProps}>Click me</Button>}>
-        <Box width={180} height={80} padding="medium">
+        <Box tabIndex={0} width={180} height={80} padding="medium">
           I'm in a popover!
         </Box>
       </Popover>


### PR DESCRIPTION
I noticed in the keystone-ui website, there was a section showing an example of popover. The example has a bug and the error was something around this line `Your focus-trap must have at least one container with at least one tabbable node in it at all times`. I attempt to fix this with this PR. 

Add tabIndex={0} will make the element in question tabbable. 