### PR TITLE
Remove deprecated config.db.adapter option

### DIFF
--- a/.changeset/gold-pillows-look.md
+++ b/.changeset/gold-pillows-look.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Removed the deprecated `config.db.adapter` option. Please use `config.db.provider` to indicate the database provider for your system.

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -139,7 +139,7 @@ const makeVercelIncludeTheSQLiteDB = (
   directoryOfFileToBeWritten: string,
   config: KeystoneConfig
 ) => {
-  if (config.db.adapter === 'prisma_sqlite' || config.db.provider === 'sqlite') {
+  if (config.db.provider === 'sqlite') {
     const sqliteDbAbsolutePath = path.resolve(cwd, config.db.url.replace('file:', ''));
 
     return `import path from 'path';

--- a/packages/keystone/src/lib/createSystem.ts
+++ b/packages/keystone/src/lib/createSystem.ts
@@ -6,9 +6,9 @@ import { makeCreateContext } from './context/createContext';
 import { initialiseLists } from './core/types-for-lists';
 
 export function getDBProvider(db: KeystoneConfig['db']): DatabaseProvider {
-  if (db.adapter === 'prisma_postgresql' || db.provider === 'postgresql') {
+  if (db.provider === 'postgresql') {
     return 'postgresql';
-  } else if (db.adapter === 'prisma_sqlite' || db.provider === 'sqlite') {
+  } else if (db.provider === 'sqlite') {
     return 'sqlite';
   } else {
     throw new Error(

--- a/packages/keystone/src/types/config/index.ts
+++ b/packages/keystone/src/types/config/index.ts
@@ -57,32 +57,8 @@ export type DatabaseConfig = {
   useMigrations?: boolean;
   enableLogging?: boolean;
   idField?: IdFieldConfig;
-} & (
-  | (
-      | {
-          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
-          adapter: 'prisma_postgresql';
-          provider?: undefined;
-        }
-      | {
-          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'postgresql' }` */
-          adapter?: undefined;
-          provider: 'postgresql';
-        }
-    )
-  | (
-      | {
-          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
-          adapter: 'prisma_sqlite';
-          provider?: undefined;
-        }
-      | {
-          /** @deprecated The `adapter` option is deprecated. Please use `{ provider: 'sqlite' }` */
-          adapter?: undefined;
-          provider: 'sqlite';
-        }
-    )
-);
+  provider: 'postgresql' | 'sqlite';
+};
 
 // config.ui
 

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -5,7 +5,7 @@ import { KeystoneConfig, DatabaseProvider } from '@keystone-next/keystone/types'
 // export it from `@keystone-next/keystone/testing`.
 export const apiTestConfig = (
   config: Omit<KeystoneConfig, 'db'> & {
-    db?: Omit<KeystoneConfig['db'], 'provider' | 'url' | 'adapter'>;
+    db?: Omit<KeystoneConfig['db'], 'provider' | 'url'>;
   }
 ): KeystoneConfig => ({
   ...config,


### PR DESCRIPTION
This isn't something we need to bring forward to GA, so let's get rid of it now.