### PR TITLE
Consolidate concept of sudo internally

### DIFF
--- a/.changeset/nine-coins-yawn.md
+++ b/.changeset/nine-coins-yawn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Removed `context.schemaName` from the `context` object. This value was an internal API which is no longer required.

--- a/.changeset/short-jokes-hug.md
+++ b/.changeset/short-jokes-hug.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/auth': major
+'@keystone-next/keystone': major
+---
+
+Renamed the `skipAccessControl` argument to `createContext` to `sudo` for consistency with `context.sudo()`.

--- a/docs/pages/docs/apis/context.mdx
+++ b/docs/pages/docs/apis/context.mdx
@@ -57,7 +57,6 @@ context = {
   // Internal state
   totalResults,
   maxTotalResults,
-  schemaName,
 
   // Deprecated
   gqlNames,
@@ -154,8 +153,6 @@ These properties are used internally by Keystone and generally do not need to be
 `totalResults`: The cumulative total number of results returned by the current request. See [`config.graphql.queryLimits`](./config#graphql).
 
 `maxTotalResults`: The maximum number of results which can be returned before a query limit error is triggered. See [`config.graphql.queryLimits`](./apis/config#graphql).
-
-`schemaName`: The internal name used by Keystone to refer to the GraphQL schema.
 
 ### Deprecated
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -227,7 +227,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
       ...sessionStrategy,
       get: async ({ req, createContext }) => {
         const session = await get({ req, createContext });
-        const sudoContext = createContext({}).sudo();
+        const sudoContext = createContext({ sudo: true });
         if (
           !session ||
           !session.listKey ||

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
@@ -6,5 +6,5 @@ export function createListsAPI(config: KeystoneConfig, prismaClient: any) {
   const { getKeystone } = createSystem(initConfig(config));
   const keystone = getKeystone(prismaClient);
   keystone.connect();
-  return keystone.createContext().sudo().lists;
+  return keystone.createContext({ sudo: true }).lists;
 }

--- a/packages/keystone/src/types/context.ts
+++ b/packages/keystone/src/types/context.ts
@@ -18,7 +18,6 @@ export type KeystoneContext = {
   images: ImagesContext | undefined;
   totalResults: number;
   maxTotalResults: number;
-  schemaName: 'public' | 'internal';
   /** @deprecated */
   gqlNames: (listKey: string) => GqlNames;
   experimental?: {

--- a/packages/keystone/src/types/core.ts
+++ b/packages/keystone/src/types/core.ts
@@ -17,7 +17,7 @@ export type FieldDefaultValue<T, TGeneratedListTypes extends BaseGeneratedListTy
 
 export type CreateContext = (args: {
   sessionContext?: SessionContext<any>;
-  skipAccessControl?: boolean;
+  sudo?: boolean;
   req?: IncomingMessage;
 }) => KeystoneContext;
 


### PR DESCRIPTION
The concepts around internal schemas, schema names, sudo, skipAccessControl have all been conflated. This PR is an attempt to consolidate behind the `sudo()` concept and adapt our types/functions/variables accordingly.