### PR TITLE
`create-keystone-app` outputed URLs sometimes have hidden characters, cater for this

### DIFF
--- a/docs/pages/docs/examples.tsx
+++ b/docs/pages/docs/examples.tsx
@@ -2,17 +2,17 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/react';
 
+import Link from 'next/link';
 import { GitHubExamplesCTA } from '../../components/docs/GitHubExamplesCTA';
 import { Type } from '../../components/primitives/Type';
 import { DocsPage } from '../../components/Page';
 import { Well } from '../../components/primitives/Well';
 import { useMediaQuery } from '../../lib/media';
 import { InlineCode } from '../../components/primitives/Code';
-import Link from 'next/link';
-
-const mq = useMediaQuery();
 
 export default function Docs() {
+  const mq = useMediaQuery();
+
   return (
     <DocsPage
       noRightNav

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -114,6 +114,14 @@ const CURRENT = [
     destination: '/updates/keystone-5-vs-keystone-6-preview',
     permanent: true,
   },
+  {
+    // create-keystone-app has hidden characters in it's console output when it
+    // links to this page (when a console does not support hyperlinks), adding
+    // this condition in case someone copies them accidentally
+    source: '/docs/guides/keystone-5-vs-keystone-next%E2%80%8B',
+    destination: '/docs/guides/keystone-5-vs-keystone-next',
+    permanent: true,
+  },
 ];
 
 module.exports = [...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];

--- a/prisma-utils/CHANGELOG.md
+++ b/prisma-utils/CHANGELOG.md
@@ -1,8 +1,7 @@
 # @keystone-next/prisma-utils
 
 ## 0.0.1
+
 ### Patch Changes
-
-
 
 - [#6433](https://github.com/keystonejs/keystone/pull/6433) [`bb0c6c626`](https://github.com/keystonejs/keystone/commit/bb0c6c62610eda20ae93a6b67185276bdbba3248) Thanks [@renovate](https://github.com/apps/renovate)! - Updated Prisma dependencies to `2.30.2`.


### PR DESCRIPTION
Added redirect to cater for this issue, paraphrased from @Noviny:

>The links the keystone generator spits sometimes don’t work, specifically don’t work in some terminal environments.

>The error is that the library adds \u200B to the end of the link as which some terminals don't support links natively, but then you click or copy the link, it includes the space in the URL when copied, which is then not a valid URL.