### PR TITLE
[RFC] Rename `context.lists` to `context.query` and `context.db.lists` to `context.db`

### DIFF
--- a/.changeset/large-pugs-exist.md
+++ b/.changeset/large-pugs-exist.md
@@ -1,0 +1,6 @@
+---
+'@keystone-next/auth': major
+'@keystone-next/keystone': major
+---
+
+The API `context.lists` has been renamed to `context.query`, and `context.db.lists` has been renamed to `context.db`.

--- a/.changeset/large-pugs-exist.md
+++ b/.changeset/large-pugs-exist.md
@@ -4,3 +4,5 @@
 ---
 
 The API `context.lists` has been renamed to `context.query`, and `context.db.lists` has been renamed to `context.db`.
+
+When using the experimental option `config.experimental.generateNodeAPI`, the `api` module now exports `query` rather than `lists`.

--- a/.changeset/popular-goats-juggle.md
+++ b/.changeset/popular-goats-juggle.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': patch
 ---
 
-Fixed a bug in `context.db.lists` API when finding items that don't exist.
+Fixed a bug in `context.db` API when finding items that don't exist.

--- a/docs/components/docs/Navigation.tsx
+++ b/docs/components/docs/Navigation.tsx
@@ -192,7 +192,7 @@ export function DocsNavigation() {
 
         <SubHeading>Context</SubHeading>
         <NavItem href="/docs/apis/context">Context API</NavItem>
-        <NavItem href="/docs/apis/queries">Query API</NavItem>
+        <NavItem href="/docs/apis/query">Query API</NavItem>
         <NavItem href="/docs/apis/db-items">DB API</NavItem>
 
         <SubHeading>GraphQL</SubHeading>

--- a/docs/components/docs/Navigation.tsx
+++ b/docs/components/docs/Navigation.tsx
@@ -192,8 +192,8 @@ export function DocsNavigation() {
 
         <SubHeading>Context</SubHeading>
         <NavItem href="/docs/apis/context">Context API</NavItem>
-        <NavItem href="/docs/apis/list-items">List Item API</NavItem>
-        <NavItem href="/docs/apis/db-items">DB Item API</NavItem>
+        <NavItem href="/docs/apis/queries">Query API</NavItem>
+        <NavItem href="/docs/apis/db-items">DB API</NavItem>
 
         <SubHeading>GraphQL</SubHeading>
         <NavItem href="/docs/apis/graphql">

--- a/docs/pages/docs/apis/context.mdx
+++ b/docs/pages/docs/apis/context.mdx
@@ -67,13 +67,13 @@ context = {
 
 `req`: The [IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) object from the HTTP request which called the GraphQL API.
 
-### List item API
+### Query API
 
-`lists`: The [list items API](./list-items), which can be used to perform CRUD operations against your GraphQL API.
+`query`: The [Query API](./query), which can be used to perform CRUD operations against your GraphQL API and return a queried value.
 
-### Database item API
+### Database API
 
-`db.lists`: The [database items API](./db-items), which can be used to retrieve objects suitable for return from mutations in [schema extensions](../guides/schema-extension).
+`db`: The [Database API](./db-items), which can be used to perform CRUD operations against your GraphQL API and return database objects suitable for return from mutations in [schema extensions](../guides/schema-extension).
 
 ### GraphQL helpers
 
@@ -107,7 +107,7 @@ See the [session API](./session#session-context) for more details.
 
 ### New context creators
 
-When using the `context.lists`, `context.graphql.run`, and `context.graphql.raw` APIs, access control and session information is passed through to these calls from the `context` object.
+When using the `context.query`, `context.graphql.run`, and `context.graphql.raw` APIs, access control and session information is passed through to these calls from the `context` object.
 The following functions will create a new `KeystoneContext` object with this behaviour modified.
 
 `sudo()`: A function which returns a new `KeystoneContext` object with all access control disabled and all filters enabled for subsequent API calls.
@@ -165,13 +165,13 @@ They will be removed in future releases.
 
 <RelatedContent>
   <Well
-    heading="List Items API Reference"
-    href="/docs/apis/list-items"
+    heading="Query API Reference"
+    href="/docs/apis/query"
     >
-    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.lists.&lt;listName&gt;</InlineCode>
+    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.query.&lt;listName&gt;</InlineCode>
   </Well>
   <Well
-    heading="DB Items API Reference"
+    heading="DB API Reference"
     href="/docs/apis/db-items"
     >
     The API for running CRUD operations against the internal GraphQL resolvers in your system. It returns internal item objects, which can be returned from GraphQL resolvers.

--- a/docs/pages/docs/apis/db-items.mdx
+++ b/docs/pages/docs/apis/db-items.mdx
@@ -3,9 +3,9 @@ import { Well } from '../../../components/primitives/Well';
 import { RelatedContent } from '../../../components/RelatedContent';
 import { InlineCode } from '../../../components/primitives/Code';
 
-# Database Items API
+# Database API
 
-The database items API provides a programmatic API for running CRUD operations against the internal GraphQL resolvers in your system.
+The database API provides a programmatic API for running CRUD operations against the internal GraphQL resolvers in your system.
 Importantly, this API bypasses the GraphQL Server itself, instead invoking the resolver functions directly.
 The return values of this API are **internal item** objects, which are suitable to be returned from GraphQL resolvers.
 
@@ -14,7 +14,7 @@ Refer to the [internal items guide](../guides/internal-items) for details on how
 This API executes the [`access control`](../guides/access-control) rules and [`hooks`](../guides/hooks) defined in your system.
 To bypass these, you can directly use the Prisma Client at [`context.prisma`](./context#database-access).
 
-For each list in your system the following API is available at `context.db.lists.<listName>`.
+For each list in your system the following API is available at `context.db.<listName>`.
 
 ```
 {
@@ -36,7 +36,7 @@ Unless otherwise specified, the arguments to all functions are required.
 ### findOne
 
 ```typescript
-const user = await context.db.lists.User.findOne({
+const user = await context.db.User.findOne({
   where: { id: '...' },
 });
 ```
@@ -46,7 +46,7 @@ const user = await context.db.lists.User.findOne({
 All arguments are optional.
 
 ```typescript
-const users = await context.db.lists.User.findMany({
+const users = await context.db.User.findMany({
   where: { name: { startsWith: 'A' } },
   take: 10,
   skip: 20,
@@ -59,7 +59,7 @@ const users = await context.db.lists.User.findMany({
 All arguments are optional.
 
 ```typescript
-const count = await context.db.lists.User.count({
+const count = await context.db.User.count({
   where: { name: { startsWith: 'A' } },
 });
 ```
@@ -67,7 +67,7 @@ const count = await context.db.lists.User.count({
 ### createOne
 
 ```typescript
-const user = await context.db.lists.User.createOne({
+const user = await context.db.User.createOne({
   data: {
     name: 'Alice',
     posts: { create: [{ title: 'My first post' }] },
@@ -78,7 +78,7 @@ const user = await context.db.lists.User.createOne({
 ### createMany
 
 ```typescript
-const users = await context.db.lists.User.createMany({
+const users = await context.db.User.createMany({
   data: [
     {
       name: 'Alice',
@@ -95,7 +95,7 @@ const users = await context.db.lists.User.createMany({
 ### updateOne
 
 ```typescript
-const user = await context.db.lists.User.updateOne({
+const user = await context.db.User.updateOne({
   where: { id: '...' },
   data: {
     name: 'Alice',
@@ -107,7 +107,7 @@ const user = await context.db.lists.User.updateOne({
 ### updateMany
 
 ```typescript
-const users = await context.db.lists.User.updateMany({
+const users = await context.db.User.updateMany({
   data: [
     {
       where: { id: '...' },
@@ -130,7 +130,7 @@ const users = await context.db.lists.User.updateMany({
 ### deleteOne
 
 ```typescript
-const user = await context.db.lists.User.deleteOne({
+const user = await context.db.User.deleteOne({
   where: { id: '...' },
 });
 ```
@@ -138,7 +138,7 @@ const user = await context.db.lists.User.deleteOne({
 ### deleteMany
 
 ```typescript
-const users = await context.db.lists.User.deleteMany({
+const users = await context.db.User.deleteMany({
   where: [{ id: '...' }, { id: '...' }],
 });
 ```
@@ -147,10 +147,10 @@ const users = await context.db.lists.User.deleteMany({
 
 <RelatedContent>
   <Well
-    heading="List Items API Reference"
-    href="/docs/apis/list-items"
+    heading="Query API Reference"
+    href="/docs/apis/query"
     >
-    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.lists.&lt;listName&gt;</InlineCode>.
+    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.query.&lt;listName&gt;</InlineCode>.
   </Well>
   <Well
     heading="Context API Reference"
@@ -160,4 +160,4 @@ const users = await context.db.lists.User.deleteMany({
   </Well>
 </RelatedContent>
 
-export default ({ children }) => <Markdown description="Keystone’s database items API is a programmatic API for running CRUD operations against the internal GraphQL resolvers in your system. It bypasses the GraphQL Server itself, invoking resolver functions directly.">{children}</Markdown>;
+export default ({ children }) => <Markdown description="Keystone’s database API is a programmatic API for running CRUD operations against the internal GraphQL resolvers in your system. It bypasses the GraphQL Server itself, invoking resolver functions directly.">{children}</Markdown>;

--- a/docs/pages/docs/apis/hooks.mdx
+++ b/docs/pages/docs/apis/hooks.mdx
@@ -69,15 +69,15 @@ For field hooks, the return value should be an updated value for that specific f
 For list hooks, the return value should be a [`resolved data`](#resolved-data-stages) object.
 The result of `resolveInput` will be passed as `resolvedData` into the next stages of the operation.
 
-| Argument        | Description                                                                                                                                                                       |
-| :-------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                            |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                        |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                         |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                     |
-| `existingItem`  | The currently stored item (`undefined` for `create` operations). This object is an unresolved list item. [list item API](./list-items) for more details on unresolved list items. |
-| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after default values, relationship resolvers, and field resolvers have been applied.                   |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                   |
+| Argument        | Description                                                                                                                                                                  |
+| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`       | The key of the list being operated on.                                                                                                                                       |
+| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                   |
+| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                    |
+| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                |
+| `existingItem`  | The currently stored item (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after default values, relationship resolvers, and field resolvers have been applied.              |
+| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                              |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -131,16 +131,16 @@ It is invoked after the `resolveInput` hooks have been run.
 If the `resolvedData` is invalid then the function should report validation errors with `addValidationError(msg)`.
 These error messages will be returned as a `ValidationFailureError` from the GraphQL API, and the operation will not be completed.
 
-| Argument                  | Description                                                                                                                                                                                                 |
-| :------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`                 | The key of the list being operated on.                                                                                                                                                                      |
-| `fieldKey`                | The key of the field being operated on (field hooks only).                                                                                                                                                  |
-| `operation`               | The operation being performed (`'create'` or `'update'`).                                                                                                                                                   |
-| `originalInput`           | The value of `data` passed into the mutation.                                                                                                                                                               |
-| `existingItem`            | The current value of the item being updated (`undefined` for `create` operations). This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `resolvedData`            | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                              |
-| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                             |
-| `addValidationError(msg)` | Used to set a validation error.                                                                                                                                                                             |
+| Argument                  | Description                                                                                                                                                                                    |
+| :------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`                 | The key of the list being operated on.                                                                                                                                                         |
+| `fieldKey`                | The key of the field being operated on (field hooks only).                                                                                                                                     |
+| `operation`               | The operation being performed (`'create'` or `'update'`).                                                                                                                                      |
+| `originalInput`           | The value of `data` passed into the mutation.                                                                                                                                                  |
+| `existingItem`            | The current value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `resolvedData`            | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                 |
+| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                |
+| `addValidationError(msg)` | Used to set a validation error.                                                                                                                                                                |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -187,15 +187,15 @@ The `beforeChange` function is used to perform side effects just before the data
 
 It is invoked after all `validateInput` hooks have been run, but before the data is saved to the database.
 
-| Argument        | Description                                                                                                                                                                                                 |
-| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                                                      |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                                  |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                                   |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                               |
-| `existingItem`  | The current value of the item being updated (`undefined` for `create` operations). This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                              |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                             |
+| Argument        | Description                                                                                                                                                                                    |
+| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`       | The key of the list being operated on.                                                                                                                                                         |
+| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                     |
+| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                      |
+| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                  |
+| `existingItem`  | The current value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                 |
+| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -238,15 +238,15 @@ export default config({
 
 The `afterChange` function is used to perform side effects after the data for a `create` or `update` operation has been saved to the database.
 
-| Argument        | Description                                                                                                                                                                                                  |
-| :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                                                       |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                                   |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                                    |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                                |
-| `existingItem`  | The previous value of the item being updated (`undefined` for `create` operations). This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `updatedItem`   | The new value of the item being updated or created. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items.                                 |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                              |
+| Argument        | Description                                                                                                                                                                                     |
+| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`       | The key of the list being operated on.                                                                                                                                                          |
+| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                      |
+| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                       |
+| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                   |
+| `existingItem`  | The previous value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `updatedItem`   | The new value of the item being updated or created. This object is an internal database item. [DB API](./db-items) for more details on internal database items.                                 |
+| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                 |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -299,14 +299,14 @@ It is invoked after access control has been applied.
 If the delete operation is invalid then the function should report validation errors with `addValidationError(msg)`.
 These error messages will be returned as a `ValidationFailureError` from the GraphQL API.
 
-| Argument                  | Description                                                                                                                                                   |
-| :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `listKey`                 | The key of the list being operated on.                                                                                                                        |
-| `fieldKey`                | The key of the field being operated on (field hooks only).                                                                                                    |
-| `operation`               | The operation being performed (`'delete'`).                                                                                                                   |
-| `existingItem`            | The value of the item to be deleted. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                               |
-| `addValidationError(msg)` | Used to set a validation error.                                                                                                                               |
+| Argument                  | Description                                                                                                                                      |
+| :------------------------ | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`                 | The key of the list being operated on.                                                                                                           |
+| `fieldKey`                | The key of the field being operated on (field hooks only).                                                                                       |
+| `operation`               | The operation being performed (`'delete'`).                                                                                                      |
+| `existingItem`            | The value of the item to be deleted. This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                  |
+| `addValidationError(msg)` | Used to set a validation error.                                                                                                                  |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -349,13 +349,13 @@ The `beforeDelete` function is used to perform side effects just before the data
 
 It is invoked after all `validateDelete` hooks have been run.
 
-| Argument       | Description                                                                                                                                                   |
-| :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `listKey`      | The key of the list being operated on.                                                                                                                        |
-| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                                    |
-| `operation`    | The operation being performed (`'delete'`).                                                                                                                   |
-| `existingItem` | The value of the item to be deleted. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                               |
+| Argument       | Description                                                                                                                                      |
+| :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`      | The key of the list being operated on.                                                                                                           |
+| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                       |
+| `operation`    | The operation being performed (`'delete'`).                                                                                                      |
+| `existingItem` | The value of the item to be deleted. This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                  |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -387,13 +387,13 @@ export default config({
 
 The `afterDelete` function is used to perform side effects after the data for a `delete` operation has been removed from the database.
 
-| Argument       | Description                                                                                                                                                  |
-| :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`      | The key of the list being operated on.                                                                                                                       |
-| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                                   |
-| `operation`    | The operation being performed (`'delete'`).                                                                                                                  |
-| `existingItem` | The value of the item, now deleted. This object is an unresolved list item. See the [list item API](./list-items) for more details on unresolved list items. |
-| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                              |
+| Argument       | Description                                                                                                                                     |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`      | The key of the list being operated on.                                                                                                          |
+| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                      |
+| `operation`    | The operation being performed (`'delete'`).                                                                                                     |
+| `existingItem` | The value of the item, now deleted. This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                 |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';

--- a/docs/pages/docs/apis/index.tsx
+++ b/docs/pages/docs/apis/index.tsx
@@ -76,10 +76,10 @@ export default function Docs() {
         <Well grad="grad4" heading="Context API" href="/docs/apis/context">
           The primary API entry point for all of the run-time functionally of your Keystone system.
         </Well>
-        <Well grad="grad4" heading="List Items API" href="/docs/apis/list-items">
+        <Well grad="grad4" heading="Query API" href="/docs/apis/query">
           A programmatic API for running CRUD operations against your GraphQL API.
         </Well>
-        <Well grad="grad4" heading="Database Items API" href="/docs/apis/db-items">
+        <Well grad="grad4" heading="Database API" href="/docs/apis/db-items">
           A programmatic API for running CRUD operations against the internal GraphQL resolvers in
           your system.
         </Well>

--- a/docs/pages/docs/apis/query.mdx
+++ b/docs/pages/docs/apis/query.mdx
@@ -2,10 +2,10 @@ import { Markdown } from '../../../components/Markdown';
 import { Well } from '../../../components/primitives/Well';
 import { RelatedContent } from '../../../components/RelatedContent';
 
-# List Items API
+# Query API
 
-The list items API provides a programmatic API for running CRUD operations against your GraphQL API.
-For each list in your system the following API is available at `context.lists.<listName>`.
+The Query API provides a programmatic API for running CRUD operations against your GraphQL API.
+For each list in your system the following API is available at `context.query.<listName>`.
 
 ```
 {
@@ -31,7 +31,7 @@ The functions in the API all work by directly executing queries and mutations ag
 ### findOne
 
 ```typescript
-const user = await context.lists.User.findOne({
+const user = await context.query.User.findOne({
   where: { id: '...' },
   query: 'id name posts { id title }',
 });
@@ -42,7 +42,7 @@ const user = await context.lists.User.findOne({
 All arguments are optional.
 
 ```typescript
-const users = await context.lists.User.findMany({
+const users = await context.query.User.findMany({
   where: { name: { startsWith: 'A' } },
   take: 10,
   skip: 20,
@@ -56,7 +56,7 @@ const users = await context.lists.User.findMany({
 All arguments are optional.
 
 ```typescript
-const count = await context.lists.User.count({
+const count = await context.query.User.count({
   where: { name: { startsWith: 'A' } },
 });
 ```
@@ -64,7 +64,7 @@ const count = await context.lists.User.count({
 ### createOne
 
 ```typescript
-const user = await context.lists.User.createOne({
+const user = await context.query.User.createOne({
   data: {
     name: 'Alice',
     posts: { create: [{ title: 'My first post' }] },
@@ -76,7 +76,7 @@ const user = await context.lists.User.createOne({
 ### createMany
 
 ```typescript
-const users = await context.lists.User.createMany({
+const users = await context.query.User.createMany({
   data: [
     {
       name: 'Alice',
@@ -94,7 +94,7 @@ const users = await context.lists.User.createMany({
 ### updateOne
 
 ```typescript
-const user = await context.lists.User.updateOne({
+const user = await context.query.User.updateOne({
   where: { id: '...' },
   data: {
     name: 'Alice',
@@ -107,7 +107,7 @@ const user = await context.lists.User.updateOne({
 ### updateMany
 
 ```typescript
-const users = await context.lists.User.updateMany({
+const users = await context.query.User.updateMany({
   data: [
     {
       where: { id: '...' },
@@ -131,7 +131,7 @@ const users = await context.lists.User.updateMany({
 ### deleteOne
 
 ```typescript
-const user = await context.lists.User.deleteOne({
+const user = await context.query.User.deleteOne({
   where: { id: '...' },
   query: 'id name posts { id title }',
 });
@@ -140,7 +140,7 @@ const user = await context.lists.User.deleteOne({
 ### deleteMany
 
 ```typescript
-const users = await context.lists.User.deleteMany({
+const users = await context.query.User.deleteMany({
   where: [{ id: '...' }, { id: '...' }],
   query: 'id name posts { id title }',
 });
@@ -156,11 +156,11 @@ const users = await context.lists.User.deleteMany({
     The API for run-time functionality in your Keystone system. Use it to write business logic for access control, hooks, testing, GraphQL schema extensions, and more.
   </Well>
   <Well
-    heading="DB Items API Reference"
+    heading="DB API Reference"
     href="/docs/apis/db-items"
     >
     The API for running CRUD operations against the internal GraphQL resolvers in your system. It returns internal item objects, which can be returned from GraphQL resolvers.
   </Well>
 </RelatedContent>
 
-export default ({ children }) => <Markdown description="Reference docs for Keystone‘s List Items API: a programmatic API for running CRUD operations against your GraphQL API.">{children}</Markdown>;
+export default ({ children }) => <Markdown description="Reference docs for Keystone‘s Query API: a programmatic API for running CRUD operations against your GraphQL API.">{children}</Markdown>;

--- a/docs/pages/docs/guides/testing.mdx
+++ b/docs/pages/docs/guides/testing.mdx
@@ -67,11 +67,11 @@ This includes things like access control, hooks, virtual fields, and GraphQL API
 ### Context API
 
 The [context API](../apis/context) lets you easily manipulate data in your system.
-We can use the [list items API](../apis/list-items) to ensure that we can do basic CRUD operations.
+We can use the [Query API](../apis/query) to ensure that we can do basic CRUD operations.
 
 ```typescript
 runner(async ({ context }) => {
-  const person = await context.lists.Person.createOne({
+  const person = await context.query.Person.createOne({
     data: { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
     query: 'id name email password { isSet }',
   });
@@ -110,7 +110,7 @@ In the example below, the access control only allows users to update their own t
 ```
 runner(async ({ context }) => {
   // Create some users
-  const [alice, bob] = await context.lists.Person.createMany({
+  const [alice, bob] = await context.query.Person.createMany({
     data: [
       { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
       { name: 'Bob', email: 'bob@example.com', password: 'super-secret' },
@@ -118,7 +118,7 @@ runner(async ({ context }) => {
   });
 
   // Create a task assigned to Alice
-  const task = await context.lists.Task.createOne({
+  const task = await context.query.Task.createOne({
     data: {
       label: 'Experiment with Keystone',
       priority: 'high',
@@ -257,10 +257,10 @@ describe('Example tests using test environment', () => {
     The API for run-time functionality in your Keystone system. Use it to write business logic for access control, hooks, testing, GraphQL schema extensions, and more.
   </Well>
   <Well
-    heading="List Items API Reference"
-    href="/docs/apis/list-items"
+    heading="Query API Reference"
+    href="/docs/apis/query"
     >
-    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.lists.&lt;listName&gt;</InlineCode>.
+    A programmatic API for running CRUD operations against your GraphQL API. For each list in your system you get an API at <InlineCode>context.query.&lt;listName&gt;</InlineCode>.
   </Well>
 </RelatedContent>
 

--- a/docs/pages/docs/guides/virtual-fields.mdx
+++ b/docs/pages/docs/guides/virtual-fields.mdx
@@ -96,7 +96,7 @@ export default config({
           type: graphql.String,
           field: graphql.field({
             async resolve(item, args, context) {
-              const { author } = await context.lists.Post.findOne({
+              const { author } = await context.query.Post.findOne({
                 where: { id: item.id.toString() },
                 query: 'author { name }',
               });
@@ -281,7 +281,7 @@ export const lists = {
           graphql.field({
             type: lists.Post.types.output,
             async resolve(item, args, context) {
-              const { posts } = await context.lists.Author.findOne({
+              const { posts } = await context.query.Author.findOne({
                 where: { id: item.id.toString() },
                 query: `posts(
                     orderBy: { publishDate: desc }
@@ -289,7 +289,7 @@ export const lists = {
                   ) { id }`,
               });
               if (posts.length > 0) {
-                return context.db.lists.Post.findOne({
+                return context.db.Post.findOne({
                   where: { id: posts[0].id }
                 });
               }

--- a/docs/pages/docs/index.tsx
+++ b/docs/pages/docs/index.tsx
@@ -209,10 +209,10 @@ export default function Docs() {
         <Well grad="grad4" heading="Context API" href="/docs/apis/context">
           The primary API entry point for all of the run-time functionally of your Keystone system.
         </Well>
-        <Well grad="grad4" heading="List Items API" href="/docs/apis/list-items">
+        <Well grad="grad4" heading="Query API" href="/docs/apis/query">
           A programmatic API for running CRUD operations against your GraphQL API.
         </Well>
-        <Well grad="grad4" heading="Database Items API" href="/docs/apis/db-items">
+        <Well grad="grad4" heading="Database API" href="/docs/apis/db-items">
           A programmatic API for running CRUD operations against the internal GraphQL resolvers in
           your system.
         </Well>

--- a/docs/pages/releases/2021-04-20.mdx
+++ b/docs/pages/releases/2021-04-20.mdx
@@ -47,12 +47,12 @@ const [post] = await context.lists.Post.findMany({
 
 ### 2. Return the unresolved item data with read hooks
 
-This **replaces the `resolveFields: boolean` use case**. We now have a new set of APIs on `context.db.lists.{List}` which return unresolved item data from your database (but with read hooks applied). They can be referenced directly or returned from a custom mutation or query in the GraphQL API to be handled by the Field resolvers.
+This **replaces the `resolveFields: boolean` use case**. We now have a new set of APIs on `context.db.{List}` which return unresolved item data from your database (but with read hooks applied). They can be referenced directly or returned from a custom mutation or query in the GraphQL API to be handled by the Field resolvers.
 
 For example, to query for the raw data stored in the database:
 
 ```js
-const [post] = await context.db.lists.Post.findMany({
+const [post] = await context.db.Post.findMany({
   where: { slug },
 });
 ```

--- a/docs/pages/releases/2021-04-20.mdx
+++ b/docs/pages/releases/2021-04-20.mdx
@@ -47,12 +47,12 @@ const [post] = await context.lists.Post.findMany({
 
 ### 2. Return the unresolved item data with read hooks
 
-This **replaces the `resolveFields: boolean` use case**. We now have a new set of APIs on `context.db.{List}` which return unresolved item data from your database (but with read hooks applied). They can be referenced directly or returned from a custom mutation or query in the GraphQL API to be handled by the Field resolvers.
+This **replaces the `resolveFields: boolean` use case**. We now have a new set of APIs on `context.db.lists.{List}` which return unresolved item data from your database (but with read hooks applied). They can be referenced directly or returned from a custom mutation or query in the GraphQL API to be handled by the Field resolvers.
 
 For example, to query for the raw data stored in the database:
 
 ```js
-const [post] = await context.db.Post.findMany({
+const [post] = await context.db.lists.Post.findMany({
   where: { slug },
 });
 ```

--- a/docs/pages/updates/new-graphql-api.mdx
+++ b/docs/pages/updates/new-graphql-api.mdx
@@ -396,7 +396,7 @@ While there are a lot of changes to this API, we've put a lot of effort into mak
 3. Update mutation arguments to match the new input types. Make sure you replace `{ id: "..."}` with `{where: { id: "..."} }` in your `update` and `delete` operations.
 4. Update relationship inputs to `create` and `update` operations. Ensure you've replaced usage of `{ disconnectAll: true }` with `{ set: [] }` in to-many relationships, and have used `{ disconnect: true }` rather than `{ disconnect: { id: "..."} }` in to-one relationships.
 
-!> Finally, make sure you apply corresponding changes to filters and input arguments when using the [List Items API](/docs/apis/list-items).
+!> Finally, make sure you apply corresponding changes to filters and input arguments when using the [Query API](/docs/apis/query).
 
 ---
 

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -214,8 +214,8 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
         const data = Array.from({ length: 238 }).map((x, i) => ({ title: `Post ${i}` }));
         // note this usage of the type is important because it tests that the generated
         // KeystoneListsTypeInfo extends Record<string, BaseGeneratedListTypes>
-        const lists = context.lists as KeystoneListsAPI<KeystoneListsTypeInfo>;
-        return lists.Post.createMany({ data });
+        const query = context.query as KeystoneListsAPI<KeystoneListsTypeInfo>;
+        return query.Post.createMany({ data });
       },
     },
     Query: {

--- a/examples-staging/ecommerce/mutations/addToCart.ts
+++ b/examples-staging/ecommerce/mutations/addToCart.ts
@@ -13,7 +13,7 @@ async function addToCart(
     throw new Error('You must be logged in to do this!');
   }
   // 2. Query the current users cart
-  const allCartItems = await context.lists.CartItem.findMany({
+  const allCartItems = await context.query.CartItem.findMany({
     where: { user: { id: { equals: sesh.itemId } }, product: { id: { equals: productId } } },
     query: 'id quantity',
   });
@@ -24,13 +24,13 @@ async function addToCart(
     console.log(`There are already ${existingCartItem.quantity}, increment by 1!`);
     // 3. See if the current item is in their cart
     // 4. if itis, increment by 1
-    return await context.db.lists.CartItem.updateOne({
+    return await context.db.CartItem.updateOne({
       where: { id: existingCartItem.id },
       data: { quantity: existingCartItem.quantity + 1 },
     });
   }
   // 4. if it isnt, create a new cart item!
-  return await context.db.lists.CartItem.createOne({
+  return await context.db.CartItem.createOne({
     data: {
       product: { connect: { id: productId } },
       user: { connect: { id: sesh.itemId } },

--- a/examples-staging/ecommerce/mutations/checkout.ts
+++ b/examples-staging/ecommerce/mutations/checkout.ts
@@ -15,7 +15,7 @@ async function checkout(root: any, { token }: Arguments, context: KeystoneContex
     throw new Error('Sorry! You must be signed in to create an order!');
   }
   // 1.5 Query the current user
-  const user = await context.lists.User.findOne({
+  const user = await context.query.User.findOne({
     where: { id: userId },
     query: graphql`
       id
@@ -75,7 +75,7 @@ async function checkout(root: any, { token }: Arguments, context: KeystoneContex
   });
   console.log('gonna create the order');
   // 5. Create the order and return it
-  const order = await context.db.lists.Order.createOne({
+  const order = await context.db.Order.createOne({
     data: {
       total: charge.amount,
       charge: charge.id,
@@ -87,7 +87,7 @@ async function checkout(root: any, { token }: Arguments, context: KeystoneContex
   // 6. Clean up any old cart item
   const cartItemIds = user.cart.map((cartItem: any) => cartItem.id);
   console.log('gonna create delete cartItems');
-  await context.lists.CartItem.deleteMany({
+  await context.query.CartItem.deleteMany({
     where: cartItemIds.map((id: string) => ({ id })),
   });
   return order;

--- a/examples-staging/ecommerce/tests/mutations.test.ts
+++ b/examples-staging/ecommerce/tests/mutations.test.ts
@@ -36,7 +36,7 @@ describe(`Custom mutations`, () => {
     test(
       'A users cart should correctly convert into an order',
       runner(async ({ context }) => {
-        const { Product, User } = context.sudo().lists;
+        const { Product, User } = context.sudo().query;
 
         // Create some products: FIXME: createMany
         const product1 = await Product.createOne({
@@ -178,7 +178,7 @@ describe(`Custom mutations`, () => {
     test(
       'Adding DRAFT product should throw',
       runner(async ({ context }) => {
-        const { User, Product } = context.sudo().lists;
+        const { User, Product } = context.sudo().query;
         // Setup user
         const user = await User.createOne({
           data: { name: 'Test User', email: 'test@example.com' },
@@ -203,7 +203,7 @@ describe(`Custom mutations`, () => {
     test(
       'Adding UNAVAILABLE product should throw',
       runner(async ({ context }) => {
-        const { User, Product } = context.sudo().lists;
+        const { User, Product } = context.sudo().query;
         // Setup user
         const user = await User.createOne({
           data: { name: 'Test User', email: 'test@example.com' },
@@ -228,7 +228,7 @@ describe(`Custom mutations`, () => {
     test(
       'Adding AVAILABLE product should return a cart item with a quantity of 1',
       runner(async ({ context }) => {
-        const { User, Product } = context.sudo().lists;
+        const { User, Product } = context.sudo().query;
         // Setup user
         const user = await User.createOne({
           data: { name: 'Test User', email: 'test@example.com' },
@@ -255,7 +255,7 @@ describe(`Custom mutations`, () => {
     test(
       'Adding a product multiple times should return a cart item with the correct quantity',
       runner(async ({ context }) => {
-        const { User, Product } = context.sudo().lists;
+        const { User, Product } = context.sudo().query;
         // Setup user
         const user = await User.createOne({
           data: { name: 'Test User', email: 'test@example.com' },
@@ -289,7 +289,7 @@ describe(`Custom mutations`, () => {
     test(
       'Adding different products multiple times should return cart items with the correct quantity',
       runner(async ({ context }) => {
-        const { User, Product } = context.sudo().lists;
+        const { User, Product } = context.sudo().query;
         // Setup user
         const user = await User.createOne({
           data: { name: 'Test User', email: 'test@example.com' },
@@ -310,13 +310,13 @@ describe(`Custom mutations`, () => {
         await q({ query, variables: { productId: product1.id } });
         await q({ query, variables: { productId: product2.id } });
         await q({ query, variables: { productId: product1.id } });
-        const result1 = await context.sudo().lists.CartItem.findMany({
+        const result1 = await context.sudo().query.CartItem.findMany({
           where: { product: { id: { equals: product1.id } } },
           query: 'quantity',
         });
         expect(result1).toHaveLength(1);
         expect(result1[0].quantity).toEqual(3);
-        const result2 = await context.sudo().lists.CartItem.findMany({
+        const result2 = await context.sudo().query.CartItem.findMany({
           where: { product: { id: { equals: product2.id } } },
           query: 'quantity',
         });

--- a/examples/blog/seed-data/index.ts
+++ b/examples/blog/seed-data/index.ts
@@ -20,13 +20,13 @@ export async function insertSeedData(context: KeystoneContext) {
   const createAuthor = async (authorData: AuthorProps) => {
     let author = null;
     try {
-      author = await context.lists.Author.findOne({
+      author = await context.query.Author.findOne({
         where: { email: authorData.email },
         query: 'id',
       });
     } catch (e) {}
     if (!author) {
-      author = await context.lists.Author.createOne({
+      author = await context.query.Author.createOne({
         data: authorData,
         query: 'id',
       });
@@ -37,7 +37,7 @@ export async function insertSeedData(context: KeystoneContext) {
   const createPost = async (postData: PostProps) => {
     let authors;
     try {
-      authors = await context.lists.Author.findMany({
+      authors = await context.query.Author.findMany({
         where: { name: { equals: postData.author } },
         query: 'id',
       });
@@ -45,7 +45,7 @@ export async function insertSeedData(context: KeystoneContext) {
       authors = [];
     }
     postData.author = { connect: { id: authors[0].id } };
-    const post = await context.lists.Post.createOne({
+    const post = await context.query.Post.createOne({
       data: postData,
       query: 'id',
     });

--- a/examples/default-values/README.md
+++ b/examples/default-values/README.md
@@ -59,7 +59,7 @@ We use `originalInput`, which contains the input passed to the GraphQL create mu
       }),
 ```
 
-We use [`context`](https://keystonejs.com/docs/apis/context) along with the [list items API](https://keystonejs.com/docs/apis/list-items) to set the default assignee of a task to be a user named `"Anonymous"`.
+We use [`context`](https://keystonejs.com/docs/apis/context) along with the [Query API](https://keystonejs.com/docs/apis/query) to set the default assignee of a task to be a user named `"Anonymous"`.
 
 ```typescript
       assignedTo: relationship({
@@ -67,7 +67,7 @@ We use [`context`](https://keystonejs.com/docs/apis/context) along with the [lis
         many: false,
         // Dynamic default: Find an anonymous user and assign the task to them
         defaultValue: async ({ context }) => {
-          const anonymous = await context.lists.Person.findMany({
+          const anonymous = await context.query.Person.findMany({
             where: { name: 'Anonymous' },
           });
           if (anonymous.length > 0) {

--- a/examples/default-values/schema.ts
+++ b/examples/default-values/schema.ts
@@ -31,7 +31,7 @@ export const lists = {
           // Dynamic default: Find an anonymous user and assign the task to them
           async resolveInput({ context, operation, resolvedData }) {
             if (operation === 'create' && !resolvedData.assignedTo) {
-              const anonymous = await context.db.lists.Person.findMany({
+              const anonymous = await context.db.Person.findMany({
                 where: { name: { equals: 'Anonymous' } },
               });
               if (anonymous.length > 0) {

--- a/examples/extend-graphql-schema/README.md
+++ b/examples/extend-graphql-schema/README.md
@@ -39,7 +39,7 @@ We add a custom mutation to our schema using `type Mutation` in the `typeDefs`, 
     resolvers: {
       Mutation: {
         publishPost: (root, { id }, context) => {
-          return context.db.lists.Post.updateOne({
+          return context.db.Post.updateOne({
             id,
             data: { status: 'published', publishDate: new Date().toUTCString() },
           });
@@ -66,7 +66,7 @@ We add a custom query to our schema using `type Query` in the `typeDefs`, and de
           const cutoff = new Date(
             new Date().setUTCDate(new Date().getUTCDate() - days)
           ).toUTCString();
-          return context.db.lists.Post.findMany({
+          return context.db.Post.findMany({
             where: { author: { id }, publishDate_gt: cutoff },
           });
         },
@@ -97,13 +97,13 @@ We add a custom type to our schema using `type Statisics` in the `typeDefs`, and
     resolvers: {
       Query: {
         stats: async (root, { id }, context) => {
-          const draft = await context.lists.Post.count({
+          const draft = await context.query.Post.count({
             where: { author: { id }, status: 'draft' },
           });
-          const published = await context.lists.Post.count({
+          const published = await context.query.Post.count({
             where: { author: { id }, status: 'published' },
           });
-          const { posts } = await context.lists.Author.findOne({
+          const { posts } = await context.query.Author.findOne({
             where: { id },
             query: 'posts(take: 1, orderBy: { publishDate: desc }) { id }',
           });
@@ -112,7 +112,7 @@ We add a custom type to our schema using `type Statisics` in the `typeDefs`, and
       },
       Statistics: {
         latest: (root, args, context) =>
-          context.db.lists.Post.findOne({ where: { id: root.latestPostId } }),
+          context.db.Post.findOne({ where: { id: root.latestPostId } }),
       },
     },
   }),

--- a/examples/extend-graphql-schema/custom-schema.ts
+++ b/examples/extend-graphql-schema/custom-schema.ts
@@ -25,11 +25,11 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
   resolvers: {
     Mutation: {
       publishPost: (root, { id }, context) => {
-        // Note we use `context.db.lists.Post` here as we have a return type
+        // Note we use `context.db.Post` here as we have a return type
         // of Post, and this API provides results in the correct format.
-        // If you accidentally use `context.lists.Post` here you can expect problems
+        // If you accidentally use `context.query.Post` here you can expect problems
         // when accessing the fields in your GraphQL client.
-        return context.db.lists.Post.updateOne({
+        return context.db.Post.updateOne({
           where: { id },
           data: { status: 'published', publishDate: new Date().toUTCString() },
         });
@@ -42,22 +42,22 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
           new Date().setUTCDate(new Date().getUTCDate() - days)
         ).toUTCString();
 
-        // Note we use `context.db.lists.Post` here as we have a return type
+        // Note we use `context.db.Post` here as we have a return type
         // of [Post], and this API provides results in the correct format.
-        // If you accidentally use `context.lists.Post` here you can expect problems
+        // If you accidentally use `context.query.Post` here you can expect problems
         // when accessing the fields in your GraphQL client.
-        return context.db.lists.Post.findMany({
+        return context.db.Post.findMany({
           where: { author: { id: { equals: id } }, publishDate: { gt: cutoff } },
         });
       },
       stats: async (root, { id }, context) => {
-        const draft = await context.lists.Post.count({
+        const draft = await context.query.Post.count({
           where: { author: { id: { equals: id } }, status: { equals: 'draft' } },
         });
-        const published = await context.lists.Post.count({
+        const published = await context.query.Post.count({
           where: { author: { id: { equals: id } }, status: { equals: 'published' } },
         });
-        const { posts } = await context.lists.Author.findOne({
+        const { posts } = await context.query.Author.findOne({
           where: { id },
           query: 'posts(take: 1, orderBy: { publishDate: desc }) { id }',
         });
@@ -69,9 +69,9 @@ export const extendGraphqlSchema = graphQLSchemaExtension({
       // the root value. We use that object to further resolve ths specific fields.
       // In this case we want to take root.latestPostId and resolve it as a Post object
       //
-      // As above we use the context.db.lists.Post API to achieve this.
+      // As above we use the context.db.Post API to achieve this.
       latest: (root, args, context) =>
-        context.db.lists.Post.findOne({ where: { id: root.latestPostId } }),
+        context.db.Post.findOne({ where: { id: root.latestPostId } }),
       // We don't need to define resolvers for draft and published, as apollo will
       // return root.draft and root.published respectively.
     },

--- a/examples/task-manager/seed-data/index.ts
+++ b/examples/task-manager/seed-data/index.ts
@@ -19,13 +19,13 @@ export async function insertSeedData(context: KeystoneContext) {
   const createPerson = async (personData: PersonProps) => {
     let person = null;
     try {
-      person = await context.lists.Person.findOne({
+      person = await context.query.Person.findOne({
         where: { name: personData.name },
         query: 'id',
       });
     } catch (e) {}
     if (!person) {
-      person = await context.lists.Person.createOne({
+      person = await context.query.Person.createOne({
         data: personData,
         query: 'id',
       });
@@ -36,7 +36,7 @@ export async function insertSeedData(context: KeystoneContext) {
   const createTask = async (taskData: TaskProps) => {
     let persons;
     try {
-      persons = await context.lists.Person.findMany({
+      persons = await context.query.Person.findMany({
         where: { name: { equals: taskData.assignedTo } },
         query: 'id',
       });
@@ -44,7 +44,7 @@ export async function insertSeedData(context: KeystoneContext) {
       persons = [];
     }
     taskData.assignedTo = { connect: { id: persons[0].id } };
-    const task = await context.lists.Task.createOne({
+    const task = await context.query.Task.createOne({
       data: taskData,
       query: 'id',
     });

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -42,7 +42,7 @@ which should give output ending with:
 ```
  PASS  ./example.test.ts (14.245 s)
   Example tests using test runner
-    ✓ Create a Person using the list items API (3820 ms)
+    ✓ Create a Person using the Query API (3820 ms)
     ✓ Create a Person using a hand-crafted GraphQL query sent over HTTP (780 ms)
     ✓ Check that trying to create user with no name (required field) fails (722 ms)
     ✓ Check access control by running updateTask as a specific user via context.withSession() (759 ms)
@@ -70,7 +70,7 @@ const runner = setupTestRunner({ config });
 
 describe('Example tests using test runner', () => {
   test(
-    'Create a Person using the list items API',
+    'Create a Person using the Query API',
     runner(async ({ context }) => {
       ...
     })
@@ -86,9 +86,9 @@ The test runner provides the test function with a [`KeystoneContext`](https://ke
 
 ```typescript
 test(
-  'Create a Person using the list items API',
+  'Create a Person using the Query API',
   runner(async ({ context }) => {
-    const person = await context.lists.Person.createOne({
+    const person = await context.query.Person.createOne({
       data: { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
       query: 'id name email password { isSet }',
     });

--- a/examples/testing/example.test.ts
+++ b/examples/testing/example.test.ts
@@ -8,11 +8,11 @@ const runner = setupTestRunner({ config });
 
 describe('Example tests using test runner', () => {
   test(
-    'Create a Person using the list items API',
+    'Create a Person using the Query API',
     runner(async ({ context }) => {
       // We can use the context argument provided by the test runner to access
       // the full context API.
-      const person = await context.lists.Person.createOne({
+      const person = await context.query.Person.createOne({
         data: { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
         query: 'id name email password { isSet }',
       });
@@ -71,7 +71,7 @@ describe('Example tests using test runner', () => {
       // are behaving as expected.
 
       // Create some users
-      const [alice, bob] = await context.lists.Person.createMany({
+      const [alice, bob] = await context.query.Person.createMany({
         data: [
           { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
           { name: 'Bob', email: 'bob@example.com', password: 'super-secret' },
@@ -82,7 +82,7 @@ describe('Example tests using test runner', () => {
       expect(bob.name).toEqual('Bob');
 
       // Create a task assigned to Alice
-      const task = await context.lists.Task.createOne({
+      const task = await context.query.Task.createOne({
         data: {
           label: 'Experiment with Keystone',
           priority: 'high',
@@ -172,7 +172,7 @@ describe('Example tests using test environment', () => {
     await testEnv.connect();
 
     // Create a person in the database to be used in multiple tests
-    person = (await context.lists.Person.createOne({
+    person = (await context.query.Person.createOne({
       data: { name: 'Alice', email: 'alice@example.com', password: 'super-secret' },
     })) as { id: string };
   });
@@ -181,7 +181,7 @@ describe('Example tests using test environment', () => {
   });
 
   test('Check that the persons password is set', async () => {
-    const { password } = await context.lists.Person.findOne({
+    const { password } = await context.query.Person.findOne({
       where: { id: person.id },
       query: 'password { isSet }',
     });
@@ -189,7 +189,7 @@ describe('Example tests using test environment', () => {
   });
 
   test('Update the persons email address', async () => {
-    const { email } = await context.lists.Person.updateOne({
+    const { email } = await context.query.Person.updateOne({
       where: { id: person.id },
       data: { email: 'new-email@example.com' },
       query: 'email',

--- a/examples/testing/schema.ts
+++ b/examples/testing/schema.ts
@@ -23,7 +23,7 @@ export const lists = {
     access: {
       item: {
         update: async ({ session, item, context }) => {
-          const task = await context.lists.Task.findOne({
+          const task = await context.query.Task.findOne({
             where: { id: item.id },
             query: 'assignedTo { id }',
           });

--- a/examples/virtual-field/README.md
+++ b/examples/virtual-field/README.md
@@ -107,7 +107,7 @@ relatedPosts: virtual({
       resolve(item, args, context) {
         // this could have some logic to get posts that are actually related to this one somehow
         // this is a just a naive "get the three latest posts that aren't this one"
-        return context.db.lists.Post.findMany({
+        return context.db.Post.findMany({
           take: 3,
           where: { id_not: item.id, status: 'published' },
           orderBy: [{ publishDate: 'desc' }],

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -80,7 +80,7 @@ export const lists = {
         field: graphql.field({
           type: graphql.String,
           async resolve(item, args, context) {
-            const { author } = await context.lists.Post.findOne({
+            const { author } = await context.query.Post.findOne({
               where: { id: item.id.toString() },
               query: 'author { name }',
             });
@@ -101,7 +101,7 @@ export const lists = {
           graphql.field({
             type: lists.Post.types.output,
             async resolve(item, args, context) {
-              const { posts } = await context.lists.Author.findOne({
+              const { posts } = await context.query.Author.findOne({
                 where: { id: item.id.toString() },
                 query: `posts(
                     orderBy: { publishDate: desc }
@@ -109,7 +109,7 @@ export const lists = {
                   ) { id }`,
               });
               if (posts.length > 0) {
-                return context.db.lists.Post.findOne({ where: { id: posts[0].id } });
+                return context.db.Post.findOne({ where: { id: posts[0].id } });
               }
             },
           }),

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -57,7 +57,7 @@ export function getBaseAuthSchema<I extends string, S extends string>({
             throw new Error('No session implementation available on context');
           }
 
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const result = await validateSecret(
             secretFieldImpl,
             identityField,
@@ -89,7 +89,7 @@ export function getBaseAuthSchema<I extends string, S extends string>({
       Query: {
         async authenticatedItem(root, args, { session, db }) {
           if (typeof session?.itemId === 'string' && typeof session.listKey === 'string') {
-            return db.lists[session.listKey].findOne({ where: { id: session.itemId } });
+            return db[session.listKey].findOne({ where: { id: session.itemId } });
           }
           return null;
         },

--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -47,7 +47,7 @@ export function getInitFirstItemSchema({
             throw new Error('No session implementation available on context');
           }
 
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const count = await dbItemAPI.count({});
           if (count !== 0) {
             throw new Error('Initial items can only be created when no items exist in that list');

--- a/packages/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -56,7 +56,7 @@ export function getMagicAuthLinkSchema<I extends string>({
     resolvers: {
       Mutation: {
         async [gqlNames.sendItemMagicAuthLink](root: any, args: { [P in I]: string }, context) {
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const tokenType = 'magicAuth';
           const identity = args[identityField];
 
@@ -100,7 +100,7 @@ export function getMagicAuthLinkSchema<I extends string>({
             throw new Error('No session implementation available on context');
           }
 
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const tokenType = 'magicAuth';
           const result = await validateAuthToken(
             listKey,

--- a/packages/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages/auth/src/gql/getPasswordResetSchema.ts
@@ -61,7 +61,7 @@ export function getPasswordResetSchema<I extends string, S extends string>({
     resolvers: {
       Mutation: {
         async [gqlNames.sendItemPasswordResetLink](root: any, args: { [P in I]: string }, context) {
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const tokenType = 'passwordReset';
           const identity = args[identityField];
 
@@ -101,7 +101,7 @@ export function getPasswordResetSchema<I extends string, S extends string>({
           args: { [P in I]: string } & { [P in S]: string } & { token: string },
           context
         ) {
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const tokenType = 'passwordReset';
           const result = await validateAuthToken(
             listKey,
@@ -152,7 +152,7 @@ export function getPasswordResetSchema<I extends string, S extends string>({
           args: { [P in I]: string } & { token: string },
           context
         ) {
-          const dbItemAPI = context.sudo().db.lists[listKey];
+          const dbItemAPI = context.sudo().db[listKey];
           const tokenType = 'passwordReset';
           const result = await validateAuthToken(
             listKey,

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -100,7 +100,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
     }
 
     if (!session && initFirstItem) {
-      const count = await context.sudo().lists[listKey].count({});
+      const count = await context.sudo().query[listKey].count({});
       if (count === 0) {
         if (pathname !== '/init') {
           return { kind: 'redirect', to: '/init' };
@@ -227,7 +227,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
           !session.listKey ||
           session.listKey !== listKey ||
           !session.itemId ||
-          !sudoContext.lists[session.listKey]
+          !sudoContext.query[session.listKey]
         ) {
           return;
         }
@@ -238,7 +238,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
         try {
           // If no field selection is specified, just load the id. We still load the item,
           // because doing so validates that it exists in the database
-          const data = await sudoContext.lists[listKey].findOne({
+          const data = await sudoContext.query[listKey].findOne({
             where: { id: session.itemId },
             query: sessionData || 'id',
           });
@@ -282,7 +282,7 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
           const accessingInitPage =
             url?.pathname === '/init' &&
             url?.host === host &&
-            (await context.sudo().lists[listKey].count({})) === 0;
+            (await context.sudo().query[listKey].count({})) === 0;
           return (
             accessingInitPage ||
             (keystoneConfig.ui?.isAccessAllowed

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
@@ -6,5 +6,5 @@ export function createListsAPI(config: KeystoneConfig, prismaClient: any) {
   const { getKeystone } = createSystem(initConfig(config));
   const keystone = getKeystone(prismaClient);
   keystone.connect();
-  return keystone.createContext({ sudo: true }).lists;
+  return keystone.createContext({ sudo: true }).query;
 }

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/node-api.ts
@@ -2,7 +2,7 @@ import { KeystoneConfig } from '../types';
 import { createSystem } from '../lib/createSystem';
 import { initConfig } from '../lib/config/initConfig';
 
-export function createListsAPI(config: KeystoneConfig, prismaClient: any) {
+export function createQueryAPI(config: KeystoneConfig, prismaClient: any) {
   const { getKeystone } = createSystem(initConfig(config));
   const keystone = getKeystone(prismaClient);
   keystone.connect();

--- a/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
+++ b/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
@@ -412,7 +412,7 @@ const fetchItemForItemViewFieldMode = extendContext(context => {
     if (items.has(id)) {
       return items.get(id)!;
     }
-    let promise = context.db.lists[listKey].findOne({ where: { id } });
+    let promise = context.db[listKey].findOne({ where: { id } });
     items.set(id, promise);
     return promise;
   };

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -123,10 +123,10 @@ const nodeAPIJS = (
   config: KeystoneConfig
 ) => `import keystoneConfig from '../../keystone';
 import { PrismaClient } from '.prisma/client';
-import { createListsAPI } from '@keystone-next/keystone/___internal-do-not-use-will-break-in-patch/node-api';
+import { createQueryAPI } from '@keystone-next/keystone/___internal-do-not-use-will-break-in-patch/node-api';
 ${makeVercelIncludeTheSQLiteDB(cwd, path.join(cwd, 'node_modules/.keystone/next'), config)}
 
-export const lists = createListsAPI(keystoneConfig, PrismaClient);
+export const lists = createQueryAPI(keystoneConfig, PrismaClient);
 `;
 
 const nodeAPIDTS = `import { KeystoneListsAPI } from '@keystone-next/keystone/types';

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -126,13 +126,13 @@ import { PrismaClient } from '.prisma/client';
 import { createQueryAPI } from '@keystone-next/keystone/___internal-do-not-use-will-break-in-patch/node-api';
 ${makeVercelIncludeTheSQLiteDB(cwd, path.join(cwd, 'node_modules/.keystone/next'), config)}
 
-export const lists = createQueryAPI(keystoneConfig, PrismaClient);
+export const query = createQueryAPI(keystoneConfig, PrismaClient);
 `;
 
 const nodeAPIDTS = `import { KeystoneListsAPI } from '@keystone-next/keystone/types';
 import { KeystoneListsTypeInfo } from './types';
 
-export const lists: KeystoneListsAPI<KeystoneListsTypeInfo>;`;
+export const query: KeystoneListsAPI<KeystoneListsTypeInfo>;`;
 
 const makeVercelIncludeTheSQLiteDB = (
   cwd: string,

--- a/packages/keystone/src/fields/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/tests/test-fixtures.ts
@@ -17,7 +17,7 @@ export const skipRequiredTest = true;
 export const skipUniqueTest = true;
 
 const getIDs = async (context: KeystoneContext) => {
-  const items = await context.lists.Test.findMany({ query: 'id name' });
+  const items = await context.query.Test.findMany({ query: 'id name' });
   return Object.fromEntries(items.map(({ id, name }) => [name, id]));
 };
 
@@ -28,7 +28,7 @@ export const filterTests = (withKeystone: any) => {
     expected: any[]
   ) =>
     expect(
-      await context.lists.Test.findMany({ where, orderBy: { name: 'asc' }, query: 'id name' })
+      await context.query.Test.findMany({ where, orderBy: { name: 'asc' }, query: 'id name' })
     ).toEqual(expected);
 
   test(

--- a/packages/keystone/src/fields/types/autoIncrement/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/autoIncrement/tests/test-fixtures.ts
@@ -42,7 +42,7 @@ export const filterTests = (withKeystone: (arg: any) => any) => {
   const _storedValues = storedValues();
   const match = async (context: KeystoneContext, where: Record<string, any>, expected: any[]) =>
     expect(
-      await context.lists.Test.findMany({
+      await context.query.Test.findMany({
         where,
         orderBy: { name: 'asc' },
         query: 'name orderNumber',

--- a/packages/keystone/src/fields/types/file/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/file/tests/test-fixtures.ts
@@ -65,7 +65,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
       'upload values should match expected',
       keystoneTestWrapper(async ({ context }: { context: any }) => {
         const filename = 'keystone.jpeg';
-        const data = await context.lists.Test.createOne({
+        const data = await context.query.Test.createOne({
           data: { secretFile: prepareFile(filename) },
           query: `
               secretFile {
@@ -90,7 +90,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
       'From existing item succeeds',
       keystoneTestWrapper(async ({ context }: { context: any }) => {
         // Create an initial item
-        const initialItem = await context.lists.Test.createOne({
+        const initialItem = await context.query.Test.createOne({
           data: { secretFile: prepareFile('keystone.jpg') },
           query: `
             secretFile {
@@ -106,7 +106,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
 
         // Create a new item base on the first items ref
         const ref = initialItem.secretFile.ref;
-        const newItem = await context.lists.Test.createOne({
+        const newItem = await context.query.Test.createOne({
           data: { secretFile: { ref } },
           query: `
             secretFile {
@@ -167,7 +167,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
     test(
       'Both upload and ref fails - valid ref',
       keystoneTestWrapper(async ({ context }: { context: any }) => {
-        const initialItem = await context.lists.Test.createOne({
+        const initialItem = await context.query.Test.createOne({
           data: { secretFile: prepareFile('keystone.jpg') },
           query: `secretFile { ref }`,
         });

--- a/packages/keystone/src/fields/types/image/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/image/tests/test-fixtures.ts
@@ -67,7 +67,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
       keystoneTestWrapper(async ({ context }: { context: KeystoneContext }) => {
         const filenames = ['keystone.jpeg', 'keystone.jpg', 'keystone'];
         for (const filename of filenames) {
-          const data = await context.lists.Test.createOne({
+          const data = await context.query.Test.createOne({
             data: { avatar: prepareFile(filename) },
             query: `
               avatar {
@@ -122,7 +122,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
       'From existing item succeeds',
       keystoneTestWrapper(async ({ context }: { context: KeystoneContext }) => {
         // Create an initial item
-        const initialItem = await context.lists.Test.createOne({
+        const initialItem = await context.query.Test.createOne({
           data: { avatar: prepareFile('keystone.jpg') },
           query: `
             avatar {
@@ -141,7 +141,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
 
         // Create a new item base on the first items ref
         const ref = initialItem.avatar.ref;
-        const newItem = await context.lists.Test.createOne({
+        const newItem = await context.query.Test.createOne({
           data: { avatar: { ref } },
           query: `
             avatar {
@@ -207,7 +207,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
     test(
       'Both upload and ref fails - valid ref',
       keystoneTestWrapper(async ({ context }: { context: KeystoneContext }) => {
-        const initialItem = await context.lists.Test.createOne({
+        const initialItem = await context.query.Test.createOne({
           data: { avatar: prepareFile('keystone.jpg') },
           query: `avatar { ref }`,
         });

--- a/packages/keystone/src/fields/types/password/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/password/tests/test-fixtures.ts
@@ -44,7 +44,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
     'setting a password below the minLength fails',
     keystoneTestWrapper(async ({ context }: { context: any }) => {
       await expect(
-        context.lists.Test.createOne({
+        context.query.Test.createOne({
           data: { password: '123' },
         })
       ).rejects.toMatchInlineSnapshot(
@@ -56,14 +56,14 @@ export const crudTests = (keystoneTestWrapper: any) => {
     'setting a common password fails',
     keystoneTestWrapper(async ({ context }: { context: any }) => {
       await expect(
-        context.lists.Test.createOne({
+        context.query.Test.createOne({
           data: { passwordRejectCommon: 'password' },
           query: ``,
         })
       ).rejects.toMatchInlineSnapshot(
         `[GraphQLError: [password:rejectCommon:Test:passwordRejectCommon] Common and frequently-used passwords are not allowed.]`
       );
-      const data = await context.lists.Test.createOne({
+      const data = await context.query.Test.createOne({
         data: { passwordRejectCommon: 'sdfinwedvhweqfoiuwdfnvjiewrijnf' },
         query: `passwordRejectCommon {isSet}`,
       });

--- a/packages/keystone/src/fields/types/timestamp/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/timestamp/tests/test-fixtures.ts
@@ -49,7 +49,7 @@ export const filterTests = (withKeystone: (args: any) => any) => {
     expected: any,
     orderBy: Record<string, 'asc' | 'desc'> = { name: 'asc' }
   ) =>
-    expect(await context.lists.Test.findMany({ where, orderBy, query: 'name lastOnline' })).toEqual(
+    expect(await context.query.Test.findMany({ where, orderBy, query: 'name lastOnline' })).toEqual(
       expected
     );
 

--- a/packages/keystone/src/lib/context/createContext.ts
+++ b/packages/keystone/src/lib/context/createContext.ts
@@ -73,11 +73,11 @@ export function makeCreateContext({
       }
       return result.data as Record<string, any>;
     };
-    const dbAPI: KeystoneContext['db']['lists'] = {};
-    const itemAPI: KeystoneContext['lists'] = {};
+    const dbAPI: KeystoneContext['db'] = {};
+    const itemAPI: KeystoneContext['query'] = {};
     const contextToReturn: KeystoneContext = {
-      db: { lists: dbAPI },
-      lists: itemAPI,
+      db: dbAPI,
+      query: itemAPI,
       totalResults: 0,
       prisma: prismaClient,
       graphql: { raw: rawGraphQL, run: runGraphQL, schema },

--- a/packages/keystone/src/lib/context/itemAPI.ts
+++ b/packages/keystone/src/lib/context/itemAPI.ts
@@ -61,7 +61,7 @@ function defaultQueryParam(query?: string, resolveFields?: string | false) {
 /* NOTE
  *
  * The `resolveFields` param has been deprecated in favor of `query` (when selecting fields to
- * query) or the new dbAPI which is available via `context.db.lists.{List}`, which replaces
+ * query) or the new dbAPI which is available via `context.db.{List}`, which replaces
  * the previous `resolveFields: false` behaviour.
  *
  * We'll be removing the option to use `resolveFields` entirely in a future release.

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -28,7 +28,7 @@ function getResolvedUniqueWheres(
     // Validate and resolve the input filter
     const uniqueWhere = await resolveUniqueWhereInput(uniqueInput, foreignList.fields, context);
     // Check whether the item exists
-    const item = await context.db.lists[foreignList.listKey].findOne({ where: uniqueInput });
+    const item = await context.db[foreignList.listKey].findOne({ where: uniqueInput });
     if (item === null) {
       throw new Error('Unable to find item to connect to.');
     }

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -29,7 +29,7 @@ async function handleCreateAndUpdate(
     const uniqueWhere = await resolveUniqueWhereInput(value.connect, foreignList.fields, context);
     // Check whether the item exists
     try {
-      const item = await context.db.lists[foreignList.listKey].findOne({ where: value.connect });
+      const item = await context.db[foreignList.listKey].findOne({ where: value.connect });
       if (item === null) {
         throw new Error(`Unable to connect a ${target}`);
       }

--- a/packages/keystone/src/scripts/tests/artifacts.test.ts
+++ b/packages/keystone/src/scripts/tests/artifacts.test.ts
@@ -118,14 +118,14 @@ describe('postinstall', () => {
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import keystoneConfig from '../../keystone';
       import { PrismaClient } from '.prisma/client';
-      import { createListsAPI } from '@keystone-next/keystone/___internal-do-not-use-will-break-in-patch/node-api';
+      import { createQueryAPI } from '@keystone-next/keystone/___internal-do-not-use-will-break-in-patch/node-api';
       import path from 'path';
 
           path.join(__dirname, "../../../app.db");
           path.join(process.cwd(), "app.db");
-          
 
-      export const lists = createListsAPI(keystoneConfig, PrismaClient);
+
+      export const lists = createQueryAPI(keystoneConfig, PrismaClient);
 
     `);
     expect(recording()).toMatchInlineSnapshot(`"✨ GraphQL and Prisma schemas are up to date"`);
@@ -155,7 +155,7 @@ describe('postinstall', () => {
 
           path.join(__dirname, "../../../app.db");
           path.join(process.cwd(), "app.db");
-          
+
 
       export const config = {
         api: {

--- a/packages/keystone/src/scripts/tests/artifacts.test.ts
+++ b/packages/keystone/src/scripts/tests/artifacts.test.ts
@@ -114,7 +114,7 @@ describe('postinstall', () => {
       import { KeystoneListsAPI } from '@keystone-next/keystone/types';
       import { KeystoneListsTypeInfo } from './types';
 
-      export const lists: KeystoneListsAPI<KeystoneListsTypeInfo>;
+      export const query: KeystoneListsAPI<KeystoneListsTypeInfo>;
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import keystoneConfig from '../../keystone';
       import { PrismaClient } from '.prisma/client';
@@ -125,7 +125,7 @@ describe('postinstall', () => {
           path.join(process.cwd(), "app.db");
           
 
-      export const lists = createQueryAPI(keystoneConfig, PrismaClient);
+      export const query = createQueryAPI(keystoneConfig, PrismaClient);
 
     `);
     expect(recording()).toMatchInlineSnapshot(`"✨ GraphQL and Prisma schemas are up to date"`);

--- a/packages/keystone/src/scripts/tests/artifacts.test.ts
+++ b/packages/keystone/src/scripts/tests/artifacts.test.ts
@@ -123,7 +123,7 @@ describe('postinstall', () => {
 
           path.join(__dirname, "../../../app.db");
           path.join(process.cwd(), "app.db");
-
+          
 
       export const lists = createQueryAPI(keystoneConfig, PrismaClient);
 
@@ -155,7 +155,7 @@ describe('postinstall', () => {
 
           path.join(__dirname, "../../../app.db");
           path.join(process.cwd(), "app.db");
-
+          
 
       export const config = {
         api: {

--- a/packages/keystone/src/types/context.ts
+++ b/packages/keystone/src/types/context.ts
@@ -6,8 +6,8 @@ import type { BaseGeneratedListTypes, GqlNames } from './utils';
 
 export type KeystoneContext = {
   req?: IncomingMessage;
-  db: { lists: KeystoneDbAPI<Record<string, BaseGeneratedListTypes>> };
-  lists: KeystoneListsAPI<Record<string, BaseGeneratedListTypes>>;
+  db: KeystoneDbAPI<Record<string, BaseGeneratedListTypes>>;
+  query: KeystoneListsAPI<Record<string, BaseGeneratedListTypes>>;
   graphql: KeystoneGraphQLAPI<any>;
   sudo: () => KeystoneContext;
   exitSudo: () => KeystoneContext;
@@ -91,7 +91,7 @@ type ResolveFields = {
    * @deprecated
    *
    * resolveFields has been deprecated. Please use the `query` param to query fields,
-   * or `context.db.lists.{List}` instead of passing `resolveFields: false`
+   * or `context.db.{List}` instead of passing `resolveFields: false`
    */
   readonly resolveFields?: false | string;
 };

--- a/tests/api-tests/access-control/authed-user.test.ts
+++ b/tests/api-tests/access-control/authed-user.test.ts
@@ -28,12 +28,12 @@ const afterConnect = async ({ context }: { context: KeystoneContext }) => {
   type T = { id: IdType; name: string }[];
   const items: Record<string, T> = {};
   for (const [listKey, _items] of Object.entries(initialData)) {
-    items[listKey] = (await context.lists[listKey].createMany({
+    items[listKey] = (await context.query[listKey].createMany({
       data: _items,
       query: 'id name',
     })) as T;
   }
-  const user = (await context.lists.User.createOne({
+  const user = (await context.query.User.createOne({
     data: { name: 'test', yesRead: 'yes', noRead: 'no' },
     query: 'id name yesRead noRead',
   })) as { id: IdType; name: string; yesRead: string; noRead: string };

--- a/tests/api-tests/access-control/field-access.test.ts
+++ b/tests/api-tests/access-control/field-access.test.ts
@@ -22,7 +22,7 @@ describe(`Field access`, () => {
 
     items = {};
     for (const [listKey, _items] of Object.entries(initialData)) {
-      items[listKey] = (await context.sudo().lists[listKey].createMany({
+      items[listKey] = (await context.sudo().query[listKey].createMany({
         data: _items,
         query: 'id, name',
       })) as { id: IdType; name: string }[];
@@ -38,7 +38,7 @@ describe(`Field access`, () => {
         const item = items[listKey][0];
         const fieldName = getFieldName(access);
         const singleQueryName = context.gqlNames(listKey).itemQueryName;
-        await context.sudo().lists[listKey].updateOne({
+        await context.sudo().query[listKey].updateOne({
           where: { id: item.id },
           data: { [fieldName]: 'hello' },
         });
@@ -55,7 +55,7 @@ describe(`Field access`, () => {
         const item = items[listKey][0];
         const fieldName = getFieldName(access);
         const allQueryName = context.gqlNames(listKey).listQueryName;
-        await context.sudo().lists[listKey].updateOne({
+        await context.sudo().query[listKey].updateOne({
           where: { id: item.id },
           data: { [fieldName]: 'hello' },
         });

--- a/tests/api-tests/access-control/mutations-field.test.ts
+++ b/tests/api-tests/access-control/mutations-field.test.ts
@@ -53,7 +53,7 @@ describe('Access control', () => {
     runner(async ({ context, graphQLRequest }) => {
       const item = await context
         .sudo()
-        .lists.User.createOne({ data: { name: 'foo', badAccess: 'bar' } });
+        .query.User.createOne({ data: { name: 'foo', badAccess: 'bar' } });
 
       const { body } = await graphQLRequest({
         query: `query { users { id name badAccess } }`,
@@ -73,7 +73,7 @@ describe('Access control', () => {
     'createOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
+      await context.query.User.createOne({ data: { name: 'good', other: 'a' } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -91,7 +91,7 @@ describe('Access control', () => {
       ]);
 
       // Only the original user should exist
-      const _users = await context.lists.User.findMany({ query: 'id name other' });
+      const _users = await context.query.User.findMany({ query: 'id name other' });
       expect(_users.map(({ name }) => name)).toEqual(['good']);
       expect(_users.map(({ other }) => other)).toEqual(['a']);
     })
@@ -101,7 +101,7 @@ describe('Access control', () => {
     'createOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
       // Valid name should pass
-      await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
+      await context.query.User.createOne({ data: { name: 'good', other: 'a' } });
 
       // Invalid name
       const { body } = await graphQLRequest({
@@ -119,7 +119,7 @@ describe('Access control', () => {
       ]);
 
       // Only the original user should exist
-      const _users = await context.lists.User.findMany({ query: 'id name other' });
+      const _users = await context.query.User.findMany({ query: 'id name other' });
       expect(_users.map(({ name }) => name)).toEqual(['good']);
       expect(_users.map(({ other }) => other)).toEqual(['a']);
     })
@@ -129,8 +129,8 @@ describe('Access control', () => {
     'updateOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      const user = await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
-      await context.lists.User.updateOne({
+      const user = await context.query.User.createOne({ data: { name: 'good', other: 'a' } });
+      await context.query.User.updateOne({
         where: { id: user.id },
         data: { name: 'better', other: 'b' },
       });
@@ -151,7 +151,7 @@ describe('Access control', () => {
       ]);
 
       // User should have its original name
-      const _users = await context.lists.User.findMany({ query: 'id name other' });
+      const _users = await context.query.User.findMany({ query: 'id name other' });
       expect(_users.map(({ name }) => name)).toEqual(['better']);
       expect(_users.map(({ other }) => other)).toEqual(['b']);
     })
@@ -161,8 +161,8 @@ describe('Access control', () => {
     'updateOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
       // Valid name should pass
-      const user = await context.lists.User.createOne({ data: { name: 'good', other: 'a' } });
-      await context.lists.User.updateOne({
+      const user = await context.query.User.createOne({ data: { name: 'good', other: 'a' } });
+      await context.query.User.updateOne({
         where: { id: user.id },
         data: { name: 'better', other: 'b' },
       });
@@ -183,7 +183,7 @@ describe('Access control', () => {
       ]);
 
       // User should have its original name
-      const _users = await context.lists.User.findMany({ query: 'id name other' });
+      const _users = await context.query.User.findMany({ query: 'id name other' });
       expect(_users.map(({ name }) => name)).toEqual(['better']);
       expect(_users.map(({ other }) => other)).toEqual(['b']);
     })
@@ -230,7 +230,7 @@ describe('Access control', () => {
       ]);
 
       // Valid users should exist in the database
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -245,7 +245,7 @@ describe('Access control', () => {
     'updateMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1', other: 'a' },
           { name: 'good 2', other: 'a' },
@@ -292,7 +292,7 @@ describe('Access control', () => {
       ]);
 
       // All users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });

--- a/tests/api-tests/access-control/mutations-list-filter.test.ts
+++ b/tests/api-tests/access-control/mutations-list-filter.test.ts
@@ -26,11 +26,11 @@ describe('Access control - Filter', () => {
     'updateOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      const user = await context.lists.User.createOne({ data: { name: 'good' } });
-      await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
+      const user = await context.query.User.createOne({ data: { name: 'good' } });
+      await context.query.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
 
       // Setting up a bad name
-      await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'bad' } });
+      await context.query.User.updateOne({ where: { id: user.id }, data: { name: 'bad' } });
 
       // Now it has a bad name, we can't update it.
       const { data, errors } = await context.graphql.raw({
@@ -48,7 +48,7 @@ describe('Access control - Filter', () => {
       ]);
 
       // User should have its original name
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['bad']);
     })
   );
@@ -57,9 +57,9 @@ describe('Access control - Filter', () => {
     'deleteOne',
     runner(async ({ context }) => {
       // Valid names should pass
-      const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
-      const user2 = await context.lists.User.createOne({ data: { name: 'no delete' } });
-      await context.lists.User.deleteOne({ where: { id: user1.id } });
+      const user1 = await context.query.User.createOne({ data: { name: 'good' } });
+      const user2 = await context.query.User.createOne({ data: { name: 'no delete' } });
+      await context.query.User.deleteOne({ where: { id: user1.id } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -77,7 +77,7 @@ describe('Access control - Filter', () => {
       ]);
 
       // Bad users should still be in the database.
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['no delete']);
     })
   );
@@ -86,7 +86,7 @@ describe('Access control - Filter', () => {
     'updateMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'good 2' },
@@ -98,7 +98,7 @@ describe('Access control - Filter', () => {
       });
 
       // Set up some of them with bad names
-      await context.lists.User.updateMany({
+      await context.query.User.updateMany({
         data: [
           { where: { id: users[1].id }, data: { name: 'bad' } },
           { where: { id: users[3].id }, data: { name: 'bad' } },
@@ -140,7 +140,7 @@ describe('Access control - Filter', () => {
       ]);
 
       // All users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -158,7 +158,7 @@ describe('Access control - Filter', () => {
     'deleteMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'no delete 1' },
@@ -200,7 +200,7 @@ describe('Access control - Filter', () => {
       });
 
       // Three users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });

--- a/tests/api-tests/access-control/mutations-list-item.test.ts
+++ b/tests/api-tests/access-control/mutations-list-item.test.ts
@@ -51,7 +51,7 @@ describe('Access control - Item', () => {
     'createOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      await context.lists.User.createOne({ data: { name: 'good' } });
+      await context.query.User.createOne({ data: { name: 'good' } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -69,7 +69,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Only the original user should exist
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['good']);
     })
   );
@@ -93,7 +93,7 @@ describe('Access control - Item', () => {
       ]);
 
       // No items should exist
-      const _users = await context.lists.BadAccess.findMany({ query: 'id name' });
+      const _users = await context.query.BadAccess.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual([]);
     })
   );
@@ -102,8 +102,8 @@ describe('Access control - Item', () => {
     'updateOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      const user = await context.lists.User.createOne({ data: { name: 'good' } });
-      await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
+      const user = await context.query.User.createOne({ data: { name: 'good' } });
+      await context.query.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -121,7 +121,7 @@ describe('Access control - Item', () => {
       ]);
 
       // User should have its original name
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['better']);
     })
   );
@@ -129,7 +129,7 @@ describe('Access control - Item', () => {
   test(
     'updateOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
-      const item = await context.sudo().lists.BadAccess.createOne({ data: { name: 'good' } });
+      const item = await context.sudo().query.BadAccess.createOne({ data: { name: 'good' } });
 
       // Valid name
       const { body } = await graphQLRequest({
@@ -147,7 +147,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Item should have its original name
-      const _items = await context.lists.BadAccess.findMany({ query: 'id name' });
+      const _items = await context.query.BadAccess.findMany({ query: 'id name' });
       expect(_items.map(({ name }) => name)).toEqual(['good']);
     })
   );
@@ -156,9 +156,9 @@ describe('Access control - Item', () => {
     'deleteOne',
     runner(async ({ context }) => {
       // Valid names should pass
-      const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
-      const user2 = await context.lists.User.createOne({ data: { name: 'no delete' } });
-      await context.lists.User.deleteOne({ where: { id: user1.id } });
+      const user1 = await context.query.User.createOne({ data: { name: 'good' } });
+      const user2 = await context.query.User.createOne({ data: { name: 'no delete' } });
+      await context.query.User.deleteOne({ where: { id: user1.id } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -176,7 +176,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Bad users should still be in the database.
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['no delete']);
     })
   );
@@ -184,7 +184,7 @@ describe('Access control - Item', () => {
   test(
     'deleteOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
-      const item = await context.sudo().lists.BadAccess.createOne({ data: { name: 'good' } });
+      const item = await context.sudo().query.BadAccess.createOne({ data: { name: 'good' } });
 
       // Valid name
       const { body } = await graphQLRequest({
@@ -202,7 +202,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Item should have its original name
-      const _items = await context.lists.BadAccess.findMany({ query: 'id name' });
+      const _items = await context.query.BadAccess.findMany({ query: 'id name' });
       expect(_items.map(({ name }) => name)).toEqual(['good']);
     })
   );
@@ -248,7 +248,7 @@ describe('Access control - Item', () => {
       ]);
 
       // The good users should exist in the database
-      const users = await context.lists.User.findMany();
+      const users = await context.query.User.findMany();
       // the ordering isn't consistent so we order them ourselves here
       expect(users.map(x => x.id).sort()).toEqual(
         [data!.createUsers[0].id, data!.createUsers[2].id, data!.createUsers[4].id].sort()
@@ -260,7 +260,7 @@ describe('Access control - Item', () => {
     'updateMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'good 2' },
@@ -305,7 +305,7 @@ describe('Access control - Item', () => {
       ]);
 
       // All users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -323,7 +323,7 @@ describe('Access control - Item', () => {
     'deleteMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'no delete 1' },
@@ -362,7 +362,7 @@ describe('Access control - Item', () => {
         },
       ]);
 
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });

--- a/tests/api-tests/access-control/mutations-list-operation.test.ts
+++ b/tests/api-tests/access-control/mutations-list-operation.test.ts
@@ -52,7 +52,7 @@ describe('Access control - Item', () => {
       ]);
 
       // No items should exist
-      const _items = await context.sudo().lists.BadAccess.findMany({ query: 'id name' });
+      const _items = await context.sudo().query.BadAccess.findMany({ query: 'id name' });
       expect(_items.map(({ name }) => name)).toEqual([]);
     })
   );
@@ -76,7 +76,7 @@ describe('Access control - Item', () => {
       ]);
 
       // No items should exist
-      const _users = await context.sudo().lists.BadAccess.findMany({ query: 'id name' });
+      const _users = await context.sudo().query.BadAccess.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual([]);
     })
   );
@@ -84,7 +84,7 @@ describe('Access control - Item', () => {
   test(
     'updateOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
-      const item = await context.sudo().lists.BadAccess.createOne({ data: { name: 'good' } });
+      const item = await context.sudo().query.BadAccess.createOne({ data: { name: 'good' } });
 
       // Valid name
       const { body } = await graphQLRequest({
@@ -102,7 +102,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Item should have its original name
-      const _items = await context.sudo().lists.BadAccess.findMany({ query: 'id name' });
+      const _items = await context.sudo().query.BadAccess.findMany({ query: 'id name' });
       expect(_items.map(({ name }) => name)).toEqual(['good']);
     })
   );
@@ -110,7 +110,7 @@ describe('Access control - Item', () => {
   test(
     'deleteOne - Bad function return value',
     runner(async ({ context, graphQLRequest }) => {
-      const item = await context.sudo().lists.BadAccess.createOne({ data: { name: 'good' } });
+      const item = await context.sudo().query.BadAccess.createOne({ data: { name: 'good' } });
 
       // Valid name
       const { body } = await graphQLRequest({
@@ -128,7 +128,7 @@ describe('Access control - Item', () => {
       ]);
 
       // Item should have its original name
-      const _items = await context.sudo().lists.BadAccess.findMany({ query: 'id name' });
+      const _items = await context.sudo().query.BadAccess.findMany({ query: 'id name' });
       expect(_items.map(({ name }) => name)).toEqual(['good']);
     })
   );

--- a/tests/api-tests/access-control/schema.test.ts
+++ b/tests/api-tests/access-control/schema.test.ts
@@ -303,7 +303,7 @@ describe(`Public schema`, () => {
           });
 
           test(`adminMeta - not build mode ${JSON.stringify(config)} on ${listName}`, async () => {
-            const item = await context.sudo().lists[listName].createOne({ data: {} });
+            const item = await context.sudo().query[listName].createOne({ data: {} });
             const query = `
               query q($listName: String!) {
                 keystone {

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -81,7 +81,7 @@ describe('Auth testing', () => {
     runner(async ({ context }) => {
       // seed the db
       for (const [listKey, data] of Object.entries(initialData)) {
-        await context.sudo().lists[listKey].createMany({ data });
+        await context.sudo().query[listKey].createMany({ data });
       }
       const { data, errors } = await context.graphql.raw({ query: '{ users { id } }' });
       expect(data).toEqual({ users: [] });
@@ -135,7 +135,7 @@ describe('Auth testing', () => {
       'Allows access with bearer token',
       runner(async ({ context, graphQLRequest }) => {
         for (const [listKey, data] of Object.entries(initialData)) {
-          await context.sudo().lists[listKey].createMany({ data });
+          await context.sudo().query[listKey].createMany({ data });
         }
         const { sessionToken } = await login(
           graphQLRequest,
@@ -159,7 +159,7 @@ describe('Auth testing', () => {
       'Allows access with cookie',
       runner(async ({ context, graphQLRequest }) => {
         for (const [listKey, data] of Object.entries(initialData)) {
-          await context.sudo().lists[listKey].createMany({ data });
+          await context.sudo().query[listKey].createMany({ data });
         }
         const { sessionToken } = await login(
           graphQLRequest,

--- a/tests/api-tests/default-value/defaults.test.ts
+++ b/tests/api-tests/default-value/defaults.test.ts
@@ -11,7 +11,7 @@ describe('defaultValue field config', () => {
   test(
     'Has no default by default',
     setupList({ name: text() })(async ({ context }) => {
-      const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+      const result = await context.query.User.createOne({ data: {}, query: 'name' });
       expect(result).toMatchObject({ name: null });
     })
   );
@@ -19,7 +19,7 @@ describe('defaultValue field config', () => {
   test(
     'Sets undefined as a default',
     setupList({ name: text({ defaultValue: undefined }) })(async ({ context }) => {
-      const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+      const result = await context.query.User.createOne({ data: {}, query: 'name' });
       expect(result).toMatchObject({ name: null });
     })
   );
@@ -27,7 +27,7 @@ describe('defaultValue field config', () => {
   test(
     'Sets null as a default',
     setupList({ name: text({ defaultValue: null }) })(async ({ context }) => {
-      const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+      const result = await context.query.User.createOne({ data: {}, query: 'name' });
       expect(result).toMatchObject({ name: null });
     })
   );
@@ -35,7 +35,7 @@ describe('defaultValue field config', () => {
   test(
     'Sets a scalar as a default',
     setupList({ name: text({ defaultValue: 'hello' }) })(async ({ context }) => {
-      const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+      const result = await context.query.User.createOne({ data: {}, query: 'name' });
       expect(result).toMatchObject({ name: 'hello' });
     })
   );
@@ -43,7 +43,7 @@ describe('defaultValue field config', () => {
   test(
     'executes a function to get default',
     setupList({ name: text({ defaultValue: () => 'foobar' }) })(async ({ context }) => {
-      const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+      const result = await context.query.User.createOne({ data: {}, query: 'name' });
       expect(result).toMatchObject({ name: 'foobar' });
     })
   );
@@ -52,7 +52,7 @@ describe('defaultValue field config', () => {
     'handles promises returned from function',
     setupList({ name: text({ defaultValue: () => Promise.resolve('zippity') }) })(
       async ({ context }) => {
-        const result = await context.lists.User.createOne({ data: {}, query: 'name' });
+        const result = await context.query.User.createOne({ data: {}, query: 'name' });
         expect(result).toMatchObject({ name: 'zippity' });
       }
     )
@@ -61,7 +61,7 @@ describe('defaultValue field config', () => {
   test('executes the function with the correct parameters', () => {
     const defaultValue = jest.fn();
     return setupList({ name: text({ defaultValue }) })(async ({ context }) => {
-      await context.lists.User.createOne({ data: {} });
+      await context.query.User.createOne({ data: {} });
       expect(defaultValue).toHaveBeenCalledTimes(1);
       expect(defaultValue).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -76,7 +76,7 @@ describe('defaultValue field config', () => {
     const defaultValue = jest.fn(({ originalInput }) => `${originalInput.salutation} X`);
     return setupList({ name: text({ defaultValue }), salutation: text() })(async ({ context }) => {
       const data = { salutation: 'Doctor' };
-      const result = await context.lists.User.createOne({ data, query: 'name' });
+      const result = await context.query.User.createOne({ data, query: 'name' });
       expect(defaultValue).toHaveBeenCalledTimes(1);
       expect(defaultValue).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -37,7 +37,7 @@ testModules
         runner(async ({ context, ...rest }) => {
           // Populate the database before running the tests
           for (const data of mod.initItems(matrixValue, context)) {
-            await context.lists[listKey].createOne({ data });
+            await context.query[listKey].createOne({ data });
           }
           return testFn({ context, listKey, provider: process.env.TEST_ADAPTER, ...rest });
         });
@@ -114,7 +114,7 @@ testModules
             }) => void | Promise<void>
           ) => {
             return async ({ context, listKey }: { context: KeystoneContext; listKey: string }) => {
-              const items = await context.lists[listKey].findMany({
+              const items = await context.query[listKey].findMany({
                 orderBy: { name: 'asc' },
                 query,
               });
@@ -129,7 +129,7 @@ testModules
               'Create',
               keystoneTestWrapper(
                 withHelpers(async ({ context, listKey }) => {
-                  const data = await context.lists[listKey].createOne({
+                  const data = await context.query[listKey].createOne({
                     data: { name: 'Newly created', [fieldName]: exampleValue(matrixValue) },
                     query,
                   });
@@ -147,7 +147,7 @@ testModules
               'Read',
               keystoneTestWrapper(
                 withHelpers(async ({ context, listKey, items }) => {
-                  const data = await context.lists[listKey].findOne({
+                  const data = await context.query[listKey].findOne({
                     where: { id: items[0].id },
                     query,
                   });
@@ -166,7 +166,7 @@ testModules
                 'Updating the value',
                 keystoneTestWrapper(
                   withHelpers(async ({ context, items, listKey }) => {
-                    const data = await context.lists[listKey].updateOne({
+                    const data = await context.query[listKey].updateOne({
                       where: { id: items[0].id },
                       data: { [fieldName]: exampleValue2(matrixValue) },
                       query,
@@ -185,7 +185,7 @@ testModules
                 'Updating the value to null',
                 keystoneTestWrapper(
                   withHelpers(async ({ context, items, listKey }) => {
-                    const data = await context.lists[listKey].updateOne({
+                    const data = await context.query[listKey].updateOne({
                       where: { id: items[0].id },
                       data: { [fieldName]: null },
                       query,
@@ -200,7 +200,7 @@ testModules
                 'Updating without this field',
                 keystoneTestWrapper(
                   withHelpers(async ({ context, items, listKey }) => {
-                    const data = await context.lists[listKey].updateOne({
+                    const data = await context.query[listKey].updateOne({
                       where: { id: items[0].id },
                       data: { name: 'Updated value' },
                       query,
@@ -223,7 +223,7 @@ testModules
               'Delete',
               keystoneTestWrapper(
                 withHelpers(async ({ context, items, listKey }) => {
-                  const data = await context.lists[listKey].deleteOne({
+                  const data = await context.query[listKey].deleteOne({
                     where: { id: items[0].id },
                     query,
                   });
@@ -233,7 +233,7 @@ testModules
                     subfieldName ? data?.[fieldName][subfieldName] : data?.[fieldName]
                   ).toEqual(subfieldName ? items[0][fieldName][subfieldName] : items[0][fieldName]);
 
-                  const allItems = await context.lists[listKey].findMany({ query });
+                  const allItems = await context.query[listKey].findMany({ query });
                   expect(allItems).toEqual(expect.not.arrayContaining([data]));
                 })
               )

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -33,7 +33,7 @@ testModules
           // Populate the database before running the tests
           // Note: this seeding has to be in an order defined by the array returned by `mod.initItems()`
           for (const data of mod.initItems(matrixValue, context)) {
-            await context.lists[listKey].createOne({ data });
+            await context.query[listKey].createOne({ data });
           }
           return testFn({ context, listKey, provider, ...rest });
         });
@@ -106,7 +106,7 @@ testModules
                 expected = storedValues.filter((v: any) => !expectedWithoutNegation.has(v));
               }
               expect(
-                await context.lists[listKey].findMany({
+                await context.query[listKey].findMany({
                   where: kind === 'with negation' ? { NOT: where } : where,
                   orderBy: { name: 'asc' },
                   query,
@@ -422,13 +422,13 @@ testModules
                   // Populate the database before running the tests
                   // Note: this seeding has to be in an order defined by the array returned by `mod.initItems()`
                   for (const data of mod.initItems(matrixValue, context)) {
-                    await context.lists[listKey].createOne({
+                    await context.query[listKey].createOne({
                       data: { field: data[fieldName] },
                     });
                   }
                   await Promise.all(
                     storedValues.map(async (val: any) => {
-                      const promise = context.lists[listKey].findOne({
+                      const promise = context.query[listKey].findOne({
                         where: { field: val[fieldName] },
                         query: 'field',
                       });

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -77,7 +77,7 @@ testModules
         test(
           'Update an object with the required field having a null value',
           runner(async ({ context }) => {
-            const data0 = await context.lists.Test.createOne({
+            const data0 = await context.query.Test.createOne({
               data: {
                 name: 'test entry',
                 testField: mod.exampleValue(matrixValue),
@@ -102,13 +102,13 @@ testModules
         test(
           'Update an object without the required field',
           runner(async ({ context }) => {
-            const data0 = await context.lists.Test.createOne({
+            const data0 = await context.query.Test.createOne({
               data: {
                 name: 'test entry',
                 testField: mod.exampleValue(matrixValue),
               },
             });
-            const data = await context.lists.Test.updateOne({
+            const data = await context.query.Test.updateOne({
               where: { id: data0.id },
               data: { name: 'updated test entry' },
               query: 'id name',

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -32,7 +32,7 @@ describe('Virtual field type', () => {
         }),
       }),
     })(async ({ context }) => {
-      const data = await context.lists.Post.createOne({
+      const data = await context.query.Post.createOne({
         data: { value: 1 },
         query: 'value foo',
       });
@@ -55,7 +55,7 @@ describe('Virtual field type', () => {
         }),
       }),
     })(async ({ context }) => {
-      const data = await context.lists.Post.createOne({
+      const data = await context.query.Post.createOne({
         data: { value: 1 },
         query: 'value foo(x: 10, y: 20)',
       });
@@ -103,12 +103,12 @@ describe('Virtual field type', () => {
                     }),
                     async resolve(rootVal, args, context) {
                       const [personAuthors, organisationAuthors] = await Promise.all([
-                        context.db.lists.Person.findMany({
+                        context.db.Person.findMany({
                           where: {
                             authoredPosts: { some: { id: { equals: rootVal.id.toString() } } },
                           },
                         }),
-                        context.db.lists.Organisation.findMany({
+                        context.db.Organisation.findMany({
                           where: {
                             authoredPosts: { some: { id: { equals: rootVal.id.toString() } } },
                           },
@@ -128,7 +128,7 @@ describe('Virtual field type', () => {
         },
       }),
     })(async ({ context }) => {
-      const data = await context.lists.Post.createOne({
+      const data = await context.query.Post.createOne({
         data: { personAuthor: { create: { name: 'person author' } } },
         query: `
                 author {
@@ -144,7 +144,7 @@ describe('Virtual field type', () => {
       });
       expect(data.author.name).toEqual('person author');
       expect(data.author.__typename).toEqual('Person');
-      const data2 = await context.lists.Post.createOne({
+      const data2 = await context.query.Post.createOne({
         data: { organisationAuthor: { create: { name: 'organisation author' } } },
         query: `
                 author {

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -53,8 +53,8 @@ const runner = setupTestRunner({
 });
 
 const initData = async ({ context }: { context: KeystoneContext }) => {
-  const alice = await context.lists.Author.createOne({ data: { name: 'Alice' } });
-  const bob = await context.lists.Author.createOne({
+  const alice = await context.query.Author.createOne({ data: { name: 'Alice' } });
+  const bob = await context.query.Author.createOne({
     data: {
       name: 'Bob',
       bio: [
@@ -74,7 +74,7 @@ const initData = async ({ context }: { context: KeystoneContext }) => {
       ],
     },
   });
-  const charlie = await context.lists.Author.createOne({ data: { name: 'Charlie' } });
+  const charlie = await context.query.Author.createOne({ data: { name: 'Charlie' } });
   const bio = [
     {
       type: 'paragraph',
@@ -103,7 +103,7 @@ const initData = async ({ context }: { context: KeystoneContext }) => {
       ],
     },
   ];
-  const dave = await context.lists.Author.createOne({ data: { name: 'Dave', bio } });
+  const dave = await context.query.Author.createOne({ data: { name: 'Dave', bio } });
   type T = { id: string; label?: string; data?: Record<string, any> | null };
   const content = [
     {
@@ -159,7 +159,7 @@ const initData = async ({ context }: { context: KeystoneContext }) => {
       ],
     },
   ];
-  const post = await context.lists.Post.createOne({ data: { content } });
+  const post = await context.query.Post.createOne({ data: { content } });
   return { alice, bob, charlie, dave, post, content, bio };
 };
 
@@ -169,7 +169,7 @@ describe('Document field type', () => {
     runner(async ({ context }) => {
       const { post, content } = await initData({ context });
 
-      const _post = await context.lists.Post.findOne({
+      const _post = await context.query.Post.findOne({
         where: { id: post.id },
         query: 'content { document }',
       });
@@ -182,7 +182,7 @@ describe('Document field type', () => {
     runner(async ({ context }) => {
       const { post, content } = await initData({ context });
 
-      const _post = await context.lists.Post.findOne({
+      const _post = await context.query.Post.findOne({
         where: { id: post.id },
         query: 'content { document(hydrateRelationships: false) }',
       });
@@ -195,7 +195,7 @@ describe('Document field type', () => {
     runner(async ({ context }) => {
       const { alice, bob, charlie, post, content } = await initData({ context });
 
-      const _post = await context.lists.Post.findOne({
+      const _post = await context.query.Post.findOne({
         where: { id: post.id },
         query: 'content { document(hydrateRelationships: true) }',
       });
@@ -215,8 +215,8 @@ describe('Document field type', () => {
     'hydrateRelationships: true - dangling reference',
     runner(async ({ context }) => {
       const { alice, bob, charlie, post, content } = await initData({ context });
-      await context.lists.Author.deleteOne({ where: { id: bob.id } });
-      const _post = await context.lists.Post.findOne({
+      await context.query.Author.deleteOne({ where: { id: bob.id } });
+      const _post = await context.query.Post.findOne({
         where: { id: post.id },
         query: 'content { document(hydrateRelationships: true) }',
       });
@@ -238,7 +238,7 @@ describe('Document field type', () => {
     runner(async ({ context }) => {
       const { alice, charlie, dave, bio } = await initData({ context });
 
-      const _dave = await context.lists.Author.findOne({
+      const _dave = await context.query.Author.findOne({
         where: { id: dave.id },
         query: 'bio { document(hydrateRelationships: true) }',
       });
@@ -256,7 +256,7 @@ describe('Document field type', () => {
     'hydrateRelationships: true - selection has bad fields',
     runner(async ({ context, graphQLRequest }) => {
       const { alice } = await initData({ context });
-      const badBob = await context.lists.Author.createOne({
+      const badBob = await context.query.Author.createOne({
         data: {
           name: 'Bob',
           badBio: [

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -57,7 +57,7 @@ testModules
         test(
           'uniqueness is enforced over multiple mutations',
           runner(async ({ context, graphQLRequest }) => {
-            await context.lists.Test.createOne({
+            await context.query.Test.createOne({
               data: { testField: mod.exampleValue(matrixValue) },
             });
 
@@ -116,7 +116,7 @@ testModules
         test(
           'Configuring uniqueness on one field does not affect others',
           runner(async ({ context }) => {
-            const items = await context.lists.Test.createMany({
+            const items = await context.query.Test.createMany({
               data: [
                 { testField: mod.exampleValue(matrixValue), name: 'jess' },
                 { testField: mod.exampleValue2(matrixValue), name: 'jess' },

--- a/tests/api-tests/hooks/auth-hooks.test.skip.ts
+++ b/tests/api-tests/hooks/auth-hooks.test.skip.ts
@@ -124,7 +124,7 @@ describe('Auth Hooks', () => {
     'Auth/unauth with valid creds',
     runner(async ({ context }) => {
       // Add a user with a password
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { name: 'test', email: 'test@example.com', password: 'testing123' },
       });
 
@@ -162,7 +162,7 @@ describe('Auth Hooks', () => {
     'Auth with bad resolveAuthInput return value',
     runner(async ({ context }) => {
       // Add a user with a password
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: { name: 'test', email: 'test@example.com', password: 'testing123' },
       });
       // FIXME: move this functionality into the `testing` package
@@ -191,7 +191,7 @@ describe('Auth Hooks', () => {
     'Auth/unauth with good resolveAuthInput return value',
     runner(async ({ context }) => {
       // Add a user with a password
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { name: 'test', email: 'test@example.com', password: 'testing123' },
       });
       // FIXME: move this functionality into the `testing` package
@@ -228,7 +228,7 @@ describe('Auth Hooks', () => {
     'Auth with values caught in validation hook return value',
     runner(async ({ context }) => {
       // Add a user with a password
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: { name: 'test', email: 'test@example.com', password: 'testing123' },
       });
       // FIXME: move this functionality into the `testing` package

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -122,7 +122,7 @@ const runner = (debug: boolean | undefined) =>
               'createOne',
               runner(debug)(async ({ context, graphQLRequest }) => {
                 // Valid name should pass
-                await context.lists.User.createOne({ data: { name: 'good' } });
+                await context.query.User.createOne({ data: { name: 'good' } });
 
                 // Trigger an error
                 const { data, errors } = await runQuery(context, graphQLRequest, {
@@ -149,7 +149,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // Only the original user should exist for 'before', both exist for 'after'
-                const _users = await context.lists.User.findMany({ query: 'id name' });
+                const _users = await context.query.User.findMany({ query: 'id name' });
                 expect(_users.map(({ name }) => name)).toEqual(
                   phase === 'before' ? ['good'] : ['good', 'trigger after']
                 );
@@ -160,8 +160,8 @@ const runner = (debug: boolean | undefined) =>
               'updateOne',
               runner(debug)(async ({ context, graphQLRequest }) => {
                 // Valid name should pass
-                const user = await context.lists.User.createOne({ data: { name: 'good' } });
-                await context.lists.User.updateOne({
+                const user = await context.query.User.createOne({ data: { name: 'good' } });
+                await context.query.User.updateOne({
                   where: { id: user.id },
                   data: { name: 'better' },
                 });
@@ -191,7 +191,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // User should have its original name for 'before', and the new name for 'after'.
-                const _users = await context.lists.User.findMany({ query: 'id name' });
+                const _users = await context.query.User.findMany({ query: 'id name' });
                 expect(_users.map(({ name }) => name)).toEqual(
                   phase === 'before' ? ['better'] : ['trigger after']
                 );
@@ -202,11 +202,11 @@ const runner = (debug: boolean | undefined) =>
               'deleteOne',
               runner(debug)(async ({ context, graphQLRequest }) => {
                 // Valid names should pass
-                const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
-                const user2 = await context.lists.User.createOne({
+                const user1 = await context.query.User.createOne({ data: { name: 'good' } });
+                const user2 = await context.query.User.createOne({
                   data: { name: `trigger ${phase} delete` },
                 });
-                await context.lists.User.deleteOne({ where: { id: user1.id } });
+                await context.query.User.deleteOne({ where: { id: user1.id } });
 
                 // Invalid name
                 const { data, errors } = await runQuery(context, graphQLRequest, {
@@ -233,7 +233,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // Bad users should still be in the database for 'before', deleted for 'after'.
-                const _users = await context.lists.User.findMany({ query: 'id name' });
+                const _users = await context.query.User.findMany({ query: 'id name' });
                 expect(_users.map(({ name }) => name)).toEqual(
                   phase === 'before' ? ['trigger before delete'] : []
                 );
@@ -297,7 +297,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // Three users should exist in the database for 'before,' five for 'after'.
-                const users = await context.lists.User.findMany({
+                const users = await context.query.User.findMany({
                   orderBy: { name: 'asc' },
                   query: 'id name',
                 });
@@ -313,7 +313,7 @@ const runner = (debug: boolean | undefined) =>
               'updateMany',
               runner(debug)(async ({ context, graphQLRequest }) => {
                 // Start with some users
-                const users = await context.lists.User.createMany({
+                const users = await context.query.User.createMany({
                   data: [
                     { name: 'good 1' },
                     { name: 'good 2' },
@@ -376,7 +376,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // All users should still exist in the database, un-changed for `before`, changed for `after`.
-                const _users = await context.lists.User.findMany({
+                const _users = await context.query.User.findMany({
                   orderBy: { name: 'asc' },
                   query: 'id name',
                 });
@@ -392,7 +392,7 @@ const runner = (debug: boolean | undefined) =>
               'deleteMany',
               runner(debug)(async ({ context, graphQLRequest }) => {
                 // Start with some users
-                const users = await context.lists.User.createMany({
+                const users = await context.query.User.createMany({
                   data: [
                     { name: 'good 1' },
                     { name: `trigger ${phase} delete` },
@@ -450,7 +450,7 @@ const runner = (debug: boolean | undefined) =>
                 ]);
 
                 // Three users should still exist in the database for `before`, only 1 for `after`.
-                const _users = await context.lists.User.findMany({
+                const _users = await context.query.User.findMany({
                   orderBy: { name: 'asc' },
                   query: 'id name',
                 });
@@ -469,7 +469,7 @@ const runner = (debug: boolean | undefined) =>
             test(
               'update',
               runner(debug)(async ({ context, graphQLRequest }) => {
-                const post = await context.lists.Post.createOne({
+                const post = await context.query.Post.createOne({
                   data: { title: 'original title', content: 'original content' },
                 });
 
@@ -505,7 +505,7 @@ const runner = (debug: boolean | undefined) =>
                 expect(data).toEqual({ updatePost: null });
 
                 // Post should have its original data for 'before', and the new data for 'after'.
-                const _post = await context.lists.Post.findOne({
+                const _post = await context.query.Post.findOne({
                   where: { id: post.id },
                   query: 'title content',
                 });
@@ -520,7 +520,7 @@ const runner = (debug: boolean | undefined) =>
             test(
               `delete`,
               runner(debug)(async ({ context, graphQLRequest }) => {
-                const post = await context.lists.Post.createOne({
+                const post = await context.query.Post.createOne({
                   data: { title: `trigger ${phase} delete`, content: `trigger ${phase} delete` },
                 });
                 const { data, errors } = await runQuery(context, graphQLRequest, {

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -39,7 +39,7 @@ describe('List Hooks: #resolveInput()', () => {
   test(
     'resolves fields first, then passes them to the list',
     runner(async ({ context }) => {
-      const user = await context.lists.User.createOne({ data: { name: 'jess' }, query: 'name' });
+      const user = await context.query.User.createOne({ data: { name: 'jess' }, query: 'name' });
       // Field should be executed first, appending `-field`, then the list
       // should be executed which appends `-list`, and finally that total
       // result should be stored.

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -69,7 +69,7 @@ describe('List Hooks: #validateInput()', () => {
     'createOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      await context.lists.User.createOne({ data: { name: 'good' } });
+      await context.query.User.createOne({ data: { name: 'good' } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -84,7 +84,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // Only the original user should exist
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['good']);
     })
   );
@@ -93,8 +93,8 @@ describe('List Hooks: #validateInput()', () => {
     'updateOne',
     runner(async ({ context }) => {
       // Valid name should pass
-      const user = await context.lists.User.createOne({ data: { name: 'good' } });
-      await context.lists.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
+      const user = await context.query.User.createOne({ data: { name: 'good' } });
+      await context.query.User.updateOne({ where: { id: user.id }, data: { name: 'better' } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -109,7 +109,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // User should have its original name
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['better']);
     })
   );
@@ -118,9 +118,9 @@ describe('List Hooks: #validateInput()', () => {
     'deleteOne',
     runner(async ({ context }) => {
       // Valid names should pass
-      const user1 = await context.lists.User.createOne({ data: { name: 'good' } });
-      const user2 = await context.lists.User.createOne({ data: { name: 'no delete' } });
-      await context.lists.User.deleteOne({ where: { id: user1.id } });
+      const user1 = await context.query.User.createOne({ data: { name: 'good' } });
+      const user2 = await context.query.User.createOne({ data: { name: 'no delete' } });
+      await context.query.User.deleteOne({ where: { id: user1.id } });
 
       // Invalid name
       const { data, errors } = await context.graphql.raw({
@@ -135,7 +135,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // Bad users should still be in the database.
-      const _users = await context.lists.User.findMany({ query: 'id name' });
+      const _users = await context.query.User.findMany({ query: 'id name' });
       expect(_users.map(({ name }) => name)).toEqual(['no delete']);
     })
   );
@@ -174,7 +174,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // Three users should exist in the database
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -186,7 +186,7 @@ describe('List Hooks: #validateInput()', () => {
     'updateMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'good 2' },
@@ -226,7 +226,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // All users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -244,7 +244,7 @@ describe('List Hooks: #validateInput()', () => {
     'deleteMany',
     runner(async ({ context }) => {
       // Start with some users
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { name: 'good 1' },
           { name: 'no delete 1' },
@@ -279,7 +279,7 @@ describe('List Hooks: #validateInput()', () => {
       ]);
 
       // Three users should still exist in the database
-      const _users = await context.lists.User.findMany({
+      const _users = await context.query.User.findMany({
         orderBy: { name: 'asc' },
         query: 'id name',
       });
@@ -292,7 +292,7 @@ describe('Field Hooks: #validateInput()', () => {
   test(
     'update',
     runner(async ({ context }) => {
-      const post = await context.lists.Post.createOne({ data: {} });
+      const post = await context.query.Post.createOne({ data: {} });
 
       const { data, errors } = await context.graphql.raw({
         query: `mutation ($id: ID! $data: PostUpdateInput!) { updatePost(where: { id: $id }, data: $data) { id } }`,
@@ -315,7 +315,7 @@ describe('Field Hooks: #validateInput()', () => {
   test(
     'delete',
     runner(async ({ context }) => {
-      const post = await context.lists.Post.createOne({ data: {} });
+      const post = await context.query.Post.createOne({ data: {} });
       const { data, errors } = await context.graphql.raw({
         query: `mutation ($id: ID!) { deletePost(where: { id: $id }) { id } }`,
         variables: { id: post.id },

--- a/tests/api-tests/id-field.test.ts
+++ b/tests/api-tests/id-field.test.ts
@@ -105,7 +105,7 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   test(
     'Creating an item',
     runner(async ({ context }) => {
-      const { id } = await context.lists.User.createOne({ data: { name: 'something' } });
+      const { id } = await context.query.User.createOne({ data: { name: 'something' } });
       switch (kind) {
         case 'autoincrement': {
           expect(id).toEqual('1');
@@ -139,10 +139,10 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   test(
     'searching for uppercased uuid works',
     runner(async ({ context }) => {
-      const { id } = (await context.lists.User.createOne({
+      const { id } = (await context.query.User.createOne({
         data: { name: 'something' },
       })) as { id: string };
-      const { id: fromFound } = await context.lists.User.findOne({
+      const { id: fromFound } = await context.query.User.findOne({
         where: { id: id.toUpperCase() },
       });
       // it returns lower-cased
@@ -163,7 +163,7 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   test(
     'searching for uppercased cuid does not work',
     runner(async ({ context, graphQLRequest }) => {
-      const { id } = (await context.lists.User.createOne({
+      const { id } = (await context.query.User.createOne({
         data: { name: 'something' },
       })) as { id: string };
 

--- a/tests/api-tests/new-interfaces.test.ts
+++ b/tests/api-tests/new-interfaces.test.ts
@@ -14,7 +14,7 @@ const runner = setupTestRunner({
 test(
   'Smoke test',
   runner(async ({ context }) => {
-    const users = await context.db.lists.User.findMany({});
+    const users = await context.db.User.findMany({});
     expect(users).toEqual([]);
   })
 );

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -72,7 +72,7 @@ const runner = setupTestRunner({
 });
 
 const addFixtures = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: 'Jess', favNumber: 1 },
       { name: 'Johanna', favNumber: 8 },
@@ -80,7 +80,7 @@ const addFixtures = async (context: KeystoneContext) => {
     ],
   });
 
-  const posts = await context.lists.Post.createMany({
+  const posts = await context.query.Post.createMany({
     data: [
       { author: { connect: [{ id: users[0].id }] }, title: 'One author' },
       { author: { connect: [{ id: users[0].id }, { id: users[1].id }] }, title: 'Two authors' },

--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -74,9 +74,9 @@ const runner = setupTestRunner({
 
 const initialiseData = async ({ context }: { context: KeystoneContext }) => {
   // Use shuffled data to ensure that ordering is actually happening.
-  for (const listKey of Object.keys(context.lists)) {
+  for (const listKey of Object.keys(context.query)) {
     if (listKey === 'User' || listKey === 'SecondaryList') continue;
-    await context.lists[listKey].createMany({
+    await context.query[listKey].createMany({
       data: [
         { a: 1, b: 10 },
         { a: 1, b: 30 },
@@ -96,14 +96,14 @@ describe('filtering on field name', () => {
   test(
     'filter works when there is no dash in field name',
     runner(async ({ context }) => {
-      const users = await context.lists.User.findMany({ where: { noDash: { equals: 'aValue' } } });
+      const users = await context.query.User.findMany({ where: { noDash: { equals: 'aValue' } } });
       expect(users).toEqual([]);
     })
   );
   test(
     'filter works when there is one dash in field name',
     runner(async ({ context }) => {
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: { single_dash: { equals: 'aValue' } },
       });
       expect(users).toEqual([]);
@@ -112,7 +112,7 @@ describe('filtering on field name', () => {
   test(
     'filter works when there are multiple dashes in field name',
     runner(async ({ context }) => {
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: { many_many_many_dashes: { equals: 'aValue' } },
       });
       expect(users).toEqual([]);
@@ -121,7 +121,7 @@ describe('filtering on field name', () => {
   test(
     'filter works when there are multiple dashes in a row in a field name',
     runner(async ({ context }) => {
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: { multi____dash: { equals: 'aValue' } },
       });
       expect(users).toEqual([]);
@@ -130,7 +130,7 @@ describe('filtering on field name', () => {
   test(
     'filter works when there is one dash in field name as part of a relationship',
     runner(async ({ context }) => {
-      const secondaries = await context.lists.SecondaryList.findMany({
+      const secondaries = await context.query.SecondaryList.findMany({
         where: { NOT: { someUser: null } },
       });
       expect(secondaries).toEqual([]);
@@ -176,7 +176,7 @@ describe('filtering on relationships', () => {
   test(
     'findMany returns all items with empty relationship query value',
     runner(async ({ context, graphQLRequest }) => {
-      await context.lists.SecondaryList.createOne({
+      await context.query.SecondaryList.createOne({
         data: { otherUsers: { create: [{ noDash: 'a' }, { noDash: 'b' }] } },
       });
       const { body } = await graphQLRequest({
@@ -196,7 +196,7 @@ describe('searching by unique fields', () => {
   test(
     'findOne works on a unique text field',
     runner(async ({ context }) => {
-      const item = await context.lists.User.createOne({ data: { email: 'test@example.com' } });
+      const item = await context.query.User.createOne({ data: { email: 'test@example.com' } });
       const { data, errors } = await context.graphql.raw({
         query: '{ user(where: { email: "test@example.com" }) { id email } }',
       });
@@ -223,7 +223,7 @@ describe('searching by unique fields', () => {
   test(
     'findOne throws error with more than one where values',
     runner(async ({ context, graphQLRequest }) => {
-      const item = await context.lists.User.createOne({ data: { email: 'test@example.com' } });
+      const item = await context.query.User.createOne({ data: { email: 'test@example.com' } });
       const { body } = await graphQLRequest({
         query: `{ user(where: { id: "${item.id}" email: "test@example.com" }) { id email } }`,
       });

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -40,7 +40,7 @@ describe('maxResults Limit', () => {
     test(
       'users',
       runner(async ({ context }) => {
-        const users = await context.lists.User.createMany({
+        const users = await context.query.User.createMany({
           data: [
             { name: 'Jess', favNumber: 1 },
             { name: 'Johanna', favNumber: 8 },
@@ -159,14 +159,14 @@ describe('maxResults Limit', () => {
     test(
       'posts by user',
       runner(async ({ context }) => {
-        const users = await context.lists.User.createMany({
+        const users = await context.query.User.createMany({
           data: [
             { name: 'Jess', favNumber: 1 },
             { name: 'Johanna', favNumber: 8 },
             { name: 'Sam', favNumber: 5 },
           ],
         });
-        await context.lists.Post.createMany({
+        await context.query.Post.createMany({
           data: [
             { author: { connect: [{ id: users[0].id }] }, title: 'One author' },
             {
@@ -182,7 +182,7 @@ describe('maxResults Limit', () => {
         // Reset the count for each query
         context.totalResults = 0;
         // A basic query that should work
-        let posts = await context.lists.Post.findMany({
+        let posts = await context.query.Post.findMany({
           where: { title: { equals: 'One author' } },
           query: 'title author { name }',
         });
@@ -192,7 +192,7 @@ describe('maxResults Limit', () => {
         // Reset the count for each query
         context.totalResults = 0;
         // Each subquery is within the limit (even though the total isn't)
-        posts = await context.lists.Post.findMany({
+        posts = await context.query.Post.findMany({
           where: {
             OR: [{ title: { equals: 'One author' } }, { title: { equals: 'Two authors' } }],
           },
@@ -228,7 +228,7 @@ describe('maxResults Limit', () => {
         // Requesting the too-many-authors post is okay as long as the authors aren't returned
         // Reset the count for each query
         context.totalResults = 0;
-        posts = await context.lists.Post.findMany({
+        posts = await context.query.Post.findMany({
           where: { title: { equals: 'Three authors' } },
           query: 'title',
         });

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -61,8 +61,8 @@ const runner = setupTestRunner({
 
 const initialiseData = async ({ context }: { context: KeystoneContext }) => {
   // Use shuffled data to ensure that ordering is actually happening.
-  for (const listKey of Object.keys(context.lists)) {
-    await context.lists[listKey].createMany({
+  for (const listKey of Object.keys(context.query)) {
+    await context.query[listKey].createMany({
       data: [
         { a: 1, b: 10 },
         { a: 1, b: 30 },
@@ -83,7 +83,7 @@ describe('Ordering by a single field', () => {
     'Single ascending filter - a',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({ orderBy: [{ a: 'asc' }], query: 'a' });
+      const users = await context.query.User.findMany({ orderBy: [{ a: 'asc' }], query: 'a' });
       expect(users.map(({ a }) => a)).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
     })
   );
@@ -91,7 +91,7 @@ describe('Ordering by a single field', () => {
     'Single descending filter - a',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({ orderBy: [{ a: 'desc' }], query: 'a' });
+      const users = await context.query.User.findMany({ orderBy: [{ a: 'desc' }], query: 'a' });
       expect(users.map(({ a }) => a)).toEqual([3, 3, 3, 2, 2, 2, 1, 1, 1]);
     })
   );
@@ -99,7 +99,7 @@ describe('Ordering by a single field', () => {
     'Single ascending filter - b',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({ orderBy: [{ b: 'asc' }], query: 'b' });
+      const users = await context.query.User.findMany({ orderBy: [{ b: 'asc' }], query: 'b' });
       expect(users.map(({ b }) => b)).toEqual([10, 10, 10, 20, 20, 20, 30, 30, 30]);
     })
   );
@@ -107,7 +107,7 @@ describe('Ordering by a single field', () => {
     'Single descending filter - b',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({ orderBy: [{ b: 'desc' }], query: 'b' });
+      const users = await context.query.User.findMany({ orderBy: [{ b: 'desc' }], query: 'b' });
       expect(users.map(({ b }) => b)).toEqual([30, 30, 30, 20, 20, 20, 10, 10, 10]);
     })
   );
@@ -116,7 +116,7 @@ describe('Ordering by a single field', () => {
     'Single ascending filter - non-list - a',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({ orderBy: { a: 'asc' }, query: 'a' });
+      const users = await context.query.User.findMany({ orderBy: { a: 'asc' }, query: 'a' });
       expect(users.map(({ a }) => a)).toEqual([1, 1, 1, 2, 2, 2, 3, 3, 3]);
     })
   );
@@ -127,7 +127,7 @@ describe('Ordering by Multiple', () => {
     'Multi ascending/ascending filter - a,b ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ a: 'asc' }, { b: 'asc' }],
         query: 'a b',
       });
@@ -148,7 +148,7 @@ describe('Ordering by Multiple', () => {
     'Multi ascending/ascending filter - b,a ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ b: 'asc' }, { a: 'asc' }],
         query: 'a b',
       });
@@ -170,7 +170,7 @@ describe('Ordering by Multiple', () => {
     'Multi ascending/descending filter - a,b ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ a: 'asc' }, { b: 'desc' }],
         query: 'a b',
       });
@@ -191,7 +191,7 @@ describe('Ordering by Multiple', () => {
     'Multi ascending/descending filter - b,a ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ b: 'asc' }, { a: 'desc' }],
         query: 'a b',
       });
@@ -213,7 +213,7 @@ describe('Ordering by Multiple', () => {
     'Multi descending/ascending filter - a,b ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ a: 'desc' }, { b: 'asc' }],
         query: 'a b',
       });
@@ -234,7 +234,7 @@ describe('Ordering by Multiple', () => {
     'Multi descending/ascending filter - b,a ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ b: 'desc' }, { a: 'asc' }],
         query: 'a b',
       });
@@ -256,7 +256,7 @@ describe('Ordering by Multiple', () => {
     'Multi descending/descending filter - a,b ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ a: 'desc' }, { b: 'desc' }],
         query: 'a b',
       });
@@ -277,7 +277,7 @@ describe('Ordering by Multiple', () => {
     'Multi descending/descending filter - b,a ',
     runner(async ({ context }) => {
       await initialiseData({ context });
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         orderBy: [{ b: 'desc' }, { a: 'desc' }],
         query: 'a b',
       });

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -32,10 +32,10 @@ describe('Querying with relationship filters', () => {
       'with data',
       runner(async ({ context }) => {
         // Create an item to link against
-        const users = await context.lists.User.createMany({
+        const users = await context.query.User.createMany({
           data: [{ name: 'Jess' }, { name: 'Johanna' }, { name: 'Sam' }],
         });
-        const posts = await context.lists.Post.createMany({
+        const posts = await context.query.Post.createMany({
           data: [
             { author: { connect: { id: users[0].id } }, title: sampleOne(alphanumGenerator) },
             { author: { connect: { id: users[1].id } }, title: sampleOne(alphanumGenerator) },
@@ -46,7 +46,7 @@ describe('Querying with relationship filters', () => {
         });
 
         // Create an item that does the linking
-        const allPosts = await context.lists.Post.findMany({
+        const allPosts = await context.query.Post.findMany({
           where: { author: { name: { contains: 'J' } } },
           query: 'id title',
         });
@@ -63,8 +63,8 @@ describe('Querying with relationship filters', () => {
       'without data',
       runner(async ({ context }) => {
         // Create an item to link against
-        const user = await context.lists.User.createOne({ data: { name: 'Jess' } });
-        const posts = await context.lists.Post.createMany({
+        const user = await context.query.User.createOne({ data: { name: 'Jess' } });
+        const posts = await context.query.Post.createMany({
           data: [
             { author: { connect: { id: user.id } }, title: sampleOne(alphanumGenerator) },
             { title: sampleOne(alphanumGenerator) },
@@ -73,7 +73,7 @@ describe('Querying with relationship filters', () => {
         });
 
         // Create an item that does the linking
-        const _posts = await context.lists.Post.findMany({
+        const _posts = await context.query.Post.findMany({
           where: { author: { name: { contains: 'J' } } },
           query: 'id title author { id name }',
         });
@@ -113,11 +113,11 @@ describe('Querying with relationship filters', () => {
       'every condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // EVERY
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { every: { title: { contains: 'J' } } } },
           query: 'id name feed { id title }',
         });
@@ -130,11 +130,11 @@ describe('Querying with relationship filters', () => {
       'some condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // SOME
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { some: { title: { contains: 'J' } } } },
           query: 'id feed(orderBy: { title: asc }) { title }',
         });
@@ -153,11 +153,11 @@ describe('Querying with relationship filters', () => {
       'none condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // NONE
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { none: { title: { contains: 'J' } } } },
           query: 'id name feed { id title }',
         });
@@ -194,11 +194,11 @@ describe('Querying with relationship filters', () => {
       'every condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // EVERY
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { every: { title: { contains: 'J' } } } },
           query: 'id feed { id title }',
         });
@@ -213,11 +213,11 @@ describe('Querying with relationship filters', () => {
       'some condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // SOME
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { some: { title: { contains: 'J' } } } },
           query: 'id name feed(orderBy: { title: asc }) { id title }',
         });
@@ -233,11 +233,11 @@ describe('Querying with relationship filters', () => {
       'none condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // NONE
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { none: { title: { contains: 'J' } } } },
           query: 'id feed { title }',
         });
@@ -267,11 +267,11 @@ describe('Querying with relationship filters', () => {
       'every condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // EVERY
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { every: { title: { contains: 'J' } } } },
           query: 'id feed { id title }',
         });
@@ -289,11 +289,11 @@ describe('Querying with relationship filters', () => {
       'some condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // SOME
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { some: { author: { id: { equals: users[0].id } } } } },
           query: 'id name feed { id title }',
         });
@@ -305,11 +305,11 @@ describe('Querying with relationship filters', () => {
       'none condition',
       runner(async ({ context }) => {
         const create = async (listKey: string, data: any) =>
-          context.lists[listKey].createOne({ data });
+          context.query[listKey].createOne({ data });
         const { users } = await setup(create);
 
         // NONE
-        const _users = await context.lists.User.findMany({
+        const _users = await context.query.User.findMany({
           where: { feed: { none: { title: { contains: 'J' } } } },
           query: 'id feed { title }',
         });

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -22,7 +22,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  const user = await context.lists.User.createOne({
+  const user = await context.query.User.createOne({
     data: { friends: { create: [{ name: sampleOne(alphanumGenerator) }] } },
     query: 'id friends { id }',
   });
@@ -50,7 +50,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C];
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: ['A', 'A', 'B', 'B', 'C', 'C', 'D', 'D', 'E'].map(name => ({ name })),
     query: 'id name',
   });
@@ -68,7 +68,7 @@ const createReadData = async (context: KeystoneContext) => {
       [], //  ->  (E1) -> []
     ].map(async (locationIdxs, j) => {
       const ids = locationIdxs.map(i => ({ id: users[i].id }));
-      await context.lists.User.updateOne({
+      await context.query.User.updateOne({
         where: { id: users[j].id },
         data: { friends: { connect: ids } },
         query: 'id friends { name }',
@@ -103,7 +103,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 3],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { some: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -122,7 +122,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 6],
             ['D', 9],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { none: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -141,7 +141,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 1],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { every: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -156,7 +156,7 @@ describe(`Many-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const count = await context.lists.User.count();
+        const count = await context.query.User.count();
         expect(count).toEqual(3);
       })
     );
@@ -168,7 +168,7 @@ describe(`Many-to-many relationships`, () => {
       runner(async ({ context }) => {
         const { users } = await createInitialData(context);
         const user = users[0];
-        const _user = (await context.lists.User.createOne({
+        const _user = (await context.query.User.createOne({
           data: { friends: { connect: [{ id: user.id }] } },
           query: 'id friends { id }',
         })) as { id: IdType; friends: { id: IdType }[] };
@@ -185,7 +185,7 @@ describe(`Many-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const friendName = sampleOne(alphanumGenerator);
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friends: { create: [{ name: friendName }] } },
           query: 'id friends { id }',
         });
@@ -200,7 +200,7 @@ describe(`Many-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friends: null },
           query: 'id friends { id }',
         });
@@ -222,7 +222,7 @@ describe(`Many-to-many relationships`, () => {
         // `...not.toBe(expect.anything())` allows null and undefined values
         expect(user.friends).not.toBe(expect.anything());
 
-        await context.lists.User.updateOne({
+        await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { connect: [{ id: friend.id }] } },
           query: 'id friends { id }',
@@ -240,7 +240,7 @@ describe(`Many-to-many relationships`, () => {
         const { users } = await createInitialData(context);
         let user = users[0];
         const friendName = sampleOne(alphanumGenerator);
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { create: [{ name: friendName }] } },
           query: 'id friends { id name }',
@@ -260,7 +260,7 @@ describe(`Many-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { disconnect: [{ id: friend.id }] } },
           query: 'id friends { id name }',
@@ -281,7 +281,7 @@ describe(`Many-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { set: [] } },
           query: 'id friends { id name }',
@@ -302,7 +302,7 @@ describe(`Many-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query with a null operation
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: null },
           query: 'id friends { id name }',
@@ -324,7 +324,7 @@ describe(`Many-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.deleteOne({ where: { id: user.id } });
+        const _user = await context.query.User.deleteOne({ where: { id: user.id } });
         expect(_user?.id).toBe(user.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -22,7 +22,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  const user = await context.lists.User.createOne({
+  const user = await context.query.User.createOne({
     data: { friend: { create: { name: sampleOne(alphanumGenerator) } } },
     query: 'id friend { id }',
   });
@@ -36,7 +36,7 @@ const createUserAndFriend = async (context: KeystoneContext) => {
 };
 
 const createComplexData = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: 'A', friend: { create: { name: 'A1' } } },
       { name: 'B', friend: { create: { name: 'D1' } } },
@@ -53,7 +53,7 @@ const createComplexData = async (context: KeystoneContext) => {
   expect(users[2].friend.name).toEqual('B1');
   expect(users[3].name).toEqual('E');
   expect(users[3].friend).toBe(null);
-  const _users = await context.lists.User.createMany({
+  const _users = await context.query.User.createMany({
     data: [{ name: 'D', friend: { connect: { id: users[2].friend.id } } }, { name: 'C1' }],
     query: 'id name friend { id name }',
   });
@@ -61,7 +61,7 @@ const createComplexData = async (context: KeystoneContext) => {
   expect(_users[0].friend.name).toEqual('B1');
   expect(_users[1].name).toEqual('C1');
 
-  return { users: await context.lists.User.findMany({ query: 'id name friend { id name }' }) };
+  return { users: await context.query.User.findMany({ query: 'id name friend { id name }' }) };
 };
 
 const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friendId: IdType) => {
@@ -103,7 +103,7 @@ describe(`One-to-many relationships`, () => {
             ['D', 1],
             ['E', 0],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friend: { name: { contains: name } } },
             });
             expect(users.length).toEqual(count);
@@ -115,7 +115,7 @@ describe(`One-to-many relationships`, () => {
       'is null',
       runner(async ({ context }) => {
         await createComplexData(context);
-        const users = await context.lists.User.findMany({ where: { friend: null } });
+        const users = await context.query.User.findMany({ where: { friend: null } });
         expect(users.length).toEqual(5);
       })
     );
@@ -123,7 +123,7 @@ describe(`One-to-many relationships`, () => {
       'is not null',
       runner(async ({ context }) => {
         await createComplexData(context);
-        const users = await context.lists.User.findMany({ where: { NOT: { friend: null } } });
+        const users = await context.query.User.findMany({ where: { NOT: { friend: null } } });
         expect(users.length).toEqual(4);
       })
     );
@@ -134,7 +134,7 @@ describe(`One-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const count = await context.lists.User.count();
+        const count = await context.query.User.count();
         expect(count).toEqual(3);
       })
     );
@@ -146,7 +146,7 @@ describe(`One-to-many relationships`, () => {
       runner(async ({ context }) => {
         const { users } = await createInitialData(context);
         const user = users[0];
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: { friend: { connect: { id: user.id } } },
           query: 'id friend { id }',
         });
@@ -163,7 +163,7 @@ describe(`One-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const friendName = sampleOne(alphanumGenerator);
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friend: { create: { name: friendName } } },
           query: 'id friend { id }',
         });
@@ -178,7 +178,7 @@ describe(`One-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friend: null },
           query: 'id friend { id }',
         });
@@ -200,7 +200,7 @@ describe(`One-to-many relationships`, () => {
         // `...not.toBe(expect.anything())` allows null and undefined values
         expect(user.friend).not.toBe(expect.anything());
 
-        await context.lists.User.updateOne({
+        await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { connect: { id: friend.id } } },
           query: 'id friend { id }',
@@ -218,7 +218,7 @@ describe(`One-to-many relationships`, () => {
         const { users } = await createInitialData(context);
         let user = users[0];
         const friendName = sampleOne(alphanumGenerator);
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { create: { name: friendName } } },
           query: 'id friend { id name }',
@@ -238,7 +238,7 @@ describe(`One-to-many relationships`, () => {
         const { friend, user } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { disconnect: true } },
           query: 'id friend { id name }',
@@ -259,7 +259,7 @@ describe(`One-to-many relationships`, () => {
         const { friend, user } = await createUserAndFriend(context);
 
         // Run the query with a null operation
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: null },
           query: 'id friend { id name }',
@@ -281,7 +281,7 @@ describe(`One-to-many relationships`, () => {
         const { friend, user } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.deleteOne({ where: { id: user.id } });
+        const _user = await context.query.User.deleteOne({ where: { id: user.id } });
         expect(_user?.id).toBe(user.id);
 
         // Check the link has been broken
@@ -299,12 +299,12 @@ describe(`One-to-many relationships`, () => {
 
           // Delete company {name}
           const id = users.find(company => company.name === name)?.id;
-          const _user = await context.lists.User.deleteOne({ where: { id } });
+          const _user = await context.query.User.deleteOne({ where: { id } });
           expect(_user?.id).toBe(id);
 
           // Check all the companies look how we expect
           await (async () => {
-            const _users = (await context.lists.User.findMany({
+            const _users = (await context.query.User.findMany({
               orderBy: { name: 'asc' },
               query: 'id name friend { id name }',
             })) as { name: string; friend: { name: string } }[];
@@ -333,7 +333,7 @@ describe(`One-to-many relationships`, () => {
 
           // Check all the friends look how we expect
           await (async () => {
-            const _users = (await context.lists.User.findMany({
+            const _users = (await context.query.User.findMany({
               orderBy: { name: 'asc' },
               query: 'id name',
             })) as { name: string }[];
@@ -356,12 +356,12 @@ describe(`One-to-many relationships`, () => {
 
           // Delete friend {name}
           const id = users.find(user => user.name === name)?.id;
-          const _user = await context.lists.User.deleteOne({ where: { id } });
+          const _user = await context.query.User.deleteOne({ where: { id } });
           expect(_user?.id).toBe(id);
 
           // Check all the companies look how we expect
           await (async () => {
-            const _users = (await context.lists.User.findMany({
+            const _users = (await context.query.User.findMany({
               orderBy: { name: 'asc' },
               query: 'id name friend { id name }',
             })) as { name: string; friend: { name: string } }[];
@@ -396,7 +396,7 @@ describe(`One-to-many relationships`, () => {
 
           // Check all the friends look how we expect
           await (async () => {
-            const _users = (await context.lists.User.findMany({
+            const _users = (await context.query.User.findMany({
               orderBy: { name: 'asc' },
               query: 'id name',
             })) as { name: string }[];

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -22,7 +22,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  const user = await context.lists.User.createOne({
+  const user = await context.query.User.createOne({
     data: { friends: { create: [{ name: sampleOne(alphanumGenerator) }] } },
     query: 'id friends { id friendOf { id } }',
   });
@@ -57,7 +57,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C];
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: ['A', 'A', 'B', 'B', 'C', 'C', 'D'].map(name => ({ name })),
     query: 'id name',
   });
@@ -69,7 +69,7 @@ const createReadData = async (context: KeystoneContext) => {
       '': [], //  -> []
     }).map(async ([name, locationIdxs]) => {
       const ids = locationIdxs.map((i: number) => ({ id: users[i].id }));
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: { name, friends: { connect: ids } },
         query: 'id friends { id friendOf { id } }',
       });
@@ -108,7 +108,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 4],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friendOf: { name: { contains: name } } },
             });
             expect(users.length).toEqual(count);
@@ -120,7 +120,7 @@ describe(`One-to-many relationships`, () => {
       'is null',
       runner(async ({ context }) => {
         await createReadData(context);
-        const users = await context.lists.User.findMany({ where: { friendOf: null } });
+        const users = await context.query.User.findMany({ where: { friendOf: null } });
         expect(users.length).toEqual(5);
       })
     );
@@ -128,7 +128,7 @@ describe(`One-to-many relationships`, () => {
       'is not null',
       runner(async ({ context }) => {
         await createReadData(context);
-        const users = await context.lists.User.findMany({ where: { NOT: { friendOf: null } } });
+        const users = await context.query.User.findMany({ where: { NOT: { friendOf: null } } });
         expect(users.length).toEqual(6);
       })
     );
@@ -143,7 +143,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { some: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -162,7 +162,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2 + 7],
             ['D', 4 + 7],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { none: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -181,7 +181,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2 + 7],
             ['D', 1 + 7],
           ].map(async ([name, count]) => {
-            const users = await context.lists.User.findMany({
+            const users = await context.query.User.findMany({
               where: { friends: { every: { name: { equals: name } } } },
             });
             expect(users.length).toEqual(count);
@@ -196,7 +196,7 @@ describe(`One-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const count = await context.lists.User.count();
+        const count = await context.query.User.count();
         expect(count).toEqual(3);
       })
     );
@@ -208,7 +208,7 @@ describe(`One-to-many relationships`, () => {
       runner(async ({ context }) => {
         const { users } = await createInitialData(context);
         const user = users[0];
-        const _user = (await context.lists.User.createOne({
+        const _user = (await context.query.User.createOne({
           data: { friends: { connect: [{ id: user.id }] } },
           query: 'id friends { id  }',
         })) as { id: IdType; friends: { id: IdType }[] };
@@ -227,7 +227,7 @@ describe(`One-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const friendName = sampleOne(alphanumGenerator);
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: { friends: { create: [{ name: friendName }] } },
           query: 'id friends { id }',
         });
@@ -247,7 +247,7 @@ describe(`One-to-many relationships`, () => {
         const user = users[0];
         const friendName = sampleOne(alphanumGenerator);
 
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: {
             friends: { create: [{ name: friendName, friendOf: { connect: { id: user.id } } }] },
           },
@@ -260,7 +260,7 @@ describe(`One-to-many relationships`, () => {
         expect(User.friends.map(({ id }) => id.toString())).toEqual([Friend.id]);
         expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
-        const _users = (await context.lists.User.findMany({
+        const _users = (await context.query.User.findMany({
           query: 'id friends { id friendOf { id } }',
         })) as {
           id: IdType;
@@ -285,7 +285,7 @@ describe(`One-to-many relationships`, () => {
         const friendName = sampleOne(alphanumGenerator);
         const friendOfName = sampleOne(alphanumGenerator);
 
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: {
             friends: {
               create: [{ name: friendName, friendOf: { create: { name: friendOfName } } }],
@@ -300,7 +300,7 @@ describe(`One-to-many relationships`, () => {
         expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
         // The nested company should not have a location
-        const users = (await context.lists.User.findMany({
+        const users = (await context.query.User.findMany({
           query: 'id friends { id friendOf { id } }',
         })) as {
           id: IdType;
@@ -318,7 +318,7 @@ describe(`One-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friends: null },
           query: 'id friends { id }',
         });
@@ -341,7 +341,7 @@ describe(`One-to-many relationships`, () => {
         expect(user.friends).not.toBe(expect.anything());
         expect(friend.friendOf).not.toBe(expect.anything());
 
-        await context.lists.User.updateOne({
+        await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { connect: [{ id: friend.id }] } },
           query: 'id friends { id }',
@@ -360,7 +360,7 @@ describe(`One-to-many relationships`, () => {
         const { users } = await createInitialData(context);
         let user = users[0];
         const friendName = sampleOne(alphanumGenerator);
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { create: [{ name: friendName }] } },
           query: 'id friends { id name }',
@@ -381,7 +381,7 @@ describe(`One-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { disconnect: [{ id: friend.id }] } },
           query: 'id friends { id name }',
@@ -403,7 +403,7 @@ describe(`One-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: { set: [] } },
           query: 'id friends { id name }',
@@ -425,7 +425,7 @@ describe(`One-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query with a null operation
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friends: null },
           query: 'id friends { id name }',
@@ -447,7 +447,7 @@ describe(`One-to-many relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.deleteOne({ where: { id: user.id } });
+        const _user = await context.query.User.deleteOne({ where: { id: user.id } });
         expect(_user?.id).toBe(user.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const users = await context.lists.User.createMany({
+  const users = await context.query.User.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -22,7 +22,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createUserAndFriend = async (context: KeystoneContext) => {
-  const user = await context.lists.User.createOne({
+  const user = await context.query.User.createOne({
     data: {
       name: sampleOne(alphanumGenerator),
       friend: { create: { name: sampleOne(alphanumGenerator) } },
@@ -78,7 +78,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { user, friend } = await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({
+        const users = await context.query.User.findMany({
           where: { friend: { name: { equals: friend.name } } },
         });
         expect(users.length).toEqual(1);
@@ -91,7 +91,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { user, friend } = await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({
+        const users = await context.query.User.findMany({
           where: { friendOf: { name: { equals: user.name } } },
         });
         expect(users.length).toEqual(1);
@@ -103,7 +103,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({ where: { friend: null } });
+        const users = await context.query.User.findMany({ where: { friend: null } });
         expect(users.length).toEqual(4);
       })
     );
@@ -112,7 +112,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({ where: { friendOf: null } });
+        const users = await context.query.User.findMany({ where: { friendOf: null } });
         expect(users.length).toEqual(4);
       })
     );
@@ -121,7 +121,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({ where: { NOT: { friend: null } } });
+        const users = await context.query.User.findMany({ where: { NOT: { friend: null } } });
         expect(users.length).toEqual(1);
       })
     );
@@ -130,7 +130,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const users = await context.lists.User.findMany({ where: { NOT: { friendOf: null } } });
+        const users = await context.query.User.findMany({ where: { NOT: { friendOf: null } } });
         expect(users.length).toEqual(1);
       })
     );
@@ -139,7 +139,7 @@ describe(`One-to-one relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const count = await context.lists.User.count();
+        const count = await context.query.User.count();
         expect(count).toEqual(3);
       })
     );
@@ -149,7 +149,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { friend } = await createUserAndFriend(context);
-        const count = await context.lists.User.count({
+        const count = await context.query.User.count({
           where: { friend: { name: { equals: friend.name } } },
         });
         expect(count).toEqual(1);
@@ -161,7 +161,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { user } = await createUserAndFriend(context);
-        const count = await context.lists.User.count({
+        const count = await context.query.User.count({
           where: { friendOf: { name: { equals: user.name } } },
         });
         expect(count).toEqual(1);
@@ -172,7 +172,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const count = await context.lists.User.count({ where: { friend: null } });
+        const count = await context.query.User.count({ where: { friend: null } });
         expect(count).toEqual(4);
       })
     );
@@ -182,7 +182,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createUserAndFriend(context);
-        const count = await context.lists.User.count({ where: { friendOf: null } });
+        const count = await context.query.User.count({ where: { friendOf: null } });
         expect(count).toEqual(4);
       })
     );
@@ -194,7 +194,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         const { users } = await createInitialData(context);
         const user = users[0];
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: { friend: { connect: { id: user.id } } },
           query: 'id friend { id friendOf { id } }',
         });
@@ -212,7 +212,7 @@ describe(`One-to-one relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const friendName = sampleOne(alphanumGenerator);
-        const user = await context.lists.User.createOne({
+        const user = await context.query.User.createOne({
           data: { friend: { create: { name: friendName } } },
           query: 'id friend { id friendOf { id } }',
         });
@@ -232,7 +232,7 @@ describe(`One-to-one relationships`, () => {
         const user = users[0];
         const friendName = sampleOne(alphanumGenerator);
 
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: {
             friend: { create: { name: friendName, friendOf: { connect: { id: user.id } } } },
           },
@@ -244,7 +244,7 @@ describe(`One-to-one relationships`, () => {
         expect(User.friend.id.toString()).toBe(Friend.id.toString());
         expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
-        const _users = (await context.lists.User.findMany({
+        const _users = (await context.query.User.findMany({
           query: 'id friend { id friendOf { id } }',
         })) as { id: IdType; friend: { id: IdType; friendOf: { id: IdType } } }[];
         // The nested company should not have a location
@@ -263,7 +263,7 @@ describe(`One-to-one relationships`, () => {
         const friendName = sampleOne(alphanumGenerator);
         const friendOfName = sampleOne(alphanumGenerator);
 
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: {
             friend: {
               create: { name: friendName, friendOf: { create: { name: friendOfName } } },
@@ -278,7 +278,7 @@ describe(`One-to-one relationships`, () => {
         expect(Friend.friendOf.id.toString()).toBe(User.id.toString());
 
         // The nested company should not have a location
-        const users = (await context.lists.User.findMany({
+        const users = (await context.query.User.findMany({
           query: 'id friend { id friendOf { id }}',
         })) as {
           id: IdType;
@@ -296,7 +296,7 @@ describe(`One-to-one relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const _user = await context.lists.User.createOne({
+        const _user = await context.query.User.createOne({
           data: { friend: null },
           query: 'id friend { id  }',
         });
@@ -319,7 +319,7 @@ describe(`One-to-one relationships`, () => {
         expect(user.friend).not.toBe(expect.anything());
         expect(friend.friendOf).not.toBe(expect.anything());
 
-        await context.lists.User.updateOne({
+        await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { connect: { id: friend.id } } },
           query: 'id friend { id }',
@@ -338,7 +338,7 @@ describe(`One-to-one relationships`, () => {
         const { users } = await createInitialData(context);
         let user = users[0];
         const friendName = sampleOne(alphanumGenerator);
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { create: { name: friendName } } },
           query: 'id friend { id name }',
@@ -359,7 +359,7 @@ describe(`One-to-one relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: { disconnect: true } },
           query: 'id friend { id name }',
@@ -382,7 +382,7 @@ describe(`One-to-one relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query with a null operation
-        const _user = await context.lists.User.updateOne({
+        const _user = await context.query.User.updateOne({
           where: { id: user.id },
           data: { friend: null },
           query: 'id friend { id name }',
@@ -404,7 +404,7 @@ describe(`One-to-one relationships`, () => {
         const { user, friend } = await createUserAndFriend(context);
 
         // Run the query to disconnect the location from company
-        const _user = await context.lists.User.deleteOne({ where: { id: user.id } });
+        const _user = await context.query.User.deleteOne({ where: { id: user.id } });
         expect(_user?.id).toBe(user.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
@@ -10,14 +10,14 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   });
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -28,7 +28,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const company = await context.lists.Company.createOne({
+  const company = await context.query.Company.createOne({
     data: { locations: { create: [{ name: sampleOne(alphanumGenerator) }] } },
     query: 'id locations { id }',
   });
@@ -65,7 +65,7 @@ const getCompanyAndLocation = async (
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C];
   const data = ['A', 'A', 'B', 'B', 'C', 'C'].map(name => ({ name }));
-  const locations = await context.lists.Location.createMany({ data, query: 'id name' });
+  const locations = await context.query.Location.createMany({ data, query: 'id name' });
   await Promise.all(
     [
       [0, 1, 2, 3, 4, 5], //  -> [A, A, B, B, C, C]
@@ -78,7 +78,7 @@ const createReadData = async (context: KeystoneContext) => {
       [2], //  -> [B]
       [], //  -> []
     ].map(async locationIdxs => {
-      await context.lists.Company.createOne({
+      await context.query.Company.createOne({
         data: { locations: { connect: locationIdxs.map(i => ({ id: locations[i].id })) } },
         query: 'id locations { name }',
       });
@@ -113,7 +113,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 3],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { some: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -132,7 +132,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 6],
             ['D', 9],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { none: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -151,7 +151,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 1],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { every: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -166,8 +166,8 @@ describe(`Many-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const companiesCount = await context.lists.Company.count();
-        const locationsCount = await context.lists.Location.count();
+        const companiesCount = await context.query.Company.count();
+        const locationsCount = await context.query.Location.count();
         expect(companiesCount).toEqual(3);
         expect(locationsCount).toEqual(3);
       })
@@ -184,7 +184,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 3],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { some: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -203,7 +203,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 6],
             ['D', 9],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { none: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -222,7 +222,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 1],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { every: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -239,7 +239,7 @@ describe(`Many-to-many relationships`, () => {
         const { locations } = await createInitialData(context);
         const location = locations[0];
         type T = { id: IdType; locations: { id: IdType }[] };
-        const company = (await context.lists.Company.createOne({
+        const company = (await context.query.Company.createOne({
           data: { locations: { connect: [{ id: location.id }] } },
           query: 'id locations { id }',
         })) as T;
@@ -255,7 +255,7 @@ describe(`Many-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const locationName = sampleOne(alphanumGenerator);
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id }',
         });
@@ -274,7 +274,7 @@ describe(`Many-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: null },
           query: 'id locations { id }',
         });
@@ -296,7 +296,7 @@ describe(`Many-to-many relationships`, () => {
         // `...not.toBe(expect.anything())` allows null and undefined values
         expect(company.locations).not.toBe(expect.anything());
 
-        await context.lists.Company.updateOne({
+        await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { connect: [{ id: location.id }] } },
           query: 'id locations { id }',
@@ -314,7 +314,7 @@ describe(`Many-to-many relationships`, () => {
         const { companies } = await createInitialData(context);
         let company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id name }',
@@ -338,7 +338,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { disconnect: [{ id: location.id }] } },
           query: 'id locations { id name }',
@@ -359,7 +359,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { set: [] } },
           query: 'id locations { id name }',
@@ -380,7 +380,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query with a null operation
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: null },
           query: 'id locations { id name }',
@@ -402,7 +402,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.deleteOne({ where: { id: company.id } });
+        const _company = await context.query.Company.deleteOne({ where: { id: company.id } });
         expect(_company?.id).toBe(company.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many.test.ts
@@ -10,14 +10,14 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   });
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -28,7 +28,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const company = await context.lists.Company.createOne({
+  const company = await context.query.Company.createOne({
     data: { locations: { create: [{ name: sampleOne(alphanumGenerator) }] } },
     query: 'id locations { id companies { id } }',
   });
@@ -68,7 +68,7 @@ const getCompanyAndLocation = async (
 
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C];
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: ['A', 'A', 'B', 'B', 'C', 'C'].map(name => ({ name })),
     query: 'id name',
   });
@@ -84,7 +84,7 @@ const createReadData = async (context: KeystoneContext) => {
       [2], //  -> [B]
       [], //  -> []
     ].map(async locationIdxs => {
-      await context.lists.Company.createOne({
+      await context.query.Company.createOne({
         data: { locations: { connect: locationIdxs.map(i => ({ id: locations[i].id })) } },
         query: 'id locations { name }',
       });
@@ -124,7 +124,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 3],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { some: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -143,7 +143,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 6],
             ['D', 9],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { none: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -162,7 +162,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 1],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { every: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -177,8 +177,8 @@ describe(`Many-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const companiesCount = await context.lists.Company.count();
-        const locationsCount = await context.lists.Location.count();
+        const companiesCount = await context.query.Company.count();
+        const locationsCount = await context.query.Location.count();
         expect(companiesCount).toEqual(3);
         expect(locationsCount).toEqual(3);
       })
@@ -194,7 +194,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 3],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { some: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -213,7 +213,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 6],
             ['D', 9],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { none: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -232,7 +232,7 @@ describe(`Many-to-many relationships`, () => {
             ['C', 1],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const _count = await context.lists.Company.count({
+            const _count = await context.query.Company.count({
               where: { locations: { every: { name: { equals: name } } } },
             });
             expect(_count).toEqual(count);
@@ -248,7 +248,7 @@ describe(`Many-to-many relationships`, () => {
       runner(async ({ context }) => {
         const { locations } = await createInitialData(context);
         const location = locations[0];
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: { connect: [{ id: location.id }] } },
           query: 'id locations { id }',
         });
@@ -266,7 +266,7 @@ describe(`Many-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const locationName = sampleOne(alphanumGenerator);
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id }',
         });
@@ -290,7 +290,7 @@ describe(`Many-to-many relationships`, () => {
         const company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
 
-        const _company = await context.lists.Company.createOne({
+        const _company = await context.query.Company.createOne({
           data: {
             locations: {
               create: [{ name: locationName, companies: { connect: [{ id: company.id }] } }],
@@ -312,7 +312,7 @@ describe(`Many-to-many relationships`, () => {
           locations: { id: IdType; companies: { id: IdType }[] }[];
         }[];
 
-        const _companies = (await context.lists.Company.findMany({
+        const _companies = (await context.query.Company.findMany({
           query: 'id locations { id companies { id } }',
         })) as T;
         // Both companies should have a location, and the location should have two companies
@@ -334,7 +334,7 @@ describe(`Many-to-many relationships`, () => {
         const locationName = sampleOne(alphanumGenerator);
         const companyName = sampleOne(alphanumGenerator);
 
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: {
             locations: {
               create: [{ name: locationName, companies: { create: [{ name: companyName }] } }],
@@ -359,7 +359,7 @@ describe(`Many-to-many relationships`, () => {
           locations: { id: IdType; companies: { id: IdType }[] }[];
         }[];
 
-        const _companies = (await context.lists.Company.findMany({
+        const _companies = (await context.query.Company.findMany({
           query: 'id locations { id companies { id } }',
         })) as T;
         _companies.forEach(({ locations }) => {
@@ -374,7 +374,7 @@ describe(`Many-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: null },
           query: 'id locations { id }',
         });
@@ -397,7 +397,7 @@ describe(`Many-to-many relationships`, () => {
         expect(company.locations).not.toBe(expect.anything());
         expect(location.companies).not.toBe(expect.anything());
 
-        await context.lists.Company.updateOne({
+        await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { connect: [{ id: location.id }] } },
           query: 'id locations { id }',
@@ -416,7 +416,7 @@ describe(`Many-to-many relationships`, () => {
         const { companies } = await createInitialData(context);
         let company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id name }',
@@ -441,7 +441,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { disconnect: [{ id: location.id }] } },
           query: 'id locations { id name }',
@@ -463,7 +463,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { set: [] } },
           query: 'id locations { id name }',
@@ -485,7 +485,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query with a null operation
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: null },
           query: 'id locations { id name }',
@@ -507,7 +507,7 @@ describe(`Many-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.deleteOne({ where: { id: company.id } });
+        const _company = await context.query.Company.deleteOne({ where: { id: company.id } });
         expect(_company?.id).toBe(company.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -10,14 +10,14 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   });
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -28,7 +28,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const company = await context.lists.Company.createOne({
+  const company = await context.query.Company.createOne({
     data: { location: { create: { name: sampleOne(alphanumGenerator) } } },
     query: 'id location { id }',
   });
@@ -45,7 +45,7 @@ const createCompanyAndLocation = async (context: KeystoneContext) => {
 };
 
 const createComplexData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: 'A', location: { create: { name: 'A' } } },
       { name: 'B', location: { create: { name: 'D' } } },
@@ -63,11 +63,11 @@ const createComplexData = async (context: KeystoneContext) => {
   expect(companies[3].name).toEqual('E');
   expect(companies[3].location).toBe(null);
 
-  const _company = await context.lists.Company.createOne({
+  const _company = await context.query.Company.createOne({
     data: { name: 'D', location: { connect: { id: companies[2].location.id } } },
     query: 'id name location { id name }',
   });
-  const _location = await context.lists.Location.createOne({
+  const _location = await context.query.Location.createOne({
     data: { name: 'C' },
     query: 'id name',
   });
@@ -76,7 +76,7 @@ const createComplexData = async (context: KeystoneContext) => {
   expect(_location.name).toEqual('C');
 
   type T3 = { id: IdType; name: string }[];
-  const locations = (await context.lists.Location.findMany({ query: 'id name' })) as T3;
+  const locations = (await context.query.Location.findMany({ query: 'id name' })) as T3;
   return { companies: [...companies, _company], locations };
 };
 
@@ -130,7 +130,7 @@ describe(`One-to-many relationships`, () => {
             ['D', 1],
             ['E', 0],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { location: { name: { contains: name } } },
             });
             expect(companies.length).toEqual(count);
@@ -142,7 +142,7 @@ describe(`One-to-many relationships`, () => {
       'is null',
       runner(async ({ context }) => {
         await createComplexData(context);
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { location: null },
         });
         expect(companies.length).toEqual(1);
@@ -152,7 +152,7 @@ describe(`One-to-many relationships`, () => {
       'is not null',
       runner(async ({ context }) => {
         await createComplexData(context);
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { NOT: { location: null } },
         });
         expect(companies.length).toEqual(4);
@@ -165,8 +165,8 @@ describe(`One-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const companiesCount = await context.lists.Company.count();
-        const locationsCount = await context.lists.Location.count();
+        const companiesCount = await context.query.Company.count();
+        const locationsCount = await context.query.Location.count();
         expect(companiesCount).toEqual(3);
         expect(locationsCount).toEqual(3);
       })
@@ -179,7 +179,7 @@ describe(`One-to-many relationships`, () => {
       runner(async ({ context }) => {
         const { locations } = await createInitialData(context);
         const location = locations[0];
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: { connect: { id: location.id } } },
           query: 'id location { id }',
         });
@@ -195,7 +195,7 @@ describe(`One-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const locationName = sampleOne(alphanumGenerator);
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: { create: { name: locationName } } },
           query: 'id location { id }',
         });
@@ -214,7 +214,7 @@ describe(`One-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: null },
           query: 'id location { id }',
         });
@@ -236,7 +236,7 @@ describe(`One-to-many relationships`, () => {
         // `...not.toBe(expect.anything())` allows null and undefined values
         expect(company.location).not.toBe(expect.anything());
 
-        await context.lists.Company.updateOne({
+        await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { connect: { id: location.id } } },
         });
@@ -253,7 +253,7 @@ describe(`One-to-many relationships`, () => {
         const { companies } = await createInitialData(context);
         let company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { create: { name: locationName } } },
           query: 'id location { id name }',
@@ -276,7 +276,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { disconnect: true } },
           query: 'id location { id name }',
@@ -297,7 +297,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query with a null operation
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: null },
           query: 'id location { id name }',
@@ -319,7 +319,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.deleteOne({ where: { id: company.id } });
+        const _company = await context.query.Company.deleteOne({ where: { id: company.id } });
         expect(_company?.id).toBe(company.id);
 
         // Check the link has been broken
@@ -337,12 +337,12 @@ describe(`One-to-many relationships`, () => {
 
           // Delete company {name}
           const id = companies.find(company => company.name === name)?.id;
-          const _company = await context.lists.Company.deleteOne({ where: { id } });
+          const _company = await context.query.Company.deleteOne({ where: { id } });
           expect(_company?.id).toBe(id);
 
           // Check all the companies look how we expect
           await (async () => {
-            const _companies = await context.lists.Company.findMany({
+            const _companies = await context.query.Company.findMany({
               orderBy: { name: 'asc' },
               query: 'id name location { id name }',
             });
@@ -370,7 +370,7 @@ describe(`One-to-many relationships`, () => {
 
           // Check all the locations look how we expect
           await (async () => {
-            const _locations = await context.lists.Location.findMany({
+            const _locations = await context.query.Location.findMany({
               orderBy: { name: 'asc' },
               query: 'id name',
             });
@@ -392,12 +392,12 @@ describe(`One-to-many relationships`, () => {
 
           // Delete location {name}
           const id = locations.find(location => location.name === name)?.id;
-          const deleted = await context.lists.Location.deleteOne({ where: { id } });
+          const deleted = await context.query.Location.deleteOne({ where: { id } });
           expect(deleted).not.toBe(null);
           expect(deleted!.id).toBe(id);
 
           // Check all the companies look how we expect
-          const companies = await context.lists.Company.findMany({
+          const companies = await context.query.Company.findMany({
             orderBy: { name: 'asc' },
             query: 'id name location { id name }',
           });
@@ -429,7 +429,7 @@ describe(`One-to-many relationships`, () => {
           expect(companies[4].location).toBe(null);
 
           // Check all the locations look how we expect
-          const _locations = await context.lists.Location.findMany({
+          const _locations = await context.query.Location.findMany({
             orderBy: { name: 'asc' },
             query: 'id name',
           });

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -10,14 +10,14 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   });
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -28,7 +28,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const company = await context.lists.Company.createOne({
+  const company = await context.query.Company.createOne({
     data: { locations: { create: [{ name: sampleOne(alphanumGenerator) }] } },
     query: 'id locations { id company { id } }',
   });
@@ -68,7 +68,7 @@ const getCompanyAndLocation = async (
 
 const createReadData = async (context: KeystoneContext) => {
   // create locations [A, A, B, B, C, C, D];
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: ['A', 'A', 'B', 'B', 'C', 'C', 'D'].map(name => ({ name })),
     query: 'id name',
   });
@@ -80,7 +80,7 @@ const createReadData = async (context: KeystoneContext) => {
       '': [], //  -> []
     }).map(async ([name, locationIdxs]) => {
       const ids = locationIdxs.map((i: number) => ({ id: locations[i].id }));
-      await context.lists.Company.createOne({ data: { name, locations: { connect: ids } } });
+      await context.query.Company.createOne({ data: { name, locations: { connect: ids } } });
     })
   );
 };
@@ -117,7 +117,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 4],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const locations = await context.lists.Location.findMany({
+            const locations = await context.query.Location.findMany({
               where: { company: { name: { contains: name } } },
             });
             expect(locations.length).toEqual(count);
@@ -129,7 +129,7 @@ describe(`One-to-many relationships`, () => {
       'is null',
       runner(async ({ context }) => {
         await createReadData(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { company: null },
         });
         expect(locations.length).toEqual(1);
@@ -139,7 +139,7 @@ describe(`One-to-many relationships`, () => {
       'is not null',
       runner(async ({ context }) => {
         await createReadData(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { NOT: { company: null } },
         });
         expect(locations.length).toEqual(6);
@@ -156,7 +156,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2],
             ['D', 0],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { some: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -175,7 +175,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2],
             ['D', 4],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { none: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -194,7 +194,7 @@ describe(`One-to-many relationships`, () => {
             ['C', 2],
             ['D', 1],
           ].map(async ([name, count]) => {
-            const companies = await context.lists.Company.findMany({
+            const companies = await context.query.Company.findMany({
               where: { locations: { every: { name: { equals: name } } } },
             });
             expect(companies.length).toEqual(count);
@@ -209,8 +209,8 @@ describe(`One-to-many relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const companiesCount = await context.lists.Company.count();
-        const locationsCount = await context.lists.Location.count();
+        const companiesCount = await context.query.Company.count();
+        const locationsCount = await context.query.Location.count();
         expect(companiesCount).toEqual(3);
         expect(locationsCount).toEqual(3);
       })
@@ -224,7 +224,7 @@ describe(`One-to-many relationships`, () => {
         const { locations } = await createInitialData(context);
         const location = locations[0];
         type T = { id: IdType; locations: { id: IdType }[] };
-        const company = (await context.lists.Company.createOne({
+        const company = (await context.query.Company.createOne({
           data: { locations: { connect: [{ id: location.id }] } },
           query: 'id locations { id }',
         })) as T;
@@ -243,7 +243,7 @@ describe(`One-to-many relationships`, () => {
       'With create',
       runner(async ({ context }) => {
         const locationName = sampleOne(alphanumGenerator);
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id }',
         });
@@ -268,7 +268,7 @@ describe(`One-to-many relationships`, () => {
 
         const locationName = sampleOne(alphanumGenerator);
 
-        const _company = await context.lists.Company.createOne({
+        const _company = await context.query.Company.createOne({
           data: {
             locations: {
               create: [{ name: locationName, company: { connect: { id: company.id } } }],
@@ -287,7 +287,7 @@ describe(`One-to-many relationships`, () => {
         expect(Company.locations.map(({ id }) => id.toString())).toEqual([Location.id]);
         expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-        const allCompanies = await context.lists.Company.findMany({
+        const allCompanies = await context.query.Company.findMany({
           query: 'id locations { id company { id } }',
         });
 
@@ -309,7 +309,7 @@ describe(`One-to-many relationships`, () => {
         const locationName = sampleOne(alphanumGenerator);
         const companyName = sampleOne(alphanumGenerator);
 
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: {
             locations: {
               create: [{ name: locationName, company: { create: { name: companyName } } }],
@@ -328,7 +328,7 @@ describe(`One-to-many relationships`, () => {
         expect(Location.company.id.toString()).toBe(Company.id.toString());
 
         // The nested company should not have a location
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           query: 'id locations { id company { id } }',
         });
         expect(companies.filter(({ id }) => id === Company.id)[0].locations[0].company.id).toEqual(
@@ -345,7 +345,7 @@ describe(`One-to-many relationships`, () => {
     test(
       'With null',
       runner(async ({ context }) => {
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { locations: null },
           query: 'id locations { id }',
         });
@@ -368,7 +368,7 @@ describe(`One-to-many relationships`, () => {
         expect(company.locations).not.toBe(expect.anything());
         expect(location.company).not.toBe(expect.anything());
 
-        await context.lists.Company.updateOne({
+        await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { connect: [{ id: location.id }] } },
         });
@@ -386,7 +386,7 @@ describe(`One-to-many relationships`, () => {
         const { companies } = await createInitialData(context);
         let company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { create: [{ name: locationName }] } },
           query: 'id locations { id name }',
@@ -411,7 +411,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { disconnect: [{ id: location.id }] } },
           query: 'id locations { id name }',
@@ -433,7 +433,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: { set: [] } },
           query: 'id locations { id name }',
@@ -455,7 +455,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query with a null operation
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { locations: null },
           query: 'id locations { id name }',
@@ -477,7 +477,7 @@ describe(`One-to-many relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.deleteOne({ where: { id: company.id } });
+        const _company = await context.query.Company.deleteOne({ where: { id: company.id } });
         expect(_company?.id).toBe(company.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -10,14 +10,14 @@ type IdType = any;
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = await context.lists.Company.createMany({
+  const companies = await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   });
-  const locations = await context.lists.Location.createMany({
+  const locations = await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -29,7 +29,7 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const company = await context.lists.Company.createOne({
+  const company = await context.query.Company.createOne({
     data: {
       name: sampleOne(alphanumGenerator),
       location: { create: { name: sampleOne(alphanumGenerator) } },
@@ -50,7 +50,7 @@ const createCompanyAndLocation = async (context: KeystoneContext) => {
 };
 
 const createLocationAndCompany = async (context: KeystoneContext) => {
-  const location = await context.lists.Location.createOne({
+  const location = await context.query.Location.createOne({
     data: {
       name: sampleOne(alphanumGenerator),
       company: { create: { name: sampleOne(alphanumGenerator) } },
@@ -117,10 +117,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { location, company } = await createCompanyAndLocation(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { company: { name: { equals: company.name } } },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { location: { name: { equals: location.name } } },
         });
         expect(locations.length).toEqual(1);
@@ -134,10 +134,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { location, company } = await createLocationAndCompany(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { company: { name: { equals: company.name } } },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { location: { name: { equals: location.name } } },
         });
         expect(locations.length).toEqual(1);
@@ -151,10 +151,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createCompanyAndLocation(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { company: null },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { location: null },
         });
         expect(locations.length).toEqual(4);
@@ -166,10 +166,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createLocationAndCompany(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { company: null },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { location: null },
         });
         expect(locations.length).toEqual(4);
@@ -181,10 +181,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createCompanyAndLocation(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { NOT: { company: null } },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { NOT: { location: null } },
         });
         expect(locations.length).toEqual(1);
@@ -196,10 +196,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createLocationAndCompany(context);
-        const locations = await context.lists.Location.findMany({
+        const locations = await context.query.Location.findMany({
           where: { NOT: { company: null } },
         });
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           where: { NOT: { location: null } },
         });
         expect(locations.length).toEqual(1);
@@ -211,8 +211,8 @@ describe(`One-to-one relationships`, () => {
       'Count',
       runner(async ({ context }) => {
         await createInitialData(context);
-        const companiesCount = await context.lists.Company.count();
-        const locationsCount = await context.lists.Location.count();
+        const companiesCount = await context.query.Company.count();
+        const locationsCount = await context.query.Location.count();
         expect(companiesCount).toEqual(3);
         expect(locationsCount).toEqual(4);
       })
@@ -223,10 +223,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { location, company } = await createCompanyAndLocation(context);
-        const locationsCount = await context.lists.Location.count({
+        const locationsCount = await context.query.Location.count({
           where: { company: { name: { equals: company.name } } },
         });
-        const companiesCount = await context.lists.Company.count({
+        const companiesCount = await context.query.Company.count({
           where: { location: { name: { equals: location.name } } },
         });
         expect(companiesCount).toEqual(1);
@@ -238,10 +238,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         const { location, company } = await createLocationAndCompany(context);
-        const locationsCount = await context.lists.Location.count({
+        const locationsCount = await context.query.Location.count({
           where: { company: { name: { equals: company.name } } },
         });
-        const companiesCount = await context.lists.Company.count({
+        const companiesCount = await context.query.Company.count({
           where: { location: { name: { equals: location.name } } },
         });
         expect(companiesCount).toEqual(1);
@@ -253,10 +253,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createCompanyAndLocation(context);
-        const locationsCount = await context.lists.Location.count({
+        const locationsCount = await context.query.Location.count({
           where: { company: null },
         });
-        const companiesCount = await context.lists.Company.count({
+        const companiesCount = await context.query.Company.count({
           where: { location: null },
         });
         expect(companiesCount).toEqual(3);
@@ -268,10 +268,10 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         await createInitialData(context);
         await createLocationAndCompany(context);
-        const locationsCount = await context.lists.Location.count({
+        const locationsCount = await context.query.Location.count({
           where: { company: null },
         });
-        const companiesCount = await context.lists.Company.count({
+        const companiesCount = await context.query.Company.count({
           where: { location: null },
         });
         expect(companiesCount).toEqual(3);
@@ -286,7 +286,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         const { locations } = await createInitialData(context);
         const location = locations[0];
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: { connect: { id: location.id } } },
           query: 'id location { id }',
         });
@@ -304,7 +304,7 @@ describe(`One-to-one relationships`, () => {
       runner(async ({ context }) => {
         const { companies } = await createInitialData(context);
         const company = companies[0];
-        const location = await context.lists.Location.createOne({
+        const location = await context.query.Location.createOne({
           data: { company: { connect: { id: company.id } } },
           query: 'id company { id }',
         });
@@ -321,7 +321,7 @@ describe(`One-to-one relationships`, () => {
       'With create A',
       runner(async ({ context }) => {
         const locationName = sampleOne(alphanumGenerator);
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: { create: { name: locationName } } },
           query: 'id location { id }',
         });
@@ -342,7 +342,7 @@ describe(`One-to-one relationships`, () => {
       'With create B',
       runner(async ({ context }) => {
         const companyName = sampleOne(alphanumGenerator);
-        const location = await context.lists.Location.createOne({
+        const location = await context.query.Location.createOne({
           data: { company: { create: { name: companyName } } },
           query: 'id company { id }',
         });
@@ -366,7 +366,7 @@ describe(`One-to-one relationships`, () => {
         const company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
 
-        const _company = await context.lists.Company.createOne({
+        const _company = await context.query.Company.createOne({
           data: {
             location: {
               create: { name: locationName, company: { connect: { id: company.id } } },
@@ -383,7 +383,7 @@ describe(`One-to-one relationships`, () => {
         expect(Company.location.id.toString()).toBe(Location.id.toString());
         expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-        const _companies = await context.lists.Company.findMany({
+        const _companies = await context.query.Company.findMany({
           query: 'id location { id company { id } }',
         });
         // The nested company should not have a location
@@ -405,7 +405,7 @@ describe(`One-to-one relationships`, () => {
         const location = locations[0];
         const companyName = sampleOne(alphanumGenerator);
 
-        const _location = await context.lists.Location.createOne({
+        const _location = await context.query.Location.createOne({
           data: {
             company: {
               create: { name: companyName, location: { connect: { id: location.id } } },
@@ -422,7 +422,7 @@ describe(`One-to-one relationships`, () => {
         expect(Company.location.id.toString()).toBe(Location.id.toString());
         expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-        const allLocations = await context.lists.Location.findMany({
+        const allLocations = await context.query.Location.findMany({
           query: 'id company { id location { id } }',
         });
         // The nested company should not have a location
@@ -443,7 +443,7 @@ describe(`One-to-one relationships`, () => {
         const locationName = sampleOne(alphanumGenerator);
         const companyName = sampleOne(alphanumGenerator);
 
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: {
             location: {
               create: { name: locationName, company: { create: { name: companyName } } },
@@ -462,7 +462,7 @@ describe(`One-to-one relationships`, () => {
         expect(Location.company.id.toString()).toBe(Company.id.toString());
 
         // The nested company should not have a location
-        const companies = await context.lists.Company.findMany({
+        const companies = await context.query.Company.findMany({
           query: 'id location { id company { id } }',
         });
         expect(companies.filter(({ id }) => id === Company.id)[0].location.company.id).toEqual(
@@ -479,12 +479,12 @@ describe(`One-to-one relationships`, () => {
       'Dual create A',
       runner(async ({ context }) => {
         // Create a Location
-        const location = await context.lists.Location.createOne({
+        const location = await context.query.Location.createOne({
           data: { name: sampleOne(alphanumGenerator) },
         });
 
         // Create a Company pointing to Location
-        const company1 = await context.lists.Company.createOne({
+        const company1 = await context.query.Company.createOne({
           data: {
             name: sampleOne(alphanumGenerator),
             location: { connect: { id: location.id } },
@@ -493,7 +493,7 @@ describe(`One-to-one relationships`, () => {
         });
 
         // Create another Company pointing to Location
-        const company2 = await context.lists.Company.createOne({
+        const company2 = await context.query.Company.createOne({
           data: {
             name: sampleOne(alphanumGenerator),
             location: { connect: { id: location.id } },
@@ -502,18 +502,18 @@ describe(`One-to-one relationships`, () => {
         });
 
         // Make sure the original Company does not point to the location
-        const result = await context.lists.Location.findMany({
+        const result = await context.query.Location.findMany({
           query: 'id name company { id }',
         });
         expect(result).toHaveLength(1);
 
-        const result1 = await context.lists.Company.findOne({
+        const result1 = await context.query.Company.findOne({
           where: { id: company1.id },
           query: 'id location { id }',
         });
         expect(result1?.location).toBe(null);
 
-        const result2 = await context.lists.Company.findOne({
+        const result2 = await context.query.Company.findOne({
           where: { id: company2.id },
           query: 'id location { id }',
         });
@@ -524,12 +524,12 @@ describe(`One-to-one relationships`, () => {
       'Dual create B',
       runner(async ({ context }) => {
         // Create a Company
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { name: sampleOne(alphanumGenerator) },
         });
 
         // Create a Location pointing to Company
-        const location1 = await context.lists.Location.createOne({
+        const location1 = await context.query.Location.createOne({
           data: {
             name: sampleOne(alphanumGenerator),
             company: { connect: { id: company.id } },
@@ -538,7 +538,7 @@ describe(`One-to-one relationships`, () => {
         });
 
         // Create another Location pointing to Company
-        const location2 = await context.lists.Location.createOne({
+        const location2 = await context.query.Location.createOne({
           data: {
             name: sampleOne(alphanumGenerator),
             company: { connect: { id: company.id } },
@@ -547,16 +547,16 @@ describe(`One-to-one relationships`, () => {
         });
 
         // Make sure the original Company does not point to the location
-        const result = await context.lists.Company.findMany({ query: 'id location { id }' });
+        const result = await context.query.Company.findMany({ query: 'id location { id }' });
         expect(result).toHaveLength(1);
 
-        const result1 = await context.lists.Location.findOne({
+        const result1 = await context.query.Location.findOne({
           where: { id: location1.id },
           query: 'id company { id }',
         });
         expect(result1?.company).toBe(null);
 
-        const result2 = await context.lists.Location.findOne({
+        const result2 = await context.query.Location.findOne({
           where: { id: location2.id },
           query: 'id company { id }',
         });
@@ -567,7 +567,7 @@ describe(`One-to-one relationships`, () => {
     test(
       'With null A',
       runner(async ({ context }) => {
-        const company = await context.lists.Company.createOne({
+        const company = await context.query.Company.createOne({
           data: { location: null },
           query: 'id location { id }',
         });
@@ -580,7 +580,7 @@ describe(`One-to-one relationships`, () => {
     test(
       'With null B',
       runner(async ({ context }) => {
-        const location = await context.lists.Location.createOne({
+        const location = await context.query.Location.createOne({
           data: { company: null },
           query: 'id company { id }',
         });
@@ -602,7 +602,7 @@ describe(`One-to-one relationships`, () => {
         expect(company.location).not.toBe(expect.anything());
         expect(location.company).not.toBe(expect.anything());
 
-        await context.lists.Company.updateOne({
+        await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { connect: { id: location.id } } },
           query: 'id location { id }',
@@ -626,7 +626,7 @@ describe(`One-to-one relationships`, () => {
         expect(company.location).not.toBe(expect.anything());
         expect(location.company).not.toBe(expect.anything());
 
-        await context.lists.Location.updateOne({
+        await context.query.Location.updateOne({
           where: { id: location.id },
           data: { company: { connect: { id: company.id } } },
         });
@@ -643,7 +643,7 @@ describe(`One-to-one relationships`, () => {
         const { companies } = await createInitialData(context);
         let company = companies[0];
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { create: { name: locationName } } },
           query: 'id location { id name }',
@@ -667,7 +667,7 @@ describe(`One-to-one relationships`, () => {
         const { locations } = await createInitialData(context);
         let location = locations[0];
         const companyName = sampleOne(alphanumGenerator);
-        const _location = await context.lists.Location.updateOne({
+        const _location = await context.query.Location.updateOne({
           where: { id: location.id },
           data: { company: { create: { name: companyName } } },
           query: 'id company { id name }',
@@ -693,7 +693,7 @@ describe(`One-to-one relationships`, () => {
 
         // Update company.location to be a new thing.
         const locationName = sampleOne(alphanumGenerator);
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { create: { name: locationName } } },
           query: 'id location { id name }',
@@ -712,7 +712,7 @@ describe(`One-to-one relationships`, () => {
         const originalLocationId = Location.id;
         await (async () => {
           const locationName = sampleOne(alphanumGenerator);
-          const _company = await context.lists.Company.updateOne({
+          const _company = await context.query.Company.updateOne({
             where: { id: company.id },
             data: { location: { create: { name: locationName } } },
             query: 'id location { id name }',
@@ -727,7 +727,7 @@ describe(`One-to-one relationships`, () => {
           expect(Company.location.id.toString()).toBe(Location.id.toString());
           expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-          const data2 = await context.lists.Location.findOne({
+          const data2 = await context.query.Location.findOne({
             where: { id: originalLocationId },
             query: 'id company { id }',
           });
@@ -742,7 +742,7 @@ describe(`One-to-one relationships`, () => {
         const { locations } = await createInitialData(context);
         let location = locations[0];
         const companyName = sampleOne(alphanumGenerator);
-        const _location = await context.lists.Location.updateOne({
+        const _location = await context.query.Location.updateOne({
           where: { id: location.id },
           data: { company: { create: { name: companyName } } },
           query: 'id company { id name }',
@@ -761,7 +761,7 @@ describe(`One-to-one relationships`, () => {
         const originalCompanyId = Company.id;
         await (async () => {
           const companyName = sampleOne(alphanumGenerator);
-          const _location = await context.lists.Location.updateOne({
+          const _location = await context.query.Location.updateOne({
             where: { id: location.id },
             data: { company: { create: { name: companyName } } },
             query: 'id company { id name }',
@@ -776,7 +776,7 @@ describe(`One-to-one relationships`, () => {
           expect(Company.location.id.toString()).toBe(Location.id.toString());
           expect(Location.company.id.toString()).toBe(Company.id.toString());
 
-          const _company = await context.lists.Company.findOne({
+          const _company = await context.query.Company.findOne({
             where: { id: originalCompanyId },
             query: 'id location { id }',
           });
@@ -792,7 +792,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: { disconnect: true } },
           query: 'id location { id name }',
@@ -814,7 +814,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createLocationAndCompany(context);
 
         // Run the query to disconnect the location from company
-        const _location = await context.lists.Location.updateOne({
+        const _location = await context.query.Location.updateOne({
           where: { id: location.id },
           data: { company: { disconnect: true } },
           query: 'id company { id name }',
@@ -836,7 +836,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query with a null operation
-        const _company = await context.lists.Company.updateOne({
+        const _company = await context.query.Company.updateOne({
           where: { id: company.id },
           data: { location: null },
           query: 'id location { id name }',
@@ -856,7 +856,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createLocationAndCompany(context);
 
         // Run the query with a null operation
-        const _location = await context.lists.Location.updateOne({
+        const _location = await context.query.Location.updateOne({
           where: { id: location.id },
           data: { company: null },
           query: 'id company { id name }',
@@ -878,7 +878,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createCompanyAndLocation(context);
 
         // Run the query to disconnect the location from company
-        const _company = await context.lists.Company.deleteOne({ where: { id: company.id } });
+        const _company = await context.query.Company.deleteOne({ where: { id: company.id } });
         expect(_company?.id).toBe(company.id);
 
         // Check the link has been broken
@@ -895,7 +895,7 @@ describe(`One-to-one relationships`, () => {
         const { location, company } = await createLocationAndCompany(context);
 
         // Run the query to disconnect the location from company
-        const _location = await context.lists.Location.deleteOne({ where: { id: location.id } });
+        const _location = await context.query.Location.deleteOne({ where: { id: location.id } });
         expect(_location?.id).toBe(location.id);
 
         // Check the link has been broken

--- a/tests/api-tests/relationships/filtering/access-control.test.ts
+++ b/tests/api-tests/relationships/filtering/access-control.test.ts
@@ -41,7 +41,7 @@ describe('relationship filtering with access control', () => {
       const posts = await Promise.all(
         postNames.map(name => {
           const postContent = sampleOne(alphanumGenerator);
-          return context.sudo().lists.PostLimitedRead.createOne({
+          return context.sudo().query.PostLimitedRead.createOne({
             data: { content: postContent, name },
           });
         })
@@ -50,7 +50,7 @@ describe('relationship filtering with access control', () => {
       // Create a user that owns 2 posts which are different from the one
       // specified in the read access control filter
       const username = sampleOne(alphanumGenerator);
-      const user = await context.sudo().lists.UserToPostLimitedRead.createOne({
+      const user = await context.sudo().query.UserToPostLimitedRead.createOne({
         data: {
           username,
           posts: { connect: [{ id: postIds[1] }, { id: postIds[2] }] },
@@ -58,7 +58,7 @@ describe('relationship filtering with access control', () => {
       });
 
       // Create an item that does the linking
-      const item = await context.lists.UserToPostLimitedRead.findOne({
+      const item = await context.query.UserToPostLimitedRead.findOne({
         where: { id: user.id },
         query: 'id username posts { id }',
       });
@@ -78,7 +78,7 @@ describe('relationship filtering with access control', () => {
       const posts = await Promise.all(
         postNames.map(name => {
           const postContent = sampleOne(alphanumGenerator);
-          return context.sudo().lists.PostLimitedRead.createOne({
+          return context.sudo().query.PostLimitedRead.createOne({
             data: { content: postContent, name },
           });
         })
@@ -87,7 +87,7 @@ describe('relationship filtering with access control', () => {
       // Create a user that owns 2 posts which are different from the one
       // specified in the read access control filter
       const username = sampleOne(alphanumGenerator);
-      const user = await context.sudo().lists.UserToPostLimitedRead.createOne({
+      const user = await context.sudo().query.UserToPostLimitedRead.createOne({
         data: {
           username,
           posts: { connect: [{ id: postIds[1] }, { id: postIds[2] }] },
@@ -95,7 +95,7 @@ describe('relationship filtering with access control', () => {
       });
 
       // Create an item that does the linking
-      const item = await context.lists.UserToPostLimitedRead.findOne({
+      const item = await context.query.UserToPostLimitedRead.findOne({
         where: { id: user.id },
         // Knowingly filter to an ID I don't have read access to
         // to see if the filter is correctly "AND"d with the access control

--- a/tests/api-tests/relationships/filtering/filtering.test.ts
+++ b/tests/api-tests/relationships/filtering/filtering.test.ts
@@ -24,17 +24,17 @@ describe('relationship filtering', () => {
   test(
     'nested to-single relationships can be filtered within AND clause',
     runner(async ({ context }) => {
-      const company = await context.lists.Company.createOne({ data: { name: 'Thinkmill' } });
-      const otherCompany = await context.lists.Company.createOne({ data: { name: 'Cete' } });
+      const company = await context.query.Company.createOne({ data: { name: 'Thinkmill' } });
+      const otherCompany = await context.query.Company.createOne({ data: { name: 'Cete' } });
 
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { company: { connect: { id: company.id } } },
       });
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: { company: { connect: { id: otherCompany.id } } },
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: {
           AND: [
             { company: { name: { contains: 'in' } } },
@@ -54,17 +54,17 @@ describe('relationship filtering', () => {
   test(
     'nested to-single relationships can be filtered within OR clause',
     runner(async ({ context }) => {
-      const company = await context.lists.Company.createOne({ data: { name: 'Thinkmill' } });
-      const otherCompany = await context.lists.Company.createOne({ data: { name: 'Cete' } });
+      const company = await context.query.Company.createOne({ data: { name: 'Thinkmill' } });
+      const otherCompany = await context.query.Company.createOne({ data: { name: 'Cete' } });
 
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { company: { connect: { id: company.id } } },
       });
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: { company: { connect: { id: otherCompany.id } } },
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: {
           OR: [
             { company: { name: { contains: 'in' } } },
@@ -85,18 +85,18 @@ describe('relationship filtering', () => {
     runner(async ({ context }) => {
       const ids = [];
 
-      ids.push((await context.lists.Post.createOne({ data: { content: 'Hello world' } })).id);
-      ids.push((await context.lists.Post.createOne({ data: { content: 'hi world' } })).id);
-      ids.push((await context.lists.Post.createOne({ data: { content: 'Hello? Or hi?' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'Hello world' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'hi world' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'Hello? Or hi?' } })).id);
 
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { posts: { connect: ids.map(id => ({ id })) } },
       });
 
       // Create a dummy user to make sure we're actually filtering it out
-      await context.lists.User.createOne({ data: {} });
+      await context.query.User.createOne({ data: {} });
 
-      const users = (await context.lists.User.findMany({
+      const users = (await context.query.User.findMany({
         where: {
           AND: [
             { posts: { some: { content: { contains: 'hi' } } } },
@@ -117,18 +117,18 @@ describe('relationship filtering', () => {
     runner(async ({ context }) => {
       const ids = [];
 
-      ids.push((await context.lists.Post.createOne({ data: { content: 'Hello world' } })).id);
-      ids.push((await context.lists.Post.createOne({ data: { content: 'hi world' } })).id);
-      ids.push((await context.lists.Post.createOne({ data: { content: 'Hello? Or hi?' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'Hello world' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'hi world' } })).id);
+      ids.push((await context.query.Post.createOne({ data: { content: 'Hello? Or hi?' } })).id);
 
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { posts: { connect: ids.map(id => ({ id })) } },
       });
 
       // Create a dummy user to make sure we're actually filtering it out
-      await context.lists.User.createOne({ data: {} });
+      await context.query.User.createOne({ data: {} });
 
-      const users = (await context.lists.User.findMany({
+      const users = (await context.query.User.findMany({
         where: {
           OR: [
             { posts: { some: { content: { contains: 'o w' } } } },
@@ -147,50 +147,50 @@ describe('relationship filtering', () => {
   test(
     'many-to-many filtering composes with one-to-many filtering',
     runner(async ({ context }) => {
-      const adsCompany = await context.lists.Company.createOne({
+      const adsCompany = await context.query.Company.createOne({
         data: { name: 'AdsAdsAds' },
         query: 'id name',
       });
-      const otherCompany = await context.lists.Company.createOne({
+      const otherCompany = await context.query.Company.createOne({
         data: { name: 'Thinkmill' },
         query: 'id name',
       });
 
       // Content can have multiple authors
-      const spam1 = await context.lists.Post.createOne({ data: { content: 'spam' } });
-      const spam2 = await context.lists.Post.createOne({ data: { content: 'spam' } });
-      const content = await context.lists.Post.createOne({
+      const spam1 = await context.query.Post.createOne({ data: { content: 'spam' } });
+      const spam2 = await context.query.Post.createOne({ data: { content: 'spam' } });
+      const content = await context.query.Post.createOne({
         data: { content: 'cute cat pics' },
       });
 
-      const spammyUser = await context.lists.User.createOne({
+      const spammyUser = await context.query.User.createOne({
         data: {
           company: { connect: { id: adsCompany.id } },
           posts: { connect: [{ id: spam1.id }, { id: spam2.id }] },
         },
       });
-      const mixedUser = await context.lists.User.createOne({
+      const mixedUser = await context.query.User.createOne({
         data: {
           company: { connect: { id: adsCompany.id } },
           posts: { connect: [{ id: spam1.id }, { id: content.id }] },
         },
       });
-      const nonSpammyUser = await context.lists.User.createOne({
+      const nonSpammyUser = await context.query.User.createOne({
         data: {
           company: { connect: { id: adsCompany.id } },
           posts: { connect: [{ id: content.id }] },
         },
       });
-      const quietUser = await context.lists.User.createOne({
+      const quietUser = await context.query.User.createOne({
         data: { company: { connect: { id: adsCompany.id } } },
       });
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: {
           company: { connect: { id: otherCompany.id } },
           posts: { connect: [{ id: content.id }] },
         },
       });
-      await context.lists.User.createOne({
+      await context.query.User.createOne({
         data: {
           company: { connect: { id: otherCompany.id } },
           posts: { connect: [{ id: spam1.id }] },
@@ -204,7 +204,7 @@ describe('relationship filtering', () => {
         company: { id: IdType; name: string };
         posts: { content: string }[];
       }[];
-      const users = (await context.lists.User.findMany({
+      const users = (await context.query.User.findMany({
         where: {
           company: { name: { equals: adsCompany.name } },
           posts: { every: { content: { equals: 'spam' } } },
@@ -217,7 +217,7 @@ describe('relationship filtering', () => {
       expect(users.map(u => u.posts.every(p => p.content === 'spam'))).toEqual([true, true]);
 
       // adsCompany users with no spam
-      const users2 = (await context.lists.User.findMany({
+      const users2 = (await context.query.User.findMany({
         where: {
           company: { name: { equals: adsCompany.name } },
           posts: { none: { content: { equals: 'spam' } } },
@@ -231,7 +231,7 @@ describe('relationship filtering', () => {
       expect(users2.map(u => u.posts.every(p => p.content !== 'spam'))).toEqual([true, true]);
 
       // adsCompany users with some spam
-      const users3 = (await context.lists.User.findMany({
+      const users3 = (await context.query.User.findMany({
         where: {
           company: { name: { equals: adsCompany.name } },
           posts: { some: { content: { equals: 'spam' } } },

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -24,18 +24,18 @@ describe('relationship filtering', () => {
   test(
     'nested to-many relationships can be filtered',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = (await context.lists.User.findMany({
+      const users = (await context.query.User.findMany({
         query: `id posts (where: { content: { contains: "hi" } }){ id content }`,
       })) as { id: IdType; posts: { id: IdType; content: string }[] }[];
       expect(users).toHaveLength(2);
@@ -51,18 +51,18 @@ describe('relationship filtering', () => {
   test.skip(
     'nested to-many relationships can be limited',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query: 'id posts(take: 1, orderBy: { content: asc }) { id }',
       });
       expect(users).toContainEqual({ id: user.id, posts: [ids[0]] });
@@ -73,18 +73,18 @@ describe('relationship filtering', () => {
   test(
     'nested to-many relationships can be filtered within AND clause',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query:
           'id posts(where: { AND: [{ content: { contains: "hi" } }, { content: { contains: "lo" } }] }){ id }',
       });
@@ -97,18 +97,18 @@ describe('relationship filtering', () => {
   test(
     'nested to-many relationships can be filtered within OR clause',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query:
           'id posts(where: { OR: [{ content: { contains: "i w" } }, { content: { contains: "? O" } }] }){ id content }',
       });
@@ -126,9 +126,9 @@ describe('relationship filtering', () => {
   test(
     'Filtering out all items by nested field should return []',
     runner(async ({ context }) => {
-      await context.lists.User.createOne({ data: {} });
+      await context.query.User.createOne({ data: {} });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         where: { posts: { some: { content: { contains: 'foo' } } } },
         query: 'posts { id }',
       });
@@ -141,18 +141,18 @@ describe('relationship meta filtering', () => {
   test(
     'nested to-many relationships return meta info',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({ query: 'id postsCount' });
+      const users = await context.query.User.findMany({ query: 'id postsCount' });
       expect(users).toHaveLength(2);
       expect(users).toContainEqual({ id: user.id, postsCount: 3 });
       expect(users).toContainEqual({ id: user2.id, postsCount: 1 });
@@ -162,18 +162,18 @@ describe('relationship meta filtering', () => {
   test(
     'nested to-many relationship meta can be filtered',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query: 'id postsCount(where: { content: { contains: "hi" } })',
       });
       expect(users).toHaveLength(2);
@@ -185,18 +185,18 @@ describe('relationship meta filtering', () => {
   test(
     'nested to-many relationship meta can be filtered within AND clause',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query: `id postsCount(where: { AND: [{ content: { contains: "hi" } }, { content: { contains: "lo" } }] })`,
       });
 
@@ -209,18 +209,18 @@ describe('relationship meta filtering', () => {
   test(
     'nested to-many relationship meta can be filtered within OR clause',
     runner(async ({ context }) => {
-      const ids = await context.lists.Post.createMany({
+      const ids = await context.query.Post.createMany({
         data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
       });
 
-      const [user, user2] = await context.lists.User.createMany({
+      const [user, user2] = await context.query.User.createMany({
         data: [
           { posts: { connect: ids } },
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
 
-      const users = await context.lists.User.findMany({
+      const users = await context.query.User.findMany({
         query:
           'id postsCount(where: { OR: [{ content: { contains: "i w" } }, { content: { contains: "? O" } }] })',
       });

--- a/tests/api-tests/relationships/many-to-one-to-one.test.ts
+++ b/tests/api-tests/relationships/many-to-one-to-one.test.ts
@@ -10,14 +10,14 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 type IdType = any;
 
 const createInitialData = async (context: KeystoneContext) => {
-  const companies = (await context.lists.Company.createMany({
+  const companies = (await context.query.Company.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
     ],
   })) as { id: IdType }[];
-  const locations = (await context.lists.Location.createMany({
+  const locations = (await context.query.Location.createMany({
     data: [
       { name: sampleOne(alphanumGenerator) },
       { name: sampleOne(alphanumGenerator) },
@@ -25,10 +25,10 @@ const createInitialData = async (context: KeystoneContext) => {
       { name: sampleOne(alphanumGenerator) },
     ],
   })) as { id: IdType }[];
-  const owners = await context.lists.Owner.createMany({
+  const owners = await context.query.Owner.createMany({
     data: companies.map(({ id }) => ({ name: `Owner_of_${id}`, companies: { connect: [{ id }] } })),
   });
-  const custodians = await context.lists.Custodian.createMany({
+  const custodians = await context.query.Custodian.createMany({
     data: locations.map(({ id }) => ({
       name: `Custodian_of_${id}`,
       locations: { connect: [{ id }] },
@@ -38,11 +38,11 @@ const createInitialData = async (context: KeystoneContext) => {
 };
 
 const createCompanyAndLocation = async (context: KeystoneContext) => {
-  const [cu1, cu2] = await context.lists.Custodian.createMany({
+  const [cu1, cu2] = await context.query.Custodian.createMany({
     data: [{ name: sampleOne(alphanumGenerator) }, { name: sampleOne(alphanumGenerator) }],
   });
 
-  return context.lists.Owner.createOne({
+  return context.query.Owner.createOne({
     data: {
       name: sampleOne(alphanumGenerator),
       companies: {
@@ -122,7 +122,7 @@ describe(`One-to-one relationships`, () => {
         await createInitialData(context);
         const owner = await createCompanyAndLocation(context);
         const name1 = owner.companies[0].location.custodians[0].name;
-        const owners = await context.lists.Owner.findMany({
+        const owners = await context.query.Owner.findMany({
           where: {
             companies: {
               some: { location: { custodians: { some: { name: { equals: name1 } } } } },
@@ -140,7 +140,7 @@ describe(`One-to-one relationships`, () => {
         await createInitialData(context);
         const owner = await createCompanyAndLocation(context);
         const name1 = owner.name;
-        const custodians = await context.lists.Custodian.findMany({
+        const custodians = await context.query.Custodian.findMany({
           where: {
             locations: { some: { company: { owners: { some: { name: { equals: name1 } } } } } },
           },
@@ -155,7 +155,7 @@ describe(`One-to-one relationships`, () => {
         await createInitialData(context);
         const owner = await createCompanyAndLocation(context);
         const name1 = owner.name;
-        const owners = await context.lists.Owner.findMany({
+        const owners = await context.query.Owner.findMany({
           where: {
             companies: {
               some: {
@@ -184,7 +184,7 @@ describe(`One-to-one relationships`, () => {
         const owner = await createCompanyAndLocation(context);
         const name1 = owner.companies[0].location.custodians[0].name;
 
-        const custodians = await context.lists.Custodian.findMany({
+        const custodians = await context.query.Custodian.findMany({
           where: {
             locations: {
               some: {

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -59,10 +59,10 @@ describe('no access control', () => {
       const noteContent = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
 
       // Create an item that does the linking
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { username: 'A thing', notes: { connect: [{ id: createNote.id }] } },
         query: 'id notes { id }',
       });
@@ -70,7 +70,7 @@ describe('no access control', () => {
       expect(user).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
 
       // Create an item that does the linking
-      const user1 = await context.lists.User.createOne({
+      const user1 = await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }, { id: createNote.id }] },
@@ -81,7 +81,7 @@ describe('no access control', () => {
       expect(user1).toMatchObject({ id: expect.any(String), notes: expect.any(Array) });
 
       // Test an empty list of related notes
-      const user2 = await context.lists.User.createOne({
+      const user2 = await context.query.User.createOne({
         data: { username: 'A thing', notes: { connect: [] } },
         query: 'id notes { id }',
       });
@@ -97,13 +97,13 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item that does the linking
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: [
           { username: 'A thing 1', notes: { connect: [{ id: createNote.id }] } },
           { username: 'A thing 2', notes: { connect: [{ id: createNote2.id }] } },
@@ -121,16 +121,16 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({ data: { username: 'A thing' } });
+      const createUser = await context.query.User.createOne({ data: { username: 'A thing' } });
 
       // Update the item and link the relationship field
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: { username: 'A thing', notes: { connect: [{ id: createNote.id }] } },
         query: 'id notes { id content }',
@@ -142,7 +142,7 @@ describe('no access control', () => {
       });
 
       // Update the item and link multiple relationship fields
-      const _user = await context.lists.User.updateOne({
+      const _user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: {
           username: 'A thing',
@@ -167,18 +167,18 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: { username: 'A thing', notes: { connect: [{ id: createNote.id }] } },
       });
 
       // Update the item and link the relationship field
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: { username: 'A thing', notes: { connect: [{ id: createNote2.id }] } },
         query: 'id notes { id content }',
@@ -201,21 +201,21 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: {
           username: 'user1',
           notes: { connect: [{ id: createNote.id }, { id: createNote2.id }] },
         },
       });
-      const createUser2 = await context.lists.User.createOne({ data: { username: 'user2' } });
+      const createUser2 = await context.query.User.createOne({ data: { username: 'user2' } });
 
-      const users = await context.lists.User.updateMany({
+      const users = await context.query.User.updateMany({
         data: [
           {
             where: { id: createUser.id },
@@ -269,7 +269,7 @@ describe('non-matching filter', () => {
       const FAKE_ID = 'cabc123';
 
       // Create an item to link against
-      const createUser = await context.lists.User.createOne({ data: {} });
+      const createUser = await context.query.User.createOne({ data: {} });
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -302,7 +302,7 @@ describe('non-matching filter', () => {
     'errors on incomplete data',
     runner(async ({ context }) => {
       // Create an item to link against
-      const createUser = await context.lists.User.createOne({ data: {} });
+      const createUser = await context.query.User.createOne({ data: {} });
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -337,7 +337,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNoteNoRead = await context.sudo().lists.NoteNoRead.createOne({
+        const createNoteNoRead = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
@@ -369,12 +369,12 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNote = await context.sudo().lists.NoteNoRead.createOne({
+        const createNote = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
         // Create an item to update
-        const createUser = await context.sudo().lists.UserToNotesNoRead.createOne({
+        const createUser = await context.sudo().query.UserToNotesNoRead.createOne({
           data: { username: 'A thing' },
         });
 
@@ -412,12 +412,12 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNoteNoCreate = await context.sudo().lists.NoteNoCreate.createOne({
+        const createNoteNoCreate = await context.sudo().query.NoteNoCreate.createOne({
           data: { content: noteContent },
         });
 
         // Create an item that does the linking
-        const data = await context.lists.UserToNotesNoCreate.createOne({
+        const data = await context.query.UserToNotesNoCreate.createOne({
           data: { username: 'A thing', notes: { connect: [{ id: createNoteNoCreate.id }] } },
         });
 
@@ -431,17 +431,17 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNote = await context.sudo().lists.NoteNoCreate.createOne({
+        const createNote = await context.sudo().query.NoteNoCreate.createOne({
           data: { content: noteContent },
         });
 
         // Create an item to update
-        const createUser = await context.sudo().lists.UserToNotesNoCreate.createOne({
+        const createUser = await context.sudo().query.UserToNotesNoCreate.createOne({
           data: { username: 'A thing' },
         });
 
         // Update the item and link the relationship field
-        const data = await context.lists.UserToNotesNoCreate.updateOne({
+        const data = await context.query.UserToNotesNoCreate.updateOne({
           where: { id: createUser.id },
           data: { username: 'A thing', notes: { connect: [{ id: createNote.id }] } },
         });

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -97,10 +97,10 @@ describe('no access control', () => {
       const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
       // Create an item to link against
-      const createGroup = await context.lists.Group.createOne({ data: { name: groupName } });
+      const createGroup = await context.query.Group.createOne({ data: { name: groupName } });
 
       // Create an item that does the linking
-      const event = await context.lists.Event.createOne({
+      const event = await context.query.Event.createOne({
         data: { title: 'A thing', group: { connect: { id: createGroup.id } } },
       });
 
@@ -114,13 +114,13 @@ describe('no access control', () => {
       const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
       // Create an item to link against
-      const createGroup = await context.lists.Group.createOne({ data: { name: groupName } });
+      const createGroup = await context.query.Group.createOne({ data: { name: groupName } });
 
       // Create an item to update
-      const event = await context.lists.Event.createOne({ data: { title: 'A thing' } });
+      const event = await context.query.Event.createOne({ data: { title: 'A thing' } });
 
       // Update the item and link the relationship field
-      const _event = await context.lists.Event.updateOne({
+      const _event = await context.query.Event.updateOne({
         where: { id: event.id },
         data: { title: 'A thing', group: { connect: { id: createGroup.id } } },
         query: 'id group { id name }',
@@ -167,7 +167,7 @@ describe('non-matching filter', () => {
       const FAKE_ID = 'cabc123';
 
       // Create an item to link against
-      const createEvent = await context.lists.Event.createOne({ data: {} });
+      const createEvent = await context.query.Event.createOne({ data: {} });
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -196,7 +196,7 @@ describe('non-matching filter', () => {
     'errors on incomplete data',
     runner(async ({ context }) => {
       // Create an item to link against
-      const createEvent = await context.lists.Event.createOne({ data: {} });
+      const createEvent = await context.query.Event.createOne({ data: {} });
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -239,13 +239,13 @@ describe('with access control', () => {
 
             // Create an item to link against
             // We can't use the graphQL query here (it's `create: () => false`)
-            const { id } = await context.sudo().lists[group.name].createOne({
+            const { id } = await context.sudo().query[group.name].createOne({
               data: { name: groupName },
             });
             expect(id).toBeTruthy();
 
             // Create an item that does the linking
-            const data = await context.lists[`EventTo${group.name}`].createOne({
+            const data = await context.query[`EventTo${group.name}`].createOne({
               data: { title: 'A thing', group: { connect: { id } } },
               query: 'id group { id }',
             });
@@ -259,19 +259,19 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to link against
-            const groupModel = await context.sudo().lists[group.name].createOne({
+            const groupModel = await context.sudo().query[group.name].createOne({
               data: { name: groupName },
             });
             expect(groupModel.id).toBeTruthy();
 
             // Create an item to update
-            const eventModel = await context.sudo().lists[`EventTo${group.name}`].createOne({
+            const eventModel = await context.sudo().query[`EventTo${group.name}`].createOne({
               data: { title: 'A Thing' },
             });
             expect(eventModel.id).toBeTruthy();
 
             // Update the item and link the relationship field
-            const data = await context.lists[`EventTo${group.name}`].updateOne({
+            const data = await context.query[`EventTo${group.name}`].updateOne({
               where: { id: eventModel.id },
               data: { title: 'A thing', group: { connect: { id: groupModel.id } } },
               query: 'id group { id name }',
@@ -283,7 +283,7 @@ describe('with access control', () => {
             });
 
             // See that it actually stored the group ID on the Event record
-            const event = await context.sudo().lists[`EventTo${group.name}`].findOne({
+            const event = await context.sudo().query[`EventTo${group.name}`].findOne({
               where: { id: data.id },
               query: 'id group { id name }',
             });
@@ -299,13 +299,13 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to link against
-            const groupModel = await context.sudo().lists[group.name].createOne({
+            const groupModel = await context.sudo().query[group.name].createOne({
               data: { name: groupName },
             });
             expect(groupModel.id).toBeTruthy();
 
             // Create an item to update
-            const eventModel = await context.lists[`EventTo${group.name}`].createOne({
+            const eventModel = await context.query[`EventTo${group.name}`].createOne({
               data: { title: 'A thing' },
             });
             expect(eventModel.id).toBeTruthy();
@@ -341,7 +341,7 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to link against
-            const { id } = await context.sudo().lists[group.name].createOne({
+            const { id } = await context.sudo().query[group.name].createOne({
               data: { name: groupName },
             });
             expect(id).toBeTruthy();

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -62,11 +62,11 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
 
       // Create an item that does the linking
       type T = { id: IdType; notes: { id: IdType; content: string }[] };
-      const user = (await context.lists.User.createOne({
+      const user = (await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }], create: [{ content: noteContent2 }] },
@@ -83,7 +83,7 @@ describe('no access control', () => {
       });
 
       // Sanity check that the items are actually created
-      const allNotes = await context.lists.Note.findMany({
+      const allNotes = await context.query.Note.findMany({
         where: { id: { in: user.notes.map(({ id }) => id) } },
         query: 'id content',
       });
@@ -99,14 +99,14 @@ describe('no access control', () => {
       const noteContent2 = sampleOne(alphanumGenerator);
 
       // Create an item to link against
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({ data: { username: 'A thing' } });
+      const createUser = await context.query.User.createOne({ data: { username: 'A thing' } });
 
       // Update the item and link the relationship field
       type T = { id: IdType; notes: { id: IdType; content: string }[] };
-      const user = (await context.lists.User.updateOne({
+      const user = (await context.query.User.updateOne({
         where: { id: createUser.id },
         data: {
           username: 'A thing',
@@ -124,7 +124,7 @@ describe('no access control', () => {
       });
 
       // Sanity check that the items are actually created
-      const allNotes = await context.lists.Note.findMany({
+      const allNotes = await context.query.Note.findMany({
         where: { id: { in: user.notes.map(({ id }) => id) } },
         query: 'id content',
       });
@@ -169,7 +169,7 @@ describe('with access control', () => {
         const noteContent2 = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNoteNoRead = await context.sudo().lists.NoteNoRead.createOne({
+        const createNoteNoRead = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
@@ -206,12 +206,12 @@ describe('with access control', () => {
         const noteContent2 = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNote = await context.sudo().lists.NoteNoRead.createOne({
+        const createNote = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
         // Create an item to update
-        const createUser = await context.lists.UserToNotesNoRead.createOne({
+        const createUser = await context.query.UserToNotesNoRead.createOne({
           data: { username: 'A thing' },
         });
 

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -83,7 +83,7 @@ test(
   'afterChange is called for nested creates',
   runner2(async ({ context }) => {
     // Update an item that does the nested create
-    const item = await context.lists.User.createOne({
+    const item = await context.query.User.createOne({
       data: { username: 'something', notes: { create: [{ content: 'some content' }] } },
       query: 'username notes {content}',
     });
@@ -100,7 +100,7 @@ describe('no access control', () => {
       const noteContent3 = `c${sampleOne(alphanumGenerator)}`;
 
       // Create an item that does the nested create
-      const user = await context.lists.User.createOne({
+      const user = await context.query.User.createOne({
         data: { username: 'A thing', notes: { create: [{ content: noteContent }] } },
         query: 'id notes(orderBy: { content: asc }) { id content }',
       });
@@ -113,7 +113,7 @@ describe('no access control', () => {
       // Create an item that does the nested create
       type T = { id: IdType; notes: { id: IdType; content: string }[] };
 
-      const user1 = (await context.lists.User.createOne({
+      const user1 = (await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { create: [{ content: noteContent2 }, { content: noteContent3 }] },
@@ -130,13 +130,13 @@ describe('no access control', () => {
       });
 
       // Sanity check that the items are actually created
-      const notes = await context.lists.Note.findMany({
+      const notes = await context.query.Note.findMany({
         where: { id: { in: user1.notes.map(({ id }) => id) } },
       });
       expect(notes).toHaveLength(user1.notes.length);
 
       // Test an empty list of related notes
-      const user2 = await context.lists.User.createOne({
+      const user2 = await context.query.User.createOne({
         data: { username: 'A thing', notes: { create: [] } },
         query: 'id notes { id }',
       });
@@ -152,10 +152,10 @@ describe('no access control', () => {
       const noteContent3 = `c${sampleOne(alphanumGenerator)}`;
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({ data: { username: 'A thing' } });
+      const createUser = await context.query.User.createOne({ data: { username: 'A thing' } });
 
       // Update an item that does the nested create
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: { username: 'A thing', notes: { create: [{ content: noteContent }] } },
         query: 'id notes { id content }',
@@ -167,7 +167,7 @@ describe('no access control', () => {
       });
 
       type T = { id: IdType; notes: { id: IdType; content: string }[] };
-      const _user = (await context.lists.User.updateOne({
+      const _user = (await context.query.User.updateOne({
         where: { id: createUser.id },
         data: {
           username: 'A thing',
@@ -186,7 +186,7 @@ describe('no access control', () => {
       });
 
       // Sanity check that the items are actually created
-      const notes = await context.lists.Note.findMany({
+      const notes = await context.query.Note.findMany({
         where: { id: { in: _user.notes.map(({ id }) => id) } },
       });
       expect(notes).toHaveLength(_user.notes.length);
@@ -251,7 +251,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to update
-        const createUser = await context.lists.UserToNotesNoRead.createOne({
+        const createUser = await context.query.UserToNotesNoRead.createOne({
           data: { username: 'A thing' },
         });
 
@@ -306,10 +306,10 @@ describe('with access control', () => {
         ]);
 
         // Confirm it didn't insert either of the records anyway
-        const allNoteNoCreates = await context.lists.NoteNoCreate.findMany({
+        const allNoteNoCreates = await context.query.NoteNoCreate.findMany({
           where: { content: { equals: noteContent } },
         });
-        const allUserToNotesNoCreates = await context.lists.UserToNotesNoCreate.findMany({
+        const allUserToNotesNoCreates = await context.query.UserToNotesNoCreate.findMany({
           where: { username: { equals: userName } },
         });
         expect(allNoteNoCreates).toMatchObject([]);
@@ -323,7 +323,7 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to update
-        const createUserToNotesNoCreate = await context.lists.UserToNotesNoCreate.createOne({
+        const createUserToNotesNoCreate = await context.query.UserToNotesNoCreate.createOne({
           data: { username: 'A thing' },
         });
 
@@ -354,7 +354,7 @@ describe('with access control', () => {
         ]);
 
         // Confirm it didn't insert the record anyway
-        const items = await context.lists.NoteNoCreate.findMany({
+        const items = await context.query.NoteNoCreate.findMany({
           where: { content: { equals: noteContent } },
         });
         expect(items).toMatchObject([]);

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -114,7 +114,7 @@ describe('no access control', () => {
       const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
       // Create an item that does the nested create
-      const event = await context.lists.Event.createOne({
+      const event = await context.query.Event.createOne({
         data: { title: 'A thing', group: { create: { name: groupName } } },
         query: 'id group { id name }',
       });
@@ -124,7 +124,7 @@ describe('no access control', () => {
         group: { id: expect.any(String), name: groupName },
       });
 
-      const group = await context.lists.Group.findOne({
+      const group = await context.query.Group.findOne({
         where: { id: event.group.id },
         query: 'id name',
       });
@@ -138,10 +138,10 @@ describe('no access control', () => {
       const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
       // Create an item to update
-      const createEvent = await context.lists.Event.createOne({ data: { title: 'A thing' } });
+      const createEvent = await context.query.Event.createOne({ data: { title: 'A thing' } });
 
       // Update an item that does the nested create
-      const event = await context.lists.Event.updateOne({
+      const event = await context.query.Event.updateOne({
         where: { id: createEvent.id },
         data: { title: 'A thing', group: { create: { name: groupName } } },
         query: 'id group { id name }',
@@ -152,7 +152,7 @@ describe('no access control', () => {
         group: { id: expect.any(String), name: groupName },
       });
 
-      const group = await context.lists.Group.findOne({
+      const group = await context.query.Group.findOne({
         where: { id: event.group.id },
         query: 'id name',
       });
@@ -178,14 +178,14 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item that does the nested create{
-            const data = await context.lists[`EventTo${group.name}`].createOne({
+            const data = await context.query[`EventTo${group.name}`].createOne({
               data: { title: 'A thing', group: { create: { name: groupName } } },
             });
 
             expect(data).toMatchObject({ id: expect.any(String) });
 
             // See that it actually stored the group ID on the Event record
-            const event = await context.sudo().lists[`EventTo${group.name}`].findOne({
+            const event = await context.sudo().query[`EventTo${group.name}`].findOne({
               where: { id: data.id },
               query: 'id group { id name }',
             });
@@ -201,12 +201,12 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to update
-            const eventModel = await context.lists[`EventTo${group.name}`].createOne({
+            const eventModel = await context.query[`EventTo${group.name}`].createOne({
               data: { title: 'A thing' },
             });
 
             // Update an item that does the nested create
-            const data = await context.lists[`EventTo${group.name}`].updateOne({
+            const data = await context.query[`EventTo${group.name}`].updateOne({
               where: { id: eventModel.id },
               data: { title: 'A thing', group: { create: { name: groupName } } },
             });
@@ -214,7 +214,7 @@ describe('with access control', () => {
             expect(data).toMatchObject({ id: expect.any(String) });
 
             // See that it actually stored the group ID on the Event record
-            const event = await context.sudo().lists[`EventTo${group.name}`].findOne({
+            const event = await context.sudo().query[`EventTo${group.name}`].findOne({
               where: { id: data.id },
               query: 'id group { id name }',
             });
@@ -264,14 +264,14 @@ describe('with access control', () => {
               ]);
             }
             // Confirm it didn't insert either of the records anyway
-            const data1 = await context.sudo().lists[group.name].findMany({
+            const data1 = await context.sudo().query[group.name].findMany({
               where: { name: { equals: groupName } },
               query: 'id name',
             });
             expect(data1).toMatchObject([]);
 
             // Confirm it didn't insert either of the records anyway
-            const data2 = await context.sudo().lists[`EventTo${group.name}`].findMany({
+            const data2 = await context.sudo().query[`EventTo${group.name}`].findMany({
               where: { title: { equals: eventName } },
               query: 'id title',
             });
@@ -285,7 +285,7 @@ describe('with access control', () => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to update
-            const eventModel = await context.lists[`EventTo${group.name}`].createOne({
+            const eventModel = await context.query[`EventTo${group.name}`].createOne({
               data: { title: 'A thing' },
             });
 
@@ -325,7 +325,7 @@ describe('with access control', () => {
             }
 
             // Confirm it didn't insert the record anyway
-            const groups = await context.sudo().lists[group.name].findMany({
+            const groups = await context.sudo().query[group.name].findMany({
               where: { name: { equals: groupName } },
               query: 'id name',
             });

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -60,13 +60,13 @@ describe('no access control', () => {
       const noteContent2 = `foo${sampleOne(alphanumGenerator)}`;
 
       // Create two items with content that can be matched
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }, { id: createNote2.id }] },
@@ -74,7 +74,7 @@ describe('no access control', () => {
       });
 
       // Update the item and link the relationship field
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: { username: 'A thing', notes: { disconnect: [{ id: createNote2.id }] } },
         query: 'id notes { id content }',
@@ -113,7 +113,7 @@ describe('non-matching filter', () => {
     'errors if items to disconnect cannot be found during update',
     runner(async ({ context }) => {
       // Create an item to link against
-      const createUser = await context.lists.User.createOne({ data: {} });
+      const createUser = await context.query.User.createOne({ data: {} });
 
       // Create an item that does the linking
       const { data, errors } = await context.graphql.raw({
@@ -148,12 +148,12 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNote = await context.sudo().lists.NoteNoRead.createOne({
+        const createNote = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
         // Create an item to update
-        const createUser = await context.sudo().lists.UserToNotesNoRead.createOne({
+        const createUser = await context.sudo().query.UserToNotesNoRead.createOne({
           data: {
             username: 'A thing',
             notes: { connect: [{ id: createNote.id }] },
@@ -183,7 +183,7 @@ describe('with access control', () => {
           ]);
         }
 
-        const data = await context.sudo().lists.UserToNotesNoRead.findOne({
+        const data = await context.sudo().query.UserToNotesNoRead.findOne({
           where: { id: createUser.id },
           query: 'id notes { id }',
         });

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -44,10 +44,10 @@ describe('no access control', () => {
     runner(async ({ context }) => {
       const groupName = `foo${sampleOne(alphanumGenerator)}`;
 
-      const createGroup = await context.lists.Group.createOne({ data: { name: groupName } });
+      const createGroup = await context.query.Group.createOne({ data: { name: groupName } });
 
       // Create an item to update
-      const createEvent = await context.lists.Event.createOne({
+      const createEvent = await context.query.Event.createOne({
         data: { title: 'A thing', group: { connect: { id: createGroup.id } } },
         query: 'id group { id }',
       });
@@ -57,7 +57,7 @@ describe('no access control', () => {
       expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
       // Update the item and link the relationship field
-      const event = await context.lists.Event.updateOne({
+      const event = await context.query.Event.updateOne({
         where: { id: createEvent.id },
         data: { group: { disconnect: true } },
         query: 'id group { id }',
@@ -66,7 +66,7 @@ describe('no access control', () => {
       expect(event).toMatchObject({ id: expect.any(String), group: null });
 
       // Avoid false-positives by checking the database directly
-      const eventData = await context.lists.Event.findOne({
+      const eventData = await context.query.Event.findOne({
         where: { id: createEvent.id },
         query: 'id group { id }',
       });
@@ -102,10 +102,10 @@ describe('no access control', () => {
     'silently succeeds if no item to disconnect during update',
     runner(async ({ context }) => {
       // Create an item to link against
-      const createEvent = await context.lists.Event.createOne({ data: {} });
+      const createEvent = await context.query.Event.createOne({ data: {} });
 
       // Create an item that does the linking
-      const event = await context.lists.Event.updateOne({
+      const event = await context.query.Event.updateOne({
         where: { id: createEvent.id },
         data: { group: { disconnect: true } },
         query: 'id group { id }',
@@ -124,12 +124,12 @@ describe('with access control', () => {
         const groupName = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createGroup = await context.sudo().lists.GroupNoRead.createOne({
+        const createGroup = await context.sudo().query.GroupNoRead.createOne({
           data: { name: groupName },
         });
 
         // Create an item to update
-        const createEvent = await context.sudo().lists.EventToGroupNoRead.createOne({
+        const createEvent = await context.sudo().query.EventToGroupNoRead.createOne({
           data: { group: { connect: { id: createGroup.id } } },
           query: 'id group { id }',
         });
@@ -139,13 +139,13 @@ describe('with access control', () => {
         expect(createEvent.group.id.toString()).toBe(createGroup.id);
 
         // Update the item and link the relationship field
-        await context.lists.EventToGroupNoRead.updateOne({
+        await context.query.EventToGroupNoRead.updateOne({
           where: { id: createEvent.id },
           data: { group: { disconnect: true } },
         });
 
         // Avoid false-positives by checking the database directly
-        const eventData = await context.sudo().lists.EventToGroupNoRead.findOne({
+        const eventData = await context.sudo().query.EventToGroupNoRead.findOne({
           where: { id: createEvent.id },
           query: 'id group { id }',
         });

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -29,18 +29,18 @@ describe('Reconnect', () => {
     'Reconnect from the many side',
     runner(async ({ context }) => {
       // Create some notes
-      const [noteA, noteB, noteC, noteD] = await context.lists.Note.createMany({
+      const [noteA, noteB, noteC, noteD] = await context.query.Note.createMany({
         data: [{ title: 'A' }, { title: 'B' }, { title: 'C' }, { title: 'D' }],
       });
 
       // Create some users that does the linking
       type T = { id: IdType; notes: { id: IdType; title: string }[] };
-      const alice = (await context.lists.User.createOne({
+      const alice = (await context.query.User.createOne({
         data: { username: 'Alice', notes: { connect: [{ id: noteA.id }, { id: noteB.id }] } },
         query: 'id notes(orderBy: { title: asc }) { id title }',
       })) as T;
 
-      const bob = (await context.lists.User.createOne({
+      const bob = (await context.query.User.createOne({
         data: { username: 'Bob', notes: { connect: [{ id: noteC.id }, { id: noteD.id }] } },
         query: 'id notes(orderBy: { title: asc }) { id title }',
       })) as T;
@@ -54,7 +54,7 @@ describe('Reconnect', () => {
       // Set Bob as the author of note B
       await (async () => {
         type T = { id: IdType; notes: { id: IdType; title: string }[] };
-        const user = (await context.lists.User.updateOne({
+        const user = (await context.query.User.updateOne({
           where: { id: bob.id },
           data: { notes: { connect: [{ id: noteB.id }] } },
           query: 'id notes(orderBy: { title: asc }) { id title }',
@@ -66,7 +66,7 @@ describe('Reconnect', () => {
 
       // B should see Bob as its author
       await (async () => {
-        const note = await context.lists.Note.findOne({
+        const note = await context.query.Note.findOne({
           where: { id: noteB.id },
           query: 'id author { id username }',
         });
@@ -76,7 +76,7 @@ describe('Reconnect', () => {
       // Alice should no longer see `B` in her notes
       await (async () => {
         type T = { id: IdType; notes: { id: IdType; title: string }[] };
-        const user = (await context.lists.User.findOne({
+        const user = (await context.query.User.findOne({
           where: { id: alice.id },
           query: 'id notes(orderBy: { title: asc }) { id title }',
         })) as T;

--- a/tests/api-tests/relationships/nested-mutations/set-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/set-many.test.ts
@@ -60,13 +60,13 @@ describe('no access control', () => {
       const noteContent2 = `foo${sampleOne(alphanumGenerator)}`;
 
       // Create two items with content that can be matched
-      const createNote = await context.lists.Note.createOne({ data: { content: noteContent } });
-      const createNote2 = await context.lists.Note.createOne({
+      const createNote = await context.query.Note.createOne({ data: { content: noteContent } });
+      const createNote2 = await context.query.Note.createOne({
         data: { content: noteContent2 },
       });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }, { id: createNote2.id }] },
@@ -74,7 +74,7 @@ describe('no access control', () => {
       });
 
       // Update the item and link the relationship field
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: { username: 'A thing', notes: { set: [] } },
         query: 'id notes { id content }',
@@ -87,12 +87,12 @@ describe('no access control', () => {
   test(
     'set and connect removes all existing items and adds the items specified in set and connect',
     runner(async ({ context }) => {
-      const createNote = await context.lists.Note.createOne({ data: {} });
-      const createNote2 = await context.lists.Note.createOne({ data: {} });
-      const createNote3 = await context.lists.Note.createOne({ data: {} });
+      const createNote = await context.query.Note.createOne({ data: {} });
+      const createNote2 = await context.query.Note.createOne({ data: {} });
+      const createNote3 = await context.query.Note.createOne({ data: {} });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }] },
@@ -100,7 +100,7 @@ describe('no access control', () => {
       });
 
       // Update the item and link the relationship field
-      const user = await context.lists.User.updateOne({
+      const user = await context.query.User.updateOne({
         where: { id: createUser.id },
         data: {
           username: 'A thing',
@@ -118,10 +118,10 @@ describe('no access control', () => {
   test(
     'set and disconnect throws an error',
     runner(async ({ context }) => {
-      const createNote = await context.lists.Note.createOne({ data: {} });
+      const createNote = await context.query.Note.createOne({ data: {} });
 
       // Create an item to update
-      const createUser = await context.lists.User.createOne({
+      const createUser = await context.query.User.createOne({
         data: {
           username: 'A thing',
           notes: { connect: [{ id: createNote.id }] },
@@ -182,12 +182,12 @@ describe('with access control', () => {
         const noteContent = sampleOne(alphanumGenerator);
 
         // Create an item to link against
-        const createNote = await context.sudo().lists.NoteNoRead.createOne({
+        const createNote = await context.sudo().query.NoteNoRead.createOne({
           data: { content: noteContent },
         });
 
         // Create an item to update
-        const createUser = await context.sudo().lists.UserToNotesNoRead.createOne({
+        const createUser = await context.sudo().query.UserToNotesNoRead.createOne({
           data: {
             username: 'A thing',
             notes: { connect: [{ id: createNote.id }] },
@@ -195,12 +195,12 @@ describe('with access control', () => {
         });
 
         // Update the item and link the relationship field
-        await context.lists.UserToNotesNoRead.updateOne({
+        await context.query.UserToNotesNoRead.updateOne({
           where: { id: createUser.id },
           data: { username: 'A thing', notes: { set: [] } },
         });
 
-        const data = await context.sudo().lists.UserToNotesNoRead.findOne({
+        const data = await context.sudo().query.UserToNotesNoRead.findOne({
           where: { id: createUser.id },
           query: 'id notes { id }',
         });

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -31,7 +31,7 @@ const runner = setupTestRunner({
 });
 
 const getTeacher = async (context: KeystoneContext, teacherId: IdType) =>
-  context.lists.Teacher.findOne({
+  context.query.Teacher.findOne({
     where: { id: teacherId },
     query: 'id students { id }',
   });
@@ -63,12 +63,12 @@ describe('update many to many relationship back reference', () => {
       'during create mutation',
       runner(async ({ context }) => {
         // Manually setup a connected Student <-> Teacher
-        let teacher1 = await context.lists.Teacher.createOne({ data: {} });
+        let teacher1 = await context.query.Teacher.createOne({ data: {} });
         await new Promise(resolve => process.nextTick(resolve));
-        let teacher2 = await context.lists.Teacher.createOne({ data: {} });
+        let teacher2 = await context.query.Teacher.createOne({ data: {} });
 
         // canaryStudent is used as a canary to make sure nothing crosses over
-        let canaryStudent = await context.lists.Student.createOne({ data: {} });
+        let canaryStudent = await context.query.Student.createOne({ data: {} });
 
         teacher1 = await getTeacher(context, teacher1.id);
         teacher2 = await getTeacher(context, teacher2.id);
@@ -80,7 +80,7 @@ describe('update many to many relationship back reference', () => {
         expect(toStr(teacher2.students)).toHaveLength(0);
 
         // Run the query to disconnect the teacher from student
-        let newStudent = await context.lists.Student.createOne({
+        let newStudent = await context.query.Student.createOne({
           data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
           query: 'id teachers { id }',
         });
@@ -102,12 +102,12 @@ describe('update many to many relationship back reference', () => {
       'during update mutation',
       runner(async ({ context }) => {
         // Manually setup a connected Student <-> Teacher
-        let teacher1 = await context.lists.Teacher.createOne({ data: {} });
-        let teacher2 = await context.lists.Teacher.createOne({ data: {} });
-        let student1 = await context.lists.Student.createOne({ data: {} });
+        let teacher1 = await context.query.Teacher.createOne({ data: {} });
+        let teacher2 = await context.query.Teacher.createOne({ data: {} });
+        let student1 = await context.query.Student.createOne({ data: {} });
         // Student2 is used as a canary to make sure things don't accidentally
         // cross over
-        let student2 = await context.lists.Student.createOne({ data: {} });
+        let student2 = await context.query.Student.createOne({ data: {} });
 
         teacher1 = await getTeacher(context, teacher1.id);
         teacher2 = await getTeacher(context, teacher2.id);
@@ -121,7 +121,7 @@ describe('update many to many relationship back reference', () => {
         expect(toStr(teacher2.students)).toHaveLength(0);
 
         // Run the query to disconnect the teacher from student
-        await context.lists.Student.updateOne({
+        await context.query.Student.updateOne({
           where: { id: student1.id },
           data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
           query: 'id teachers { id }',
@@ -150,7 +150,7 @@ describe('update many to many relationship back reference', () => {
         const teacherName2 = sampleOne(alphanumGenerator);
 
         // Run the query to disconnect the teacher from student
-        let newStudent = await context.lists.Student.createOne({
+        let newStudent = await context.query.Student.createOne({
           data: { teachers: { create: [{ name: teacherName1 }, { name: teacherName2 }] } },
           query: 'id teachers(orderBy: { id: asc }) { id }',
         });
@@ -171,12 +171,12 @@ describe('update many to many relationship back reference', () => {
     test(
       'during update mutation',
       runner(async ({ context }) => {
-        let student = await context.lists.Student.createOne({ data: {} });
+        let student = await context.query.Student.createOne({ data: {} });
         const teacherName1 = sampleOne(alphanumGenerator);
         const teacherName2 = sampleOne(alphanumGenerator);
 
         // Run the query to disconnect the teacher from student
-        const _student = await context.lists.Student.updateOne({
+        const _student = await context.query.Student.updateOne({
           where: { id: student.id },
           data: { teachers: { create: [{ name: teacherName1 }, { name: teacherName2 }] } },
           query: 'id teachers { id }',
@@ -200,16 +200,16 @@ describe('update many to many relationship back reference', () => {
     'nested disconnect during update mutation',
     runner(async ({ context }) => {
       // Manually setup a connected Student <-> Teacher
-      let teacher1 = await context.lists.Teacher.createOne({ data: {} });
-      let teacher2 = await context.lists.Teacher.createOne({ data: {} });
-      let student1 = await context.lists.Student.createOne({
+      let teacher1 = await context.query.Teacher.createOne({ data: {} });
+      let teacher2 = await context.query.Teacher.createOne({ data: {} });
+      let student1 = await context.query.Student.createOne({
         data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
       });
-      let student2 = await context.lists.Student.createOne({
+      let student2 = await context.query.Student.createOne({
         data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
       });
 
-      await context.lists.Teacher.updateMany({
+      await context.query.Teacher.updateMany({
         data: [
           {
             where: { id: teacher1.id },
@@ -234,7 +234,7 @@ describe('update many to many relationship back reference', () => {
       compareIds(teacher2.students, [student1, student2]);
 
       // Run the query to disconnect the teacher from student
-      await context.lists.Student.updateOne({
+      await context.query.Student.updateOne({
         where: { id: student1.id },
         data: { teachers: { disconnect: [{ id: teacher1.id }] } },
         query: 'id teachers { id }',
@@ -258,16 +258,16 @@ describe('update many to many relationship back reference', () => {
     'nested set: [] during update mutation',
     runner(async ({ context }) => {
       // Manually setup a connected Student <-> Teacher
-      let teacher1 = await context.lists.Teacher.createOne({ data: {} });
-      let teacher2 = await context.lists.Teacher.createOne({ data: {} });
-      let student1 = await context.lists.Student.createOne({
+      let teacher1 = await context.query.Teacher.createOne({ data: {} });
+      let teacher2 = await context.query.Teacher.createOne({ data: {} });
+      let student1 = await context.query.Student.createOne({
         data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
       });
-      let student2 = await context.lists.Student.createOne({
+      let student2 = await context.query.Student.createOne({
         data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
       });
 
-      await context.lists.Teacher.updateMany({
+      await context.query.Teacher.updateMany({
         data: [
           {
             where: { id: teacher1.id },
@@ -292,7 +292,7 @@ describe('update many to many relationship back reference', () => {
       compareIds(teacher2.students, [student1, student2]);
 
       // Run the query to disconnect the teacher from student
-      await context.lists.Student.updateOne({
+      await context.query.Student.updateOne({
         where: { id: student1.id },
         data: { teachers: { set: [] } },
         query: 'id teachers { id }',
@@ -317,16 +317,16 @@ test(
   'delete mutation updates back references in to-many relationship',
   runner(async ({ context }) => {
     // Manually setup a connected Student <-> Teacher
-    let teacher1 = await context.lists.Teacher.createOne({ data: {} });
-    let teacher2 = await context.lists.Teacher.createOne({ data: {} });
-    let student1 = await context.lists.Student.createOne({
+    let teacher1 = await context.query.Teacher.createOne({ data: {} });
+    let teacher2 = await context.query.Teacher.createOne({ data: {} });
+    let student1 = await context.query.Student.createOne({
       data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
     });
-    let student2 = await context.lists.Student.createOne({
+    let student2 = await context.query.Student.createOne({
       data: { teachers: { connect: [{ id: teacher1.id }, { id: teacher2.id }] } },
     });
 
-    await context.lists.Teacher.updateMany({
+    await context.query.Teacher.updateMany({
       data: [
         {
           where: { id: teacher1.id },
@@ -351,7 +351,7 @@ test(
     compareIds(teacher2.students, [student1, student2]);
 
     // Run the query to delete the student
-    await context.lists.Student.deleteOne({ where: { id: student1.id } });
+    await context.query.Student.deleteOne({ where: { id: student1.id } });
     teacher1 = await getTeacher(context, teacher1.id);
     teacher2 = await getTeacher(context, teacher2.id);
     student1 = await getStudent(context, student1.id);

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
@@ -32,7 +32,7 @@ describe('update one to one relationship back reference', () => {
     'nested create',
     runner(async ({ context }) => {
       const locationName = sampleOne(alphanumGenerator);
-      const _company = await context.lists.Company.createOne({
+      const _company = await context.query.Company.createOne({
         data: { location: { create: { name: locationName } } },
         query: 'id location { id }',
       });
@@ -40,7 +40,7 @@ describe('update one to one relationship back reference', () => {
       const companyId = _company.id;
       const locationId = _company.location.id;
 
-      const company = (await context.lists.Company.findOne({
+      const company = (await context.query.Company.findOne({
         where: { id: companyId },
         query: 'id location { id }',
       })) as { id: any; location: { id: any } };

--- a/tests/api-tests/relationships/shared-names.test.ts
+++ b/tests/api-tests/relationships/shared-names.test.ts
@@ -7,15 +7,15 @@ import { apiTestConfig } from '../utils';
 type IdType = any;
 
 const createInitialData = async (context: KeystoneContext) => {
-  const roles = (await context.lists.Role.createMany({
+  const roles = (await context.query.Role.createMany({
     data: [{ name: 'RoleA' }, { name: 'RoleB' }, { name: 'RoleC' }],
     query: 'id name',
   })) as { id: IdType; name: string }[];
-  const companies = (await context.lists.Company.createMany({
+  const companies = (await context.query.Company.createMany({
     data: [{ name: 'CompanyA' }, { name: 'CompanyB' }, { name: 'CompanyC' }],
     query: 'id name',
   })) as { id: IdType; name: string }[];
-  const employees = (await context.lists.Employee.createMany({
+  const employees = (await context.query.Employee.createMany({
     data: [
       {
         name: 'EmployeeA',
@@ -35,7 +35,7 @@ const createInitialData = async (context: KeystoneContext) => {
     ],
     query: 'id name',
   })) as { id: IdType; name: string }[];
-  await context.lists.Location.createMany({
+  await context.query.Location.createMany({
     data: [
       {
         name: 'LocationA',
@@ -64,7 +64,7 @@ const createInitialData = async (context: KeystoneContext) => {
     ],
     query: 'id name',
   });
-  await context.lists.Role.updateMany({
+  await context.query.Role.updateMany({
     data: [
       {
         where: { id: roles.find(({ name }) => name === 'RoleA')!.id },
@@ -128,7 +128,7 @@ test(
   'Query',
   runner(async ({ context }) => {
     await createInitialData(context);
-    const employees = await context.lists.Employee.findMany({
+    const employees = await context.query.Employee.findMany({
       where: { company: { employees: { some: { role: { name: { equals: 'RoleA' } } } } } },
       query: 'id name',
     });

--- a/tests/benchmarks/fixtures/query.js
+++ b/tests/benchmarks/fixtures/query.js
@@ -26,7 +26,7 @@ const group = new FixtureGroup(runner);
 
 group.add({
   fn: async ({ context, provider }) => {
-    const { id: userId } = await context.lists.User.createOne({
+    const { id: userId } = await context.query.User.createOne({
       data: { name: 'test', posts: { create: [] } },
     });
     const query = `query getPost($userId: ID!) { User(where: { id: $userId }) { id } }`;
@@ -37,7 +37,7 @@ group.add({
 
 group.add({
   fn: async ({ context, provider }) => {
-    const { id: userId } = await context.lists.User.createOne({
+    const { id: userId } = await context.query.User.createOne({
       data: { name: 'test', posts: { create: [] } },
     });
     const query = `query getUser($userId: ID!) { User(where: { id: $userId }) { id } }`;
@@ -57,7 +57,7 @@ range(14).forEach(i => {
   group.add({
     fn: async ({ context, provider }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: populate(N, i => ({ name: `test${i}`, posts })),
       });
       const userId = users[0].id;
@@ -85,7 +85,7 @@ range(k).forEach(i => {
   group.add({
     fn: async ({ context, provider }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: populate(N, i => ({ name: `test${i}`, posts })),
       });
       const userId = users[0].id;
@@ -112,7 +112,7 @@ range(14).forEach(i => {
   group.add({
     fn: async ({ context, provider }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: populate(N, i => ({ name: `test${i}`, posts })),
       });
       const userId = users[0].id;
@@ -139,7 +139,7 @@ range(k).forEach(i => {
   group.add({
     fn: async ({ context, provider }) => {
       const posts = { create: populate(M, i => ({ title: `post${i}` })) };
-      const users = await context.lists.User.createMany({
+      const users = await context.query.User.createMany({
         data: populate(N, i => ({ name: `test${i}`, posts })),
       });
       const userId = users[0].id;


### PR DESCRIPTION
(context provided by @JedWatson, this was my idea but @timleslie did the PR)

Based on my experience using and teaching the new Lists and DB APIs to developers picking up Keystone 6, they're both important and unique APIs that you really need to understand how to use well, but it's tricky to explain.

Once you get the mental model you're good but getting there isn't super intuitive. The hope is that this change will improve that for developers starting Keystone 6 or picking up Keystone project codebases in the future.

---

### TL;DR:

> If you want to query fields, use the **Query API**. It's functionally the same as the GraphQL API, available in a server-side context. If you want to retrieve data stored in the database, use the **DB API**. Input arguments, Access control and Hooks work identically in both APIs.

### Updated Reasoning + Explanation:

#### Query API

This lets you run queries and mutations against lists in the Keystone schema, as a shortcut for executing full GraphQL queries yourself. You provide the same input arguments and query the same output fields as in the GraphQL API (behind the scenes this is just sugar for executing queries against the internal schema)

Because it resolves return data through the GraphQL Schema you can query virtual fields, return deeply nested relational data, etc.

#### Database API

This lets you run the same queries and mutations against lists in the Keystone schema that the Query API does, but will return the backing data for each item directly from the database without going through the GraphQL field resolvers.

The only difference is in the return type; the input arguments (for where / data / etc) as well as access control and hooks functionality is identical between both APIs.

The primary use for this API is if you want to return a Keystone item type from a custom query or mutation in your GraphQL extensions.

Additionally, you get all the data stored in the database for the item (equivalent to `select * from {table}`) so you can access some data that fields do not make accessible through their GraphQL resolvers, like password hashes which you would need to query to compare with a candidate when validating a signing attempt (but are never available through the GraphQL API)