### PR TITLE
Updated `Quote` component styles in Docsfield Demo

### DIFF
--- a/examples-staging/basic/admin/fieldViews/Content.tsx
+++ b/examples-staging/basic/admin/fieldViews/Content.tsx
@@ -264,12 +264,22 @@ export const componentBlocks = {
       return (
         <div
           css={{
-            borderLeft: '3px solid #CBD5E0',
             paddingLeft: 16,
+            backgroundColor: '#f3f5f6',
+            padding: '4px 12px 16px 48px',
+            position: 'relative',
+            borderRadius: '6px',
+            ':after': {
+              content: '"\\201C"',
+              position: 'absolute',
+              top: '0',
+              left: '16px',
+              fontSize: '4rem',
+            },
           }}
         >
           <div css={{ fontStyle: 'italic', color: '#4A5568' }}>{content}</div>
-          <div css={{ fontWeight: 'bold', color: '#718096' }}>
+          <div css={{ fontWeight: 'bold', color: '#47546b' }}>
             <NotEditable>— </NotEditable>
             {attribution}
           </div>

--- a/examples-staging/basic/admin/fieldViews/Content.tsx
+++ b/examples-staging/basic/admin/fieldViews/Content.tsx
@@ -268,12 +268,12 @@ export const componentBlocks = {
             backgroundColor: '#f3f5f6',
             padding: '4px 12px 16px 48px',
             position: 'relative',
-            borderRadius: '6px',
+            borderRadius: 6,
             ':after': {
               content: '"\\201C"',
               position: 'absolute',
-              top: '0',
-              left: '16px',
+              top: 0,
+              left: 16,
               fontSize: '4rem',
             },
           }}


### PR DESCRIPTION
Differentiates component styling from the other `chromeful` examples in Docsfield demo