### PR TITLE
Remove `createSchema`

### DIFF
--- a/.changeset/nervous-geese-pump.md
+++ b/.changeset/nervous-geese-pump.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Removed `createSchema` function, you can remove the call to `createSchema` and pass the lists directly to the `lists` property

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -91,11 +91,11 @@ const componentBlocks = {
 type DocumentFieldConfig = Parameters<typeof import('@keystone-next/fields-document').document>[0];
 
 function documentFeaturesCodeExample(config: DocumentFieldConfig | DocumentFeatures) {
-  return `import { config, createSchema, list } from '@keystone-next/keystone';
+  return `import { config, list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: document({
@@ -128,7 +128,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 `;

--- a/docs/pages/docs/apis/access-control.mdx
+++ b/docs/pages/docs/apis/access-control.mdx
@@ -6,18 +6,18 @@ The `access` property of the [list configuration](./schema) object configures wh
 The `access` property of the [field configuration](./fields) object configures who can read, create, and update specific field values of an item.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       fields: {
         fieldName: text({ access: { /* ... */ }, }),
       },
       access: { /* ... */ },
     }),
-  }),
+  },
 });
 ```
 
@@ -59,10 +59,10 @@ Individual functions can be provided for each of the operations.
 !> These functions must return `true` if the operation is allowed, or `false` if it is not allowed.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         operation: {
@@ -73,7 +73,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -92,11 +92,11 @@ In general, the filter access control functions will return GraphQL filters.
 They can also return boolean values `true` or `false` to match or exclude all items.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { checkbox } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       fields: {
         isReadable: checkbox(),
@@ -117,7 +117,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -135,11 +135,11 @@ It’s available to `create`, `update`, and `delete` mutations, and lets you wri
 !> These functions must return `true` if the operation is allowed, or `false` if it is not allowed.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { checkbox } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         item: {
@@ -149,7 +149,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -192,11 +192,11 @@ No errors will be returned for `read` access denied.
 !> The `read` access control is applied to fields returned from both **queries** and **mutations**.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       fields: {
         fieldName: text({
@@ -208,7 +208,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 

--- a/docs/pages/docs/apis/auth.mdx
+++ b/docs/pages/docs/apis/auth.mdx
@@ -10,7 +10,7 @@ Additional options to this function provide support for creating an initial item
 For examples of how to use authentication in your system please see the [authentication guide](../guides/auth).
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, password, checkbox } from '@keystone-next/keystone/fields';
 import { createAuth } from '@keystone-next/auth';
 
@@ -39,7 +39,7 @@ const { withAuth } = createAuth({
 
 export default withAuth(
   config({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           email: text({ isIndexed: 'unique', isFilterable: true }),
@@ -48,7 +48,7 @@ export default withAuth(
         },
       }),
       session: { /* ... */ },
-    }),
+    },
   })
 );
 ```

--- a/docs/pages/docs/apis/config.mdx
+++ b/docs/pages/docs/apis/config.mdx
@@ -39,15 +39,14 @@ This type definition should be considered the source of truth for the available 
 The `lists` config option is where you define the data model, or schema, of the Keystone system.
 It has a TypeScript type of `ListSchemaConfig`.
 This is where you define and configure the `lists` and their `fields` of the data model.
-In general you will use the `createSchema()` function to create this configuration option.
 See the [Schema API](./schema) docs for details on how to use this function.
 
 ```typescript
 import type { ListSchemaConfig } from '@keystone-next/keystone/types';
-import { config, createSchema } from '@keystone-next/keystone';
+import { config } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({ /* ... */ }),
+  lists: { /* ... */ },
   /* ... */
 });
 ```

--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -12,7 +12,7 @@ This document covers the different field types which are available and the confi
 To see how to access fields in the GraphQL API please see the [GraphQL API](./graphql) docs.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import {
   // Scalar types
   checkbox,
@@ -43,7 +43,7 @@ import { document } from '@keystone-next/fields-document';
 import { cloudinaryImage } from '@keystone-next/cloudinary';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: text({ /* ... */ }),
@@ -51,7 +51,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -94,7 +94,7 @@ Options:
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: text({
@@ -124,7 +124,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -148,11 +148,11 @@ Options:
   if a user doesn't have access to create the particular field regardless of whether or not they specify the field in the create.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { checkbox } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: checkbox({
@@ -170,7 +170,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -191,11 +191,11 @@ Options:
   - If `'unique'` then all values of this field must be unique.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { integer } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: integer({
@@ -207,7 +207,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -220,11 +220,11 @@ Currently the `json` field is non-orderable and non-filterable.
 - `isRequired` (default: `false`): If `true` then this field can never be set to `null`.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { json } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: json({
@@ -234,7 +234,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -255,11 +255,11 @@ Options:
   - If `'unique'` then all values of this field must be unique.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { float } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: float({
@@ -271,7 +271,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -294,11 +294,11 @@ Options:
   - If `'unique'` then all values of this field must be unique.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { decimal } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: decimal({
@@ -312,7 +312,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -330,11 +330,11 @@ Options:
   This module will be used for all encryption routines in the `password` field.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { password } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: password({
@@ -347,7 +347,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -378,11 +378,11 @@ Options:
   Can be one of `['select', 'segmented-control']`.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { select } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: select({
@@ -400,7 +400,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -423,11 +423,11 @@ Options:
   Can be one of `['input', 'textarea']`.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: text({
@@ -440,7 +440,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -462,11 +462,11 @@ Options:
   - If `'unique'` then all values of this field must be unique.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { timestamp } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: timestamp({
@@ -478,7 +478,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -512,11 +512,11 @@ Read our [relationships guide](../guides/relationships) for details on Keystoneâ
 - `ui.displayMode === 'count'` only supports `many` relationships
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: relationship({
@@ -545,7 +545,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -563,11 +563,11 @@ Options:
 - `isIndexed`
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { autoIncrement } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: autoIncrement({
@@ -579,7 +579,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -597,11 +597,11 @@ Options:
 - `graphQLReturnFragment` (default: `''` ): The sub-fields that should be fetched by the Admin UI when displaying this field.
 
 ```typescript
-import { config, createSchema, list, graphql } from '@keystone-next/keystone';
+import { config, list, graphql } from '@keystone-next/keystone';
 import { virtual } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: virtual({
@@ -617,7 +617,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -633,11 +633,11 @@ A `file` field represents a file of any type.
 See [`config.files`](./config#files) for details on how to configure your Keystone system with support for the `file` field type.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { file } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         repo: file(),
@@ -645,7 +645,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -657,11 +657,11 @@ An `image` field represents an image file, i.e. `.jpg`, `.png`, `.webp`, or `.gi
 See [`config.images`](./config#images) for details on how to configure your Keystone system with support for the `image` field type.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { image } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         avatar: image(),
@@ -669,7 +669,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -690,11 +690,11 @@ Options:
 - `layouts`
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: document({
@@ -712,7 +712,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -728,11 +728,11 @@ export default config({
   - `folder`
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { cloudinaryImage } from '@keystone-next/cloudinary';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: cloudinaryImage({
@@ -747,7 +747,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```

--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -12,13 +12,13 @@ Keystone generates a CRUD (create, read, update, delete) GraphQL API based on th
 Consider the following system definition:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({ fields: { name: text({ isOrderable: true }) } }),
-  }),
+  },
   /* ... */
 });
 ```

--- a/docs/pages/docs/apis/hooks.mdx
+++ b/docs/pages/docs/apis/hooks.mdx
@@ -15,11 +15,11 @@ All hook functions are async and, with the exception of `resolveInput`, do not r
 For examples of how to use hooks in your system please see the [hooks guide](../guides/hooks).
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         // Hooks for create and update operations
@@ -50,7 +50,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -80,11 +80,11 @@ The result of `resolveInput` will be passed as `resolvedData` into the next stag
 | `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                   |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         resolveInput: async ({
@@ -118,7 +118,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -143,11 +143,11 @@ These error messages will be returned as a `ValidationFailureError` from the Gra
 | `addValidationError(msg)` | Used to set a validation error.                                                                                                                                                                             |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         validateInput: async ({
@@ -177,7 +177,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -198,11 +198,11 @@ It is invoked after all `validateInput` hooks have been run, but before the data
 | `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                             |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         beforeChange: async ({
@@ -230,7 +230,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -249,11 +249,11 @@ The `afterChange` function is used to perform side effects after the data for a 
 | `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                              |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         afterChange: async ({
@@ -281,7 +281,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -309,11 +309,11 @@ These error messages will be returned as a `ValidationFailureError` from the Gra
 | `addValidationError(msg)` | Used to set a validation error.                                                                                                                               |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         validateDelete: async ({
@@ -339,7 +339,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -358,11 +358,11 @@ It is invoked after all `validateDelete` hooks have been run.
 | `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                               |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         beforeDelete: async ({ listKey, operation, existingItem, context }) => {
@@ -379,7 +379,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -396,11 +396,11 @@ The `afterDelete` function is used to perform side effects after the data for a 
 | `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                              |
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       hooks: {
         afterDelete: async ({ listKey, operation, existingItem, context }) => {
@@ -417,7 +417,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 

--- a/docs/pages/docs/apis/schema.mdx
+++ b/docs/pages/docs/apis/schema.mdx
@@ -5,14 +5,13 @@ import { RelatedContent } from '../../../components/RelatedContent';
 # Schema API
 
 The `lists` property of the [system configuration](./config) object is where you define the data model, or schema, of your Keystone system.
-To setup the `lists` property of the system configuration you need to use the `createSchema()` function.
-This function accepts an object with list names as keys, and `list()` configurations as values.
+It accepts an object with list names as keys, and `list()` configurations as values.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: ({
     ListName: list({
       fields: { /* ... */ },
       access: { /* ... */ },
@@ -43,11 +42,11 @@ The `fields` option defines the names, types, and configuration of the fields in
 This configuration option takes an object with field names as keys, and configured field types as values.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: text({ /* ... */ }),
@@ -55,7 +54,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -109,11 +108,11 @@ Options:
   - `pageSize` (default: `50`): Sets the number of items to show per page in the list view.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields`;
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: { name: text({ /* ... */ }) },
       ui: {
@@ -138,7 +137,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -169,10 +168,10 @@ Options:
 
 ```typescript
 import { CacheScope } from 'apollo-cache-control';
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       graphql: {
         description: '...',
@@ -185,7 +184,7 @@ export default config({
       /* ... */
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```
@@ -200,10 +199,10 @@ Options:
   The default across all lists can be changed at the root-level `db.idField` config.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       db: {
         idField: { kind: 'uuid' },
@@ -211,7 +210,7 @@ export default config({
       /* ... */
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -22,10 +22,10 @@ The document field provides a number of different formatting options, all of whi
 To get started with a fully featured editor experience, you can turn on all of the built-in options.
 
 ```typescript
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       content: document({
@@ -39,7 +39,7 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};
 ```
 
 This has enabled all of the **formatting** options, enabled inline **links**, section **dividers**, and both 2 and 3 column **layouts**.
@@ -161,12 +161,12 @@ For example, you might want to include twitter-style mentions of other users in 
 We can achieve this with the `relationships` option to the document field.
 
 ```tsx
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         content: document({
@@ -186,7 +186,7 @@ export default config({
         name: text(),
       }
     }),
-  }),
+  },
 });
 ```
 
@@ -352,12 +352,12 @@ You need to import the `componentBlocks` and pass it to the document field along
 `keystone.ts`
 
 ```ts
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 import { componentBlocks } from './component-blocks';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: document({
@@ -368,7 +368,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -571,11 +571,11 @@ fields.object({
 To use relationship fields on component blocks, you need to add a relationship to the document field config.
 
 ```tsx
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { document } from '@keystone-next/fields-document';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListName: list({
       fields: {
         fieldName: document({
@@ -593,7 +593,7 @@ export default config({
       },
     }),
     /* ... */
-  }),
+  },
   /* ... */
 });
 ```

--- a/docs/pages/docs/guides/hooks.mdx
+++ b/docs/pages/docs/guides/hooks.mdx
@@ -16,11 +16,11 @@ A hook is a function you define as part of your [schema configuration](../apis/s
 Let's look at a basic example to log a message to the console whenever a new user is created.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -34,7 +34,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -54,11 +54,11 @@ The `resolveInput` hook lets us take the data which has been provided to the Gra
 Let's write a hook which takes the data for a blog post and converts the first letter to upper-case.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         title: text({ isRequired: true }),
@@ -76,7 +76,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -101,11 +101,11 @@ An empty string, `""`, is a perfectly valid `String` value to pass into GraphQL.
 Let's use a validation hook to ensure that this value doesn't make it into our database.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         title: text({ isRequired: true }),
@@ -121,7 +121,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -145,13 +145,13 @@ We can use the `beforeChange` and `afterChange` hooks to do this.
 Let's send an email after a user is created.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 // Keystone leaves it up to you to decide how best to implement email in your system
 import { sendWelcomeEmail } from './lib/welcomeEmail';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -165,7 +165,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -198,11 +198,11 @@ For example, you might have an email validation function which want to use in yo
 You could always write this as a list hook, but it will make your code more clear if you write this as a field hook.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -218,7 +218,7 @@ export default config({
         }),
        },
     }),
-  }),
+  },
 });
 ```
 

--- a/docs/pages/docs/guides/relationships.mdx
+++ b/docs/pages/docs/guides/relationships.mdx
@@ -28,11 +28,11 @@ These topics are easier to understand by example. We’ll explore them, as well 
 Relationships are made using the [`relationship`](../apis/fields#relationship) field type within a [`list()`](../apis/schema). In our blog example we can connect a blog `post` to some `users` using the relationship field’s `ref` configuration option like so:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({ fields: { name: text() } }),
     Post: list({
       fields: {
@@ -41,7 +41,7 @@ export default config({
         authors: relationship({ ref: 'User', many: true, }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -72,11 +72,11 @@ query {
 If we can find all the `authors` of a post, we can also find all the posts written by a particular user. To do this we need to configure a two-sided relationship in our schema:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -92,7 +92,7 @@ export default config({
         authors: relationship({ ref: 'User.posts', many: true }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -121,29 +121,29 @@ query {
 Keystone also lets you define one, and two-sided **relationships that refer to the same list**. To make a _one-sided_ Twitter style following relationship we do the following:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
         follows: relationship({ ref: 'User', many: true }),
       },
     }),
-  }),
+  },
 });
 ```
 
 Or change this into a _two-sided_ relationship to also access the followers of every user:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -151,7 +151,7 @@ export default config({
         followers: relationship({ ref: 'User.follows', many: true }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -184,11 +184,11 @@ Let’s explore how to set up each type of cardinality in the context of our blo
 - Users can have multiple posts
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 import { text, relationship } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -201,7 +201,7 @@ export default config({
         author: relationship({ ref: 'User', many: false }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -212,7 +212,7 @@ export default config({
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -225,7 +225,7 @@ export default config({
         authors: relationship({ ref: 'User', many: true }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -240,7 +240,7 @@ export default config({
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -254,7 +254,7 @@ export default config({
         author: relationship({ ref: 'User.post', many: false }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -265,7 +265,7 @@ export default config({
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -279,7 +279,7 @@ export default config({
         author: relationship({ ref: 'User.posts', many: false }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -292,7 +292,7 @@ export default config({
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     User: list({
       fields: {
         name: text(),
@@ -306,7 +306,7 @@ export default config({
         authors: relationship({ ref: 'User.posts', many: true }),
       },
     }),
-  }),
+  },
 });
 ```
 

--- a/docs/pages/docs/guides/virtual-fields.mdx
+++ b/docs/pages/docs/guides/virtual-fields.mdx
@@ -18,11 +18,11 @@ In this guide we'll introduce the syntax for adding virtual fields, and show how
 We'll start with a list called `Example` and create a virtual field called `hello`.
 
 ```typescript
-import { config, createSchema, list, graphql } from '@keystone-next/keystone';
+import { config, list, graphql } from '@keystone-next/keystone';
 import { virtual } from '@keystone-next/keystone/fields';
 
 export default config({
-  lists: createSchema({
+  lists: {
     Example: list({
       fields: {
         hello: virtual({
@@ -35,7 +35,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -87,7 +87,7 @@ We can do this with a `virtual` field which queries for the related `author` and
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         content: text(),
@@ -111,7 +111,7 @@ export default config({
         name: text({ isRequired: true }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -126,7 +126,7 @@ We use the `args` option to define the GraphQL field arguments we want to suppor
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         content: text(),
@@ -155,7 +155,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -193,7 +193,7 @@ We can set up a GraphQL type called `PostCounts` to represent this data using th
 
 ```typescript
 export default config({
-  lists: createSchema({
+  lists: {
     Post: list({
       fields: {
         content: text(),
@@ -224,7 +224,7 @@ export default config({
         }),
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -262,7 +262,7 @@ The argument `lists` contains the type information for all of the Keystone lists
 In our case, we want the output type of the `Post` list, so we specify `type: lists.Post.types.output`.
 
 ```ts
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text(),
@@ -299,7 +299,7 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};
 ```
 
 Once again we need to specify `graphQLReturnFragment` on this virtual field to specify which fields of the `Post` to display in the Admin UI.

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -414,10 +414,10 @@ export default function IndexPage() {
               <CodeWindow lines={21}>
                 <WindowL>
                   <SourceCode>
-                    {`import { createSchema, list } from '@keystone-next/keystone';
+                    {`import { list } from '@keystone-next/keystone';
 import { document, text, timestamp, password, relationship } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -434,7 +434,7 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});`}
+};`}
                   </SourceCode>
                 </WindowL>
               </CodeWindow>

--- a/docs/pages/updates/new-access-control.mdx
+++ b/docs/pages/updates/new-access-control.mdx
@@ -13,16 +13,16 @@ Previous versions of Keystone allowed you to control which operations were inclu
 For example, the following access control definition would omit all delete operations for the list from the GraphQL API.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         delete: false,
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -32,16 +32,16 @@ If you would like to exclude an operation from the GraphQL API, you can use the 
 To exclude all `delete` operations, you would write:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       graphql: {
         omit: ['delete'],
       }
     }),
-  }),
+  },
 });
 ```
 
@@ -75,10 +75,10 @@ If you are using **static** access control, you will generally want to update th
 If you previously had the following:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         create: false,
@@ -87,17 +87,17 @@ export default config({
         delete: false,
       },
     }),
-  }),
+  },
 });
 ```
 
 you will need to change it to:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         operation: {
@@ -108,7 +108,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 
@@ -120,10 +120,10 @@ If you are using **declarative** access control, you will neeed to update this t
 If you previously had the following:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         read: { isAdmin: { equals: true } },
@@ -131,17 +131,17 @@ export default config({
         delete: { isAdmin: { equals: true } },
       },
     }),
-  }),
+  },
 });
 ```
 
 you will need to change it to:
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
+import { config, list } from '@keystone-next/keystone';
 
 export default config({
-  lists: createSchema({
+  lists: {
     ListKey: list({
       access: {
         filter: {
@@ -151,7 +151,7 @@ export default config({
         }
       },
     }),
-  }),
+  },
 });
 ```
 

--- a/docs/pages/updates/new-graphql-api.mdx
+++ b/docs/pages/updates/new-graphql-api.mdx
@@ -13,8 +13,8 @@ This guide describes the improvements we've made, and walks you through the step
 
 To illustrate the changes, we’ll refer to the `Task` list in the following schema, from our [Task Manager](https://github.com/keystonejs/keystone/tree/master/examples/task-manager) example project.
 
-```
-export const lists = createSchema({
+```ts
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -43,7 +43,7 @@ export const lists = createSchema({
       name: text(),
     },
   }),
-});
+};
 ```
 
 ## Query

--- a/examples-staging/assets-cloud/schema.ts
+++ b/examples-staging/assets-cloud/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp, image, file } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -26,4 +26,4 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});
+};

--- a/examples-staging/assets-local/schema.ts
+++ b/examples-staging/assets-local/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp, image } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -25,4 +25,4 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});
+};

--- a/examples-staging/auth/schema.ts
+++ b/examples-staging/auth/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text, checkbox, password } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   User: list({
     access: {
       operation: {
@@ -80,4 +80,4 @@ export const lists = createSchema({
       */
     },
   }),
-});
+};

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -1,4 +1,4 @@
-import { createSchema, list, graphQLSchemaExtension, gql } from '@keystone-next/keystone';
+import { list, graphQLSchemaExtension, gql } from '@keystone-next/keystone';
 import {
   text,
   relationship,
@@ -34,7 +34,7 @@ export const access = {
 
 const randomNumber = () => Math.round(Math.random() * 10);
 
-export const lists = createSchema({
+export const lists = {
   User: list({
     ui: {
       listView: {
@@ -186,7 +186,7 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};
 
 export const extendGraphqlSchema = graphQLSchemaExtension({
   typeDefs: gql`

--- a/examples-staging/ecommerce/keystone.ts
+++ b/examples-staging/ecommerce/keystone.ts
@@ -1,5 +1,5 @@
 import { createAuth } from '@keystone-next/auth';
-import { config, createSchema } from '@keystone-next/keystone';
+import { config } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { permissionsList } from './schemas/fields';
 import { Role } from './schemas/Role';
@@ -59,7 +59,7 @@ export default withAuth(
             }
           },
         },
-    lists: createSchema({
+    lists: {
       // Schema items go in here
       User,
       Product,
@@ -68,7 +68,7 @@ export default withAuth(
       OrderItem,
       Order,
       Role,
-    }),
+    },
     extendGraphqlSchema,
     ui: {
       // Show the UI only for poeple who pass this test

--- a/examples-staging/graphql-api-endpoint/schema.ts
+++ b/examples-staging/graphql-api-endpoint/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text, relationship, password, timestamp, select } from '@keystone-next/keystone/fields';
 import { document } from '@keystone-next/fields-document';
 
-export const lists = createSchema({
+export const lists = {
   User: list({
     ui: {
       listView: {
@@ -77,4 +77,4 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};

--- a/examples-staging/roles/schema.ts
+++ b/examples-staging/roles/schema.ts
@@ -1,4 +1,4 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, password, relationship, text } from '@keystone-next/keystone/fields';
 
 import { isSignedIn, permissions, rules } from './access';
@@ -12,7 +12,7 @@ import { isSignedIn, permissions, rules } from './access';
   - All users can see and manage todo items assigned to themselves
 */
 
-export const lists = createSchema({
+export const lists = {
   Todo: list({
     /*
       SPEC
@@ -228,4 +228,4 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};

--- a/examples-staging/sandbox/schema.ts
+++ b/examples-staging/sandbox/schema.ts
@@ -1,4 +1,4 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 
 // this implementation for createdBy and updatedBy is currently wrong so they're disabled for now
@@ -44,7 +44,7 @@ const trackingFields = {
   // }),
 };
 
-export const lists = createSchema({
+export const lists = {
   Todo: list({
     ui: {
       listView: {
@@ -79,4 +79,4 @@ export const lists = createSchema({
       ...trackingFields,
     },
   }),
-});
+};

--- a/examples/blog/schema.ts
+++ b/examples/blog/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true, isFilterable: true }),
@@ -24,4 +24,4 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});
+};

--- a/examples/custom-admin-ui-logo/schema.ts
+++ b/examples/custom-admin-ui-logo/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -29,4 +29,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/custom-admin-ui-navigation/schema.ts
+++ b/examples/custom-admin-ui-navigation/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -29,4 +29,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/custom-admin-ui-pages/schema.ts
+++ b/examples/custom-admin-ui-pages/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -29,4 +29,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/custom-field-view/schema.ts
+++ b/examples/custom-field-view/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { json, select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -38,4 +38,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/custom-field/schema.ts
+++ b/examples/custom-field/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { stars } from './stars-field';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -26,4 +26,4 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});
+};

--- a/examples/default-values/schema.ts
+++ b/examples/default-values/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -61,4 +61,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/document-field/schema.ts
+++ b/examples/document-field/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { document } from '@keystone-next/fields-document';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -60,4 +60,4 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};

--- a/examples/extend-graphql-schema/schema.ts
+++ b/examples/extend-graphql-schema/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -24,4 +24,4 @@ export const lists = createSchema({
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-});
+};

--- a/examples/json/schema.ts
+++ b/examples/json/schema.ts
@@ -1,7 +1,7 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, json, relationship, text } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Package: list({
     fields: {
       label: text({ isRequired: true }),
@@ -16,4 +16,4 @@ export const lists = createSchema({
       packages: relationship({ ref: 'Package.ownedBy', many: true }),
     },
   }),
-});
+};

--- a/examples/task-manager/schema.ts
+++ b/examples/task-manager/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -29,4 +29,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/testing/schema.ts
+++ b/examples/testing/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -44,4 +44,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp, virtual } from '@keystone-next/keystone/fields';
 import { graphql } from '@keystone-next/keystone/types';
 
-export const lists = createSchema({
+export const lists = {
   Post: list({
     fields: {
       title: text({ isRequired: true }),
@@ -117,4 +117,4 @@ export const lists = createSchema({
       }),
     },
   }),
-});
+};

--- a/examples/with-auth/schema.ts
+++ b/examples/with-auth/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -37,4 +37,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -1,2 +1,2 @@
-export { createSchema, list, gql, graphQLSchemaExtension, config } from './schema/schema';
+export { list, gql, graphQLSchemaExtension, config } from './schema/schema';
 export type { ListSchemaConfig, ListConfig, ExtendGraphqlSchema, BaseFields } from './types';

--- a/packages/keystone/src/schema/schema.ts
+++ b/packages/keystone/src/schema/schema.ts
@@ -8,12 +8,7 @@ import type {
   GraphQLSchemaExtension,
   KeystoneConfig,
   ListConfig,
-  ListSchemaConfig,
 } from '../types';
-
-export function createSchema(config: ListSchemaConfig) {
-  return config;
-}
 
 export function config(config: KeystoneConfig) {
   return config;

--- a/tests/api-tests/access-control/mutations-field.test.ts
+++ b/tests/api-tests/access-control/mutations-field.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectAccessDenied, expectInternalServerError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       // Imperative -> Static access control
       User: list({
         fields: {
@@ -43,7 +43,7 @@ const runner = setupTestRunner({
           }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/access-control/mutations-list-filter.test.ts
+++ b/tests/api-tests/access-control/mutations-list-filter.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectAccessDenied } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       // Filter access control
       User: list({
         fields: { name: text({ isOrderable: true }) },
@@ -17,7 +17,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/access-control/mutations-list-item.test.ts
+++ b/tests/api-tests/access-control/mutations-list-item.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectAccessDenied, expectInternalServerError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       // Item access control
       User: list({
         fields: { name: text({ isFilterable: true, isOrderable: true }) },
@@ -42,7 +42,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/access-control/mutations-list-operation.test.ts
+++ b/tests/api-tests/access-control/mutations-list-operation.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectInternalServerError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       BadAccess: list({
         fields: { name: text({ isFilterable: true, isOrderable: true }) },
         access: {
@@ -29,7 +29,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/access-control/schema-utils.ts
+++ b/tests/api-tests/access-control/schema-utils.ts
@@ -1,5 +1,5 @@
 import { relationship, text } from '@keystone-next/keystone/fields';
-import { list } from '@keystone-next/keystone';
+import { list, ListSchemaConfig } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { apiTestConfig } from '../utils';
 
@@ -100,7 +100,7 @@ const createRelatedFields = (config: ListConfig) => ({
   [`${getListPrefix(config)}many`]: relationship({ ref: getListName(config), many: true }),
 });
 
-const lists = {};
+const lists: ListSchemaConfig = {};
 
 listConfigVariables.forEach(config => {
   lists[getListName(config)] = list({

--- a/tests/api-tests/access-control/schema-utils.ts
+++ b/tests/api-tests/access-control/schema-utils.ts
@@ -1,5 +1,5 @@
 import { relationship, text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { apiTestConfig } from '../utils';
 
@@ -100,7 +100,7 @@ const createRelatedFields = (config: ListConfig) => ({
   [`${getListPrefix(config)}many`]: relationship({ ref: getListName(config), many: true }),
 });
 
-const lists = createSchema({});
+const lists = {};
 
 listConfigVariables.forEach(config => {
   lists[getListName(config)] = list({

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -1,5 +1,5 @@
 import { text, password } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import { apiTestConfig } from '../utils';
@@ -103,7 +103,7 @@ const createFieldImperative = (fieldAccess: BooleanAccess) => ({
   }),
 });
 
-const lists = createSchema({
+const lists = {
   User: list({
     fields: {
       name: text(),
@@ -113,7 +113,7 @@ const lists = createSchema({
       yesRead: text({ access: { read: () => true } }),
     },
   }),
-});
+};
 
 listAccessVariations.forEach(access => {
   lists[getOperationListName(access)] = list({

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -1,5 +1,5 @@
 import { text, password } from '@keystone-next/keystone/fields';
-import { list } from '@keystone-next/keystone';
+import { list, ListSchemaConfig } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import { apiTestConfig } from '../utils';
@@ -103,7 +103,7 @@ const createFieldImperative = (fieldAccess: BooleanAccess) => ({
   }),
 });
 
-const lists = {
+const lists: ListSchemaConfig = {
   User: list({
     fields: {
       name: text(),

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -1,5 +1,5 @@
 import { text, timestamp, password } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { statelessSessions } from '@keystone-next/keystone/session';
 import { createAuth } from '@keystone-next/auth';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
@@ -26,7 +26,7 @@ const auth = createAuth({
 const runner = setupTestRunner({
   config: auth.withAuth(
     apiTestConfig({
-      lists: createSchema({
+      lists: {
         Post: list({
           fields: {
             title: text(),
@@ -48,7 +48,7 @@ const runner = setupTestRunner({
             },
           },
         }),
-      }),
+      },
       session: statelessSessions({ secret: COOKIE_SECRET }),
     })
   ),
@@ -106,7 +106,7 @@ describe('Auth testing', () => {
       setupTestEnv({
         config: auth.withAuth(
           apiTestConfig({
-            lists: createSchema({
+            lists: {
               User: list({
                 fields: {
                   name: text(),
@@ -114,7 +114,7 @@ describe('Auth testing', () => {
                   password: password(),
                 },
               }),
-            }),
+            },
 
             session: statelessSessions({ secret: COOKIE_SECRET }),
           })

--- a/tests/api-tests/default-value/defaults.test.ts
+++ b/tests/api-tests/default-value/defaults.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { BaseFields } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../utils';
 
 const setupList = (fields: BaseFields<any>) =>
-  setupTestRunner({ config: apiTestConfig({ lists: createSchema({ User: list({ fields }) }) }) });
+  setupTestRunner({ config: apiTestConfig({ lists: { User: list({ fields }) } }) });
 
 describe('defaultValue field config', () => {
   test(

--- a/tests/api-tests/extend-express-app.test.ts
+++ b/tests/api-tests/extend-express-app.test.ts
@@ -1,4 +1,4 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import supertest from 'supertest';
@@ -6,7 +6,7 @@ import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({ User: list({ fields: { name: text() } }) }),
+    lists: { User: list({ fields: { name: text() } }) },
     server: {
       extendExpressApp: app => {
         app.get('/magic', (req, res) => {

--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -1,4 +1,4 @@
-import { createSchema, list, graphQLSchemaExtension, gql } from '@keystone-next/keystone';
+import { list, graphQLSchemaExtension, gql } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectInternalServerError } from '../utils';
@@ -23,11 +23,11 @@ const withAccessCheck = <T, Args extends unknown[]>(
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: { name: text() },
       }),
-    }),
+    },
     extendGraphqlSchema: graphQLSchemaExtension({
       typeDefs: gql`
         type Query {

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
@@ -21,14 +21,14 @@ testModules
       const listKey = 'Test';
       const runner = setupTestRunner({
         config: apiTestConfig({
-          lists: createSchema({
+          lists: {
             [listKey]: list({
               fields: {
                 name: text({ isOrderable: true }),
                 ...mod.getTestFields(matrixValue),
               },
             }),
-          }),
+          },
           images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
           files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
         }),

--- a/tests/api-tests/fields/filter.test.ts
+++ b/tests/api-tests/fields/filter.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
@@ -19,11 +19,11 @@ testModules
       const listKey = 'Test';
       const runner = setupTestRunner({
         config: apiTestConfig({
-          lists: createSchema({
+          lists: {
             [listKey]: list({
               fields: { name: text({ isOrderable: true }), ...mod.getTestFields(matrixValue) },
             }),
-          }),
+          },
           images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
           files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
         }),
@@ -410,13 +410,13 @@ testModules
                 'Unique equality',
                 setupTestRunner({
                   config: apiTestConfig({
-                    lists: createSchema({
+                    lists: {
                       [listKey]: list({
                         fields: {
                           field: mod.typeFunction({ isIndexed: 'unique', isFilterable: true }),
                         },
                       }),
-                    }),
+                    },
                   }),
                 })(async ({ context }) => {
                   // Populate the database before running the tests

--- a/tests/api-tests/fields/non-null.test.ts
+++ b/tests/api-tests/fields/non-null.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestEnv } from '@keystone-next/keystone/testing';
 import { assertInputObjectType, assertObjectType, GraphQLNonNull } from 'graphql';
@@ -41,7 +41,7 @@ testModules
         const getSchema = async (fieldConfig: any) => {
           const { testArgs } = await setupTestEnv({
             config: apiTestConfig({
-              lists: createSchema({
+              lists: {
                 Test: list({
                   fields: {
                     name: text(),
@@ -51,7 +51,7 @@ testModules
                     }),
                   },
                 }),
-              }),
+              },
               images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
               files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
             }),

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectValidationError } from '../utils';
@@ -39,7 +39,7 @@ testModules
 
         const runner = setupTestRunner({
           config: apiTestConfig({
-            lists: createSchema({
+            lists: {
               Test: list({
                 fields: {
                   name: text(),
@@ -49,7 +49,7 @@ testModules
                   }),
                 },
               }),
-            }),
+            },
             images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
             files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
           }),

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -1,5 +1,5 @@
 import { integer, relationship, text, virtual } from '@keystone-next/keystone/fields';
-import { BaseFields, createSchema, list } from '@keystone-next/keystone';
+import { BaseFields, list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { graphql } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -7,14 +7,14 @@ import { apiTestConfig } from '../../utils';
 function makeRunner(fields: BaseFields<any>) {
   return setupTestRunner({
     config: apiTestConfig({
-      lists: createSchema({
+      lists: {
         Post: list({
           fields: {
             value: integer(),
             ...fields,
           },
         }),
-      }),
+      },
     }),
   });
 }
@@ -91,7 +91,7 @@ describe('Virtual field type', () => {
     'referencing other list type',
     setupTestRunner({
       config: apiTestConfig({
-        lists: createSchema({
+        lists: {
           Organisation: list({
             fields: {
               name: text(),
@@ -147,7 +147,7 @@ describe('Virtual field type', () => {
               }),
             },
           }),
-        }),
+        },
       }),
     })(async ({ context }) => {
       const data = await context.lists.Post.createOne({

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -1,13 +1,13 @@
 import { text } from '@keystone-next/keystone/fields';
 import { document } from '@keystone-next/fields-document';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig, expectInternalServerError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Post: list({
         fields: {
           content: document({
@@ -48,7 +48,7 @@ const runner = setupTestRunner({
         },
         access: { filter: { query: () => ({ name: { not: { equals: 'Charlie' } } }) } },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestEnv, setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectPrismaError } from '../utils';
@@ -39,7 +39,7 @@ testModules
         });
         const runner = setupTestRunner({
           config: apiTestConfig({
-            lists: createSchema({
+            lists: {
               Test: list({
                 fields: {
                   name: text(),
@@ -49,7 +49,7 @@ testModules
                   }),
                 },
               }),
-            }),
+            },
             images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
             files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
           }),
@@ -147,7 +147,7 @@ testModules
           try {
             await setupTestEnv({
               config: apiTestConfig({
-                lists: createSchema({
+                lists: {
                   Test: list({
                     fields: {
                       name: text(),
@@ -157,7 +157,7 @@ testModules
                       }),
                     },
                   }),
-                }),
+                },
                 images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
                 files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
               }),

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -1,5 +1,5 @@
 import globby from 'globby';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestEnv } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../utils';
@@ -45,11 +45,11 @@ if (unsupportedModules.length > 0) {
             async () =>
               await setupTestEnv({
                 config: apiTestConfig({
-                  lists: createSchema({
+                  lists: {
                     [listKey]: list({
                       fields: { name: text(), ...mod.getTestFields(matrixValue) },
                     }),
-                  }),
+                  },
                   images: { upload: 'local', local: { storagePath: 'tmp_test_images' } },
                   files: { upload: 'local', local: { storagePath: 'tmp_test_files' } },
                 }),

--- a/tests/api-tests/healthcheck.test.ts
+++ b/tests/api-tests/healthcheck.test.ts
@@ -1,4 +1,4 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import supertest from 'supertest';
@@ -7,7 +7,7 @@ import { apiTestConfig } from './utils';
 const makeRunner = (healthCheck: any) =>
   setupTestRunner({
     config: apiTestConfig({
-      lists: createSchema({ User: list({ fields: { name: text() } }) }),
+      lists: { User: list({ fields: { name: text() } }) },
       server: { healthCheck },
     }),
   });

--- a/tests/api-tests/hooks/auth-hooks.test.skip.ts
+++ b/tests/api-tests/hooks/auth-hooks.test.skip.ts
@@ -2,14 +2,14 @@ import { AddressInfo } from 'net';
 // @ts-ignore
 import superagent from 'superagent';
 import express from 'express';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text, password } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text(),
@@ -17,7 +17,7 @@ const runner = setupTestRunner({
           password: password(),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -1,5 +1,5 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { GraphQLRequest, setupTestRunner } from '@keystone-next/keystone/testing';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig, expectExtensionError } from '../utils';
@@ -7,7 +7,7 @@ import { apiTestConfig, expectExtensionError } from '../utils';
 const runner = (debug: boolean | undefined) =>
   setupTestRunner({
     config: apiTestConfig({
-      lists: createSchema({
+      lists: {
         User: list({
           fields: { name: text({ isFilterable: true, isOrderable: true }) },
           hooks: {
@@ -85,7 +85,7 @@ const runner = (debug: boolean | undefined) =>
             }),
           },
         }),
-      }),
+      },
       graphql: { debug },
     }),
   });

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectExtensionError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({
@@ -31,7 +31,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -1,11 +1,11 @@
 import { text } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectValidationError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: { name: text({ isOrderable: true }) },
         hooks: {
@@ -60,7 +60,7 @@ const runner = setupTestRunner({
           }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/id-field.test.ts
+++ b/tests/api-tests/id-field.test.ts
@@ -1,4 +1,4 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { isCuid } from 'cuid';
@@ -13,9 +13,9 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   const runner = setupTestRunner({
     config: apiTestConfig({
       db: { idField: { kind } },
-      lists: createSchema({
+      lists: {
         User: list({ fields: { name: text() } }),
-      }),
+      },
     }),
   });
   test(
@@ -131,9 +131,9 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   const runner = setupTestRunner({
     config: apiTestConfig({
       db: { idField: { kind: 'uuid' } },
-      lists: createSchema({
+      lists: {
         User: list({ fields: { name: text() } }),
-      }),
+      },
     }),
   });
   test(
@@ -155,9 +155,9 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
   const runner = setupTestRunner({
     config: apiTestConfig({
       db: { idField: { kind: 'cuid' } },
-      lists: createSchema({
+      lists: {
         User: list({ fields: { name: text() } }),
-      }),
+      },
     }),
   });
   test(

--- a/tests/api-tests/new-interfaces.test.ts
+++ b/tests/api-tests/new-interfaces.test.ts
@@ -1,13 +1,13 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { text } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({ fields: { name: text() } }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -1,13 +1,13 @@
 import { CacheScope } from 'apollo-server-types';
 import { text, relationship, integer } from '@keystone-next/keystone/fields';
-import { list, createSchema, graphQLSchemaExtension } from '@keystone-next/keystone';
+import { list, graphQLSchemaExtension } from '@keystone-next/keystone';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Post: list({
         fields: {
           title: text(),
@@ -40,7 +40,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
     extendGraphqlSchema: graphQLSchemaExtension({
       typeDefs: `
         type MyType {

--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -1,11 +1,11 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectInternalServerError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           noDash: text({ isFilterable: true, isOrderable: true }),
@@ -21,7 +21,7 @@ const runner = setupTestRunner({
           otherUsers: relationship({ ref: 'User', isFilterable: true, many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -1,12 +1,12 @@
 import { text, integer, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectGraphQLValidationError, expectLimitsExceededError } from '../utils';
 import { depthLimit, definitionLimit, fieldLimit } from './validation';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Post: list({
         fields: {
           title: text({ isFilterable: true, isOrderable: true }),
@@ -25,7 +25,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
     graphql: {
       queryLimits: { maxTotalResults: 6 },
       apolloConfig: {

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -1,19 +1,19 @@
 import { integer } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig, expectBadUserInput } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           a: integer({ isOrderable: true }),
           b: integer({ isOrderable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -1,7 +1,7 @@
 import { gen, sampleOne } from 'testcheck';
 
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../utils';
 
@@ -9,7 +9,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Post: list({
         fields: {
           title: text({ isFilterable: true, isOrderable: true }),
@@ -22,7 +22,7 @@ const runner = setupTestRunner({
           feed: relationship({ ref: 'Post', many: true, isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -79,14 +79,14 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({ isFilterable: true }),
           friends: relationship({ ref: 'User', many: true, isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -84,7 +84,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({ isFilterable: true }),
@@ -92,7 +92,7 @@ const runner = setupTestRunner({
           friends: relationship({ ref: 'User.friendOf', many: true, isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -78,14 +78,14 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({ isFilterable: true, isOrderable: true }),
           friend: relationship({ ref: 'User', isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -79,7 +79,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({ isFilterable: true, isOrderable: true }),
@@ -91,7 +91,7 @@ const runner = setupTestRunner({
           }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -59,7 +59,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text({ isFilterable: true }),
@@ -67,7 +67,7 @@ const runner = setupTestRunner({
           friend: relationship({ ref: 'User.friendOf', isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -88,7 +88,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text(),
@@ -96,7 +96,7 @@ const runner = setupTestRunner({
         },
       }),
       Location: list({ fields: { name: text({ isFilterable: true }) } }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -94,7 +94,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text(),
@@ -107,7 +107,7 @@ const runner = setupTestRunner({
           companies: relationship({ ref: 'Company.locations', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -100,7 +100,7 @@ const getCompanyAndLocation = async (
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text({ isOrderable: true }),
@@ -112,7 +112,7 @@ const runner = setupTestRunner({
           name: text({ isFilterable: true, isOrderable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -87,7 +87,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text({ isFilterable: true, isOrderable: true }),
@@ -100,7 +100,7 @@ const runner = setupTestRunner({
           company: relationship({ ref: 'Company.locations', isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import type { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
@@ -93,7 +93,7 @@ const getCompanyAndLocation = async (
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text({ isFilterable: true }),
@@ -106,7 +106,7 @@ const runner = setupTestRunner({
           company: relationship({ ref: 'Company.location', isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/filtering/access-control.test.ts
+++ b/tests/api-tests/relationships/filtering/access-control.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../../utils';
 
@@ -10,7 +10,7 @@ const postNames = ['Post 1', 'Post 2', 'Post 3'];
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       UserToPostLimitedRead: list({
         fields: {
           username: text(),
@@ -29,7 +29,7 @@ const runner = setupTestRunner({
           },
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/filtering/filtering.test.ts
+++ b/tests/api-tests/relationships/filtering/filtering.test.ts
@@ -1,5 +1,5 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../../utils';
 
@@ -7,7 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           company: relationship({ ref: 'Company', isFilterable: true }),
@@ -16,7 +16,7 @@ const runner = setupTestRunner({
       }),
       Company: list({ fields: { name: text({ isFilterable: true }) } }),
       Post: list({ fields: { content: text({ isFilterable: true }) } }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -1,13 +1,13 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { apiTestConfig } from '../../utils';
 
 type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           company: relationship({ ref: 'Company', isFilterable: true }),
@@ -16,7 +16,7 @@ const runner = setupTestRunner({
       }),
       Company: list({ fields: { name: text() } }),
       Post: list({ fields: { content: text({ isFilterable: true }) } }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/many-to-one-to-one.test.ts
+++ b/tests/api-tests/relationships/many-to-one-to-one.test.ts
@@ -1,7 +1,7 @@
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../utils';
 
@@ -83,7 +83,7 @@ const createCompanyAndLocation = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Owner: list({
         fields: {
           name: text({ isFilterable: true }),
@@ -110,7 +110,7 @@ const runner = setupTestRunner({
           locations: relationship({ ref: 'Location.custodians', many: true, isFilterable: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectRelationshipError } from '../../utils';
 
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text(),
@@ -48,7 +48,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'NoteNoCreate', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -1,12 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectRelationshipError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Group: list({
         fields: {
           name: text(),
@@ -86,7 +86,7 @@ const runner = setupTestRunner({
           group: relationship({ ref: 'GroupNoUpdateHard' }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectRelationshipError } from '../../utils';
 
@@ -10,7 +10,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text(),
@@ -50,7 +50,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'NoteNoCreate', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
@@ -1,11 +1,11 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectRelationshipError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Group: list({
         fields: {
           name: text(),
@@ -17,7 +17,7 @@ const runner = setupTestRunner({
           group: relationship({ ref: 'Group' }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectRelationshipError } from '../../utils';
 
@@ -10,7 +10,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text({ isOrderable: true }),
@@ -50,7 +50,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'NoteNoCreate', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 
@@ -58,7 +58,7 @@ let afterChangeWasCalled = false;
 
 const runner2 = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text({ isOrderable: true }),
@@ -75,7 +75,7 @@ const runner2 = setupTestRunner({
           notes: relationship({ ref: 'Note', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -1,12 +1,12 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectGraphQLValidationError, expectRelationshipError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Group: list({
         fields: {
           name: text(),
@@ -103,7 +103,7 @@ const runner = setupTestRunner({
           group: relationship({ ref: 'GroupNoUpdateHard' }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectGraphQLValidationError, expectRelationshipError } from '../../utils';
 
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text(),
@@ -48,7 +48,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'NoteNoCreate', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectGraphQLValidationError } from '../../utils';
 
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Group: list({
         fields: {
           name: text(),
@@ -34,7 +34,7 @@ const runner = setupTestRunner({
           group: relationship({ ref: 'GroupNoRead' }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -1,5 +1,5 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../../utils';
 
@@ -7,7 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           title: text({ isOrderable: true }),
@@ -20,7 +20,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'Note.author', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/set-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/set-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig, expectGraphQLValidationError, expectRelationshipError } from '../../utils';
 
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Note: list({
         fields: {
           content: text(),
@@ -48,7 +48,7 @@ const runner = setupTestRunner({
           notes: relationship({ ref: 'NoteNoCreate', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../../../utils';
@@ -13,7 +13,7 @@ const toStr = (items: any[]) => items.map(item => item.toString());
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Student: list({
         fields: {
           name: text(),
@@ -26,7 +26,7 @@ const runner = setupTestRunner({
           students: relationship({ ref: 'Student.teachers', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
@@ -1,6 +1,6 @@
 import { gen, sampleOne } from 'testcheck';
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { apiTestConfig } from '../../../utils';
 
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Company: list({
         fields: {
           name: text(),
@@ -23,7 +23,7 @@ const runner = setupTestRunner({
           company: relationship({ ref: 'Company.location', isRequired: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/api-tests/relationships/shared-names.test.ts
+++ b/tests/api-tests/relationships/shared-names.test.ts
@@ -1,5 +1,5 @@
 import { text, relationship } from '@keystone-next/keystone/fields';
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { setupTestRunner } from '@keystone-next/keystone/testing';
 import { KeystoneContext } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../utils';
@@ -93,7 +93,7 @@ const createInitialData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       Employee: list({
         fields: {
           name: text(),
@@ -120,7 +120,7 @@ const runner = setupTestRunner({
           employees: relationship({ ref: 'Employee', many: true }),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/benchmarks/fixtures/create-related.js
+++ b/tests/benchmarks/fixtures/create-related.js
@@ -1,12 +1,12 @@
 const { text, relationship } = require('@keystone-next/keystone/fields');
-const { list, createSchema } = require('@keystone-next/keystone');
+const { list } = require('@keystone-next/keystone');
 const { setupTestRunner } = require('@keystone-next/keystone/testing');
 const { apiTestConfig } = require('../../utils.ts');
 const { FixtureGroup, timeQuery, populate, range } = require('../lib/utils');
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text(),
@@ -18,7 +18,7 @@ const runner = setupTestRunner({
           title: text(),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/benchmarks/fixtures/create.js
+++ b/tests/benchmarks/fixtures/create.js
@@ -1,18 +1,18 @@
 const { text } = require('@keystone-next/keystone/fields');
-const { list, createSchema } = require('@keystone-next/keystone');
+const { list } = require('@keystone-next/keystone');
 const { setupTestRunner } = require('@keystone-next/keystone/testing');
 const { apiTestConfig } = require('../../utils.ts');
 const { FixtureGroup, timeQuery, populate, range } = require('../lib/utils');
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text(),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/benchmarks/fixtures/query.js
+++ b/tests/benchmarks/fixtures/query.js
@@ -1,12 +1,12 @@
 const { text, relationship } = require('@keystone-next/keystone/fields');
-const { createSchema, list } = require('@keystone-next/keystone');
+const { list } = require('@keystone-next/keystone');
 const { setupTestRunner } = require('@keystone-next/keystone/testing');
 const { apiTestConfig } = require('../../utils.ts');
 const { FixtureGroup, timeQuery, populate, range } = require('../lib/utils');
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: createSchema({
+    lists: {
       User: list({
         fields: {
           name: text(),
@@ -18,7 +18,7 @@ const runner = setupTestRunner({
           title: text(),
         },
       }),
-    }),
+    },
   }),
 });
 

--- a/tests/test-projects/basic/schema.ts
+++ b/tests/test-projects/basic/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     fields: {
       label: text({ isRequired: true }),
@@ -38,4 +38,4 @@ export const lists = createSchema({
       isHidden: true,
     },
   }),
-});
+};

--- a/tests/test-projects/crud-notifications/schema.ts
+++ b/tests/test-projects/crud-notifications/schema.ts
@@ -1,8 +1,8 @@
-import { createSchema, list } from '@keystone-next/keystone';
+import { list } from '@keystone-next/keystone';
 import { checkbox, relationship, text, timestamp } from '@keystone-next/keystone/fields';
 import { select } from '@keystone-next/keystone/fields';
 
-export const lists = createSchema({
+export const lists = {
   Task: list({
     access: {
       item: {
@@ -37,4 +37,4 @@ export const lists = createSchema({
     defaultIsFilterable: true,
     defaultIsOrderable: true,
   }),
-});
+};


### PR DESCRIPTION
Unlike `config` and `list` which actually aid in auto complete and type checking, `createSchema` doesn't help since you're gonna call `list` anyway.