### PR TITLE
enable prisma preview features from keystone config

### DIFF
--- a/.changeset/witty-candles-explain.md
+++ b/.changeset/witty-candles-explain.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/prisma-preview-features': minor
+'@keystone-next/keystone': minor
+'@keystone-next/types': minor
+---
+
+Enable prisma preview features from keystone config file

--- a/examples/prisma-preview-features/CHANGELOG.md
+++ b/examples/prisma-preview-features/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @keystone-next/prisma-preview-features

--- a/examples/prisma-preview-features/README.md
+++ b/examples/prisma-preview-features/README.md
@@ -1,0 +1,21 @@
+## Feature Example - Prisma Preview Features
+
+This project demonstrates how to use the prisma preview features with custom queries .
+It builds on the [extend-graphql-schema](../extend-graphql-schema) starter project.
+
+## Instructions
+
+To run this project, clone the Keystone repository locally then navigate to this directory and run:
+
+```shell
+yarn dev
+```
+
+This will start the Admin UI at [localhost:3000](http://localhost:3000).
+You can use the Admin UI to create items in your database.
+
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL query `exampleWithPrismaPreviewFeatures`.
+
+## Features
+
+This project demonstrates how to use the Prisma Preview Features like `orderRelation`.

--- a/examples/prisma-preview-features/custom-schema.ts
+++ b/examples/prisma-preview-features/custom-schema.ts
@@ -1,0 +1,23 @@
+import { graphQLSchemaExtension } from '@keystone-next/keystone/schema';
+
+export const extendGraphqlSchema = graphQLSchemaExtension({
+  typeDefs: `
+    type Query {
+      exampleWithPrismaPreviewFeatures: [Post]
+    }
+  `,
+  resolvers: {
+    Query: {
+      exampleWithPrismaPreviewFeatures: async (root, args, context) => {
+        const data = await context.prisma.post.findMany({
+          orderBy: {
+            author: {
+              name: 'desc',
+            },
+          },
+        });
+        return data;
+      },
+    },
+  },
+});

--- a/examples/prisma-preview-features/keystone.ts
+++ b/examples/prisma-preview-features/keystone.ts
@@ -1,0 +1,13 @@
+import { config } from '@keystone-next/keystone/schema';
+import { lists } from './schema';
+import { extendGraphqlSchema } from './custom-schema';
+
+export default config({
+  db: {
+    provider: 'sqlite',
+    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+    prismaPreviewFeatures: ['orderByRelation'],
+  },
+  lists,
+  extendGraphqlSchema,
+});

--- a/examples/prisma-preview-features/package.json
+++ b/examples/prisma-preview-features/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@keystone-next/prisma-preview-features",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "dev": "keystone-next dev",
+    "start": "keystone-next start",
+    "build": "keystone-next build"
+  },
+  "dependencies": {
+    "@keystone-next/fields": "^11.0.0",
+    "@keystone-next/keystone": "^20.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.3.4"
+  },
+  "engines": {
+    "node": "^12.20 || >= 14.13"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/master/examples/prisma-preview-features"
+}

--- a/examples/prisma-preview-features/schema.graphql
+++ b/examples/prisma-preview-features/schema.graphql
@@ -1,0 +1,464 @@
+"""
+ A keystone list
+"""
+type Post {
+  id: ID!
+  title: String
+  status: PostStatusType
+  content: String
+  publishDate: String
+  author: Author
+}
+
+enum PostStatusType {
+  draft
+  published
+}
+
+input PostWhereInput {
+  AND: [PostWhereInput!]
+  OR: [PostWhereInput!]
+  id: ID
+  id_not: ID
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  title: String
+  title_not: String
+  title_contains: String
+  title_not_contains: String
+  title_in: [String]
+  title_not_in: [String]
+  status: PostStatusType
+  status_not: PostStatusType
+  status_in: [PostStatusType]
+  status_not_in: [PostStatusType]
+  content: String
+  content_not: String
+  content_contains: String
+  content_not_contains: String
+  content_in: [String]
+  content_not_in: [String]
+  publishDate: String
+  publishDate_not: String
+  publishDate_lt: String
+  publishDate_lte: String
+  publishDate_gt: String
+  publishDate_gte: String
+  publishDate_in: [String]
+  publishDate_not_in: [String]
+  author: AuthorWhereInput
+  author_is_null: Boolean
+}
+
+input PostWhereUniqueInput {
+  id: ID
+}
+
+enum SortPostsBy {
+  id_ASC
+  id_DESC
+  title_ASC
+  title_DESC
+  status_ASC
+  status_DESC
+  content_ASC
+  content_DESC
+  publishDate_ASC
+  publishDate_DESC
+}
+
+input PostOrderByInput {
+  id: OrderDirection
+  title: OrderDirection
+  status: OrderDirection
+  content: OrderDirection
+  publishDate: OrderDirection
+}
+
+enum OrderDirection {
+  asc
+  desc
+}
+
+input PostUpdateInput {
+  title: String
+  status: PostStatusType
+  content: String
+  publishDate: String
+  author: AuthorRelateToOneInput
+}
+
+input AuthorRelateToOneInput {
+  create: AuthorCreateInput
+  connect: AuthorWhereUniqueInput
+  disconnect: AuthorWhereUniqueInput
+  disconnectAll: Boolean
+}
+
+input PostsUpdateInput {
+  id: ID!
+  data: PostUpdateInput
+}
+
+input PostCreateInput {
+  title: String
+  status: PostStatusType
+  content: String
+  publishDate: String
+  author: AuthorRelateToOneInput
+}
+
+input PostsCreateInput {
+  data: PostCreateInput
+}
+
+"""
+ A keystone list
+"""
+type Author {
+  id: ID!
+  name: String
+  email: String
+  posts(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Post!]
+  _postsMeta(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int
+}
+
+type _QueryMeta {
+  count: Int
+}
+
+input AuthorWhereInput {
+  AND: [AuthorWhereInput!]
+  OR: [AuthorWhereInput!]
+  id: ID
+  id_not: ID
+  id_lt: ID
+  id_lte: ID
+  id_gt: ID
+  id_gte: ID
+  id_in: [ID]
+  id_not_in: [ID]
+  name: String
+  name_not: String
+  name_contains: String
+  name_not_contains: String
+  name_in: [String]
+  name_not_in: [String]
+  email: String
+  email_not: String
+  email_contains: String
+  email_not_contains: String
+  email_in: [String]
+  email_not_in: [String]
+
+  """
+   condition must be true for all nodes
+  """
+  posts_every: PostWhereInput
+
+  """
+   condition must be true for at least 1 node
+  """
+  posts_some: PostWhereInput
+
+  """
+   condition must be false for all nodes
+  """
+  posts_none: PostWhereInput
+}
+
+input AuthorWhereUniqueInput {
+  id: ID
+  email: String
+}
+
+enum SortAuthorsBy {
+  id_ASC
+  id_DESC
+  name_ASC
+  name_DESC
+  email_ASC
+  email_DESC
+}
+
+input AuthorOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+  email: OrderDirection
+}
+
+input AuthorUpdateInput {
+  name: String
+  email: String
+  posts: PostRelateToManyInput
+}
+
+input PostRelateToManyInput {
+  create: [PostCreateInput]
+  connect: [PostWhereUniqueInput]
+  disconnect: [PostWhereUniqueInput]
+  disconnectAll: Boolean
+}
+
+input AuthorsUpdateInput {
+  id: ID!
+  data: AuthorUpdateInput
+}
+
+input AuthorCreateInput {
+  name: String
+  email: String
+  posts: PostRelateToManyInput
+}
+
+input AuthorsCreateInput {
+  data: AuthorCreateInput
+}
+
+"""
+The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSON
+  @specifiedBy(
+    url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"
+  )
+
+type Mutation {
+  """
+   Create a single Post item.
+  """
+  createPost(data: PostCreateInput): Post
+
+  """
+   Create multiple Post items.
+  """
+  createPosts(data: [PostsCreateInput]): [Post]
+
+  """
+   Update a single Post item by ID.
+  """
+  updatePost(id: ID!, data: PostUpdateInput): Post
+
+  """
+   Update multiple Post items by ID.
+  """
+  updatePosts(data: [PostsUpdateInput]): [Post]
+
+  """
+   Delete a single Post item by ID.
+  """
+  deletePost(id: ID!): Post
+
+  """
+   Delete multiple Post items by ID.
+  """
+  deletePosts(ids: [ID!]): [Post]
+
+  """
+   Create a single Author item.
+  """
+  createAuthor(data: AuthorCreateInput): Author
+
+  """
+   Create multiple Author items.
+  """
+  createAuthors(data: [AuthorsCreateInput]): [Author]
+
+  """
+   Update a single Author item by ID.
+  """
+  updateAuthor(id: ID!, data: AuthorUpdateInput): Author
+
+  """
+   Update multiple Author items by ID.
+  """
+  updateAuthors(data: [AuthorsUpdateInput]): [Author]
+
+  """
+   Delete a single Author item by ID.
+  """
+  deleteAuthor(id: ID!): Author
+
+  """
+   Delete multiple Author items by ID.
+  """
+  deleteAuthors(ids: [ID!]): [Author]
+}
+
+type Query {
+  """
+   Search for all Post items which match the where clause.
+  """
+  allPosts(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Post!]
+
+  """
+   Search for the Post item with the matching ID.
+  """
+  Post(where: PostWhereUniqueInput!): Post
+
+  """
+   Perform a meta-query on all Post items which match the where clause.
+  """
+  _allPostsMeta(
+    where: PostWhereInput! = {}
+    search: String
+    sortBy: [SortPostsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [PostOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use postsCount instead."
+    )
+  postsCount(where: PostWhereInput! = {}): Int
+
+  """
+   Search for all Author items which match the where clause.
+  """
+  allAuthors(
+    where: AuthorWhereInput! = {}
+    search: String
+    sortBy: [SortAuthorsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): [Author!]
+
+  """
+   Search for the Author item with the matching ID.
+  """
+  Author(where: AuthorWhereUniqueInput!): Author
+
+  """
+   Perform a meta-query on all Author items which match the where clause.
+  """
+  _allAuthorsMeta(
+    where: AuthorWhereInput! = {}
+    search: String
+    sortBy: [SortAuthorsBy!]
+      @deprecated(reason: "sortBy has been deprecated in favour of orderBy")
+    orderBy: [AuthorOrderByInput!]! = []
+    first: Int
+    skip: Int! = 0
+  ): _QueryMeta
+    @deprecated(
+      reason: "This query will be removed in a future version. Please use authorsCount instead."
+    )
+  authorsCount(where: AuthorWhereInput! = {}): Int
+  exampleWithPrismaPreviewFeatures: [Post]
+  keystone: KeystoneMeta!
+}
+
+type KeystoneMeta {
+  adminMeta: KeystoneAdminMeta!
+}
+
+type KeystoneAdminMeta {
+  enableSignout: Boolean!
+  enableSessionItem: Boolean!
+  lists: [KeystoneAdminUIListMeta!]!
+  list(key: String!): KeystoneAdminUIListMeta
+}
+
+type KeystoneAdminUIListMeta {
+  key: String!
+  itemQueryName: String!
+  listQueryName: String!
+  hideCreate: Boolean!
+  hideDelete: Boolean!
+  path: String!
+  label: String!
+  singular: String!
+  plural: String!
+  description: String
+  initialColumns: [String!]!
+  pageSize: Int!
+  labelField: String!
+  fields: [KeystoneAdminUIFieldMeta!]!
+  initialSort: KeystoneAdminUISort
+  isHidden: Boolean!
+}
+
+type KeystoneAdminUIFieldMeta {
+  path: String!
+  label: String!
+  isOrderable: Boolean!
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  createView: KeystoneAdminUIFieldMetaCreateView!
+  listView: KeystoneAdminUIFieldMetaListView!
+  itemView(id: ID!): KeystoneAdminUIFieldMetaItemView
+}
+
+type KeystoneAdminUIFieldMetaCreateView {
+  fieldMode: KeystoneAdminUIFieldMetaCreateViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaCreateViewFieldMode {
+  edit
+  hidden
+}
+
+type KeystoneAdminUIFieldMetaListView {
+  fieldMode: KeystoneAdminUIFieldMetaListViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaListViewFieldMode {
+  read
+  hidden
+}
+
+type KeystoneAdminUIFieldMetaItemView {
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldMode {
+  edit
+  read
+  hidden
+}
+
+type KeystoneAdminUISort {
+  field: String!
+  direction: KeystoneAdminUISortDirection!
+}
+
+enum KeystoneAdminUISortDirection {
+  ASC
+  DESC
+}

--- a/examples/prisma-preview-features/schema.prisma
+++ b/examples/prisma-preview-features/schema.prisma
@@ -1,0 +1,29 @@
+datasource sqlite {
+  url      = env("DATABASE_URL")
+  provider = "sqlite"
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  output          = "node_modules/.prisma/client"
+  previewFeatures = ["orderByRelation"]
+}
+
+model Post {
+  id          Int       @id @default(autoincrement())
+  title       String?
+  status      String?
+  content     String?
+  publishDate DateTime?
+  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId    Int?      @map("author")
+
+  @@index([authorId])
+}
+
+model Author {
+  id    Int     @id @default(autoincrement())
+  name  String?
+  email String? @unique
+  posts Post[]  @relation("Post_author")
+}

--- a/examples/prisma-preview-features/schema.ts
+++ b/examples/prisma-preview-features/schema.ts
@@ -1,0 +1,28 @@
+import { createSchema, list } from '@keystone-next/keystone/schema';
+import { relationship, text, timestamp } from '@keystone-next/fields';
+import { select } from '@keystone-next/fields';
+
+export const lists = createSchema({
+  Post: list({
+    fields: {
+      title: text({ isRequired: true }),
+      status: select({
+        dataType: 'enum',
+        options: [
+          { label: 'Draft', value: 'draft' },
+          { label: 'Published', value: 'published' },
+        ],
+      }),
+      content: text(),
+      publishDate: timestamp(),
+      author: relationship({ ref: 'Author.posts', many: false }),
+    },
+  }),
+  Author: list({
+    fields: {
+      name: text({ isRequired: true }),
+      email: text({ isRequired: true, isUnique: true }),
+      posts: relationship({ ref: 'Post.author', many: true }),
+    },
+  }),
+});

--- a/packages-next/keystone/src/artifacts.ts
+++ b/packages-next/keystone/src/artifacts.ts
@@ -31,7 +31,8 @@ export async function getCommittedArtifacts(
   const prismaSchema = printPrismaSchema(
     lists,
     getDBProvider(config.db),
-    'node_modules/.prisma/client'
+    'node_modules/.prisma/client',
+    config.db.prismaPreviewFeatures
   );
   return {
     graphql: format(printSchema(graphQLSchema), { parser: 'graphql' }),

--- a/packages-next/keystone/src/lib/core/prisma-schema.ts
+++ b/packages-next/keystone/src/lib/core/prisma-schema.ts
@@ -193,8 +193,13 @@ function assertDbFieldIsValidForIdField(
 export function printPrismaSchema(
   lists: ListsWithResolvedRelations,
   provider: DatabaseProvider,
-  clientDir: string
+  clientDir: string,
+  prismaPreviewFeatures?: string[]
 ) {
+  let prismaFlags = '';
+  if (prismaPreviewFeatures && prismaPreviewFeatures.length) {
+    prismaFlags = `\n  previewFeatures = ["${prismaPreviewFeatures.join('","')}"]`;
+  }
   let prismaSchema = `datasource ${provider} {
   url = env("DATABASE_URL")
   provider = "${provider}"
@@ -202,7 +207,7 @@ export function printPrismaSchema(
 
 generator client {
   provider = "prisma-client-js"
-  output = "${clientDir}"
+  output = "${clientDir}"${prismaFlags}
 }
 \n`;
   for (const [listKey, { resolvedDbFields }] of Object.entries(lists)) {

--- a/packages-next/types/src/config/index.ts
+++ b/packages-next/types/src/config/index.ts
@@ -57,6 +57,7 @@ export type DatabaseConfig = {
   onConnect?: (args: KeystoneContext) => Promise<void>;
   useMigrations?: boolean;
   enableLogging?: boolean;
+  prismaPreviewFeatures?: string[];
 } & (
   | (
       | {


### PR DESCRIPTION
ability to enable Prisma preview features via Keystone config, example:

```
export default config({
  db: {
    provider: 'sqlite',
    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
    prismaPreviewFeatures: ['orderByRelation'],
  },
  lists,
  extendGraphqlSchema,
});
```