### PR TITLE
Remove unused code path in Admin UI

### DIFF
--- a/.changeset/healthy-cougars-tickle.md
+++ b/.changeset/healthy-cougars-tickle.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Removed check for access denied on count operations in the Admin UI databoard queries, as these errors are no longer returned.

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
@@ -182,11 +182,6 @@ export const HomePage = () => {
                 return null;
               }
               const result = dataGetter.get(key);
-              // TODO: Checking based on the message is bad, but we need to revisit GraphQL errors in
-              // Keystone to fix it and that's a whole other can of worms...
-              if (result.errors?.[0].message === 'You do not have access to this resource') {
-                return <ListCard count={{ type: 'no-access' }} key={key} listKey={key} />;
-              }
               return (
                 <ListCard
                   count={


### PR DESCRIPTION
Access control failures for count never return an error, they simply return zero.