### PR TITLE
Return correct error messages on failed auth attempts

### DIFF
--- a/.changeset/smooth-candles-crash.md
+++ b/.changeset/smooth-candles-crash.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Fixed bug with incorrect errors being returned on invalid auth attempts.

--- a/packages/auth/src/lib/findMatchingIdentity.ts
+++ b/packages/auth/src/lib/findMatchingIdentity.ts
@@ -10,13 +10,10 @@ export async function findMatchingIdentity(
   | { success: false; code: AuthTokenRequestErrorCode }
   | { success: true; item: { id: any; [prop: string]: any } }
 > {
-  try {
-    const item = await dbItemAPI.findOne({ where: { [identityField]: identity } });
+  const item = await dbItemAPI.findOne({ where: { [identityField]: identity } });
+  if (item) {
     return { success: true, item };
-  } catch (err: any) {
-    if (err.message === 'You do not have access to this resource') {
-      return { success: false, code: 'IDENTITY_NOT_FOUND' };
-    }
-    throw err;
+  } else {
+    return { success: false, code: 'IDENTITY_NOT_FOUND' };
   }
 }


### PR DESCRIPTION
Now that a `findOne()` returns `null` on missing items, this code needs updating.

### Before

<img width="626" alt="Screen Shot 2021-09-17 at 2 57 47 pm" src="https://user-images.githubusercontent.com/616382/133727238-3974a607-8370-43a3-95e1-5bd2f6a2c4b2.png">

### After

<img width="621" alt="Screen Shot 2021-09-17 at 2 59 26 pm" src="https://user-images.githubusercontent.com/616382/133727232-d35dd5ff-118e-4d65-9e76-dfdbfc0abb62.png">
