### PR TITLE
Remove internal protectIdentities flag

### DIFF
--- a/.changeset/cyan-wolves-cover.md
+++ b/.changeset/cyan-wolves-cover.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Removed the internal `protectIdentities` variable.

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -9,14 +9,12 @@ export function getBaseAuthSchema<I extends string, S extends string>({
   listKey,
   identityField,
   secretField,
-  protectIdentities,
   gqlNames,
   secretFieldImpl,
 }: {
   listKey: string;
   identityField: I;
   secretField: S;
-  protectIdentities: boolean;
   gqlNames: AuthGqlNames;
   secretFieldImpl: SecretFieldImpl;
 }): GraphQLSchemaExtension {
@@ -65,7 +63,6 @@ export function getBaseAuthSchema<I extends string, S extends string>({
             identityField,
             args[identityField],
             secretField,
-            protectIdentities,
             args[secretField],
             dbItemAPI
           );

--- a/packages/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -9,14 +9,12 @@ import { getAuthTokenErrorMessage } from '../lib/getErrorMessage';
 export function getMagicAuthLinkSchema<I extends string>({
   listKey,
   identityField,
-  protectIdentities,
   gqlNames,
   magicAuthLink,
   magicAuthTokenSecretFieldImpl,
 }: {
   listKey: string;
   identityField: I;
-  protectIdentities: boolean;
   gqlNames: AuthGqlNames;
   magicAuthLink: AuthTokenTypeConfig;
   magicAuthTokenSecretFieldImpl: SecretFieldImpl;
@@ -62,15 +60,10 @@ export function getMagicAuthLinkSchema<I extends string>({
           const tokenType = 'magicAuth';
           const identity = args[identityField];
 
-          const result = await createAuthToken(
-            identityField,
-            protectIdentities,
-            identity,
-            dbItemAPI
-          );
+          const result = await createAuthToken(identityField, identity, dbItemAPI);
 
           // Note: `success` can be false with no code
-          // If protectIdentities === true then result.code will *always* be undefined.
+          // result.code will *always* be undefined.
           if (!result.success && result.code) {
             const message = getAuthTokenErrorMessage({
               identityField,
@@ -115,7 +108,6 @@ export function getMagicAuthLinkSchema<I extends string>({
             tokenType,
             identityField,
             args[identityField],
-            protectIdentities,
             magicAuthLink.tokensValidForMins,
             args.token,
             dbItemAPI

--- a/packages/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages/auth/src/gql/getPasswordResetSchema.ts
@@ -10,7 +10,6 @@ export function getPasswordResetSchema<I extends string, S extends string>({
   listKey,
   identityField,
   secretField,
-  protectIdentities,
   gqlNames,
   passwordResetLink,
   passwordResetTokenSecretFieldImpl,
@@ -18,7 +17,6 @@ export function getPasswordResetSchema<I extends string, S extends string>({
   listKey: string;
   identityField: I;
   secretField: S;
-  protectIdentities: boolean;
   gqlNames: AuthGqlNames;
   passwordResetLink: AuthTokenTypeConfig;
   passwordResetTokenSecretFieldImpl: SecretFieldImpl;
@@ -67,15 +65,10 @@ export function getPasswordResetSchema<I extends string, S extends string>({
           const tokenType = 'passwordReset';
           const identity = args[identityField];
 
-          const result = await createAuthToken(
-            identityField,
-            protectIdentities,
-            identity,
-            dbItemAPI
-          );
+          const result = await createAuthToken(identityField, identity, dbItemAPI);
 
           // Note: `success` can be false with no code
-          // If protectIdentities === true then result.code will *always* be undefined.
+          // result.code will *always* be undefined.
           if (!result.success && result.code) {
             const message = getAuthTokenErrorMessage({
               identityField,
@@ -116,7 +109,6 @@ export function getPasswordResetSchema<I extends string, S extends string>({
             tokenType,
             identityField,
             args[identityField],
-            protectIdentities,
             passwordResetLink.tokensValidForMins,
             args.token,
             dbItemAPI
@@ -168,7 +160,6 @@ export function getPasswordResetSchema<I extends string, S extends string>({
             tokenType,
             identityField,
             args[identityField],
-            protectIdentities,
             passwordResetLink.tokensValidForMins,
             args.token,
             dbItemAPI

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -28,11 +28,6 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   passwordResetLink,
   sessionData,
 }: AuthConfig<GeneratedListTypes>) {
-  // The protectIdentities flag is currently under review to see whether it should be
-  // part of the createAuth API (in which case its use cases need to be documented and tested)
-  // or whether always being true is what we want, in which case we can refactor our code
-  // to match this. -TL
-  const protectIdentities = true;
   const gqlNames: AuthGqlNames = {
     // Core
     authenticateItemWithPassword: `authenticate${listKey}WithPassword`,
@@ -163,7 +158,6 @@ export function createAuth<GeneratedListTypes extends BaseGeneratedListTypes>({
   const extendGraphqlSchema = getSchemaExtension({
     identityField,
     listKey,
-    protectIdentities,
     secretField,
     gqlNames,
     initFirstItem,

--- a/packages/auth/src/lib/createAuthToken.ts
+++ b/packages/auth/src/lib/createAuthToken.ts
@@ -14,7 +14,6 @@ function generateToken(length: number): string {
 // We don't (currently) make any effort to mitigate the time taken to record the new token or sent the email when successful
 export async function createAuthToken(
   identityField: string,
-  protectIdentities: boolean,
   identity: string,
   dbItemAPI: KeystoneDbAPI<any>[string]
 ): Promise<
@@ -22,11 +21,11 @@ export async function createAuthToken(
   | { success: true; itemId: string | number; token: string }
 > {
   const match = await findMatchingIdentity(identityField, identity, dbItemAPI);
-  // Identity failures with helpful errors (unless it would violate our protectIdentities config)
+  // Identity failures with helpful errors.
   if (match.success) {
     return { success: true, itemId: match.item.id, token: generateToken(20) };
   } else {
     // There is no generic `AUTH_TOKEN_REQUEST_FAILURE` code; it's existance would alow values in the identity field to be probed
-    return { success: false, code: protectIdentities ? undefined : match.code };
+    return { success: false, code: undefined };
   }
 }

--- a/packages/auth/src/lib/validateAuthToken.ts
+++ b/packages/auth/src/lib/validateAuthToken.ts
@@ -15,7 +15,6 @@ export async function validateAuthToken(
   tokenType: 'passwordReset' | 'magicAuth',
   identityField: string,
   identity: string,
-  protectIdentities: boolean,
   tokenValidMins: number | undefined,
   token: string,
   dbItemAPI: KeystoneDbAPI<any>[string]
@@ -28,7 +27,6 @@ export async function validateAuthToken(
     identityField,
     identity,
     `${tokenType}Token`,
-    protectIdentities,
     token,
     dbItemAPI
   );
@@ -36,7 +34,7 @@ export async function validateAuthToken(
     // Rewrite error codes
     if (result.code === 'SECRET_NOT_SET') return { success: false, code: 'TOKEN_NOT_SET' };
     if (result.code === 'SECRET_MISMATCH') return { success: false, code: 'TOKEN_MISMATCH' };
-    // Will generally be { success: false, code: 'FAILURE' } due to protectIdentities
+    // Will generally be { success: false, code: 'FAILURE' }
     // Could be due to:
     // - Missing identity
     // - Missing secret
@@ -44,7 +42,7 @@ export async function validateAuthToken(
     return result as { success: false; code: AuthTokenRedemptionErrorCode };
   }
 
-  // Now that we know the identity and token are valid, we can always return 'helpful' errors and stop worrying about protectIdentities
+  // Now that we know the identity and token are valid, we can always return 'helpful' errors and stop worrying about protecting identities.
   const { item } = result;
   const fieldKeys = { issuedAt: `${tokenType}IssuedAt`, redeemedAt: `${tokenType}RedeemedAt` };
 

--- a/packages/auth/src/lib/validateSecret.ts
+++ b/packages/auth/src/lib/validateSecret.ts
@@ -7,7 +7,6 @@ export async function validateSecret(
   identityField: string,
   identity: string,
   secretField: string,
-  protectIdentities: boolean,
   secret: string,
   dbItemAPI: KeystoneDbAPI<any>[string]
 ): Promise<
@@ -25,11 +24,8 @@ export async function validateSecret(
 
   if (code) {
     // See "Identity Protection" in the README as to why this is a thing
-    if (protectIdentities) {
-      await secretFieldImpl.generateHash('simulated-password-to-counter-timing-attack');
-      code = 'FAILURE';
-    }
-    return { success: false, code };
+    await secretFieldImpl.generateHash('simulated-password-to-counter-timing-attack');
+    return { success: false, code: 'FAILURE' };
   }
 
   const { item } = match as { success: true; item: { id: any; [prop: string]: any } };
@@ -37,6 +33,6 @@ export async function validateSecret(
     // Authenticated!
     return { success: true, item };
   } else {
-    return { success: false, code: protectIdentities ? 'FAILURE' : 'SECRET_MISMATCH' };
+    return { success: false, code: 'FAILURE' };
   }
 }

--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -42,7 +42,6 @@ export const getSchemaExtension =
   ({
     identityField,
     listKey,
-    protectIdentities,
     secretField,
     gqlNames,
     initFirstItem,
@@ -51,7 +50,6 @@ export const getSchemaExtension =
   }: {
     identityField: string;
     listKey: string;
-    protectIdentities: boolean;
     secretField: string;
     gqlNames: AuthGqlNames;
     initFirstItem?: InitFirstItemConfig<any>;
@@ -78,7 +76,6 @@ export const getSchemaExtension =
       getBaseAuthSchema({
         identityField,
         listKey,
-        protectIdentities,
         secretField,
         gqlNames,
         secretFieldImpl: getSecretFieldImpl(schema, listKey, secretField),
@@ -95,7 +92,6 @@ export const getSchemaExtension =
         getPasswordResetSchema({
           identityField,
           listKey,
-          protectIdentities,
           secretField,
           passwordResetLink,
           gqlNames,
@@ -109,7 +105,6 @@ export const getSchemaExtension =
         getMagicAuthLinkSchema({
           identityField,
           listKey,
-          protectIdentities,
           magicAuthLink,
           gqlNames,
           magicAuthTokenSecretFieldImpl: getSecretFieldImpl(schema, listKey, 'magicAuthToken'),


### PR DESCRIPTION
There's no immediate plans to implement this as a configurable option, so we're removing the unnecessary plumbing.

This will unblock further cleanups in followup PRs.