### PR TITLE
Add Splitbee Analytics to Website

### DIFF
--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -72,6 +72,7 @@ class MyDocument extends Document {
             async
             src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
           />
+          <script async data-api="/_sb" src="/sb.js" />
           <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
           <script
             dangerouslySetInnerHTML={{

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -121,10 +121,12 @@ const SPLITBEE = [
   {
     source: '/sb.js',
     destination: 'https://cdn.splitbee.io/sb.js',
+    permanent: false,
   },
   {
     source: '/_sb/:slug',
     destination: 'https://hive.splitbee.io/:slug',
+    permanent: false,
   },
 ];
 

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -116,4 +116,16 @@ const CURRENT = [
   },
 ];
 
-module.exports = [...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];
+/* Splitbee Proxy */
+const SPLITBEE = [
+  {
+    source: '/sb.js',
+    destination: 'https://cdn.splitbee.io/sb.js',
+  },
+  {
+    source: '/_sb/:slug',
+    destination: 'https://hive.splitbee.io/:slug',
+  },
+];
+
+module.exports = [...SPLITBEE, ...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];


### PR DESCRIPTION
This sets up [splitbee](http://splitbee.io) analytics on the website so we can try it out (looks like a more privacy-friendly alternative to Google Analytics)