### PR TITLE
Improve the createContext API in extendExpressApp

### DIFF
--- a/docs/pages/docs/apis/config.mdx
+++ b/docs/pages/docs/apis/config.mdx
@@ -256,6 +256,11 @@ config({
 
 This lets you modify the express app that Keystone creates _before_ the Apollo Server and Admin UI Middleware are added to it (but after the `cors` and `healthcheck` options are applied).
 
+The function is passed two arguments:
+
+- `app`: The express app keystone has created
+- `async createContext(req, res)`: A function you can call to create a Keystone Context for the request
+
 For example, you could add your own request logging middleware:
 
 ```ts
@@ -284,6 +289,24 @@ export default config({
   },
 });
 ```
+
+You could also use it to add custom REST endpoints to your server, by creating a context for the request and using the Query API Keystone provides:
+
+```ts
+export default config({
+  server: {
+    extendExpressApp: (app, createContext) => {
+      app.get('/api/users', async (req, res) => {
+        const context = await createContext(req, res);
+        const users = await context.query.User.findMany();
+        res.json(users);
+      });
+    },
+  },
+});
+```
+
+The created context will be bound to the request, including the current visitor's session, meaning access control will work the same as for GraphQL API requests.
 
 ## session
 

--- a/packages/keystone/src/types/config/index.ts
+++ b/packages/keystone/src/types/config/index.ts
@@ -3,7 +3,7 @@ import { CorsOptions } from 'cors';
 import express from 'express';
 import type { GraphQLSchema } from 'graphql';
 
-import type { AssetMode, CreateContext, KeystoneContext } from '..';
+import type { AssetMode, CreateRequestContext, KeystoneContext } from '..';
 
 import { SessionStrategy } from '../session';
 import type { MaybePromise } from '../utils';
@@ -103,7 +103,7 @@ export type ServerConfig = {
   /** Health check configuration. Set to `true` to add a basic `/_healthcheck` route, or specify the path and data explicitly */
   healthCheck?: HealthCheckConfig | true;
   /** Hook to extend the Express App that Keystone creates */
-  extendExpressApp?: (app: express.Express, createContext: CreateContext) => void;
+  extendExpressApp?: (app: express.Express, createContext: CreateRequestContext) => void;
 };
 
 // config.graphql

--- a/packages/keystone/src/types/core.ts
+++ b/packages/keystone/src/types/core.ts
@@ -15,6 +15,11 @@ export type FieldDefaultValue<T, TGeneratedListTypes extends BaseGeneratedListTy
   | null
   | ((args: FieldDefaultValueArgs<TGeneratedListTypes>) => MaybePromise<T | null | undefined>);
 
+export type CreateRequestContext = (
+  req: IncomingMessage,
+  res: ServerResponse
+) => Promise<KeystoneContext>;
+
 export type CreateContext = (args: {
   sessionContext?: SessionContext<any>;
   sudo?: boolean;


### PR DESCRIPTION
This makes the `createContext` API we added in #6616 much easier to use, in particular avoiding the challenge involved in correctly binding the new context to the current request (which is almost always what you want)

It also brings the default usage inline with the behaviour in graphql extensions, making transitioning between REST APIs (and/or other custom route handlers in express) and GraphQL resolvers really simple.

I'm also working on an example of how to use the Keystone Schema to create a custom REST API using these features, which I'll open a separate PR for after this lands.

**Note** I haven't added a changeset, because this only modifies an API that hasn't been released yet... if we'd released, this would actually be a major, but it's not, and I think including another changeset would make the resulting changelog when we do release make less sense 🤷 