### PR TITLE
Add Splitbee Analytics to Website (alt)

### DIFF
--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -72,6 +72,7 @@ class MyDocument extends Document {
             async
             src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
           />
+          <script async data-api="/_sb" src="/sb.js" />
           <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
           <script
             dangerouslySetInnerHTML={{

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -124,4 +124,18 @@ const CURRENT = [
   },
 ];
 
-module.exports = [...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];
+/* Splitbee Proxy */
+const SPLITBEE = [
+  {
+    source: '/sb.js',
+    destination: 'https://cdn.splitbee.io/sb.js',
+    permanent: false,
+  },
+  {
+    source: '/_sb/:slug',
+    destination: 'https://hive.splitbee.io/:slug',
+    permanent: false,
+  },
+];
+
+module.exports = [...SPLITBEE, ...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];


### PR DESCRIPTION
Copy of https://github.com/keystonejs/keystone/pull/6631 targeting `website_live`.