### PR TITLE
Optimise relationship queries

### DIFF
--- a/.changeset/forty-bobcats-join.md
+++ b/.changeset/forty-bobcats-join.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Improved query generation performance when querying single relationships without filter-based access control.

--- a/docs/pages/docs/apis/access-control.mdx
+++ b/docs/pages/docs/apis/access-control.mdx
@@ -124,6 +124,9 @@ export default config({
 !> Filter access control cannot be used on `create` operations, as there is no pre-existing item to filter against.
 To restrict `create` operations configure either `access.operation.create` or `access.item.create`.
 
+?> Filter based access control can impact the performance when querying related items on a list.
+Keystone optimises queries for to-one relationships, however these optimisations cannot be used in conjunction with access control filters.
+
 ### Item (mutations only)
 
 `item` is the final and most powerful level of access control.

--- a/packages/keystone/src/lib/core/queries/output-field.ts
+++ b/packages/keystone/src/lib/core/queries/output-field.ts
@@ -60,7 +60,7 @@ function getRelationVal(
         return null;
       }
 
-      if (accessFilters === true && fk) {
+      if (accessFilters === true && fk !== undefined) {
         // We know the exact item we're looking for, and there are no other filters to apply,
         // so we can use findUnique to get the item. This allows Prisma to group multiple
         // findUnique operations into a single database query, which solves the N+1 problem
@@ -73,9 +73,10 @@ function getRelationVal(
         // If we have a foreign key, we'll search directly on this ID, and merge in the access filters.
         // If we don't have a foreign key, we'll use the general solution, which is a filter based
         // on the original item's ID, merged with any access control filters.
-        const relationFilter = fk
-          ? { id: fk }
-          : { [dbField.field]: oppositeDbField.mode === 'many' ? { some: { id } } : { id } };
+        const relationFilter =
+          fk !== undefined
+            ? { id: fk }
+            : { [dbField.field]: oppositeDbField.mode === 'many' ? { some: { id } } : { id } };
 
         // There's no need to check isFilterable access here (c.f. `findOne()`), as
         // the filter has been constructed internally, not as part of user input.


### PR DESCRIPTION
When resolving related items, we often have a foreign key available to us that we can use to help optimise the subsequent related item query. If, on top of this, there are no filter-based access control rules in place, then we can use the Prisma `findUnique` operation, which will group all the operations into a single database query. This solves the GraphQL N+1 query problem in this specific instance.

```
prisma:query SELECT `main`.`Post`.`id`, `main`.`Post`.`title`, `main`.`Post`.`status`, `main`.`Post`.`content`, `main`.`Post`.`publishDate`, `main`.`Post`.`author` FROM `main`.`Post` WHERE 1=1 LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE (`main`.`Author`.`id`) IN (SELECT `t0`.`id` FROM `main`.`Author` AS `t0` INNER JOIN `main`.`Post` AS `j0` ON (`j0`.`author`) = (`t0`.`id`) WHERE (`j0`.`id` = ? AND `t0`.`id` IS NOT NULL)) LIMIT ? OFFSET ?
```

becomes

```
prisma:query SELECT `main`.`Post`.`id`, `main`.`Post`.`title`, `main`.`Post`.`status`, `main`.`Post`.`content`, `main`.`Post`.`publishDate`, `main`.`Post`.`author` FROM `main`.`Post` WHERE 1=1 LIMIT ? OFFSET ?
prisma:query SELECT `main`.`Author`.`id`, `main`.`Author`.`name`, `main`.`Author`.`email` FROM `main`.`Author` WHERE `main`.`Author`.`id` IN (?,?,?,?) LIMIT ? OFFSET ?
```

for the query

```
query Query {
  posts {
    id
    title
    author {
      id
      name
    }
  }
}
```