### PR TITLE
Use extensionError for all extensions

### DIFF
--- a/.changeset/little-colts-deliver.md
+++ b/.changeset/little-colts-deliver.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Improved the error messages provided from the GraphQL API when extension code (e.g access control functions, hooks, etc) throw exceptions.

--- a/packages/keystone/src/lib/core/mutations/access-control.ts
+++ b/packages/keystone/src/lib/core/mutations/access-control.ts
@@ -1,6 +1,5 @@
 import { KeystoneContext } from '../../../types';
-import { validateFieldAccessControl } from '../access-control';
-import { accessDeniedError, accessReturnError } from '../graphql-errors';
+import { accessDeniedError, accessReturnError, extensionError } from '../graphql-errors';
 import { mapUniqueWhereToWhere } from '../queries/resolvers';
 import { InitialisedList } from '../types-for-lists';
 import { runWithPrisma } from '../utils';
@@ -52,7 +51,15 @@ export async function getAccessControlledItemForDelete(
   const args = { operation, session: context.session, listKey: list.listKey, context, item };
 
   // List level 'item' access control
-  const result = await access(args);
+  let result;
+  try {
+    result = await access(args);
+  } catch (error: any) {
+    throw extensionError('Access control', [
+      { error, tag: `${args.listKey}.access.item.${args.operation}` },
+    ]);
+  }
+
   const resultType = typeof result;
 
   // It's important that we don't cast objects to truthy values, as there's a strong chance that the user
@@ -102,7 +109,14 @@ export async function getAccessControlledItemForUpdate(
   };
 
   // List level 'item' access control
-  const result = await access(args);
+  let result;
+  try {
+    result = await access(args);
+  } catch (error: any) {
+    throw extensionError('Access control', [
+      { error, tag: `${args.listKey}.access.item.${args.operation}` },
+    ]);
+  }
   const resultType = typeof result;
 
   // It's important that we don't cast objects to truthy values, as there's a strong chance that the user
@@ -125,32 +139,37 @@ export async function getAccessControlledItemForUpdate(
   }
 
   // Field level 'item' access control
-  const fieldAccess = await Promise.all(
-    Object.keys(originalInput!).map(async fieldKey => [
-      fieldKey,
-      await validateFieldAccessControl({
-        access: list.fields[fieldKey].access[operation],
-        args: { ...args, fieldKey },
-      }),
-    ])
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const nonBooleans = fieldAccess.filter(([_, result]) => typeof result !== 'boolean');
-  if (nonBooleans.length) {
-    throw accessReturnError(
-      nonBooleans.map(([fieldKey, result]) => ({
+  const nonBooleans = [];
+  const fieldsDenied = [];
+  const accessErrors = [];
+  for (const fieldKey of Object.keys(originalInput)) {
+    let result;
+    try {
+      result =
+        typeof list.fields[fieldKey].access[operation] === 'function'
+          ? await list.fields[fieldKey].access[operation]({ ...args, fieldKey })
+          : access;
+    } catch (error: any) {
+      accessErrors.push({ error, tag: `${args.listKey}.${fieldKey}.access.${args.operation}` });
+      continue;
+    }
+    if (typeof result !== 'boolean') {
+      nonBooleans.push({
         tag: `${args.listKey}.${fieldKey}.access.${args.operation}`,
         returned: typeof result,
-      }))
-    );
+      });
+    } else if (!result) {
+      fieldsDenied.push(fieldKey);
+    }
   }
 
-  const fieldsDenied = fieldAccess
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .filter(([_, result]) => !result)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .map(([fieldKey, _]) => fieldKey);
+  if (accessErrors.length) {
+    throw extensionError('Access control', accessErrors);
+  }
+
+  if (nonBooleans.length) {
+    throw accessReturnError(nonBooleans);
+  }
 
   if (fieldsDenied.length) {
     throw accessDeniedError(
@@ -181,7 +200,15 @@ export async function applyAccessControlForCreate(
   };
 
   // List level 'item' access control
-  const result = await access(args);
+  let result;
+  try {
+    result = await access(args);
+  } catch (error: any) {
+    throw extensionError('Access control', [
+      { error, tag: `${args.listKey}.access.item.${args.operation}` },
+    ]);
+  }
+
   const resultType = typeof result;
 
   // It's important that we don't cast objects to truthy values, as there's a strong chance that the user
@@ -204,32 +231,38 @@ export async function applyAccessControlForCreate(
   }
 
   // Field level 'item' access control
-  const fieldAccess = await Promise.all(
-    Object.keys(originalInput!).map(async fieldKey => [
-      fieldKey,
-      await validateFieldAccessControl({
-        access: list.fields[fieldKey].access[operation],
-        args: { ...args, fieldKey },
-      }),
-    ])
-  );
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const nonBooleans = fieldAccess.filter(([_, result]) => typeof result !== 'boolean');
-  if (nonBooleans.length) {
-    throw accessReturnError(
-      nonBooleans.map(([fieldKey, result]) => ({
+  // Field level 'item' access control
+  const nonBooleans = [];
+  const fieldsDenied = [];
+  const accessErrors = [];
+  for (const fieldKey of Object.keys(originalInput)) {
+    let result;
+    try {
+      result =
+        typeof list.fields[fieldKey].access[operation] === 'function'
+          ? await list.fields[fieldKey].access[operation]({ ...args, fieldKey })
+          : access;
+    } catch (error: any) {
+      accessErrors.push({ error, tag: `${args.listKey}.${fieldKey}.access.${args.operation}` });
+      continue;
+    }
+    if (typeof result !== 'boolean') {
+      nonBooleans.push({
         tag: `${args.listKey}.${fieldKey}.access.${args.operation}`,
         returned: typeof result,
-      }))
-    );
+      });
+    } else if (!result) {
+      fieldsDenied.push(fieldKey);
+    }
   }
 
-  const fieldsDenied = fieldAccess
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .filter(([_, result]) => !result)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    .map(([fieldKey, _]) => fieldKey);
+  if (accessErrors.length) {
+    throw extensionError('Access control', accessErrors);
+  }
+
+  if (nonBooleans.length) {
+    throw accessReturnError(nonBooleans);
+  }
 
   if (fieldsDenied.length) {
     throw accessDeniedError(

--- a/packages/keystone/src/lib/core/mutations/create-update.ts
+++ b/packages/keystone/src/lib/core/mutations/create-update.ts
@@ -328,7 +328,7 @@ async function getResolvedData(
           fieldKey,
         });
       } catch (error: any) {
-        fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}` });
+        fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.${hookName}` });
       }
     }
   }
@@ -342,7 +342,7 @@ async function getResolvedData(
     try {
       resolvedData = (await list.hooks.resolveInput({ ...hookArgs, resolvedData })) as any;
     } catch (error: any) {
-      throw extensionError(hookName, [{ error, tag: list.listKey }]);
+      throw extensionError(hookName, [{ error, tag: `${list.listKey}.hooks.${hookName}` }]);
     }
   }
 

--- a/packages/keystone/src/lib/core/mutations/hooks.ts
+++ b/packages/keystone/src/lib/core/mutations/hooks.ts
@@ -37,7 +37,7 @@ export async function runSideEffectOnlyHook<
       try {
         await field.hooks[hookName]?.({ fieldKey, ...args });
       } catch (error: any) {
-        fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}` });
+        fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.${hookName}` });
       }
     }
   }
@@ -49,6 +49,6 @@ export async function runSideEffectOnlyHook<
   try {
     await list.hooks[hookName]?.(args);
   } catch (error: any) {
-    throw extensionError(hookName, [{ error, tag: list.listKey }]);
+    throw extensionError(hookName, [{ error, tag: `${list.listKey}.hooks.${hookName}` }]);
   }
 }

--- a/packages/keystone/src/lib/core/mutations/validation.ts
+++ b/packages/keystone/src/lib/core/mutations/validation.ts
@@ -1,4 +1,4 @@
-import { validationFailureError } from '../graphql-errors';
+import { extensionError, validationFailureError } from '../graphql-errors';
 import { InitialisedList } from '../types-for-lists';
 
 type UpdateCreateHookArgs = Parameters<
@@ -36,18 +36,31 @@ export async function validateUpdateCreate({
     }
   }
 
+  const fieldsErrors: { error: Error; tag: string }[] = [];
   // Field validation hooks
   for (const [fieldKey, field] of Object.entries(list.fields)) {
     const addValidationError = (msg: string) =>
       messages.push(`${list.listKey}.${fieldKey}: ${msg}`);
-    // @ts-ignore
-    await field.hooks.validateInput?.({ ...hookArgs, addValidationError, fieldKey });
+    try {
+      // @ts-ignore
+      await field.hooks.validateInput?.({ ...hookArgs, addValidationError, fieldKey });
+    } catch (error: any) {
+      fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.validateInput` });
+    }
+  }
+  if (fieldsErrors.length) {
+    throw extensionError('validateInput', fieldsErrors);
   }
 
   // List validation hooks
   const addValidationError = (msg: string) => messages.push(`${list.listKey}: ${msg}`);
-  // @ts-ignore
-  await list.hooks.validateInput?.({ ...hookArgs, addValidationError });
+  try {
+    // @ts-ignore
+    await list.hooks.validateInput?.({ ...hookArgs, addValidationError });
+  } catch (error: any) {
+    throw extensionError('validateInput', [{ error, tag: `${list.listKey}.hooks.validateInput` }]);
+  }
+
   if (messages.length) {
     throw validationFailureError(messages);
   }
@@ -62,18 +75,29 @@ export async function validateDelete({
   hookArgs: Omit<DeleteHookArgs, 'addValidationError'>;
 }) {
   const messages: string[] = [];
-
+  const fieldsErrors: { error: Error; tag: string }[] = [];
   // Field validation
   for (const [fieldKey, field] of Object.entries(list.fields)) {
     const addValidationError = (msg: string) =>
       messages.push(`${list.listKey}.${fieldKey}: ${msg}`);
-    await field.hooks.validateDelete?.({ ...hookArgs, addValidationError, fieldKey });
+    try {
+      await field.hooks.validateDelete?.({ ...hookArgs, addValidationError, fieldKey });
+    } catch (error: any) {
+      fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.validateDelete` });
+    }
   }
-
+  if (fieldsErrors.length) {
+    throw extensionError('validateDelete', fieldsErrors);
+  }
   // List validation
   const addValidationError = (msg: string) => messages.push(`${list.listKey}: ${msg}`);
-  await list.hooks.validateDelete?.({ ...hookArgs, addValidationError });
-
+  try {
+    await list.hooks.validateDelete?.({ ...hookArgs, addValidationError });
+  } catch (error: any) {
+    throw extensionError('validateDelete', [
+      { error, tag: `${list.listKey}.hooks.validateDelete` },
+    ]);
+  }
   if (messages.length) {
     throw validationFailureError(messages);
   }

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -136,7 +136,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Change`, [
                   {
                     path: ['createUser'],
-                    messages: [`User: Simulated error: ${phase}Change`],
+                    messages: [`User.hooks.${phase}Change: Simulated error: ${phase}Change`],
                     debug: [
                       {
                         message,
@@ -178,7 +178,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Change`, [
                   {
                     path: ['updateUser'],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Change: ${message}`],
                     debug: [
                       {
                         message,
@@ -220,7 +220,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Delete`, [
                   {
                     path: ['deleteUser'],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Delete: ${message}`],
                     debug: [
                       {
                         message,
@@ -272,7 +272,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Change`, [
                   {
                     path: ['createUsers', 1],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Change: ${message}`],
                     debug: [
                       {
                         message,
@@ -284,7 +284,7 @@ const runner = (debug: boolean | undefined) =>
                   },
                   {
                     path: ['createUsers', 3],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Change: ${message}`],
                     debug: [
                       {
                         message,
@@ -351,7 +351,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Change`, [
                   {
                     path: ['updateUsers', 1],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Change: ${message}`],
                     debug: [
                       {
                         message,
@@ -363,7 +363,7 @@ const runner = (debug: boolean | undefined) =>
                   },
                   {
                     path: ['updateUsers', 3],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Change: ${message}`],
                     debug: [
                       {
                         message,
@@ -425,7 +425,7 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Delete`, [
                   {
                     path: ['deleteUsers', 1],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Delete: ${message}`],
                     debug: [
                       {
                         message,
@@ -437,7 +437,7 @@ const runner = (debug: boolean | undefined) =>
                   },
                   {
                     path: ['deleteUsers', 3],
-                    messages: [`User: ${message}`],
+                    messages: [`User.hooks.${phase}Delete: ${message}`],
                     debug: [
                       {
                         message,
@@ -485,7 +485,10 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Change`, [
                   {
                     path: ['updatePost'],
-                    messages: [`Post.title: ${message1}`, `Post.content: ${message2}`],
+                    messages: [
+                      `Post.title.hooks.${phase}Change: ${message1}`,
+                      `Post.content.hooks.${phase}Change: ${message2}`,
+                    ],
                     debug: [
                       {
                         message: message1,
@@ -532,7 +535,10 @@ const runner = (debug: boolean | undefined) =>
                 expectExtensionError(mode, useHttp, debug, errors, `${phase}Delete`, [
                   {
                     path: ['deletePost'],
-                    messages: [`Post.title: ${message1}`, `Post.content: ${message2}`],
+                    messages: [
+                      `Post.title.hooks.${phase}Delete: ${message1}`,
+                      `Post.content.hooks.${phase}Delete: ${message2}`,
+                    ],
                     debug: [
                       {
                         message: message1,

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -61,7 +61,7 @@ describe('List Hooks: #resolveInput()', () => {
       expectExtensionError('dev', false, undefined, errors, `resolveInput`, [
         {
           path: ['createUser'],
-          messages: [`User: ${message}`],
+          messages: [`User.hooks.resolveInput: ${message}`],
           debug: [
             {
               message,
@@ -89,7 +89,7 @@ describe('List Hooks: #resolveInput()', () => {
       expectExtensionError('dev', false, undefined, errors, `resolveInput`, [
         {
           path: ['createUser'],
-          messages: [`User.name: ${message}`],
+          messages: [`User.name.hooks.resolveInput: ${message}`],
           debug: [
             {
               message,


### PR DESCRIPTION
Provide consistent error messaging when developer-provided code throws an exception. Catch and group errors thrown while iterating over fields.