### PR TITLE
Re-enable all field-type CRUD tests

### DIFF
--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -32,6 +32,7 @@
     "@keystone-ui/popover": "^4.0.3",
     "@keystone-ui/tooltip": "^4.0.2",
     "@types/react": "^17.0.24",
+    "apollo-server-errors": "^3.1.0",
     "apply-ref": "^1.0.0",
     "fp-ts": "^2.11.4",
     "graphql": "^15.6.0",

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -7,6 +7,7 @@ import {
   graphql,
   JSONValue,
 } from '@keystone-next/keystone/types';
+import { userInputError } from '@keystone-next/keystone/src/lib/core/graphql-errors';
 import { Relationships } from './DocumentEditor/relationship';
 import { ComponentBlock } from './component-blocks';
 import { DocumentFeatures } from './views';
@@ -99,7 +100,7 @@ export const document =
 
     const inputResolver = (data: JSONValue | null | undefined): any => {
       if (data === null) {
-        throw new Error(`Document fields cannot be set to null`);
+        throw userInputError(`Document fields cannot be set to null`);
       }
       if (data === undefined) {
         return data;

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { ApolloError } from 'apollo-server-errors';
 import {
   BaseGeneratedListTypes,
   CommonFieldConfig,
@@ -7,7 +8,6 @@ import {
   graphql,
   JSONValue,
 } from '@keystone-next/keystone/types';
-import { userInputError } from '@keystone-next/keystone/src/lib/core/graphql-errors';
 import { Relationships } from './DocumentEditor/relationship';
 import { ComponentBlock } from './component-blocks';
 import { DocumentFeatures } from './views';
@@ -100,7 +100,7 @@ export const document =
 
     const inputResolver = (data: JSONValue | null | undefined): any => {
       if (data === null) {
-        throw userInputError(`Document fields cannot be set to null`);
+        throw new ApolloError('Input error: Document fields cannot be set to null')
       }
       if (data === undefined) {
         return data;

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -100,7 +100,7 @@ export const document =
 
     const inputResolver = (data: JSONValue | null | undefined): any => {
       if (data === null) {
-        throw new ApolloError('Input error: Document fields cannot be set to null')
+        throw new ApolloError('Input error: Document fields cannot be set to null');
       }
       if (data === undefined) {
         return data;

--- a/packages/fields-document/src/tests/test-fixtures.ts
+++ b/packages/fields-document/src/tests/test-fixtures.ts
@@ -12,6 +12,7 @@ export const updateReturnedValue = [
   { type: 'paragraph', children: [{ text: '' }] },
 ];
 
+export const neverNull = true;
 export const supportsUnique = false;
 export const skipRequiredTest = true;
 export const fieldName = 'content';

--- a/packages/keystone/src/fields/types/checkbox/index.ts
+++ b/packages/keystone/src/fields/types/checkbox/index.ts
@@ -51,7 +51,7 @@ export const checkbox =
           }),
           resolve(val) {
             if (val === null) {
-              throw userInputError('checkbox fields cannot be set to null');
+              throw userInputError('Checkbox fields cannot be set to null');
             }
             return val ?? defaultValue;
           },
@@ -60,7 +60,7 @@ export const checkbox =
           arg: graphql.arg({ type: graphql.Boolean }),
           resolve(val) {
             if (val === null) {
-              throw userInputError('checkbox fields cannot be set to null');
+              throw userInputError('Checkbox fields cannot be set to null');
             }
             return val;
           },

--- a/packages/keystone/src/fields/types/checkbox/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/checkbox/tests/test-fixtures.ts
@@ -4,6 +4,7 @@ export const name = 'Checkbox';
 export const typeFunction = checkbox;
 export const exampleValue = () => true;
 export const exampleValue2 = () => false;
+export const neverNull = true;
 export const supportsUnique = false;
 export const fieldName = 'enabled';
 export const skipRequiredTest = true;

--- a/packages/keystone/src/fields/types/decimal/index.ts
+++ b/packages/keystone/src/fields/types/decimal/index.ts
@@ -132,6 +132,9 @@ export const decimal =
           if (val === null && validation?.isRequired) {
             args.addValidationError(`${fieldLabel} is required`);
           }
+          if (val === null && config.isNullable === false) {
+            args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
+          }
           if (val != null) {
             if (min !== undefined && val.lessThan(min)) {
               args.addValidationError(`${fieldLabel} must be greater than or equal to ${min}`);

--- a/packages/keystone/src/fields/types/decimal/index.ts
+++ b/packages/keystone/src/fields/types/decimal/index.ts
@@ -129,11 +129,8 @@ export const decimal =
         async validateInput(args) {
           const val: Decimal | null | undefined = args.resolvedData[meta.fieldKey];
 
-          if (val === null && validation?.isRequired) {
+          if (val === null && (validation?.isRequired || config.isNullable === false)) {
             args.addValidationError(`${fieldLabel} is required`);
-          }
-          if (val === null && config.isNullable === false) {
-            args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
           }
           if (val != null) {
             if (min !== undefined && val.lessThan(min)) {

--- a/packages/keystone/src/fields/types/decimal/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/decimal/tests/test-fixtures.ts
@@ -5,6 +5,7 @@ export const name = 'Decimal';
 export const typeFunction = decimal;
 export const exampleValue = () => '6.28';
 export const exampleValue2 = () => '6.45';
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const skipRequiredTest = true;
 export const fieldName = 'price';

--- a/packages/keystone/src/fields/types/file/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/file/tests/test-fixtures.ts
@@ -25,6 +25,7 @@ export const exampleValue2 = () => prepareFile('react.jpg');
 export const createReturnedValue = 3250;
 export const updateReturnedValue = 5562;
 
+export const supportsNullInput = true;
 export const supportsUnique = false;
 export const skipRequiredTest = true;
 export const fieldName = 'secretFile';
@@ -161,7 +162,9 @@ export const crudTests = (keystoneTestWrapper: any) => {
         });
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
-        expect(errors![0].message).toEqual('Either ref or upload must be passed to FileFieldInput');
+        expect(errors![0].message).toEqual(
+          'Input error: Either ref or upload must be passed to FileFieldInput'
+        );
       })
     );
     test(
@@ -192,7 +195,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toEqual(
-          'Only one of ref and upload can be passed to FileFieldInput'
+          'Input error: Only one of ref and upload can be passed to FileFieldInput'
         );
       })
     );
@@ -216,7 +219,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toEqual(
-          'Only one of ref and upload can be passed to FileFieldInput'
+          'Input error: Only one of ref and upload can be passed to FileFieldInput'
         );
       })
     );

--- a/packages/keystone/src/fields/types/float/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/float/tests/test-fixtures.ts
@@ -4,6 +4,7 @@ export const name = 'Float';
 export const typeFunction = float;
 export const exampleValue = () => 6.28;
 export const exampleValue2 = () => 6.283;
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const fieldName = 'testField';
 

--- a/packages/keystone/src/fields/types/image/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/image/tests/test-fixtures.ts
@@ -26,6 +26,7 @@ export const exampleValue2 = () => prepareFile('react.jpg');
 export const createReturnedValue = 'jpg';
 export const updateReturnedValue = createReturnedValue;
 
+export const supportsNullInput = true;
 export const supportsUnique = false;
 export const skipRequiredTest = true;
 export const fieldName = 'avatar';
@@ -200,7 +201,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toEqual(
-          'Either ref or upload must be passed to ImageFieldInput'
+          'Input error: Either ref or upload must be passed to ImageFieldInput'
         );
       })
     );
@@ -230,7 +231,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toEqual(
-          'Only one of ref and upload can be passed to ImageFieldInput'
+          'Input error: Only one of ref and upload can be passed to ImageFieldInput'
         );
       })
     );
@@ -254,7 +255,7 @@ export const crudTests = (keystoneTestWrapper: any) => {
         expect(data).toEqual({ createTest: null });
         expect(errors).toHaveLength(1);
         expect(errors![0].message).toEqual(
-          'Only one of ref and upload can be passed to ImageFieldInput'
+          'Input error: Only one of ref and upload can be passed to ImageFieldInput'
         );
       })
     );

--- a/packages/keystone/src/fields/types/integer/index.ts
+++ b/packages/keystone/src/fields/types/integer/index.ts
@@ -128,7 +128,7 @@ export const integer =
           const value = args.resolvedData[meta.fieldKey];
 
           if (
-            validation?.isRequired &&
+            (validation?.isRequired || config.isNullable === false) &&
             (value === null ||
               (args.operation === 'create' && value === undefined && !hasAutoIncDefault))
           ) {

--- a/packages/keystone/src/fields/types/integer/tests/non-null/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/integer/tests/non-null/test-fixtures.ts
@@ -1,0 +1,38 @@
+import { integer } from '../..';
+
+export const name = 'Integer with isNullable: false';
+export const typeFunction = (x: any) => integer({ isNullable: false, ...x });
+export const exampleValue = () => 37;
+export const exampleValue2 = () => 38;
+export const supportsGraphQLIsNonNull = true;
+export const supportsUnique = true;
+export const skipRequiredTest = true;
+export const fieldName = 'testField';
+
+export const getTestFields = () => ({
+  testField: integer({ isFilterable: true, isNullable: false }),
+});
+
+export const initItems = () => {
+  return [
+    { name: 'person1', testField: 0 },
+    { name: 'person2', testField: 1 },
+    { name: 'person3', testField: 2 },
+    { name: 'person4', testField: 3 },
+    { name: 'person5', testField: 37 },
+    { name: 'person6', testField: 10 },
+    { name: 'person7', testField: 20 },
+  ];
+};
+
+export const storedValues = () => [
+  { name: 'person1', testField: 0 },
+  { name: 'person2', testField: 1 },
+  { name: 'person3', testField: 2 },
+  { name: 'person4', testField: 3 },
+  { name: 'person5', testField: 37 },
+  { name: 'person6', testField: 10 },
+  { name: 'person7', testField: 20 },
+];
+
+export const supportedFilters = () => [];

--- a/packages/keystone/src/fields/types/integer/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/integer/tests/test-fixtures.ts
@@ -4,6 +4,7 @@ export const name = 'Integer';
 export const typeFunction = integer;
 export const exampleValue = () => 37;
 export const exampleValue2 = () => 38;
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const skipRequiredTest = true;
 export const fieldName = 'testField';

--- a/packages/keystone/src/fields/types/json/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/json/tests/test-fixtures.ts
@@ -8,6 +8,7 @@ export const exampleValue = () => ({
 export const exampleValue2 = () => ({
   b: [],
 });
+export const supportsNullInput = true;
 export const supportsUnique = false;
 export const skipRequiredTest = true;
 export const fieldName = 'testField';

--- a/packages/keystone/src/fields/types/select/index.ts
+++ b/packages/keystone/src/fields/types/select/index.ts
@@ -107,6 +107,9 @@ export const select =
             ) {
               args.addValidationError(`${fieldLabel} is required`);
             }
+            if (value === null && config.isNullable === false) {
+              args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
+            }
             await config.hooks?.validateInput?.(args);
           },
         },

--- a/packages/keystone/src/fields/types/select/index.ts
+++ b/packages/keystone/src/fields/types/select/index.ts
@@ -102,9 +102,8 @@ export const select =
               args.addValidationError(`${value} is not a possible value for ${fieldLabel}`);
             }
             if (
-              (validation?.isRequired &&
-                (value === null || (value === undefined && args.operation === 'create'))) ||
-              (value === null && config.isNullable === false)
+              (validation?.isRequired || config.isNullable === false) &&
+              (value === null || (value === undefined && args.operation === 'create'))
             ) {
               args.addValidationError(`${fieldLabel} is required`);
             }

--- a/packages/keystone/src/fields/types/select/index.ts
+++ b/packages/keystone/src/fields/types/select/index.ts
@@ -102,13 +102,11 @@ export const select =
               args.addValidationError(`${value} is not a possible value for ${fieldLabel}`);
             }
             if (
-              validation?.isRequired &&
-              (value === null || (value === undefined && args.operation === 'create'))
+              (validation?.isRequired &&
+                (value === null || (value === undefined && args.operation === 'create'))) ||
+              (value === null && config.isNullable === false)
             ) {
               args.addValidationError(`${fieldLabel} is required`);
-            }
-            if (value === null && config.isNullable === false) {
-              args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
             }
             await config.hooks?.validateInput?.(args);
           },

--- a/packages/keystone/src/fields/types/select/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/select/tests/test-fixtures.ts
@@ -8,6 +8,7 @@ export const exampleValue = (matrixValue: MatrixValue) =>
   matrixValue === 'enum' ? 'thinkmill' : matrixValue === 'string' ? 'a string' : 1;
 export const exampleValue2 = (matrixValue: MatrixValue) =>
   matrixValue === 'enum' ? 'atlassian' : matrixValue === 'string' ? '1number' : 2;
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const skipRequiredTest = true;
 export const fieldConfig = (matrixValue: MatrixValue) => {

--- a/packages/keystone/src/fields/types/text/index.ts
+++ b/packages/keystone/src/fields/types/text/index.ts
@@ -97,6 +97,9 @@ export const text =
           if (val === null && validation?.isRequired) {
             args.addValidationError(`${fieldLabel} is required`);
           }
+          if (val === null && config.isNullable !== true) {
+            args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
+          }
           if (val != null) {
             if (validation?.length?.min !== undefined && val.length < validation.length.min) {
               if (validation.length.min === 1) {

--- a/packages/keystone/src/fields/types/text/index.ts
+++ b/packages/keystone/src/fields/types/text/index.ts
@@ -94,11 +94,8 @@ export const text =
         ...config.hooks,
         async validateInput(args) {
           const val = args.resolvedData[meta.fieldKey];
-          if (val === null && validation?.isRequired) {
+          if (val === null && (validation?.isRequired || config.isNullable !== true)) {
             args.addValidationError(`${fieldLabel} is required`);
-          }
-          if (val === null && config.isNullable !== true) {
-            args.addValidationError(`${fieldLabel} cannot be set to 'null'`);
           }
           if (val != null) {
             if (validation?.length?.min !== undefined && val.length < validation.length.min) {

--- a/packages/keystone/src/fields/types/text/tests/nullable/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/text/tests/nullable/test-fixtures.ts
@@ -5,6 +5,7 @@ export const name = 'Text with isNullable: true';
 export const typeFunction = (config: any) => text({ ...config, isNullable: true });
 export const exampleValue = () => 'foo';
 export const exampleValue2 = () => 'bar';
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const skipRequiredTest = true;
 export const fieldName = 'testField';

--- a/packages/keystone/src/fields/types/text/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/text/tests/test-fixtures.ts
@@ -4,6 +4,7 @@ export const name = 'Text';
 export const typeFunction = text;
 export const exampleValue = () => 'foo';
 export const exampleValue2 = () => 'bar';
+export const supportsNullInput = false;
 export const supportsUnique = true;
 export const skipRequiredTest = true;
 export const supportsGraphQLIsNonNull = true;

--- a/packages/keystone/src/fields/types/timestamp/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/timestamp/tests/test-fixtures.ts
@@ -5,6 +5,7 @@ export const name = 'DateTimeUtc';
 export const typeFunction = timestamp;
 export const exampleValue = () => '1990-12-31T12:34:56.789Z';
 export const exampleValue2 = () => '2000-01-20T00:08:00.000Z';
+export const supportsNullInput = true;
 export const supportsUnique = true;
 export const fieldName = 'lastOnline';
 

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -15,7 +15,6 @@ testModules
     ({ skipCrudTest, unSupportedAdapterList = [] }) =>
       !skipCrudTest && !unSupportedAdapterList.includes(process.env.TEST_ADAPTER)
   )
-  .filter(mod => mod.name === 'Integer')
   .forEach(mod => {
     (mod.testMatrix || ['default']).forEach((matrixValue: string) => {
       const listKey = 'Test';

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -215,7 +215,7 @@ testModules
                           {
                             path: [updateMutationName],
                             messages: [
-                              `Test.${fieldName}: ${humanize(fieldName)} cannot be set to 'null'`,
+                              `Test.${fieldName}: ${humanize(fieldName)} is required`,
                             ],
                           },
                         ]);

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -214,9 +214,7 @@ testModules
                         expectValidationError(errors, [
                           {
                             path: [updateMutationName],
-                            messages: [
-                              `Test.${fieldName}: ${humanize(fieldName)} is required`,
-                            ],
+                            messages: [`Test.${fieldName}: ${humanize(fieldName)} is required`],
                           },
                         ]);
                       }

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -161,12 +161,13 @@ export const expectLimitsExceededError = (
 
 export const expectBadUserInput = (
   errors: readonly any[] | undefined,
-  args: { path: any[]; message: string }[]
+  args: { path: any[]; message: string }[],
+  httpQuery = true
 ) => {
   const unpackedErrors = unpackErrors(errors);
   expect(unpackedErrors).toEqual(
     args.map(({ path, message }) => ({
-      extensions: { code: 'INTERNAL_SERVER_ERROR' },
+      ...(httpQuery ? { extensions: { code: 'INTERNAL_SERVER_ERROR' } } : {}),
       path,
       message: `Input error: ${message}`,
     }))


### PR DESCRIPTION
Not sure when this filter slipped in, but it's definitely not what we want!

I believe all these changes are covered under existing changesets.