### PR TITLE
Rename originalInput to inputData in hook functions

### DIFF
--- a/.changeset/ten-moles-warn.md
+++ b/.changeset/ten-moles-warn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Renamed the `originalInput` argument for hook functions to `inputData`.

--- a/docs/pages/docs/apis/hooks.mdx
+++ b/docs/pages/docs/apis/hooks.mdx
@@ -69,15 +69,15 @@ For field hooks, the return value should be an updated value for that specific f
 For list hooks, the return value should be a [`resolved data`](#resolved-data-stages) object.
 The result of `resolveInput` will be passed as `resolvedData` into the next stages of the operation.
 
-| Argument        | Description                                                                                                                                                                  |
-| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                       |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                   |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                    |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                |
-| `existingItem`  | The currently stored item (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
-| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after default values, relationship resolvers, and field resolvers have been applied.              |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                              |
+| Argument       | Description                                                                                                                                                                  |
+| :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`      | The key of the list being operated on.                                                                                                                                       |
+| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                                                   |
+| `operation`    | The operation being performed (`'create'` or `'update'`).                                                                                                                    |
+| `inputData`    | The value of `data` passed into the mutation.                                                                                                                                |
+| `existingItem` | The currently stored item (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `resolvedData` | A [`resolved data`](#resolved-data-stages) object. The resolved data value after default values, relationship resolvers, and field resolvers have been applied.              |
+| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                              |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -90,7 +90,7 @@ export default config({
         resolveInput: async ({
           listKey,
           operation,
-          originalInput,
+          inputData,
           existingItem,
           resolvedData,
           context,
@@ -106,7 +106,7 @@ export default config({
               listKey,
               fieldKey,
               operation,
-              originalInput,
+              inputData,
               existingItem,
               resolvedData,
               context,
@@ -136,7 +136,7 @@ These error messages will be returned as a `ValidationFailureError` from the Gra
 | `listKey`                 | The key of the list being operated on.                                                                                                                                                         |
 | `fieldKey`                | The key of the field being operated on (field hooks only).                                                                                                                                     |
 | `operation`               | The operation being performed (`'create'` or `'update'`).                                                                                                                                      |
-| `originalInput`           | The value of `data` passed into the mutation.                                                                                                                                                  |
+| `inputData`               | The value of `data` passed into the mutation.                                                                                                                                                  |
 | `existingItem`            | The current value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
 | `resolvedData`            | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                 |
 | `context`                 | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                |
@@ -153,7 +153,7 @@ export default config({
         validateInput: async ({
           listKey,
           operation,
-          originalInput,
+          inputData,
           existingItem,
           resolvedData,
           context,
@@ -167,7 +167,7 @@ export default config({
               listKey,
               fieldKey,
               operation,
-              originalInput,
+              inputData,
               existingItem,
               resolvedData,
               context,
@@ -187,15 +187,15 @@ The `beforeChange` function is used to perform side effects just before the data
 
 It is invoked after all `validateInput` hooks have been run, but before the data is saved to the database.
 
-| Argument        | Description                                                                                                                                                                                    |
-| :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                                         |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                     |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                      |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                  |
-| `existingItem`  | The current value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
-| `resolvedData`  | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                 |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                |
+| Argument       | Description                                                                                                                                                                                    |
+| :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`      | The key of the list being operated on.                                                                                                                                                         |
+| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                                                                     |
+| `operation`    | The operation being performed (`'create'` or `'update'`).                                                                                                                                      |
+| `inputData`    | The value of `data` passed into the mutation.                                                                                                                                                  |
+| `existingItem` | The current value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `resolvedData` | A [`resolved data`](#resolved-data-stages) object. The resolved data value after all data resolver stages have been completed.                                                                 |
+| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -208,7 +208,7 @@ export default config({
         beforeChange: async ({
           listKey,
           operation,
-          originalInput,
+          inputData,
           existingItem,
           resolvedData,
           context,
@@ -221,7 +221,7 @@ export default config({
               listKey,
               fieldKey,
               operation,
-              originalInput,
+              inputData,
               existingItem,
               resolvedData,
               context,
@@ -238,15 +238,15 @@ export default config({
 
 The `afterChange` function is used to perform side effects after the data for a `create` or `update` operation has been saved to the database.
 
-| Argument        | Description                                                                                                                                                                                     |
-| :-------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `listKey`       | The key of the list being operated on.                                                                                                                                                          |
-| `fieldKey`      | The key of the field being operated on (field hooks only).                                                                                                                                      |
-| `operation`     | The operation being performed (`'create'` or `'update'`).                                                                                                                                       |
-| `originalInput` | The value of `data` passed into the mutation.                                                                                                                                                   |
-| `existingItem`  | The previous value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
-| `updatedItem`   | The new value of the item being updated or created. This object is an internal database item. [DB API](./db-items) for more details on internal database items.                                 |
-| `context`       | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                 |
+| Argument       | Description                                                                                                                                                                                     |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `listKey`      | The key of the list being operated on.                                                                                                                                                          |
+| `fieldKey`     | The key of the field being operated on (field hooks only).                                                                                                                                      |
+| `operation`    | The operation being performed (`'create'` or `'update'`).                                                                                                                                       |
+| `inputData`    | The value of `data` passed into the mutation.                                                                                                                                                   |
+| `existingItem` | The previous value of the item being updated (`undefined` for `create` operations). This object is an internal database item. [DB API](./db-items) for more details on internal database items. |
+| `updatedItem`  | The new value of the item being updated or created. This object is an internal database item. [DB API](./db-items) for more details on internal database items.                                 |
+| `context`      | The [`KeystoneContext`](./context) object of the originating GraphQL operation.                                                                                                                 |
 
 ```typescript
 import { config, list } from '@keystone-next/keystone';
@@ -259,7 +259,7 @@ export default config({
         afterChange: async ({
           listKey,
           operation,
-          originalInput,
+          inputData,
           existingItem,
           updatedItem,
           context,
@@ -272,7 +272,7 @@ export default config({
               listKey,
               fieldKey,
               operation,
-              originalInput,
+              inputData,
               existingItem,
               updatedItem,
               context,

--- a/docs/pages/docs/guides/hooks.mdx
+++ b/docs/pages/docs/guides/hooks.mdx
@@ -84,7 +84,7 @@ export default config({
 
 The `resolveInput` hook is called whenever we update or create an item.
 The value of `resolvedData` will contain the input provided to the mutation itself, along with any `defaultValues` applied on fields.
-If you just want to see what the original input before default values was, you can use the `originalInput` argument.
+If you just want to see what the original input before default values was, you can use the `inputData` argument.
 
 If you're performing an update operation, you might also want to access the current value of the item stored in the database.
 This is available as the `existingItem` argument.
@@ -133,7 +133,7 @@ There might be multiple problems with the input, so you can call `addValidationE
 
 Keystone will abort the operation and convert these error messages into GraphQL errors which will be returned to the caller.
 
-The `validateInput` hook also receives the `operation`, `originalInput`, `existingItem` and `context` arguments if you want to perform more advanced checks.
+The `validateInput` hook also receives the `operation`, `inputData`, `existingItem` and `context` arguments if you want to perform more advanced checks.
 
 ?> Don't confuse data **validation** with **access control**. If you want to check whether a user is **allowed** to do something, you should set up [access control rules](./access-control).
 

--- a/examples/default-values/schema.ts
+++ b/examples/default-values/schema.ts
@@ -14,9 +14,9 @@ export const lists = {
           { label: 'High', value: 'high' },
         ],
         hooks: {
-          resolveInput({ resolvedData, originalInput }) {
-            if (originalInput.priority === undefined) {
-              if (originalInput.label && originalInput.label.toLowerCase().includes('urgent')) {
+          resolveInput({ resolvedData, inputData }) {
+            if (inputData.priority === undefined) {
+              if (inputData.label && inputData.label.toLowerCase().includes('urgent')) {
                 return 'high';
               } else {
                 return 'low';

--- a/packages/keystone/src/lib/core/mutations/create-update.ts
+++ b/packages/keystone/src/lib/core/mutations/create-update.ts
@@ -223,15 +223,15 @@ async function getResolvedData(
     context: KeystoneContext;
     listKey: string;
     operation: 'create' | 'update';
-    originalInput: Record<string, any>;
+    inputData: Record<string, any>;
     existingItem: Record<string, any> | undefined;
   },
   nestedMutationState: NestedMutationState
 ) {
-  const { context, operation, originalInput } = hookArgs;
+  const { context, operation, inputData } = hookArgs;
 
   // Start with the original input
-  let resolvedData = hookArgs.originalInput;
+  let resolvedData = hookArgs.inputData;
 
   // Apply default values
   // We don't expect any errors from here, so we can wrap all these operations
@@ -244,7 +244,7 @@ async function getResolvedData(
           if (input === undefined && field.__legacy?.defaultValue !== undefined) {
             input =
               typeof field.__legacy.defaultValue === 'function'
-                ? await field.__legacy.defaultValue({ originalInput, context })
+                ? await field.__legacy.defaultValue({ originalInput: inputData, context })
                 : field.__legacy.defaultValue;
           }
           return [fieldKey, input] as const;
@@ -352,7 +352,7 @@ async function getResolvedData(
 async function resolveInputForCreateOrUpdate(
   list: InitialisedList,
   context: KeystoneContext,
-  originalInput: Record<string, any>,
+  inputData: Record<string, any>,
   existingItem: Record<string, any> | undefined
 ) {
   const operation: 'create' | 'update' = existingItem === undefined ? 'create' : 'update';
@@ -362,7 +362,7 @@ async function resolveInputForCreateOrUpdate(
     context,
     listKey,
     operation,
-    originalInput,
+    inputData,
     existingItem,
     resolvedData: {},
   };

--- a/packages/keystone/src/lib/core/mutations/hooks.ts
+++ b/packages/keystone/src/lib/core/mutations/hooks.ts
@@ -24,8 +24,8 @@ export async function runSideEffectOnlyHook<
   // was specified in the original input.
   let shouldRunFieldLevelHook: (fieldKey: string) => boolean;
   if (hookName === 'beforeChange' || hookName === 'afterChange') {
-    const originalInputKeys = new Set(Object.keys(args.originalInput));
-    shouldRunFieldLevelHook = fieldKey => originalInputKeys.has(fieldKey);
+    const inputDataKeys = new Set(Object.keys(args.inputData));
+    shouldRunFieldLevelHook = fieldKey => inputDataKeys.has(fieldKey);
   } else {
     shouldRunFieldLevelHook = () => true;
   }

--- a/packages/keystone/src/types/config/hooks.ts
+++ b/packages/keystone/src/types/config/hooks.ts
@@ -56,7 +56,7 @@ type ArgsForCreateOrUpdateOperation<TGeneratedListTypes extends BaseGeneratedLis
       /**
        * The GraphQL input **before** default values are applied
        */
-      originalInput: TGeneratedListTypes['inputs']['create'];
+      inputData: TGeneratedListTypes['inputs']['create'];
       /**
        * The GraphQL input **after** default values are applied
        */
@@ -68,7 +68,7 @@ type ArgsForCreateOrUpdateOperation<TGeneratedListTypes extends BaseGeneratedLis
       /**
        * The GraphQL input **before** default values are applied
        */
-      originalInput: TGeneratedListTypes['inputs']['update'];
+      inputData: TGeneratedListTypes['inputs']['update'];
       /**
        * The GraphQL input **after** default values are applied
        */


### PR DESCRIPTION
This change is part of a final review of the Access Control and hooks APIs.