### PR TITLE
Move `graphql` export to `@keystone-next/keystone`

### DIFF
--- a/.changeset/plenty-clouds-divide.md
+++ b/.changeset/plenty-clouds-divide.md
@@ -1,0 +1,7 @@
+---
+'@keystone-next/cloudinary': major
+'@keystone-next/fields-document': major
+'@keystone-next/keystone': major
+---
+
+Moved `graphql` export of `@keystone-next/keystone/types` to `@keystone-next/keystone`

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -1,4 +1,4 @@
-import { list, graphQLSchemaExtension, gql } from '@keystone-next/keystone';
+import { list, graphQLSchemaExtension, gql, graphql } from '@keystone-next/keystone';
 import {
   text,
   relationship,
@@ -12,7 +12,7 @@ import {
 } from '@keystone-next/keystone/fields';
 import { document } from '@keystone-next/fields-document';
 // import { cloudinaryImage } from '@keystone-next/cloudinary';
-import { KeystoneListsAPI, graphql } from '@keystone-next/keystone/types';
+import { KeystoneListsAPI } from '@keystone-next/keystone/types';
 import { componentBlocks } from './admin/fieldViews/Content';
 import { KeystoneListsTypeInfo } from '.keystone/types';
 

--- a/examples-staging/ecommerce/schemas/Order.ts
+++ b/examples-staging/ecommerce/schemas/Order.ts
@@ -1,6 +1,5 @@
 import { integer, text, relationship, virtual } from '@keystone-next/keystone/fields';
-import { list } from '@keystone-next/keystone';
-import { graphql } from '@keystone-next/keystone/types';
+import { list, graphql } from '@keystone-next/keystone';
 import { isSignedIn, rules } from '../access';
 import formatMoney from '../lib/formatMoney';
 

--- a/examples/custom-field/stars-field/index.ts
+++ b/examples/custom-field/stars-field/index.ts
@@ -5,9 +5,9 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   orderDirectionEnum,
-  graphql,
   filters,
 } from '@keystone-next/keystone/types';
+import { graphql } from '@keystone-next/keystone';
 
 // this field is based on the integer field
 // but with validation to ensure the value is within an expected range

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -1,6 +1,5 @@
-import { list } from '@keystone-next/keystone';
+import { list, graphql } from '@keystone-next/keystone';
 import { select, relationship, text, timestamp, virtual } from '@keystone-next/keystone/fields';
-import { graphql } from '@keystone-next/keystone/types';
 
 export const lists = {
   Post: list({

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -4,8 +4,8 @@ import {
   BaseGeneratedListTypes,
   FieldTypeFunc,
   jsonFieldTypePolyfilledForSQLite,
-  graphql,
 } from '@keystone-next/keystone/types';
+import { graphql } from '@keystone-next/keystone';
 import { FileUpload } from 'graphql-upload';
 import cuid from 'cuid';
 import cloudinary from 'cloudinary';

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -5,9 +5,9 @@ import {
   CommonFieldConfig,
   FieldTypeFunc,
   jsonFieldTypePolyfilledForSQLite,
-  graphql,
   JSONValue,
 } from '@keystone-next/keystone/types';
+import { graphql } from '@keystone-next/keystone';
 import { Relationships } from './DocumentEditor/relationship';
 import { ComponentBlock } from './component-blocks';
 import { DocumentFeatures } from './views';

--- a/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
+++ b/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
@@ -9,7 +9,7 @@ import {
   FieldMetaRootVal,
   ItemRootValue,
 } from '../../types';
-import { graphql as graphqlBoundToKeystoneContext } from '../../..';
+import { graphql as graphqlBoundToKeystoneContext } from '../..';
 
 import { InitialisedList } from '../../lib/core/types-for-lists';
 

--- a/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
+++ b/packages/keystone/src/admin-ui/system/getAdminMetaSchema.ts
@@ -2,7 +2,6 @@ import { GraphQLSchema, GraphQLObjectType, assertScalarType, assertEnumType } fr
 import {
   JSONValue,
   QueryMode,
-  graphql as graphqlBoundToKeystoneContext,
   KeystoneContext,
   KeystoneConfig,
   AdminMetaRootVal,
@@ -10,6 +9,8 @@ import {
   FieldMetaRootVal,
   ItemRootValue,
 } from '../../types';
+import { graphql as graphqlBoundToKeystoneContext } from '../../..';
+
 import { InitialisedList } from '../../lib/core/types-for-lists';
 
 const graphql = {

--- a/packages/keystone/src/fields/types/checkbox/index.ts
+++ b/packages/keystone/src/fields/types/checkbox/index.ts
@@ -5,9 +5,9 @@ import {
   fieldType,
   FieldTypeFunc,
   orderDirectionEnum,
-  graphql,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 

--- a/packages/keystone/src/fields/types/decimal/index.ts
+++ b/packages/keystone/src/fields/types/decimal/index.ts
@@ -4,12 +4,12 @@ import {
   FieldTypeFunc,
   BaseGeneratedListTypes,
   CommonFieldConfig,
-  graphql,
   orderDirectionEnum,
   Decimal,
   filters,
   FieldData,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 

--- a/packages/keystone/src/fields/types/file/index.ts
+++ b/packages/keystone/src/fields/types/file/index.ts
@@ -2,13 +2,13 @@ import { FileUpload } from 'graphql-upload';
 import { userInputError } from '../../../lib/core/graphql-errors';
 import {
   fieldType,
-  graphql,
   FieldTypeFunc,
   CommonFieldConfig,
   BaseGeneratedListTypes,
   KeystoneContext,
   FileData,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { getFileRef } from './utils';
 

--- a/packages/keystone/src/fields/types/float/index.ts
+++ b/packages/keystone/src/fields/types/float/index.ts
@@ -4,11 +4,11 @@ import {
   BaseGeneratedListTypes,
   FieldTypeFunc,
   CommonFieldConfig,
-  graphql,
   fieldType,
   orderDirectionEnum,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 

--- a/packages/keystone/src/fields/types/image/index.ts
+++ b/packages/keystone/src/fields/types/image/index.ts
@@ -8,8 +8,8 @@ import {
   ImageData,
   ImageExtension,
   KeystoneContext,
-  graphql,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { getImageRef, SUPPORTED_IMAGE_EXTENSIONS } from './utils';
 

--- a/packages/keystone/src/fields/types/integer/index.ts
+++ b/packages/keystone/src/fields/types/integer/index.ts
@@ -5,9 +5,9 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   orderDirectionEnum,
-  graphql,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 

--- a/packages/keystone/src/fields/types/json/index.ts
+++ b/packages/keystone/src/fields/types/json/index.ts
@@ -4,8 +4,8 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   jsonFieldTypePolyfilledForSQLite,
-  graphql,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
 export type JsonFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =

--- a/packages/keystone/src/fields/types/password/index.ts
+++ b/packages/keystone/src/fields/types/password/index.ts
@@ -8,8 +8,8 @@ import {
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
-  graphql,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { PasswordFieldMeta } from './views';
 

--- a/packages/keystone/src/fields/types/relationship/index.ts
+++ b/packages/keystone/src/fields/types/relationship/index.ts
@@ -3,9 +3,9 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   fieldType,
-  graphql,
   AdminMetaRootVal,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
 // This is the default display mode for Relationships

--- a/packages/keystone/src/fields/types/select/index.ts
+++ b/packages/keystone/src/fields/types/select/index.ts
@@ -6,9 +6,9 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   orderDirectionEnum,
-  graphql,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 

--- a/packages/keystone/src/fields/types/text/index.ts
+++ b/packages/keystone/src/fields/types/text/index.ts
@@ -3,11 +3,11 @@ import {
   BaseGeneratedListTypes,
   CommonFieldConfig,
   fieldType,
-  graphql,
   orderDirectionEnum,
   FieldTypeFunc,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 

--- a/packages/keystone/src/fields/types/timestamp/index.ts
+++ b/packages/keystone/src/fields/types/timestamp/index.ts
@@ -1,13 +1,13 @@
 import {
   BaseGeneratedListTypes,
   fieldType,
-  graphql,
   FieldTypeFunc,
   CommonFieldConfig,
   orderDirectionEnum,
   FieldDefaultValue,
   filters,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
 export type TimestampFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =

--- a/packages/keystone/src/fields/types/virtual/index.ts
+++ b/packages/keystone/src/fields/types/virtual/index.ts
@@ -1,7 +1,6 @@
 import { getNamedType, isLeafType } from 'graphql';
 import {
   BaseGeneratedListTypes,
-  graphql,
   ItemRootValue,
   CommonFieldConfig,
   FieldTypeFunc,
@@ -9,6 +8,7 @@ import {
   ListInfo,
   getGqlNames,
 } from '../../../types';
+import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
 type VirtualFieldGraphQLField = graphql.Field<ItemRootValue, any, graphql.OutputType, string>;

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -1,2 +1,3 @@
 export { list, gql, graphQLSchemaExtension, config } from './schema/schema';
 export type { ListSchemaConfig, ListConfig, ExtendGraphqlSchema, BaseFields } from './types';
+export { graphql } from './types/schema';

--- a/packages/keystone/src/lib/core/field-assertions.ts
+++ b/packages/keystone/src/lib/core/field-assertions.ts
@@ -1,4 +1,4 @@
-import { graphql } from '../../types';
+import { graphql } from '../..';
 import { InitialisedField } from './types-for-lists';
 
 export type ListForValidation = { listKey: string; fields: Record<string, InitialisedField> };

--- a/packages/keystone/src/lib/core/graphql-schema.ts
+++ b/packages/keystone/src/lib/core/graphql-schema.ts
@@ -1,5 +1,6 @@
 import { GraphQLNamedType, GraphQLSchema } from 'graphql';
-import { DatabaseProvider, graphql } from '../../types';
+import { DatabaseProvider } from '../../types';
+import { graphql } from '../..';
 import { InitialisedList } from './types-for-lists';
 
 import { getMutationsForList } from './mutations';

--- a/packages/keystone/src/lib/core/mutations/index.ts
+++ b/packages/keystone/src/lib/core/mutations/index.ts
@@ -1,4 +1,5 @@
-import { DatabaseProvider, getGqlNames, graphql } from '../../../types';
+import { DatabaseProvider, getGqlNames } from '../../../types';
+import { graphql } from '../../..';
 import { InitialisedList } from '../types-for-lists';
 import * as createAndUpdate from './create-update';
 import * as deletes from './delete';

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-many-input-resolvers.ts
@@ -1,4 +1,5 @@
-import { KeystoneContext, TypesForList, graphql } from '../../../types';
+import { KeystoneContext, TypesForList } from '../../../types';
+import { graphql } from '../../..';
 import { resolveUniqueWhereInput, UniqueInputFilter, UniquePrismaFilter } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { isRejected, isFulfilled } from '../utils';

--- a/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
+++ b/packages/keystone/src/lib/core/mutations/nested-mutation-one-input-resolvers.ts
@@ -1,4 +1,5 @@
-import { KeystoneContext, TypesForList, graphql } from '../../../types';
+import { KeystoneContext, TypesForList } from '../../../types';
+import { graphql } from '../../..';
 import { resolveUniqueWhereInput } from '../where-inputs';
 import { InitialisedList } from '../types-for-lists';
 import { userInputError } from '../graphql-errors';

--- a/packages/keystone/src/lib/core/queries/index.ts
+++ b/packages/keystone/src/lib/core/queries/index.ts
@@ -1,4 +1,5 @@
-import { getGqlNames, graphql } from '../../../types';
+import { getGqlNames } from '../../../types';
+import { graphql } from '../../..';
 import { InitialisedList } from '../types-for-lists';
 import * as queries from './resolvers';
 

--- a/packages/keystone/src/lib/core/queries/output-field.ts
+++ b/packages/keystone/src/lib/core/queries/output-field.ts
@@ -5,12 +5,12 @@ import {
   IndividualFieldAccessControl,
   BaseGeneratedListTypes,
   ItemRootValue,
-  graphql,
   FindManyArgsValue,
   KeystoneContext,
   TypesForList,
   FieldReadItemAccessArgs,
 } from '../../../types';
+import { graphql } from '../../..';
 import { getOperationAccess, getAccessFilters } from '../access-control';
 import { ResolvedDBField, ResolvedRelationDBField } from '../resolve-relationships';
 import { InitialisedList } from '../types-for-lists';

--- a/packages/keystone/src/lib/core/types-for-lists.ts
+++ b/packages/keystone/src/lib/core/types-for-lists.ts
@@ -1,6 +1,5 @@
 import { CacheHint } from 'apollo-server-types';
 import {
-  graphql,
   ItemRootValue,
   TypesForList,
   getGqlNames,
@@ -14,6 +13,7 @@ import {
   CacheHintArgs,
   MaybePromise,
 } from '../../types';
+import { graphql } from '../..';
 import { FieldHooks } from '../../types/config/hooks';
 import { FilterOrderArgs } from '../../types/config/fields';
 import {

--- a/packages/keystone/src/lib/id-field.ts
+++ b/packages/keystone/src/lib/id-field.ts
@@ -7,8 +7,8 @@ import {
   IdFieldConfig,
   orderDirectionEnum,
   ScalarDBField,
-  graphql,
 } from '../types';
+import { graphql } from '..';
 import { packagePath } from '../package-path';
 import { userInputError } from './core/graphql-errors';
 

--- a/packages/keystone/src/session/index.ts
+++ b/packages/keystone/src/session/index.ts
@@ -9,8 +9,8 @@ import {
   SessionStoreFunction,
   SessionContext,
   CreateContext,
-  graphql,
 } from '../types';
+import { graphql } from '..';
 // uid-safe is what express-session uses so let's just use it
 
 function generateSessionId() {

--- a/packages/keystone/src/types/index.ts
+++ b/packages/keystone/src/types/index.ts
@@ -6,5 +6,4 @@ export * from './admin-meta';
 export * from './context';
 export * from './next-fields';
 export * as filters from './filters';
-export * from './schema';
 export { jsonFieldTypePolyfilledForSQLite } from './json-field-type-polyfill-for-sqlite';

--- a/packages/keystone/src/types/json-field-type-polyfill-for-sqlite.ts
+++ b/packages/keystone/src/types/json-field-type-polyfill-for-sqlite.ts
@@ -1,8 +1,8 @@
+import { graphql } from './schema';
 import {
   JSONValue,
   ItemRootValue,
   KeystoneContext,
-  graphql,
   UpdateFieldInputArg,
   ScalarDBField,
   CreateFieldInputArg,

--- a/packages/keystone/src/types/next-fields.ts
+++ b/packages/keystone/src/types/next-fields.ts
@@ -1,8 +1,8 @@
 import Decimal from 'decimal.js';
+import { graphql } from '..';
 import { BaseGeneratedListTypes } from './utils';
 import { CommonFieldConfig } from './config';
 import { DatabaseProvider, FieldDefaultValue } from './core';
-import { graphql } from './schema';
 import { AdminMetaRootVal, JSONValue, KeystoneContext, MaybePromise } from '.';
 
 export { Decimal };

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -1,7 +1,6 @@
 import { integer, relationship, text, virtual } from '@keystone-next/keystone/fields';
-import { BaseFields, list } from '@keystone-next/keystone';
+import { BaseFields, list, graphql } from '@keystone-next/keystone';
 import { setupTestEnv, setupTestRunner } from '@keystone-next/keystone/testing';
-import { graphql } from '@keystone-next/keystone/types';
 import { apiTestConfig } from '../../utils';
 
 function makeRunner(fields: BaseFields<any>) {


### PR DESCRIPTION
This time I didn't forget to actually move it 😆 

After we do the release, https://github.com/keystonejs/keystone/pull/6561 will need to reverted (the docs on master are consistent with the change in this PR)