### PR TITLE
Update virtual-fields.mdx

### DIFF
--- a/docs/pages/docs/guides/virtual-fields.mdx
+++ b/docs/pages/docs/guides/virtual-fields.mdx
@@ -94,8 +94,8 @@ export default config({
         content: text(),
         author: relationship({ ref: 'Author', many: false }),
         authorName: virtual({
-          type: graphql.String,
           field: graphql.field({
+          type: graphql.String,
             async resolve(item, args, context) {
               const { author } = await context.lists.Post.findOne({
                 where: { id: item.id.toString() },


### PR DESCRIPTION
There is a typo in docs of virtual-field page's Resolver-arguments section example.
type is suppose to be a property of graphql.field config object but it shown as a property of virtual config object.

![image](https://user-images.githubusercontent.com/24270559/135689063-0f7e0485-7cfc-4760-a310-0e7f9e822796.png)
