### PR TITLE
Better display for document fields in list view and card view

### DIFF
--- a/.changeset/lazy-parrots-do.md
+++ b/.changeset/lazy-parrots-do.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/fields-document': minor
+---
+
+Add short plain-text display to document fields for Cell (list view; resolves #6522) and a rendered document view in CardValue

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "^7.15.4",
     "@braintree/sanitize-url": "^5.0.2",
     "@emotion/weak-memoize": "^0.2.5",
+    "@keystone-next/document-renderer": "^4.0.0",
     "@keystone-ui/button": "^5.0.1",
     "@keystone-ui/core": "^3.2.0",
     "@keystone-ui/fields": "^4.1.3",

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -53,7 +53,11 @@ export const Cell: CellComponent = ({ item, field, linkTo }) => {
   if (!value) return null;
   const plainText = serialize(value);
   const cutText = plainText.length > 100 ? plainText.slice(0, 100) + '...' : plainText;
-  return linkTo ? <CellLink {...linkTo}>{cutText}</CellLink> : <CellContainer>{cutText}</CellContainer>;
+  return linkTo ? (
+    <CellLink {...linkTo}>{cutText}</CellLink>
+  ) : (
+    <CellContainer>{cutText}</CellContainer>
+  );
 };
 Cell.supportsLinkTo = true;
 

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -53,7 +53,7 @@ export const Cell: CellComponent = ({ item, field, linkTo }) => {
   if (!value) return null;
   const plainText = serialize(value);
   const cutText = plainText.length > 100 ? plainText.slice(0, 100) + '...' : plainText;
-  return linkTo ? <CellLink>{cutText}</CellLink> : <CellContainer>{cutText}</CellContainer>;
+  return linkTo ? <CellLink {...linkTo}>{cutText}</CellLink> : <CellContainer>{cutText}</CellContainer>;
 };
 Cell.supportsLinkTo = true;
 

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -4,6 +4,7 @@
 import { jsx } from '@keystone-ui/core';
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
 import { Descendant, Node, Text } from 'slate';
+import { DocumentRenderer } from '@keystone-next/document-renderer';
 
 import {
   CardValueComponent,
@@ -13,6 +14,7 @@ import {
   FieldProps,
 } from '@keystone-next/keystone/types';
 import weakMemoize from '@emotion/weak-memoize';
+import { CellContainer, CellLink } from '@keystone-next/keystone/admin-ui/components';
 import { DocumentEditor } from './DocumentEditor';
 import { ComponentBlock } from './component-blocks';
 import { Relationships } from './DocumentEditor/relationship';
@@ -42,15 +44,24 @@ export const Field = ({
   </FieldContainer>
 );
 
-export const Cell: CellComponent = () => {
-  return null;
+const serialize = (nodes: Node[]) => {
+  return nodes.map((n: Node) => Node.string(n)).join('\n');
 };
+
+export const Cell: CellComponent = ({ item, field, linkTo }) => {
+  const value = item[field.path]?.document;
+  if (!value) return null;
+  const plainText = serialize(value);
+  const cutText = plainText.length > 100 ? plainText.slice(0, 100) + '...' : plainText;
+  return linkTo ? <CellLink>{cutText}</CellLink> : <CellContainer>{cutText}</CellContainer>;
+};
+Cell.supportsLinkTo = true;
 
 export const CardValue: CardValueComponent = ({ item, field }) => {
   return (
     <FieldContainer>
       <FieldLabel>{field.label}</FieldLabel>
-      <pre>{JSON.stringify(item[field.path], null, 2)}</pre>
+      <DocumentRenderer document={item[field.path].document} />
     </FieldContainer>
   );
 };


### PR DESCRIPTION
This change resolves #6522 by serializing documents to plain text for list view. Additionally, I changed the display for card view from JSON to a DocumentRenderer - while the former may be useful to a developer, I feel like many end users are not developers and might be expecting that their rich text will be at least readable.