### PR TITLE
Fix references to `graphql` export

### DIFF
--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -581,8 +581,7 @@ Options:
 - `graphQLReturnFragment` (default: `''` ): The sub-fields that should be fetched by the Admin UI when displaying this field.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
-import { graphql } from '@keystone-next/keystone/types';
+import { config, createSchema, list, graphql } from '@keystone-next/keystone';
 import { virtual } from '@keystone-next/keystone/fields';
 
 export default config({

--- a/docs/pages/docs/guides/custom-fields.mdx
+++ b/docs/pages/docs/guides/custom-fields.mdx
@@ -29,11 +29,11 @@ import {
   FieldTypeFunc,
   CommonFieldConfig,
   fieldType,
-  graphql,
   orderDirectionEnum,
   filters,
   FieldDefaultValue,
 } from '@keystone-next/keystone/types';
+import { graphql } from '@keystone-next/keystone';
 
 export type MyIntFieldConfig<TGeneratedListTypes extends BaseGeneratedListTypes> =
   CommonFieldConfig<TGeneratedListTypes> & {

--- a/docs/pages/docs/guides/virtual-fields.mdx
+++ b/docs/pages/docs/guides/virtual-fields.mdx
@@ -18,8 +18,7 @@ In this guide we'll introduce the syntax for adding virtual fields, and show how
 We'll start with a list called `Example` and create a virtual field called `hello`.
 
 ```typescript
-import { config, createSchema, list } from '@keystone-next/keystone';
-import { graphql } from '@keystone-next/keystone/types';
+import { config, createSchema, list, graphql } from '@keystone-next/keystone';
 import { virtual } from '@keystone-next/keystone/fields';
 
 export default config({


### PR DESCRIPTION
Reverts keystonejs/keystone#6561

Now that this change has actually landed properly, this can be reverted