### PR TITLE
fix bad async flow in filters test

### DIFF
--- a/tests/admin-ui-tests/filters.test.ts
+++ b/tests/admin-ui-tests/filters.test.ts
@@ -15,8 +15,8 @@ adminUITests('./tests/test-projects/basic', browserType => {
 
   describe('relationship filters', () => {
     afterEach(async () => {
-      context.clearCookies();
-      page.evaluate(() => {
+      await context.clearCookies();
+      await page.evaluate(() => {
         window.localStorage.clear();
       });
       await deleteAllData('./tests/test-projects/basic');


### PR DESCRIPTION
we're not awaiting on certain playwright async methods,, this is causing more than the usual intermittent failure.