### PR TITLE
Enable skipped test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Install Dependencies
         run: yarn
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
+      - name: foo
+        run: psql -l
+        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         run: yarn jest --ci --runInBand api-tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,9 +143,6 @@ jobs:
       - name: Install Dependencies
         run: yarn
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-      - name: foo
-        run: psql -l
-        if: needs.should_run_tests.outputs.shouldRunTests == 'true'
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
         run: yarn jest --ci --runInBand api-tests

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -61,6 +61,10 @@ describe('relationship filtering', () => {
         ],
       });
 
+      const foo = await context.query.User.findMany({
+        query: 'id posts(orderBy: { content: asc }) { id content }',
+      });
+      console.log(foo.map(u=>u.posts));
       const users = await context.query.User.findMany({
         query: 'id posts(take: 1, orderBy: { content: asc }) { id }',
       });

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -65,6 +65,22 @@ describe('relationship filtering', () => {
         query: 'id posts(orderBy: { content: asc }) { id content }',
       });
       console.log(foo.map(u=>u.posts));
+
+      const fob = await context.query.User.findMany({
+        query: 'id posts(take: 1, orderBy: { content: asc }) { id content }',
+      });
+      console.log(fob.map(u=>u.posts));
+
+      const bar = await context.query.User.findMany({
+        query: 'id posts(orderBy: { content: desc }) { id content }',
+      });
+      console.log(bar.map(u=>u.posts));
+
+      const baz = await context.query.User.findMany({
+        query: 'id posts(take: 1, orderBy: { content: desc }) { id content }',
+      });
+      console.log(baz.map(u=>u.posts));
+
       const users = await context.query.User.findMany({
         query: 'id posts(take: 1, orderBy: { content: asc }) { id }',
       });

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -7,6 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
+    db: { enableLogging: true },
     lists: {
       User: list({
         fields: {
@@ -46,7 +47,7 @@ describe('relationship filtering', () => {
     })
   );
 
-  test(
+  test.only(
     'nested to-many relationships can be limited',
     runner(async ({ context }) => {
       const ids = await context.query.Post.createMany({

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -7,7 +7,6 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    db: { enableLogging: true },
     lists: {
       User: list({
         fields: {
@@ -47,7 +46,7 @@ describe('relationship filtering', () => {
     })
   );
 
-  test.only(
+  test(
     'nested to-many relationships can be limited',
     runner(async ({ context }) => {
       const ids = await context.query.Post.createMany({
@@ -60,26 +59,6 @@ describe('relationship filtering', () => {
           { posts: { connect: [ids[0]] } }, // Create a dummy user to make sure we're actually filtering it out
         ],
       });
-
-      const foo = await context.query.User.findMany({
-        query: 'id posts(orderBy: { content: asc }) { id content }',
-      });
-      console.log(foo.map(u=>u.posts));
-
-      const fob = await context.query.User.findMany({
-        query: 'id posts(take: 1, orderBy: { content: asc }) { id content }',
-      });
-      console.log(fob.map(u=>u.posts));
-
-      const bar = await context.query.User.findMany({
-        query: 'id posts(orderBy: { content: desc }) { id content }',
-      });
-      console.log(bar.map(u=>u.posts));
-
-      const baz = await context.query.User.findMany({
-        query: 'id posts(take: 1, orderBy: { content: desc }) { id content }',
-      });
-      console.log(baz.map(u=>u.posts));
 
       const users = await context.query.User.findMany({
         query: 'id posts(take: 1, orderBy: { content: asc }) { id }',

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -51,7 +51,7 @@ describe('relationship filtering', () => {
     'nested to-many relationships can be limited',
     runner(async ({ context }) => {
       const ids = await context.query.Post.createMany({
-        data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hello? Or hi?' }],
+        data: [{ content: 'Hello world' }, { content: 'hi world' }, { content: 'Hellox Or hi?' }],
       });
 
       const [user, user2] = await context.query.User.createMany({

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -46,9 +46,7 @@ describe('relationship filtering', () => {
     })
   );
 
-  // this is failing on GitHub Actions rn for some unknown reason so going to disable it for now
-  // eslint-disable-next-line jest/no-disabled-tests
-  test.skip(
+  test(
     'nested to-many relationships can be limited',
     runner(async ({ context }) => {
       const ids = await context.query.Post.createMany({


### PR DESCRIPTION
I'm about 80% sure that the issue here is that the LC_COLLATE being used in CI is different to what I have locally (`C`), and that's why we have a different sort order on CI https://www.postgresql.org/docs/13/locale.html.

I don't care to confirm this 100%, this change moves us away from a special character `?` as the thing we happen to be sorting on and that seems to fix things 🤷‍♂️ 