### PR TITLE
Remove `resolveFields`

### DIFF
--- a/.changeset/gentle-plums-end.md
+++ b/.changeset/gentle-plums-end.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': major
+---
+
+Removed `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to the `context.query` or you `context.db` if you were providing `false`.

--- a/.changeset/gentle-plums-end.md
+++ b/.changeset/gentle-plums-end.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': major
 ---
 
-Removed `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to the `context.query` or you `context.db` if you were providing `false`.
+Removed the deprecated `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to the `context.query` or you `context.db` if you were providing `false`.

--- a/.changeset/gentle-plums-end.md
+++ b/.changeset/gentle-plums-end.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': major
 ---
 
-Removed the deprecated `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to the `context.query` or you `context.db` if you were providing `false`.
+Removed the deprecated `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to `context.query` or use `context.db` if you were providing `false`.

--- a/.changeset/gentle-plums-end.md
+++ b/.changeset/gentle-plums-end.md
@@ -2,4 +2,4 @@
 '@keystone-next/keystone': major
 ---
 
-Removed the deprecated `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to `context.query` or use `context.db` if you were providing `false`.
+Removed the deprecated `resolveFields` from `context.query`, if you were still using it, you should switch to providing `the query option` to `context.query` or use `context.db` if you were providing `false`. The `context.query` functions will now also throw an error if an empty string is passed to `query` rather than silently returning what the `context.db` functions return, you must select at least one field or omit the `query` option to default to selecting the `id`.

--- a/packages/keystone/src/fields/types/password/tests/test-fixtures.ts
+++ b/packages/keystone/src/fields/types/password/tests/test-fixtures.ts
@@ -60,7 +60,6 @@ export const crudTests = (keystoneTestWrapper: any) => {
       await expect(
         context.query.Test.createOne({
           data: { passwordRejectCommon: 'password' },
-          query: ``,
         })
       ).rejects.toMatchInlineSnapshot(`
               [GraphQLError: You provided invalid data for this operation.

--- a/packages/keystone/src/lib/context/createContext.ts
+++ b/packages/keystone/src/lib/context/createContext.ts
@@ -105,7 +105,7 @@ export function makeCreateContext({
     const dbAPIFactories = sudo ? sudoDbApiFactories : publicDbApiFactories;
     for (const listKey of Object.keys(gqlNamesByList)) {
       dbAPI[listKey] = dbAPIFactories[listKey](contextToReturn);
-      itemAPI[listKey] = itemAPIForList(listKey, contextToReturn, dbAPI[listKey]);
+      itemAPI[listKey] = itemAPIForList(listKey, contextToReturn);
     }
     return contextToReturn;
   };

--- a/packages/keystone/src/types/context.ts
+++ b/packages/keystone/src/types/context.ts
@@ -87,13 +87,6 @@ type ResolveFields = {
    * @default 'id'
    */
   readonly query?: string;
-  /**
-   * @deprecated
-   *
-   * resolveFields has been deprecated. Please use the `query` param to query fields,
-   * or `context.db.{List}` instead of passing `resolveFields: false`
-   */
-  readonly resolveFields?: false | string;
 };
 
 export type KeystoneDbAPI<KeystoneListsTypeInfo extends Record<string, BaseGeneratedListTypes>> = {


### PR DESCRIPTION
This was deprecated quite a while ago and we even renamed `context.lists` to `context.query` while this was deprecated so I'd be surprised if many people are still using it.