### PR TITLE
Use GraphQL Playground instead of Apollo Studio

### DIFF
--- a/packages/keystone/src/lib/server/createApolloServer.ts
+++ b/packages/keystone/src/lib/server/createApolloServer.ts
@@ -2,6 +2,10 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { GraphQLError, GraphQLSchema } from 'graphql';
 import { ApolloServer as ApolloServerMicro } from 'apollo-server-micro';
 import { ApolloServer as ApolloServerExpress } from 'apollo-server-express';
+import {
+  ApolloServerPluginLandingPageDisabled,
+  ApolloServerPluginLandingPageGraphQLPlayground,
+} from 'apollo-server-core';
 import type { CreateContext, GraphQLConfig, SessionStrategy } from '../../types';
 import { createSessionContext } from '../../session';
 
@@ -65,6 +69,11 @@ const _createApolloServerConfig = ({
   return {
     schema: graphQLSchema,
     debug: graphqlConfig?.debug, // If undefined, use Apollo default of NODE_ENV !== 'production'
+    plugins: [
+      ApolloServerPluginLandingPageGraphQLPlayground({
+        settings: { 'request.credentials': 'same-origin' },
+      }),
+    ],
     ...apolloConfig,
     formatError: formatError(graphqlConfig),
   };


### PR DESCRIPTION
This is to fix https://github.com/keystonejs/keystone/issues/6796

*I'm looking for contributors: I wont be able to continue this work.*

Commit fce0ea04a re-introduces GraphQL Playground, and forcibly loads it instead of Apollo Studio.

What's left to do:

- [ ] Accept a `playground` flag on the `apolloConfig` object
- [ ] Parse that flag [like we used to](https://github.com/keystonejs/keystone/blob/e2a336c541d5891ed75a887d5b057678e48cc7f9/packages/keystone/src/lib/server/createApolloServer.ts#L70-L88).
  - NOTE: Need to ensure we add the `ApolloServerPluginLandingPageDisabled` plugin if `playground: false`, otherwise Apollo Studio will show up by default (boo, hiss).
- [ ] Add an option for `'studio'` which just uses the default config from Apollo Server v3 (ie; does nothing)