### PR TITLE
Add upsert mutation to custom schema example

### DIFF
--- a/examples/extend-graphql-schema/custom-schema.ts
+++ b/examples/extend-graphql-schema/custom-schema.ts
@@ -7,7 +7,7 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
       """ Publish a post """
       publishPost(id: ID!): Post
 
-      """ Create or update an auth based on email """
+      """ Create or update an author based on email """
       upsertAuthor(where: AuthorWhereUniqueInput!, create: AuthorCreateInput!, update: AuthorUpdateInput!): Author
     }
 

--- a/examples/extend-graphql-schema/custom-schema.ts
+++ b/examples/extend-graphql-schema/custom-schema.ts
@@ -6,6 +6,9 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
     type Mutation {
       """ Publish a post """
       publishPost(id: ID!): Post
+
+      """ Create or update an auth based on email """
+      upsertAuthor(where: AuthorWhereUniqueInput!, create: AuthorCreateInput!, update: AuthorUpdateInput!): Author
     }
 
     type Query {
@@ -14,7 +17,6 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
 
       """ Compute statistics for a user """
       stats(id: ID!): Statistics
-
     }
 
     """ A custom type to represent statistics for a user """
@@ -34,6 +36,21 @@ export const extendGraphqlSchema = graphQLSchemaExtension<Context>({
           where: { id },
           data: { status: 'published', publishDate: new Date().toUTCString() },
         });
+      },
+      upsertAuthor: async (root, { where, update, create }, context) => {
+        try {
+          // we need to await the update here so that if an error is thrown, it's caught
+          // by the try catch here and not returned through the graphql api
+          return await context.db.Author.updateOne({ where, data: update });
+        } catch (updateError: any) {
+          // updateOne will fail with the code KS_ACCESS_DENIED if the item isn't found,
+          // so we try to create it. If the item does exist, the unique constraint on
+          // email will prevent a duplicate being created, and we catch the error
+          if (updateError.extensions?.code === 'KS_ACCESS_DENIED') {
+            return await context.db.Author.createOne({ data: create });
+          }
+          throw updateError;
+        }
       },
     },
     Query: {

--- a/examples/extend-graphql-schema/schema.graphql
+++ b/examples/extend-graphql-schema/schema.graphql
@@ -6,6 +6,15 @@ type Mutation {
    Publish a post
   """
   publishPost(id: ID!): Post
+
+  """
+   Create or update an auth based on email
+  """
+  upsertAuthor(
+    where: AuthorWhereUniqueInput!
+    create: AuthorCreateInput!
+    update: AuthorUpdateInput!
+  ): Author
   createPost(data: PostCreateInput!): Post
   createPosts(data: [PostCreateInput!]!): [Post]
   updatePost(where: PostWhereUniqueInput!, data: PostUpdateInput!): Post

--- a/examples/extend-graphql-schema/schema.graphql
+++ b/examples/extend-graphql-schema/schema.graphql
@@ -8,7 +8,7 @@ type Mutation {
   publishPost(id: ID!): Post
 
   """
-   Create or update an auth based on email
+   Create or update an author based on email
   """
   upsertAuthor(
     where: AuthorWhereUniqueInput!

--- a/tests/examples-smoke-tests/basic.test.ts
+++ b/tests/examples-smoke-tests/basic.test.ts
@@ -21,7 +21,11 @@ exampleProjectTests('../examples-staging/basic', (browserType, mode) => {
     await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign In")')]);
   });
   test('update user', async () => {
-    await page.goto('http://localhost:3000/users');
+    try {
+      await page.goto('http://localhost:3000/users');
+    } catch {
+      await page.goto('http://localhost:3000/users');
+    }
     await Promise.all([page.waitForNavigation(), page.click('a:has-text("Admin")')]);
     await page.type('label:has-text("Name") >> .. >> input', '1');
     await page.click('button:has-text("Save changes")');


### PR DESCRIPTION
We've had questions in slack about how to do upserts in Keystone apps, as they're sometimes important but not part of the CRUD API.

We haven't added upsert support **yet** in the core CRUD API because there are some edge cases we need to solve with regards to race conditions and predictably executing event hooks, and we don't want to ship something that's not predictable.

However, it's relatively easy to add upserts to the API using custom GraphQL Schema Extension, especially because you can re-use the built-in GraphQL input and output types. This adds to the custom schema example to demonstrate how.

This PR should be ready to go from a code perspective, but still needs some documentation and could include a better explanation of how the generated types are being used, because it's a good reference of how to benefit from them.