### PR TITLE
Set credentials: same-origin in GraphQL playground

### DIFF
--- a/packages/keystone/src/lib/server/createApolloServer.ts
+++ b/packages/keystone/src/lib/server/createApolloServer.ts
@@ -76,7 +76,9 @@ const _createApolloServerConfig = ({
         ? apolloConfig?.plugins
         : [
             playgroundOption
-              ? ApolloServerPluginLandingPageGraphQLPlayground()
+              ? ApolloServerPluginLandingPageGraphQLPlayground({
+                  settings: { 'request.credentials': 'same-origin' },
+                })
               : ApolloServerPluginLandingPageDisabled(),
             ...(apolloConfig?.plugins || []),
           ],


### PR DESCRIPTION
https://github.com/keystonejs/keystone/pull/6824#pullrequestreview-788842476 
Closes #6796

no changeset because there hasn't been a released version since the other PR