### PR TITLE
Update references to Apollo Sandbox to GraphQL Playground

### DIFF
--- a/docs/pages/docs/guides/cli.mdx
+++ b/docs/pages/docs/guides/cli.mdx
@@ -195,7 +195,7 @@ yarn keystone-next start
     heading="Getting Started with create-keystone-app"
     href="/docs/walkthroughs/getting-started-with-create-keystone-app"
     >
-    How to use Keystone's CLI app to standup a new local project with an Admin UI & the Apollo Sandbox.
+    How to use Keystone's CLI app to standup a new local project with an Admin UI & the GraphQL Playground.
   </Well>
 </RelatedContent>
 

--- a/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
@@ -35,7 +35,7 @@ Here's what we're going to do:
 - Create a Next.js app
 - Embed Keystone, and run an Admin UI you can read and write to locally
 - Add a simple Keystone [Schema](/apis/schema) with a `Post` List
-- Setup a secure read-only GraphQL API endpoint (and Apollo Sandbox) that you can access in production
+- Setup a secure read-only GraphQL API endpoint (and GraphQL Playground) that you can access in production
 - Deploy the app to Vercel 🚀
 
 ## Setup a Next.js app
@@ -284,7 +284,7 @@ Run `yarn dev` again.
 
 ## Bonus: add the GraphQL API to the frontend
 
-To get a read-only GraphQL API and Apollo Sandbox in production, add `/pages/api/graphql.tsx`with the following:
+To get a read-only GraphQL API and GraphQL Playground in production, add `/pages/api/graphql.tsx`with the following:
 
 ```tsx
 // pages/api/graphql.tsx
@@ -292,7 +292,7 @@ To get a read-only GraphQL API and Apollo Sandbox in production, add `/pages/api
 export { default, config } from '.keystone/next/graphql-api';
 ```
 
-This takes the fully functional GraphQL API that Keystone is already generating and makes it available as an endpoint and Apollo Sandbox within the Next.js frontend app at [http://localhost:3000/api/graphql](http://localhost:3000/api/graphql).
+This takes the fully functional GraphQL API that Keystone is already generating and makes it available as an endpoint and GraphQL Playground within the Next.js frontend app at [http://localhost:3000/api/graphql](http://localhost:3000/api/graphql).
 
 ![A browser displaying the GraphQL playground](/assets/walkthroughs/embedded-nextjs/graphql-api.png)
 
@@ -334,7 +334,7 @@ Keystone’s Embedded mode and SQLite support gives you the option to run a self
     heading="Getting Started with create-keystone-app"
     href="/docs/walkthroughs/getting-started-with-create-keystone-app"
     >
-    How to use Keystone's CLI app to standup a new local project with an Admin UI & the Apollo Sandbox.
+    How to use Keystone's CLI app to standup a new local project with an Admin UI & the GraphQL Playground.
   </Well>
 </RelatedContent>
 

--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -645,7 +645,7 @@ export default function WhyKeystonePage() {
             <Type as="p" look="body18" color="var(--muted)" margin="1rem 0 0 0">
               Use an API-first content platform to unlocks the power of multichannel content ops.
               Connect to your audience where they want to be. Ship content to any frontend over
-              performant APIs. Use the built-in Apollo Sandbox to query with ease.
+              performant APIs. Use the built-in GraphQL Playground to query with ease.
             </Type>
           </div>
           <TweetBox

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -15,7 +15,7 @@ To run this project:
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 Congratulations, you're now up and running with Keystone! 🚀
 
@@ -29,6 +29,6 @@ This example includes sample data. To add it to your database:
 
 ## Next steps
 
-Experiment with the code in this example to see how Keystone works, familiarise yourself with the Admin UI, and learn about the Apollo Sandbox.
+Experiment with the code in this example to see how Keystone works, familiarise yourself with the Admin UI, and learn about the GraphQL Playground.
 
 When you’ve got the hang of this base project, try a [feature project](../) to learn Keystone’s advanced features and take your knowledge to the next level.

--- a/examples/custom-admin-ui-logo/README.md
+++ b/examples/custom-admin-ui-logo/README.md
@@ -14,7 +14,7 @@ This will start the Admin UI at [localhost:3000](http://localhost:3000).
 
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 🚀 Congratulations, you're now up and running with Keystone!
 

--- a/examples/custom-admin-ui-navigation/README.md
+++ b/examples/custom-admin-ui-navigation/README.md
@@ -14,7 +14,7 @@ This will start the Admin UI at [localhost:3000](http://localhost:3000).
 
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## admin/config.ts
 

--- a/examples/custom-admin-ui-pages/README.md
+++ b/examples/custom-admin-ui-pages/README.md
@@ -15,7 +15,7 @@ This will start the Admin UI at [localhost:3000](http://localhost:3000).
 
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 🚀 Congratulations, you're now up and running with Keystone!
 

--- a/examples/custom-field-view/README.md
+++ b/examples/custom-field-view/README.md
@@ -14,7 +14,7 @@ This will start the Admin UI at [localhost:3000](http://localhost:3000).
 
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 

--- a/examples/custom-field/README.md
+++ b/examples/custom-field/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Stars field
 

--- a/examples/default-values/README.md
+++ b/examples/default-values/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 

--- a/examples/document-field/README.md
+++ b/examples/document-field/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 In a separate terminal, start the frontend dev server:
 

--- a/examples/extend-graphql-schema/README.md
+++ b/examples/extend-graphql-schema/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 🚀 Congratulations, you're now up and running with Keystone!
 

--- a/examples/task-manager/README.md
+++ b/examples/task-manager/README.md
@@ -14,7 +14,7 @@ To run this project:
 
 This will start Keystone’s Admin UI at [localhost:3000](http://localhost:3000), where you can add items to an empty database.
 
-You can also access Keystone’s Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql) to explore the GraphQL API, and run [queries](https://keystonejs.com/docs/guides/filters) and [mutations](https://keystonejs.com/docs/apis/graphql#mutations) on your data.
+You can also access Keystone’s GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql) to explore the GraphQL API, and run [queries](https://keystonejs.com/docs/guides/filters) and [mutations](https://keystonejs.com/docs/apis/graphql#mutations) on your data.
 
 Congratulations, you’re now up and running with Keystone! 🚀
 
@@ -28,6 +28,6 @@ This example includes sample data. To add it to your database:
 
 ## Next steps
 
-Experiment with the code in this example to see how Keystone works, familiarise yourself with the Admin UI, and learn about the Apollo Sandbox.
+Experiment with the code in this example to see how Keystone works, familiarise yourself with the Admin UI, and learn about the GraphQL Playground.
 
 When you’ve got the hang of this base project, try a [feature project](../) to learn Keystone’s advanced features and take your knowledge to the next level.

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 

--- a/examples/virtual-field/README.md
+++ b/examples/virtual-field/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -14,7 +14,7 @@ yarn dev
 This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
-You can also access a Apollo Sandbox at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
 
 ## Features
 


### PR DESCRIPTION
Since we're back to GraphQL Playground by default, these should be talking about GraphQL Playground