### PR TITLE
Fix flakey test

### DIFF
--- a/tests/examples-smoke-tests/custom-admin-ui-pages.test.ts
+++ b/tests/examples-smoke-tests/custom-admin-ui-pages.test.ts
@@ -1,18 +1,7 @@
+import retry from 'async-retry';
 import { Browser, Page } from 'playwright';
-import { exampleProjectTests, loadIndex } from './utils';
 
-async function retry(cb: () => Promise<void>, maxTimes: number) {
-  while (true) {
-    try {
-      return await cb();
-    } catch (err) {
-      if (maxTimes === 0) {
-        throw err;
-      }
-      maxTimes--;
-    }
-  }
-}
+import { exampleProjectTests, loadIndex } from './utils';
 
 exampleProjectTests('custom-admin-ui-pages', browserType => {
   let browser: Browser = undefined as any;
@@ -22,11 +11,14 @@ exampleProjectTests('custom-admin-ui-pages', browserType => {
     page = await browser.newPage();
     await loadIndex(page);
   });
-  test('Load list', () =>
-    retry(async () => {
+
+  test('Load list', async () => {
+    await retry(async () => {
       await page.goto('http://localhost:3000/custom-page');
       await page.waitForSelector('main h1:has-text("This is a custom Admin UI page")');
-    }, 5));
+    });
+  });
+
   afterAll(async () => {
     await browser.close();
   });

--- a/tests/examples-smoke-tests/custom-admin-ui-pages.test.ts
+++ b/tests/examples-smoke-tests/custom-admin-ui-pages.test.ts
@@ -1,6 +1,19 @@
 import { Browser, Page } from 'playwright';
 import { exampleProjectTests, loadIndex } from './utils';
 
+async function retry(cb: () => Promise<void>, maxTimes: number) {
+  while (true) {
+    try {
+      return await cb();
+    } catch (err) {
+      if (maxTimes === 0) {
+        throw err;
+      }
+      maxTimes--;
+    }
+  }
+}
+
 exampleProjectTests('custom-admin-ui-pages', browserType => {
   let browser: Browser = undefined as any;
   let page: Page = undefined as any;
@@ -9,10 +22,11 @@ exampleProjectTests('custom-admin-ui-pages', browserType => {
     page = await browser.newPage();
     await loadIndex(page);
   });
-  test('Load list', async () => {
-    await page.goto('http://localhost:3000/custom-page');
-    await page.waitForSelector('main h1:has-text("This is a custom Admin UI page")');
-  });
+  test('Load list', () =>
+    retry(async () => {
+      await page.goto('http://localhost:3000/custom-page');
+      await page.waitForSelector('main h1:has-text("This is a custom Admin UI page")');
+    }, 5));
   afterAll(async () => {
     await browser.close();
   });

--- a/tests/examples-smoke-tests/package.json
+++ b/tests/examples-smoke-tests/package.json
@@ -11,7 +11,9 @@
   "repository": "https://github.com/keystonejs/keystone/tree/main/tests/examples-smoke-tests",
   "homepage": "https://github.com/keystonejs/keystone",
   "dependencies": {
+    "@types/async-retry": "^1.4.3",
     "@types/tough-cookie": "^4.0.1",
+    "async-retry": "1.3.3",
     "execa": "^5.1.1",
     "node-fetch": "^2.6.5",
     "playwright": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,6 +2579,13 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
   integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
+"@types/async-retry@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.3.tgz#8b78f6ce88d97e568961732cdd9e5325cdc8c246"
+  integrity sha512-B3C9QmmNULVPL2uSJQ088eGWTNPIeUk35hca6CV8rRDJ8GXuQJP5CCVWA1ZUCrb9xYP7Js/RkLqnNNwKhe+Zsw==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.16":
   version "7.1.16"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.16.tgz#bc12c74b7d65e82d29876b5d0baf5c625ac58702"
@@ -3036,7 +3043,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/retry@^0.12.0":
+"@types/retry@*", "@types/retry@^0.12.0":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
@@ -3798,7 +3805,7 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-retry@^1.2.1:
+async-retry@1.3.3, async-retry@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==


### PR DESCRIPTION
We think that the failures happen because Playwright goes through the test really fast and a request is cancelled when trying to navigate to the custom page so it just doesn't navigate to the page? (this is very much a guess, it's quite hard to actually debug this since we haven't been able to reproduce it locally) So we're just gonna retry it. We've retried it three times and it hasn't failed yet so hopefully it's ok