### PR TITLE
Fix build failing with uniquely named types error

### DIFF
--- a/.changeset/rude-mangos-peel.md
+++ b/.changeset/rude-mangos-peel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed `Schema must contain uniquely named types but contains multiple types named "OrderDirection".` error when running `keystone-next build`.

--- a/packages/keystone/src/admin-ui/system/buildAdminUI.ts
+++ b/packages/keystone/src/admin-ui/system/buildAdminUI.ts
@@ -1,10 +1,21 @@
 export async function buildAdminUI(projectAdminPath: string) {
+  let prevNodeEnv = process.env.NODE_ENV;
   // Next does a broken build unless we set NODE_ENV to production
   // @ts-ignore
   process.env.NODE_ENV = 'production';
-  // importing next/dist/build is quite expensive so we're requiring it lazily
-  /** We do this to stop webpack from bundling next inside of next */
-  const next = 'next/dist/build';
-  const build = require(next).default;
-  await build(projectAdminPath);
+  try {
+    // importing next/dist/build is quite expensive so we're requiring it lazily
+    /** We do this to stop webpack from bundling next inside of next */
+    const next = 'next/dist/build';
+    const build = require(next).default;
+    await build(projectAdminPath);
+  } finally {
+    if (prevNodeEnv === undefined) {
+      // @ts-ignore
+      delete process.env.NODE_ENV;
+    } else {
+      // @ts-ignore
+      process.env.NODE_ENV = prevNodeEnv;
+    }
+  }
 }

--- a/packages/keystone/src/admin-ui/system/buildAdminUI.ts
+++ b/packages/keystone/src/admin-ui/system/buildAdminUI.ts
@@ -1,7 +1,7 @@
 export async function buildAdminUI(projectAdminPath: string) {
-  if (process.env.NODE_ENV !== 'production') {
-    throw new Error('process.env.NODE_ENV must be set to production to build the Admin UI');
-  }
+  // Next does a broken build unless we set NODE_ENV to production
+  // @ts-ignore
+  process.env.NODE_ENV = 'production';
   // importing next/dist/build is quite expensive so we're requiring it lazily
   /** We do this to stop webpack from bundling next inside of next */
   const next = 'next/dist/build';

--- a/packages/keystone/src/scripts/build/build.ts
+++ b/packages/keystone/src/scripts/build/build.ts
@@ -55,10 +55,6 @@ const reexportKeystoneConfig = async (cwd: string, isDisabled?: boolean) => {
 };
 
 export async function build(cwd: string) {
-  // Next does a broken build unless we set NODE_ENV to production
-  // @ts-ignore
-  process.env.NODE_ENV = 'production';
-
   const config = initConfig(requireSource(getConfigPath(cwd)).default);
 
   const { graphQLSchema, adminMeta } = createSystem(config);


### PR DESCRIPTION
Background: Preconstruct generates a version of the CJS code for when `process.env.NODE_ENV === 'production'` and another for when not, where the one for `process.env.NODE_ENV === 'production'` has `process.env.NODE_ENV` statically replaced with `'production'` so that checking it to decide whether to show more informative error messages and etc. is very fast. This isn't really useful for Keystone but is useful for some other projects.

So that caused two versions of Keystone to be loaded because we got the dev version loaded by the CLI and then when we set `process.env.NODE_ENV = 'production'` and require the user's code, they load the prod version of keystone so boom two copies of the GraphQL types.

The resetting it NODE_ENV back after the build is done isn't really necessary but if this was used in a different way in the future, it would be if you e.g. import keystone -> do build of one project -> do build of another project (all in the same process) then  (none of these sort of things would be possible today because this stuff isn't exported).

I'll probably make one of the smoke tests or something use a built version so that this sort of this is caught in the future.