### PR TITLE
Return Prisma type errors in dev

### DIFF
--- a/.changeset/itchy-eggs-cheer.md
+++ b/.changeset/itchy-eggs-cheer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Runtime type errors from Prisma are now actually returned instead of being returned as `Prisma error:`

--- a/packages/keystone/src/lib/core/graphql-errors.ts
+++ b/packages/keystone/src/lib/core/graphql-errors.ts
@@ -7,6 +7,13 @@ export const accessDeniedError = (msg: string) =>
   new ApolloError(`Access denied: ${msg}`, 'KS_ACCESS_DENIED');
 
 export const prismaError = (err: Error) => {
+  if ((err as any).code === undefined) {
+    return new ApolloError(`Prisma error`, 'KS_PRISMA_ERROR', {
+      debug: {
+        message: err.message,
+      },
+    });
+  }
   return new ApolloError(
     `Prisma error: ${err.message.split('\n').slice(-1)[0].trim()}`,
     'KS_PRISMA_ERROR',

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -16,7 +16,7 @@ export const apiTestConfig = (
   },
 });
 
-const unpackErrors = (errors: readonly any[] | undefined) =>
+export const unpackErrors = (errors: readonly any[] | undefined) =>
   (errors || []).map(({ locations, ...unpacked }) => unpacked);
 
 const j = (messages: string[]) => messages.map(m => `  - ${m}`).join('\n');


### PR DESCRIPTION
Errors when Prisma doesn't return a code should just be when there are type errors in the request and the request would never be valid rather than like a unique constraint error where the inputs are fine, it's just that at that particular point in time, it failed because of the state of the database.