### PR TITLE
Filtering fixes to `document-field` example

### DIFF
--- a/.changeset/eleven-lemons-fetch.md
+++ b/.changeset/eleven-lemons-fetch.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/example-document-field': patch
+---
+
+Updated GraphQL filters to use most recent API.

--- a/examples/document-field/src/pages/author/[id].tsx
+++ b/examples/document-field/src/pages/author/[id].tsx
@@ -27,13 +27,13 @@ export default function Post({ author }: { author: any }) {
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   const data = await fetchGraphQL(gql`
     query {
-      allAuthors {
+      authors {
         id
       }
     }
   `);
   return {
-    paths: data.allAuthors.map((post: any) => ({ params: { id: post.id } })),
+    paths: data.authors.map((post: any) => ({ params: { id: post.id } })),
     fallback: 'blocking',
   };
 }
@@ -42,12 +42,12 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   const data = await fetchGraphQL(
     gql`
       query ($id: ID!) {
-        Author(where: { id: $id }) {
+        author(where: { id: $id }) {
           name
           bio {
             document
           }
-          posts {
+          posts(where: { status: { equals: published } }, orderBy: { publishDate: desc }) {
             id
             title
             slug
@@ -57,5 +57,5 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
     `,
     { id: params!.id }
   );
-  return { props: { author: data.Author }, revalidate: 60 };
+  return { props: { author: data.author }, revalidate: 60 };
 }

--- a/examples/document-field/src/pages/index.tsx
+++ b/examples/document-field/src/pages/index.tsx
@@ -33,10 +33,10 @@ export default function Index({ authors }: { authors: Author[] }) {
 export async function getStaticProps() {
   const data = await fetchGraphQL(gql`
     query {
-      allAuthors {
+      authors {
         id
         name
-        posts(where: { status: published }, orderBy: { publishDate: desc }) {
+        posts(where: { status: { equals: published } }, orderBy: { publishDate: desc }) {
           id
           slug
           title
@@ -44,5 +44,5 @@ export async function getStaticProps() {
       }
     }
   `);
-  return { props: { authors: data.allAuthors }, revalidate: 30 };
+  return { props: { authors: data.authors }, revalidate: 30 };
 }

--- a/examples/document-field/src/pages/post/[slug].tsx
+++ b/examples/document-field/src/pages/post/[slug].tsx
@@ -66,13 +66,13 @@ export default function Post({ post }: { post: any }) {
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   const data = await fetchGraphQL(gql`
     query {
-      allPosts {
+      posts {
         slug
       }
     }
   `);
   return {
-    paths: data.allPosts.map((post: any) => ({ params: { slug: post.slug } })),
+    paths: data.posts.map((post: any) => ({ params: { slug: post.slug } })),
     fallback: 'blocking',
   };
 }
@@ -83,7 +83,7 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   const data = await fetchGraphQL(
     gql`
       query ($slug: String!) {
-        Post(where: { slug: $slug }) {
+        post(where: { slug: $slug }) {
           title
           content {
             document(hydrateRelationships: true)
@@ -98,5 +98,5 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
     `,
     { slug: params!.slug }
   );
-  return { props: { post: data.Post }, revalidate: 60 };
+  return { props: { post: data.post }, revalidate: 60 };
 }


### PR DESCRIPTION
As reported in https://github.com/keystonejs/keystone/issues/6887, the `document-field` example is out of date and failing.

Additionally, draft posts were visible on the author page, this has been tweaked so they no longer show.