### PR TITLE
Log when `sessionData` is invalid

### DIFF
--- a/.changeset/shy-candles-cheer.md
+++ b/.changeset/shy-candles-cheer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+When the `sessionData` option is invalid, the error will now be logged instead of silently ignored


### PR DESCRIPTION
Closes #6655

The code shown in that issue works fine, the reason why things were breaking for the users in the slack thread linked is that the `sessionData` was wrong.