### PR TITLE
Update Node Engine Versions (and update test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,6 @@
     "babel-plugin-remove-graphql-queries": "2.7.2"
   },
   "engines": {
-    "node": "^12.20 || >= 14.13"
+    "node": "^14.15 || ^16.13"
   }
 }

--- a/tests/admin-ui-tests/navigation.test.ts
+++ b/tests/admin-ui-tests/navigation.test.ts
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import { Browser, Page } from 'playwright';
 import { adminUITests, loadIndex, makeGqlRequest } from './utils';
 
@@ -19,10 +20,12 @@ adminUITests('./tests/test-projects/basic', browserType => {
     expect(ariaCurrent).toBe('location');
   });
   test('When navigated to a List route, the representative list NavItem is selected', async () => {
-    await page.goto('http://localhost:3000/tasks');
-    const element = await page.waitForSelector('nav a:has-text("Tasks")');
-    const ariaCurrent = await element?.getAttribute('aria-current');
-    expect(ariaCurrent).toBe('location');
+    await retry(async () => {
+      await page.goto('http://localhost:3000/tasks');
+      const element = await page.waitForSelector('nav a:has-text("Tasks")');
+      const ariaCurrent = await element?.getAttribute('aria-current');
+      expect(ariaCurrent).toBe('location');
+    });
   });
   test('Can access all list pages via the navigation', async () => {
     await page.goto('http://localhost:3000');


### PR DESCRIPTION
There are issues with Node 17 (Next.js, Prisma) and we shouldn't be using it for production regardless. since it won't ever be LTS.

Also, Node 12 is old enough to phase out now that we have Node 14 and Node 16 as LTS.

I feel we should support Node 14 and Node 16 in the ranges as per PR.

The Node 14 and Node 16 ranges are as per LTS releases here - https://nodejs.org/en/download/releases/

Node 16 LTS also matches our test suites.

This also needs to be rolled out to all other Keystone repos using Keystone 6.