### PR TITLE
Fix default renderer of layout block

### DIFF
--- a/.changeset/shy-poets-taste.md
+++ b/.changeset/shy-poets-taste.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/document-renderer': patch
+---
+
+Fixed default renderer of `layout`

--- a/.changeset/shy-poets-taste.md
+++ b/.changeset/shy-poets-taste.md
@@ -2,4 +2,4 @@
 '@keystone-next/document-renderer': patch
 ---
 
-Fixed default renderer of `layout`
+Fixed default renderer of `layout` block

--- a/packages/document-renderer/src/index.tsx
+++ b/packages/document-renderer/src/index.tsx
@@ -42,7 +42,6 @@ interface Renderers {
     blockquote: OnlyChildrenComponent;
     code: Component<{ children: string }> | keyof JSX.IntrinsicElements;
     layout: Component<{ layout: [number, ...number[]]; children: ReactElement[] }>;
-    layoutArea: OnlyChildrenComponent;
     divider: Component<{}> | keyof JSX.IntrinsicElements;
     heading: Component<{
       level: 1 | 2 | 3 | 4 | 5 | 6;
@@ -98,11 +97,12 @@ export const defaultRenderers: Renderers = {
             gridTemplateColumns: layout.map(x => `${x}fr`).join(' '),
           }}
         >
-          {children}
+          {children.map((element, i) => (
+            <div key={i}>{element}</div>
+          ))}
         </div>
       );
     },
-    layoutArea: 'div',
   },
 };
 
@@ -150,9 +150,6 @@ function DocumentNode({
     }
     case 'layout': {
       return <renderers.block.layout layout={node.layout as any} children={children} />;
-    }
-    case 'layout-area': {
-      return <renderers.block.layoutArea children={children} />;
     }
     case 'divider': {
       return <renderers.block.divider />;

--- a/packages/document-renderer/src/index.tsx
+++ b/packages/document-renderer/src/index.tsx
@@ -42,6 +42,7 @@ interface Renderers {
     blockquote: OnlyChildrenComponent;
     code: Component<{ children: string }> | keyof JSX.IntrinsicElements;
     layout: Component<{ layout: [number, ...number[]]; children: ReactElement[] }>;
+    layoutArea: OnlyChildrenComponent;
     divider: Component<{}> | keyof JSX.IntrinsicElements;
     heading: Component<{
       level: 1 | 2 | 3 | 4 | 5 | 6;
@@ -101,6 +102,7 @@ export const defaultRenderers: Renderers = {
         </div>
       );
     },
+    layoutArea: 'div',
   },
 };
 
@@ -148,6 +150,9 @@ function DocumentNode({
     }
     case 'layout': {
       return <renderers.block.layout layout={node.layout as any} children={children} />;
+    }
+    case 'layout-area': {
+      return <renderers.block.layoutArea children={children} />;
     }
     case 'divider': {
       return <renderers.block.divider />;


### PR DESCRIPTION
Hey, while developing some project I noticed a very annoying bug. They layout in the editor does not correlate to the layout rendered by the `<DocumentRenderer />` component.
for example:
## editor (Slate):
![image](https://user-images.githubusercontent.com/22598347/142214581-ea943e50-60ef-4fc1-80ab-10bff31a1e6b.png)
![image](https://user-images.githubusercontent.com/22598347/142214653-905433e3-164b-4781-9ec2-596391c3097e.png)
DOM is structured correctly
```
div.grid
├── div
│   └── h1
└── div
    ├── h4
    └── p
```


## app (DocumentRenderer):
![image](https://user-images.githubusercontent.com/22598347/142215290-5317b4ff-1368-4d6b-ae58-f98f9b1d0d2c.png)
![image](https://user-images.githubusercontent.com/22598347/142215343-7e7bf3f3-356d-4a88-85e0-b7e57d61bcc2.png)
DOM is structured incorrectly
```
div.grid
├── h1
├── h4
└── p
```
-------------------------
To be honest I have no idea how this wasn't reported yet, but the fix is simple (I think, it's hard to test within the repo)

Please tell me if I missed something I should do <3

