### PR TITLE
Aligning the `assets-local` example with the `assets-cloud` example

### DIFF
--- a/examples-staging/assets-local/keystone.ts
+++ b/examples-staging/assets-local/keystone.ts
@@ -10,4 +10,7 @@ export default config({
   images: {
     upload: 'local',
   },
+  files: {
+    upload: 'local',
+  },
 });

--- a/examples-staging/assets-local/schema.graphql
+++ b/examples-staging/assets-local/schema.graphql
@@ -9,6 +9,7 @@ type Post {
   publishDate: DateTime
   author: Author
   hero: ImageFieldOutput
+  attachment: FileFieldOutput
 }
 
 enum PostStatusType {
@@ -36,6 +37,13 @@ enum ImageExtension {
   gif
 }
 
+interface FileFieldOutput {
+  filename: String!
+  filesize: Int!
+  ref: String!
+  url: String!
+}
+
 input PostWhereUniqueInput {
   id: ID
 }
@@ -56,6 +64,20 @@ type CloudImageFieldOutput implements ImageFieldOutput {
   width: Int!
   height: Int!
   extension: ImageExtension!
+  ref: String!
+  url: String!
+}
+
+type LocalFileFieldOutput implements FileFieldOutput {
+  filename: String!
+  filesize: Int!
+  ref: String!
+  url: String!
+}
+
+type CloudFileFieldOutput implements FileFieldOutput {
+  filename: String!
+  filesize: Int!
   ref: String!
   url: String!
 }
@@ -149,6 +171,7 @@ input PostUpdateInput {
   publishDate: DateTime
   author: AuthorRelateToOneForUpdateInput
   hero: ImageFieldInput
+  attachment: FileFieldInput
 }
 
 input AuthorRelateToOneForUpdateInput {
@@ -167,6 +190,11 @@ The `Upload` scalar type represents a file upload.
 """
 scalar Upload
 
+input FileFieldInput {
+  upload: Upload
+  ref: String
+}
+
 input PostUpdateArgs {
   where: PostWhereUniqueInput!
   data: PostUpdateInput!
@@ -179,6 +207,7 @@ input PostCreateInput {
   publishDate: DateTime
   author: AuthorRelateToOneForCreateInput
   hero: ImageFieldInput
+  attachment: FileFieldInput
 }
 
 input AuthorRelateToOneForCreateInput {

--- a/examples-staging/assets-local/schema.prisma
+++ b/examples-staging/assets-local/schema.prisma
@@ -13,19 +13,22 @@ generator client {
 }
 
 model Post {
-  id             String    @id @default(cuid())
-  title          String    @default("")
-  status         String?
-  content        String    @default("")
-  publishDate    DateTime?
-  author         Author?   @relation("Post_author", fields: [authorId], references: [id])
-  authorId       String?   @map("author")
-  hero_filesize  Int?
-  hero_extension String?
-  hero_width     Int?
-  hero_height    Int?
-  hero_mode      String?
-  hero_id        String?
+  id                  String    @id @default(cuid())
+  title               String    @default("")
+  status              String?
+  content             String    @default("")
+  publishDate         DateTime?
+  author              Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId            String?   @map("author")
+  hero_filesize       Int?
+  hero_extension      String?
+  hero_width          Int?
+  hero_height         Int?
+  hero_mode           String?
+  hero_id             String?
+  attachment_filesize Int?
+  attachment_mode     String?
+  attachment_filename String?
 
   @@index([authorId])
 }

--- a/examples-staging/assets-local/schema.ts
+++ b/examples-staging/assets-local/schema.ts
@@ -1,5 +1,5 @@
 import { list } from '@keystone-next/keystone';
-import { select, relationship, text, timestamp, image } from '@keystone-next/keystone/fields';
+import { select, relationship, text, timestamp, image, file } from '@keystone-next/keystone/fields';
 
 export const lists = {
   Post: list({
@@ -16,6 +16,7 @@ export const lists = {
       publishDate: timestamp(),
       author: relationship({ ref: 'Author.posts', many: false }),
       hero: image(),
+      attachment: file(),
     },
   }),
   Author: list({


### PR DESCRIPTION
The `assets-cloud` example includes an `attachment: file()` field on the Post list. This adds the corresponding field to the `assets-local` example so they have the same schema and both examples use the image and file field.