### PR TITLE
Fix relationship field not respecting ui.displayMode: cards in create view

### DIFF
--- a/.changeset/large-bobcats-teach.md
+++ b/.changeset/large-bobcats-teach.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Fixed `relationship` field not respecting `ui.displayMode: 'cards'` in the create view.

--- a/packages/keystone/src/fields/types/relationship/views/cards/index.tsx
+++ b/packages/keystone/src/fields/types/relationship/views/cards/index.tsx
@@ -75,23 +75,23 @@ export function Cards({
 }: {
   foreignList: ListMeta;
   localList: ListMeta;
-  field: ReturnType<typeof controller> & { display: { mode: 'cards' } };
-  id: string;
+  id: string | null;
   forceValidation: boolean | undefined;
   value: { kind: 'cards-view' };
-} & Pick<FieldProps<typeof controller>, 'value' | 'onChange'>) {
+} & FieldProps<typeof controller>) {
+  const { displayOptions } = value;
   let selectedFields = [
-    ...new Set([...field.display.cardFields, ...(field.display.inlineEdit?.fields || [])]),
+    ...new Set([...displayOptions.cardFields, ...(displayOptions.inlineEdit?.fields || [])]),
   ]
     .map(fieldPath => {
       return foreignList.fields[fieldPath].controller.graphqlSelection;
     })
     .join('\n');
-  if (!field.display.cardFields.includes('id')) {
+  if (!displayOptions.cardFields.includes('id')) {
     selectedFields += '\nid';
   }
   if (
-    !field.display.cardFields.includes(foreignList.labelField) &&
+    !displayOptions.cardFields.includes(foreignList.labelField) &&
     foreignList.labelField !== 'id'
   ) {
     selectedFields += `\n${foreignList.labelField}`;
@@ -164,7 +164,7 @@ export function Cards({
               {isEditMode ? (
                 <InlineEdit
                   list={foreignList}
-                  fields={field.display.inlineEdit!.fields}
+                  fields={displayOptions.inlineEdit!.fields}
                   onSave={newItemGetter => {
                     setItems({
                       ...items,
@@ -191,7 +191,7 @@ export function Cards({
               ) : (
                 <Fragment>
                   <Stack gap="xlarge">
-                    {field.display.cardFields.map(fieldPath => {
+                    {displayOptions.cardFields.map(fieldPath => {
                       const field = foreignList.fields[fieldPath];
                       const itemForField: Record<string, any> = {};
                       for (const graphqlField of getRootGraphQLFieldsFromFieldController(
@@ -219,7 +219,7 @@ export function Cards({
                     })}
                   </Stack>
                   <Stack across gap="small" marginTop="xlarge">
-                    {field.display.inlineEdit && onChange !== undefined && (
+                    {displayOptions.inlineEdit && onChange !== undefined && (
                       <Button
                         size="small"
                         disabled={onChange === undefined}
@@ -234,7 +234,7 @@ export function Cards({
                         Edit
                       </Button>
                     )}
-                    {field.display.removeMode === 'disconnect' && onChange !== undefined && (
+                    {displayOptions.removeMode === 'disconnect' && onChange !== undefined && (
                       <Tooltip content="This item will not be deleted. It will only be removed from this field.">
                         {props => (
                           <Button
@@ -256,7 +256,7 @@ export function Cards({
                         )}
                       </Tooltip>
                     )}
-                    {field.display.linkToItem && (
+                    {displayOptions.linkToItem && (
                       <Button
                         size="small"
                         weight="link"
@@ -275,7 +275,7 @@ export function Cards({
           );
         })}
       </Stack>
-      {onChange === undefined ? null : field.display.inlineConnect && showConnectItems ? (
+      {onChange === undefined ? null : displayOptions.inlineConnect && showConnectItems ? (
         <CardContainer mode="edit">
           <Stack
             gap="small"
@@ -366,7 +366,7 @@ export function Cards({
         <CardContainer mode="create">
           <InlineCreate
             selectedFields={selectedFields}
-            fields={field.display.inlineCreate!.fields}
+            fields={displayOptions.inlineCreate!.fields}
             list={foreignList}
             onCancel={() => {
               onChange({ ...value, itemBeingCreated: false });
@@ -382,10 +382,10 @@ export function Cards({
             }}
           />
         </CardContainer>
-      ) : field.display.inlineCreate || field.display.inlineConnect ? (
+      ) : displayOptions.inlineCreate || displayOptions.inlineConnect ? (
         <CardContainer mode="create">
           <Stack gap="small" marginTop="medium" across>
-            {field.display.inlineCreate && (
+            {displayOptions.inlineCreate && (
               <Button
                 size="small"
                 disabled={onChange === undefined}
@@ -400,7 +400,7 @@ export function Cards({
                 Create {foreignList.singular}
               </Button>
             )}
-            {field.display.inlineConnect && (
+            {displayOptions.inlineConnect && (
               <Button
                 size="small"
                 weight="none"

--- a/packages/keystone/src/fields/types/relationship/views/cards/index.tsx
+++ b/packages/keystone/src/fields/types/relationship/views/cards/index.tsx
@@ -76,7 +76,6 @@ export function Cards({
   foreignList: ListMeta;
   localList: ListMeta;
   id: string | null;
-  forceValidation: boolean | undefined;
   value: { kind: 'cards-view' };
 } & FieldProps<typeof controller>) {
   const { displayOptions } = value;

--- a/packages/keystone/src/fields/types/relationship/views/cards/useItemState.tsx
+++ b/packages/keystone/src/fields/types/relationship/views/cards/useItemState.tsx
@@ -22,7 +22,7 @@ export function useItemState({
   selectedFields: string;
   localList: ListMeta;
   field: ReturnType<typeof controller>;
-  id: string;
+  id: string | null;
 }) {
   const { data, error, loading } = useQuery(
     gql`query($id: ID!) {
@@ -33,7 +33,7 @@ export function useItemState({
     }
   }
 }`,
-    { variables: { id }, errorPolicy: 'all' }
+    { variables: { id }, errorPolicy: 'all', skip: id === null }
   );
   const { itemsArrFromData, relationshipGetter } = useMemo(() => {
     const dataGetter = makeDataGetter(data, error?.graphQLErrors);


### PR DESCRIPTION
I also ended up refactoring some things to avoid awkward type things because what the display mode is was represented in two places and the `Field` view needed to access both of them.

Note the relationship field doesn't respect `ui.displayMode: 'count'` on the create view and this doesn't change that, I think that's fine and good given that would just mean showing nothing, and `ui.displayMode: 'count'` just exists because our other UIs are bad at handling relationships with a lot of related items so we might as well give users a better UI when we know that it's okay.