### PR TITLE
Fix item page crashing when failing to fetch an item

### DIFF
--- a/.changeset/purple-beans-thank.md
+++ b/.changeset/purple-beans-thank.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+The item page in the Admin UI no longer crashes when failing to fetch an item.

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -408,50 +408,64 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
           <Notice tone="negative">{metaQueryErrors[0].message}</Notice>
         </Box>
       ) : (
-        <Fragment>
-          <ColumnLayout>
-            <ItemForm
-              fieldModes={itemViewFieldModesByField}
-              selectedFields={selectedFields}
-              showDelete={!data.keystone.adminMeta.list!.hideDelete}
-              listKey={listKey}
-              itemGetter={dataGetter.get('item') as DataGetter<ItemData>}
-            />
-
-            <StickySidebar>
-              <FieldLabel>Item ID</FieldLabel>
-              <div
-                css={{
-                  display: 'flex',
-                  alignItems: 'center',
-                }}
-              >
-                <TextInput
-                  css={{
-                    marginRight: spacing.medium,
-                    fontFamily: typography.fontFamily.monospace,
-                    fontSize: typography.fontSize.small,
-                  }}
-                  readOnly
-                  value={data.item.id}
+        <ColumnLayout>
+          {data?.item == null ? (
+            <Box marginY="xlarge">
+              {error?.graphQLErrors.length || error?.networkError ? (
+                <GraphQLErrorNotice
+                  errors={error?.graphQLErrors}
+                  networkError={error?.networkError}
                 />
-                <Tooltip content="Copy ID">
-                  {props => (
-                    <Button
-                      {...props}
-                      aria-label="Copy ID"
-                      onClick={() => {
-                        copyToClipboard(data.item.id);
-                      }}
-                    >
-                      <ClipboardIcon size="small" />
-                    </Button>
-                  )}
-                </Tooltip>
-              </div>
-            </StickySidebar>
-          </ColumnLayout>
-        </Fragment>
+              ) : (
+                <Notice tone="negative">
+                  The item with id "{id}" could not be found or you don't have access to it.
+                </Notice>
+              )}
+            </Box>
+          ) : (
+            <Fragment>
+              <ItemForm
+                fieldModes={itemViewFieldModesByField}
+                selectedFields={selectedFields}
+                showDelete={!data.keystone.adminMeta.list!.hideDelete}
+                listKey={listKey}
+                itemGetter={dataGetter.get('item') as DataGetter<ItemData>}
+              />
+              <StickySidebar>
+                <FieldLabel>Item ID</FieldLabel>
+                <div
+                  css={{
+                    display: 'flex',
+                    alignItems: 'center',
+                  }}
+                >
+                  <TextInput
+                    css={{
+                      marginRight: spacing.medium,
+                      fontFamily: typography.fontFamily.monospace,
+                      fontSize: typography.fontSize.small,
+                    }}
+                    readOnly
+                    value={data.item.id}
+                  />
+                  <Tooltip content="Copy ID">
+                    {props => (
+                      <Button
+                        {...props}
+                        aria-label="Copy ID"
+                        onClick={() => {
+                          copyToClipboard(data.item.id);
+                        }}
+                      >
+                        <ClipboardIcon size="small" />
+                      </Button>
+                    )}
+                  </Tooltip>
+                </div>
+              </StickySidebar>
+            </Fragment>
+          )}
+        </ColumnLayout>
       )}
     </PageContainer>
   );


### PR DESCRIPTION
Before in prod:
<img width="1840" alt="Something went wrong text in the middle of a web page with a button to reload the page" src="https://user-images.githubusercontent.com/11481355/142557324-ee4fc10b-697a-42c6-b944-0c077ccecb5f.png">
Before in dev:
<img width="1840" alt="Error from Next.js in the middle of a web page pointing to an line in Keystone's source" src="https://user-images.githubusercontent.com/11481355/142557343-d8feddbd-531f-4c76-8738-a85e598a4017.png">

In this PR:
<img width="1840" alt="Keystone Admin UI on the item page with the nav bar shown with no fields but an error notice saying the item could not be found or you don't have access to it" src="https://user-images.githubusercontent.com/11481355/142557352-ac767079-b381-4c0f-a0c0-b78b2f294306.png">

