### PR TITLE
Removing unnecessary types

### DIFF
--- a/.changeset/spotty-jokes-type.md
+++ b/.changeset/spotty-jokes-type.md
@@ -1,0 +1,7 @@
+---
+"@keystone-ui/fields": patch
+"@keystone-ui/options": patch
+"@keystone-next/keystone": patch
+---
+
+Removed unnecessary `@types/` dependencies

--- a/design-system/packages/fields/package.json
+++ b/design-system/packages/fields/package.json
@@ -12,7 +12,6 @@
     "@keystone-ui/core": "^3.2.1",
     "@keystone-ui/icons": "^4.0.2",
     "@keystone-ui/popover": "^4.0.5",
-    "@types/react-select": "^5.0.0",
     "date-fns": "^2.25.0",
     "react": "^17.0.2",
     "react-day-picker": "npm:react-day-picker@^7.4.8",

--- a/design-system/packages/options/package.json
+++ b/design-system/packages/options/package.json
@@ -15,7 +15,6 @@
     "@keystone-ui/core": "^3.2.1",
     "@keystone-ui/fields": "^5.0.1",
     "@keystone-ui/icons": "^4.0.2",
-    "@types/react-select": "^5.0.0",
     "react-select": "^5.2.1"
   },
   "engines": {

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -58,7 +58,6 @@
     "@types/bcryptjs": "^2.4.2",
     "@types/cookie": "^0.4.1",
     "@types/express": "^4.17.13",
-    "@types/form-data": "2.5.0",
     "@types/fs-extra": "^9.0.13",
     "@types/graphql-upload": "^8.0.7",
     "@types/inflection": "^1.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2746,13 +2746,6 @@
   resolved "https://registry.yarnpkg.com/@types/facepaint/-/facepaint-1.2.2.tgz#1432acb1b09696216861a457a037186afeb95346"
   integrity sha512-Xl9tAINsQL1s0TdXG5IiG75kZrxem5esbnKJF5gQgFel92OdS5zLtFYnbBw6fBruCMPYJQ9mK5pVmSsMl3Puug==
 
-"@types/form-data@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.5.0.tgz#5025f7433016f923348434c40006d9a797c1b0e8"
-  integrity sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==
-  dependencies:
-    form-data "*"
-
 "@types/fs-capacitor@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz#17113e25817f584f58100fb7a08eed288b81956e"
@@ -3036,13 +3029,6 @@
   integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
     "@types/react" "*"
-
-"@types/react-select@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-5.0.1.tgz#04fc85edd34a72675a0ab56ad4c30428aab0e444"
-  integrity sha512-h5Im0AP0dr4AVeHtrcvQrLV+gmPa7SA0AGdxl2jOhtwiE6KgXBFSogWw8az32/nusE6AQHlCOHQWjP1S/+oMWA==
-  dependencies:
-    react-select "*"
 
 "@types/react-transition-group@^4.4.0":
   version "4.4.4"
@@ -6423,7 +6409,7 @@ foreach@^2.0.5:
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
   integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
-form-data@*, form-data@4.0.0:
+form-data@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
   integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
@@ -10849,7 +10835,7 @@ react-remove-scroll@^2.4.3:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-select@*, react-select@^5.2.1:
+react-select@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.2.1.tgz#416c25c6b79b94687702374e019c4f2ed9d159d6"
   integrity sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==


### PR DESCRIPTION
Just noticed that on a fresh install, we get the following warnings in the console:

```
warning @keystone-next/auth > @keystone-ui/fields > @types/react-select@5.0.1: This is a stub types definition. react-select provides its own type definitions, so you do not need this installed.
warning @keystone-next/keystone > @keystone-ui/options > @types/react-select@5.0.1: This is a stub types definition. react-select provides its own type definitions, so you do not need this installed.
warning @keystone-next/keystone > @types/form-data@2.5.0: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
```

I can vouch in particular for types being included in `react-select@5.x` so I've removed both dependencies.