### PR TITLE
Pin @apollo/client to 3.4.17 - fixes Unhandled Runtime Error when loading Admin UI for fresh installs

### DIFF
--- a/.changeset/nervous-ads-hammer.md
+++ b/.changeset/nervous-ads-hammer.md
@@ -1,0 +1,7 @@
+---
+"@keystone-next/keystone": patch
+---
+
+Pinned `@apollo/client` to 3.4.17, fixes an incompatibility between `@apollo/client` >= 3.5.0 and `apollo-upload` that breaks the Admin UI.
+
+We can revert this when [jaydenseric/apollo-upload-client#273](https://github.com/jaydenseric/apollo-upload-client/issues/273) has been resolved (may also be resolved by [apollographql/apollo-client#9103](https://github.com/apollographql/apollo-client/pull/9103))

--- a/.changeset/nervous-ads-hammer.md
+++ b/.changeset/nervous-ads-hammer.md
@@ -2,6 +2,6 @@
 "@keystone-next/keystone": patch
 ---
 
-Pinned `@apollo/client` to 3.4.17, fixes an incompatibility between `@apollo/client` >= 3.5.0 and `apollo-upload` that breaks the Admin UI.
+Pinned `@apollo/client` to 3.4.17, fixes an incompatibility between `@apollo/client` >= 3.5.0 and `apollo-upload-client` that breaks the Admin UI.
 
 We can revert this when [jaydenseric/apollo-upload-client#273](https://github.com/jaydenseric/apollo-upload-client/issues/273) has been resolved (may also be resolved by [apollographql/apollo-client#9103](https://github.com/apollographql/apollo-client/pull/9103))

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -26,7 +26,7 @@
     "keystone-next": "bin/cli.js"
   },
   "dependencies": {
-    "@apollo/client": "^3.4.17",
+    "@apollo/client": "3.4.17",
     "@babel/core": "^7.16.0",
     "@babel/runtime": "^7.16.3",
     "@emotion/hash": "^0.8.0",


### PR DESCRIPTION
There's an issue with `@apollo.cilent` >= 3.5.0 and `apollo-upload-client` which breaks Keystone's Admin UI for fresh installs.

Pinning the version of `@apollo-client` we're using until this has been resolved, ref jaydenseric/apollo-upload-client#273 and apollographql/apollo-client#9103

A note for visibility / searchability: this error surfaces as

> **Unhandled Runtime Error**
> Error: An error occurred when loading Admin Metadata

If you're using yarn@1.x, you can work around this in the meantime using resolutions by adding the following to your `package.json`:

```
  "resolutions": {
    "**/@apollo/client": "3.4.17"
  },
```