### PR TITLE
add canonical Dockerfile to examples/basic

### DIFF
--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -1,0 +1,18 @@
+# Build
+FROM node:16-alpine as build
+COPY . /app
+WORKDIR /app
+
+ENV NODE_ENV production
+ENV SESSION_SECRET 'temporary SESSION_SECRET for build'
+RUN yarn install
+RUN yarn build
+
+# Serve
+FROM node:16-alpine
+
+WORKDIR /app
+COPY --from=build /app .
+
+ENV NODE_ENV production
+CMD ["yarn", "keystone", "start"]

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -1,4 +1,4 @@
-# Build
+# build
 FROM node:lts-alpine as build
 COPY . /app
 WORKDIR /app
@@ -8,7 +8,7 @@ RUN corepack enable
 RUN pnpm install
 RUN pnpm build
 
-# Serve
+# serve
 FROM node:lts-alpine
 
 WORKDIR /app

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -1,18 +1,18 @@
 # Build
-FROM node:16-alpine as build
+FROM node:lts-alpine as build
 COPY . /app
 WORKDIR /app
 
 ENV NODE_ENV production
-ENV SESSION_SECRET 'temporary SESSION_SECRET for build'
-RUN yarn install
-RUN yarn build
+RUN corepack enable
+RUN pnpm install
+RUN pnpm build
 
 # Serve
-FROM node:16-alpine
+FROM node:lts-alpine
 
 WORKDIR /app
 COPY --from=build /app .
 
 ENV NODE_ENV production
-CMD ["yarn", "keystone", "start"]
+CMD ["pnpm", "start"]

--- a/examples/basic/Dockerfile
+++ b/examples/basic/Dockerfile
@@ -13,6 +13,7 @@ FROM node:lts-alpine
 
 WORKDIR /app
 COPY --from=build /app .
+RUN corepack enable
 
 ENV NODE_ENV production
 CMD ["pnpm", "start"]


### PR DESCRIPTION
This is a draft.

I am open to community thoughts on where this example should live?
We want to encourage test deployments of our examples in different environments for users trial Keystonejs.
However,  as is,  we'll end up copying a `Dockerfile` to every example. 

We might also want to promote different environments, `arm64`, `x86_64` et al;  files for each of those (and other deployment examples) does not scale, and would add noise to the examples as documentation.

- [ ] Add `USER`
- [x] Fix the `SESSION_SECRET` `keystone build` problems
- [x] `migrate deploy` shouldn't need `keystone.ts`