### PR TITLE
docs: next version needs to match keystone

### DIFF
--- a/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
@@ -58,6 +58,8 @@ Delete the `/pages/api` directory. We’ll add a GraphQL API later in the tutori
    └── index.tsx
 ```
 
+Next, make sure that the `next` version in your `package.json` matches the version from [keystone](https://github.com/keystonejs/keystone/blob/main/packages/keystone/package.json#L107).
+
 ### Start your local server
 
 Run `yarn dev` at the root of your project.

--- a/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
@@ -58,7 +58,7 @@ Delete the `/pages/api` directory. We’ll add a GraphQL API later in the tutori
    └── index.tsx
 ```
 
-Next, make sure that the `next` version in your `package.json` matches the version from [keystone](https://github.com/keystonejs/keystone/blob/main/packages/keystone/package.json#L107).
+It is recommended that you use the same major version of `next` as used internally by [keystone](https://github.com/keystonejs/keystone/blob/main/packages/core/package.json#L107).
 
 ### Start your local server
 


### PR DESCRIPTION
- fixes #6847, #6848 
- in case your next version does not match with the one from keystone
  you will see errors such as 
  ```
  TypeError: Cannot destructure property 'inAmpMode' of '(0 , _react).useContext(...)' as it is null.
  ```