### PR TITLE
Add capability to always send field in update* mutations

### DIFF
--- a/.changeset/rotten-bananas-attend.md
+++ b/.changeset/rotten-bananas-attend.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add support to always include certain fields in update mutation

--- a/packages/core/src/admin-ui/utils/item-form.ts
+++ b/packages/core/src/admin-ui/utils/item-form.ts
@@ -40,6 +40,12 @@ export function useChangedFieldsAndDataForUpdate(
     changedFields.forEach(fieldKey => {
       Object.assign(dataForUpdate, serializedFieldValues[fieldKey]);
     });
+    Object.keys(serializedFieldValues)
+      .filter(key => fields[key].itemView.alwaysSend)
+      .filter(key => !changedFields.has(key))
+      .forEach(alwaysSendKey => {
+        Object.assign(dataForUpdate, serializedFieldValues[alwaysSendKey]);
+      });
     return { changedFields: changedFields as ReadonlySet<string>, dataForUpdate };
-  }, [serializedFieldValues, serializedValuesFromItem]);
+  }, [serializedFieldValues, serializedValuesFromItem, fields]);
 }

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -88,6 +88,11 @@ export type FieldMeta = {
      * `null` indicates that the value is dynamic and must be fetched for any given item
      */
     fieldMode: 'edit' | 'read' | 'hidden' | null;
+    /**
+     * `true` indicates that this field will be sent on every create/update regardless
+     * of whether it was changed or not (useful for optimistic locking fields).
+     */
+    alwaysSend?: boolean;
   };
 };
 


### PR DESCRIPTION
- this serves as the basis for optimistic locking
- you can now configure a `version` field as readonly and have it
  included in all update calls
- on the server side you can then validate the version with the
  `item.version` and then throw a validation error in case it does not
  match
- that way a concurrent modification on the server can be identified

fixes #6851