### PR TITLE
Fix the input in the link dialog in the document editor not being focusable

### DIFF
--- a/.changeset/hot-pots-drum.md
+++ b/.changeset/hot-pots-drum.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixed the input in the link dialog not being focusable 


### PR DESCRIPTION
Closes #7027

`website_live` as of opening this PR: https://keystone-next-docs-gvc8100wy-keystonejs.vercel.app/docs/guides/document-field-demo
This PR: https://keystone-next-docs-git-fix-input-in-link-dial-2dbc5e-keystonejs.vercel.app/docs/guides/document-field-demo