### PR TITLE
Reword homepage intro for easy of understanding

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -55,13 +55,13 @@ export default function IndexPage() {
             The <Highlight look="grad1">superpowered</Highlight> CMS for developers
           </IntroHeading>
           <IntroLead>
-            Keystone helps you build faster and scale further than any other CMS or App Framework.
-            Just describe your schema, and get a powerful GraphQL API & beautiful Management UI for
-            content and data.
+            Build faster and scale further than any other CMS or App Framework. Describe your
+            schema in code to get a powerful GraphQL API + beautiful Management UI for content
+            and data.
           </IntroLead>
           <IntroLead>
-            No boilerplate or bootstrapping – just elegant APIs to help you ship the code that
-            matters without sacrificing the flexibility or power of a bespoke back-end.
+            Keystone's elegant APIs help you ship the code that matters. Without sacrificing
+            the flexibility or power of a bespoke back-end.
           </IntroLead>
         </IntroWrapper>
 


### PR DESCRIPTION
I found the homepage intro very hard to understand when first reading it. I came across the following stumbling blocks:

- Very long sentences
- The first paragraph used the work `and` 4 times
- Too many ideas per sentence
- Generic words detracted from the powerful message in the sentences

I've taken a stab at rewriting the intro to have:

- Short sentences; makes the content much easier to digest
- Single idea per sentence; understanding the key benefits is much easier this way
- Removed a few filler + generic words; keeps it succinct and to the point. Every sentence encourages the user to read the next.


<img width="1013" alt="Screen Shot 2021-12-01 at 3 50 12 pm" src="https://user-images.githubusercontent.com/612020/144173881-5fa7fd17-f061-44d2-8b33-649b11c738e6.png">