### PR TITLE
fixing the type of title field

### DIFF
--- a/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
@@ -102,7 +102,7 @@ import { text } from '@keystone-6/core/fields';
 
 const Post = list({
   fields: {
-    title: text({ isRequired: true }),
+    title: text({ validation: { isRequired: true } }),
     slug: text({ isIndexed: 'unique', isFilterable: true }),
     content: text(),
   },


### PR DESCRIPTION
Hi, congrats on the launch 🥳 .
while i was following the guide for embedding keystone in next.js i got a type error because of the missing validation object so this pr has it in the docs