### PR TITLE
Improve performance of generating artifacts for projects in the repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,17 +94,6 @@ jobs:
     name: Package Unit Tests
     needs: should_run_tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: keystone5
-          POSTGRES_PASSWORD: k3yst0n3
-          POSTGRES_DB: test_db
-        ports:
-          - 5432:5432
-    env:
-      DATABASE_URL: 'postgres://keystone5:k3yst0n3@localhost:5432/test_db'
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,8 +353,5 @@ jobs:
       - name: Remark
         run: yarn lint:markdown
 
-      - name: Example schemas
-        run: yarn lint:examples
-
       - name: Prisma Filters
         run: yarn lint:filters

--- a/examples-staging/ecommerce/keystone.ts
+++ b/examples-staging/ecommerce/keystone.ts
@@ -46,18 +46,16 @@ export default withAuth(
         credentials: true,
       },
     },
-    db: process.env.DATABASE_URL
-      ? { provider: 'postgresql', url: process.env.DATABASE_URL }
-      : {
-          provider: 'sqlite',
-          url: databaseURL,
-          async onConnect(context) {
-            console.log('Connected to the database!');
-            if (process.argv.includes('--seed-data')) {
-              await insertSeedData(context);
-            }
-          },
-        },
+    db: {
+      provider: 'sqlite',
+      url: databaseURL,
+      async onConnect(context) {
+        console.log('Connected to the database!');
+        if (process.argv.includes('--seed-data')) {
+          await insertSeedData(context);
+        }
+      },
+    },
     lists: {
       // Schema items go in here
       User,

--- a/examples-staging/sandbox/keystone.ts
+++ b/examples-staging/sandbox/keystone.ts
@@ -7,14 +7,9 @@ import { config } from '@keystone-6/core';
 import { lists } from './schema';
 
 export default config({
-  db: process.env.DATABASE_URL?.startsWith('postgres')
-    ? {
-        provider: 'postgresql',
-        url: process.env.DATABASE_URL,
-      }
-    : {
-        provider: 'sqlite',
-        url: process.env.DATABASE_URL || 'file:./dev.db',
-      },
+  db: {
+    provider: 'sqlite',
+    url: process.env.DATABASE_URL || 'file:./dev.db',
+  },
   lists,
 });

--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
     "publish-changed": "yarn build && changeset publish --public",
     "version-packages": "changeset version",
     "build": "preconstruct build",
-    "prepare": "manypkg check && preconstruct dev && yarn run --silent contributing-guide && cd examples-staging/basic && yarn keystone postinstall",
+    "prepare": "manypkg check && preconstruct dev && yarn run --silent contributing-guide && node scripts/generate-artifacts-for-projects",
     "contributing-guide": "is-ci && exit 0 || chalk -t \"{bold 📝 Contributing to KeystoneJS?}\" && terminal-link \"🔗 Read the full Contributing Guide\" \"https://github.com/keystonejs/keystone/blob/main/CONTRIBUTING.md\"",
     "npm-tag": "manypkg npm-tag",
     "update": "manypkg upgrade",
-    "postinstall-examples": "for d in `find examples -type d -maxdepth 1 -mindepth 1`; do echo $d; cd $d; yarn keystone postinstall --fix; cd ../..; done; for d in `find examples-staging -type d -maxdepth 1 -mindepth 1`; do echo $d; cd $d; yarn keystone postinstall --fix; cd ../..; done; for d in `find tests/test-projects -type d -maxdepth 1 -mindepth 1`; do echo $d; cd $d; yarn keystone postinstall --fix; cd ../../..; done",
-    "lint:examples": "for d in `find examples -type d -maxdepth 1 -mindepth 1`; do cd $d; echo $d; SKIP_PROMPTS=1 yarn keystone postinstall; if [ $? -ne 0 ]; then exit 1; fi; cd ../..; done; for d in `find examples-staging -type d -maxdepth 1 -mindepth 1`; do cd $d; echo $d; SKIP_PROMPTS=1 yarn keystone postinstall; if [ $? -ne 0 ]; then exit 1; fi; cd ../..; done; for d in `find tests/test-projects -type d -maxdepth 1 -mindepth 1`; do cd $d; echo $d; SKIP_PROMPTS=1 yarn keystone postinstall; if [ $? -ne 0 ]; then exit 1; fi; cd ../../..; done",
+    "update-project-schemas": "cross-env UPDATE_SCHEMAS=1 node scripts/generate-artifacts-for-projects",
     "generate-filters": "cd prisma-utils && yarn generate",
     "lint:filters": "cd prisma-utils && yarn verify"
   },
@@ -120,14 +119,16 @@
       "tests/benchmarks",
       "tests/examples-smoke-tests",
       "tests/test-projects/*",
-      "prisma-utils"
+      "prisma-utils",
+      "scripts/*"
     ]
   },
   "preconstruct": {
     "packages": [
       "packages/*",
       "design-system/packages/*",
-      "prisma-utils"
+      "prisma-utils",
+      "scripts/*"
     ]
   },
   "manypkg": {

--- a/packages/keystone/___internal-do-not-use-will-break-in-patch/require-source/package.json
+++ b/packages/keystone/___internal-do-not-use-will-break-in-patch/require-source/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-require-source.cjs.js",
+  "module": "dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-require-source.esm.js"
+}

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -141,7 +141,7 @@
       "index.ts",
       "system.ts",
       "next.ts",
-      "___internal-do-not-use-will-break-in-patch/{node-api,next-graphql}.ts",
+      "___internal-do-not-use-will-break-in-patch/{node-api,next-graphql,require-source}.ts",
       "___internal-do-not-use-will-break-in-patch/admin-ui/pages/*/index.tsx",
       "___internal-do-not-use-will-break-in-patch/admin-ui/{next-config.ts,id-field-view.tsx}",
       "artifacts.ts",

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/require-source.ts
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/require-source.ts
@@ -1,0 +1,1 @@
+export { requireSource } from '../lib/config/requireSource';

--- a/scripts/generate-artifacts-for-projects/package.json
+++ b/scripts/generate-artifacts-for-projects/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@keystone-6/generate-artifacts-for-projects",
+  "version": "0.0.0",
+  "private": true,
+  "main": "dist/keystone-6-generate-artifacts-for-projects.cjs.js",
+  "dependencies": {
+    "@keystone-6/core": "^1.0.0"
+  },
+  "repository": "https://github.com/keystonejs/keystone/tree/main/scripts/generate-artifacts-for-projects"
+}

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -45,6 +45,10 @@ async function main() {
     )
   ).flat();
 
+  // this breaks if we do this entirely in parallel (it only seemed to consistently fail on Vercel though)
+  // because of Prisma's loading native libraries and child processes stuff and it seems racey
+  // it's fine if we just do one and then the rest together though
+  // so we do that so we get decent parallelism
   const [firstProject, ...otherProjects] = projectDirectories;
 
   await generateArtifactsForProjectDir(firstProject);

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -1,0 +1,55 @@
+import path from 'path';
+import fs from 'fs/promises';
+import { format } from 'util';
+import { createSystem, initConfig } from '@keystone-6/core/system';
+import {
+  validateCommittedArtifacts,
+  generateNodeModulesArtifacts,
+  generateCommittedArtifacts,
+} from '@keystone-6/core/artifacts';
+import { requireSource } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/require-source';
+
+async function main() {
+  const repoRoot = path.resolve(__dirname, '../../../');
+  const directoriesOfProjects = [
+    path.join(repoRoot, 'examples'),
+    path.join(repoRoot, 'examples-staging'),
+    path.join(repoRoot, 'tests/test-projects'),
+  ];
+  const projectDirectories = (
+    await Promise.all(
+      directoriesOfProjects.map(async dir => {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        return entries.filter(x => x.isDirectory()).map(x => path.join(dir, x.name));
+      })
+    )
+  ).flat();
+
+  const mode = process.env.UPDATE_SCHEMAS ? 'generate' : 'validate';
+
+  await Promise.all(
+    projectDirectories.map(async projectDir => {
+      try {
+        const config = initConfig(requireSource(path.join(projectDir, 'keystone')).default);
+        const { graphQLSchema } = createSystem(config, false);
+        if (mode === 'validate') {
+          await validateCommittedArtifacts(graphQLSchema, config, projectDir);
+        } else {
+          await generateCommittedArtifacts(graphQLSchema, config, projectDir);
+        }
+        await generateNodeModulesArtifacts(graphQLSchema, config, projectDir);
+      } catch (err) {
+        throw new Error(
+          `An error occurred generating/validating the artifacts for the project at ${projectDir}:\n${format(
+            err
+          )}\n`
+        );
+      }
+    })
+  );
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3037,7 +3037,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.35", "@types/react@^17.0.35":
+"@types/react@*", "@types/react@^17.0.35":
   version "17.0.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
   integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==


### PR DESCRIPTION
Currently we have some shell stuff that ends up being very slow(~2 minutes) because of the way the Keystone repo is setup, we end up basically re-compiling Keystone for every project. This script takes ~10 seconds instead which ofc isn't great but it's probably good enough for now. The big motivation here being that we'll be able to use the generated types in examples without making our postinstall take 2 minutes. 