### PR TITLE
TS type generation refactoring

### DIFF
--- a/.changeset/breezy-beans-roll.md
+++ b/.changeset/breezy-beans-roll.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Refactoring of TypeScript type generation

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -185,12 +185,11 @@ export async function generateNodeModulesArtifactsWithoutPrismaClient(
 ) {
   const lists = initialiseLists(config);
 
-  const printedSchema = printSchema(graphQLSchema);
   const dotKeystoneDir = path.join(cwd, 'node_modules/.keystone');
   await Promise.all([
     fs.outputFile(
       path.join(dotKeystoneDir, 'types.d.ts'),
-      printGeneratedTypes(printedSchema, graphQLSchema, lists)
+      printGeneratedTypes(graphQLSchema, lists)
     ),
     fs.outputFile(path.join(dotKeystoneDir, 'types.js'), ''),
     ...(config.experimental?.generateNodeAPI


### PR DESCRIPTION
The main thing here here is generating the types with the schema object rather than printing and then parsing the schema and using the AST because that was unnecessary + removing some dead code.