### PR TITLE
fix artifact API types

### DIFF
--- a/.changeset/gentle-paws-cough.md
+++ b/.changeset/gentle-paws-cough.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-import changed in articaft.ts from KeystoneListsTypeInfo to Lists since KeystoneListsTypeInfo is no longer in types (changes in https://github.com/keystonejs/keystone/pull/7001)
+Fix Lists import in artifacts types (changed in https://github.com/keystonejs/keystone/pull/7001)

--- a/.changeset/gentle-paws-cough.md
+++ b/.changeset/gentle-paws-cough.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+import changed in articaft.ts from KeystoneListsTypeInfo to Lists since KeystoneListsTypeInfo is no longer in types (changes in https://github.com/keystonejs/keystone/pull/7001)

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -133,9 +133,9 @@ export const query = createQueryAPI(keystoneConfig, PrismaClient);
 `;
 
 const nodeAPIDTS = `import { KeystoneListsAPI } from '@keystone-6/core/types';
-import { Lists } from './types';
+import { Context } from './types';
 
-export const query: KeystoneListsAPI<Lists>;`;
+export const query: Context['query'];
 
 const makeVercelIncludeTheSQLiteDB = (
   cwd: string,

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -135,7 +135,7 @@ export const query = createQueryAPI(keystoneConfig, PrismaClient);
 const nodeAPIDTS = `import { KeystoneListsAPI } from '@keystone-6/core/types';
 import { Context } from './types';
 
-export const query: Context['query'];
+export const query: Context['query'];`;
 
 const makeVercelIncludeTheSQLiteDB = (
   cwd: string,

--- a/packages/keystone/src/artifacts.ts
+++ b/packages/keystone/src/artifacts.ts
@@ -133,9 +133,9 @@ export const query = createQueryAPI(keystoneConfig, PrismaClient);
 `;
 
 const nodeAPIDTS = `import { KeystoneListsAPI } from '@keystone-6/core/types';
-import { KeystoneListsTypeInfo } from './types';
+import { Lists } from './types';
 
-export const query: KeystoneListsAPI<KeystoneListsTypeInfo>;`;
+export const query: KeystoneListsAPI<Lists>;`;
 
 const makeVercelIncludeTheSQLiteDB = (
   cwd: string,

--- a/packages/keystone/src/scripts/tests/artifacts.test.ts
+++ b/packages/keystone/src/scripts/tests/artifacts.test.ts
@@ -112,9 +112,9 @@ describe('postinstall', () => {
     expect(await getFiles(tmp, ['node_modules/.keystone/api.{d.ts,js}'])).toMatchInlineSnapshot(`
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import { KeystoneListsAPI } from '@keystone-6/core/types';
-      import { Lists } from './types';
+      import { Context } from './types';
 
-      export const query: KeystoneListsAPI<Lists>;
+      export const query: Context['query'];
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import keystoneConfig from '../../keystone';
       import { PrismaClient } from '.prisma/client';

--- a/packages/keystone/src/scripts/tests/artifacts.test.ts
+++ b/packages/keystone/src/scripts/tests/artifacts.test.ts
@@ -112,9 +112,9 @@ describe('postinstall', () => {
     expect(await getFiles(tmp, ['node_modules/.keystone/api.{d.ts,js}'])).toMatchInlineSnapshot(`
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.d.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import { KeystoneListsAPI } from '@keystone-6/core/types';
-      import { KeystoneListsTypeInfo } from './types';
+      import { Lists } from './types';
 
-      export const query: KeystoneListsAPI<KeystoneListsTypeInfo>;
+      export const query: KeystoneListsAPI<Lists>;
       ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/api.js ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
       import keystoneConfig from '../../keystone';
       import { PrismaClient } from '.prisma/client';


### PR DESCRIPTION
import changed in articaft.ts from KeystoneListsTypeInfo to Lists since KeystoneListsTypeInfo is no longer in types (changes in https://github.com/keystonejs/keystone/pull/7001)