### PR TITLE
add titles to pages in admin UI

### DIFF
--- a/.changeset/big-fireants-doubt.md
+++ b/.changeset/big-fireants-doubt.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/keystone': patch
+---
+
+Page names now reflect the page you are on: Item view shows the item's label, list view shows the list name, other pages show 'Keystone'

--- a/.changeset/moody-pianos-sell.md
+++ b/.changeset/moody-pianos-sell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-next/auth': patch
+---
+
+Add titles to initi and sign-in pages

--- a/examples/custom-admin-ui-pages/README.md
+++ b/examples/custom-admin-ui-pages/README.md
@@ -45,6 +45,7 @@ PageContainer has the following types:
 type PageContainerProps = {
   header: ReactElement;
   children: ReactNode;
+  title?: string;
 };
 ```
 

--- a/packages/auth/src/components/SigninContainer.tsx
+++ b/packages/auth/src/components/SigninContainer.tsx
@@ -7,31 +7,37 @@ import { jsx, Box, Center, useTheme } from '@keystone-ui/core';
 
 type SigninContainerProps = {
   children: ReactNode;
+  title?: string;
 };
 
-export const SigninContainer = ({ children }: SigninContainerProps) => {
+export const SigninContainer = ({ children, title }: SigninContainerProps) => {
   const { colors, shadow } = useTheme();
   return (
-    <Center
-      css={{
-        minWidth: '100vw',
-        minHeight: '100vh',
-        backgroundColor: colors.backgroundMuted,
-      }}
-      rounding="medium"
-    >
-      <Box
+    <div>
+      <head>
+        <title>{title || 'Keystone'}</title>
+      </head>
+      <Center
         css={{
-          background: colors.background,
-          width: 600,
-          boxShadow: shadow.s100,
+          minWidth: '100vw',
+          minHeight: '100vh',
+          backgroundColor: colors.backgroundMuted,
         }}
-        margin="medium"
-        padding="xlarge"
         rounding="medium"
       >
-        {children}
-      </Box>
-    </Center>
+        <Box
+          css={{
+            background: colors.background,
+            width: 600,
+            boxShadow: shadow.s100,
+          }}
+          margin="medium"
+          padding="xlarge"
+          rounding="medium"
+        >
+          {children}
+        </Box>
+      </Center>
+    </div>
   );
 };

--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -224,7 +224,7 @@ const InitPage = ({ fieldPaths, listKey, enableWelcome }: InitPageProps) => {
   }
 
   return mode === 'init' ? (
-    <SigninContainer>
+    <SigninContainer title="Welcome to KeystoneJS">
       <H1>Welcome to KeystoneJS</H1>
       <p>Create your first user to get started</p>
       <form

--- a/packages/auth/src/pages/SigninPage.tsx
+++ b/packages/auth/src/pages/SigninPage.tsx
@@ -74,7 +74,7 @@ export const SigninPage = ({
   }
 
   return (
-    <SigninContainer>
+    <SigninContainer title="Keystone - Sign In">
       <Stack
         gap="xlarge"
         as="form"

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -345,8 +345,14 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
   // placment of the save and delete buttons.
   const hideCreate = true; // data?.keystone.adminMeta.list.hideCreate;
 
+  const pageTitle = loading
+    ? undefined
+    : (data && data.item && (data.item[list.labelField] || data.item.id)) || id;
+  console.log('ey', a);
+
   return (
     <PageContainer
+      title={pageTitle}
       header={
         <Container
           css={{

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -345,10 +345,9 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
   // placment of the save and delete buttons.
   const hideCreate = true; // data?.keystone.adminMeta.list.hideCreate;
 
-  const pageTitle = loading
+  const pageTitle: string = loading
     ? undefined
     : (data && data.item && (data.item[list.labelField] || data.item.id)) || id;
-  console.log('ey', a);
 
   return (
     <PageContainer

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -242,7 +242,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
   const showCreate = !(metaQuery.data?.keystone.adminMeta.list?.hideCreate ?? true) || null;
 
   return (
-    <PageContainer header={<ListPageHeader listKey={listKey} />}>
+    <PageContainer header={<ListPageHeader listKey={listKey} />} title={list.label}>
       {metaQuery.error ? (
         // TODO: Show errors nicely and with information
         'Error...'

--- a/packages/keystone/src/admin-ui/components/PageContainer.tsx
+++ b/packages/keystone/src/admin-ui/components/PageContainer.tsx
@@ -10,6 +10,7 @@ import { Logo } from './Logo';
 type PageContainerProps = {
   children: ReactNode;
   header: ReactNode;
+  title?: string;
 };
 
 export const HEADER_HEIGHT = 80;
@@ -70,7 +71,7 @@ const Content = (props: HTMLAttributes<HTMLElement>) => {
   );
 };
 
-export const PageContainer = ({ children, header }: PageContainerProps) => {
+export const PageContainer = ({ children, header, title }: PageContainerProps) => {
   const { colors, spacing } = useTheme();
   return (
     <PageWrapper>
@@ -99,6 +100,7 @@ export const PageContainer = ({ children, header }: PageContainerProps) => {
           paddingRight: spacing.xlarge,
         }}
       >
+        <title>{title ? `Keystone - ${title}` : 'Keystone'}</title>
         {header}
       </header>
       <Sidebar>


### PR DESCRIPTION
Found that we didn't have titles on Keystone pages, so it just showed the URL path.

This would have been fine, EXCEPT the title didn't get updated on Next.js page transitions, meaning it was often misleading, and kind of annoying if you had multiple tabs open.

PR defaults it to being set to `Keystone` which will eliminate confusion.
- Item view pages use the item's label or id as 'Keystone - label/id'
- List view pages use the list's plural name: `Keystone - People' eg

Sign in and init both have custom titles