### PR TITLE
make seed data work better with KS6

### DIFF
--- a/examples/blog/seed-data/index.ts
+++ b/examples/blog/seed-data/index.ts
@@ -18,38 +18,30 @@ export async function insertSeedData(context: KeystoneContext) {
   console.log(`🌱 Inserting seed data`);
 
   const createAuthor = async (authorData: AuthorProps) => {
-    let author = null;
-    try {
-      author = await context.query.Author.findOne({
-        where: { email: authorData.email },
-        query: 'id',
-      });
-    } catch (e) {}
+    let author = await context.query.Author.findOne({
+      where: { email: authorData.email },
+      query: 'id',
+    });
+
     if (!author) {
       author = await context.query.Author.createOne({
         data: authorData,
         query: 'id',
       });
     }
-    return author;
   };
 
   const createPost = async (postData: PostProps) => {
-    let authors;
-    try {
-      authors = await context.query.Author.findMany({
-        where: { name: { equals: postData.author } },
-        query: 'id',
-      });
-    } catch (e) {
-      authors = [];
-    }
+    let authors = await context.query.Author.findMany({
+      where: { name: { equals: postData.author } },
+      query: 'id',
+    });
+
     postData.author = { connect: { id: authors[0].id } };
-    const post = await context.query.Post.createOne({
+    await context.query.Post.createOne({
       data: postData,
       query: 'id',
     });
-    return post;
   };
 
   for (const author of authors) {

--- a/examples/rest-api/schema.graphql
+++ b/examples/rest-api/schema.graphql
@@ -156,6 +156,7 @@ type Person {
 
 input PersonWhereUniqueInput {
   id: ID
+  name: String
 }
 
 input PersonWhereInput {

--- a/examples/rest-api/schema.prisma
+++ b/examples/rest-api/schema.prisma
@@ -25,6 +25,6 @@ model Task {
 
 model Person {
   id    String @id @default(cuid())
-  name  String @default("")
+  name  String @unique @default("")
   tasks Task[] @relation("Task_assignedTo")
 }

--- a/examples/rest-api/schema.ts
+++ b/examples/rest-api/schema.ts
@@ -21,7 +21,7 @@ export const lists = {
   }),
   Person: list({
     fields: {
-      name: text({ validation: { isRequired: true } }),
+      name: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
       tasks: relationship({ ref: 'Task.assignedTo', many: true }),
     },
   }),

--- a/examples/rest-api/seed-data/index.ts
+++ b/examples/rest-api/seed-data/index.ts
@@ -17,38 +17,30 @@ export async function insertSeedData(context: KeystoneContext) {
   console.log(`🌱 Inserting seed data`);
 
   const createPerson = async (personData: PersonProps) => {
-    let person = null;
-    try {
-      person = await context.query.Person.findOne({
-        where: { name: personData.name },
-        query: 'id',
-      });
-    } catch (e) {}
+    let person = await context.query.Person.findOne({
+      where: { name: personData.name },
+      query: 'id',
+    });
+
     if (!person) {
-      person = await context.query.Person.createOne({
+      await context.query.Person.createOne({
         data: personData,
         query: 'id',
       });
     }
-    return person;
   };
 
   const createTask = async (taskData: TaskProps) => {
-    let persons;
-    try {
-      persons = await context.query.Person.findMany({
-        where: { name: { equals: taskData.assignedTo } },
-        query: 'id',
-      });
-    } catch (e) {
-      persons = [];
-    }
+    let persons = await context.query.Person.findMany({
+      where: { name: { equals: taskData.assignedTo } },
+      query: 'id',
+    });
+
     taskData.assignedTo = { connect: { id: persons[0].id } };
-    const task = await context.query.Task.createOne({
+    await context.query.Task.createOne({
       data: taskData,
       query: 'id',
     });
-    return task;
   };
 
   for (const person of persons) {

--- a/examples/task-manager/schema.graphql
+++ b/examples/task-manager/schema.graphql
@@ -156,6 +156,7 @@ type Person {
 
 input PersonWhereUniqueInput {
   id: ID
+  name: String
 }
 
 input PersonWhereInput {

--- a/examples/task-manager/schema.prisma
+++ b/examples/task-manager/schema.prisma
@@ -25,6 +25,6 @@ model Task {
 
 model Person {
   id    String @id @default(cuid())
-  name  String @default("")
+  name  String @unique @default("")
   tasks Task[] @relation("Task_assignedTo")
 }

--- a/examples/task-manager/schema.ts
+++ b/examples/task-manager/schema.ts
@@ -21,7 +21,7 @@ export const lists = {
   }),
   Person: list({
     fields: {
-      name: text({ validation: { isRequired: true } }),
+      name: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
       tasks: relationship({ ref: 'Task.assignedTo', many: true }),
     },
   }),

--- a/examples/task-manager/seed-data/index.ts
+++ b/examples/task-manager/seed-data/index.ts
@@ -17,38 +17,31 @@ export async function insertSeedData(context: KeystoneContext) {
   console.log(`🌱 Inserting seed data`);
 
   const createPerson = async (personData: PersonProps) => {
-    let person = null;
-    try {
-      person = await context.query.Person.findOne({
-        where: { name: personData.name },
-        query: 'id',
-      });
-    } catch (e) {}
+    let person = await context.query.Person.findOne({
+      where: { name: personData.name },
+      query: 'id',
+    });
+
     if (!person) {
       person = await context.query.Person.createOne({
         data: personData,
         query: 'id',
       });
     }
-    return person;
   };
 
   const createTask = async (taskData: TaskProps) => {
-    let persons;
-    try {
-      persons = await context.query.Person.findMany({
-        where: { name: { equals: taskData.assignedTo } },
-        query: 'id',
-      });
-    } catch (e) {
-      persons = [];
-    }
+    let persons = await context.query.Person.findMany({
+      where: { name: { equals: taskData.assignedTo } },
+      query: 'id',
+    });
+
     taskData.assignedTo = { connect: { id: persons[0].id } };
-    const task = await context.query.Task.createOne({
+
+    await context.query.Task.createOne({
       data: taskData,
       query: 'id',
     });
-    return task;
   };
 
   for (const person of persons) {


### PR DESCRIPTION
During the KS6 upgrade, examples were kept working, but the data seeding got left behind a bit.

Fixed it so we are no longer doing try/catches

Also, while the add functions were returning data, we were not doing anything with it, so I stopped returning things.