### PR TITLE
Fix types for field hooks

### DIFF
--- a/.changeset/stupid-elephants-smoke.md
+++ b/.changeset/stupid-elephants-smoke.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Change types for 'list field types' so hooks can accept 'undefined' when appropriate

--- a/.changeset/stupid-elephants-smoke.md
+++ b/.changeset/stupid-elephants-smoke.md
@@ -2,4 +2,5 @@
 '@keystone-6/core': patch
 ---
 
-Change types for 'list field types' so hooks can accept 'undefined' when appropriate
+Differentiate types for the field `resolveInput` hook and the list `resolveInput` hook.
+`undefined` may  be returned by field `resolveInput` hooks (indicates a no-op), but not for lists.

--- a/packages/keystone/src/types/config/hooks.ts
+++ b/packages/keystone/src/types/config/hooks.ts
@@ -46,7 +46,7 @@ export type FieldHooks<ListTypeInfo extends BaseListTypeInfo> = AddFieldPathArgT
   /**
    * Used to **modify the input** for create and update operations after default values and access control have been applied
    */
-  resolveInput?: resolveFieldInputHook<ListTypeInfo>;
+  resolveInput?: ResolveInputFieldHook<ListTypeInfo>;
   /**
    * Used to **validate the input** for create and update operations once all resolveInput hooks resolved
    */
@@ -109,7 +109,7 @@ type ResolveInputListHook<ListTypeInfo extends BaseListTypeInfo> = (
   | boolean
   | null;
 
-type resolveFieldInputHook<ListTypeInfo extends BaseListTypeInfo> = (
+type ResolveInputFieldHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & CommonArgs<ListTypeInfo>
 ) =>
   | Promise<ListTypeInfo['inputs']['create'] | ListTypeInfo['inputs']['update']>

--- a/packages/keystone/src/types/config/hooks.ts
+++ b/packages/keystone/src/types/config/hooks.ts
@@ -13,7 +13,7 @@ export type ListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * Used to **modify the input** for create and update operations after default values and access control have been applied
    */
-  resolveInput?: ResolveInputHook<ListTypeInfo>;
+  resolveInput?: ResolveInputListHook<ListTypeInfo>;
   /**
    * Used to **validate the input** for create and update operations once all resolveInput hooks resolved
    */
@@ -42,9 +42,28 @@ type AddFieldPathArgToAllPropsOnObj<T extends Record<string, (arg: any) => any>>
   [Key in keyof T]: AddFieldPathToObj<T[Key]>;
 };
 
-export type FieldHooks<ListTypeInfo extends BaseListTypeInfo> = AddFieldPathArgToAllPropsOnObj<
-  ListHooks<ListTypeInfo>
->;
+export type FieldHooks<ListTypeInfo extends BaseListTypeInfo> = AddFieldPathArgToAllPropsOnObj<{
+  /**
+   * Used to **modify the input** for create and update operations after default values and access control have been applied
+   */
+  resolveInput?: resolveFieldInputHook<ListTypeInfo>;
+  /**
+   * Used to **validate the input** for create and update operations once all resolveInput hooks resolved
+   */
+  validateInput?: ValidateInputHook<ListTypeInfo>;
+  /**
+   * Used to **validate** that a delete operation can happen after access control has occurred
+   */
+  validateDelete?: ValidateDeleteHook<ListTypeInfo>;
+  /**
+   * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
+   */
+  beforeOperation?: BeforeOperationHook<ListTypeInfo>;
+  /**
+   * Used to **cause side effects** after a create, update, or delete operation operation has occurred
+   */
+  afterOperation?: AfterOperationHook<ListTypeInfo>;
+}>;
 
 type ArgsForCreateOrUpdateOperation<ListTypeInfo extends BaseListTypeInfo> =
   | {
@@ -76,7 +95,7 @@ type ArgsForCreateOrUpdateOperation<ListTypeInfo extends BaseListTypeInfo> =
       resolvedData: ListTypeInfo['inputs']['update'];
     };
 
-type ResolveInputHook<ListTypeInfo extends BaseListTypeInfo> = (
+type ResolveInputListHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & CommonArgs<ListTypeInfo>
 ) =>
   | Promise<ListTypeInfo['inputs']['create'] | ListTypeInfo['inputs']['update']>
@@ -89,6 +108,22 @@ type ResolveInputHook<ListTypeInfo extends BaseListTypeInfo> = (
   | number
   | boolean
   | null;
+
+type resolveFieldInputHook<ListTypeInfo extends BaseListTypeInfo> = (
+  args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & CommonArgs<ListTypeInfo>
+) =>
+  | Promise<ListTypeInfo['inputs']['create'] | ListTypeInfo['inputs']['update']>
+  | ListTypeInfo['inputs']['create']
+  | ListTypeInfo['inputs']['update']
+  // TODO: I'm pretty sure this is wrong, but without these additional types you can't define a
+  // resolveInput hook for a field that returns a simple value (e.g timestamp)
+  | Record<string, any>
+  | string
+  | number
+  | boolean
+  | null
+  // Undefined is necessary for field input hooks, but we don't want it for list input hooks
+  | undefined;
 
 type ValidateInputHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & {

--- a/packages/keystone/src/types/config/hooks.ts
+++ b/packages/keystone/src/types/config/hooks.ts
@@ -101,8 +101,8 @@ type ResolveInputListHook<ListTypeInfo extends BaseListTypeInfo> = (
   | Promise<ListTypeInfo['inputs']['create'] | ListTypeInfo['inputs']['update']>
   | ListTypeInfo['inputs']['create']
   | ListTypeInfo['inputs']['update']
-  // TODO: I'm pretty sure this is wrong, but without these additional types you can't define a
-  // resolveInput hook for a field that returns a simple value (e.g timestamp)
+  // TODO: These were here to support field hooks before we created a separate type
+  // (see ResolveInputFieldHook), check whether they're safe to remove now
   | Record<string, any>
   | string
   | number
@@ -115,14 +115,14 @@ type ResolveInputFieldHook<ListTypeInfo extends BaseListTypeInfo> = (
   | Promise<ListTypeInfo['inputs']['create'] | ListTypeInfo['inputs']['update']>
   | ListTypeInfo['inputs']['create']
   | ListTypeInfo['inputs']['update']
-  // TODO: I'm pretty sure this is wrong, but without these additional types you can't define a
+  // TODO: These may or may not be correct, but without them you can't define a
   // resolveInput hook for a field that returns a simple value (e.g timestamp)
   | Record<string, any>
   | string
   | number
   | boolean
   | null
-  // Undefined is necessary for field input hooks, but we don't want it for list input hooks
+  // Fields need to be able to return `undefined` to say "don't touch this field"
   | undefined;
 
 type ValidateInputHook<ListTypeInfo extends BaseListTypeInfo> = (


### PR DESCRIPTION
Currently, you can't return `undefined` from field hooks, as they are using the same types as list hooks.

This PR separates the two and adds undefined to the types for field hooks.