### PR TITLE
Allow admin UI base path customization in config

### DIFF
--- a/.changeset/popular-cars-hug.md
+++ b/.changeset/popular-cars-hug.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Allow custom base path for Admin UI

--- a/packages/keystone/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/keystone/src/lib/server/createAdminUIMiddleware.ts
@@ -18,9 +18,10 @@ export const createAdminUIMiddleware = async (
 ) => {
   /** We do this to stop webpack from bundling next inside of next */
   const { ui, graphql, session } = config;
+  const basePath = ui?.path;
   const _next = 'next';
   const next = require(_next);
-  const app = next({ dev, dir: projectAdminPath });
+  const app = basePath ? next({ dev, dir: projectAdminPath, conf: { basePath } }) : next({ dev, dir: projectAdminPath });
   const handle = app.getRequestHandler();
   await app.prepare();
 

--- a/packages/keystone/src/types/config/index.ts
+++ b/packages/keystone/src/types/config/index.ts
@@ -73,8 +73,7 @@ export type AdminUIConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   /** An array of page routes that can be accessed without passing the isAccessAllowed check */
   publicPages?: readonly string[];
   /** The basePath for the Admin UI App */
-  // FIXME: currently unused
-  // path?: string;
+  path?: string;
   getAdditionalFiles?: readonly ((
     config: KeystoneConfig<TypeInfo>
   ) => MaybePromise<readonly AdminFileToWrite[]>)[];


### PR DESCRIPTION
Added (or rather uncommented) a config variable to set the admin UI base path and set the conf accordingly in `createAdminUIMiddleware.ts`. Thanks to @thekarinka for help in making this work!