### PR TITLE
Don't churn dependency requirements

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,11 @@
   "extends": ["config:base"],
   "ignorePaths": ["packages/build-field-tyes/__fixtures__/**/*"],
   "lockFileMaintenance": { "enabled": true },
-  "separateMinorPatch": true,
+  "separateMinorPatch": false,
+  "separateMajorMinor": true,
   "prConcurrentLimit": 0,
-  "baseBranches": ["renovating"],
+  "prHourlyLimit": 3,
+  "baseBranches": ["main"],
   "packageRules": [
     {
       "packagePatterns": [
@@ -20,7 +22,7 @@
       "groupName": "patch dependencies"
     }
   ],
-  "rangeStrategy": "bump",
+  "rangeStrategy": "update-lockfile",
   "schedule": ["before 7am on Tuesday", "before 7am on Wednesday"],
   "timezone": "Australia/Sydney",
   "updateNotScheduled": false


### PR DESCRIPTION
At this time,  Renovate routinely `bump`s our `package.json` dependencies to new major, minor and patch versions;  twice a week as scheduled.

Typically,  for Keystone dependencies,  [we use `^x.y.z` caret version ranges for our dependencies.](https://github.com/npm/node-semver#caret-ranges-123-025-004)

If we bump a package from `^1.1.0` to `^1.2.0`, we are signalling to our users that we _need_ a particular MINOR version (a feature) for Keystone to work.

If we bump a package from `^1.0.0` to `^1.0.3`, we are signalling to our users that we _need_ a particular PATCH version (a fix) for Keystone to work.

When Renovate bumps our dependencies, say from `^1.1.0` to `^1.2.0`,  we are signalling to our users that suddenly our requirements for "Keystone to work" have changed,  _except_,  they haven't.

The reason we use a `yarn.lock` is for consistency in development and our CI/CD pipeline.
The primary reason we use Renovate is routinely update our `yarn.lock` such that we receive a :red_circle: signal if any new bugs or incompatibles occur as part of routine maintenance.  This acts as a proxy for the experience new users will face when installing from scratch.  This should be _rare_ if the ecosystem is adhering to [semver](https://semver.org/).

If a package is breaking our build :red_circle:,  and we cannot compatibly fix the code without also upgrading the package - then - we should be bumping the dependency to it's new version (whatever that may be, major, minor or patch).

As is,  by repeatedly raising the minimum bar of what transitive dependencies our users need to have,  we are churning our user's `yarn.lock` files and `node_modules` directories,  and inevitably forcing our users to routinely manually resolve any incompatible package resolutions.

This change stops that by changing Renovates `"rangeStrategy": "bump"` to `"rangeStrategy": "update-lockfile"` only.
The frequency of pull requests may stay the same for now,  but a :red_circle: should only indicate that intervention may be needed.  We should not see `package.json` files updating routinely.