### PR TITLE
Noviny/accurise changelogs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/website
+# @keystone-6/website
 
 ## 0.0.1
 
@@ -6,6 +6,8 @@
 
 - Updated dependencies [[`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde), [`f4554980f`](https://github.com/keystonejs/keystone/commit/f4554980f6243a6545eee6c887d946ff25cd90e3)]:
   - @keystone-6/fields-document@1.0.0
+
+# @keystone-next/website
 
 ## 4.0.0
 

--- a/examples-staging/assets-cloud/CHANGELOG.md
+++ b/examples-staging/assets-cloud/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-assets-cloud
+# @keystone-6/example-assets-cloud
 
 ## 0.0.1
 

--- a/examples-staging/assets-local/CHANGELOG.md
+++ b/examples-staging/assets-local/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-assets-local
+# @keystone-6/example-assets-local
 
 ## 0.0.1
 

--- a/examples-staging/auth/CHANGELOG.md
+++ b/examples-staging/auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-auth
+# @keystone-6/example-auth
 
 ## 0.0.1
 

--- a/examples-staging/basic/CHANGELOG.md
+++ b/examples-staging/basic/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-app-basic
+# @keystone-6/example-app-basic
 
 ## 0.0.1
 

--- a/examples-staging/ecommerce/CHANGELOG.md
+++ b/examples-staging/ecommerce/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-ecommerce
+# @keystone-6/example-ecommerce
 
 ## 0.0.1
 

--- a/examples-staging/embedded-nextjs/CHANGELOG.md
+++ b/examples-staging/embedded-nextjs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-next-lite
+# @keystone-6/example-next-lite
 
 ## 0.0.1
 

--- a/examples-staging/roles/CHANGELOG.md
+++ b/examples-staging/roles/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-roles
+# @keystone-6/example-roles
 
 ## 0.0.1
 

--- a/examples-staging/sandbox/CHANGELOG.md
+++ b/examples-staging/sandbox/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-sandbox
+# @keystone-6/example-sandbox
 
 ## 0.0.1
 

--- a/examples/blog/CHANGELOG.md
+++ b/examples/blog/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-blog
+# @keystone-6/example-blog
 
 ## 0.0.1
 

--- a/examples/custom-admin-ui-logo/CHANGELOG.md
+++ b/examples/custom-admin-ui-logo/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-custom-admin-ui-logo
+# @keystone-6/example-custom-admin-ui-logo
 
 ## 0.0.1
 

--- a/examples/custom-admin-ui-navigation/CHANGELOG.md
+++ b/examples/custom-admin-ui-navigation/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-custom-navigation-component
+# @keystone-6/example-custom-navigation-component
 
 ## 0.0.1
 

--- a/examples/custom-admin-ui-pages/CHANGELOG.md
+++ b/examples/custom-admin-ui-pages/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-custom-admin-ui-pages
+# @keystone-6/example-custom-admin-ui-pages
 
 ## 0.0.1
 

--- a/examples/custom-field-view/CHANGELOG.md
+++ b/examples/custom-field-view/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-custom-field-view
+# @keystone-6/example-custom-field-view
 
 ## 0.0.1
 

--- a/examples/custom-field/CHANGELOG.md
+++ b/examples/custom-field/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-custom-field
+# @keystone-6/example-custom-field
 
 ## 0.0.1
 

--- a/examples/default-values/CHANGELOG.md
+++ b/examples/default-values/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-default-values
+# @keystone-6/example-default-values
 
 ## 0.0.1
 

--- a/examples/document-field/CHANGELOG.md
+++ b/examples/document-field/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-document-field
+# @keystone-6/example-document-field
 
 ## 0.0.1
 

--- a/examples/extend-graphql-schema-graphql-ts/CHANGELOG.md
+++ b/examples/extend-graphql-schema-graphql-ts/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-extend-graphql-schema-graphql-ts
+# @keystone-6/example-extend-graphql-schema-graphql-ts
 
 ## 0.0.1
 

--- a/examples/extend-graphql-schema-nexus/CHANGELOG.md
+++ b/examples/extend-graphql-schema-nexus/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-extend-graphql-schema
+# @keystone-6/example-extend-graphql-schema
 
 ## 0.0.1
 

--- a/examples/extend-graphql-schema/CHANGELOG.md
+++ b/examples/extend-graphql-schema/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-extend-graphql-schema
+# @keystone-6/example-extend-graphql-schema
 
 ## 0.0.1
 

--- a/examples/json/CHANGELOG.md
+++ b/examples/json/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-json
+# @keystone-6/example-json
 
 ## 0.0.1
 

--- a/examples/rest-api/CHANGELOG.md
+++ b/examples/rest-api/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-rest-api
+# @keystone-6/example-rest-api
 
 ## 0.0.1
 

--- a/examples/task-manager/CHANGELOG.md
+++ b/examples/task-manager/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-task-manager
+# @keystone-6/example-task-manager
 
 ## 0.0.1
 

--- a/examples/testing/CHANGELOG.md
+++ b/examples/testing/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-testing
+# @keystone-6/example-testing
 
 ## 0.0.1
 

--- a/examples/virtual-field/CHANGELOG.md
+++ b/examples/virtual-field/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-virtual-field
+# @keystone-6/example-virtual-field
 
 ## 0.0.1
 

--- a/examples/with-auth/CHANGELOG.md
+++ b/examples/with-auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/example-with-auth
+# @keystone-6/example-with-auth
 
 ## 0.0.1
 

--- a/packages/auth/CHANGELOG.md
+++ b/packages/auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/auth
+# @keystone-6/auth
 
 ## 1.0.1
 
@@ -43,6 +43,8 @@
 
 - Updated dependencies [[`7dddbe0fd`](https://github.com/keystonejs/keystone/commit/7dddbe0fd5b42a2596ba4dc0bbe1813cb54571c7), [`fb7844ab5`](https://github.com/keystonejs/keystone/commit/fb7844ab50c1d4a6d14b2ad46a568665f6661921), [`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde), [`f4554980f`](https://github.com/keystonejs/keystone/commit/f4554980f6243a6545eee6c887d946ff25cd90e3)]:
   - @keystone-6/core@1.0.0
+
+# @keystone-next/auth
 
 ## 37.0.0
 

--- a/packages/cloudinary/CHANGELOG.md
+++ b/packages/cloudinary/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/cloudinary
+# @keystone-6/cloudinary
 
 ## 1.0.0
 
@@ -34,6 +34,8 @@
 
 - Updated dependencies [[`7dddbe0fd`](https://github.com/keystonejs/keystone/commit/7dddbe0fd5b42a2596ba4dc0bbe1813cb54571c7), [`fb7844ab5`](https://github.com/keystonejs/keystone/commit/fb7844ab50c1d4a6d14b2ad46a568665f6661921), [`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde), [`f4554980f`](https://github.com/keystonejs/keystone/commit/f4554980f6243a6545eee6c887d946ff25cd90e3)]:
   - @keystone-6/core@1.0.0
+
+# @keystone-next/cloudinary
 
 ## 12.0.0
 

--- a/packages/document-renderer/CHANGELOG.md
+++ b/packages/document-renderer/CHANGELOG.md
@@ -1,10 +1,12 @@
-# @keystone-next/document-renderer
+# @keystone-6/document-renderer
 
 ## 1.0.0
 
 ### Major Changes
 
 - [#7028](https://github.com/keystonejs/keystone/pull/7028) [`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde) Thanks [@mitchellhamilton](https://github.com/mitchellhamilton)! - Released Keystone 6
+
+# @keystone-next/document-renderer
 
 ## 5.0.0
 

--- a/packages/fields-document/CHANGELOG.md
+++ b/packages/fields-document/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/fields-document
+# @keystone-6/fields-document
 
 ## 1.0.1
 
@@ -41,6 +41,8 @@
 - Updated dependencies [[`7dddbe0fd`](https://github.com/keystonejs/keystone/commit/7dddbe0fd5b42a2596ba4dc0bbe1813cb54571c7), [`fb7844ab5`](https://github.com/keystonejs/keystone/commit/fb7844ab50c1d4a6d14b2ad46a568665f6661921), [`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde), [`f4554980f`](https://github.com/keystonejs/keystone/commit/f4554980f6243a6545eee6c887d946ff25cd90e3)]:
   - @keystone-6/core@1.0.0
   - @keystone-6/document-renderer@1.0.0
+
+# @keystone-next/fields-document
 
 ## 14.0.0
 

--- a/packages/keystone/CHANGELOG.md
+++ b/packages/keystone/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/keystone
+# @keystone-6/core
 
 ## 1.0.1
 
@@ -61,6 +61,7 @@
 
 - [#7005](https://github.com/keystonejs/keystone/pull/7005) [`fb7844ab5`](https://github.com/keystonejs/keystone/commit/fb7844ab50c1d4a6d14b2ad46a568665f6661921) Thanks [@gwyneplaine](https://github.com/gwyneplaine)! - Improve console output for when you need to restart the server because of schema changes
 
+# @keystone-next/keystone
 ## 29.0.0
 
 ### Major Changes

--- a/packages/session-store-redis/CHANGELOG.md
+++ b/packages/session-store-redis/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/session-store-redis
+# @keystone-6/session-store-redis
 
 ## 1.0.0
 
@@ -10,6 +10,8 @@
 
 - Updated dependencies [[`7dddbe0fd`](https://github.com/keystonejs/keystone/commit/7dddbe0fd5b42a2596ba4dc0bbe1813cb54571c7), [`fb7844ab5`](https://github.com/keystonejs/keystone/commit/fb7844ab50c1d4a6d14b2ad46a568665f6661921), [`3c7a581c1`](https://github.com/keystonejs/keystone/commit/3c7a581c1e53ae49c9f74509de3927ebf2703bde), [`f4554980f`](https://github.com/keystonejs/keystone/commit/f4554980f6243a6545eee6c887d946ff25cd90e3)]:
   - @keystone-6/core@1.0.0
+
+# @keystone-next/session-store-redis
 
 ## 9.0.0
 

--- a/prisma-utils/CHANGELOG.md
+++ b/prisma-utils/CHANGELOG.md
@@ -1,10 +1,12 @@
-# @keystone-next/prisma-utils
+# @keystone-6/prisma-utils
 
 ## 0.0.1
 
 ### Patch Changes
 
 - [#7062](https://github.com/keystonejs/keystone/pull/7062) [`30b3cacb0`](https://github.com/keystonejs/keystone/commit/30b3cacb08601a8db445e3c7be85dee10d0d2958) Thanks [@dcousens](https://github.com/dcousens)! - Updated prisma monorepo to [v3.6.0 (minor)](https://github.com/prisma/prisma/releases/tag/3.6.0).
+
+# @keystone-next/prisma-utils
 
 ## 2.0.0
 

--- a/tests/admin-ui-tests/CHANGELOG.md
+++ b/tests/admin-ui-tests/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/admin-ui-tests
+# @keystone-6/admin-ui-tests
 
 ## 1.0.0
 

--- a/tests/test-projects/basic/CHANGELOG.md
+++ b/tests/test-projects/basic/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/test-projects-basic
+# @keystone-6/test-projects-basic
 
 ## 0.0.1
 

--- a/tests/test-projects/crud-notifications/CHANGELOG.md
+++ b/tests/test-projects/crud-notifications/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/test-projects-crud-notifications
+# @keystone-6/test-projects-crud-notifications
 
 ## 1.0.1
 

--- a/tests/test-projects/live-reloading/CHANGELOG.md
+++ b/tests/test-projects/live-reloading/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @keystone-next/test-projects-live-reloading
+# @keystone-6/test-projects-live-reloading
 
 ## 1.0.1
 


### PR DESCRIPTION
Was browsing files with Dan and found that changelogs got missed a bit in the rename.

I've renamed everything using the `keystone-next` namespace to refer to `keystone-6` in their CHANGELOG.md files

For packages that are external, I left old changelogs extant, but put the previous title at the top of the old changelogs.

At some point there was talk of moving this old content into a separate changelog file, such as 'changelog-old' - I haven't done that pending a decision.

I decided not to do a changeset, as the change seems not worth the package churn, and can get picked up in the next release.