### PR TITLE
Another attempt at less noisy renovation strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:base"],
-  "ignorePaths": ["packages/build-field-tyes/__fixtures__/**/*"],
   "lockFileMaintenance": { "enabled": true },
   "separateMinorPatch": false,
   "separateMajorMinor": true,
@@ -16,13 +15,9 @@
         "^slate"
       ],
       "enabled": false
-    },
-    {
-      "updateTypes": ["patch"],
-      "groupName": "patch dependencies"
     }
   ],
-  "rangeStrategy": "update-lockfile",
+  "rangeStrategy": "replace",
   "schedule": ["before 7am on Tuesday", "before 7am on Wednesday"],
   "timezone": "Australia/Sydney",
   "updateNotScheduled": false


### PR DESCRIPTION
Following on from https://github.com/keystonejs/keystone/pull/7149

> The frequency of pull requests may stay the same for now, but a red_circle should only indicate that intervention may be needed. We should not see package.json files updating routinely.

This pull request reduces the frequency of pull requests by changing the strategy to `replace`, which _should_ limit the pull requests submitted by Renovate to:

> Replace the range with a newer one if the new version falls outside it, and update nothing otherwise

- When using a `^x.y.z` range,  this should be equivalent to major updates only, and
- Lock file maintenance