### PR TITLE
Add option to use BigInt in autoincrement idField

### DIFF
--- a/.changeset/honest-lamps-bow.md
+++ b/.changeset/honest-lamps-bow.md
@@ -1,5 +1,6 @@
 ---
 '@keystone-6/core': minor
+'@keystone-6/auth': patch
 ---
 
 Added support for BigInt autoincrement id fields with `idField: { kind: 'autoincrement', type: 'BigInt' }`

--- a/.changeset/honest-lamps-bow.md
+++ b/.changeset/honest-lamps-bow.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Ability to use BigInt as autoincrement idField

--- a/.changeset/honest-lamps-bow.md
+++ b/.changeset/honest-lamps-bow.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Ability to use BigInt as autoincrement idField
+Added support for BigInt autoincrement id fields with `idField: { kind: 'autoincrement', type: 'BigInt' }`

--- a/docs/pages/docs/apis/config.mdx
+++ b/docs/pages/docs/apis/config.mdx
@@ -75,6 +75,7 @@ Advanced configuration:
 - `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
 - `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
   This can also be customised at the list level `db.idField`.
+  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 - `prismaPreviewFeatures` (default: `[]`): Enable [Prisma preview features](https://www.prisma.io/docs/concepts/components/preview-features) by providing an array of strings.
 - `shadowDatabaseUrl` (default: `undefined`): Enable [shadow databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually) for some cloud providers.
 
@@ -102,6 +103,7 @@ Advanced configuration:
 - `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
 - `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
   This can also be customised at the list level `db.idField`.
+  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 - `prismaPreviewFeatures` (default: `[]`): Enable [Prisma preview features](https://www.prisma.io/docs/concepts/components/preview-features) by providing an array of strings.
 
 ```typescript
@@ -127,6 +129,7 @@ Advanced configuration:
 - `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
 - `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
   This can also be customised at the list level `db.idField`.
+  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 
 ```typescript
 export default config({

--- a/docs/pages/docs/apis/schema.mdx
+++ b/docs/pages/docs/apis/schema.mdx
@@ -197,6 +197,7 @@ Options:
 
 - `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
   The default across all lists can be changed at the root-level `db.idField` config.
+  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 - `map`: Adds a [Prisma `@@map`](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#map-1) attribute to the Prisma model for this list which specifies a custom database table name for the list, instead of using the list key
 
 ```typescript

--- a/packages/auth/src/lib/createAuthToken.ts
+++ b/packages/auth/src/lib/createAuthToken.ts
@@ -14,7 +14,9 @@ export async function createAuthToken(
   identityField: string,
   identity: string,
   dbItemAPI: KeystoneDbAPI<any>[string]
-): Promise<{ success: false } | { success: true; itemId: string | number; token: string }> {
+): Promise<
+  { success: false } | { success: true; itemId: string | number | bigint; token: string }
+> {
   const item = await dbItemAPI.findOne({ where: { [identityField]: identity } });
   if (item) {
     return { success: true, itemId: item.id, token: generateToken(20) };

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -22,7 +22,7 @@ export type AuthGqlNames = {
 };
 
 export type SendTokenFn = (args: {
-  itemId: string | number;
+  itemId: string | number | bigint;
   identity: string;
   token: string;
   context: KeystoneContext;

--- a/packages/core/src/lib/config/applyIdFieldDefaults.ts
+++ b/packages/core/src/lib/config/applyIdFieldDefaults.ts
@@ -5,6 +5,15 @@ import { idFieldType } from '../id-field';
 export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
   const lists: KeystoneConfig['lists'] = {};
   const defaultIdField = config.db.idField ?? { kind: 'cuid' };
+  if (
+    defaultIdField.kind === 'autoincrement' &&
+    defaultIdField.type === 'BigInt' &&
+    config.db.provider === 'sqlite'
+  ) {
+    throw new Error(
+      'BigInt autoincrements are not supported on SQLite but they are configured as the global id field type at db.idField'
+    );
+  }
   Object.keys(config.lists).forEach(key => {
     const listConfig = config.lists[key];
     if (listConfig.fields.id) {
@@ -12,6 +21,15 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['li
         `A field with the \`id\` path is defined in the fields object on the ${JSON.stringify(
           key
         )} list. This is not allowed, use the idField option instead.`
+      );
+    }
+    if (
+      listConfig.db?.idField?.kind === 'autoincrement' &&
+      listConfig.db.idField.type === 'BigInt' &&
+      config.db.provider === 'sqlite'
+    ) {
+      throw new Error(
+        `BigInt autoincrements are not supported on SQLite but they are configured at db.idField on the ${key} list`
       );
     }
     const idField = idFieldType(listConfig.db?.idField ?? defaultIdField);

--- a/packages/core/src/lib/core/prisma-schema.ts
+++ b/packages/core/src/lib/core/prisma-schema.ts
@@ -165,7 +165,7 @@ function assertDbFieldIsValidForIdField(
   // this may be loosened in the future
   if (field.scalar !== 'String' && field.scalar !== 'Int' && field.scalar !== 'BigInt') {
     throw new Error(
-      `id fields must be either String or Int Prisma scalars but the id field for the ${listKey} list is a ${field.scalar} scalar`
+      `id fields must be String, Int or BigInt Prisma scalars but the id field for the ${listKey} list is a ${field.scalar} scalar`
     );
   }
   if (field.mode !== 'required') {

--- a/packages/core/src/lib/core/prisma-schema.ts
+++ b/packages/core/src/lib/core/prisma-schema.ts
@@ -163,7 +163,7 @@ function assertDbFieldIsValidForIdField(
     );
   }
   // this may be loosened in the future
-  if (field.scalar !== 'String' && field.scalar !== 'Int') {
+  if (field.scalar !== 'String' && field.scalar !== 'Int' && field.scalar !== 'BigInt') {
     throw new Error(
       `id fields must be either String or Int Prisma scalars but the id field for the ${listKey} list is a ${field.scalar} scalar`
     );

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -30,13 +30,13 @@ const idParsers = {
   },
   autoincrementBigInt(val: string | null) {
     if (val === null) {
-      throw userInputError('Only BigInt integer can be passed to id filters');
+      throw userInputError('Only a bigint can be passed to id filters');
     }
     const parsed = BigInt(val);
     if (typeof parsed === 'bigint') {
       return parsed;
     }
-    throw userInputError('Only BigInt integer can be passed to id filters');
+    throw userInputError('Only a bigint can be passed to id filters');
   },
   cuid(val: string | null) {
     // isCuid is just "it's a string and it starts with c"
@@ -82,17 +82,16 @@ const filterArg = graphql.arg({ type: IDFilter });
 
 function resolveVal(
   input: Exclude<graphql.InferValueFromArg<typeof filterArg>, undefined>,
-  kind: IdFieldConfig['kind']
+  parseId: (id: string | null) => unknown
 ): any {
   if (input === null) {
     throw userInputError('id filter cannot be null');
   }
-  const idParser = idParsers[kind];
   const obj: any = {};
   for (const key of ['equals', 'gt', 'gte', 'lt', 'lte'] as const) {
     const val = input[key];
     if (val !== undefined) {
-      const parsed = idParser(val);
+      const parsed = parseId(val);
       obj[key] = parsed;
     }
   }
@@ -102,11 +101,11 @@ function resolveVal(
       if (val === null) {
         throw userInputError(`${key} id filter cannot be null`);
       }
-      obj[key] = val.map(x => idParser(x));
+      obj[key] = val.map(x => parseId(x));
     }
   }
   if (input.not !== undefined) {
-    obj.not = resolveVal(input.not, kind);
+    obj.not = resolveVal(input.not, parseId);
   }
   return obj;
 }
@@ -114,18 +113,15 @@ function resolveVal(
 export const idFieldType =
   (config: IdFieldConfig): FieldTypeFunc<BaseListTypeInfo> =>
   meta => {
-    const parseVal = idParsers[config.kind];
+    const parseVal =
+      config.kind === 'autoincrement' && config.type === 'BigInt'
+        ? idParsers.autoincrementBigInt
+        : idParsers[config.kind];
     return fieldType({
       kind: 'scalar',
       mode: 'required',
       scalar:
-        config.kind === 'autoincrement'
-          ? // SQLite doesn't support autoincrement feature for BigInt fields, solution is using Int field
-            // because it is 64 bit integer always in SQLite, more info here https://github.com/linq2db/linq2db/issues/930
-            config.useBigInt && meta.provider !== 'sqlite'
-            ? 'BigInt'
-            : 'Int'
-          : 'String',
+        config.kind === 'autoincrement' ? (config.type === 'BigInt' ? 'BigInt' : 'Int') : 'String',
       nativeType: meta.provider === 'postgresql' && config.kind === 'uuid' ? 'Uuid' : undefined,
       default: { kind: config.kind },
     })({
@@ -137,7 +133,7 @@ export const idFieldType =
         where: {
           arg: filterArg,
           resolve(val) {
-            return resolveVal(val, config.kind);
+            return resolveVal(val, parseVal);
           },
         },
         uniqueWhere: { arg: graphql.arg({ type: graphql.ID }), resolve: parseVal },

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -118,11 +118,14 @@ export const idFieldType =
     return fieldType({
       kind: 'scalar',
       mode: 'required',
-      scalar: config.kind === 'autoincrement'
-      // SQLite doesn't support autoincrement feature for BigInt fields, solution is using Int field
-      // because it is 64 bit integer always in SQLite, more info here https://github.com/linq2db/linq2db/issues/930
-      ? config.useBigInt && meta.provider !== 'sqlite' ? 'BigInt' : 'Int'
-        : 'String',
+      scalar:
+        config.kind === 'autoincrement'
+          ? // SQLite doesn't support autoincrement feature for BigInt fields, solution is using Int field
+            // because it is 64 bit integer always in SQLite, more info here https://github.com/linq2db/linq2db/issues/930
+            config.useBigInt && meta.provider !== 'sqlite'
+            ? 'BigInt'
+            : 'Int'
+          : 'String',
       nativeType: meta.provider === 'postgresql' && config.kind === 'uuid' ? 'Uuid' : undefined,
       default: { kind: config.kind },
     })({

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -28,6 +28,16 @@ const idParsers = {
     }
     throw userInputError('Only an integer can be passed to id filters');
   },
+  autoincrementBigInt(val: string | null) {
+    if (val === null) {
+      throw userInputError('Only BigInt integer can be passed to id filters');
+    }
+    const parsed = BigInt(val);
+    if (typeof parsed === 'bigint') {
+      return parsed;
+    }
+    throw userInputError('Only BigInt integer can be passed to id filters');
+  },
   cuid(val: string | null) {
     // isCuid is just "it's a string and it starts with c"
     // https://github.com/ericelliott/cuid/blob/215b27bdb78d3400d4225a4eeecb3b71891a5f6f/index.js#L69-L73
@@ -108,7 +118,9 @@ export const idFieldType =
     return fieldType({
       kind: 'scalar',
       mode: 'required',
-      scalar: config.kind === 'autoincrement' ? 'Int' : 'String',
+      scalar: config.kind === 'autoincrement'
+        ? config.useBigInt ? 'BigInt' : 'Int'
+        : 'String',
       nativeType: meta.provider === 'postgresql' && config.kind === 'uuid' ? 'Uuid' : undefined,
       default: { kind: config.kind },
     })({

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -32,11 +32,11 @@ const idParsers = {
     if (val === null) {
       throw userInputError('Only a bigint can be passed to id filters');
     }
-    const parsed = BigInt(val);
-    if (typeof parsed === 'bigint') {
-      return parsed;
+    try {
+      return BigInt(val);
+    } catch (err) {
+      throw userInputError('Only a bigint can be passed to id filters');
     }
-    throw userInputError('Only a bigint can be passed to id filters');
   },
   cuid(val: string | null) {
     // isCuid is just "it's a string and it starts with c"

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -119,7 +119,9 @@ export const idFieldType =
       kind: 'scalar',
       mode: 'required',
       scalar: config.kind === 'autoincrement'
-        ? config.useBigInt ? 'BigInt' : 'Int'
+      // SQLite doesn't support autoincrement feature for BigInt fields, solution is using Int field
+      // because it is 64 bit integer always in SQLite, more info here https://github.com/linq2db/linq2db/issues/930
+      ? config.useBigInt && meta.provider !== 'sqlite' ? 'BigInt' : 'Int'
         : 'String',
       nativeType: meta.provider === 'postgresql' && config.kind === 'uuid' ? 'Uuid' : undefined,
       default: { kind: config.kind },

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -10,6 +10,7 @@ export type ListSchemaConfig = Record<string, ListConfig<any, BaseFields<BaseLis
 
 export type IdFieldConfig = {
   kind: 'cuid' | 'uuid' | 'autoincrement';
+  useBigInt?: boolean;
 };
 
 export type ListConfig<

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -9,12 +9,14 @@ import type { BaseFields, FilterOrderArgs } from './fields';
 export type ListSchemaConfig = Record<string, ListConfig<any, BaseFields<BaseListTypeInfo>>>;
 
 export type IdFieldConfig =
-  | {
-      kind: 'cuid' | 'uuid';
-    }
+  | { kind: 'cuid' | 'uuid' }
   | {
       kind: 'autoincrement';
-      useBigInt?: boolean;
+      /**
+       * Configures the database type of the id field. Only `Int` is supported on SQLite.
+       * @default 'Int'
+       */
+      type?: 'Int' | 'BigInt';
     };
 
 export type ListConfig<

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -8,10 +8,14 @@ import type { BaseFields, FilterOrderArgs } from './fields';
 
 export type ListSchemaConfig = Record<string, ListConfig<any, BaseFields<BaseListTypeInfo>>>;
 
-export type IdFieldConfig = {
-  kind: 'cuid' | 'uuid' | 'autoincrement';
-  useBigInt?: boolean;
-};
+export type IdFieldConfig =
+  | {
+      kind: 'cuid' | 'uuid';
+    }
+  | {
+      kind: 'autoincrement';
+      useBigInt?: boolean;
+    };
 
 export type ListConfig<
   ListTypeInfo extends BaseListTypeInfo,

--- a/tests/api-tests/id-field.test.ts
+++ b/tests/api-tests/id-field.test.ts
@@ -3,16 +3,23 @@ import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import { isCuid } from 'cuid';
 import { validate } from 'uuid';
-import { apiTestConfig, expectBadUserInput } from './utils';
+import { apiTestConfig, dbProvider, expectBadUserInput } from './utils';
 
 export function assertNever(arg: never) {
   throw new Error('expected to never be called but received: ' + JSON.stringify(arg));
 }
 
-describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
+describe.each([
+  'autoincrement',
+  'cuid',
+  'uuid',
+  ...(dbProvider === 'sqlite' ? [] : (['bigint'] as const)),
+] as const)('%s', kind => {
   const runner = setupTestRunner({
     config: apiTestConfig({
-      db: { idField: { kind } },
+      db: {
+        idField: kind === 'bigint' ? { kind: 'autoincrement', type: 'BigInt' } : { kind },
+      },
       lists: {
         User: list({ fields: { name: text() } }),
       },
@@ -103,20 +110,48 @@ describe.each(['autoincrement', 'cuid', 'uuid'] as const)('%s', kind => {
     })
   );
   test(
+    'Querying with findOne',
+    runner(async ({ context }) => {
+      const { id } = await context.query.User.createOne({ data: { name: 'something' } });
+      await context.query.User.createOne({ data: { name: 'another' } });
+      const item = await context.query.User.findOne({ where: { id } });
+      expect(item.id).toBe(id);
+    })
+  );
+  test(
+    'Querying with findMany',
+    runner(async ({ context }) => {
+      const { id } = await context.query.User.createOne({ data: { name: 'something' } });
+      await context.query.User.createOne({ data: { name: 'another' } });
+      const items = await context.query.User.findMany({ where: { id: { equals: id } } });
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe(id);
+    })
+  );
+  test(
     'Creating an item',
     runner(async ({ context }) => {
       const { id } = await context.query.User.createOne({ data: { name: 'something' } });
+      const dbItem = await context.db.User.findOne({ where: { id } });
       switch (kind) {
         case 'autoincrement': {
-          expect(id).toEqual('1');
+          expect(id).toBe('1');
+          expect(dbItem.id).toBe(1);
           return;
         }
         case 'cuid': {
           expect(isCuid(id)).toBe(true);
+          expect(dbItem.id).toBe(id);
           return;
         }
         case 'uuid': {
           expect(validate(id)).toBe(true);
+          expect(dbItem.id).toBe(id);
+          return;
+        }
+        case 'bigint': {
+          expect(id).toEqual('1');
+          expect(dbItem.id).toBe(1n);
           return;
         }
         default: {


### PR DESCRIPTION
Now for `autoincrement` idField only Integer field type is used, which sometimes is not enough.

In this PR I've implemented an option "useBigInt" in `idField` configuration, that switches to use BigInt as idField in database. Here is an example how to enable this feature:
```js
    db: {
      idField: {
        kind: 'autoincrement',
        useBigInt: true,
      }
    }
```

Related discussion: https://github.com/keystonejs/keystone/discussions/6969