### PR TITLE
fix invalid field value in component block docs

### DIFF
--- a/.changeset/good-mirrors-enjoy.md
+++ b/.changeset/good-mirrors-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/website': patch
+---
+
+Fix invalid field value for Selection in docs for Component Block Relationship Fields

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -583,7 +583,7 @@ export default config({
             featuredAuthors: {
               kind: 'prop',
               listKey: 'Author',
-              selection: 'posts { id title }',
+              selection: 'id title',
               many: true,
             },
           },


### PR DESCRIPTION
Made my query in the same format and ended up with 400 errors when the app attempted to fetch the list for the select box. 

Found some similar code a little bit further up the same page and everything is now dandy: https://keystonejs.com/docs/guides/document-fields#inline-relationships

First day using keystone so I have no idea what I'm doing