### PR TITLE
Add select and include to findOne and findMany

### DIFF
--- a/.changeset/afraid-timers-divide.md
+++ b/.changeset/afraid-timers-divide.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add select and include options to findOne and findMany DB API calls

--- a/packages/keystone/src/types/context.ts
+++ b/packages/keystone/src/types/context.ts
@@ -4,6 +4,7 @@ import { GraphQLSchema, ExecutionResult, DocumentNode } from 'graphql';
 import { InitialisedList } from '../lib/core/types-for-lists';
 import { BaseListTypeInfo } from './type-info';
 import { GqlNames, BaseKeystoneTypeInfo } from '.';
+import { Prisma } from '@prisma/client';
 
 export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneTypeInfo> = {
   req?: IncomingMessage;
@@ -104,9 +105,13 @@ export type KeystoneDbAPI<KeystoneListsTypeInfo extends Record<string, BaseListT
       readonly orderBy?:
         | KeystoneListsTypeInfo[Key]['inputs']['orderBy']
         | readonly KeystoneListsTypeInfo[Key]['inputs']['orderBy'][];
+      readonly select?: Prisma.UserSelect;
+      readonly include?: Prisma.UserInclude;
     }): Promise<readonly KeystoneListsTypeInfo[Key]['item'][]>;
     findOne(args: {
       readonly where: KeystoneListsTypeInfo[Key]['inputs']['uniqueWhere'];
+      readonly select?: Prisma.UserSelect;
+      readonly include?: Prisma.UserInclude;
     }): Promise<KeystoneListsTypeInfo[Key]['item']>;
     count(args?: {
       readonly where?: KeystoneListsTypeInfo[Key]['inputs']['where'];

--- a/packages/keystone/src/types/next-fields.ts
+++ b/packages/keystone/src/types/next-fields.ts
@@ -4,6 +4,7 @@ import { BaseListTypeInfo } from './type-info';
 import { CommonFieldConfig } from './config';
 import { DatabaseProvider } from './core';
 import { AdminMetaRootVal, JSONValue, KeystoneContext, MaybePromise } from '.';
+import { Prisma } from '@prisma/client';
 
 export { Decimal };
 
@@ -446,6 +447,8 @@ export type FindManyArgs = {
   >;
   take: graphql.Arg<typeof graphql.Int>;
   skip: graphql.Arg<graphql.NonNullType<typeof graphql.Int>, true>;
+  select: Prisma.UserSelect;
+  include: Prisma.UserInclude;
 };
 
 export type FindManyArgsValue = graphql.InferValueFromArgs<FindManyArgs>;


### PR DESCRIPTION
Now `findOne` and `findMany` functions in DB API misses ability to select specific fields only, and include relationship fields too.

It is my try to add this missing functionality.

Prisma allows query specific fields, here is the documentation https://www.prisma.io/docs/concepts/components/prisma-client/select-fields#select-specific-fields

So seems we simply can pass those variables from Keystone API to Prisma API.

Here is usage example of this feature directly in Prisma, based on `examples/blog`:
```js
    async onConnect(context) {
      const result = await context.prisma.author.findMany({
        take: 2,
        select: {
          name: true,
          posts: {
            select: {
              id: true,
            },
          },
        },
      });
      console.log(result[0]);
```

And here is desired behavior in Keystone DB API:
```js
      const result = await context.db.Author.findMany({
        take: 2,
        select: {
          name: true,
          posts: {
            select: {
              id: true,
            },
          },
        },
      });
      const result2 = await context.db.Author.findMany({
        take: 2,
        include: {
          posts: true,
        },
      });
```

Resolves https://github.com/keystonejs/keystone/issues/7198