### PR TITLE
Add .vscode to .prettierignore

### DIFF
--- a/.changeset/five-kings-wonder.md
+++ b/.changeset/five-kings-wonder.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/core': patch
+---
+
+Add .vscode to .prettierignore to prevent `yarn lint` errors on `.vscode/launch.json` file, which is in "JSON with Comments" format.

--- a/.changeset/five-kings-wonder.md
+++ b/.changeset/five-kings-wonder.md
@@ -1,5 +1,0 @@
----
-'@keystone-ui/core': patch
----
-
-Add .vscode to .prettierignore to prevent `yarn lint` errors on `.vscode/launch.json` file, which is in "JSON with Comments" format.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ docs/public/assets/
 prisma-utils/src/generated
 nexus-typegen.ts
 tests/test-projects/live-reloading/schemas/syntax-error.js
+.vscode

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,4 @@ docs/public/assets/
 prisma-utils/src/generated
 nexus-typegen.ts
 tests/test-projects/live-reloading/schemas/syntax-error.js
-.vscode
+*.vscode


### PR DESCRIPTION
To prevent `yarn lint` errors on `.vscode/launch.json` file, which is in "JSON with Comments" format, like this:
```
$ yarn lint
yarn run v1.22.10
$ yarn lint:prettier && yarn lint:eslint && yarn lint:markdown && yarn lint:types && yarn lint:filters
$ prettier --list-different "**/*.{js,json,ts,tsx}"
.vscode/launch.json
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

We already have `.vscode` in `.gitignore`, so excliding it from prettier
is a good step too.