### PR TITLE
Fix cards view in the relationship field not showing up for many relationships in the create view

### DIFF
--- a/.changeset/lazy-otters-build.md
+++ b/.changeset/lazy-otters-build.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed cards view in the relationship field not showing up for many relationships in the create view

--- a/packages/keystone/src/fields/types/relationship/views/cards/useItemState.tsx
+++ b/packages/keystone/src/fields/types/relationship/views/cards/useItemState.tsx
@@ -118,6 +118,9 @@ export function useItemState({
       [setItemsState]
     ),
     state: ((): ItemsState => {
+      if (id === null) {
+        return { kind: 'loaded' };
+      }
       if (loading) {
         return { kind: 'loading' };
       }


### PR DESCRIPTION
We ofc can't fetch the item while we're creating it so we can just treat it as always "loaded"