### PR TITLE
associative solve for #7190

### DIFF
--- a/.changeset/smart-cobras-boil.md
+++ b/.changeset/smart-cobras-boil.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Improved how stacking contexts are organised in the Admin UI

--- a/packages/keystone/src/admin-ui/components/PageContainer.tsx
+++ b/packages/keystone/src/admin-ui/components/PageContainer.tsx
@@ -28,6 +28,7 @@ const PageWrapper = (props: HTMLAttributes<HTMLElement>) => {
           gridTemplateColumns: `minmax(300px, 1fr) 4fr`,
           gridTemplateRows: `${HEADER_HEIGHT}px auto`,
           height: '100vh',
+          isolation: 'isolate',
         }}
         {...props}
       />


### PR DESCRIPTION
While this solves #7190, this is also a solution to the more generalised problem of portal'd elements interacting in unexpected ways with elements that have explicit z-index declarations. 
 
At the moment we have one [stacking context](https://developer.mozilla.org/en-US/docs/Glossary/Stacking_context) globally. Both portal'd elements and elements with explicit z-index declarations interact in this global stacking context. #7190 is an example of this resulting in incorrect / buggy  stacking behaviour. 

This PR explicitly sets a new stacking context for the `<PageWrapper/>` component, leveraging the `isolation: isolate` [property.](https://developer.mozilla.org/en-US/docs/Web/CSS/isolation). This has a [browser support profile](https://caniuse.com/?search=isolation) that is compatible with Keystone's, and reduces the need for us to have to play z-index jenga (at least for portal'd elements). 

@mitchellhamilton let me know if there are any gotchas here that would make this generalised solution undesirable. Initial cursory QA, and observation of the stacking context inspector in chrome **seem** promising 