### PR TITLE
Adding an intro to the GraphQL API docs

### DIFF
--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -11,16 +11,13 @@ Keystone generates a CRUD (create, read, update, delete) GraphQL API based on th
 
 ## Using The API
 
-By default the GraphQL endpoint is served at `/api/graphql`, though this can be overridden by setting `config.graphql.path` in the [system config](https://keystonejs.com/docs/apis/config#graphql).
+By default Keystone serves your GraphQL endpoint at `/api/graphql`.
+Keystone also includes [GraphQL Playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE, giving you a great way to explore the API Keystone creates for your app.
 
-Keystone also includes [GraphQL Playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE, that gives you a great way to explore the API Keystone creates for your app.
-By default the interface is disabled when running Keystone in production.
-You can control this behaviour using the `config.graphql.playground` option in the [system config](https://keystonejs.com/docs/apis/config#graphql).
+When using Keystone's default settings in dev, both the GraphQL Playground and the GraphQL API itself will be available at [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
+This will likely be the case if you're running one of the example projects or developing your own Keystone app locally.
 
-So when using Keystone's default settings in dev, both the GraphQL Playground and the GraphQL API itself will be available at [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
-This will be the case if you're running one of the example projects or using Keystone in your own app.
-
-The URL of the GraphQL API is a important value will likely be set as an environment variable for related apps.
+The URL of the GraphQL API is an important value and will likely be set as an environment variable for related apps.
 For example, when building a frontend app with Apollo Client, you'll need the GraphQL URL when [initializing the client instance](https://www.apollographql.com/docs/react/get-started/#2-initialize-apolloclient).
 Your code may look like this:
 
@@ -30,6 +27,11 @@ const client = new ApolloClient({
   cache: new InMemoryCache()
 });
 ```
+
+If you don't like the default path you can control where the GraphQL API and playground are published by setting `config.graphql.path` in the [system config](https://keystonejs.com/docs/apis/config#graphql).
+Note that for security, both the playground and [introspection](https://graphql.org/learn/introspection/) are disabled when running Keystone in production.
+You can control this behaviour using the `config.graphql.playground` and `config.graphql.apolloConfig` options.
+For example, to disable these features in dev environments, add this to your Keystone config: `graphql: { playground: false, apolloConfig: { introspection: false } }`.
 
 ## Example
 

--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -9,6 +9,30 @@ import { InlineCode } from '../../../components/primitives/Code';
 
 Keystone generates a CRUD (create, read, update, delete) GraphQL API based on the [schema](./schema) definition provided in the system [config](./config).
 
+## Using The API
+
+By default the GraphQL endpoint is served at `/api/graphql`, though this can be overridden by setting `config.graphql.path` in the [system config](https://keystonejs.com/docs/apis/config#graphql).
+
+Keystone also includes [GraphQL Playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE, that gives you a great way to explore the API Keystone creates for your app.
+By default the interface is disabled when running Keystone in production.
+You can control this behaviour using the `config.graphql.playground` option in the [system config](https://keystonejs.com/docs/apis/config#graphql).
+
+So when using Keystone's default settings in dev, both the GraphQL Playground and the GraphQL API itself will be available at [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
+This will be the case if you're running one of the example projects or using Keystone in your own app.
+
+The URL of the GraphQL API is a important value will likely be set as an environment variable for related apps.
+For example, when building a frontend app with Apollo Client, you'll need the GraphQL URL when [initializing the client instance](https://www.apollographql.com/docs/react/get-started/#2-initialize-apolloclient).
+Your code may look like this:
+
+```js
+const client = new ApolloClient({
+  uri: process.env.APOLLO_CLIENT_GRAPHQL_URI || 'http://localhost:3000/api/graphql',
+  cache: new InMemoryCache()
+});
+```
+
+## Example
+
 Consider the following system definition:
 
 ```typescript
@@ -134,9 +158,9 @@ input UserCreateInput {
 }
 ```
 
-## Queries
+### Queries
 
-### user
+#### `user`
 
 ```graphql
 type Query {
@@ -153,7 +177,7 @@ input UserWhereUniqueInput {
 }
 ```
 
-### users
+#### `users`
 
 ```graphql
 type Query {
@@ -234,7 +258,7 @@ enum OrderDirection {
 }
 ```
 
-### usersCount
+#### `usersCount`
 
 ```graphql
 type Query {
@@ -295,9 +319,9 @@ input NestedStringNullableFilter {
 }
 ```
 
-## Mutations
+### Mutations
 
-### createUser
+#### `createUser`
 
 ```graphql
 type Mutation {
@@ -314,7 +338,7 @@ type User {
 }
 ```
 
-### createUsers
+#### `createUsers`
 
 ```graphql
 type Mutation {
@@ -331,7 +355,7 @@ type User {
 }
 ```
 
-### updateUser
+#### `updateUser`
 
 ```graphql
 type Mutation {
@@ -352,7 +376,7 @@ type User {
 }
 ```
 
-### updateUsers
+#### `updateUsers`
 
 ```graphql
 type Mutation {
@@ -378,7 +402,7 @@ type User {
 }
 ```
 
-### deleteUser
+#### `deleteUser`
 
 ```graphql
 type Mutation {
@@ -395,7 +419,7 @@ type User {
 }
 ```
 
-### deleteUsers
+#### `deleteUsers`
 
 ```graphql
 type Mutation {


### PR DESCRIPTION
Adding an intro to the GraphQL API docs with basic info and context, like where to find the endpoint and what to do with it.

Not 100% sure this is the right place for this content (possibly should be part of a more general getting started-type guide?) but I feel that giving beginner devs some basic context here is helpful. Not everyone has used GraphQL before and our docs should probably do a better job of orienting people within the ecosystem.