### PR TITLE
Add code illustration of authentication mutation

### DIFF
--- a/docs/pages/docs/apis/auth.mdx
+++ b/docs/pages/docs/apis/auth.mdx
@@ -110,7 +110,7 @@ The argument names for this function are the values of `identityField` and `secr
 ```graphql
 mutation {
   authenticateUserWithPassword(
-    email: "admin@domain.com",
+    email: "username@example.com",
     password: "password"
   ) {
    ... on UserAuthenticationWithPasswordSuccess {

--- a/docs/pages/docs/apis/auth.mdx
+++ b/docs/pages/docs/apis/auth.mdx
@@ -107,6 +107,25 @@ type UserAuthenticationWithPasswordFailure {
 This mutation will check the supplied credentials and start a new [session](./session) if the credentials are valid.
 The argument names for this function are the values of `identityField` and `secretField`.
 
+```graphql
+mutation {
+  authenticateUserWithPassword(
+    email: "admin@domain.com",
+    password: "password"
+  ) {
+   ... on UserAuthenticationWithPasswordSuccess {
+    item {
+      id
+      email
+    }
+  }
+    ... on UserAuthenticationWithPasswordFailure {
+      message
+    }
+  }
+}
+```
+
 On success the session handler will start a new session and return the encoded session cookie data as `sessionToken`.
 The authenticated item will be returned as `item`.
 


### PR DESCRIPTION
As a newbie to GraphQL and experienced REST dev, i was challenged to put the auth documentation together into working request because I didn't understand 'union' types. 

Aside: the website is awesome at documenting the internal APIs, but I think there's a blindspot in client-side architecture and integration as acknowledged here: https://stackoverflow.com/questions/70220020/keystonejs-login-via-graphql-mutation#comment124149182_70220475 I'm happy to help document this subject as I part of my own journey into understanding the framework.

Thanks to @Nathan Wood on #keystone-6 for this snippet: https://keystonejs.slack.com/archives/C01STDMEW3S/p1643384145390369?thread_ts=1643352053.372569&cid=C01STDMEW3S