### PR TITLE
Fix/responsive popover

### DIFF
--- a/.changeset/chilled-coins-punch.md
+++ b/.changeset/chilled-coins-punch.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-ui/popover': minor
+'@keystone-ui/popover': patch
 ---
 
 Clicking the meatballs menu again will close the Popover dialog

--- a/.changeset/chilled-coins-punch.md
+++ b/.changeset/chilled-coins-punch.md
@@ -2,6 +2,7 @@
 '@keystone-ui/popover': patch
 ---
 
-Clicking the meatballs menu again will close the Popover dialog
-This is necessary because the Admin UI has limited usability on mobile phones, and when this dialog is open, it is hard to close back
-This adds the option of closing it by clicking the menu button again, which is more natural
+Fixed Popover component to toggle open and closed on click of the trigger, previously trigger click would only open the dialog.
+
+This is necessary because the Admin UI has limited usability on mobile phones, and when certain dialogs open, it is difficult to close by clicking outside.
+This adds the option of closing it by clicking the menu button again.

--- a/.changeset/chilled-coins-punch.md
+++ b/.changeset/chilled-coins-punch.md
@@ -1,0 +1,7 @@
+---
+'@keystone-ui/popover': minor
+---
+
+Clicking the meatballs menu again will close the Popover dialog
+This is necessary because the Admin UI has limited usability on mobile phones, and when this dialog is open, it is hard to close back
+This adds the option of closing it by clicking the menu button again, which is more natural

--- a/.changeset/great-rats-nail.md
+++ b/.changeset/great-rats-nail.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed popover behaviour to accomodate mobile usages.

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -164,7 +164,7 @@ export const Popover = ({ placement = 'bottom', triggerRenderer, ...props }: Pro
         triggerProps: {
           ref: trigger.ref,
           ...trigger.props,
-          onClick: () => setOpen(open => !open),
+          onClick: () => setOpen(!isOpen),
         },
       })}
       <PopoverDialog

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -202,7 +202,9 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
 
     useEffect(() => {
       if (focusTrapRef?.current) {
-        focusTrap.current = focusTrapModule.createFocusTrap(focusTrapRef.current);
+        focusTrap.current = focusTrapModule.createFocusTrap(focusTrapRef.current, {
+          allowOutsideClick: true,
+        });
       }
     }, [focusTrapRef]);
 

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -164,7 +164,7 @@ export const Popover = ({ placement = 'bottom', triggerRenderer, ...props }: Pro
         triggerProps: {
           ref: trigger.ref,
           ...trigger.props,
-          onClick: () => setOpen(true),
+          onClick: () => setOpen(open => !open),
         },
       })}
       <PopoverDialog

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterAdd.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterAdd.tsx
@@ -60,7 +60,7 @@ export function FilterAdd({
         size="small"
         {...trigger.props}
         ref={trigger.ref}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen(!isOpen)}
       >
         <Box as="span" marginRight="xsmall">
           Filter List

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterList.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/FilterList.tsx
@@ -41,7 +41,7 @@ function FilterPill({ filter, field }: { filter: Filter; field: FieldMeta }) {
         }}
         {...trigger.props}
         ref={trigger.ref}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen(!isOpen)}
         weight="light"
         tone="passive"
         onRemove={() => {

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
@@ -31,7 +31,7 @@ export function SortSelection({
         weight="link"
         css={{ padding: 4 }}
         ref={trigger.ref}
-        onClick={() => setOpen(true)}
+        onClick={() => setOpen(!isOpen)}
       >
         <span css={{ display: 'inline-flex', justifyContent: 'center', alignItems: 'center' }}>
           {sort


### PR DESCRIPTION
An addendum to #7136, added the `allowOutsideClick` config option to the invocation of `focusTrap` to allow @moselhy's fix to work. 