### PR TITLE
Move relationship config for relationships in component blocks

### DIFF
--- a/.changeset/lemon-penguins-hammer.md
+++ b/.changeset/lemon-penguins-hammer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': major
+---
+
+The config for relationships in props on component blocks in the document field has moved so that it's configured at the relationship prop rather than in the `relationships` key on the document field config. The `relationships` key in the document field config now exclusively refers to inline relationships.

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -237,7 +237,7 @@ const DocumentFeaturesContext = React.createContext<{
 
 export function DocumentFeaturesProvider({ children }: { children: ReactNode }) {
   const [formValue, setFormValue] = useState<DocumentFeaturesFormValue>(() =>
-    getInitialPropsValue(documentFeaturesProp, {})
+    getInitialPropsValue(documentFeaturesProp)
   );
   return (
     <DocumentFeaturesContext.Provider

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -172,7 +172,6 @@ export default config({
         content: document({
           relationships: {
             mention: {
-              kind: 'inline',
               listKey: 'Author',
               label: 'Mention',
               selection: 'id name',
@@ -189,9 +188,6 @@ export default config({
   },
 });
 ```
-
-We use the `kind: 'inline'` option to indicate that we want to have an inline relationship.
-The other option, `kind: 'prop'`, is used with custom component blocks, which are discussed [below](#component-blocks).
 
 When you add an inline relationship to your document field, it becomes accessible in the Admin UI behind the `+` icon.
 This menu uses the `label` specified in the relationship config.
@@ -506,7 +502,60 @@ export const componentBlocks = {
 
 There are a variety of fields you can configure.
 
-{/** TBC: ### Child Fields **/}
+#### Child Fields
+
+Child fields allow you to embed an editable region inside of a component block preview.
+
+They can either have `kind: 'inline'`, or `kind: 'block'`.
+This refers to **what elements can be inside of them**.
+`kind: 'inline'` child fields can only contain text with marks/links/inline relationships.
+`kind: 'block'` child fields contain block-level elements such as paragraph, lists, etc.
+
+They require a placeholder which is shown when there is no text inside the child field.
+The placeholder is required though it can be an empty string if it'll be clear to editors that the location of the child field is editable.
+
+By default, child fields can only contain plain text, if you'd like to enable other features of the document editor inside a child field, you can enable the features similarly to enabling them in the document field config.
+Unlike the document field config though, these options accept `'inherit'` instead of `true`, this is because if `'inherit'` is set then that feature will be enabled **if it's also enabled at the document field config level** so you can't enable features in a child field but not in the rest of the document field.
+
+In the preview, child fields appear as React nodes that should be rendered.
+Note that you **must** render child fields in the preview.
+If they are not rendered, you will receive errors.
+
+```tsx
+import { NotEditable, component, fields } from '@keystone-6/fields-document/component-blocks';
+
+component({
+  component: ({ attribution, content }) => {
+    return (
+      <div
+        style={{
+          borderLeft: '3px solid #CBD5E0',
+          paddingLeft: 16,
+        }}
+      >
+        <div style={{ fontStyle: 'italic', color: '#4A5568' }}>{content}</div>
+        <div style={{ fontWeight: 'bold', color: '#718096' }}>
+          <NotEditable>— </NotEditable>
+          {attribution}
+        </div>
+      </div>
+    );
+  },
+  label: 'Quote',
+  props: {
+    content: fields.child({
+      kind: 'block',
+      placeholder: 'Quote...',
+      formatting: { inlineMarks: 'inherit', softBreaks: 'inherit' },
+      links: 'inherit',
+    }),
+    attribution: fields.child({ kind: 'inline', placeholder: 'Attribution...' }),
+  },
+  chromeless: true,
+})
+```
+
+> Note: You have to be careful to wrap `NotEditable` around other elements in the preview but you cannot wrap it around a child field.
 
 #### Form Fields
 
@@ -568,42 +617,19 @@ fields.object({
 
 #### Relationship Fields
 
-To use relationship fields on component blocks, you need to add a relationship to the document field config.
-
-```tsx
-import { config, list } from '@keystone-6/core';
-import { document } from '@keystone-6/fields-document';
-
-export default config({
-  lists: {
-    ListName: list({
-      fields: {
-        fieldName: document({
-          relationships: {
-            featuredAuthors: {
-              kind: 'prop',
-              listKey: 'Author',
-              selection: 'id title',
-              many: true,
-            },
-          },
-          /* ... */
-        }),
-        /* ... */
-      },
-    }),
-    /* ... */
-  },
-  /* ... */
-});
-```
-
-You can reference the key of the relationship in the relationship and in the form, it will render a relationship select like the relationship field on lists.
+To use relationship fields on component blocks, you need to add a relationship field and provide a list key, label and options selection.
+In the form, it will render a relationship select like the relationship field on lists.
+Similarly to inline relationships, they will be hydrated with this selection if `hydrateRelationships: true` is provided when fetching.
 
 ```tsx
 import { fields } from '@keystone-6/fields-document/component-blocks';
 
-fields.relationship({ label: 'Authors', relationship: 'featuredAuthors' });
+fields.relationship({
+  label: 'Authors',
+  listKey: 'Author',
+  selection: 'id name posts { title }',
+  many: true,
+ });
 ```
 
 > Note: Like inline relationships, relationship fields on component blocks are not stored like relationship fields on lists, they are stored as ids in the document structure.
@@ -637,7 +663,7 @@ fields.conditional(fields.checkbox({ label: 'Show Call to action' }), {
 
 > You might find `fields.empty()` useful which stores and renders nothing if you want to have a field in one case and nothing anything in another
 
-{/** TBC: ### Preview Props **/}
+{/* * TBC: ### Preview Props * */}
 
 ### Chromeless
 

--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -624,12 +624,14 @@ Similarly to inline relationships, they will be hydrated with this selection if 
 ```tsx
 import { fields } from '@keystone-6/fields-document/component-blocks';
 
-fields.relationship({
-  label: 'Authors',
-  listKey: 'Author',
-  selection: 'id name posts { title }',
-  many: true,
- });
+...
+someField: fields.relationship({
+    label: 'Authors',
+    listKey: 'Author',
+    selection: 'id name posts { title }',
+    many: true,
+  });
+...
 ```
 
 > Note: Like inline relationships, relationship fields on component blocks are not stored like relationship fields on lists, they are stored as ids in the document structure.

--- a/examples-staging/basic/admin/fieldViews/Content.tsx
+++ b/examples-staging/basic/admin/fieldViews/Content.tsx
@@ -144,7 +144,12 @@ export const componentBlocks = {
     },
     props: {
       title: fields.child({ kind: 'inline', placeholder: 'Title...' }),
-      authors: fields.relationship<'many'>({ label: 'Authors', relationship: 'featuredAuthors' }),
+      authors: fields.relationship({
+        label: 'Authors',
+        listKey: 'User',
+        many: true,
+        selection: `posts(take: 10) { title }`,
+      }),
     },
   }),
   notice: component({

--- a/examples-staging/basic/schema.ts
+++ b/examples-staging/basic/schema.ts
@@ -153,17 +153,8 @@ export const lists: Keystone.Lists = {
         ui: { views: require.resolve('./admin/fieldViews/Content.tsx') },
         relationships: {
           mention: {
-            kind: 'inline',
             label: 'Mention',
             listKey: 'User',
-          },
-          featuredAuthors: {
-            kind: 'prop',
-            listKey: 'User',
-            many: true,
-            selection: `posts(take: 10) {
-            title
-          }`,
           },
         },
         formatting: true,

--- a/examples/document-field/schema.ts
+++ b/examples/document-field/schema.ts
@@ -29,7 +29,6 @@ export const lists = {
         // inline relationship which references the `Author` list.
         relationships: {
           mention: {
-            kind: 'inline',
             listKey: 'Author',
             label: 'Mention', // This will display in the Admin UI toolbar behind the `+` icon
             selection: 'id name', // These fields will be available to the renderer

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -91,9 +91,10 @@ export type ChildField = {
 
 export type RelationshipField<Cardinality extends 'one' | 'many'> = {
   kind: 'relationship';
-  relationship: string;
+  listKey: string;
+  selection: string | undefined;
   label: string;
-  cardinality?: Cardinality;
+  cardinality: Cardinality;
 };
 
 export interface ObjectField<
@@ -387,14 +388,25 @@ export const fields = {
       values: values,
     };
   },
-  relationship<Cardinality extends 'one' | 'many'>({
-    relationship,
+  relationship<Many extends boolean | undefined = false>({
+    listKey,
+    selection,
     label,
+    many,
   }: {
-    relationship: string;
+    listKey: string;
     label: string;
-  }): RelationshipField<Cardinality> {
-    return { kind: 'relationship', relationship, label };
+    selection?: string;
+  } & (Many extends undefined | false ? { many?: Many } : { many: Many })): RelationshipField<
+    Many extends true ? 'many' : 'one'
+  > {
+    return {
+      kind: 'relationship',
+      listKey,
+      selection,
+      label,
+      cardinality: (many ? 'many' : 'one') as any,
+    };
   },
 };
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -89,12 +89,12 @@ export type ChildField = {
       };
 };
 
-export type RelationshipField<Cardinality extends 'one' | 'many'> = {
+export type RelationshipField<Many extends boolean> = {
   kind: 'relationship';
   listKey: string;
   selection: string | undefined;
   label: string;
-  cardinality: Cardinality;
+  many: Many;
 };
 
 export interface ObjectField<
@@ -123,7 +123,7 @@ export type ComponentPropField =
   | FormField<any, any>
   | ObjectField
   | ConditionalField<any, any, any>
-  | RelationshipField<'one' | 'many'>;
+  | RelationshipField<boolean>;
 
 export const fields = {
   text({
@@ -398,14 +398,14 @@ export const fields = {
     label: string;
     selection?: string;
   } & (Many extends undefined | false ? { many?: Many } : { many: Many })): RelationshipField<
-    Many extends true ? 'many' : 'one'
+    Many extends true ? true : false
   > {
     return {
       kind: 'relationship',
       listKey,
       selection,
       label,
-      cardinality: (many ? 'many' : 'one') as any,
+      many: (many ? true : false) as any,
     };
   },
 };
@@ -462,17 +462,16 @@ export type ExtractPropFromComponentPropFieldForPreview<Prop extends ComponentPr
             : never;
         };
       }[DiscriminantToString<Discriminant>]
-    : Prop extends RelationshipField<infer Cardinality>
+    : Prop extends RelationshipField<true>
     ? {
-        one: {
-          readonly value: HydratedRelationshipData | null;
-          onChange(relationshipData: HydratedRelationshipData | null): void;
-        };
-        many: {
-          readonly value: readonly HydratedRelationshipData[];
-          onChange(relationshipData: readonly HydratedRelationshipData[]): void;
-        };
-      }[Cardinality]
+        readonly value: readonly HydratedRelationshipData[];
+        onChange(relationshipData: readonly HydratedRelationshipData[]): void;
+      }
+    : Prop extends RelationshipField<false>
+    ? {
+        readonly value: HydratedRelationshipData | null;
+        onChange(relationshipData: HydratedRelationshipData | null): void;
+      }
     : never;
 
 type ExtractPropFromComponentPropFieldForToolbar<Prop extends ComponentPropField> =
@@ -499,17 +498,16 @@ type ExtractPropFromComponentPropFieldForToolbar<Prop extends ComponentPropField
             : never;
         };
       }[DiscriminantToString<Discriminant>]
-    : Prop extends RelationshipField<infer Cardinality>
+    : Prop extends RelationshipField<true>
     ? {
-        one: {
-          readonly value: HydratedRelationshipData | null;
-          onChange(relationshipData: HydratedRelationshipData | null): void;
-        };
-        many: {
-          readonly value: readonly HydratedRelationshipData[];
-          onChange(relationshipData: readonly HydratedRelationshipData[]): void;
-        };
-      }[Cardinality]
+        readonly value: readonly HydratedRelationshipData[];
+        onChange(relationshipData: readonly HydratedRelationshipData[]): void;
+      }
+    : Prop extends RelationshipField<false>
+    ? {
+        readonly value: HydratedRelationshipData | null;
+        onChange(relationshipData: HydratedRelationshipData | null): void;
+      }
     : never;
 
 export type HydratedRelationshipData = {
@@ -597,11 +595,10 @@ type ExtractPropFromComponentPropFieldForRendering<Prop extends ComponentPropFie
             : never;
         };
       }[DiscriminantToString<Discriminant>]
-    : Prop extends RelationshipField<infer Cardinality>
-    ? {
-        one: HydratedRelationshipData | null;
-        many: readonly HydratedRelationshipData[];
-      }[Cardinality]
+    : Prop extends RelationshipField<true>
+    ? readonly HydratedRelationshipData[]
+    : Prop extends RelationshipField<false>
+    ? HydratedRelationshipData | null
     : never;
 
 type ExtractPropsForPropsForRendering<Props extends Record<string, ComponentPropField>> = {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
@@ -264,7 +264,6 @@ function makeEditorWithChildField(
       },
       relationships: {
         mention: {
-          kind: 'inline',
           label: 'Mention',
           listKey: 'User',
           selection: null,

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form.tsx
@@ -19,7 +19,7 @@ function RelationshipFormInput({
   stringifiedPropPathToAutoFocus,
 }: {
   path: (string | number)[];
-  prop: RelationshipField<'many' | 'one'>;
+  prop: RelationshipField<boolean>;
   value: any;
   onChange(value: any): void;
   stringifiedPropPathToAutoFocus: string;
@@ -37,7 +37,7 @@ function RelationshipFormInput({
         extraSelection={prop.selection || ''}
         portalMenu
         state={
-          prop.cardinality === 'many'
+          prop.many
             ? {
                 kind: 'many',
                 value: (value as RelationshipData[]).map(x => ({

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form.tsx
@@ -5,7 +5,6 @@ import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
 import React, { useState } from 'react';
 import { Button as KeystoneUIButton } from '@keystone-ui/button';
 import { ComponentPropField, RelationshipData, ComponentBlock } from '../../component-blocks';
-import { useDocumentFieldRelationships, Relationships } from '../relationship';
 import { assertNever, getPropsForConditionalChange } from './utils';
 import { RelationshipField } from './api';
 
@@ -20,17 +19,12 @@ function RelationshipFormInput({
   stringifiedPropPathToAutoFocus,
 }: {
   path: (string | number)[];
-  prop: RelationshipField<any>;
+  prop: RelationshipField<'many' | 'one'>;
   value: any;
   onChange(value: any): void;
   stringifiedPropPathToAutoFocus: string;
 }) {
-  const relationships = useDocumentFieldRelationships();
   const keystone = useKeystone();
-  const relationship = relationships[prop.relationship] as Extract<
-    Relationships[string],
-    { kind: 'prop' }
-  >;
   const stringifiedPath = JSON.stringify(path);
   return (
     <FieldContainer>
@@ -39,11 +33,11 @@ function RelationshipFormInput({
         autoFocus={stringifiedPath === stringifiedPropPathToAutoFocus}
         controlShouldRenderValue
         isDisabled={false}
-        list={keystone.adminMeta.lists[relationship.listKey]}
-        extraSelection={relationship.selection || ''}
+        list={keystone.adminMeta.lists[prop.listKey]}
+        extraSelection={prop.selection || ''}
         portalMenu
         state={
-          relationship.many
+          prop.cardinality === 'many'
             ? {
                 kind: 'many',
                 value: (value as RelationshipData[]).map(x => ({
@@ -84,7 +78,6 @@ export function FormValueContent({
   stringifiedPropPathToAutoFocus: string;
   forceValidation: boolean;
 }) {
-  const relationships = useDocumentFieldRelationships();
   if (prop.kind === 'child') return null;
   if (prop.kind === 'object') {
     return (
@@ -113,12 +106,7 @@ export function FormValueContent({
           value={value.discriminant}
           onChange={discriminant => {
             onChange(
-              getPropsForConditionalChange(
-                { discriminant, value: value.value },
-                value,
-                prop,
-                relationships
-              )
+              getPropsForConditionalChange({ discriminant, value: value.value }, value, prop)
             );
           }}
           forceValidation={forceValidation && !prop.discriminant.validate(value)}

--- a/packages/fields-document/src/DocumentEditor/component-blocks/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/index.tsx
@@ -13,7 +13,6 @@ import { NotEditable } from '../../component-blocks';
 
 import { InlineDialog, ToolbarButton, ToolbarGroup, ToolbarSeparator } from '../primitives';
 import { ComponentPropField, ComponentBlock } from '../../component-blocks';
-import { Relationships, useDocumentFieldRelationships } from '../relationship';
 import {
   insertNodesButReplaceIfSelectionIsAtEmptyParagraphOrHeading,
   useElementWithSetNodes,
@@ -60,10 +59,9 @@ export function ComponentInlineProp(props: RenderElementProps) {
 export function insertComponentBlock(
   editor: Editor,
   componentBlocks: Record<string, ComponentBlock>,
-  componentBlock: string,
-  relationships: Relationships
+  componentBlock: string
 ) {
-  let node = getInitialValue(componentBlock, componentBlocks[componentBlock], relationships);
+  let node = getInitialValue(componentBlock, componentBlocks[componentBlock]);
   insertNodesButReplaceIfSelectionIsAtEmptyParagraphOrHeading(editor, node);
   const componentBlockEntry = Editor.above(editor, {
     match: node => node.type === 'component-block',
@@ -77,7 +75,6 @@ export function insertComponentBlock(
 export const BlockComponentsButtons = ({ onClose }: { onClose: () => void }) => {
   const editor = useStaticEditor();
   const blockComponents = useContext(ComponentBlockContext)!;
-  const relationships = useDocumentFieldRelationships();
   return (
     <Fragment>
       {Object.keys(blockComponents).map(key => (
@@ -85,7 +82,7 @@ export const BlockComponentsButtons = ({ onClose }: { onClose: () => void }) => 
           key={key}
           onMouseDown={event => {
             event.preventDefault();
-            insertComponentBlock(editor, blockComponents, key, relationships);
+            insertComponentBlock(editor, blockComponents, key);
             onClose();
           }}
         >
@@ -117,7 +114,6 @@ export const ComponentBlocksElement = ({
         )
       : true;
   }, [componentBlock, currentElement.props]);
-  const documentFieldRelationships = useDocumentFieldRelationships();
   if (!componentBlock) {
     return (
       <div css={{ border: 'red 4px solid', padding: spacing.medium }}>
@@ -201,13 +197,7 @@ Content:`}
         )}
         {!editMode &&
           (() => {
-            const toolbarProps = createPreviewProps(
-              currentElement,
-              componentBlock,
-              {},
-              documentFieldRelationships,
-              setElement
-            );
+            const toolbarProps = createPreviewProps(currentElement, componentBlock, {}, setElement);
             const ChromefulToolbar = componentBlock.toolbar
               ? componentBlock.toolbar
               : DefaultToolbarWithChrome;
@@ -345,13 +335,7 @@ function ComponentBlockRender({
     }
   });
 
-  const previewProps = createPreviewProps(
-    element,
-    componentBlock,
-    childrenByPath,
-    useDocumentFieldRelationships(),
-    onElementChange
-  );
+  const previewProps = createPreviewProps(element, componentBlock, childrenByPath, onElementChange);
 
   return (
     <Fragment>

--- a/packages/fields-document/src/DocumentEditor/component-blocks/initial-values.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/initial-values.ts
@@ -26,7 +26,7 @@ export function getInitialPropsValue(prop: ComponentPropField): any {
     case 'child':
       return undefined;
     case 'relationship':
-      return prop.cardinality === 'many' ? [] : null;
+      return prop.many ? [] : null;
     case 'conditional': {
       const defaultValue = prop.discriminant.defaultValue;
       return {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/initial-values.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/initial-values.ts
@@ -1,16 +1,8 @@
 import { ComponentPropField, ComponentBlock } from '../../component-blocks';
-import { Relationships } from '../relationship';
 import { assertNever, findChildPropPaths } from './utils';
 
-export function getInitialValue(
-  type: string,
-  componentBlock: ComponentBlock,
-  relationships: Relationships
-) {
-  const props = getInitialPropsValue(
-    { kind: 'object', value: componentBlock.props },
-    relationships
-  );
+export function getInitialValue(type: string, componentBlock: ComponentBlock) {
+  const props = getInitialPropsValue({ kind: 'object', value: componentBlock.props });
   return {
     type: 'component-block' as const,
     component: type,
@@ -27,28 +19,25 @@ export function getInitialValue(
   };
 }
 
-export function getInitialPropsValue(prop: ComponentPropField, relationships: Relationships): any {
+export function getInitialPropsValue(prop: ComponentPropField): any {
   switch (prop.kind) {
     case 'form':
       return prop.defaultValue;
     case 'child':
       return undefined;
     case 'relationship':
-      return (relationships[prop.relationship] as Extract<Relationships[string], { kind: 'prop' }>)
-        .many
-        ? []
-        : null;
+      return prop.cardinality === 'many' ? [] : null;
     case 'conditional': {
       const defaultValue = prop.discriminant.defaultValue;
       return {
         discriminant: defaultValue,
-        value: getInitialPropsValue(prop.values[defaultValue], relationships),
+        value: getInitialPropsValue(prop.values[defaultValue]),
       };
     }
     case 'object': {
       let obj: Record<string, any> = {};
       Object.keys(prop.value).forEach(key => {
-        obj[key] = getInitialPropsValue(prop.value[key], relationships);
+        obj[key] = getInitialPropsValue(prop.value[key]);
       });
       return obj;
     }

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
@@ -36,7 +36,7 @@ const componentBlocks = {
         prop: fields.text({ label: 'Prop' }),
         conditional: fields.conditional(fields.checkbox({ label: 'Conditional' }), {
           true: fields.child({ kind: 'block', placeholder: '' }),
-          false: fields.relationship({ label: 'Relationship', relationship: 'relationship' }),
+          false: fields.relationship({ label: 'Relationship', listKey: 'Something' }),
         }),
       }),
     },

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
@@ -4,7 +4,6 @@
 import { Transforms, Element, Editor } from 'slate';
 import React from 'react';
 import { jsx, makeEditor } from '../tests/utils';
-import { Relationships } from '../relationship';
 import { component, fields } from '../../component-blocks';
 import { createPreviewProps } from './preview-props';
 import { ExtractPropFromComponentPropFieldForPreview } from './api';
@@ -14,7 +13,7 @@ const objectProp = fields.object({
   prop: fields.text({ label: 'Prop' }),
   block: fields.child({ kind: 'block', placeholder: '' }),
   inline: fields.child({ kind: 'inline', placeholder: '' }),
-  many: fields.relationship<'many'>({ label: 'Relationship', relationship: 'many' }),
+  many: fields.relationship({ label: 'Relationship', listKey: 'many', many: true }),
   select: fields.select({
     label: 'Select',
     defaultValue: 'a',
@@ -25,7 +24,7 @@ const objectProp = fields.object({
   }),
   conditional: fields.conditional(fields.checkbox({ label: 'Conditional' }), {
     true: fields.child({ kind: 'block', placeholder: '' }),
-    false: fields.relationship<'one'>({ label: 'Relationship', relationship: 'one' }),
+    false: fields.relationship({ label: 'Relationship', listKey: 'one' }),
   }),
   conditionalSelect: fields.conditional(
     fields.select({
@@ -66,21 +65,6 @@ const componentBlocks = {
   }),
 };
 
-const relationships: Relationships = {
-  one: {
-    kind: 'prop',
-    many: false,
-    listKey: 'User',
-    selection: null,
-  },
-  many: {
-    kind: 'prop',
-    many: true,
-    listKey: 'User',
-    selection: null,
-  },
-};
-
 test('inserting a void component block', () => {
   let editor = makeEditor(
     <editor>
@@ -92,7 +76,7 @@ test('inserting a void component block', () => {
     </editor>,
     { componentBlocks }
   );
-  insertComponentBlock(editor, componentBlocks, 'void', relationships);
+  insertComponentBlock(editor, componentBlocks, 'void');
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <component-block
@@ -127,9 +111,9 @@ test('inserting a complex component block', () => {
         </text>
       </paragraph>
     </editor>,
-    { componentBlocks, relationships }
+    { componentBlocks }
   );
-  insertComponentBlock(editor, componentBlocks, 'complex', relationships);
+  insertComponentBlock(editor, componentBlocks, 'complex');
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <component-block
@@ -203,7 +187,6 @@ const getPreviewProps = (
       '["object","inline"]': React.createElement('inline-prop'),
       '["object","conditional","value"]': React.createElement('conditional-prop'),
     },
-    relationships,
     data => {
       Transforms.setNodes(editor, data, { at: [0] });
     }
@@ -245,7 +228,7 @@ const makeEditorWithComplexComponentBlock = () =>
         <text />
       </paragraph>
     </editor>,
-    { componentBlocks, relationships }
+    { componentBlocks }
   );
 
 test('preview props api', () => {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
@@ -228,7 +228,7 @@ test('inserting a void component block', () => {
     </editor>,
     { componentBlocks }
   );
-  insertComponentBlock(editor, componentBlocks, 'basic', {});
+  insertComponentBlock(editor, componentBlocks, 'basic');
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <component-block

--- a/packages/fields-document/src/DocumentEditor/component-blocks/preview-props.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/preview-props.ts
@@ -1,7 +1,6 @@
 import { Element } from 'slate';
 import { ReactElement } from 'react';
 import { ComponentBlock } from '../../component-blocks';
-import { Relationships } from '../relationship';
 import { getPropsForConditionalChange } from './utils';
 import { ComponentPropField } from './api';
 
@@ -10,7 +9,6 @@ function _getPreviewProps(
   value: Record<string, any>,
   childrenByPath: Record<string, ReactElement>,
   path: (string | number)[],
-  relationships: Relationships,
   onFormPropsChange: (formProps: Record<string, any>) => void
 ): any {
   switch (prop.kind) {
@@ -32,7 +30,6 @@ function _getPreviewProps(
           value[key],
           childrenByPath,
           path.concat(key),
-          relationships,
           newVal => {
             onFormPropsChange({ ...value, [key]: newVal });
           }
@@ -56,8 +53,7 @@ function _getPreviewProps(
             getPropsForConditionalChange(
               { discriminant: newDiscriminant, value: value.value },
               value,
-              prop,
-              relationships
+              prop
             )
           );
         },
@@ -67,7 +63,6 @@ function _getPreviewProps(
           value.value,
           childrenByPath,
           path.concat('value'),
-          relationships,
           val => {
             onFormPropsChange({
               discriminant: value.discriminant,
@@ -84,7 +79,6 @@ export function createPreviewProps(
   element: Element & { type: 'component-block' },
   componentBlock: ComponentBlock,
   childrenByPath: Record<string, ReactElement>,
-  relationships: Relationships,
   setNode: (props: Partial<Element & { type: 'component-block' }>) => void
 ) {
   return _getPreviewProps(
@@ -92,7 +86,6 @@ export function createPreviewProps(
     element.props,
     childrenByPath,
     [],
-    relationships,
     props => {
       setNode({ props });
     }

--- a/packages/fields-document/src/DocumentEditor/component-blocks/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/utils.ts
@@ -1,7 +1,6 @@
 import { ComponentPropField, ConditionalField } from '../../component-blocks';
 import { DocumentFeatures } from '../../views';
 import { DocumentFeaturesForNormalization } from '../document-features-normalization';
-import { Relationships } from '../relationship';
 import { Mark } from '../utils';
 import { ChildField } from './api';
 import { getInitialPropsValue } from './initial-values';
@@ -58,13 +57,12 @@ export function assertNever(arg: never) {
 export function getPropsForConditionalChange(
   newValue: Record<string, any>,
   oldValue: Record<string, any>,
-  prop: ConditionalField<any, any, any>,
-  relationships: Relationships
+  prop: ConditionalField<any, any, any>
 ) {
   if (newValue.discriminant !== oldValue.discriminant) {
     return {
       discriminant: newValue.discriminant,
-      value: getInitialPropsValue(prop.values[newValue.discriminant], relationships),
+      value: getInitialPropsValue(prop.values[newValue.discriminant]),
     };
   } else {
     return newValue;

--- a/packages/fields-document/src/DocumentEditor/document-features-normalization.ts
+++ b/packages/fields-document/src/DocumentEditor/document-features-normalization.ts
@@ -66,21 +66,17 @@ export function normalizeInlineBasedOnLinksAndRelationships(
   }
   if (
     node.type === 'relationship' &&
-    (!relationshipsEnabled ||
-      relationships[node.relationship] === undefined ||
-      relationships[node.relationship].kind !== 'inline')
+    (!relationshipsEnabled || relationships[node.relationship] === undefined)
   ) {
     const data: any = node.data;
     if (data) {
       const relationship = relationships[node.relationship];
       Transforms.insertText(
         editor,
-        `${data.label || data.id || ''} (${
-          relationship?.kind === 'inline' ? relationship.label : node.relationship
-        }:${data.id || ''})`,
-        {
-          at: Editor.before(editor, path),
-        }
+        `${data.label || data.id || ''} (${relationship?.label || node.relationship}:${
+          data.id || ''
+        })`,
+        { at: Editor.before(editor, path) }
       );
     }
     Transforms.removeNodes(editor, { at: path });

--- a/packages/fields-document/src/DocumentEditor/insert-menu.tsx
+++ b/packages/fields-document/src/DocumentEditor/insert-menu.tsx
@@ -29,26 +29,21 @@ function getOptions(
   relationships: Relationships
 ): Option[] {
   const options: (Option | boolean)[] = [
-    ...Object.entries(relationships)
-      .filter(
-        (x): x is [string, Extract<Relationships[string], { kind: 'inline' }>] =>
-          x[1].kind === 'inline'
-      )
-      .map(([relationship, { label }]) => ({
-        label,
-        insert: (editor: Editor) => {
-          Transforms.insertNodes(editor, {
-            type: 'relationship',
-            relationship,
-            data: null,
-            children: [{ text: '' }],
-          });
-        },
-      })),
+    ...Object.entries(relationships).map(([relationship, { label }]) => ({
+      label,
+      insert: (editor: Editor) => {
+        Transforms.insertNodes(editor, {
+          type: 'relationship',
+          relationship,
+          data: null,
+          children: [{ text: '' }],
+        });
+      },
+    })),
     ...Object.keys(componentBlocks).map(key => ({
       label: componentBlocks[key].label,
       insert: (editor: Editor) => {
-        insertComponentBlock(editor, componentBlocks, key, relationships);
+        insertComponentBlock(editor, componentBlocks, key);
       },
     })),
     ...toolbarState.textStyles.allowedHeadingLevels

--- a/packages/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages/fields-document/src/DocumentEditor/relationship.tsx
@@ -19,16 +19,8 @@ export type Relationships = Record<
     listKey: string;
     /** GraphQL fields to select when querying the field */
     selection: string | null;
-  } & (
-    | {
-        kind: 'inline';
-        label: string;
-      }
-    | {
-        kind: 'prop';
-        many: boolean;
-      }
-  )
+    label: string;
+  }
 >;
 
 export const DocumentFieldRelationshipsContext = createContext<Relationships>({});
@@ -59,7 +51,6 @@ export function RelationshipButton({ onClose }: { onClose: () => void }) {
   return (
     <Fragment>
       {Object.entries(relationships).map(([key, relationship]) => {
-        if (relationship.kind === 'prop') return null;
         return (
           <ToolbarButton
             key={key}

--- a/packages/fields-document/src/relationship-data.tsx
+++ b/packages/fields-document/src/relationship-data.tsx
@@ -112,7 +112,7 @@ export function addRelationshipData(
               (relationship, data) =>
                 fetchData(
                   relationship.listKey,
-                  relationship.cardinality === 'many',
+                  relationship.many,
                   relationship.selection || '',
                   data
                 )
@@ -152,7 +152,7 @@ export function addRelationshipData(
 async function addRelationshipDataToComponentProps(
   prop: ComponentPropField,
   val: any,
-  fetchData: (relationship: RelationshipField<'one' | 'many'>, data: any) => Promise<any>
+  fetchData: (relationship: RelationshipField<boolean>, data: any) => Promise<any>
 ): Promise<any> {
   switch (prop.kind) {
     case 'child':

--- a/packages/fields-document/src/relationship-data.tsx
+++ b/packages/fields-document/src/relationship-data.tsx
@@ -2,7 +2,12 @@ import { GqlNames, KeystoneGraphQLAPI } from '@keystone-6/core/types';
 import { Descendant } from 'slate';
 import { GraphQLSchema, executeSync, parse } from 'graphql';
 import weakMemoize from '@emotion/weak-memoize';
-import { ComponentBlock, ComponentPropField } from './DocumentEditor/component-blocks/api';
+import {
+  ComponentBlock,
+  ComponentPropField,
+  RelationshipData,
+  RelationshipField,
+} from './DocumentEditor/component-blocks/api';
 import { assertNever } from './DocumentEditor/component-blocks/utils';
 import { Relationships } from './DocumentEditor/relationship';
 
@@ -16,19 +21,17 @@ export function addRelationshipData(
   componentBlocks: Record<string, ComponentBlock>,
   gqlNames: (listKey: string) => GqlNames
 ): Promise<Descendant[]> {
-  let fetchData = async (relationshipKey: string, data: any) => {
-    const relationship = relationships[relationshipKey];
-    if (!relationship) return data;
-    if (relationship.kind === 'prop' && relationship.many) {
+  let fetchData = async (listKey: string, many: boolean, selection: string, data: any) => {
+    if (many) {
       const ids = Array.isArray(data) ? data.filter(item => item.id != null).map(x => x.id) : [];
 
       if (ids.length) {
-        const labelField = getLabelFieldsForLists(graphQLAPI.schema)[relationship.listKey];
+        const labelField = getLabelFieldsForLists(graphQLAPI.schema)[listKey];
         let val = await graphQLAPI.run({
           query: `query($ids: [ID!]!) {items:${
-            gqlNames(relationship.listKey).listQueryName
+            gqlNames(listKey).listQueryName
           }(where: { id: { in: $ids } }) {${idFieldAlias}:id ${labelFieldAlias}:${labelField}\n${
-            relationship.selection || ''
+            selection || ''
           }}}`,
           variables: { ids },
         });
@@ -40,46 +43,64 @@ export function addRelationshipData(
           : [];
       }
       return [];
-    } else {
-      // Single related item
-      const id = data?.id;
-      if (id != null) {
-        const labelField = getLabelFieldsForLists(graphQLAPI.schema)[relationship.listKey];
-        // An exception here indicates something wrong with either the system or the
-        // configuration (e.g. a bad selection field). These will surface as system
-        // errors from the GraphQL field resolver.
-        const val = await graphQLAPI.run({
-          query: `query($id: ID!) {item:${
-            gqlNames(relationship.listKey).itemQueryName
-          }(where: {id:$id}) {${labelFieldAlias}:${labelField}\n${relationship.selection || ''}}}`,
-          variables: { id },
-        });
-        if (val.item === null) {
-          if (!process.env.TEST_ADAPTER) {
-            // If we're unable to find the item (e.g. we have a dangling reference), or access was denied
-            // then simply return { id } and leave `label` and `data` undefined.
-            const r = JSON.stringify(relationship);
-            console.error(`Unable to fetch relationship data: relationship: ${r}, id: ${id} `);
-          }
-          return { id };
+    }
+    return fetchDataForOne(listKey, selection, data);
+  };
+
+  const fetchDataForOne = async (
+    listKey: string,
+    selection: string,
+    data: any
+  ): Promise<RelationshipData | null> => {
+    // Single related item
+    const id = data?.id;
+    if (id != null) {
+      const labelField = getLabelFieldsForLists(graphQLAPI.schema)[listKey];
+      // An exception here indicates something wrong with either the system or the
+      // configuration (e.g. a bad selection field). These will surface as system
+      // errors from the GraphQL field resolver.
+      const val = await graphQLAPI.run({
+        query: `query($id: ID!) {item:${
+          gqlNames(listKey).itemQueryName
+        }(where: {id:$id}) {${labelFieldAlias}:${labelField}\n${selection}}}`,
+        variables: { id },
+      });
+      if (val.item === null) {
+        if (!process.env.TEST_ADAPTER) {
+          // If we're unable to find the item (e.g. we have a dangling reference), or access was denied
+          // then simply return { id } and leave `label` and `data` undefined.
+          console.error(
+            `Unable to fetch relationship data: listKey: ${listKey}, many: false, selection: ${selection}, id: ${id} `
+          );
         }
-        return {
-          id,
-          label: val.item[labelFieldAlias],
-          data: (() => {
-            const { [labelFieldAlias]: _ignore, ...otherData } = val.item;
-            return otherData;
-          })(),
-        };
-      } else {
-        return null;
+        return { id, data: undefined, label: undefined };
       }
+      return {
+        id,
+        label: val.item[labelFieldAlias],
+        data: (() => {
+          const { [labelFieldAlias]: _ignore, ...otherData } = val.item;
+          return otherData;
+        })(),
+      };
+    } else {
+      return null;
     }
   };
   return Promise.all(
-    nodes.map(async node => {
+    nodes.map(async (node): Promise<Descendant> => {
       if (node.type === 'relationship') {
-        return { ...node, data: await fetchData(node.relationship as string, node.data) };
+        const relationship = relationships[node.relationship];
+        if (!relationship) return node;
+
+        return {
+          ...node,
+          data: await fetchDataForOne(
+            relationship.listKey,
+            relationship.selection || '',
+            node.data
+          ),
+        };
       }
       if (node.type === 'component-block') {
         const componentBlock = componentBlocks[node.component as string];
@@ -88,7 +109,13 @@ export function addRelationshipData(
             addRelationshipDataToComponentProps(
               { kind: 'object', value: componentBlock.props },
               node.props,
-              fetchData
+              (relationship, data) =>
+                fetchData(
+                  relationship.listKey,
+                  relationship.cardinality === 'many',
+                  relationship.selection || '',
+                  data
+                )
             ),
             addRelationshipData(
               node.children,
@@ -125,7 +152,7 @@ export function addRelationshipData(
 async function addRelationshipDataToComponentProps(
   prop: ComponentPropField,
   val: any,
-  fetchData: (relationship: string, data: any) => Promise<any>
+  fetchData: (relationship: RelationshipField<'one' | 'many'>, data: any) => Promise<any>
 ): Promise<any> {
   switch (prop.kind) {
     case 'child':
@@ -133,7 +160,7 @@ async function addRelationshipDataToComponentProps(
       return val;
     }
     case 'relationship': {
-      return fetchData(prop.relationship, val);
+      return fetchData(prop, val);
     }
     case 'object': {
       return Object.fromEntries(

--- a/packages/fields-document/src/validation.test.tsx
+++ b/packages/fields-document/src/validation.test.tsx
@@ -10,14 +10,11 @@ import { PropValidationError, validateAndNormalizeDocument } from './validation'
 // because the test utils run validation
 
 const relationships: Relationships = {
-  one: { kind: 'prop', listKey: 'Post', many: false, selection: 'somethine' },
   inline: {
-    kind: 'inline',
     label: 'Inline',
     listKey: 'Post',
     selection: `something`,
   },
-  many: { kind: 'prop', listKey: 'Post', many: true, selection: 'somethine' },
 };
 
 const componentBlocks: Record<string, ComponentBlock> = {
@@ -30,22 +27,8 @@ const componentBlocks: Record<string, ComponentBlock> = {
     component: () => null,
     label: '',
     props: {
-      one: fields.relationship({ label: '', relationship: 'one' }),
-      many: fields.relationship({ label: '', relationship: 'many' }),
-    },
-  }),
-  relationshipSpecifiedInPropThatDoesNotExist: component({
-    component: () => null,
-    label: '',
-    props: {
-      prop: fields.relationship({ label: '', relationship: 'doesNotExist' }),
-    },
-  }),
-  relationshipSpecifiedInPropIsWrongKind: component({
-    component: () => null,
-    label: '',
-    props: {
-      prop: fields.relationship({ label: '', relationship: 'inline' }),
+      one: fields.relationship({ label: '', listKey: 'Post', selection: 'something' }),
+      many: fields.relationship({ label: '', listKey: 'Post', many: true, selection: 'something' }),
     },
   }),
   object: component({
@@ -347,48 +330,6 @@ test('missing relationships', () => {
       },
     ])
   ).toMatchInlineSnapshot(`PropValidationError "Invalid relationship value" ["one"]`);
-});
-
-test('relationship specified in prop does not exist', () => {
-  expect(
-    validate([
-      {
-        type: 'component-block',
-        props: {
-          prop: null,
-        },
-        component: 'relationshipSpecifiedInPropThatDoesNotExist',
-        children: [],
-      },
-      {
-        type: 'paragraph',
-        children: [{ text: '' }],
-      },
-    ])
-  ).toMatchInlineSnapshot(
-    `PropValidationError "Relationship prop specifies the relationship \\"doesNotExist\\" but it is not an allowed relationship" ["prop"]`
-  );
-});
-
-test("relationship specified in prop is not kind: 'prop'", () => {
-  expect(
-    validate([
-      {
-        type: 'component-block',
-        props: {
-          prop: null,
-        },
-        component: 'relationshipSpecifiedInPropIsWrongKind',
-        children: [],
-      },
-      {
-        type: 'paragraph',
-        children: [{ text: '' }],
-      },
-    ])
-  ).toMatchInlineSnapshot(
-    `PropValidationError "Unexpected relationship \\"inline\\" of kind \\"inline\\" where the kind should be \\"prop\\"" ["prop"]`
-  );
 });
 
 test('excess prop', () => {

--- a/packages/fields-document/src/validation.ts
+++ b/packages/fields-document/src/validation.ts
@@ -35,7 +35,7 @@ function validateComponentBlockProps(
     return undefined;
   }
   if (prop.kind === 'relationship') {
-    if (prop.cardinality === 'many') {
+    if (prop.many) {
       if (Array.isArray(value) && value.every(isRelationshipData)) {
         // yes, ts understands this completely correctly, i'm as suprised as you are
         return value.map(x => ({ id: x.id }));

--- a/packages/fields-document/src/validation.ts
+++ b/packages/fields-document/src/validation.ts
@@ -35,23 +35,7 @@ function validateComponentBlockProps(
     return undefined;
   }
   if (prop.kind === 'relationship') {
-    // these two checks will only fail because of things done by the solution developer, not an solution user
-    // TODO: move these checks
-    const relationship = relationships[prop.relationship];
-    if (!relationship) {
-      throw new PropValidationError(
-        `Relationship prop specifies the relationship "${prop.relationship}" but it is not an allowed relationship`,
-        path
-      );
-    }
-    if (relationship.kind !== 'prop') {
-      throw new PropValidationError(
-        `Unexpected relationship "${prop.relationship}" of kind "${relationship.kind}" where the kind should be "prop"`,
-        path
-      );
-    }
-
-    if (relationship.many) {
+    if (prop.cardinality === 'many') {
       if (Array.isArray(value) && value.every(isRelationshipData)) {
         // yes, ts understands this completely correctly, i'm as suprised as you are
         return value.map(x => ({ id: x.id }));


### PR DESCRIPTION
The rationale behind this to remove the current awkward config with relationships in component blocks, especially so that we don't inherit it for components outside the document editor. See the diff in the docs changes for a before -> after of configuring it.

I also ended up adding docs for child fields and early validation for checking that relationships in the document field(both inline relationships and props in component blocks) refer to lists that actually exist