### PR TITLE
Use defined type PersonData

### DIFF
--- a/docs/pages/docs/guides/auth-and-access-control.mdx
+++ b/docs/pages/docs/guides/auth-and-access-control.mdx
@@ -503,11 +503,11 @@ const isAdmin = ({ session }: { session: Session }) =>
   session?.data.isAdmin;
 
 // Validate the current user is updating themselves
-const isPerson = ({ session, item }: { session: Session, item: Person }) =>
+const isPerson = ({ session, item }: { session: Session, item: PersonData }) =>
   session?.data.id === item.id;
 
 // Validate the current user is an Admin, or updating themselves
-const isAdminOrPerson = ({ session, item }: { session: Session, item: Person }) =>
+const isAdminOrPerson = ({ session, item }: { session: Session, item: PersonData }) =>
   isAdmin({ session }) || isPerson({ session, item });
 
 const Person = list({


### PR DESCRIPTION
Current example tries to use the value `Person = list({ ... })` as a type (and fails) and the `type PersonData` is never used.