### PR TITLE
Add support for asynchronous configuration

### DIFF
--- a/packages/core/src/lib/config/normalizeConfig.ts
+++ b/packages/core/src/lib/config/normalizeConfig.ts
@@ -1,0 +1,10 @@
+import { KeystoneConfig } from '../../types';
+
+/*
+  This function normalizes an input of KeystoneConfig or Promise<KeystoneConfig>
+  and just returns Promise<KeystoneConfig>
+*/
+
+export async function normalizeConfig(config: KeystoneConfig | Promise<KeystoneConfig>) : Promise<KeystoneConfig> {
+	return config;
+}

--- a/packages/core/src/scripts/build/build.ts
+++ b/packages/core/src/scripts/build/build.ts
@@ -4,6 +4,7 @@ import { AdminFileToWrite } from '../../types';
 import { buildAdminUI, generateAdminUI } from '../../admin-ui/system';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
+import { normalizeConfig } from '../../lib/config/normalizeConfig';
 import { requireSource } from '../../lib/config/requireSource';
 import { generateNodeModulesArtifacts, validateCommittedArtifacts } from '../../artifacts';
 import { getAdminPath, getConfigPath } from '../utils';
@@ -55,7 +56,8 @@ const reexportKeystoneConfig = async (cwd: string, isDisabled?: boolean) => {
 };
 
 export async function build(cwd: string) {
-  const config = initConfig(requireSource(getConfigPath(cwd)).default);
+  const uninitializedConfig = await normalizeConfig(requireSource(getConfigPath(cwd)).default);
+  const config = initConfig(uninitializedConfig);
 
   const { graphQLSchema, adminMeta } = createSystem(config);
 

--- a/packages/core/src/scripts/postinstall.ts
+++ b/packages/core/src/scripts/postinstall.ts
@@ -6,6 +6,7 @@ import {
 } from '../artifacts';
 import { requireSource } from '../lib/config/requireSource';
 import { initConfig } from '../lib/config/initConfig';
+import { normalizeConfig } from '../lib/config/normalizeConfig';
 import { getConfigPath } from './utils';
 
 // The postinstall step serves two purposes:
@@ -40,7 +41,8 @@ import { getConfigPath } from './utils';
 //         * only generated with generateNodeAPI option
 
 export async function postinstall(cwd: string, shouldFix: boolean) {
-  const config = initConfig(requireSource(getConfigPath(cwd)).default);
+  const uninitializedConfig = await normalizeConfig(requireSource(getConfigPath(cwd)).default);
+  const config = initConfig(uninitializedConfig);
 
   const { graphQLSchema } = createSystem(config);
 

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -3,10 +3,12 @@ import { createSystem } from '../lib/createSystem';
 import { generateNodeModulesArtifacts, validateCommittedArtifacts } from '../artifacts';
 import { requireSource } from '../lib/config/requireSource';
 import { initConfig } from '../lib/config/initConfig';
+import { normalizeConfig } from '../lib/config/normalizeConfig';
 import { ExitError, getConfigPath } from './utils';
 
 export async function prisma(cwd: string, args: string[]) {
-  const config = initConfig(requireSource(getConfigPath(cwd)).default);
+  const uninitializedConfig = await normalizeConfig(requireSource(getConfigPath(cwd)).default);
+  const config = initConfig(uninitializedConfig);
 
   const { graphQLSchema } = createSystem(config);
 

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import * as fs from 'fs-extra';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
+import { normalizeConfig } from '../../lib/config/normalizeConfig';
 import { createExpressServer } from '../../lib/server/createExpressServer';
 import { createAdminUIMiddleware } from '../../lib/server/createAdminUIMiddleware';
 import { requirePrismaClient } from '../../artifacts';
@@ -19,7 +20,8 @@ export const start = async (cwd: string) => {
   }
   // webpack will make modules that import Node ESM externals(which must be loaded with dynamic import)
   // export a promise that resolves to the actual export so yeah, we need to await a require call
-  const config = initConfig((await require(apiFile)).config);
+  const uninitializedConfig = await normalizeConfig((await require(apiFile)).config);
+  const config = initConfig(uninitializedConfig);
   const { getKeystone, graphQLSchema } = createSystem(config);
 
   const prismaClient = requirePrismaClient(cwd);

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -2,4 +2,5 @@ export { createSystem } from './lib/createSystem';
 export { createExpressServer } from './lib/server/createExpressServer';
 export { createAdminUIMiddleware } from './lib/server/createAdminUIMiddleware';
 export { initConfig } from './lib/config/initConfig';
+export { normalizeConfig } from './lib/config/normalizeConfig';
 export { createApolloServerMicro } from './lib/server/createApolloServer';

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs/promises';
 import { format } from 'util';
-import { createSystem, initConfig } from '@keystone-6/core/system';
+import { createSystem, initConfig, normalizeConfig } from '@keystone-6/core/system';
 import {
   validateCommittedArtifacts,
   generateNodeModulesArtifacts,
@@ -13,7 +13,8 @@ const mode = process.env.UPDATE_SCHEMAS ? 'generate' : 'validate';
 
 async function generateArtifactsForProjectDir(projectDir: string) {
   try {
-    const config = initConfig(requireSource(path.join(projectDir, 'keystone')).default);
+    const uninitializedConfig = await normalizeConfig(requireSource(path.join(projectDir, 'keystone')).default);
+    const config = initConfig(uninitializedConfig);
     const { graphQLSchema } = createSystem(config, false);
     if (mode === 'validate') {
       await validateCommittedArtifacts(graphQLSchema, config, projectDir);


### PR DESCRIPTION
This is a **Non-breaking** feature.
This allows keystone.ts to now return either `KeystoneConfig` or `Promise<KeystoneConfig>` 
Ref https://github.com/keystonejs/keystone/issues/7274