### PR TITLE
add line numbers to code blocks on the website

### DIFF
--- a/docs/components/primitives/Code.tsx
+++ b/docs/components/primitives/Code.tsx
@@ -152,6 +152,7 @@ export function Code({ children, className }: { children: string; className?: st
                       padding: '0 1.1em',
                       borderLeft: '3px solid var(--info)',
                       marginRight: '-1.0em',
+                      paddingLeft: 'calc(1.1em - 3px)',
                     }),
                     ':before': {
                       content: `"${i + 1}"`,

--- a/docs/components/primitives/Code.tsx
+++ b/docs/components/primitives/Code.tsx
@@ -145,14 +145,20 @@ export function Code({ children, className }: { children: string; className?: st
                 <div
                   key={i}
                   {...getLineProps({ line, key: i })}
-                  css={
-                    findRange(highlightRanges, i) && {
+                  css={{
+                    ...(findRange(highlightRanges, i) && {
                       backgroundColor: 'var(--info-bg)',
                       margin: '0 -1.1em',
                       padding: '0 1.1em',
                       borderLeft: '3px solid var(--info)',
-                    }
-                  }
+                      marginRight: '-1.0em',
+                    }),
+                    ':before': {
+                      content: `"${i + 1}"`,
+                      width: 24,
+                      display: 'inline-block',
+                    },
+                  }}
                 >
                   {line.map((token, key) => {
                     // Fix for document field import

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited


### PR DESCRIPTION
As we add more code examples on the website that use truncation, line numbers become really useful.

This adds them, properly not interfering with code blocks otherwise.

Comes with a bonus fix so adding line highlights no longer causes a scrollbar to appear