### PR TITLE
fix filtering on float field

### DIFF
--- a/.changeset/gold-frogs-beam.md
+++ b/.changeset/gold-frogs-beam.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed issues with float field filtering when the field is required with default value

--- a/packages/core/src/fields/types/float/index.ts
+++ b/packages/core/src/fields/types/float/index.ts
@@ -135,7 +135,7 @@ export const float =
           isIndexed === 'unique' ? { arg: graphql.arg({ type: graphql.Float }) } : undefined,
         where: {
           arg: graphql.arg({ type: filters[meta.provider].Float[mode] }),
-          resolve: filters.resolveCommon,
+          resolve: mode === 'optional' ? filters.resolveCommon : undefined,
         },
         create: {
           arg: graphql.arg({


### PR DESCRIPTION
bug detail in Slack

`integer` field works well, seems like float had some differences but when I tested with this changes, issue does not surface.


https://keystonejs.slack.com/archives/C01STDMEW3S/p1645110789669119

---------------
I am not able to filter float with greater than, it has issues with prisma
It has something to do with how the query being generated for float. null is used in place of undefined

```
Invalid `prisma.product.findMany()` invocation:

{
    where: {
      AND: [
        {
          AND: [
            {
              AND: undefined,
            OR: undefined,
            NOT: undefined,
            basePrice: {
                gt: 10,
              mode: undefined
            }
          },
          {
              AND: undefined,
            OR: undefined,
            NOT: undefined,
            basePrice: {
                not: null
                   ~~~~
            }
          },
          {
              AND: undefined,
            OR: undefined,
            NOT: undefined,
            basePrice: {}
          }
        ],
        OR: undefined,
        NOT: undefined,
        basePrice: {}
      }
    ]
  },
  orderBy: [],
  take: 50,
  skip: 0
}

Argument not for where.AND.0.AND.1.basePrice.not must not be null. Please use undefined instead.
```

this happens when you use float({ validation: { isRequired: true }, defaultValue: 0 }) in float field config. This interestingly does not affect integer field
to reproduce just create a field in any example with `float({ validation: { isRequired: true }, defaultValue: 0 })  and try to use filters with `gt` other filters may be affected.