### PR TITLE
Adds http.Server options as configuration server.options 

### DIFF
--- a/.changeset/five-ports-open.md
+++ b/.changeset/five-ports-open.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds http.Server options as configuration `server.options`

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import type { ListenOptions } from 'net';
 import * as fs from 'fs-extra';
 import { createSystem } from '../../lib/createSystem';
 import { initConfig } from '../../lib/config/initConfig';
@@ -44,9 +45,25 @@ export const start = async (cwd: string) => {
     console.log(`✅ Admin UI ready`);
   }
 
-  const port = config.server?.port || process.env.PORT || 3000;
-  httpServer.listen(port, (err?: any) => {
+  const options: ListenOptions = {
+    port: 3000,
+  };
+
+  if (config?.server && 'port' in config.server) {
+    options.port = config.server.port;
+  }
+
+  if (config?.server && 'options' in config.server && config.server.options) {
+    Object.assign(options, config.server.options);
+  }
+
+  // preference env.PORT if supplied
+  if ('PORT' in process.env) {
+    options.port = parseInt(process.env.PORT || '');
+  }
+
+  httpServer.listen(options, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Server Ready on http://localhost:${port}`);
+    console.log(`⭐️ Server Ready on http://localhost:${options.port}`);
   });
 };

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'http';
+import type { ListenOptions } from 'net';
 import type { Config } from 'apollo-server-express';
 import { CorsOptions } from 'cors';
 import express from 'express';
@@ -169,8 +170,6 @@ type HealthCheckConfig = {
 export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   /** Configuration options for the cors middleware. Set to `true` to use core Keystone defaults */
   cors?: CorsOptions | true;
-  /** Port number to start the server on. Defaults to process.env.PORT || 3000 */
-  port?: number;
   /** Maximum upload file size allowed (in bytes) */
   maxFileSize?: number;
   /** Health check configuration. Set to `true` to add a basic `/_healthcheck` route, or specify the path and data explicitly */
@@ -181,7 +180,16 @@ export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
     createContext: CreateRequestContext<TypeInfo>
   ) => void | Promise<void>;
   extendHttpServer?: (server: Server, createContext: CreateRequestContext<TypeInfo>) => void;
-};
+} & (
+  | {
+      /** Port number to start the server on. Defaults to process.env.PORT || 3000 */
+      port?: number;
+    }
+  | {
+      /** node http.Server options */
+      options?: ListenOptions;
+    }
+);
 
 // config.graphql
 


### PR DESCRIPTION
This pull request adds the `http.Server` options as an configuration option `server.options` for your Keystone configuration.

This will enable developers to configuration things like the `host` interface, or to bind the server to an existing `fd` descriptor (like if you are using systemd's `LISTEN_FDS`).
