### PR TITLE
Fix file and image routes

### DIFF
--- a/.changeset/stale-poems-lay.md
+++ b/.changeset/stale-poems-lay.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix routes for files and images in case baseUrl exists.
+Replace hardcoded paths with default or config paths.

--- a/packages/core/src/lib/context/createFilesContext.ts
+++ b/packages/core/src/lib/context/createFilesContext.ts
@@ -9,7 +9,7 @@ import { KeystoneConfig, FilesContext } from '../../types';
 import { parseFileRef } from '../../fields/types/file/utils';
 import { CloudAssetsAPI } from '../cloud/assets';
 
-const DEFAULT_BASE_URL = '/files';
+export const DEFAULT_FILES_BASE_URL = '/files';
 export const DEFAULT_FILES_STORAGE_PATH = './public/files';
 
 const defaultTransformer = (str: string) => slugify(str);
@@ -51,7 +51,7 @@ export function createFilesContext(
   }
 
   const { files } = config;
-  const { baseUrl = DEFAULT_BASE_URL, storagePath = DEFAULT_FILES_STORAGE_PATH } =
+  const { baseUrl = DEFAULT_FILES_BASE_URL, storagePath = DEFAULT_FILES_STORAGE_PATH } =
     files.local || {};
 
   if (files.upload === 'local') {

--- a/packages/core/src/lib/context/createImagesContext.ts
+++ b/packages/core/src/lib/context/createImagesContext.ts
@@ -7,7 +7,7 @@ import { KeystoneConfig, ImageMetadata, ImagesContext } from '../../types';
 import { parseImageRef } from '../../fields/types/image/utils';
 import { CloudAssetsAPI } from '../cloud/assets';
 
-const DEFAULT_BASE_URL = '/images';
+export const DEFAULT_IMAGES_BASE_URL = '/images';
 export const DEFAULT_IMAGES_STORAGE_PATH = './public/images';
 
 const getImageMetadataFromBuffer = async (buffer: Buffer): Promise<ImageMetadata> => {
@@ -39,7 +39,7 @@ export function createImagesContext(
   }
 
   const { images } = config;
-  const { baseUrl = DEFAULT_BASE_URL, storagePath = DEFAULT_IMAGES_STORAGE_PATH } =
+  const { baseUrl = DEFAULT_IMAGES_BASE_URL, storagePath = DEFAULT_IMAGES_STORAGE_PATH } =
     images.local || {};
 
   if (images.upload === 'local') {

--- a/packages/core/src/lib/server/createExpressServer.ts
+++ b/packages/core/src/lib/server/createExpressServer.ts
@@ -6,8 +6,8 @@ import { graphqlUploadExpress } from 'graphql-upload';
 import { ApolloServer } from 'apollo-server-express';
 import type { KeystoneConfig, CreateContext, SessionStrategy, GraphQLConfig } from '../../types';
 import { createSessionContext } from '../../session';
-import { DEFAULT_FILES_STORAGE_PATH } from '../context/createFilesContext';
-import { DEFAULT_IMAGES_STORAGE_PATH } from '../context/createImagesContext';
+import { DEFAULT_FILES_BASE_URL, DEFAULT_FILES_STORAGE_PATH } from '../context/createFilesContext';
+import { DEFAULT_IMAGES_BASE_URL, DEFAULT_IMAGES_STORAGE_PATH } from '../context/createImagesContext';
 import { createApolloServerExpress } from './createApolloServer';
 import { addHealthCheck } from './addHealthCheck';
 
@@ -106,14 +106,14 @@ export const createExpressServer = async (
 
   if (config.files) {
     expressServer.use(
-      '/files',
+      config.files.local?.baseUrl ?? DEFAULT_FILES_BASE_URL,
       express.static(config.files.local?.storagePath ?? DEFAULT_FILES_STORAGE_PATH)
     );
   }
 
   if (config.images) {
     expressServer.use(
-      '/images',
+      config.images.local?.baseUrl ?? DEFAULT_IMAGES_BASE_URL,
       express.static(config.images.local?.storagePath ?? DEFAULT_IMAGES_STORAGE_PATH)
     );
   }

--- a/packages/core/src/lib/server/createExpressServer.ts
+++ b/packages/core/src/lib/server/createExpressServer.ts
@@ -7,7 +7,10 @@ import { ApolloServer } from 'apollo-server-express';
 import type { KeystoneConfig, CreateContext, SessionStrategy, GraphQLConfig } from '../../types';
 import { createSessionContext } from '../../session';
 import { DEFAULT_FILES_BASE_URL, DEFAULT_FILES_STORAGE_PATH } from '../context/createFilesContext';
-import { DEFAULT_IMAGES_BASE_URL, DEFAULT_IMAGES_STORAGE_PATH } from '../context/createImagesContext';
+import {
+  DEFAULT_IMAGES_BASE_URL,
+  DEFAULT_IMAGES_STORAGE_PATH,
+} from '../context/createImagesContext';
 import { createApolloServerExpress } from './createApolloServer';
 import { addHealthCheck } from './addHealthCheck';
 


### PR DESCRIPTION
The options baseUrl configurations of both files and images have been ignored.
This is because the baseUrl is registered as a hardcoded path inside the construction of the express server.
The paths generated from the graphql query on the other hand are correct.

This PR exposes the previously hidden default basePaths and fixes the routes for images and files.