### PR TITLE
caption added to table for better SR browsing

### DIFF
--- a/.changeset/grumpy-news-warn.md
+++ b/.changeset/grumpy-news-warn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Minor a11y improvement to table browsing

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -4,7 +4,7 @@
 import { Fragment, HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@keystone-ui/button';
-import { Box, Center, Heading, jsx, Stack, useTheme } from '@keystone-ui/core';
+import { Box, Center, Heading, jsx, Stack, useTheme, VisuallyHidden } from '@keystone-ui/core';
 import { CheckboxControl } from '@keystone-ui/fields';
 import { ArrowRightCircleIcon } from '@keystone-ui/icons/icons/ArrowRightCircleIcon';
 import { LoadingDots } from '@keystone-ui/loading';
@@ -584,6 +584,7 @@ function ListTable({
   return (
     <Box paddingBottom="xlarge">
       <TableContainer>
+        <VisuallyHidden as="caption">{list.label} list</VisuallyHidden>
         <colgroup>
           <col width="30" />
           {shouldShowLinkIcon && <col width="30" />}


### PR DESCRIPTION
Slightly better screen reader experience for users leveraging the VO wheel. 
Also reads better in general browsing. 

Before: 

https://user-images.githubusercontent.com/12119389/157129944-9484fdfa-b9fa-4add-8716-5ae8470de15d.mov


After:

https://user-images.githubusercontent.com/12119389/157129960-e948150e-3354-4497-93e1-78b1ecdb8cff.mov


