### PR TITLE
Restore splitbee analytics

### DIFF
--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -71,6 +71,7 @@ class MyDocument extends Document {
             async
             src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"
           />
+          <script data-no-cookie data-respect-dnt async data-api="/_sb" src="/sb.js" />
         </Head>
         <body
           css={{

--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -124,4 +124,18 @@ const CURRENT = [
   },
 ];
 
-module.exports = [...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];
+/* Splitbee Proxy */
+const SPLITBEE = [
+  {
+    source: '/sb.js',
+    destination: 'https://cdn.splitbee.io/sb.js',
+    permanent: false,
+  },
+  {
+    source: '/_sb/:slug',
+    destination: 'https://hive.splitbee.io/:slug',
+    permanent: false,
+  },
+];
+
+module.exports = [...SPLITBEE, ...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];


### PR DESCRIPTION
Followup to #7335,  in context of #6262 and #6631,  this is preferred.

Additional changes are the recommended `data-*` attributes from https://splitbee.io/docs/embed-the-script,  `data-no-cookie` and `data-respect-dnt`, to follow up #6262.