### PR TITLE
refactor deserialiseDate fn to use date-fns for robustness

### DIFF
--- a/design-system/packages/fields/src/DatePicker/index.tsx
+++ b/design-system/packages/fields/src/DatePicker/index.tsx
@@ -6,7 +6,12 @@ import FocusLock from 'react-focus-lock';
 import { jsx } from '@keystone-ui/core';
 import { PopoverDialog, useControlledPopover } from '@keystone-ui/popover';
 
-import { formatDate, formatDateType, dateFormatPlaceholder } from '../utils/dateFormatters';
+import {
+  deserializeDate,
+  formatDate,
+  formatDateType,
+  dateFormatPlaceholder,
+} from '../utils/dateFormatters';
 import { DateType } from '../types';
 import { Calendar } from './Calendar';
 import { InputButton } from './components/InputButton';
@@ -29,11 +34,6 @@ export function useEventCallback<Func extends (...args: any) => any>(callback: F
     callbackRef.current = callback;
   });
   return cb as any;
-}
-
-function deserializeDate(value: string): Date {
-  const [year, month, day] = value.split('-').map(el => parseInt(el, 10));
-  return new Date(year, month - 1, day);
 }
 
 export const DatePicker = ({

--- a/design-system/packages/fields/src/utils/dateFormatters.ts
+++ b/design-system/packages/fields/src/utils/dateFormatters.ts
@@ -1,4 +1,4 @@
-import { formatISO } from 'date-fns';
+import { formatISO, parse } from 'date-fns';
 import { DateType } from '../types';
 
 /**
@@ -6,6 +6,10 @@ import { DateType } from '../types';
  */
 export const formatDateType = (date: Date): DateType => {
   return formatISO(date, { representation: 'date' });
+};
+
+export const deserializeDate = (date: string): Date => {
+  return parse(date, 'yyyy-MM-dd', new Date());
 };
 
 // undefined means we'll use the user's locale


### PR DESCRIPTION
On the tin, refactor to the solution in #7394 to rely on `date-fns` to do most of the heavy lifting around safely parsing the Date from string. 