### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/design-system/website/utils.ts
+++ b/design-system/website/utils.ts
@@ -1,4 +1,4 @@
-export const toLabel = (str: string) => str.substr(0, 1).toUpperCase() + str.substr(1);
+export const toLabel = (str: string) => str.slice(0, 1).toUpperCase() + str.slice(1);
 
 const VOWELS = ['a', 'e', 'i', 'o', 'u'];
 export const aAn = (before: string) => `a${VOWELS.includes(before.charAt(0)) ? 'n' : ''}`;

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
@@ -16,7 +16,7 @@ export function useSort(list: ListMeta, orderableFields: Set<string>) {
     let direction: 'ASC' | 'DESC' = 'ASC';
     let sortByField = sortByFromUrl;
     if (sortByFromUrl.charAt(0) === '-') {
-      sortByField = sortByFromUrl.substr(1);
+      sortByField = sortByFromUrl.slice(1);
       direction = 'DESC';
     }
     if (!orderableFields.has(sortByField)) return null;

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -3,7 +3,7 @@
  * @param {String} str The string to convert.
  * @returns The new string
  */
-export const upcase = (str: string) => str.substr(0, 1).toUpperCase() + str.substr(1);
+export const upcase = (str: string) => str.slice(0, 1).toUpperCase() + str.slice(1);
 
 /**
  * Turns a passed in string into

--- a/packages/fields-document/src/DocumentEditor/marks.tsx
+++ b/packages/fields-document/src/DocumentEditor/marks.tsx
@@ -95,7 +95,10 @@ export function withMarks(
               focus: startOfBlock,
             });
             const hasWhitespaceBeforeEndOfShortcut = /\s/.test(
-              startOfBlockToEndOfShortcutString.substr(-shortcutText.length - 1, 1)
+              startOfBlockToEndOfShortcutString.slice(
+                -shortcutText.length - 1,
+                -shortcutText.length
+              )
             );
 
             const endOfShortcutContainsExpectedContent =
@@ -111,9 +114,9 @@ export function withMarks(
             );
             // TODO: use regex probs
             for (const [offsetFromStartOfBlock] of [...strToMatchOn].reverse().entries()) {
-              const expectedShortcutText = strToMatchOn.substr(
+              const expectedShortcutText = strToMatchOn.slice(
                 offsetFromStartOfBlock,
-                shortcutText.length
+                offsetFromStartOfBlock + shortcutText.length
               );
               if (expectedShortcutText !== shortcutText) {
                 continue;

--- a/packages/fields-document/src/DocumentEditor/shortcuts.ts
+++ b/packages/fields-document/src/DocumentEditor/shortcuts.ts
@@ -25,7 +25,7 @@ export function withShortcuts(editor: Editor): Editor {
           if (pointBefore && Path.isDescendant(pointBefore.path, ancestorBlock[1])) {
             const range = { anchor: selectionPoint, focus: pointBefore };
             const str = Editor.string(editor, range);
-            if (str.substr(0, shortcut.length) === shortcut) {
+            if (str.slice(0, shortcut.length) === shortcut) {
               editor.history.undos.push([]);
               Transforms.select(editor, range);
               editor.insertText(shortcuts[shortcut] + ' ');


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.