### PR TITLE
Fix decimal field validation.min

### DIFF
--- a/.changeset/happy-bottles-greet.md
+++ b/.changeset/happy-bottles-greet.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed `validation.min` not being respected and `validation.max` being used as the min if was provided

--- a/.changeset/happy-bottles-greet.md
+++ b/.changeset/happy-bottles-greet.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixed `validation.min` not being respected and `validation.max` being used as the min if was provided
+Fixed decimal `validation.min` not being respected and `validation.max` being used as the min if was provided

--- a/.changeset/happy-bottles-greet.md
+++ b/.changeset/happy-bottles-greet.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixed decimal `validation.min` not being respected and `validation.max` being used as the min if was provided
+Fixed decimal `validation.min` not being respected and `validation.max` being used as the min if provided

--- a/packages/core/src/fields/types/decimal/index.ts
+++ b/packages/core/src/fields/types/decimal/index.ts
@@ -89,9 +89,9 @@ export const decimal =
         ? undefined
         : parseDecimalValueOption(meta, validation.max, 'validation.max');
     const min =
-      validation?.max === undefined
+      validation?.min === undefined
         ? undefined
-        : parseDecimalValueOption(meta, validation.max, 'validation.max');
+        : parseDecimalValueOption(meta, validation.min, 'validation.min');
 
     if (min !== undefined && max !== undefined && max.lessThan(min)) {
       throw new Error(

--- a/packages/core/src/fields/types/decimal/tests/test-fixtures.ts
+++ b/packages/core/src/fields/types/decimal/tests/test-fixtures.ts
@@ -55,14 +55,55 @@ export const crudTests = (keystoneTestWrapper: any) => {
           mutation {
             createTest(data: { price: "-400" }) {
               id
-              decimal
+              price
             }
           }
         `,
       });
       expect(result.data).toEqual({ createTest: null });
       expect(result.errors).toHaveLength(1);
-      expect(result.errors![0].message).toMatchInlineSnapshot();
+      expect(result.errors![0].message).toMatchInlineSnapshot(`
+        "You provided invalid data for this operation.
+          - Test.price: Price must be greater than or equal to -300"
+      `);
     })
   );
+  test(
+    'errors when above validation.min',
+    keystoneTestWrapper(async ({ context }: { context: KeystoneContext }) => {
+      const result = await context.graphql.raw({
+        query: `
+          mutation {
+            createTest(data: { price: "50000001" }) {
+              id
+              price
+            }
+          }
+        `,
+      });
+      expect(result.data).toEqual({ createTest: null });
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors![0].message).toMatchInlineSnapshot(`
+        "You provided invalid data for this operation.
+          - Test.price: Price must be less than or equal to 50000000"
+      `);
+    })
+  );
+  for (const [name, value] of [
+    ['min', '-300.00'],
+    ['max', '50000000.00'],
+  ]) {
+    test(
+      `saves when the value is exactly the ${name}`,
+      keystoneTestWrapper(async ({ context }: { context: KeystoneContext }) => {
+        const result = await context.query.Test.createOne({
+          data: {
+            price: value,
+          },
+          query: 'price',
+        });
+        expect(result).toEqual({ price: value });
+      })
+    );
+  }
 };

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -38,6 +38,8 @@ testModules
           }
         });
 
+        const fieldConfig = mod.fieldConfig ? mod.fieldConfig(matrixValue) : {};
+
         const runner = setupTestRunner({
           config: apiTestConfig({
             lists: {
@@ -45,8 +47,11 @@ testModules
                 fields: {
                   name: text(),
                   testField: mod.typeFunction({
-                    validation: { isRequired: true },
-                    ...(mod.fieldConfig ? mod.fieldConfig(matrixValue) : {}),
+                    ...fieldConfig,
+                    validation: {
+                      ...fieldConfig.validation,
+                      isRequired: true,
+                    },
                   }),
                 },
               }),


### PR DESCRIPTION
Previously we used the `validation.max` if it was provided as the min, this fixes that.