### PR TITLE
Update GraphQL documentation

### DIFF
--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -12,7 +12,7 @@ Keystone generates a CRUD (create, read, update, delete) GraphQL API based on th
 ## Using the API
 
 By default Keystone serves your GraphQL endpoint at `/api/graphql`.
-When `NODE_ENV=production` is not set, Keystone serves the [GraphQL playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE for debugging and exploring the GraphQL schema and API that Keystone built.
+When `NODE_ENV=production` is not set, by default Keystone serves the [GraphQL playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE for debugging and exploring the GraphQL schema and API that Keystone built.
 
 With the default configuration, the GraphQL playground and API endpoint is served on the path [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
 

--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -9,17 +9,15 @@ import { InlineCode } from '../../../components/primitives/Code';
 
 Keystone generates a CRUD (create, read, update, delete) GraphQL API based on the [schema](./schema) definition provided in the system [config](./config).
 
-## Using The API
+## Using the API
 
 By default Keystone serves your GraphQL endpoint at `/api/graphql`.
-Keystone also includes [GraphQL Playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE, giving you a great way to explore the API Keystone creates for your app.
+When `NODE_ENV=production` is not set, Keystone serves the [GraphQL playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE for debugging and exploring the GraphQL schema and API that Keystone built.
 
-When using Keystone's default settings in dev, both the GraphQL Playground and the GraphQL API itself will be available at [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
-This will likely be the case if you're running one of the example projects or developing your own Keystone app locally.
+With the default configuration, the GraphQL playground and API endpoint is served on the path [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
 
-The URL of the GraphQL API is an important value and will likely be set as an environment variable for related apps.
-For example, when building a frontend app with Apollo Client, you'll need the GraphQL URL when [initializing the client instance](https://www.apollographql.com/docs/react/get-started/#2-initialize-apolloclient).
-Your code may look like this:
+The URL of the GraphQL API is often configured as an environment variable when building or developing your frontend application, when [initializing your GraphQL instance](https://www.apollographql.com/docs/react/get-started/#2-initialize-apolloclient) (example is Apollo, but any GraphQL client is OK).
+For example:
 
 ```js
 const client = new ApolloClient({
@@ -28,10 +26,11 @@ const client = new ApolloClient({
 });
 ```
 
-If you don't like the default path you can control where the GraphQL API and playground are published by setting `config.graphql.path` in the [system config](https://keystonejs.com/docs/apis/config#graphql).
-Note that for security, both the playground and [introspection](https://graphql.org/learn/introspection/) are disabled when running Keystone in production.
-You can control this behaviour using the `config.graphql.playground` and `config.graphql.apolloConfig` options.
-For example, to disable these features in dev environments, add this to your Keystone config: `graphql: { playground: false, apolloConfig: { introspection: false } }`.
+If you don't like the default path you can control where the GraphQL API and playground are published by setting `config.graphql.path` in the [Keystone configuration](https://keystonejs.com/docs/apis/config#graphql).
+For security through obscurity, the playground and [introspection](https://graphql.org/learn/introspection/) is disabled when running Keystone with `NODE_ENV=production`.
+
+You can modify this behaviour using the `config.graphql.playground` and `config.graphql.apolloConfig` options.
+For example, to disable these features irrespective of the `NODE_ENV` environment variables, add this to your Keystone config: `graphql: { playground: false, apolloConfig: { introspection: false } }`.
 
 ## Example
 

--- a/docs/pages/docs/apis/graphql.mdx
+++ b/docs/pages/docs/apis/graphql.mdx
@@ -12,7 +12,7 @@ Keystone generates a CRUD (create, read, update, delete) GraphQL API based on th
 ## Using the API
 
 By default Keystone serves your GraphQL endpoint at `/api/graphql`.
-When `NODE_ENV=production` is not set, by default Keystone serves the [GraphQL playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE for debugging and exploring the GraphQL schema and API that Keystone built.
+When `NODE_ENV=production` is not set, by default Keystone serves the [GraphQL playground](https://github.com/graphql/graphql-playground), an in-browser GraphQL IDE for debugging and exploring the API and GraphQL schema that Keystone built.
 
 With the default configuration, the GraphQL playground and API endpoint is served on the path [`http://localhost:3000/api/graphql`](http://localhost:3000/api/graphql).
 


### PR DESCRIPTION
When reading @molomby's answer to https://github.com/keystonejs/keystone/discussions/7425,  I thought some of the information and specificity in that answer could be directed back into the GraphQL documentation and help others.