### PR TITLE
Add Codesandbox configs to allow launching online sandboxes for example projects

### DIFF
--- a/.changeset/shy-cycles-check.md
+++ b/.changeset/shy-cycles-check.md
@@ -1,0 +1,25 @@
+---
+'@keystone-6/example-assets-cloud': patch
+'@keystone-6/example-assets-local': patch
+'@keystone-6/example-auth': patch
+'@keystone-6/examples-app-basic': patch
+'@keystone-6/example-ecommerce': patch
+'@keystone-6/example-embedded-nextjs': patch
+'@keystone-6/example-graphql-api-endpoint': patch
+'@keystone-6/example-roles': patch
+'@keystone-6/example-blog': patch
+'@keystone-6/example-custom-admin-ui-logo': patch
+'@keystone-6/example-custom-admin-ui-navigation': patch
+'@keystone-6/example-custom-admin-ui-pages': patch
+'@keystone-6/example-custom-field': patch
+'@keystone-6/example-custom-field-view': patch
+'@keystone-6/example-default-values': patch
+'@keystone-6/example-document-field': patch
+'@keystone-6/example-extend-graphql-schema': patch
+'@keystone-6/example-extend-graphql-schema-graphql-ts': patch
+'@keystone-6/example-extend-graphql-schema-nexus': patch
+'@keystone-6/example-json-field': patch
+'@keystone-6/example-rest-api': patch
+---
+
+Added sandbox configs to allow launching sandboxes on codesandbox.io service

--- a/examples-staging/assets-cloud/sandbox.config.json
+++ b/examples-staging/assets-cloud/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/assets-local/sandbox.config.json
+++ b/examples-staging/assets-local/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/auth/sandbox.config.json
+++ b/examples-staging/auth/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/basic/sandbox.config.json
+++ b/examples-staging/basic/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/ecommerce/sandbox.config.json
+++ b/examples-staging/ecommerce/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/embedded-nextjs/sandbox.config.json
+++ b/examples-staging/embedded-nextjs/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/graphql-api-endpoint/sandbox.config.json
+++ b/examples-staging/graphql-api-endpoint/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples-staging/roles/sandbox.config.json
+++ b/examples-staging/roles/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -19,6 +19,12 @@ You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://
 
 Congratulations, you're now up and running with Keystone! 🚀
 
+### Online sandox
+
+You can play with this example online in web browser using free [codesandbox.io](https://codesandbox.io/) service. To launch the sandbox just open the url https://githubbox.com/keystonejs/keystone/tree/main/examples/blog and that's all.
+
+You can even fork this sanbox to make your own changes.
+
 ### Optional: add sample data
 
 This example includes sample data. To add it to your database:

--- a/examples/blog/sandbox.config.json
+++ b/examples/blog/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/custom-admin-ui-logo/sandbox.config.json
+++ b/examples/custom-admin-ui-logo/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/custom-admin-ui-navigation/sandbox.config.json
+++ b/examples/custom-admin-ui-navigation/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/custom-admin-ui-pages/sandbox.config.json
+++ b/examples/custom-admin-ui-pages/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/custom-field-view/sandbox.config.json
+++ b/examples/custom-field-view/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/custom-field/sandbox.config.json
+++ b/examples/custom-field/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/default-values/sandbox.config.json
+++ b/examples/default-values/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/document-field/sandbox.config.json
+++ b/examples/document-field/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/extend-graphql-schema-graphql-ts/sandbox.config.json
+++ b/examples/extend-graphql-schema-graphql-ts/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/extend-graphql-schema-nexus/sandbox.config.json
+++ b/examples/extend-graphql-schema-nexus/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/extend-graphql-schema/sandbox.config.json
+++ b/examples/extend-graphql-schema/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/idfield-overrides/sandbox.config.json
+++ b/examples/idfield-overrides/sandbox.config.json
@@ -1,7 +1,0 @@
-{
-  "template": "node",
-  "container": {
-    "startScript": "keystone dev",
-    "node": "14"
-  }
-}

--- a/examples/idfield-overrides/sandbox.config.json
+++ b/examples/idfield-overrides/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/json/sandbox.config.json
+++ b/examples/json/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}

--- a/examples/rest-api/sandbox.config.json
+++ b/examples/rest-api/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "14"
+  }
+}


### PR DESCRIPTION
As continuation to https://github.com/keystonejs/keystone/discussions/7222 I've added sandbox configs to all example projects, which allow launching Keystone examples on https://codesandbox.io/ service.

With this feature Keystone users can play with Keystone without instantly in web browser, without any manual setup on local machine. I think it will be very convenient especially for new Keystone users, that will can touch Keystone Admin UI and frontend directly in their web browsers with few clicks, and even fork them to add own changes.

Current example of URL: https://codesandbox.io/s/github/MurzNN/keystone/tree/codesandbox-configs/examples/blog

Also you can now point to that playground urls from Keystone documentation.