### PR TITLE
Prompt users in the Admin UI to confirm they want to navigate away when there are unsaved changes

### DIFF
--- a/.changeset/two-teachers-search.md
+++ b/.changeset/two-teachers-search.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+The Admin UI now prompts users to confirm they want to navigate away when there are unsaved changes.

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -148,7 +148,12 @@ function ItemForm({
   });
   const labelFieldValue = state.item.data?.[list.labelField];
   const itemId = state.item.data?.id!;
-  usePreventNavigation(!!changedFields.size);
+
+  const shouldPreventNavigation = !!changedFields.size;
+
+  usePreventNavigation(
+    useMemo(() => ({ current: shouldPreventNavigation }), [shouldPreventNavigation])
+  );
   return (
     <Box marginTop="xlarge">
       <GraphQLErrorNotice

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -149,11 +149,7 @@ function ItemForm({
   const labelFieldValue = state.item.data?.[list.labelField];
   const itemId = state.item.data?.id!;
 
-  const shouldPreventNavigation = !!changedFields.size;
-
-  usePreventNavigation(
-    useMemo(() => ({ current: shouldPreventNavigation }), [shouldPreventNavigation])
-  );
+  usePreventNavigation(!!changedFields.size);
   return (
     <Box marginTop="xlarge">
       <GraphQLErrorNotice

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -44,6 +44,7 @@ import { PageContainer, HEADER_HEIGHT } from '../../../../admin-ui/components/Pa
 import { GraphQLErrorNotice } from '../../../../admin-ui/components/GraphQLErrorNotice';
 import { CreateItemDrawer } from '../../../../admin-ui/components/CreateItemDrawer';
 import { Container } from '../../../../admin-ui/components/Container';
+import { usePreventNavigation } from '../../../../admin-ui/utils/usePreventNavigation';
 
 type ItemPageProps = {
   listKey: string;
@@ -147,6 +148,7 @@ function ItemForm({
   });
   const labelFieldValue = state.item.data?.[list.labelField];
   const itemId = state.item.data?.id!;
+  usePreventNavigation(!!changedFields.size);
   return (
     <Box marginTop="xlarge">
       <GraphQLErrorNotice

--- a/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
+++ b/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import isDeepEqual from 'fast-deep-equal';
 import { jsx, Box } from '@keystone-ui/core';
 import { Drawer } from '@keystone-ui/modals';

--- a/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
+++ b/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
@@ -91,14 +91,6 @@ export function CreateItemDrawer({
             setForceValidation(newForceValidation);
 
             if (newForceValidation) return;
-            const data: Record<string, any> = {};
-            Object.keys(list.fields).forEach(fieldPath => {
-              const { controller } = list.fields[fieldPath];
-              const serialized = controller.serialize(value[fieldPath].value);
-              if (!isDeepEqual(serialized, controller.serialize(controller.defaultValue))) {
-                Object.assign(data, serialized);
-              }
-            });
 
             createItem({
               variables: {

--- a/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
+++ b/packages/core/src/admin-ui/components/CreateItemDrawer.tsx
@@ -75,15 +75,10 @@ export function CreateItemDrawer({
       Object.assign(data, serialized);
     }
   });
-  const shouldPreventNavigation = !!returnedData?.item || Object.keys(data).length !== 0;
 
-  const shouldPreventNavigationRef = useRef(shouldPreventNavigation);
+  const shouldPreventNavigation = !returnedData?.item && Object.keys(data).length !== 0;
 
-  useEffect(() => {
-    shouldPreventNavigationRef.current = shouldPreventNavigation;
-  }, [shouldPreventNavigation]);
-
-  usePreventNavigation(shouldPreventNavigationRef);
+  usePreventNavigation(shouldPreventNavigation);
 
   return (
     <Drawer
@@ -105,7 +100,6 @@ export function CreateItemDrawer({
               },
             })
               .then(({ data }) => {
-                shouldPreventNavigationRef.current = false;
                 const label = data.item.label || data.item.id;
                 onCreate({ id: data.item.id, label });
                 toasts.addToast({

--- a/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
+++ b/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
@@ -1,28 +1,31 @@
 import { useEffect } from 'react';
 import { useRouter } from '../router';
 
-export function usePreventNavigation(shouldPreventNavigation: boolean) {
+export function usePreventNavigation(shouldPreventNavigationRef: { current: boolean }) {
   const router = useRouter();
 
   useEffect(() => {
-    if (shouldPreventNavigation) {
-      const clientSideRouteChangeHandler = () => {
-        if (!window.confirm('There are unsaved changes, are you sure you want to exit?')) {
-          // throwing from here seems to be the only way to prevent the navigation
-          // we're throwing just a string here rather than an error because throwing an error
-          // causes Next to show an error overlay in dev but it doesn't show the overlay when we throw a string
-          throw 'Navigation cancelled by user';
-        }
-      };
-      router.events.on('routeChangeStart', clientSideRouteChangeHandler);
-      const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+    const clientSideRouteChangeHandler = () => {
+      if (
+        shouldPreventNavigationRef.current &&
+        !window.confirm('There are unsaved changes, are you sure you want to exit?')
+      ) {
+        // throwing from here seems to be the only way to prevent the navigation
+        // we're throwing just a string here rather than an error because throwing an error
+        // causes Next to show an error overlay in dev but it doesn't show the overlay when we throw a string
+        throw 'Navigation cancelled by user';
+      }
+    };
+    router.events.on('routeChangeStart', clientSideRouteChangeHandler);
+    const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+      if (shouldPreventNavigationRef.current) {
         event.preventDefault();
-      };
-      window.addEventListener('beforeunload', beforeUnloadHandler);
-      return () => {
-        router.events.off('routeChangeStart', clientSideRouteChangeHandler);
-        window.removeEventListener('beforeunload', beforeUnloadHandler);
-      };
-    }
-  }, [shouldPreventNavigation, router.events]);
+      }
+    };
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+    return () => {
+      router.events.off('routeChangeStart', clientSideRouteChangeHandler);
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+    };
+  }, [shouldPreventNavigationRef, router.events]);
 }

--- a/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
+++ b/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
@@ -6,7 +6,7 @@ export function usePreventNavigation(shouldPreventNavigation: boolean) {
 
   useEffect(() => {
     if (shouldPreventNavigation) {
-      const handler = () => {
+      const clientSideRouteChangeHandler = () => {
         if (!window.confirm('There are unsaved changes, are you sure you want to exit?')) {
           // throwing from here seems to be the only way to prevent the navigation
           // we're throwing just a string here rather than an error because throwing an error
@@ -14,13 +14,13 @@ export function usePreventNavigation(shouldPreventNavigation: boolean) {
           throw 'Navigation cancelled by user';
         }
       };
-      router.events.on('routeChangeStart', handler);
+      router.events.on('routeChangeStart', clientSideRouteChangeHandler);
       const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
         event.preventDefault();
       };
       window.addEventListener('beforeunload', beforeUnloadHandler);
       return () => {
-        router.events.off('routeChangeStart', handler);
+        router.events.off('routeChangeStart', clientSideRouteChangeHandler);
         window.removeEventListener('beforeunload', beforeUnloadHandler);
       };
     }

--- a/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
+++ b/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useRouter } from '../router';
+
+export function usePreventNavigation(shouldPreventNavigation: boolean) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (shouldPreventNavigation) {
+      const handler = () => {
+        if (!window.confirm('There are unsaved changes, are you sure you want to exit?')) {
+          // throwing from here seems to be the only way to prevent the navigation
+          // we're throwing just a string here rather than an error because throwing an error
+          // causes Next to show an error overlay in dev but it doesn't show the overlay when we throw a string
+          throw 'Navigation cancelled by user';
+        }
+      };
+      router.events.on('routeChangeStart', handler);
+      const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
+        event.preventDefault();
+      };
+      window.addEventListener('beforeunload', beforeUnloadHandler);
+      return () => {
+        router.events.off('routeChangeStart', handler);
+        window.removeEventListener('beforeunload', beforeUnloadHandler);
+      };
+    }
+  }, [shouldPreventNavigation, router.events]);
+}

--- a/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
+++ b/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
@@ -1,31 +1,28 @@
 import { useEffect } from 'react';
 import { useRouter } from '../router';
 
-export function usePreventNavigation(shouldPreventNavigationRef: { current: boolean }) {
+export function usePreventNavigation(shouldPreventNavigation: boolean) {
   const router = useRouter();
 
   useEffect(() => {
-    const clientSideRouteChangeHandler = () => {
-      if (
-        shouldPreventNavigationRef.current &&
-        !window.confirm('There are unsaved changes, are you sure you want to exit?')
-      ) {
-        // throwing from here seems to be the only way to prevent the navigation
-        // we're throwing just a string here rather than an error because throwing an error
-        // causes Next to show an error overlay in dev but it doesn't show the overlay when we throw a string
-        throw 'Navigation cancelled by user';
-      }
-    };
-    router.events.on('routeChangeStart', clientSideRouteChangeHandler);
-    const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
-      if (shouldPreventNavigationRef.current) {
+    if (shouldPreventNavigation) {
+      const clientSideRouteChangeHandler = () => {
+        if (!window.confirm('There are unsaved changes, are you sure you want to exit?')) {
+          // throwing from here seems to be the only way to prevent the navigation
+          // we're throwing just a string here rather than an error because throwing an error
+          // causes Next to show an error overlay in dev but it doesn't show the overlay when we throw a string
+          throw 'Navigation cancelled by user';
+        }
+      };
+      router.events.on('routeChangeStart', clientSideRouteChangeHandler);
+      const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
         event.preventDefault();
-      }
-    };
-    window.addEventListener('beforeunload', beforeUnloadHandler);
-    return () => {
-      router.events.off('routeChangeStart', clientSideRouteChangeHandler);
-      window.removeEventListener('beforeunload', beforeUnloadHandler);
-    };
-  }, [shouldPreventNavigationRef, router.events]);
+      };
+      window.addEventListener('beforeunload', beforeUnloadHandler);
+      return () => {
+        router.events.off('routeChangeStart', clientSideRouteChangeHandler);
+        window.removeEventListener('beforeunload', beforeUnloadHandler);
+      };
+    }
+  }, [shouldPreventNavigation, router.events]);
 }


### PR DESCRIPTION
We could show one of our own modals in the local client-side navigation case but we can always add that later.