### PR TITLE
Fix read only segmented control

### DIFF
--- a/.changeset/gold-glasses-melt.md
+++ b/.changeset/gold-glasses-melt.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixed read only view for segmented control display mode in the select field
+Fixed read only view for segmented control display mode in the select field. When a `segmented-control` select field is in `read` mode, the values no longer appear editable. 

--- a/.changeset/gold-glasses-melt.md
+++ b/.changeset/gold-glasses-melt.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed read only view for segmented control display mode in the select field

--- a/.changeset/real-pigs-tease.md
+++ b/.changeset/real-pigs-tease.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/segmented-control': minor
+---
+
+Added isDisabled prop

--- a/.changeset/real-pigs-tease.md
+++ b/.changeset/real-pigs-tease.md
@@ -2,4 +2,4 @@
 '@keystone-ui/segmented-control': minor
 ---
 
-Added isDisabled prop
+Added `isReadOnly` prop and custom read only logic for the Segmented Control component.

--- a/.changeset/short-ants-smash.md
+++ b/.changeset/short-ants-smash.md
@@ -1,0 +1,6 @@
+---
+'@keystone-ui/segmented-control': minor
+'@keystone-6/core': minor
+---
+
+Added read only functionality for segmented control.

--- a/.changeset/short-ants-smash.md
+++ b/.changeset/short-ants-smash.md
@@ -1,6 +1,0 @@
----
-'@keystone-ui/segmented-control': minor
-'@keystone-6/core': minor
----
-
-Added read only functionality for segmented control.

--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -31,7 +31,6 @@ import {
   useId,
   useTheme,
   VisuallyHidden,
-  css,
 } from '@keystone-ui/core';
 
 import { SizeKey, WidthKey, useControlTokens } from './hooks/segmentedControl';
@@ -50,6 +49,8 @@ type SegmentedControlProps = {
   onChange: ManagedChangeHandler<Index>;
   /** Provide labels for each segment. */
   segments: string[];
+  /** To Disable */
+  isDisabled?: boolean;
   /** The the selected index of the segmented control. */
   selectedIndex: Index | undefined;
   /** The size of the controls. */
@@ -63,6 +64,7 @@ export const SegmentedControl = ({
   fill = false,
   onChange,
   segments,
+  isDisabled = false,
   size = 'medium',
   width = 'large',
   selectedIndex,
@@ -102,17 +104,9 @@ export const SegmentedControl = ({
   }, [animate, selectedIndex]);
 
   return (
-    <Box
-      css={css`
-        outline: 0;
-        box-sizing: border-box;
-      `}
-      {...props}
-    >
+    <Box css={{ outline: 0, boxSizing: 'border-box' }} {...props}>
       <Root
-        css={css`
-          border: 1px solid #e1e5e9;
-        `}
+        css={{ border: `1px solid ${isDisabled ? 'transparent' : '#e1e5e9'}` }}
         fill={fill}
         size={size}
         ref={rootRef}
@@ -126,6 +120,7 @@ export const SegmentedControl = ({
               fill={fill}
               isAnimated={animate}
               isSelected={isSelected}
+              disabled={isDisabled}
               key={label}
               name={name}
               onChange={event => {
@@ -209,7 +204,7 @@ const Item = (props: ItemProps) => {
         ...sizeStyles[size],
         ...(!isAnimated && isSelected && selectedStyles),
         boxSizing: 'border-box',
-        cursor: 'pointer',
+        cursor: props.disabled ? undefined : 'pointer',
         flex: fill ? 1 : undefined,
         fontWeight: typography.fontWeight.medium,
         textAlign: 'center',
@@ -220,10 +215,12 @@ const Item = (props: ItemProps) => {
           boxShadow: '0 0 0 2px #bfdbfe;',
           border: '1px solid #166bff;',
         },
-        ':hover': {
-          color: !isSelected ? colors.linkHoverColor : undefined,
-          backgroundColor: 'rgba(255, 255, 255, 0.5)',
-        },
+        ...(!props.disabled && {
+          ':hover': {
+            color: !isSelected ? colors.linkHoverColor : undefined,
+            backgroundColor: 'rgba(255, 255, 255, 0.5)',
+          },
+        }),
         ':active': {
           backgroundColor: !isSelected ? fields.hover.inputBackground : undefined,
         },

--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -151,7 +151,7 @@ export const SegmentedControl = ({
             type="radio"
             checked={noneSelected}
             disabled={getDisabled(isDisabled, isReadOnly, noneSelected)}
-            value="None Selected"
+            value="none"
           />
         </VisuallyHidden>
         {animate && selectedIndex! > -1 ? (

--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -105,13 +105,10 @@ export const SegmentedControl = ({
       });
     }
   }, [animate, selectedIndex]);
-  const noneSelected = selectedIndex === undefined;
 
-  const getDisabled = (disabled?: boolean, readOnly?: boolean, selected?: boolean) => {
-    if (isDisabled) return true;
-    if (isReadOnly && !selected) return true;
-    return false;
-  };
+  const nothingIsSelected = selectedIndex === undefined;
+  // do we want to mark the radio item as disabled?
+  const actuallyDisabled = isDisabled || (isReadOnly && !nothingIsSelected);
 
   return (
     <Box css={{ outline: 0, boxSizing: 'border-box' }} {...props}>
@@ -149,8 +146,8 @@ export const SegmentedControl = ({
           <VisuallyHidden
             as="input"
             type="radio"
-            checked={noneSelected}
-            disabled={getDisabled(isDisabled, isReadOnly, noneSelected)}
+            checked={nothingIsSelected}
+            disabled={actuallyDisabled}
             value="none"
           />
         </VisuallyHidden>
@@ -231,15 +228,8 @@ const Item = (props: ItemProps) => {
   const selectedStyles = useSelectedStyles();
   const inputRef = useRef(null);
 
-  const getDisabled = (disabled?: boolean, readOnly?: boolean, selected?: boolean) => {
-    // if its disabled we want to mark the radio item as disabled
-    if (disabled) return true;
-    // if its readOnly, we want to check if the item isSelected, if it is we want to mark the radio item as disabled
-    if (readOnly && !selected) return true;
-    return false;
-  };
-
-  const isDisabled = getDisabled(disabled, readOnly, isSelected);
+  // do we want to mark the radio item as disabled?
+  const isDisabled = disabled || (readOnly && !isSelected);
 
   return (
     <label

--- a/design-system/packages/segmented-control/src/SegmentedControl.tsx
+++ b/design-system/packages/segmented-control/src/SegmentedControl.tsx
@@ -105,6 +105,13 @@ export const SegmentedControl = ({
       });
     }
   }, [animate, selectedIndex]);
+  const noneSelected = selectedIndex === undefined;
+
+  const getDisabled = (disabled?: boolean, readOnly?: boolean, selected?: boolean) => {
+    if (isDisabled) return true;
+    if (isReadOnly && !selected) return true;
+    return false;
+  };
 
   return (
     <Box css={{ outline: 0, boxSizing: 'border-box' }} {...props}>
@@ -137,6 +144,16 @@ export const SegmentedControl = ({
             </Item>
           );
         })}
+        <VisuallyHidden as="label">
+          None Selected
+          <VisuallyHidden
+            as="input"
+            type="radio"
+            checked={noneSelected}
+            disabled={getDisabled(isDisabled, isReadOnly, noneSelected)}
+            value="None Selected"
+          />
+        </VisuallyHidden>
         {animate && selectedIndex! > -1 ? (
           <SelectedIndicator size={size} style={selectedRect} />
         ) : null}
@@ -217,7 +234,7 @@ const Item = (props: ItemProps) => {
   const getDisabled = (disabled?: boolean, readOnly?: boolean, selected?: boolean) => {
     // if its disabled we want to mark the radio item as disabled
     if (disabled) return true;
-    // if its readOnly, we want to  check if the item isSelected, if it is we want to mark the radio item as disabled
+    // if its readOnly, we want to check if the item isSelected, if it is we want to mark the radio item as disabled
     if (readOnly && !selected) return true;
     return false;
   };

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -60,7 +60,8 @@ export const Field = ({
                   ? field.options.findIndex(x => x.value === value.value!.value)
                   : undefined
               }
-              isDisabled={onChange === undefined}
+              isReadOnly={onChange === undefined}
+              // isDisabled={onChange === undefined}
               onChange={index => {
                 onChange?.({ ...value, value: field.options[index] });
                 setHasChanged(true);

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -60,6 +60,7 @@ export const Field = ({
                   ? field.options.findIndex(x => x.value === value.value!.value)
                   : undefined
               }
+              isDisabled={onChange === undefined}
               onChange={index => {
                 onChange?.({ ...value, value: field.options[index] });
                 setHasChanged(true);

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -61,7 +61,6 @@ export const Field = ({
                   : undefined
               }
               isReadOnly={onChange === undefined}
-              // isDisabled={onChange === undefined}
               onChange={index => {
                 onChange?.({ ...value, value: field.options[index] });
                 setHasChanged(true);


### PR DESCRIPTION
Fix read only display for segmented control. 
Previously the segmented control had focus-styles that were visible even in readOnly mode.
This is because under the hood the implementation is a list of radio inputs.
Radio inputs do not have a notion of `readOnly` unlike other input fields. 

We've implemented what we believe to be decent `readOnly` ux for this component. Briefly outlined below are the changes we've made: 
* `isReadOnly` prop added to the `SegmentedControl` component. When this is true, all unselected radio inputs are marked as disabled, and the focus styles for the selected input reflects its read only state. We keep the selected radio input enabled so that screen reader users browsing the form via tabbing know what field this is and what the selected value is. 
* A hidden input with a value of `none` is added to the `SegmentedControl`, this input is checked when no other input values are checked. This none input is not a field value, and is purely there for a11y purposes, such that screen reader users browsing the form via tabbing know what field this is and that no value is presently selected (even in read only mode) 

https://user-images.githubusercontent.com/28669082/167352435-d32865c1-7e82-4722-bb68-dec8de50ee5a.mov

