### PR TITLE
JSON Readonly: Style & Whitespace suggestions

### DIFF
--- a/packages/core/src/fields/types/json/views/index.tsx
+++ b/packages/core/src/fields/types/json/views/index.tsx
@@ -22,35 +22,34 @@ export const Field = ({
 }: FieldProps<typeof controller>) => {
   return (
     <FieldContainer>
-      <FieldLabel>
-        {field.label}
-        <Stack>
-          <TextArea
-            readOnly={onChange === undefined}
-            css={{
-              fontFamily: 'monospace',
-              ...(!onChange && {
-                cursor: 'default',
-                backgroundColor: '#F6F8FC',
-                '&:focus-visible': {
-                  outline: 0,
-                  backgroundColor: '#F6F8FC',
-                  boxShadow: '0 0 0 2px rgba(245,245,245,.7)',
-                  border: '1px solid rgb(220,220,220)',
-                },
-              }),
-            }}
-            autoFocus={autoFocus}
-            onChange={event => onChange?.(event.target.value)}
-            value={value}
-          />
-          {forceValidation && (
-            <Text color="red600" size="small">
-              {'Invalid JSON'}
-            </Text>
-          )}
-        </Stack>
-      </FieldLabel>
+      <FieldLabel>{field.label}</FieldLabel>
+      <Stack>
+        <TextArea
+          readOnly={onChange === undefined}
+          css={{
+            fontFamily: 'monospace',
+            ...(!onChange && {
+              cursor: 'default',
+              backgroundColor: '#eff3f6',
+              border: '1px solid transparent',
+              '&:focus-visible': {
+                outline: 0,
+                backgroundColor: '#eff3f6',
+                boxShadow: '0 0 0 2px #e1e5e9',
+                border: '1px solid #b1b5b9',
+              },
+            }),
+          }}
+          autoFocus={autoFocus}
+          onChange={event => onChange?.(event.target.value)}
+          value={value}
+        />
+        {forceValidation && (
+          <Text color="red600" size="small">
+            {'Invalid JSON'}
+          </Text>
+        )}
+      </Stack>
     </FieldContainer>
   );
 };

--- a/packages/core/src/fields/types/json/views/index.tsx
+++ b/packages/core/src/fields/types/json/views/index.tsx
@@ -22,9 +22,10 @@ export const Field = ({
 }: FieldProps<typeof controller>) => {
   return (
     <FieldContainer>
-      <FieldLabel>{field.label}</FieldLabel>
+      <FieldLabel htmlFor={field.path}>{field.label}</FieldLabel>
       <Stack>
         <TextArea
+          id={field.path}
           readOnly={onChange === undefined}
           css={{
             fontFamily: 'monospace',


### PR DESCRIPTION
### Styles

![SCR-20220504-lu8](https://user-images.githubusercontent.com/6447754/166628794-4415f732-aa33-41d1-bdc1-62adcaef8e19.png)

![SCR-20220504-lus](https://user-images.githubusercontent.com/6447754/166628800-d16532d5-dd77-4a15-8718-dbf4289dde95.png)

I altered the colour values to be derived from the [existing theme](https://github.com/keystonejs/keystone/blob/73f4d566dd580b91a096e101327786df41169347/design-system/packages/core/src/themes/default.ts#L61) instead of sourcing from the WIP UI (which uses a different root hue for the grays) so that the UI color theme can maintain consistency until the new UI ships.

TBH the background gray feels a little dark, but I opted to use a value that already exists, as opposed to a shade somewhere between [neutral100](https://github.com/keystonejs/keystone/blob/73f4d566dd580b91a096e101327786df41169347/design-system/packages/core/src/themes/default.ts#L60) and [neutral200](https://github.com/keystonejs/keystone/blob/73f4d566dd580b91a096e101327786df41169347/design-system/packages/core/src/themes/default.ts#L61)

This text/bg combination passes WCAG 2.1 with a contrast ratio of `9.23`

I also removed the border styling for the on-load state to differentiate it from other input types.

---

### Whitespace

I noticed that the `<textarea>` element was nested within the `<label>` element. Happy to revert this if it's intended for semantic/a11y reasons, but I would like us to replicate the `bottom-margin: 4px` spacing that occurs between other inputs and their labels [example](https://github.com/keystonejs/keystone/blob/rwa-styles/packages/core/src/fields/types/text/views/index.tsx#L27:L27).

![SCR-20220504-m2c](https://user-images.githubusercontent.com/6447754/166629107-2b55e9c7-1701-40ee-8644-4092d8922c4d.png)

![SCR-20220504-m1p](https://user-images.githubusercontent.com/6447754/166629113-9222fee5-2769-4356-8e31-24719c4e2335.png)


