### PR TITLE
16/refactor image UI

### DIFF
--- a/examples-staging/assets-local/schema.prisma
+++ b/examples-staging/assets-local/schema.prisma
@@ -23,11 +23,9 @@ model Post {
   hero_extension      String?
   hero_width          Int?
   hero_height         Int?
-  hero_storage        String?
   hero_id             String?
   attachment_filesize Int?
   attachment_filename String?
-  attachment_storage  String?
 
   @@index([authorId])
 }

--- a/examples-staging/assets-s3/schema.prisma
+++ b/examples-staging/assets-s3/schema.prisma
@@ -23,11 +23,9 @@ model Post {
   hero_extension      String?
   hero_width          Int?
   hero_height         Int?
-  hero_storage        String?
   hero_id             String?
   attachment_filesize Int?
   attachment_filename String?
-  attachment_storage  String?
 
   @@index([authorId])
 }

--- a/examples-staging/basic/schema.prisma
+++ b/examples-staging/basic/schema.prisma
@@ -19,11 +19,9 @@ model User {
   avatar_extension    String?
   avatar_width        Int?
   avatar_height       Int?
-  avatar_storage      String?
   avatar_id           String?
   attachment_filesize Int?
   attachment_filename String?
-  attachment_storage  String?
   password            String?
   isAdmin             Boolean       @default(false)
   roles               String        @default("")

--- a/packages/core/src/fields/types/image/views/Field.tsx
+++ b/packages/core/src/fields/types/image/views/Field.tsx
@@ -2,14 +2,12 @@
 /** @jsx jsx */
 
 import bytes from 'bytes';
-import { ReactNode, RefObject, useEffect, useMemo, useRef, useState } from 'react';
-
-import { jsx, Stack, useTheme, Text } from '@keystone-ui/core';
-
+import { Fragment, ReactNode, RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { jsx, Stack, Text } from '@keystone-ui/core';
 import { FieldContainer, FieldLabel } from '@keystone-ui/fields';
-import { Pill } from '@keystone-ui/pill';
 import { Button } from '@keystone-ui/button';
 import { FieldProps } from '../../../../types';
+import { SUPPORTED_IMAGE_EXTENSIONS } from '../utils';
 import { ImageValue } from './index';
 
 function useObjectURL(fileData: File | undefined) {
@@ -53,7 +51,10 @@ export function Field({
   // the user selects the same file again)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const inputKey = useMemo(() => Math.random(), [value]);
-
+  const accept = useMemo(
+    () => SUPPORTED_IMAGE_EXTENSIONS.map(ext => [`.${ext}`, `image/${ext}`].join(', ')).join(', '),
+    []
+  );
   return (
     <FieldContainer as="fieldset">
       <FieldLabel as="legend">{field.label}</FieldLabel>
@@ -73,8 +74,20 @@ export function Field({
         name={field.path}
         onChange={onUploadChange}
         type="file"
+        accept={accept}
         disabled={onChange === undefined}
       />
+      {errorMessage && (
+        <span
+          css={{
+            display: 'block',
+            marginTop: '8px',
+            color: 'red',
+          }}
+        >
+          {errorMessage}
+        </span>
+      )}
     </FieldContainer>
   );
 }
@@ -92,126 +105,155 @@ function ImgView({
   field: ReturnType<typeof import('.').controller>;
   inputRef: RefObject<HTMLInputElement>;
 }) {
+  const [imageDimensions, setImageDimensions] = useState({ width: 0, height: 0 });
   const imagePathFromUpload = useObjectURL(
     errorMessage === undefined && value.kind === 'upload' ? value.data.file : undefined
   );
+  const imageSrc = value.kind === 'from-server' ? value.data.src : imagePathFromUpload;
 
-  return value.kind === 'from-server' || value.kind === 'upload' ? (
-    <Stack gap="small" across align="center">
-      {errorMessage === undefined ? (
-        value.kind === 'from-server' ? (
-          <ImageWrapper>
-            <img css={{ width: '100%' }} src={value.data.src} alt={field.path} />
-          </ImageWrapper>
+  return (
+    <Stack gap="small" across align="end">
+      <ImageWrapper url={value.kind === 'from-server' ? imageSrc : undefined}>
+        {errorMessage || (value.kind !== 'from-server' && value.kind !== 'upload') ? (
+          <Placeholder />
         ) : (
-          <ImageWrapper>
-            <img
-              css={{
-                height: 'auto',
-                maxWidth: '100%',
-              }}
-              src={imagePathFromUpload}
-              alt={field.path}
-            />
-          </ImageWrapper>
-        )
-      ) : null}
-      {onChange && (
-        <Stack gap="small">
-          {value.kind === 'from-server' && (
-            <Stack padding="xxsmall" gap="xxsmall">
-              <Stack across align="center" gap="small">
-                <Text size="small">
-                  <a href={value.data.src} target="_blank">
-                    {`${value.data.id}.${value.data.extension}`}
-                  </a>
-                </Text>
-              </Stack>
-              <Text size="xsmall">{`${value.data.width} x ${value.data.height} (${bytes(
-                value.data.filesize
-              )})`}</Text>
-            </Stack>
-          )}
-          <Stack across gap="small" align="center">
-            <Button
-              size="small"
-              onClick={() => {
-                inputRef.current?.click();
-              }}
-            >
-              Change
-            </Button>
-            {value.kind === 'from-server' && (
-              <Button
-                size="small"
-                tone="negative"
-                onClick={() => {
-                  onChange({ kind: 'remove', previous: value });
-                }}
-              >
-                Remove
-              </Button>
-            )}
+          <Fragment>
             {value.kind === 'upload' && (
-              <Button
-                size="small"
-                tone="negative"
-                onClick={() => {
-                  onChange(value.previous);
+              <div
+                css={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  color: 'white',
+                  textAlign: 'center',
+                  wordWrap: 'break-word',
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '25px',
+                  backgroundColor: 'rgba(17, 24, 39, 0.65)',
+                  lineHeight: '1.15',
+                  fontWeight: 500,
                 }}
               >
-                Cancel
-              </Button>
+                Save to complete upload
+              </div>
             )}
-            {errorMessage ? (
-              <Pill tone="negative" weight="light">
-                {errorMessage}
-              </Pill>
-            ) : (
-              value.kind === 'upload' && (
-                <Pill weight="light" tone="positive">
-                  Save to upload this image
-                </Pill>
-              )
-            )}
-          </Stack>
-        </Stack>
-      )}
-    </Stack>
-  ) : (
-    <Stack gap="small">
-      <Stack css={{ alignItems: 'center' }} gap="small" across>
-        <Button
-          size="small"
-          disabled={onChange === undefined}
-          onClick={() => {
-            inputRef.current?.click();
-          }}
-          tone="positive"
-        >
-          Upload Image
-        </Button>
-        {value.kind === 'remove' && value.previous && (
-          <Button
-            size="small"
-            tone="negative"
-            onClick={() => {
-              if (value.previous !== undefined) {
-                onChange?.(value?.previous);
-              }
+            <img
+              onLoad={event => {
+                if (value.kind === 'upload') {
+                  setImageDimensions({
+                    width: event.currentTarget.naturalWidth,
+                    height: event.currentTarget.naturalHeight,
+                  });
+                }
+              }}
+              css={{
+                objectFit: 'contain',
+                width: '100%',
+                height: '100%',
+              }}
+              alt={`Image uploaded to ${field.path} field`}
+              src={imageSrc}
+            />
+          </Fragment>
+        )}
+      </ImageWrapper>
+      {value.kind === 'from-server' || value.kind === 'upload' ? (
+        onChange && (
+          <Stack
+            gap="small"
+            css={{
+              height: '120px',
+              justifyContent: 'flex-end',
             }}
           >
-            Undo removal
+            {errorMessage === undefined ? (
+              <ImageMeta
+                {...(value.kind === 'from-server'
+                  ? {
+                      width: value.data.width,
+                      height: value.data.height,
+                      url: value.data.src,
+                      name: `${value.data.id}.${value.data.extension}`,
+                      size: value.data.filesize,
+                    }
+                  : {
+                      width: imageDimensions.width,
+                      height: imageDimensions.height,
+                      size: value.data.file.size,
+                    })}
+              />
+            ) : null}
+            <Stack across gap="small" align="center">
+              <Button
+                size="small"
+                onClick={() => {
+                  inputRef.current?.click();
+                }}
+              >
+                Change
+              </Button>
+              {value.kind === 'from-server' && (
+                <Button
+                  size="small"
+                  tone="negative"
+                  onClick={() => {
+                    onChange({ kind: 'remove', previous: value });
+                  }}
+                >
+                  Remove
+                </Button>
+              )}
+              {value.kind === 'upload' && (
+                <Button
+                  size="small"
+                  tone="negative"
+                  onClick={() => {
+                    onChange(value.previous);
+                  }}
+                >
+                  Cancel
+                </Button>
+              )}
+            </Stack>
+          </Stack>
+        )
+      ) : (
+        <Stack across gap="small" align="center">
+          <Button
+            size="small"
+            disabled={onChange === undefined}
+            onClick={() => {
+              inputRef.current?.click();
+            }}
+            tone="positive"
+          >
+            Upload Image
           </Button>
-        )}
-        {value.kind === 'remove' &&
-          // NOTE -- UX decision is to not display this, I think it would only be relevant
-          // for deleting uploaded images (and we don't support that yet)
-          // <Pill weight="light" tone="warning">
-          //   Save to remove this image
-          // </Pill>
-          null}
-      </Stack>
+          {value.kind === 'remove' && value.previous && (
+            <Button
+              size="small"
+              tone="negative"
+              onClick={() => {
+                if (value.previous !== undefined) {
+                  onChange?.(value?.previous);
+                }
+              }}
+            >
+              Undo removal
+            </Button>
+          )}
+          {value.kind === 'remove' &&
+            // NOTE -- UX decision is to not display this, I think it would only be relevant
+            // for deleting uploaded images (and we don't support that yet)
+            // <Pill weight="light" tone="warning">
+            //   Save to remove this image
+            // </Pill>
+            null}
+        </Stack>
+      )}
     </Stack>
   );
 }
@@ -234,7 +276,19 @@ export function validateImage({
   }
   // check if the file is actually an image
   if (!file.type.includes('image')) {
-    return 'Only image files are allowed. Please try again.';
+    return `Sorry, that file type isn't accepted. Please try ${SUPPORTED_IMAGE_EXTENSIONS.reduce(
+      (acc, curr, currentIndex) => {
+        if (currentIndex === SUPPORTED_IMAGE_EXTENSIONS.length - 1) {
+          acc += ` or .${curr}`;
+        } else if (currentIndex > 0) {
+          acc += `, .${curr}`;
+        } else {
+          acc += `.${curr}`;
+        }
+        return acc;
+      },
+      ''
+    )}.`;
   }
 }
 
@@ -242,24 +296,82 @@ export function validateImage({
 // Styled Components
 // ==============================
 
-export const ImageWrapper = ({ children }: { children: ReactNode }) => {
-  const theme = useTheme();
+export const ImageMeta = ({
+  width = 0,
+  height = 0,
+  size,
+}: {
+  width?: number;
+  height?: number;
+  size: number;
+}) => {
+  return (
+    <Stack padding="xxsmall" gap="xxsmall">
+      <Text size="xsmall">Size: {`${bytes(size)}`}</Text>
+      <Text size="xsmall">Dimensions: {`${width} x ${height}`}</Text>
+    </Stack>
+  );
+};
 
+export const ImageWrapper = ({ children, url }: { children: ReactNode; url?: string }) => {
+  if (url) {
+    return (
+      <a
+        css={{
+          position: 'relative',
+          display: 'block',
+          overflow: 'hidden',
+          flexShrink: 0,
+          lineHeight: 0,
+          backgroundColor: '#fafbfc',
+          borderRadius: '6px',
+          textAlign: 'center',
+          width: '120px', // 120px image + chrome
+          height: '120px',
+          border: '1px solid #e1e5e9',
+        }}
+        href={url}
+      >
+        {children}
+      </a>
+    );
+  }
   return (
     <div
       css={{
-        backgroundColor: 'white',
-        borderRadius: theme.radii.medium,
-        border: `1px solid ${theme.colors.border}`,
+        position: 'relative',
+        overflow: 'hidden',
         flexShrink: 0,
         lineHeight: 0,
-        padding: 4,
-        position: 'relative',
+        backgroundColor: '#fafbfc',
+        borderRadius: '6px',
         textAlign: 'center',
-        width: '130px', // 120px image + chrome
+        width: '120px', // 120px image + chrome
+        height: '120px',
+        border: '1px solid #e1e5e9',
       }}
     >
       {children}
     </div>
+  );
+};
+
+export const Placeholder = () => {
+  return (
+    <svg
+      css={{
+        width: '100%',
+        height: '100%',
+      }}
+      width="120"
+      height="120"
+      viewBox="0 0 121 121"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M47.8604 45.6729H72.8604C73.5234 45.6729 74.1593 45.9362 74.6281 46.4051C75.097 46.8739 75.3604 47.5098 75.3604 48.1729V73.1729C75.3604 73.8359 75.097 74.4718 74.6281 74.9406C74.1593 75.4095 73.5234 75.6729 72.8604 75.6729H47.8604C47.1973 75.6729 46.5614 75.4095 46.0926 74.9406C45.6237 74.4718 45.3604 73.8359 45.3604 73.1729V48.1729C45.3604 47.5098 45.6237 46.8739 46.0926 46.4051C46.5614 45.9362 47.1973 45.6729 47.8604 45.6729ZM47.8604 65.6729V73.1729H72.8604V70.6729L66.6104 64.4229L64.6229 66.4104C64.1544 66.876 63.5208 67.1373 62.8604 67.1373C62.1999 67.1373 61.5663 66.876 61.0979 66.4104L54.1104 59.4229L47.8604 65.6729ZM68.3729 62.6479L72.8604 67.1354V48.1729H47.8604V62.1354L52.3479 57.6479C52.8163 57.1822 53.4499 56.9209 54.1104 56.9209C54.7708 56.9209 55.4044 57.1822 55.8729 57.6479L62.8604 64.6354L64.8479 62.6479C65.3163 62.1822 65.9499 61.9209 66.6104 61.9209C67.2708 61.9209 67.9044 62.1822 68.3729 62.6479ZM66.1937 57.5409C65.5771 57.9529 64.852 58.1729 64.1104 58.1729C63.1158 58.1729 62.162 57.7778 61.4587 57.0745C60.7554 56.3712 60.3604 55.4174 60.3604 54.4229C60.3604 53.6812 60.5803 52.9561 60.9923 52.3395C61.4044 51.7228 61.9901 51.2421 62.6753 50.9583C63.3605 50.6745 64.1145 50.6002 64.8419 50.7449C65.5694 50.8896 66.2376 51.2468 66.762 51.7712C67.2864 52.2956 67.6436 52.9638 67.7883 53.6913C67.933 54.4187 67.8587 55.1727 67.5749 55.8579C67.2911 56.5431 66.8104 57.1288 66.1937 57.5409ZM64.8048 53.3835C64.5993 53.2462 64.3576 53.1729 64.1104 53.1729C63.7788 53.1729 63.4609 53.3046 63.2265 53.539C62.992 53.7734 62.8604 54.0913 62.8604 54.4229C62.8604 54.6701 62.9337 54.9118 63.071 55.1173C63.2084 55.3229 63.4036 55.4831 63.632 55.5777C63.8604 55.6723 64.1117 55.6971 64.3542 55.6488C64.5967 55.6006 64.8194 55.4816 64.9942 55.3067C65.1691 55.1319 65.2881 54.9092 65.3363 54.6667C65.3846 54.4242 65.3598 54.1729 65.2652 53.9445C65.1706 53.7161 65.0104 53.5209 64.8048 53.3835Z"
+        fill="#b1b5b9"
+      />
+    </svg>
   );
 };


### PR DESCRIPTION
Refactoring the image UI to have a better upload to save flow. 
Changes in this PR: 
* Save changes pill no longer exists on upload 
* Persistent image placeholder added for layout uniformity across states
* `<img/>` is now the link to the saved image instead of the randomly generated unique filename to improve a11y for screen readers. 