### PR TITLE
Update document-fields documentation

### DIFF
--- a/docs/pages/docs/guides/document-fields.mdx
+++ b/docs/pages/docs/guides/document-fields.mdx
@@ -330,13 +330,13 @@ export const componentBlocks = {
     },
     label: 'Quote',
     props: {
+      attribution: fields.child({ kind: 'inline', placeholder: 'Attribution...' }),
       content: fields.child({
         kind: 'block',
         placeholder: 'Quote...',
         formatting: { inlineMarks: 'inherit', softBreaks: 'inherit' },
         links: 'inherit',
       }),
-      attribution: fields.child({ kind: 'inline', placeholder: 'Attribution...' }),
     },
     chromeless: true,
   }),
@@ -438,6 +438,14 @@ export const componentBlocks = {
     label: 'Notice',
     chromeless: true,
     props: {
+      content: fields.child({
+        kind: 'block',
+        placeholder: '',
+        formatting: 'inherit',
+        dividers: 'inherit',
+        links: 'inherit',
+        relationships: 'inherit',
+      }),
       intent: fields.select({
         label: 'Intent',
         options: [
@@ -447,14 +455,6 @@ export const componentBlocks = {
           { value: 'success', label: 'Success' },
         ] as const,
         defaultValue: 'info',
-      }),
-      content: fields.child({
-        kind: 'block',
-        placeholder: '',
-        formatting: 'inherit',
-        dividers: 'inherit',
-        links: 'inherit',
-        relationships: 'inherit',
       }),
     },
     toolbar({ props, onRemove }) {
@@ -543,13 +543,13 @@ component({
   },
   label: 'Quote',
   props: {
+    attribution: fields.child({ kind: 'inline', placeholder: 'Attribution...' }),
     content: fields.child({
       kind: 'block',
       placeholder: 'Quote...',
       formatting: { inlineMarks: 'inherit', softBreaks: 'inherit' },
       links: 'inherit',
     }),
-    attribution: fields.child({ kind: 'inline', placeholder: 'Attribution...' }),
   },
   chromeless: true,
 })
@@ -611,7 +611,7 @@ import { fields } from '@keystone-6/fields-document/component-blocks';
 
 fields.object({
   a: fields.text({ label: 'A' }),
-  a: fields.text({ label: 'B' }),
+  b: fields.text({ label: 'B' }),
 });
 ```
 
@@ -625,7 +625,7 @@ Similarly to inline relationships, they will be hydrated with this selection if 
 import { fields } from '@keystone-6/fields-document/component-blocks';
 
 ...
-someField: fields.relationship({
+  someField: fields.relationship({
     label: 'Authors',
     listKey: 'Author',
     selection: 'id name posts { title }',
@@ -700,6 +700,7 @@ If you're using TypeScript, you can infer the props types for component with `In
 import { DocumentRenderer } from '@keystone-6/document-renderer';
 import { InferRenderersForComponentBlocks } from '@keystone-6/fields-document/component-blocks';
 import { componentBlocks } from '../path/to/your/custom/views';
+
 const componentBlockRenderers: InferRenderersForComponentBlocks<typeof componentBlocks> = {
   someComponentBlock: props => {
     // props will be inferred from your component blocks


### PR DESCRIPTION
This pull request fixes a few typos in the documentation, and otherwise orders the `props` to be equivalent in their order of definition to the preview component defined nearby.
