### PR TITLE
Remove unused name from Auth session documentation

### DIFF
--- a/docs/pages/docs/guides/auth-and-access-control.mdx
+++ b/docs/pages/docs/guides/auth-and-access-control.mdx
@@ -136,7 +136,7 @@ You configure it like this:
 ```ts
 const { withAuth } = createAuth({
   // ...
-  sessionData: 'id isAdmin',
+  sessionData: 'isAdmin',
 });
 ```
 

--- a/docs/pages/docs/guides/auth-and-access-control.mdx
+++ b/docs/pages/docs/guides/auth-and-access-control.mdx
@@ -136,7 +136,7 @@ You configure it like this:
 ```ts
 const { withAuth } = createAuth({
   // ...
-  sessionData: 'name isAdmin',
+  sessionData: 'id isAdmin',
 });
 ```
 
@@ -147,7 +147,7 @@ The equivalent GraphQL query would look like this:
 ```graphql
 query {
   person(where: { id: $session.itemId }) {
-    name
+    id
     isAdmin
   }
 }


### PR DESCRIPTION
Quick fix to make the code sample in the guide work as expected.

The auth guide now consistently uses `id` instead of mentioning `id` but actually using `name` like it did in a previous commit https://github.com/keystonejs/keystone/blob/d0713111f1cdb76d553eb0d65a597620e0d3e056/docs/pages/docs/guides/auth-and-access-control.mdx#add-a-sessiondata-query

This is such a small change so I thought no changeset was needed, but let me know if that's required, and I'll update the PR.