### PR TITLE
Display list descriptions in the Admin UI

### DIFF
--- a/.changeset/two-guests-notice.md
+++ b/.changeset/two-guests-notice.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Fixed list description from schema to display in the Admin UI

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -248,7 +248,9 @@ const ListPage = ({ listKey }: ListPageProps) => {
         'Error...'
       ) : data && metaQuery.data ? (
         <Fragment>
-          {list.description !== null && <p>{list.description}</p>}
+          {list.description !== null && (
+            <p css={{ marginTop: '24px', maxWidth: '704px' }}>{list.description}</p>
+          )}
           <Stack across gap="medium" align="center" marginTop="xlarge">
             {showCreate && <CreateButton listKey={listKey} />}
             {data.count || filters.filters.length ? (

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -248,6 +248,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
         'Error...'
       ) : data && metaQuery.data ? (
         <Fragment>
+          {list.description !== null && <p>{list.description}</p>}
           <Stack across gap="medium" align="center" marginTop="xlarge">
             {showCreate && <CreateButton listKey={listKey} />}
             {data.count || filters.filters.length ? (


### PR DESCRIPTION
Fixed the display of lists `description` in Admin UI #7325 

<img width="890" alt="Screenshot 2022-05-16 at 3 47 12 pm" src="https://user-images.githubusercontent.com/28669082/168531644-2ac9522b-7037-4985-ad3c-9ca045370553.png">
Co-authored-by: Mitchell Hamilton <mitchellhamilton@users.noreply.github.com>