### PR TITLE
Include CodeSandbox instruction at `/examples`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ Each project below demonstrates a Keystone feature you can learn about and exper
 
 ## Running examples
 
-### In local dev
+### In your CLI
 
 To run an example, clone this repo and run the following commands:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,8 @@ Each project below demonstrates a Keystone feature you can learn about and exper
 
 ## Running examples
 
+### In local dev
+
 To run an example, clone this repo and run the following commands:
 
 ```shell
@@ -43,6 +45,10 @@ yarn dev
 
 If everything works 🤞 the GraphQL Server and Admin UI will start on [localhost:3000](http://localhost:3000).
 See the README in each example for more specific details.
+
+### In CodeSandbox
+
+You can also run our examples from your web browser using the free CodeSandbox service. Just look for the "Try it in CodeSandbox" heading in each example project’s README ([example](https://github.com/keystonejs/keystone/tree/main/examples/task-manager#try-it-out-in-code-sandbox-)).
 
 ## Getting in touch
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,7 +48,7 @@ See the README in each example for more specific details.
 
 ### In CodeSandbox
 
-You can also run our examples from your web browser using the free CodeSandbox service. Just look for the "Try it in CodeSandbox" heading in each example project’s README ([example](https://github.com/keystonejs/keystone/tree/main/examples/task-manager#try-it-out-in-code-sandbox-)).
+You can also run our examples from your web browser using the free CodeSandbox service. Just look for the "Try it in CodeSandbox" heading in each example project’s README ([example](https://github.com/keystonejs/keystone/tree/main/examples/task-manager#try-it-out-in-codesandbox-)).
 
 ## Getting in touch
 

--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -27,7 +27,7 @@ This example includes sample data. To add it to your database:
 2. Run `yarn seed-data`. This will populate your database with sample content.
 3. Run `yarn dev` again to startup Admin UI with sample data in place.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/blog. You can also fork this sandbox to make your own changes.
 

--- a/examples/custom-admin-ui-logo/README.md
+++ b/examples/custom-admin-ui-logo/README.md
@@ -27,6 +27,6 @@ If you have specific components you think should also be exposed from this confi
 **NOTE** The Keystone monorepo leverages a babel config that means we use the old jsx transform (this doesn't have an impact on the code we ship to npm).
 This is why there are `import React from 'react'` statements in our examples. This is NOT necessary outside of the Keystone repo (unless you have a babel config with the old jsx transform which is currently the default with @babel/preset-react) as you'll be using Next.js' babel config which uses the new jsx transform.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/custom-admin-ui-logo. You can also fork this sandbox to make your own changes.

--- a/examples/custom-admin-ui-navigation/README.md
+++ b/examples/custom-admin-ui-navigation/README.md
@@ -161,6 +161,6 @@ By default the `isSelected` value if left undefined, will be evaluated by the co
 
 See also the [Custom Navigation guide](httpes://keystonejs.com/docs/guides/custom-admin-ui-navigation).
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/custom-admin-ui-navigation. You can also fork this sandbox to make your own changes.

--- a/examples/custom-admin-ui-pages/README.md
+++ b/examples/custom-admin-ui-pages/README.md
@@ -62,6 +62,6 @@ export default () => {
 };
 ```
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/custom-admin-ui-pages. You can also fork this sandbox to make your own changes.

--- a/examples/custom-field-view/README.md
+++ b/examples/custom-field-view/README.md
@@ -62,6 +62,6 @@ will be rendered as.
   <img src="./custom-field-ui.png" width="445">
 </div>
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/custom-field-view. You can also fork this sandbox to make your own changes.

--- a/examples/custom-field/README.md
+++ b/examples/custom-field/README.md
@@ -20,6 +20,6 @@ You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://
 
 The `stars` fields in the `stars-field` directory shows a custom field that validates that the value is between 0 and some maximum number of stars and shows a radio input to select the number of stars in the Admin UI. The backend for the field type is in `stars-field/index.ts` and the frontend is in `stars-field/views.tsx`.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/custom-field. You can also fork this sandbox to make your own changes.

--- a/examples/default-values/README.md
+++ b/examples/default-values/README.md
@@ -20,6 +20,6 @@ You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://
 
 This project demonstrates how to provide default values to fields.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/default-values. You can also fork this sandbox to make your own changes.

--- a/examples/document-field/README.md
+++ b/examples/document-field/README.md
@@ -104,6 +104,6 @@ const renderers: DocumentRendererProps['renderers'] = {
 <DocumentRenderer document={post.content.document} renderers={renderers} />;
 ```
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/document-field. You can also fork this sandbox to make your own changes.

--- a/examples/extend-graphql-schema-graphql-ts/README.md
+++ b/examples/extend-graphql-schema-graphql-ts/README.md
@@ -25,6 +25,6 @@ The `graphql.extend` function allows you to extend the existing query and mutati
 
 See the [`@graphql-ts/schema`](https://docsmill.dev/npm/@graphql-ts/schema) and [`@graphql-ts/extend`](https://docsmill.dev/npm/@graphql-ts/extend) docs for more information.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-graphql-ts. You can also fork this sandbox to make your own changes.

--- a/examples/extend-graphql-schema-nexus/README.md
+++ b/examples/extend-graphql-schema-nexus/README.md
@@ -33,6 +33,6 @@ There's also a Prisma plugin for Nexus in development here: <https://github.com/
 
 When it's ready, it would make a good addition to this example (showing how to integrate the Prisma plugin with the Keystone-generated Prisma schema to auto-generate Nexus schema)
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-nexus. You can also fork this sandbox to make your own changes.

--- a/examples/extend-graphql-schema/README.md
+++ b/examples/extend-graphql-schema/README.md
@@ -131,6 +131,6 @@ Note that we're not doing any actual fetching inside `Query.stats`, we're doing 
   }),
 ```
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema. You can also fork this sandbox to make your own changes.

--- a/examples/json/README.md
+++ b/examples/json/README.md
@@ -31,6 +31,6 @@ This accepts any valid JSON including:
 
 The JSON field type stores its value in the `jsonb` format, as specified by Prisma. However if `sqlite` is specified as the database type instead, then the value is stored as a `string`.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/json. You can also fork this sandbox to make your own changes.

--- a/examples/rest-api/README.md
+++ b/examples/rest-api/README.md
@@ -16,6 +16,6 @@ You can use the Admin UI to create items in your database.
 
 To run the seed data script, pass the `--seed-data` flag when starting the app.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/rest-api. You can also fork this sandbox to make your own changes.

--- a/examples/task-manager/README.md
+++ b/examples/task-manager/README.md
@@ -32,6 +32,6 @@ Experiment with the code in this example to see how Keystone works, familiarise 
 
 When you’ve got the hang of this base project, try a [feature project](../) to learn Keystone’s advanced features and take your knowledge to the next level.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/task-manager. You can also fork this sandbox to make your own changes.

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -155,6 +155,6 @@ describe('Example tests using test environment', () => {
 The value `testArgs` contains the same values that are passed into test functions by the test runner.
 The `connect` and `disconnect` functions are used to connect to the database before the tests run, then disconnect once all tests have completed.
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/testing. You can also fork this sandbox to make your own changes.

--- a/examples/virtual-field/README.md
+++ b/examples/virtual-field/README.md
@@ -118,6 +118,6 @@ relatedPosts: virtual({
 }),
 ```
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/virtual-field. You can also fork this sandbox to make your own changes.

--- a/examples/with-auth/README.md
+++ b/examples/with-auth/README.md
@@ -81,6 +81,6 @@ export default withAuth(
 );
 ```
 
-## Try it out in Code Sandbox 🧪
+## Try it out in CodeSandbox 🧪
 
 You can play with this example online in a web browser using the free [codesandbox.io](https://codesandbox.io/) service. To launch this example, open the URL https://githubbox.com/keystonejs/keystone/tree/main/examples/with-auth. You can also fork this sandbox to make your own changes.


### PR DESCRIPTION
Lets the developer know that they can test projects in CodeSandbox from `/examples` for easier onboarding.