### PR TITLE
Fix the viewport shifting when opening the date picker in a modal

### DIFF
--- a/.changeset/lazy-knives-hammer.md
+++ b/.changeset/lazy-knives-hammer.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/popover': patch
+---
+
+Fixed bug where focustrap wasn't deactivating on unmount.

--- a/.changeset/lazy-knives-hammer.md
+++ b/.changeset/lazy-knives-hammer.md
@@ -2,4 +2,4 @@
 '@keystone-ui/popover': patch
 ---
 
-Fixed bug where focustrap wasn't deactivating on unmount.
+Fixed bug where focus trap wasn't deactivating on unmount.

--- a/.changeset/poor-schools-give.md
+++ b/.changeset/poor-schools-give.md
@@ -1,0 +1,6 @@
+---
+'@keystone-ui/fields': patch
+'@keystone-6/core': patch
+---
+
+Fixed the viewport sometimes shifting when opening the date picker in the create drawer.

--- a/design-system/packages/fields/src/DatePicker/index.tsx
+++ b/design-system/packages/fields/src/DatePicker/index.tsx
@@ -115,11 +115,13 @@ export const DatePicker = ({
       >
         {formattedDate || dateFormatPlaceholder}
       </InputButton>
-      <PopoverDialog arrow={arrow} isVisible={isOpen} ref={dialog.ref} {...dialog.props}>
-        <FocusLock autoFocus returnFocus disabled={!isOpen}>
-          <Calendar onDayClick={handleDayClick} selected={selectedDay} />
-        </FocusLock>
-      </PopoverDialog>
+      {isOpen && (
+        <PopoverDialog arrow={arrow} isVisible ref={dialog.ref} {...dialog.props}>
+          <FocusLock autoFocus returnFocus disabled={!isOpen}>
+            <Calendar onDayClick={handleDayClick} selected={selectedDay} />
+          </FocusLock>
+        </PopoverDialog>
+      )}
     </Fragment>
   );
 };

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -216,6 +216,9 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
           focusTrap.current.deactivate();
         }
       }
+      return () => {
+        focusTrap.current?.deactivate();
+      };
     }, [isVisible, focusTrap]);
 
     return (

--- a/design-system/packages/popover/src/Popover.tsx
+++ b/design-system/packages/popover/src/Popover.tsx
@@ -201,7 +201,7 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
     const focusTrap = useRef<focusTrapModule.FocusTrap | null>(null);
 
     useEffect(() => {
-      if (focusTrapRef?.current) {
+      if (focusTrapRef.current) {
         focusTrap.current = focusTrapModule.createFocusTrap(focusTrapRef.current, {
           allowOutsideClick: true,
         });
@@ -209,16 +209,17 @@ export const PopoverDialog = forwardRef<HTMLDivElement, DialogProps>(
     }, [focusTrapRef]);
 
     useEffect(() => {
-      if (focusTrap?.current) {
+      const focusTrapInstance = focusTrap.current;
+      if (focusTrapInstance) {
         if (isVisible) {
-          focusTrap.current.activate();
+          focusTrapInstance.activate();
+          return () => {
+            focusTrapInstance.deactivate();
+          };
         } else {
-          focusTrap.current.deactivate();
+          focusTrapInstance.deactivate();
         }
       }
-      return () => {
-        focusTrap.current?.deactivate();
-      };
     }, [isVisible, focusTrap]);
 
     return (


### PR DESCRIPTION
This probably isn't the _ideal_ fix but it works fine and figuring out positioning things is annoying.

Closes #6534