### PR TITLE
Replace Keystone Admin UI popover button in production with Sign-out button

### DIFF
--- a/.changeset/tall-months-clean.md
+++ b/.changeset/tall-months-clean.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Removed all Keystone Links, i.e. API explorer, GitHub repository and Keystone documentation, from the popover and replacing the popover button with `Sign out` button in production

--- a/packages/core/src/admin-ui/components/Navigation.tsx
+++ b/packages/core/src/admin-ui/components/Navigation.tsx
@@ -79,35 +79,41 @@ const AuthenticatedItemDialog = ({ item }: { item: AuthenticatedItem | undefined
           Signed in as <strong>{item.label}</strong>
         </div>
       ) : (
-        <div css={{ fontSize: typography.fontSize.small }}>GraphQL Playground and Docs</div>
+        process.env.NODE_ENV !== 'production' && (
+          <div css={{ fontSize: typography.fontSize.small }}>GraphQL Playground and Docs</div>
+        )
       )}
 
-      <Popover
-        placement="bottom"
-        triggerRenderer={({ triggerProps }) => (
-          <Button
-            size="small"
-            style={{ padding: 0, width: 36 }}
-            aria-label="Links and signout"
-            {...triggerProps}
-          >
-            <MoreHorizontalIcon />
-          </Button>
-        )}
-      >
-        <Stack gap="medium" padding="large" dividers="between">
-          <PopoverLink target="_blank" href={apiPath}>
-            API Explorer
-          </PopoverLink>
-          <PopoverLink target="_blank" href="https://github.com/keystonejs/keystone">
-            GitHub Repository
-          </PopoverLink>
-          <PopoverLink target="_blank" href="https://keystonejs.com">
-            Keystone Documentation
-          </PopoverLink>
-          {item && item.state === 'authenticated' && <SignoutButton />}
-        </Stack>
-      </Popover>
+      {process.env.NODE_ENV === 'production' ? (
+        item && item.state === 'authenticated' && <SignoutButton />
+      ) : (
+        <Popover
+          placement="bottom"
+          triggerRenderer={({ triggerProps }) => (
+            <Button
+              size="small"
+              style={{ padding: 0, width: 36 }}
+              aria-label="Links and signout"
+              {...triggerProps}
+            >
+              <MoreHorizontalIcon />
+            </Button>
+          )}
+        >
+          <Stack gap="medium" padding="large" dividers="between">
+            <PopoverLink target="_blank" href={apiPath}>
+              API Explorer
+            </PopoverLink>
+            <PopoverLink target="_blank" href="https://github.com/keystonejs/keystone">
+              GitHub Repository
+            </PopoverLink>
+            <PopoverLink target="_blank" href="https://keystonejs.com">
+              Keystone Documentation
+            </PopoverLink>
+            {item && item.state === 'authenticated' && <SignoutButton />}
+          </Stack>
+        </Popover>
+      )}
     </div>
   );
 };

--- a/packages/core/src/admin-ui/components/Navigation.tsx
+++ b/packages/core/src/admin-ui/components/Navigation.tsx
@@ -76,7 +76,7 @@ const AuthenticatedItemDialog = ({ item }: { item: AuthenticatedItem | undefined
     >
       {item && item.state === 'authenticated' ? (
         <div css={{ fontSize: typography.fontSize.small }}>
-          Signed in as <strong>{item.label}</strong>
+          Signed in as <strong css={{ display: 'block' }}>{item.label}</strong>
         </div>
       ) : (
         process.env.NODE_ENV !== 'production' && (

--- a/tests/examples-smoke-tests/basic.test.ts
+++ b/tests/examples-smoke-tests/basic.test.ts
@@ -2,7 +2,7 @@ import { Browser, Page } from 'playwright';
 import fetch from 'node-fetch';
 import { exampleProjectTests, initFirstItemTest, loadIndex } from './utils';
 
-exampleProjectTests('../examples-staging/basic', browserType => {
+exampleProjectTests('../examples-staging/basic', (browserType, mode) => {
   let browser: Browser = undefined as any;
   let page: Page = undefined as any;
   beforeAll(async () => {
@@ -12,7 +12,9 @@ exampleProjectTests('../examples-staging/basic', browserType => {
   });
   initFirstItemTest(() => page);
   test('sign out and sign in', async () => {
-    await page.click('[aria-label="Links and signout"]');
+    if (mode === 'dev') {
+      await page.click('[aria-label="Links and signout"]');
+    }
     await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign out")')]);
     await page.fill('[placeholder="email"]', 'admin@keystonejs.com');
     await page.fill('[placeholder="password"]', 'password');

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -75,7 +75,7 @@ export const initFirstItemTest = (getPage: () => playwright.Page) => {
 
 export const exampleProjectTests = (
   exampleName: string,
-  tests: (browser: playwright.BrowserType<playwright.Browser>) => void
+  tests: (browser: playwright.BrowserType<playwright.Browser>, mode: 'dev' | 'prod') => void
 ) => {
   const projectDir = path.join(__dirname, '..', '..', 'examples', exampleName);
   describe.each(['dev', 'prod'] as const)('%s', mode => {
@@ -151,7 +151,7 @@ export const exampleProjectTests = (
       beforeAll(async () => {
         await deleteAllData(projectDir);
       });
-      tests(playwright[browserName]);
+      tests(playwright[browserName], mode);
     });
   });
 };


### PR DESCRIPTION
The keystone Admin UI popover button that consisted of Keystone links to API Explorer, GitHub Repository and Keystone Documentation, present at the top of the left side-bar is replaced with only the `Sign out` button in `production mode` after authentication.
<img width="572" alt="Screenshot 2022-05-23 at 12 54 37 pm" src="https://user-images.githubusercontent.com/28669082/169734594-27a98fa1-535f-424a-afbf-27443261dedd.png">

