### PR TITLE
Fix document editor preventing tabbing out of the editor

### DIFF
--- a/.changeset/kind-peas-hug.md
+++ b/.changeset/kind-peas-hug.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixed document editor preventing tabbing out of the editor

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -99,13 +99,11 @@ const getKeyDownHandler = (editor: Editor) => (event: KeyboardEvent) => {
     return;
   }
   if (event.key === 'Tab') {
-    if (event.shiftKey) {
-      unnestList(editor);
-    } else {
-      nestList(editor);
+    const didAction = event.shiftKey ? unnestList(editor) : nestList(editor);
+    if (didAction) {
+      event.preventDefault();
+      return;
     }
-    event.preventDefault();
-    return;
   }
   if (event.key === 'Tab' && editor.selection) {
     const layoutArea = Editor.above(editor, {


### PR DESCRIPTION
This is slightly different logic than we discussed, it's "allow the event normally to continue normally(and therefore focus the next element) if the tab in a list didn't do anything" rather than "don't allow the event to continue if in a list, otherwise allow it to continue" but I think that's probably Fine and Good?