### PR TITLE
Associate the label for the text field with the text field input

### DIFF
--- a/.changeset/small-beers-knock.md
+++ b/.changeset/small-beers-knock.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+The label shown for a text field in the Admin UI is now associated with the input so the label can be read by screen readers

--- a/packages/core/src/fields/types/text/views/index.tsx
+++ b/packages/core/src/fields/types/text/views/index.tsx
@@ -24,7 +24,7 @@ export const Field = ({
   const validationMessages = validate(value, field.validation, field.label);
   return (
     <FieldContainer>
-      <FieldLabel>{field.label}</FieldLabel>
+      <FieldLabel htmlFor={field.path}>{field.label}</FieldLabel>
       {onChange ? (
         <Stack gap="small">
           {field.displayMode === 'textarea' ? (


### PR DESCRIPTION
I'm kinda surprised that this is the only one of the fields that just shows a basic input that wasn't connected tbh