### PR TITLE
Associate document editor label with editable element

### DIFF
--- a/.changeset/lovely-eels-rest.md
+++ b/.changeset/lovely-eels-rest.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+The document editor label is now associated with the editable element so the label can be read by screen readers

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -179,20 +179,19 @@ export function createDocumentEditor(
 }
 
 export function DocumentEditor({
-  autoFocus,
   onChange,
   value,
   componentBlocks,
   relationships,
   documentFeatures,
+  ...props
 }: {
-  autoFocus?: boolean;
   onChange: undefined | ((value: Descendant[]) => void);
   value: Descendant[];
   componentBlocks: Record<string, ComponentBlock>;
   relationships: Relationships;
   documentFeatures: DocumentFeatures;
-}) {
+} & Omit<EditableProps, 'value' | 'onChange'>) {
   const isShiftPressedRef = useKeyDownRef('Shift');
   const { colors, spacing } = useTheme();
   const [expanded, setExpanded] = useState(false);
@@ -263,7 +262,7 @@ export function DocumentEditor({
               marginRight: spacing.medium,
             }
           }
-          autoFocus={autoFocus}
+          {...props}
           readOnly={onChange === undefined}
         />
         {

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -30,10 +30,13 @@ export const Field = ({
   forceValidation,
 }: FieldProps<typeof controller>) => (
   <FieldContainer>
-    <FieldLabel>{field.label}</FieldLabel>
+    <FieldLabel as="span" id={`${field.path}-label`}>
+      {field.label}
+    </FieldLabel>
     <ForceValidationProvider value={!!forceValidation}>
       <DocumentEditor
         autoFocus={autoFocus}
+        aria-labelledby={`${field.path}-label`}
         value={value}
         onChange={onChange}
         componentBlocks={field.componentBlocks}


### PR DESCRIPTION
`<label>` is not for `contenteditable` elements, I've used `aria-labelledby`.