### PR TITLE
Carry over field imports from lesson 4 end state

### DIFF
--- a/docs/pages/docs/walkthroughs/lesson-5.mdx
+++ b/docs/pages/docs/walkthroughs/lesson-5.mdx
@@ -74,7 +74,7 @@ Next, we add the document field to our `post` list:
 ```ts{4,28}[8-14,31-500]
 // keystone.ts
 import { list, config } from '@keystone-6/core';
-import { text, timestamp, relationship } from '@keystone-6/core/fields';
+import { password, text, timestamp, select, relationship } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { withAuth, session } from './auth';
 
@@ -136,7 +136,7 @@ Let’s start by adding four [formatting](docs/guides/document-fields#formatting
 ```ts{28-39}[1-6,8-14,17-27,42-500]
 // keystone.ts
 import { list, config } from '@keystone-6/core';
-import { text, timestamp, relationship } from '@keystone-6/core/fields';
+import { password, text, timestamp, select, relationship } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { withAuth, session } from './auth';
 
@@ -201,7 +201,7 @@ For a full guide on using the document field, including rendering this in your o
 ```ts
 // keystone.ts
 import { list, config } from '@keystone-6/core';
-import { text, timestamp, relationship } from '@keystone-6/core/fields';
+import { password, text, timestamp, select, relationship } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { withAuth, session } from './auth';
 


### PR DESCRIPTION
Carries over the example code state of the tutorial in Lesson 4 [here](https://github.com/keystonejs/keystone/blame/lesson-5-update/docs/pages/docs/walkthroughs/lesson-4.mdx#L288)