### PR TITLE
Center alert dialogs in the Admin UI

### DIFF
--- a/.changeset/funny-knives-kick.md
+++ b/.changeset/funny-knives-kick.md
@@ -1,0 +1,6 @@
+---
+'@keystone-ui/modals': patch
+'@keystone-6/core': patch
+---
+
+Alert dialogs are now centered in the Admin UI.

--- a/design-system/packages/modals/src/DialogBase.tsx
+++ b/design-system/packages/modals/src/DialogBase.tsx
@@ -39,27 +39,35 @@ export const DialogBase = ({ children, isOpen, onClose, width, ...props }: Dialo
         <FocusLock autoFocus returnFocus>
           <RemoveScroll enabled>
             <div
-              aria-modal="true"
-              role="dialog"
-              tabIndex={-1}
-              onKeyDown={onKeyDown}
               css={{
-                animation: `${slideInAnim} 320ms ${easing}`,
-                backgroundColor: theme.colors.background,
-                borderRadius: theme.radii.large,
-                boxShadow: theme.shadow.s400,
-                margin: theme.spacing.small,
                 position: 'fixed',
-                marginLeft: -(width / 2),
-                left: '50%',
-                top: 64,
-                transition: `transform 150ms ${easing}`,
-                width: width,
-                zIndex: theme.elevation.e400,
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
               }}
-              {...props}
             >
-              {children}
+              <div
+                aria-modal="true"
+                role="dialog"
+                tabIndex={-1}
+                onKeyDown={onKeyDown}
+                css={{
+                  animation: `${slideInAnim} 320ms ${easing}`,
+                  backgroundColor: theme.colors.background,
+                  borderRadius: theme.radii.large,
+                  boxShadow: theme.shadow.s400,
+                  transition: `transform 150ms ${easing}`,
+                  width,
+                  zIndex: theme.elevation.e400,
+                }}
+                {...props}
+              >
+                {children}
+              </div>
             </div>
           </RemoveScroll>
         </FocusLock>


### PR DESCRIPTION
This looks like this:
![screenshot of the Keystone Admin UI list view with a dialog that says Are you sure you want to delete 1 User? in the center of the screen](https://user-images.githubusercontent.com/11481355/170185020-09048e32-2ae9-4587-88c3-056db0b77670.png)

(this has already been reviewed by @raveling)