### PR TITLE
Show a confirmation modal on reset changes and move reset changes button to next to the right

### DIFF
--- a/.changeset/calm-snakes-grow.md
+++ b/.changeset/calm-snakes-grow.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+The reset changes button on the item view now presents a confirmation modal before resetting changes and it has been moved to the right of the bottom bar so it is next to the delete button.

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -554,30 +554,62 @@ const Toolbar = memo(function Toolbar({
         zIndex: 20,
       }}
     >
+      <Button
+        isDisabled={!hasChangedFields}
+        isLoading={loading}
+        weight="bold"
+        tone="active"
+        onClick={onSave}
+      >
+        Save changes
+      </Button>
       <Stack align="center" across gap="small">
-        <Button
-          isDisabled={!hasChangedFields}
-          isLoading={loading}
-          weight="bold"
-          tone="active"
-          onClick={onSave}
-        >
-          Save changes
-        </Button>
         {hasChangedFields ? (
-          <Button weight="none" onClick={onReset}>
-            Reset changes
-          </Button>
+          <ResetChangesButton onReset={onReset} />
         ) : (
           <Text weight="medium" paddingX="large" color="neutral600">
             No changes
           </Text>
         )}
+        {deleteButton}
       </Stack>
-      {deleteButton}
     </div>
   );
 });
+
+function ResetChangesButton(props: { onReset: () => void }) {
+  const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
+
+  return (
+    <Fragment>
+      <Button
+        weight="none"
+        onClick={() => {
+          setConfirmModalOpen(true);
+        }}
+      >
+        Reset changes
+      </Button>
+      <AlertDialog
+        actions={{
+          confirm: {
+            action: () => props.onReset(),
+            label: 'Reset changes',
+          },
+          cancel: {
+            action: () => setConfirmModalOpen(false),
+            label: 'Cancel',
+          },
+        }}
+        isOpen={isConfirmModalOpen}
+        title="Are you sure you want to reset changes?"
+        tone="negative"
+      >
+        {null}
+      </AlertDialog>
+    </Fragment>
+  );
+}
 
 const ColumnLayout = (props: HTMLAttributes<HTMLDivElement>) => {
   const { spacing } = useTheme();


### PR DESCRIPTION
This PR places both destructive edit actions in the same part of the UI to avoid potential errors from users clicking the `reset changes` button by accident instead of pressing `save changes`.

The confirmation modal is a second layer of protection in the event that the reset button was pressed accidentally.

It now looks like this:

![screenshot of the Keystone Admin UI item view with "No changes" text next to a delete button at the bottom of the page](https://user-images.githubusercontent.com/11481355/170186006-34b7e0b2-3daf-4927-9335-6ed66121b1b4.png)
![screenshot of the Keystone Admin UI item view with a "Reset changes" button next to a delete button at the bottom of the page](https://user-images.githubusercontent.com/11481355/170186021-690187c5-d208-424f-8028-bfe1887af49d.png)
<img width="461" alt="screenshot of a Keystone Modal that says Are you sure you want to reset changes? with buttons to cancel and reset changes" src="https://user-images.githubusercontent.com/11481355/170185572-0ed54c07-e35f-45be-8fe3-9c2db7ebc5ed.png">


This has already been reviewed by @raveling together with #7561.