### PR TITLE
Fix incorrectly splitting text with marks/inlines when toggling lists in the document editor

### DIFF
--- a/.changeset/moody-days-hope.md
+++ b/.changeset/moody-days-hope.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixed splitting text with marks/inlines into multiple list items when turning a paragraph into a list and splitting a single list item with marks/inlines into multiple paragraphs when turning a list into paragraphs

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -546,6 +546,20 @@ function withBlocksSchema(editor: Editor): Editor {
         return;
       }
       const info = editorSchema[nodeType];
+
+      if (
+        info.kind === 'blocks' &&
+        node.children.length !== 0 &&
+        node.children.every(child => !Editor.isBlock(editor, child))
+      ) {
+        Transforms.wrapNodes(
+          editor,
+          { type: info.blockToWrapInlinesIn, children: [] },
+          { at: path, match: node => !Editor.isBlock(editor, node) }
+        );
+        return;
+      }
+
       for (const [index, childNode] of node.children.entries()) {
         const childPath = [...path, index];
         if (info.kind === 'inlines') {
@@ -587,13 +601,32 @@ function handleNodeInInvalidPosition(
 ) {
   const nodeType = node.type;
   const childNodeInfo = editorSchema[nodeType];
+  // the parent of a block will never be an inline so this casting is okay
+  const parentNode = Node.get(editor, parentPath) as Block | Editor;
+
+  const parentNodeType = Editor.isEditor(parentNode) ? 'editor' : parentNode.type;
+
+  const parentNodeInfo = editorSchema[parentNodeType];
 
   if (!childNodeInfo || childNodeInfo.invalidPositionHandleMode === 'unwrap') {
+    if (parentNodeInfo.kind === 'blocks' && parentNodeInfo.blockToWrapInlinesIn) {
+      Transforms.setNodes(
+        editor,
+        {
+          type: parentNodeInfo.blockToWrapInlinesIn,
+          ...(Object.fromEntries(
+            Object.keys(node)
+              .filter(key => key !== 'type' && key !== 'children')
+              .map(key => [key, null])
+          ) as any), // the Slate types don't understand that null is allowed and it will unset properties with setNodes
+        },
+        { at: path }
+      );
+      return;
+    }
     Transforms.unwrapNodes(editor, { at: path });
     return;
   }
-  // the parent of a block will never be an inline so this casting is okay
-  const parentNode = Node.get(editor, parentPath) as Block;
 
   const info = editorSchema[parentNode.type || 'editor'];
   if (info?.kind === 'blocks' && info.allowedChildren.has(nodeType)) {

--- a/packages/fields-document/src/DocumentEditor/lists.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/lists.test.tsx
@@ -360,6 +360,101 @@ test('toggle list on line with text', () => {
   `);
 });
 
+test('toggle list on line with text with marks', () => {
+  let editor = makeEditor(
+    <editor>
+      <paragraph>
+        <text>
+          some text. <cursor />
+        </text>
+        <text bold>this is bold.</text>
+        <text> this is not bold again</text>
+      </paragraph>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>
+  );
+
+  toggleList(editor, 'ordered-list');
+
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <ordered-list>
+        <list-item>
+          <list-item-content>
+            <text>
+              some text. 
+              <cursor />
+            </text>
+            <text
+              bold={true}
+            >
+              this is bold.
+            </text>
+            <text>
+               this is not bold again
+            </text>
+          </list-item-content>
+        </list-item>
+      </ordered-list>
+      <paragraph>
+        <text>
+          
+        </text>
+      </paragraph>
+    </editor>
+  `);
+});
+
+test('toggle list on list with text with marks', () => {
+  let editor = makeEditor(
+    <editor>
+      <ordered-list>
+        <list-item>
+          <list-item-content>
+            <text>
+              some text.
+              <cursor />
+            </text>
+            <text bold>this is bold.</text>
+            <text>this is not bold again</text>
+          </list-item-content>
+        </list-item>
+      </ordered-list>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>
+  );
+
+  toggleList(editor, 'ordered-list');
+
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <paragraph>
+        <text>
+          some text.
+          <cursor />
+        </text>
+        <text
+          bold={true}
+        >
+          this is bold.
+        </text>
+        <text>
+          this is not bold again
+        </text>
+      </paragraph>
+      <paragraph>
+        <text>
+          
+        </text>
+      </paragraph>
+    </editor>
+  `);
+});
+
 test('toggle ordered-list inside of ordered-list', () => {
   let editor = makeEditor(
     <editor>


### PR DESCRIPTION
Before:

https://user-images.githubusercontent.com/11481355/170411621-2f96c57d-f1c0-4e48-b887-7701dec723fc.mp4



After:

https://user-images.githubusercontent.com/11481355/170411650-31bf3431-698b-4955-aec0-8fa105b076c5.mp4


