### PR TITLE
Singletons

### DIFF
--- a/examples/assets-local/keystone.ts
+++ b/examples/assets-local/keystone.ts
@@ -1,12 +1,12 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   storage: {
     my_images: {
       kind: 'local',

--- a/examples/assets-local/schema.ts
+++ b/examples/assets-local/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp, image, file } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/assets-s3/keystone.ts
+++ b/examples/assets-s3/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core';
 import dotenv from 'dotenv';
-import { lists } from './schema';
+import { models } from './schema';
 
 dotenv.config();
 
@@ -16,7 +16,7 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   storage: {
     my_images: {
       kind: 's3',

--- a/examples/assets-s3/schema.ts
+++ b/examples/assets-s3/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp, image, file } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/auth/keystone.ts
+++ b/examples/auth/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 /**
  * TODO: Implement validateItem. Would be invoked by the getItem() method in
@@ -63,7 +63,7 @@ export default withAuth(
       provider: 'sqlite',
       url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
-    lists,
+    models,
     ui: {},
     session:
       // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie

--- a/examples/auth/schema.ts
+++ b/examples/auth/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { text, checkbox, password } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   User: list({
     access: {
       operation: {

--- a/examples/basic/keystone.ts
+++ b/examples/basic/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
 
-import { lists, extendGraphqlSchema } from './schema';
+import { models, extendGraphqlSchema } from './schema';
 
 let sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
 let sessionMaxAge = 60 * 60 * 24 * 30; // 30 days
@@ -54,7 +54,7 @@ export default auth.withAuth(
         },
       },
     },
-    lists,
+    models,
     extendGraphqlSchema,
     session: statelessSessions({ maxAge: sessionMaxAge, secret: sessionSecret }),
     // TODO -- Create a separate example for stored/redis sessions

--- a/examples/basic/schema.ts
+++ b/examples/basic/schema.ts
@@ -12,7 +12,7 @@ import {
 } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { v4 } from 'uuid';
-import { Context, Lists } from '.keystone/types';
+import { Context, Models } from '.keystone/types';
 
 type AccessArgs = {
   session?: {
@@ -32,7 +32,7 @@ export const access = {
 
 const randomNumber = () => Math.round(Math.random() * 10);
 
-const User: Lists.User = list({
+const User: Models.User = list({
   ui: {
     listView: {
       initialColumns: ['name', 'posts', 'avatar'],
@@ -91,7 +91,7 @@ const User: Lists.User = list({
   },
 });
 
-export const lists: Lists = {
+export const models: Models = {
   User,
   PhoneNumber: list({
     ui: {

--- a/examples/blog/keystone.ts
+++ b/examples/blog/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 import { insertSeedData } from './seed-data';
 import { Context } from '.keystone/types';
 
@@ -13,5 +13,5 @@ export default config({
       }
     },
   },
-  lists,
+  models,
 });

--- a/examples/blog/schema.ts
+++ b/examples/blog/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/custom-admin-ui-logo/keystone.ts
+++ b/examples/custom-admin-ui-logo/keystone.ts
@@ -1,11 +1,11 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   ui: {},
 });

--- a/examples/custom-admin-ui-logo/schema.ts
+++ b/examples/custom-admin-ui-logo/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/custom-admin-ui-navigation/keystone.ts
+++ b/examples/custom-admin-ui-navigation/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/custom-admin-ui-navigation/schema.ts
+++ b/examples/custom-admin-ui-navigation/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/custom-admin-ui-pages/keystone.ts
+++ b/examples/custom-admin-ui-pages/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/custom-admin-ui-pages/schema.ts
+++ b/examples/custom-admin-ui-pages/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/custom-field-view/keystone.ts
+++ b/examples/custom-field-view/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/custom-field-view/schema.ts
+++ b/examples/custom-field-view/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { json, select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/custom-field/1-text-field/index.ts
+++ b/examples/custom-field/1-text-field/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -8,15 +8,15 @@ import {
 } from '@keystone-6/core/types';
 import { graphql } from '@keystone-6/core';
 
-export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type TextFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
   };
 
-export function text<ListTypeInfo extends BaseListTypeInfo>({
+export function text<ModelTypeInfo extends BaseModelTypeInfo>({
   isIndexed,
   ...config
-}: TextFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> {
+}: TextFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> {
   return meta =>
     fieldType({
       kind: 'scalar',

--- a/examples/custom-field/2-stars-field/index.ts
+++ b/examples/custom-field/2-stars-field/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -13,18 +13,18 @@ import { graphql } from '@keystone-6/core';
 // and a different input in the Admin UI
 // https://github.com/keystonejs/keystone/tree/main/packages/core/src/fields/types/integer
 
-export type StarsFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type StarsFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
     maxStars?: number;
   };
 
 export const stars =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     maxStars = 5,
     ...config
-  }: StarsFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: StarsFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta =>
     fieldType({
       // this configures what data is stored in the database

--- a/examples/custom-field/3-pair-field/index.ts
+++ b/examples/custom-field/3-pair-field/index.ts
@@ -1,20 +1,20 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
 } from '@keystone-6/core/types';
 import { graphql } from '@keystone-6/core';
 
-export type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type PairFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
   };
 
-export function pair<ListTypeInfo extends BaseListTypeInfo>({
+export function pair<ModelTypeInfo extends BaseModelTypeInfo>({
   isIndexed,
   ...config
-}: PairFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> {
+}: PairFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> {
   function resolveInput(value: string | null | undefined) {
     if (!value) return { left: value, right: value };
     const [left = '', right = ''] = value.split(' ', 2);

--- a/examples/custom-field/keystone.ts
+++ b/examples/custom-field/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/custom-field/schema.ts
+++ b/examples/custom-field/schema.ts
@@ -4,9 +4,9 @@ import { text } from './1-text-field';
 import { stars } from './2-stars-field';
 import { pair } from './3-pair-field';
 
-import { Lists } from '.keystone/types';
+import { Models } from '.keystone/types';
 
-export const lists: Lists = {
+export const models: Models = {
   Post: list({
     fields: {
       content: text({

--- a/examples/custom-session-validation/keystone.ts
+++ b/examples/custom-session-validation/keystone.ts
@@ -3,7 +3,7 @@ import { SessionStrategy } from '@keystone-6/core/src/types/session';
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 // createAuth configures signin functionality based on the config below. Note this only implements
 // authentication, i.e signing in as an item using identity and secret fields in a list. Session
@@ -93,7 +93,7 @@ export default myAuth(
         provider: 'sqlite',
         url: process.env.DATABASE_URL || 'file:./keystone-example.db',
       },
-      lists,
+      models,
       // We add our session configuration to the system here.
       session,
     })

--- a/examples/custom-session-validation/schema.ts
+++ b/examples/custom-session-validation/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/default-values/keystone.ts
+++ b/examples/default-values/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/default-values/schema.ts
+++ b/examples/default-values/schema.ts
@@ -1,9 +1,9 @@
 import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
-import { Lists } from '.keystone/types';
+import { Models } from '.keystone/types';
 
-export const lists: Lists = {
+export const models: Models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/document-field/keystone.ts
+++ b/examples/document-field/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/document-field/schema.ts
+++ b/examples/document-field/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/ecommerce/keystone.ts
+++ b/examples/ecommerce/keystone.ts
@@ -56,8 +56,7 @@ export default withAuth(
         }
       },
     },
-    lists: {
-      // Schema items go in here
+    models: {
       User,
       Product,
       ProductImage,

--- a/examples/ecommerce/schemas/Order.ts
+++ b/examples/ecommerce/schemas/Order.ts
@@ -1,7 +1,7 @@
 import { integer, text, relationship, virtual } from '@keystone-6/core/fields';
 import { list, graphql } from '@keystone-6/core';
 import { isSignedIn, rules } from '../access';
-import { Lists } from '.keystone/types';
+import { Models } from '.keystone/types';
 
 const formatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -15,7 +15,7 @@ export default function formatMoney(cents: number | null) {
 }
 
 // we add the type here, so `item` below is typed
-export const Order: Lists.Order = list({
+export const Order: Models.Order = list({
   access: {
     operation: {
       create: isSignedIn,

--- a/examples/embedded-nextjs/keystone.ts
+++ b/examples/embedded-nextjs/keystone.ts
@@ -8,5 +8,5 @@ export default config({
     generateNextGraphqlAPI: true,
     generateNodeAPI: true,
   },
-  lists: { Post },
+  models: { Post },
 });

--- a/examples/extend-graphql-schema-graphql-ts/keystone.ts
+++ b/examples/extend-graphql-schema-graphql-ts/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 import { extendGraphqlSchema } from './custom-schema';
 
 export default config({
@@ -7,6 +7,6 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   extendGraphqlSchema,
 });

--- a/examples/extend-graphql-schema-graphql-ts/schema.ts
+++ b/examples/extend-graphql-schema-graphql-ts/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/extend-graphql-schema-nexus/keystone.ts
+++ b/examples/extend-graphql-schema-nexus/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core';
 import { mergeSchemas } from '@graphql-tools/schema';
-import { lists } from './schema';
+import { models } from './schema';
 import { nexusSchema } from './nexus';
 
 export default config({
@@ -8,6 +8,6 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   extendGraphqlSchema: keystoneSchema => mergeSchemas({ schemas: [keystoneSchema, nexusSchema] }),
 });

--- a/examples/extend-graphql-schema-nexus/schema.ts
+++ b/examples/extend-graphql-schema-nexus/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/extend-graphql-schema/keystone.ts
+++ b/examples/extend-graphql-schema/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 import { extendGraphqlSchema } from './custom-schema';
 
 export default config({
@@ -7,6 +7,6 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   extendGraphqlSchema,
 });

--- a/examples/extend-graphql-schema/schema.ts
+++ b/examples/extend-graphql-schema/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/extend-graphql-subscriptions/keystone.ts
+++ b/examples/extend-graphql-subscriptions/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists, extendGraphqlSchema } from './schema';
+import { models, extendGraphqlSchema } from './schema';
 import { extendHttpServer } from './websocket';
 
 export default config({
@@ -7,7 +7,7 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
   server: {
     extendHttpServer,
   },

--- a/examples/extend-graphql-subscriptions/schema.ts
+++ b/examples/extend-graphql-subscriptions/schema.ts
@@ -2,9 +2,9 @@ import { list, graphQLSchemaExtension } from '@keystone-6/core';
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { pubSub } from './websocket';
 
-import type { Lists } from '.keystone/types';
+import type { Models } from '.keystone/types';
 
-export const lists: Lists = {
+export const models: Models = {
   Post: list({
     hooks: {
       // this hook publishes posts to the 'POST_UPDATED' channel when a post mutated

--- a/examples/graphql-api-endpoint/keystone.ts
+++ b/examples/graphql-api-endpoint/keystone.ts
@@ -2,7 +2,7 @@ import { statelessSessions } from '@keystone-6/core/session';
 
 import { config } from '@keystone-6/core';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 let sessionSecret = process.env.SESSION_SECRET;
 
@@ -39,7 +39,7 @@ export default auth.withAuth(
     ui: {
       isAccessAllowed: context => !!context.session,
     },
-    lists,
+    models,
     session: statelessSessions({ maxAge: sessionMaxAge, secret: sessionSecret }),
   })
 );

--- a/examples/graphql-api-endpoint/schema.ts
+++ b/examples/graphql-api-endpoint/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { text, relationship, password, timestamp, select } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 
-export const lists = {
+export const models = {
   User: list({
     ui: {
       listView: {

--- a/examples/json/keystone.ts
+++ b/examples/json/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/json/schema.ts
+++ b/examples/json/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core';
 import { checkbox, json, relationship, text } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Package: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/rest-api/keystone.ts
+++ b/examples/rest-api/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 import { insertSeedData } from './seed-data';
 import { getTasks } from './routes/tasks';
 import { Context } from '.keystone/types';
@@ -40,5 +40,5 @@ export default config({
       app.get('/rest/tasks', getTasks);
     },
   },
-  lists,
+  models,
 });

--- a/examples/rest-api/schema.ts
+++ b/examples/rest-api/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/roles/keystone.ts
+++ b/examples/roles/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 import { isSignedIn } from './access';
 
@@ -56,7 +56,7 @@ export default withAuth(
       provider: 'sqlite',
       url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
-    lists,
+    models,
     ui: {
       /* Everyone who is signed in can access the Admin UI */
       isAccessAllowed: isSignedIn,

--- a/examples/roles/schema.ts
+++ b/examples/roles/schema.ts
@@ -12,7 +12,7 @@ import { isSignedIn, permissions, rules } from './access';
   - All users can see and manage todo items assigned to themselves
 */
 
-export const lists = {
+export const models = {
   Todo: list({
     /*
       SPEC

--- a/examples/task-manager/keystone.ts
+++ b/examples/task-manager/keystone.ts
@@ -1,5 +1,5 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 import { insertSeedData } from './seed-data';
 import { Context } from '.keystone/types';
 
@@ -13,5 +13,5 @@ export default config({
       }
     },
   },
-  lists,
+  models,
 });

--- a/examples/task-manager/schema.ts
+++ b/examples/task-manager/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/testing/keystone.ts
+++ b/examples/testing/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 // createAuth configures signin functionality based on the config below. Note this only implements
 // authentication, i.e signing in as an item using identity and secret fields in a list. Session
@@ -38,7 +38,7 @@ export default withAuth(
       provider: 'sqlite',
       url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
-    lists,
+    models,
     // We add our session configuration to the system here.
     session,
   })

--- a/examples/testing/schema.ts
+++ b/examples/testing/schema.ts
@@ -1,9 +1,9 @@
 import { list } from '@keystone-6/core';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
-import { Lists } from '.keystone/types';
+import { Models } from '.keystone/types';
 
-export const lists: Lists = {
+export const models: Models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/examples/virtual-field/keystone.ts
+++ b/examples/virtual-field/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
   },
-  lists,
+  models,
 });

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -1,8 +1,8 @@
 import { list, graphql } from '@keystone-6/core';
 import { select, relationship, text, timestamp, virtual } from '@keystone-6/core/fields';
-import { Lists, Context } from '.keystone/types';
+import { Models, Context } from '.keystone/types';
 
-export const lists: Lists = {
+export const models: Models = {
   Post: list({
     fields: {
       title: text({ validation: { isRequired: true } }),

--- a/examples/with-auth/keystone.ts
+++ b/examples/with-auth/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { lists } from './schema';
+import { models } from './schema';
 
 // createAuth configures signin functionality based on the config below. Note this only implements
 // authentication, i.e signing in as an item using identity and secret fields in a list. Session
@@ -38,7 +38,7 @@ export default withAuth(
       provider: 'sqlite',
       url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
-    lists,
+    models,
     // We add our session configuration to the system here.
     session,
   })

--- a/examples/with-auth/schema.ts
+++ b/examples/with-auth/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, password, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -177,7 +177,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
    * Validates the provided auth config; optional step when integrating auth
    */
   const validateConfig = (keystoneConfig: KeystoneConfig) => {
-    const listConfig = keystoneConfig.lists[listKey];
+    const listConfig = keystoneConfig.models[listKey];
     if (listConfig === undefined) {
       const msg = `A createAuth() invocation specifies the list "${listKey}" but no list with that key has been defined.`;
       throw new Error(msg);
@@ -300,7 +300,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     const session = withItemData(keystoneConfig.session);
 
     const existingExtendGraphQLSchema = keystoneConfig.extendGraphqlSchema;
-    const listConfig = keystoneConfig.lists[listKey];
+    const listConfig = keystoneConfig.models[listKey];
     return {
       ...keystoneConfig,
       ui,
@@ -309,8 +309,8 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
       // TODO: The fields we're adding here shouldn't naively replace existing fields with the same key
       // Leaving existing fields in place would allow solution devs to customise these field defs (eg. access control,
       // work factor for the tokens, etc.) without abandoning the withAuth() interface
-      lists: {
-        ...keystoneConfig.lists,
+      models: {
+        ...keystoneConfig.models,
         [listKey]: { ...listConfig, fields: { ...listConfig.fields, ...fields } },
       },
       extendGraphqlSchema: existingExtendGraphQLSchema

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import {
   CommonFieldConfig,
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   FieldTypeFunc,
   jsonFieldTypePolyfilledForSQLite,
 } from '@keystone-6/core/types';
@@ -19,8 +19,8 @@ type StoredFile = {
   _meta: cloudinary.UploadApiResponse;
 };
 
-type CloudinaryImageFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+type CloudinaryImageFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     cloudinary: {
       cloudName: string;
       apiKey: string;
@@ -106,10 +106,10 @@ export const outputType = graphql.object<CloudinaryImage_File>()({
 });
 
 export const cloudinaryImage =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     cloudinary,
     ...config
-  }: CloudinaryImageFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  }: CloudinaryImageFieldConfig<ModelTypeInfo>): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
       throw Error("isIndexed: 'unique' is not a supported option for field type cloudinaryImage");

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -7,7 +7,7 @@ export function createAdminMeta(
   config: KeystoneConfig,
   initialisedLists: Record<string, InitialisedList>
 ) {
-  const { ui, lists, session } = config;
+  const { ui, models: lists, session } = config;
   const adminMetaRoot: AdminMetaRootVal = {
     enableSessionItem: ui?.enableSessionItem || false,
     enableSignout: session !== undefined,
@@ -90,7 +90,7 @@ export function createAdminMeta(
   // Populate .fields array
   for (const [key, list] of Object.entries(initialisedLists)) {
     if (omittedLists.includes(key)) continue;
-    const searchFields = new Set(config.lists[key].ui?.searchFields ?? []);
+    const searchFields = new Set(config.models[key].ui?.searchFields ?? []);
     if (searchFields.has('id')) {
       throw new Error(
         `The ui.searchFields option on the ${key} list includes 'id'. Lists can always be searched by an item's id so it must not be specified as a search field`
@@ -109,7 +109,7 @@ export function createAdminMeta(
         );
       }
     }
-    if (config.lists[key].ui?.searchFields === undefined) {
+    if (config.models[key].ui?.searchFields === undefined) {
       const labelField = adminMetaRoot.listsByKey[key].labelField;
       if (possibleSearchFields.has(labelField)) {
         searchFields.add(labelField);

--- a/packages/core/src/admin-ui/system/getAdminMetaSchema.ts
+++ b/packages/core/src/admin-ui/system/getAdminMetaSchema.ts
@@ -111,7 +111,7 @@ export function getAdminMetaSchema({
                   if (!lists[rootVal.listKey].fields[rootVal.fieldPath].graphql.isEnabled.create) {
                     return 'hidden';
                   }
-                  const listConfig = config.lists[rootVal.listKey];
+                  const listConfig = config.models[rootVal.listKey];
                   const sessionFunction =
                     lists[rootVal.listKey].fields[rootVal.fieldPath].ui?.createView?.fieldMode ??
                     listConfig.ui?.createView?.defaultFieldMode;
@@ -149,7 +149,7 @@ export function getAdminMetaSchema({
                   if (!lists[rootVal.listKey].fields[rootVal.fieldPath].graphql.isEnabled.read) {
                     return 'hidden';
                   }
-                  const listConfig = config.lists[rootVal.listKey];
+                  const listConfig = config.models[rootVal.listKey];
                   const sessionFunction =
                     lists[rootVal.listKey].fields[rootVal.fieldPath].ui?.listView?.fieldMode ??
                     listConfig.ui?.listView?.defaultFieldMode;
@@ -193,7 +193,7 @@ export function getAdminMetaSchema({
                 ) {
                   return 'read';
                 }
-                const listConfig = config.lists[rootVal.listKey];
+                const listConfig = config.models[rootVal.listKey];
 
                 const sessionFunction =
                   lists[rootVal.listKey].fields[rootVal.fieldPath].ui?.itemView?.fieldMode ??
@@ -269,7 +269,7 @@ export function getAdminMetaSchema({
               'KeystoneAdminUIListMeta.hideCreate cannot be resolved during the build process'
             );
           }
-          const listConfig = config.lists[rootVal.key];
+          const listConfig = config.models[rootVal.key];
           return runMaybeFunction(listConfig.ui?.hideCreate, false, {
             session: context.session,
             context,
@@ -284,7 +284,7 @@ export function getAdminMetaSchema({
               'KeystoneAdminUIListMeta.hideDelete cannot be resolved during the build process'
             );
           }
-          const listConfig = config.lists[rootVal.key];
+          const listConfig = config.models[rootVal.key];
           return runMaybeFunction(listConfig.ui?.hideDelete, false, {
             session: context.session,
             context,
@@ -313,7 +313,7 @@ export function getAdminMetaSchema({
               'KeystoneAdminUIListMeta.isHidden cannot be resolved during the build process'
             );
           }
-          const listConfig = config.lists[rootVal.key];
+          const listConfig = config.models[rootVal.key];
           return runMaybeFunction(listConfig.ui?.isHidden, false, {
             session: context.session,
             context,

--- a/packages/core/src/fields/non-null-graphql.ts
+++ b/packages/core/src/fields/non-null-graphql.ts
@@ -42,13 +42,13 @@ export function assertReadIsNonNullAllowed<ModelTypeInfo extends BaseModelTypeIn
   if (config.graphql?.read?.isNonNull) {
     if (resolvedIsNullable) {
       throw new Error(
-        `The field at ${meta.listKey}.${meta.fieldKey} sets graphql.read.isNonNull: true but not validation.isRequired: true or db.isNullable: false.\n` +
+        `The field at ${meta.modelKey}.${meta.fieldKey} sets graphql.read.isNonNull: true but not validation.isRequired: true or db.isNullable: false.\n` +
           `Set validation.isRequired: true or db.isNullable: false or disable graphql.read.isNonNull`
       );
     }
     if (hasReadAccessControl(config.access)) {
       throw new Error(
-        `The field at ${meta.listKey}.${meta.fieldKey} sets graphql.read.isNonNull: true and has read access control, this is not allowed.\n` +
+        `The field at ${meta.modelKey}.${meta.fieldKey} sets graphql.read.isNonNull: true and has read access control, this is not allowed.\n` +
           'Either disable graphql.read.isNonNull or read access control.'
       );
     }
@@ -64,7 +64,7 @@ export function assertCreateIsNonNullAllowed<ModelTypeInfo extends BaseModelType
 ) {
   if (config.graphql?.create?.isNonNull && hasCreateAccessControl(config.access)) {
     throw new Error(
-      `The field at ${meta.listKey}.${meta.fieldKey} sets graphql.create.isNonNull: true and has create access control, this is not allowed.\n` +
+      `The field at ${meta.modelKey}.${meta.fieldKey} sets graphql.create.isNonNull: true and has create access control, this is not allowed.\n` +
         'Either disable graphql.create.isNonNull or create access control.'
     );
   }

--- a/packages/core/src/fields/non-null-graphql.ts
+++ b/packages/core/src/fields/non-null-graphql.ts
@@ -1,7 +1,7 @@
-import { BaseListTypeInfo, FieldAccessControl, FieldData } from '../types';
+import { BaseModelTypeInfo, FieldAccessControl, FieldData } from '../types';
 
-export function hasReadAccessControl<ListTypeInfo extends BaseListTypeInfo>(
-  access: FieldAccessControl<ListTypeInfo> | undefined
+export function hasReadAccessControl<ModelTypeInfo extends BaseModelTypeInfo>(
+  access: FieldAccessControl<ModelTypeInfo> | undefined
 ) {
   if (access === undefined) {
     return false;
@@ -9,8 +9,8 @@ export function hasReadAccessControl<ListTypeInfo extends BaseListTypeInfo>(
   return typeof access === 'function' || typeof access.read === 'function';
 }
 
-export function hasCreateAccessControl<ListTypeInfo extends BaseListTypeInfo>(
-  access: FieldAccessControl<ListTypeInfo> | undefined
+export function hasCreateAccessControl<ModelTypeInfo extends BaseModelTypeInfo>(
+  access: FieldAccessControl<ModelTypeInfo> | undefined
 ) {
   if (access === undefined) {
     return false;
@@ -31,10 +31,10 @@ export function getResolvedIsNullable(
   return true;
 }
 
-export function assertReadIsNonNullAllowed<ListTypeInfo extends BaseListTypeInfo>(
+export function assertReadIsNonNullAllowed<ModelTypeInfo extends BaseModelTypeInfo>(
   meta: FieldData,
   config: {
-    access?: FieldAccessControl<ListTypeInfo> | undefined;
+    access?: FieldAccessControl<ModelTypeInfo> | undefined;
     graphql?: { read?: { isNonNull?: boolean } };
   },
   resolvedIsNullable: boolean
@@ -55,10 +55,10 @@ export function assertReadIsNonNullAllowed<ListTypeInfo extends BaseListTypeInfo
   }
 }
 
-export function assertCreateIsNonNullAllowed<ListTypeInfo extends BaseListTypeInfo>(
+export function assertCreateIsNonNullAllowed<ModelTypeInfo extends BaseModelTypeInfo>(
   meta: FieldData,
   config: {
-    access?: FieldAccessControl<ListTypeInfo> | undefined;
+    access?: FieldAccessControl<ModelTypeInfo> | undefined;
     graphql?: { create?: { isNonNull?: boolean } };
   }
 ) {

--- a/packages/core/src/fields/types/bigInt/index.ts
+++ b/packages/core/src/fields/types/bigInt/index.ts
@@ -61,12 +61,12 @@ export const bigInt =
     if (hasAutoIncDefault) {
       if (meta.provider === 'sqlite' || meta.provider === 'mysql') {
         throw new Error(
-          `The bigInt field at ${meta.listKey}.${meta.fieldKey} specifies defaultValue: { kind: 'autoincrement' }, this is not supported on ${meta.provider}`
+          `The bigInt field at ${meta.modelKey}.${meta.fieldKey} specifies defaultValue: { kind: 'autoincrement' }, this is not supported on ${meta.provider}`
         );
       }
       if (isNullable !== false) {
         throw new Error(
-          `The bigInt field at ${meta.listKey}.${meta.fieldKey} specifies defaultValue: { kind: 'autoincrement' } but doesn't specify db.isNullable: false.\n` +
+          `The bigInt field at ${meta.modelKey}.${meta.fieldKey} specifies defaultValue: { kind: 'autoincrement' } but doesn't specify db.isNullable: false.\n` +
             `Having nullable autoincrements on Prisma currently incorrectly creates a non-nullable column so it is not allowed.\n` +
             `https://github.com/prisma/prisma/issues/8663`
         );
@@ -82,13 +82,13 @@ export const bigInt =
     for (const type of ['min', 'max'] as const) {
       if (validation[type] > MAX_INT || validation[type] < MIN_INT) {
         throw new Error(
-          `The bigInt field at ${meta.listKey}.${meta.fieldKey} specifies validation.${type}: ${validation[type]} which is outside of the range of a 64bit signed integer(${MIN_INT}n - ${MAX_INT}n) which is not allowed`
+          `The bigInt field at ${meta.modelKey}.${meta.fieldKey} specifies validation.${type}: ${validation[type]} which is outside of the range of a 64bit signed integer(${MIN_INT}n - ${MAX_INT}n) which is not allowed`
         );
       }
     }
     if (validation.min > validation.max) {
       throw new Error(
-        `The bigInt field at ${meta.listKey}.${meta.fieldKey} specifies a validation.max that is less than the validation.min, and therefore has no valid options`
+        `The bigInt field at ${meta.modelKey}.${meta.fieldKey} specifies a validation.max that is less than the validation.min, and therefore has no valid options`
       );
     }
 

--- a/packages/core/src/fields/types/bigInt/index.ts
+++ b/packages/core/src/fields/types/bigInt/index.ts
@@ -1,6 +1,6 @@
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -15,8 +15,8 @@ import {
 } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type BigIntFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type BigIntFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
     defaultValue?: bigint | { kind: 'autoincrement' };
     validation?: {
@@ -43,12 +43,12 @@ const MAX_INT = 9223372036854775807n;
 const MIN_INT = -9223372036854775808n;
 
 export const bigInt =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     defaultValue: _defaultValue,
     validation: _validation,
     ...config
-  }: BigIntFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: BigIntFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const defaultValue = _defaultValue ?? null;
     const hasAutoIncDefault =

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -1,6 +1,6 @@
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -16,8 +16,8 @@ import {
 import { resolveView } from '../../resolve-view';
 import { CalendarDayFieldMeta } from './views';
 
-export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type CalendarDayFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
     validation?: {
       isRequired?: boolean;
@@ -34,12 +34,12 @@ export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const calendarDay =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     validation,
     defaultValue,
     ...config
-  }: CalendarDayFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: CalendarDayFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if (typeof defaultValue === 'string') {
       try {

--- a/packages/core/src/fields/types/checkbox/index.ts
+++ b/packages/core/src/fields/types/checkbox/index.ts
@@ -1,6 +1,6 @@
 import { userInputError } from '../../../lib/core/graphql-errors';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   CommonFieldConfig,
   fieldType,
   FieldTypeFunc,
@@ -11,8 +11,8 @@ import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type CheckboxFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type CheckboxFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     defaultValue?: boolean;
     graphql?: {
       read?: { isNonNull?: boolean };
@@ -22,10 +22,10 @@ export type CheckboxFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const checkbox =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     defaultValue = false,
     ...config
-  }: CheckboxFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: CheckboxFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
       throw Error("isIndexed: 'unique' is not a supported option for field type checkbox");

--- a/packages/core/src/fields/types/decimal/index.ts
+++ b/packages/core/src/fields/types/decimal/index.ts
@@ -2,7 +2,7 @@ import { humanize } from '../../../lib/utils';
 import {
   fieldType,
   FieldTypeFunc,
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   CommonFieldConfig,
   orderDirectionEnum,
   Decimal,
@@ -17,8 +17,8 @@ import {
   getResolvedIsNullable,
 } from '../../non-null-graphql';
 
-export type DecimalFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type DecimalFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     validation?: {
       min?: string;
       max?: string;
@@ -50,14 +50,14 @@ function parseDecimalValueOption(meta: FieldData, value: string, name: string) {
 }
 
 export const decimal =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     precision = 18,
     scale = 4,
     validation,
     defaultValue,
     ...config
-  }: DecimalFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: DecimalFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if (meta.provider === 'sqlite') {
       throw new Error('The decimal field does not support sqlite');

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -2,16 +2,16 @@ import {
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   KeystoneContext,
   FileMetadata,
 } from '../../../types';
 import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
-export type FileFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
+export type FileFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> = {
   storage: string;
-} & CommonFieldConfig<ListTypeInfo>;
+} & CommonFieldConfig<ModelTypeInfo>;
 
 const FileFieldInput = graphql.inputObject({
   name: 'FileFieldInput',
@@ -49,9 +49,9 @@ async function inputResolver(
 }
 
 export const file =
-  <ListTypeInfo extends BaseListTypeInfo>(
-    config: FileFieldConfig<ListTypeInfo>
-  ): FieldTypeFunc<ListTypeInfo> =>
+  <ModelTypeInfo extends BaseModelTypeInfo>(
+    config: FileFieldConfig<ModelTypeInfo>
+  ): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const storage = meta.getStorage(config.storage);
 

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -57,7 +57,7 @@ export const file =
 
     if (!storage) {
       throw new Error(
-        `${meta.listKey}.${meta.fieldKey} has storage set to ${config.storage}, but no storage configuration was found for that key`
+        `${meta.modelKey}.${meta.fieldKey} has storage set to ${config.storage}, but no storage configuration was found for that key`
       );
     }
 

--- a/packages/core/src/fields/types/float/index.ts
+++ b/packages/core/src/fields/types/float/index.ts
@@ -52,7 +52,7 @@ export const float =
       (typeof defaultValue !== 'number' || !Number.isFinite(defaultValue))
     ) {
       throw new Error(
-        `The float field at ${meta.listKey}.${meta.fieldKey} specifies a default value of: ${defaultValue} but it must be a valid finite number`
+        `The float field at ${meta.modelKey}.${meta.fieldKey} specifies a default value of: ${defaultValue} but it must be a valid finite number`
       );
     }
 
@@ -61,7 +61,7 @@ export const float =
       (typeof validation.min !== 'number' || !Number.isFinite(validation.min))
     ) {
       throw new Error(
-        `The float field at ${meta.listKey}.${meta.fieldKey} specifies validation.min: ${validation.min} but it must be a valid finite number`
+        `The float field at ${meta.modelKey}.${meta.fieldKey} specifies validation.min: ${validation.min} but it must be a valid finite number`
       );
     }
 
@@ -70,7 +70,7 @@ export const float =
       (typeof validation.max !== 'number' || !Number.isFinite(validation.max))
     ) {
       throw new Error(
-        `The float field at ${meta.listKey}.${meta.fieldKey} specifies validation.max: ${validation.max} but it must be a valid finite number`
+        `The float field at ${meta.modelKey}.${meta.fieldKey} specifies validation.max: ${validation.max} but it must be a valid finite number`
       );
     }
 
@@ -80,7 +80,7 @@ export const float =
       validation.min > validation.max
     ) {
       throw new Error(
-        `The float field at ${meta.listKey}.${meta.fieldKey} specifies a validation.max that is less than the validation.min, and therefore has no valid options`
+        `The float field at ${meta.modelKey}.${meta.fieldKey} specifies a validation.max that is less than the validation.min, and therefore has no valid options`
       );
     }
 

--- a/packages/core/src/fields/types/float/index.ts
+++ b/packages/core/src/fields/types/float/index.ts
@@ -1,7 +1,7 @@
 // Float in GQL: A signed double-precision floating-point value.
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   FieldTypeFunc,
   CommonFieldConfig,
   fieldType,
@@ -16,8 +16,8 @@ import {
 } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type FloatFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type FloatFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     defaultValue?: number;
     isIndexed?: boolean | 'unique';
     validation?: {
@@ -40,12 +40,12 @@ export type FloatFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const float =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     validation,
     defaultValue,
     ...config
-  }: FloatFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: FloatFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if (
       defaultValue !== undefined &&

--- a/packages/core/src/fields/types/image/index.ts
+++ b/packages/core/src/fields/types/image/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -11,9 +11,9 @@ import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { SUPPORTED_IMAGE_EXTENSIONS } from './utils';
 
-export type ImageFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
+export type ImageFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> = {
   storage: string;
-} & CommonFieldConfig<ListTypeInfo>;
+} & CommonFieldConfig<ModelTypeInfo>;
 
 const ImageExtensionEnum = graphql.enum({
   name: 'ImageExtension',
@@ -65,9 +65,9 @@ function isValidImageExtension(extension: string): extension is ImageExtension {
 }
 
 export const image =
-  <ListTypeInfo extends BaseListTypeInfo>(
-    config: ImageFieldConfig<ListTypeInfo>
-  ): FieldTypeFunc<ListTypeInfo> =>
+  <ModelTypeInfo extends BaseModelTypeInfo>(
+    config: ImageFieldConfig<ModelTypeInfo>
+  ): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const storage = meta.getStorage(config.storage);
 

--- a/packages/core/src/fields/types/integer/index.ts
+++ b/packages/core/src/fields/types/integer/index.ts
@@ -1,6 +1,6 @@
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -15,8 +15,8 @@ import {
 } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type IntegerFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type IntegerFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
     defaultValue?: number | { kind: 'autoincrement' };
     validation?: {
@@ -43,12 +43,12 @@ const MAX_INT = 2147483647;
 const MIN_INT = -2147483648;
 
 export const integer =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     defaultValue: _defaultValue,
     validation,
     ...config
-  }: IntegerFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: IntegerFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const defaultValue = _defaultValue ?? null;
     const hasAutoIncDefault =

--- a/packages/core/src/fields/types/json/index.ts
+++ b/packages/core/src/fields/types/json/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   JSONValue,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -8,17 +8,17 @@ import {
 import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 
-export type JsonFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type JsonFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     defaultValue?: JSONValue;
     db?: { map?: string };
   };
 
 export const json =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     defaultValue = null,
     ...config
-  }: JsonFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: JsonFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
       throw Error("isIndexed: 'unique' is not a supported option for field type json");

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -1,19 +1,19 @@
 import inflection from 'inflection';
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
   FieldTypeFunc,
   CommonFieldConfig,
   FieldData,
   jsonFieldTypePolyfilledForSQLite,
+  BaseModelTypeInfo,
 } from '../../../types';
 import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 import { userInputError } from '../../../lib/core/graphql-errors';
 
-export type MultiselectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> &
+export type MultiselectFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> &
     (
       | {
           /**
@@ -51,11 +51,11 @@ const MAX_INT = 2147483647;
 const MIN_INT = -2147483648;
 
 export const multiselect =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     ui,
     defaultValue = [],
     ...config
-  }: MultiselectFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  }: MultiselectFieldConfig<ModelTypeInfo>): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
       throw Error("isIndexed: 'unique' is not a supported option for field type multiselect");
@@ -157,7 +157,7 @@ export const multiselect =
   };
 
 function configToOptionsAndGraphQLType(
-  config: MultiselectFieldConfig<BaseListTypeInfo>,
+  config: MultiselectFieldConfig<BaseModelTypeInfo>,
   meta: FieldData
 ) {
   if (config.type === 'integer') {

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -100,7 +100,7 @@ export const multiselect =
     const possibleValues = new Set(transformedConfig.options.map(x => x.value));
     if (possibleValues.size !== transformedConfig.options.length) {
       throw new Error(
-        `The multiselect field at ${meta.listKey}.${meta.fieldKey} has duplicate options, this is not allowed`
+        `The multiselect field at ${meta.modelKey}.${meta.fieldKey} has duplicate options, this is not allowed`
       );
     }
 
@@ -167,7 +167,7 @@ function configToOptionsAndGraphQLType(
       )
     ) {
       throw new Error(
-        `The multiselect field at ${meta.listKey}.${meta.fieldKey} specifies integer values that are outside the range of a 32 bit signed integer`
+        `The multiselect field at ${meta.modelKey}.${meta.fieldKey} specifies integer values that are outside the range of a 32 bit signed integer`
       );
     }
     return {
@@ -188,7 +188,7 @@ function configToOptionsAndGraphQLType(
   });
 
   if (config.type === 'enum') {
-    const enumName = `${meta.listKey}${inflection.classify(meta.fieldKey)}Type`;
+    const enumName = `${meta.modelKey}${inflection.classify(meta.fieldKey)}Type`;
     const graphqlType = graphql.enum({
       name: enumName,
       values: graphql.enumValues(options.map(x => x.value)),

--- a/packages/core/src/fields/types/password/index.ts
+++ b/packages/core/src/fields/types/password/index.ts
@@ -85,20 +85,20 @@ export const password =
       const val = validation.length[type];
       if (val !== null && (!Number.isInteger(val) || val < 1)) {
         throw new Error(
-          `The password field at ${meta.listKey}.${meta.fieldKey} specifies validation.length.${type}: ${val} but it must be a positive integer >= 1`
+          `The password field at ${meta.modelKey}.${meta.fieldKey} specifies validation.length.${type}: ${val} but it must be a positive integer >= 1`
         );
       }
     }
 
     if (validation.length.max !== null && validation.length.min > validation.length.max) {
       throw new Error(
-        `The password field at ${meta.listKey}.${meta.fieldKey} specifies a validation.length.max that is less than the validation.length.min, and therefore has no valid options`
+        `The password field at ${meta.modelKey}.${meta.fieldKey} specifies a validation.length.max that is less than the validation.length.min, and therefore has no valid options`
       );
     }
 
     if (workFactor < 6 || workFactor > 31 || !Number.isInteger(workFactor)) {
       throw new Error(
-        `The password field at ${meta.listKey}.${meta.fieldKey} specifies workFactor: ${workFactor} but it must be an integer between 6 and 31`
+        `The password field at ${meta.modelKey}.${meta.fieldKey} specifies workFactor: ${workFactor} but it must be an integer between 6 and 31`
       );
     }
 

--- a/packages/core/src/fields/types/password/index.ts
+++ b/packages/core/src/fields/types/password/index.ts
@@ -3,14 +3,14 @@ import bcryptjs from 'bcryptjs';
 import dumbPasswords from 'dumb-passwords';
 import { userInputError } from '../../../lib/core/graphql-errors';
 import { humanize } from '../../../lib/utils';
-import { BaseListTypeInfo, fieldType, FieldTypeFunc, CommonFieldConfig } from '../../../types';
+import { BaseModelTypeInfo, fieldType, FieldTypeFunc, CommonFieldConfig } from '../../../types';
 import { graphql } from '../../..';
 import { resolveView } from '../../resolve-view';
 import { getResolvedIsNullable } from '../../non-null-graphql';
 import { PasswordFieldMeta } from './views';
 
-export type PasswordFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type PasswordFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     /**
      * @default 10
      */
@@ -49,12 +49,12 @@ const PasswordFilter = graphql.inputObject({
 const bcryptHashRegex = /^\$2[aby]?\$\d{1,2}\$[.\/A-Za-z0-9]{53}$/;
 
 export const password =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     bcrypt = bcryptjs,
     workFactor = 10,
     validation: _validation,
     ...config
-  }: PasswordFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: PasswordFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
       throw Error("isIndexed: 'unique' is not a supported option for field type password");

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -92,7 +92,7 @@ export const relationship =
       ): Parameters<typeof import('./views').controller>[0]['fieldMeta'] => {
         if (!meta.lists[foreignListKey]) {
           throw new Error(
-            `The ref [${ref}] on relationship [${meta.listKey}.${meta.fieldKey}] is invalid`
+            `The ref [${ref}] on relationship [${meta.modelKey}.${meta.fieldKey}] is invalid`
           );
         }
         if (config.ui?.displayMode === 'cards') {
@@ -100,7 +100,7 @@ export const relationship =
           // in newer versions of keystone, it will be there and it will not be there for older versions of keystone.
           // this is so that relationship fields doesn't break in confusing ways
           // if people are using a slightly older version of keystone
-          const currentField = adminMetaRoot.listsByKey[meta.listKey].fields.find(
+          const currentField = adminMetaRoot.listsByKey[meta.modelKey].fields.find(
             x => x.path === meta.fieldKey
           );
           if (currentField) {
@@ -115,7 +115,7 @@ export const relationship =
               for (const foreignField of foreignFields) {
                 if (!allForeignFields.has(foreignField)) {
                   throw new Error(
-                    `The ${configOption} option on the relationship field at ${meta.listKey}.${meta.fieldKey} includes the "${foreignField}" field but that field does not exist on the "${foreignListKey}" list`
+                    `The ${configOption} option on the relationship field at ${meta.modelKey}.${meta.fieldKey} includes the "${foreignField}" field but that field does not exist on the "${foreignListKey}" list`
                   );
                 }
               }
@@ -149,7 +149,7 @@ export const relationship =
     };
     if (!meta.lists[foreignListKey]) {
       throw new Error(
-        `Unable to resolve related list '${foreignListKey}' from ${meta.listKey}.${meta.fieldKey}`
+        `Unable to resolve related list '${foreignListKey}' from ${meta.modelKey}.${meta.fieldKey}`
       );
     }
     const listTypes = meta.lists[foreignListKey].types;

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   FieldTypeFunc,
   CommonFieldConfig,
   fieldType,
@@ -66,8 +66,8 @@ type ManyDbConfig = {
   };
 };
 
-export type RelationshipFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type RelationshipFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     many?: boolean;
     ref: string;
     ui?: {
@@ -77,10 +77,10 @@ export type RelationshipFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
     (SelectDisplayConfig | CardsDisplayConfig | CountDisplayConfig);
 
 export const relationship =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     ref,
     ...config
-  }: RelationshipFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  }: RelationshipFieldConfig<ModelTypeInfo>): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const { many = false } = config;
     const [foreignListKey, foreignFieldKey] = ref.split('.');

--- a/packages/core/src/fields/types/relationship/tests/implementation.test.ts
+++ b/packages/core/src/fields/types/relationship/tests/implementation.test.ts
@@ -11,7 +11,7 @@ const getSchema = (field: any) => {
     initConfig(
       config({
         db: { url: 'file:./thing.db', provider: 'sqlite' },
-        lists: {
+        models: {
           Zip: list({ fields: { thing: text() } }),
           Test: list({
             fields: {

--- a/packages/core/src/fields/types/select/index.ts
+++ b/packages/core/src/fields/types/select/index.ts
@@ -1,7 +1,7 @@
 import inflection from 'inflection';
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -16,8 +16,8 @@ import {
 } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type SelectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> &
+export type SelectFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> &
     (
       | {
           /**
@@ -67,13 +67,13 @@ const MAX_INT = 2147483647;
 const MIN_INT = -2147483648;
 
 export const select =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     ui: { displayMode = 'select', ...ui } = {},
     defaultValue,
     validation,
     ...config
-  }: SelectFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  }: SelectFieldConfig<ModelTypeInfo>): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const fieldLabel = config.label ?? humanize(meta.fieldKey);
     const resolvedIsNullable = getResolvedIsNullable(validation, config.db);
@@ -82,7 +82,7 @@ export const select =
     assertCreateIsNonNullAllowed(meta, config);
     const commonConfig = (
       options: readonly { value: string | number; label: string }[]
-    ): CommonFieldConfig<ListTypeInfo> & {
+    ): CommonFieldConfig<ModelTypeInfo> & {
       views: string;
       getAdminMeta: () => import('./views').AdminSelectFieldMeta;
     } => {

--- a/packages/core/src/fields/types/select/index.ts
+++ b/packages/core/src/fields/types/select/index.ts
@@ -89,7 +89,7 @@ export const select =
       const values = new Set(options.map(x => x.value));
       if (values.size !== options.length) {
         throw new Error(
-          `The select field at ${meta.listKey}.${meta.fieldKey} has duplicate options, this is not allowed`
+          `The select field at ${meta.modelKey}.${meta.fieldKey} has duplicate options, this is not allowed`
         );
       }
       return {
@@ -157,7 +157,7 @@ export const select =
         )
       ) {
         throw new Error(
-          `The select field at ${meta.listKey}.${meta.fieldKey} specifies integer values that are outside the range of a 32 bit signed integer`
+          `The select field at ${meta.modelKey}.${meta.fieldKey} specifies integer values that are outside the range of a 32 bit signed integer`
         );
       }
       return fieldType({
@@ -191,7 +191,7 @@ export const select =
     });
 
     if (config.type === 'enum') {
-      const enumName = `${meta.listKey}${inflection.classify(meta.fieldKey)}Type`;
+      const enumName = `${meta.modelKey}${inflection.classify(meta.fieldKey)}Type`;
       const graphQLType = graphql.enum({
         name: enumName,
         values: graphql.enumValues(options.map(x => x.value)),

--- a/packages/core/src/fields/types/text/index.ts
+++ b/packages/core/src/fields/types/text/index.ts
@@ -66,12 +66,12 @@ export const text =
       const val = _validation?.length?.[type];
       if (val !== undefined && (!Number.isInteger(val) || val < 0)) {
         throw new Error(
-          `The text field at ${meta.listKey}.${meta.fieldKey} specifies validation.length.${type}: ${val} but it must be a positive integer`
+          `The text field at ${meta.modelKey}.${meta.fieldKey} specifies validation.length.${type}: ${val} but it must be a positive integer`
         );
       }
       if (_validation?.isRequired && val !== undefined && val === 0) {
         throw new Error(
-          `The text field at ${meta.listKey}.${meta.fieldKey} specifies validation.isRequired: true and validation.length.${type}: 0, this is not allowed because validation.isRequired implies at least a min length of 1`
+          `The text field at ${meta.modelKey}.${meta.fieldKey} specifies validation.isRequired: true and validation.length.${type}: 0, this is not allowed because validation.isRequired implies at least a min length of 1`
         );
       }
     }
@@ -82,7 +82,7 @@ export const text =
       _validation?.length?.min > _validation?.length?.max
     ) {
       throw new Error(
-        `The text field at ${meta.listKey}.${meta.fieldKey} specifies a validation.length.max that is less than the validation.length.min, and therefore has no valid options`
+        `The text field at ${meta.modelKey}.${meta.fieldKey} specifies a validation.length.max that is less than the validation.length.min, and therefore has no valid options`
       );
     }
 

--- a/packages/core/src/fields/types/text/index.ts
+++ b/packages/core/src/fields/types/text/index.ts
@@ -1,6 +1,6 @@
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   CommonFieldConfig,
   fieldType,
   orderDirectionEnum,
@@ -11,8 +11,8 @@ import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
 import { resolveView } from '../../resolve-view';
 
-export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type TextFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: true | 'unique';
     ui?: {
       displayMode?: 'input' | 'textarea';
@@ -55,12 +55,12 @@ export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const text =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     defaultValue: _defaultValue,
     validation: _validation,
     ...config
-  }: TextFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: TextFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     for (const type of ['min', 'max'] as const) {
       const val = _validation?.length?.[type];

--- a/packages/core/src/fields/types/timestamp/index.ts
+++ b/packages/core/src/fields/types/timestamp/index.ts
@@ -1,6 +1,6 @@
 import { humanize } from '../../../lib/utils';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   fieldType,
   FieldTypeFunc,
   CommonFieldConfig,
@@ -16,8 +16,8 @@ import {
 import { resolveView } from '../../resolve-view';
 import { TimestampFieldMeta } from './views';
 
-export type TimestampFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type TimestampFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     isIndexed?: boolean | 'unique';
     validation?: {
       isRequired?: boolean;
@@ -35,12 +35,12 @@ export type TimestampFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const timestamp =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     isIndexed,
     validation,
     defaultValue,
     ...config
-  }: TimestampFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: TimestampFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     if (typeof defaultValue === 'string') {
       try {

--- a/packages/core/src/fields/types/timestamp/index.ts
+++ b/packages/core/src/fields/types/timestamp/index.ts
@@ -47,7 +47,7 @@ export const timestamp =
         graphql.DateTime.graphQLType.parseValue(defaultValue);
       } catch (err) {
         throw new Error(
-          `The timestamp field at ${meta.listKey}.${
+          `The timestamp field at ${meta.modelKey}.${
             meta.fieldKey
           } specifies defaultValue: ${defaultValue} but values must be provided as a full ISO8601 date-time string such as ${new Date().toISOString()}`
         );

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -63,12 +63,12 @@ export const virtual =
       (config.ui?.itemView?.fieldMode !== 'hidden' || config.ui?.listView?.fieldMode !== 'hidden')
     ) {
       throw new Error(
-        `The virtual field at ${meta.listKey}.${meta.fieldKey} requires a selection for the Admin UI but ui.query is unspecified and ui.listView.fieldMode and ui.itemView.fieldMode are not both set to 'hidden'.\n` +
+        `The virtual field at ${meta.modelKey}.${meta.fieldKey} requires a selection for the Admin UI but ui.query is unspecified and ui.listView.fieldMode and ui.itemView.fieldMode are not both set to 'hidden'.\n` +
           `Either set ui.query with what the Admin UI should fetch or hide the field from the Admin UI by setting ui.listView.fieldMode and ui.itemView.fieldMode to 'hidden'.\n` +
           `When setting ui.query, it is interpolated into a GraphQL query like this:\n` +
           `query {\n` +
           `  ${
-            getGqlNames({ listKey: meta.listKey, pluralGraphQLName: '' }).itemQueryName
+            getGqlNames({ listKey: meta.modelKey, pluralGraphQLName: '' }).itemQueryName
           }(where: { id: "..." }) {\n` +
           `    ${meta.fieldKey}\${ui.query}\n` +
           `  }\n` +

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -1,6 +1,6 @@
 import { getNamedType, isLeafType } from 'graphql';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   BaseItem,
   CommonFieldConfig,
   FieldTypeFunc,
@@ -18,13 +18,13 @@ type VirtualFieldGraphQLField<Item extends BaseItem> = graphql.Field<
   string
 >;
 
-export type VirtualFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type VirtualFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     field:
-      | VirtualFieldGraphQLField<ListTypeInfo['item']>
+      | VirtualFieldGraphQLField<ModelTypeInfo['item']>
       | ((
-          lists: Record<string, ListGraphQLTypes>
-        ) => VirtualFieldGraphQLField<ListTypeInfo['item']>);
+          models: Record<string, ListGraphQLTypes>
+        ) => VirtualFieldGraphQLField<ModelTypeInfo['item']>);
     unreferencedConcreteInterfaceImplementations?: readonly graphql.ObjectType<any>[];
     ui?: {
       /**
@@ -45,10 +45,10 @@ export type VirtualFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   };
 
 export const virtual =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     field,
     ...config
-  }: VirtualFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  }: VirtualFieldConfig<ModelTypeInfo>): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const usableField = typeof field === 'function' ? field(meta.lists) : field;
     const namedType = getNamedType(usableField.type.graphQLType);

--- a/packages/core/src/lib/config/applyIdFieldDefaults.ts
+++ b/packages/core/src/lib/config/applyIdFieldDefaults.ts
@@ -2,8 +2,8 @@ import type { KeystoneConfig } from '../../types';
 import { idFieldType } from '../id-field';
 
 /* Validate lists config and default the id field */
-export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
-  const lists: KeystoneConfig['lists'] = {};
+export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['models'] {
+  const lists: KeystoneConfig['models'] = {};
   const defaultIdField = config.db.idField ?? { kind: 'cuid' };
   if (
     defaultIdField.kind === 'autoincrement' &&
@@ -14,8 +14,8 @@ export function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['li
       'BigInt autoincrements are not supported on SQLite but they are configured as the global id field type at db.idField'
     );
   }
-  Object.keys(config.lists).forEach(key => {
-    const listConfig = config.lists[key];
+  Object.keys(config.models).forEach(key => {
+    const listConfig = config.models[key];
     if (listConfig.fields.id) {
       throw new Error(
         `A field with the \`id\` path is defined in the fields object on the ${JSON.stringify(

--- a/packages/core/src/lib/config/initConfig.ts
+++ b/packages/core/src/lib/config/initConfig.ts
@@ -14,5 +14,5 @@ export function initConfig(config: KeystoneConfig) {
     );
   }
 
-  return { ...config, lists: applyIdFieldDefaults(config) };
+  return { ...config, models: applyIdFieldDefaults(config) };
 }

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -148,7 +148,7 @@ function getListsWithInitialisedFields(
 
       const f = fieldFunc({
         fieldKey,
-        listKey,
+        modelKey: listKey,
         lists: listGraphqlTypes,
         provider,
         getStorage: storage => configStorage?.[storage],

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -79,7 +79,7 @@ function throwIfNotAFilter(x: unknown, listKey: string, fieldKey: string) {
   );
 }
 
-function getIsEnabled(listsConfig: KeystoneConfig['lists']) {
+function getIsEnabled(listsConfig: KeystoneConfig['models']) {
   const isEnabled: Record<string, IsEnabled> = {};
 
   for (const [listKey, listConfig] of Object.entries(listsConfig)) {
@@ -131,7 +131,7 @@ function getIsEnabled(listsConfig: KeystoneConfig['lists']) {
 type PartiallyInitialisedList = Omit<InitialisedList, 'lists' | 'resolvedDbFields'>;
 
 function getListsWithInitialisedFields(
-  { storage: configStorage, lists: listsConfig, db: { provider } }: KeystoneConfig,
+  { storage: configStorage, models: listsConfig, db: { provider } }: KeystoneConfig,
   listGraphqlTypes: Record<string, ListGraphQLTypes>,
   intermediateLists: Record<string, { graphql: { isEnabled: IsEnabled } }>
 ) {
@@ -212,7 +212,7 @@ function getListsWithInitialisedFields(
 }
 
 function getListGraphqlTypes(
-  listsConfig: KeystoneConfig['lists'],
+  listsConfig: KeystoneConfig['models'],
   lists: Record<string, InitialisedList>,
   intermediateLists: Record<string, { graphql: { isEnabled: IsEnabled } }>
 ): Record<string, ListGraphQLTypes> {
@@ -454,7 +454,7 @@ function getListGraphqlTypes(
  * 6.
  */
 export function initialiseLists(config: KeystoneConfig): Record<string, InitialisedList> {
-  const listsConfig = config.lists;
+  const listsConfig = config.models;
 
   let intermediateLists;
   intermediateLists = Object.fromEntries(

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -122,7 +122,7 @@ export async function promiseAllRejectWithAllErrors<T extends unknown[]>(
 
 export function getNamesFromList(
   listKey: string,
-  { graphql, ui }: KeystoneConfig['lists'][string]
+  { graphql, ui }: KeystoneConfig['models'][string]
 ) {
   const computedSingular = humanize(listKey);
   const computedPlural = pluralize.plural(computedSingular);

--- a/packages/core/src/lib/createGraphQLSchema.ts
+++ b/packages/core/src/lib/createGraphQLSchema.ts
@@ -23,7 +23,7 @@ export function createGraphQLSchema(
           }),
         }
       : {},
-    query: getAdminMetaSchema({ adminMeta, config, lists }),
+    ...getAdminMetaSchema({ adminMeta, config, lists }),
   });
 
   // Merge in the user defined graphQL API

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -26,8 +26,8 @@ function getSudoGraphQLSchema(config: KeystoneConfig) {
       ...config.ui,
       isAccessAllowed: () => true,
     },
-    lists: Object.fromEntries(
-      Object.entries(config.lists).map(([listKey, list]) => {
+    models: Object.fromEntries(
+      Object.entries(config.models).map(([listKey, list]) => {
         return [
           listKey,
           {

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -92,12 +92,12 @@ export function printGeneratedTypes(
   const printedTypes = printInputTypesFromSchema(graphQLSchema, scalars);
 
   let allListsStr = '';
-  let listsNamespaceStr = '\nexport declare namespace Lists {';
+  let listsNamespaceStr = '\nexport declare namespace Models {';
 
   for (const [listKey, list] of Object.entries(lists)) {
     const gqlNames = getGqlNames(list);
 
-    const listTypeInfoName = `Lists.${listKey}.TypeInfo`;
+    const listTypeInfoName = `Models.${listKey}.TypeInfo`;
 
     allListsStr += `\n  readonly ${listKey}: ${listTypeInfoName};`;
     listsNamespaceStr += `
@@ -141,7 +141,7 @@ ${
 }
 type __TypeInfo = TypeInfo;
 
-export type Lists = {
+export type Models = {
   [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo['lists'][Key], any>
 } & Record<string, import('@keystone-6/core').ListConfig<any, any>>;
 `;

--- a/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -107,8 +107,8 @@ export type KeystoneAdminUISortDirection =
   | "DESC";
 
 
-export declare namespace Lists {
-  export type Todo = import('@keystone-6/core').ListConfig<Lists.Todo.TypeInfo, any>;
+export declare namespace Models {
+  export type Todo = import('@keystone-6/core').ListConfig<Models.Todo.TypeInfo, any>;
   namespace Todo {
     export type Item = import('.prisma/client').Todo;
     export type TypeInfo = {
@@ -134,14 +134,14 @@ export type Context = import('@keystone-6/core/types').KeystoneContext<TypeInfo>
 
 export type TypeInfo = {
   lists: {
-  readonly Todo: Lists.Todo.TypeInfo;
+  readonly Todo: Models.Todo.TypeInfo;
   };
   prisma: import('.prisma/client').PrismaClient;
 };
 
 type __TypeInfo = TypeInfo;
 
-export type Lists = {
+export type Models = {
   [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo['lists'][Key], any>
 } & Record<string, import('@keystone-6/core').ListConfig<any, any>>;
 

--- a/packages/core/src/scripts/tests/artifacts.test.ts
+++ b/packages/core/src/scripts/tests/artifacts.test.ts
@@ -14,7 +14,7 @@ const basicKeystoneConfig = {
   kind: 'config' as const,
   config: config({
     db: { provider: 'sqlite', url: 'file:./app.db' },
-    lists: {
+    models: {
       Todo: list({
         fields: {
           title: text(),

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -13,7 +13,7 @@ import {
   testdir,
 } from './utils';
 
-const basicLists = {
+const basicModels = {
   Todo: list({
     fields: {
       title: text(),
@@ -23,12 +23,12 @@ const basicLists = {
 
 const dbUrl = 'file:./app.db';
 
-const basicKeystoneConfig = (useMigrations: boolean, lists: ListSchemaConfig = basicLists) => ({
+const basicKeystoneConfig = (useMigrations: boolean, models: ListSchemaConfig = basicModels) => ({
   kind: 'config' as const,
   config: config({
     db: { provider: 'sqlite', url: dbUrl, useMigrations },
     ui: { isDisabled: true },
-    lists,
+    models,
   }),
 });
 

--- a/packages/core/src/scripts/tests/utils.tsx
+++ b/packages/core/src/scripts/tests/utils.tsx
@@ -26,7 +26,7 @@ export const basicKeystoneConfig = js`
 
                                      export default config({
                                        db: { provider: "sqlite", url: "file:./app.db" },
-                                       lists: {
+                                       models: {
                                          Todo: list({
                                            fields: {
                                              title: text(),

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -86,7 +86,7 @@ export type StorageConfig = (
   FileOrImage;
 
 export type KeystoneConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneTypeInfo> = {
-  lists: ListSchemaConfig;
+  models: ListSchemaConfig;
   db: DatabaseConfig<TypeInfo>;
   ui?: AdminUIConfig<TypeInfo>;
   server?: ServerConfig<TypeInfo>;

--- a/packages/core/src/types/next-fields.ts
+++ b/packages/core/src/types/next-fields.ts
@@ -15,7 +15,7 @@ export type FieldData = {
   lists: Record<string, ListGraphQLTypes>;
   provider: DatabaseProvider;
   getStorage: (storage: string) => StorageConfig | undefined;
-  listKey: string;
+  modelKey: string;
   fieldKey: string;
 };
 

--- a/packages/core/src/types/next-fields.ts
+++ b/packages/core/src/types/next-fields.ts
@@ -1,6 +1,6 @@
 import Decimal from 'decimal.js';
 import { graphql } from '..';
-import { BaseListTypeInfo } from './type-info';
+import { BaseModelTypeInfo } from './type-info';
 import { CommonFieldConfig } from './config';
 import { DatabaseProvider } from './core';
 import { AdminMetaRootVal, JSONValue, KeystoneContext, MaybePromise, StorageConfig } from '.';
@@ -19,7 +19,7 @@ export type FieldData = {
   fieldKey: string;
 };
 
-export type FieldTypeFunc<ListTypeInfo extends BaseListTypeInfo> = (
+export type FieldTypeFunc<ModelTypeInfo extends BaseModelTypeInfo> = (
   data: FieldData
 ) => NextFieldType<
   DBField,
@@ -28,7 +28,7 @@ export type FieldTypeFunc<ListTypeInfo extends BaseListTypeInfo> = (
   graphql.Arg<graphql.NullableInputType, false>,
   graphql.Arg<graphql.NullableInputType, false>,
   graphql.Arg<graphql.NullableInputType, false>,
-  ListTypeInfo
+  ModelTypeInfo
 >;
 
 export type NextFieldType<
@@ -49,7 +49,7 @@ export type NextFieldType<
     graphql.NullableInputType,
     false
   >,
-  ListTypeInfo extends BaseListTypeInfo = BaseListTypeInfo
+  ModelTypeInfo extends BaseModelTypeInfo = BaseModelTypeInfo
 > = {
   dbField: TDBField;
 } & FieldTypeWithoutDBField<
@@ -59,7 +59,7 @@ export type NextFieldType<
   UniqueWhereArg,
   OrderByArg,
   FilterArg,
-  ListTypeInfo
+  ModelTypeInfo
 >;
 
 type ScalarPrismaTypes = {
@@ -375,7 +375,7 @@ export type FieldTypeWithoutDBField<
     graphql.NullableInputType,
     false
   >,
-  ListTypeInfo extends BaseListTypeInfo = BaseListTypeInfo
+  ModelTypeInfo extends BaseModelTypeInfo = BaseModelTypeInfo
 > = {
   input?: {
     uniqueWhere?: UniqueWhereFieldInputArg<DBFieldUniqueWhere<TDBField>, UniqueWhereArg>;
@@ -389,7 +389,7 @@ export type FieldTypeWithoutDBField<
   extraOutputFields?: Record<string, FieldTypeOutputField<TDBField>>;
   getAdminMeta?: (adminMeta: AdminMetaRootVal) => JSONValue;
   unreferencedConcreteInterfaceImplementations?: readonly graphql.ObjectType<any>[];
-} & CommonFieldConfig<ListTypeInfo>;
+} & CommonFieldConfig<ModelTypeInfo>;
 
 type AnyInputObj = graphql.InputObjectType<Record<string, graphql.Arg<graphql.InputType, any>>>;
 
@@ -452,7 +452,7 @@ export type FindManyArgs = {
 export type FindManyArgsValue = graphql.InferValueFromArgs<FindManyArgs>;
 
 // fieldType(dbField)(fieldInfo) => { ...fieldInfo, dbField };
-export function fieldType<TDBField extends DBField, ListTypeInfo extends BaseListTypeInfo>(
+export function fieldType<TDBField extends DBField, ModelTypeInfo extends BaseModelTypeInfo>(
   dbField: TDBField
 ) {
   return function <
@@ -477,7 +477,7 @@ export function fieldType<TDBField extends DBField, ListTypeInfo extends BaseLis
     UniqueWhereArg,
     OrderByArg,
     FilterArg,
-    ListTypeInfo
+    ModelTypeInfo
   > {
     return { ...graphQLInfo, dbField };
   };

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -24,6 +24,8 @@ export type BaseListTypeInfo = {
   all: BaseKeystoneTypeInfo;
 };
 
+export type BaseModelTypeInfo = BaseListTypeInfo;
+
 export type KeystoneContextFromListTypeInfo<ListTypeInfo extends BaseListTypeInfo> =
   KeystoneContext<ListTypeInfo['all']>;
 

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { ApolloError } from 'apollo-server-errors';
 import {
-  BaseListTypeInfo,
+  BaseModelTypeInfo,
   CommonFieldConfig,
   FieldData,
   FieldTypeFunc,
@@ -61,8 +61,8 @@ type FormattingConfig = {
   softBreaks?: true;
 };
 
-export type DocumentFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
+export type DocumentFieldConfig<ModelTypeInfo extends BaseModelTypeInfo> =
+  CommonFieldConfig<ModelTypeInfo> & {
     relationships?: RelationshipsConfig;
     componentBlocks?: Record<string, ComponentBlock>;
     formatting?: true | FormattingConfig;
@@ -75,7 +75,7 @@ export type DocumentFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
 const views = path.join(path.dirname(__dirname), 'views');
 
 export const document =
-  <ListTypeInfo extends BaseListTypeInfo>({
+  <ModelTypeInfo extends BaseModelTypeInfo>({
     componentBlocks = {},
     dividers,
     formatting,
@@ -83,7 +83,7 @@ export const document =
     relationships: configRelationships,
     links,
     ...config
-  }: DocumentFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  }: DocumentFieldConfig<ModelTypeInfo> = {}): FieldTypeFunc<ModelTypeInfo> =>
   meta => {
     const documentFeatures = normaliseDocumentFeatures({
       dividers,
@@ -181,7 +181,7 @@ export const document =
   };
 
 function normaliseRelationships(
-  configRelationships: DocumentFieldConfig<BaseListTypeInfo>['relationships'],
+  configRelationships: DocumentFieldConfig<BaseModelTypeInfo>['relationships'],
   meta: FieldData
 ) {
   const relationships: Relationships = {};
@@ -201,7 +201,7 @@ function normaliseRelationships(
 
 function normaliseDocumentFeatures(
   config: Pick<
-    DocumentFieldConfig<BaseListTypeInfo>,
+    DocumentFieldConfig<BaseModelTypeInfo>,
     'formatting' | 'dividers' | 'layouts' | 'links'
   >
 ) {

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -112,7 +112,7 @@ export const document =
         assertValidComponentSchema({ kind: 'object', fields: block.schema }, lists);
       } catch (err) {
         throw new Error(
-          `Component block ${name} in ${meta.listKey}.${meta.fieldKey}: ${(err as any).message}`
+          `Component block ${name} in ${meta.modelKey}.${meta.fieldKey}: ${(err as any).message}`
         );
       }
     }
@@ -135,7 +135,7 @@ export const document =
         },
         output: graphql.field({
           type: graphql.object<{ document: JSONValue }>()({
-            name: `${meta.listKey}_${meta.fieldKey}_Document`,
+            name: `${meta.modelKey}_${meta.fieldKey}_Document`,
             fields: {
               document: graphql.field({
                 args: {
@@ -190,7 +190,7 @@ function normaliseRelationships(
       const relationship = configRelationships[key];
       if (meta.lists[relationship.listKey] === undefined) {
         throw new Error(
-          `An inline relationship ${relationship.label} (${key}) in the field at ${meta.listKey}.${meta.fieldKey} has listKey set to "${relationship.listKey}" but no list named "${relationship.listKey}" exists.`
+          `An inline relationship ${relationship.label} (${key}) in the field at ${meta.modelKey}.${meta.fieldKey} has listKey set to "${relationship.listKey}" but no list named "${relationship.listKey}" exists.`
         );
       }
       relationships[key] = { ...relationship, selection: relationship.selection ?? null };

--- a/tests/api-tests/access-control/filter-coercion-and-validation.test.ts
+++ b/tests/api-tests/access-control/filter-coercion-and-validation.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectExtensionError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       BadAccess: list({
         fields: { name: text() },
         access: {

--- a/tests/api-tests/access-control/mutations-field.test.ts
+++ b/tests/api-tests/access-control/mutations-field.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectAccessDenied, expectAccessReturnError } from '../u
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       // Imperative -> Static access control
       User: list({
         fields: {

--- a/tests/api-tests/access-control/mutations-list-filter.test.ts
+++ b/tests/api-tests/access-control/mutations-list-filter.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectAccessDenied } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       // Filter access control
       User: list({
         fields: { name: text() },

--- a/tests/api-tests/access-control/mutations-list-item.test.ts
+++ b/tests/api-tests/access-control/mutations-list-item.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectAccessDenied, expectAccessReturnError } from '../u
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       // Item access control
       User: list({
         fields: { name: text() },

--- a/tests/api-tests/access-control/mutations-list-operation.test.ts
+++ b/tests/api-tests/access-control/mutations-list-operation.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectAccessReturnError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       BadAccess: list({
         fields: { name: text() },
         access: {

--- a/tests/api-tests/access-control/schema-utils.ts
+++ b/tests/api-tests/access-control/schema-utils.ts
@@ -100,10 +100,10 @@ const createRelatedFields = (config: ListConfig) => ({
   [`${getListPrefix(config)}many`]: relationship({ ref: getListName(config), many: true }),
 });
 
-const lists: ListSchemaConfig = {};
+const models: ListSchemaConfig = {};
 
 listConfigVariables.forEach(config => {
-  lists[getListName(config)] = list({
+  models[getListName(config)] = list({
     fields: Object.assign(
       { name: text() },
       ...fieldMatrix.map(variation => createFieldStatic(variation))
@@ -114,12 +114,12 @@ listConfigVariables.forEach(config => {
   });
 });
 
-lists.RelatedToAll = list({
+models.RelatedToAll = list({
   fields: Object.assign({}, ...listConfigVariables.map(config => createRelatedFields(config))),
 });
 
 const config = apiTestConfig({
-  lists,
+  models,
   session: statelessSessions({ secret: COOKIE_SECRET }),
   ui: {
     isAccessAllowed: () => true,

--- a/tests/api-tests/access-control/utils.ts
+++ b/tests/api-tests/access-control/utils.ts
@@ -103,7 +103,7 @@ const createFieldImperative = (fieldAccess: BooleanAccess) => ({
   }),
 });
 
-const lists: ListSchemaConfig = {
+const models: ListSchemaConfig = {
   User: list({
     fields: {
       name: text(),
@@ -116,7 +116,7 @@ const lists: ListSchemaConfig = {
 };
 
 listAccessVariations.forEach(access => {
-  lists[getOperationListName(access)] = list({
+  models[getOperationListName(access)] = list({
     fields: Object.assign(
       { name: text() },
       ...fieldMatrix.map(variation => createFieldStatic(variation))
@@ -130,7 +130,7 @@ listAccessVariations.forEach(access => {
       },
     },
   });
-  lists[getFilterListName(access)] = list({
+  models[getFilterListName(access)] = list({
     fields: { name: text() },
     access: {
       filter: {
@@ -141,7 +141,7 @@ listAccessVariations.forEach(access => {
       },
     },
   });
-  lists[getFilterBoolListName(access)] = list({
+  models[getFilterBoolListName(access)] = list({
     fields: { name: text() },
     access: {
       filter: {
@@ -151,7 +151,7 @@ listAccessVariations.forEach(access => {
       },
     },
   });
-  lists[getItemListName(access)] = list({
+  models[getItemListName(access)] = list({
     fields: Object.assign(
       { name: text() },
       ...fieldMatrix.map(variation => createFieldImperative(variation))
@@ -174,7 +174,7 @@ const auth = createAuth({
 
 const config = auth.withAuth(
   apiTestConfig({
-    lists,
+    models,
     session: statelessSessions({ secret: COOKIE_SECRET }),
   })
 );

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -9,7 +9,7 @@ const runner = setupTestRunner({
     ui: {
       isAccessAllowed: () => false,
     },
-    lists: { User: list({ fields: { name: text() } }) },
+    models: { User: list({ fields: { name: text() } }) },
   }),
 });
 
@@ -116,7 +116,7 @@ test(
 
   setupTestRunner({
     config: apiTestConfig({
-      lists: {
+      models: {
         Test: list({
           fields: { name: text() },
           ui: names,

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -28,7 +28,7 @@ function setup(options?: any) {
   return setupTestRunner({
     config: auth.withAuth(
       apiTestConfig({
-        lists: {
+        models: {
           Post: list({
             fields: {
               title: text(),
@@ -111,7 +111,7 @@ describe('Auth testing', () => {
       setupTestEnv({
         config: auth.withAuth(
           apiTestConfig({
-            lists: {
+            models: {
               User: list({
                 fields: {
                   name: text(),

--- a/tests/api-tests/auth-stored-session.test.ts
+++ b/tests/api-tests/auth-stored-session.test.ts
@@ -36,7 +36,7 @@ function setup(options?: any) {
   return setupTestRunner({
     config: auth.withAuth(
       apiTestConfig({
-        lists: {
+        models: {
           Post: list({
             fields: {
               title: text(),

--- a/tests/api-tests/auth.test.ts
+++ b/tests/api-tests/auth.test.ts
@@ -46,7 +46,7 @@ const auth = createAuth({
 const runner = setupTestRunner({
   config: auth.withAuth(
     apiTestConfig({
-      lists: {
+      models: {
         User: list({
           fields: {
             name: text(),

--- a/tests/api-tests/body-parser.test.ts
+++ b/tests/api-tests/body-parser.test.ts
@@ -36,7 +36,7 @@ async function tryRequest(app: express.Express, size: number) {
 function setup(options?: BodyParserOptions) {
   return setupTestRunner({
     config: apiTestConfig({
-      lists: {
+      models: {
         Thing: list({
           fields: {
             value: text(),

--- a/tests/api-tests/db-enable-logging.test.ts
+++ b/tests/api-tests/db-enable-logging.test.ts
@@ -8,7 +8,7 @@ const runner = (enableLogging: boolean) =>
   setupTestRunner({
     config: apiTestConfig({
       db: { enableLogging },
-      lists: {
+      models: {
         User: list({ fields: { name: text() } }),
       },
     }),

--- a/tests/api-tests/db-map.test.ts
+++ b/tests/api-tests/db-map.test.ts
@@ -6,7 +6,7 @@ import { apiTestConfig, dbProvider, getPrismaSchema } from './utils';
 test('db.map at the list level adds @@map with the value to the Prisma schema', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         SomeList: list({
           db: {
             map: 'some_table_name',
@@ -55,7 +55,7 @@ testModules
     test(`db.map for the field ${mod.name} adds @map with the value to the Prisma schema`, async () => {
       const prismaSchema = await getPrismaSchema(
         apiTestConfig({
-          lists: {
+          models: {
             SomeList: list({
               fields: {
                 someField: mod.typeFunction({
@@ -79,7 +79,7 @@ testModules
 test(`db.map for the field text field adds @map with the value to the Prisma schema`, async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         SomeList: list({
           fields: {
             someField: text({

--- a/tests/api-tests/default-value/defaults.test.ts
+++ b/tests/api-tests/default-value/defaults.test.ts
@@ -5,7 +5,7 @@ import type { BaseFields } from '@keystone-6/core/types';
 import { apiTestConfig } from '../utils';
 
 const setupList = (fields: BaseFields<any>) =>
-  setupTestRunner({ config: apiTestConfig({ lists: { User: list({ fields }) } }) });
+  setupTestRunner({ config: apiTestConfig({ models: { User: list({ fields }) } }) });
 
 describe('defaultValue field config', () => {
   test(

--- a/tests/api-tests/extend-express-app.test.ts
+++ b/tests/api-tests/extend-express-app.test.ts
@@ -6,7 +6,7 @@ import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: { User: list({ fields: { name: text() } }) },
+    models: { User: list({ fields: { name: text() } }) },
     server: {
       extendExpressApp: app => {
         app.get('/magic', (req, res) => {

--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -23,7 +23,7 @@ const withAccessCheck = <T, Args extends unknown[]>(
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: { name: text() },
       }),

--- a/tests/api-tests/extend-http-server.test.ts
+++ b/tests/api-tests/extend-http-server.test.ts
@@ -7,7 +7,7 @@ import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: { User: list({ fields: { name: text() } }) },
+    models: { User: list({ fields: { name: text() } }) },
     server: {
       extendHttpServer: server => {
         server.prependListener('request', (req: IncomingMessage, res: ServerResponse) => {

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -21,7 +21,7 @@ testModules
       const listKey = 'Test';
       const runner = setupTestRunner({
         config: apiTestConfig({
-          lists: {
+          models: {
             [listKey]: list({
               fields: {
                 name: text(),

--- a/tests/api-tests/fields/image-file-crud.test.ts
+++ b/tests/api-tests/fields/image-file-crud.test.ts
@@ -49,13 +49,13 @@ const getRunner = ({
   fields,
 }: {
   storage: Record<string, StorageConfig>;
-  fields: KeystoneConfig['lists'][string]['fields'];
+  fields: KeystoneConfig['models'][string]['fields'];
 }) =>
   setupTestRunner({
     config: apiTestConfig({
       db: {},
       storage,
-      lists: {
+      models: {
         Test: list({
           fields: {
             name: text(),

--- a/tests/api-tests/fields/non-null.test.ts
+++ b/tests/api-tests/fields/non-null.test.ts
@@ -44,7 +44,7 @@ testModules
         const getSchema = async (fieldConfig: any) => {
           const { testArgs } = await setupTestEnv({
             config: apiTestConfig({
-              lists: {
+              models: {
                 Test: list({
                   fields: {
                     name: text(),

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -45,7 +45,7 @@ testModules
 
         const runner = setupTestRunner({
           config: apiTestConfig({
-            lists: {
+            models: {
               Test: list({
                 fields: {
                   name: text(),

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -6,7 +6,7 @@ import { apiTestConfig } from '../../utils';
 function makeRunner(fields: BaseFields<any>) {
   return setupTestRunner({
     config: apiTestConfig({
-      lists: {
+      models: {
         Post: list({
           fields: {
             value: integer(),
@@ -67,7 +67,7 @@ describe('Virtual field type', () => {
     'referencing other list type',
     setupTestRunner({
       config: apiTestConfig({
-        lists: {
+        models: {
           Organisation: list({
             fields: {
               name: text(),
@@ -158,7 +158,7 @@ describe('Virtual field type', () => {
     await expect(
       setupTestEnv({
         config: apiTestConfig({
-          lists: {
+          models: {
             Post: list({
               fields: {
                 virtual: virtual({

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -8,7 +8,7 @@ import { apiTestConfig, expectInternalServerError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Post: list({
         fields: {
           content: document({
@@ -294,7 +294,7 @@ describe('Document field type', () => {
     await expect(
       setupTestEnv({
         config: apiTestConfig({
-          lists: {
+          models: {
             Post: list({
               fields: {
                 content: document({
@@ -319,7 +319,7 @@ describe('Document field type', () => {
     await expect(
       setupTestEnv({
         config: apiTestConfig({
-          lists: {
+          models: {
             Post: list({
               fields: {
                 content: document({

--- a/tests/api-tests/fields/types/utils.ts
+++ b/tests/api-tests/fields/types/utils.ts
@@ -11,7 +11,7 @@ const listKey = 'Test';
 const filterTestRunner = (field: FieldTypeFunc<BaseListTypeInfo>) =>
   setupTestRunner({
     config: apiTestConfig({
-      lists: {
+      models: {
         [listKey]: list({
           fields: { index: integer(), testField: field },
         }),

--- a/tests/api-tests/fields/types/utils.ts
+++ b/tests/api-tests/fields/types/utils.ts
@@ -4,11 +4,11 @@ import path from 'path';
 import { list } from '@keystone-6/core';
 import { integer } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
-import { FieldTypeFunc, BaseListTypeInfo } from '@keystone-6/core/types';
+import { FieldTypeFunc, BaseModelTypeInfo } from '@keystone-6/core/types';
 import { apiTestConfig } from '../../utils';
 
 const listKey = 'Test';
-const filterTestRunner = (field: FieldTypeFunc<BaseListTypeInfo>) =>
+const filterTestRunner = (field: FieldTypeFunc<BaseModelTypeInfo>) =>
   setupTestRunner({
     config: apiTestConfig({
       models: {
@@ -63,7 +63,7 @@ type Match = (
   expectedIndexes: readonly number[]
 ) => void;
 
-export function filterTests(field: FieldTypeFunc<BaseListTypeInfo>, cb: (match: Match) => void) {
+export function filterTests(field: FieldTypeFunc<BaseModelTypeInfo>, cb: (match: Match) => void) {
   for (const kind of ['without negation', 'with negation'] as const) {
     describe(kind, () => {
       const match: Match = (inputValues, where, expectedIndexes) =>
@@ -131,7 +131,7 @@ export function equalityFilterTests(
 }
 
 export function uniqueEqualityFilterTest(
-  field: FieldTypeFunc<BaseListTypeInfo>,
+  field: FieldTypeFunc<BaseModelTypeInfo>,
   values: readonly unknown[]
 ) {
   test(

--- a/tests/api-tests/fields/unique.test.ts
+++ b/tests/api-tests/fields/unique.test.ts
@@ -55,7 +55,7 @@ testModules
         });
         const runner = setupTestRunner({
           config: apiTestConfig({
-            lists: {
+            models: {
               Test: list({
                 fields: {
                   name: text(),
@@ -173,7 +173,7 @@ testModules
           try {
             await setupTestEnv({
               config: apiTestConfig({
-                lists: {
+                models: {
                   Test: list({
                     fields: {
                       name: text(),

--- a/tests/api-tests/fields/unsupported.test.ts
+++ b/tests/api-tests/fields/unsupported.test.ts
@@ -48,7 +48,7 @@ if (unsupportedModules.length > 0) {
             async () =>
               await setupTestEnv({
                 config: apiTestConfig({
-                  lists: {
+                  models: {
                     [listKey]: list({
                       fields: { name: text(), ...mod.getTestFields(matrixValue) },
                     }),

--- a/tests/api-tests/healthcheck.test.ts
+++ b/tests/api-tests/healthcheck.test.ts
@@ -7,7 +7,7 @@ import { apiTestConfig } from './utils';
 const makeRunner = (healthCheck: any) =>
   setupTestRunner({
     config: apiTestConfig({
-      lists: { User: list({ fields: { name: text() } }) },
+      models: { User: list({ fields: { name: text() } }) },
       server: { healthCheck },
     }),
   });

--- a/tests/api-tests/hooks/auth-hooks.test.skip.ts
+++ b/tests/api-tests/hooks/auth-hooks.test.skip.ts
@@ -8,7 +8,7 @@ import { apiTestConfig } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -7,7 +7,7 @@ import { apiTestConfig, expectExtensionError, unpackErrors } from '../utils';
 const runner = (debug: boolean | undefined) =>
   setupTestRunner({
     config: apiTestConfig({
-      lists: {
+      models: {
         User: list({
           fields: { name: text() },
           hooks: {

--- a/tests/api-tests/hooks/list-hooks.test.ts
+++ b/tests/api-tests/hooks/list-hooks.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectExtensionError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text({

--- a/tests/api-tests/hooks/validation.test.ts
+++ b/tests/api-tests/hooks/validation.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectValidationError } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: { name: text() },
         hooks: {

--- a/tests/api-tests/id-field.test.ts
+++ b/tests/api-tests/id-field.test.ts
@@ -20,7 +20,7 @@ describe.each([
       db: {
         idField: kind === 'bigint' ? { kind: 'autoincrement', type: 'BigInt' } : { kind },
       },
-      lists: {
+      models: {
         User: list({ fields: { name: text() } }),
       },
     }),
@@ -166,7 +166,7 @@ describe.each([
   const runner = setupTestRunner({
     config: apiTestConfig({
       db: { idField: { kind: 'uuid' } },
-      lists: {
+      models: {
         User: list({ fields: { name: text() } }),
       },
     }),
@@ -190,7 +190,7 @@ describe.each([
   const runner = setupTestRunner({
     config: apiTestConfig({
       db: { idField: { kind: 'cuid' } },
-      lists: {
+      models: {
         User: list({ fields: { name: text() } }),
       },
     }),

--- a/tests/api-tests/indexes.test.ts
+++ b/tests/api-tests/indexes.test.ts
@@ -7,7 +7,7 @@ import { apiTestConfig, dbProvider } from './utils';
 
 test('isIndexed: true and db.map on a text field generates a valid Prisma schema', async () => {
   const config = apiTestConfig({
-    lists: {
+    models: {
       Test: list({
         fields: {
           somethingIndexed: text({ isIndexed: true, db: { map: 'something' } }),
@@ -47,7 +47,7 @@ if (dbProvider === 'postgresql') {
   // scalar and enum fields are printed slightly differently so that's why we're also testing an enum select field
   test('isIndexed: true and db.map on an enum select field generates a valid Prisma schema', async () => {
     const config = apiTestConfig({
-      lists: {
+      models: {
         Test: list({
           fields: {
             somethingIndexed: text({ isIndexed: true, db: { map: 'something' } }),

--- a/tests/api-tests/new-interfaces.test.ts
+++ b/tests/api-tests/new-interfaces.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({ fields: { name: text() } }),
     },
   }),

--- a/tests/api-tests/parallel.test.ts
+++ b/tests/api-tests/parallel.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig } from './utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Post: list({
         fields: {
           title: text(),

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -7,7 +7,7 @@ import { apiTestConfig } from '../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Post: list({
         fields: {
           title: text(),

--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -12,7 +12,7 @@ import {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           noDash: text(),

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -6,7 +6,7 @@ import { depthLimit, definitionLimit, fieldLimit } from './validation';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Post: list({
         fields: {
           title: text(),

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -12,7 +12,7 @@ import {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           a: integer(),

--- a/tests/api-tests/queries/relationships.test.ts
+++ b/tests/api-tests/queries/relationships.test.ts
@@ -9,7 +9,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Post: list({
         fields: {
           title: text(),

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many-one-sided.test.ts
@@ -79,7 +79,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/many-to-many.test.ts
@@ -84,7 +84,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many-one-sided.test.ts
@@ -78,7 +78,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-many.test.ts
@@ -79,7 +79,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud-self-ref/one-to-one.test.ts
@@ -59,7 +59,7 @@ const getUserAndFriend = async (context: KeystoneContext, userId: IdType, friend
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many-one-sided.test.ts
@@ -88,7 +88,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud/many-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/many-to-many.test.ts
@@ -94,7 +94,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many-one-sided.test.ts
@@ -100,7 +100,7 @@ const getCompanyAndLocation = async (
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud/one-to-many.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-many.test.ts
@@ -87,7 +87,7 @@ const createReadData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/crud/one-to-one.test.ts
+++ b/tests/api-tests/relationships/crud/one-to-one.test.ts
@@ -93,7 +93,7 @@ const getCompanyAndLocation = async (
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/filtering/access-control.test.ts
+++ b/tests/api-tests/relationships/filtering/access-control.test.ts
@@ -10,7 +10,7 @@ const postNames = ['Post 1', 'Post 2', 'Post 3'];
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       UserToPostLimitedRead: list({
         fields: {
           username: text(),

--- a/tests/api-tests/relationships/filtering/filtering.test.ts
+++ b/tests/api-tests/relationships/filtering/filtering.test.ts
@@ -7,7 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           company: relationship({ ref: 'Company' }),

--- a/tests/api-tests/relationships/filtering/nested.test.ts
+++ b/tests/api-tests/relationships/filtering/nested.test.ts
@@ -7,7 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       User: list({
         fields: {
           company: relationship({ ref: 'Company' }),

--- a/tests/api-tests/relationships/foreign-key.test.ts
+++ b/tests/api-tests/relationships/foreign-key.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, dbProvider, getPrismaSchema } from '../utils';
 test('when not specifying foreignKey in a one to one relationship, the side is picked based on the list key + field key ordering', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a' }),
@@ -49,7 +49,7 @@ model B {
 test('when specifying foreignKey: true in a one to one relationship, that side has the foreign key', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a' }),
@@ -93,7 +93,7 @@ model B {
 test('when specifying foreignKey: { map } in a one to one relationship, that side has the foreign key with the map', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a' }),
@@ -138,7 +138,7 @@ test('when specifying foreignKey: true on both sides of a one to one relationshi
   await expect(
     getPrismaSchema(
       apiTestConfig({
-        lists: {
+        models: {
           A: list({
             fields: {
               b: relationship({ ref: 'B.a', db: { foreignKey: true } }),
@@ -162,7 +162,7 @@ test('when specifying foreignKey: { map } on both sides of a one to one relation
   await expect(
     getPrismaSchema(
       apiTestConfig({
-        lists: {
+        models: {
           A: list({
             fields: {
               b: relationship({ ref: 'B.a', db: { foreignKey: { map: 'blah' } } }),
@@ -186,7 +186,7 @@ test('foreignKey: true in a many to one relationship is the same as not specifyi
   const getPrismaSchemaForForeignKeyVal = (foreignKey: boolean) =>
     getPrismaSchema(
       apiTestConfig({
-        lists: {
+        models: {
           A: list({
             fields: {
               b: relationship({ ref: 'B.a', many: true }),
@@ -209,7 +209,7 @@ test('foreignKey: true in a many to one relationship is the same as not specifyi
 test('foreignKey: { map } in a many to one relationship sets the @map attribute on the foreign key', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a', many: true }),

--- a/tests/api-tests/relationships/many-to-one-to-one.test.ts
+++ b/tests/api-tests/relationships/many-to-one-to-one.test.ts
@@ -83,7 +83,7 @@ const createCompanyAndLocation = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Owner: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-many.test.ts
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),

--- a/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/connect-singular.test.ts
@@ -6,7 +6,7 @@ import { apiTestConfig, expectSingleRelationshipError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Group: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-many.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),

--- a/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-and-connect-singular.test.ts
@@ -5,7 +5,7 @@ import { apiTestConfig, expectSingleRelationshipError } from '../../utils';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Group: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/create-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-many.test.ts
@@ -10,7 +10,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),
@@ -58,7 +58,7 @@ let afterOperationWasCalled = false;
 
 const runner2 = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -10,7 +10,7 @@ import {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Group: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -12,7 +12,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Group: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/reconnect-many-to-one.test.ts
@@ -7,7 +7,7 @@ type IdType = any;
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           title: text(),

--- a/tests/api-tests/relationships/nested-mutations/set-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/set-many.test.ts
@@ -12,7 +12,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Note: list({
         fields: {
           content: text(),

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-many.test.ts
@@ -13,7 +13,7 @@ const toStr = (items: any[]) => items.map(item => item.toString());
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Student: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/two-way-backreference/to-one-required.test.ts
@@ -8,7 +8,7 @@ const alphanumGenerator = gen.alphaNumString.notEmpty();
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Company: list({
         fields: {
           name: text(),

--- a/tests/api-tests/relationships/relation-name.test.ts
+++ b/tests/api-tests/relationships/relation-name.test.ts
@@ -5,7 +5,7 @@ import { getPrismaSchema, apiTestConfig, dbProvider } from '../utils';
 test('when not specifying relationName in a many to many relationship, the name is picked based on the lexicographic list key + field key ordering', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a', many: true }),
@@ -48,7 +48,7 @@ model B {
 test("the ordering of the lists doesn't affect the relation name", async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a', many: true }),
@@ -91,7 +91,7 @@ model B {
 test('when specifying relationName in a many to many relationship, the relation name is set to that', async () => {
   const prismaSchema = await getPrismaSchema(
     apiTestConfig({
-      lists: {
+      models: {
         A: list({
           fields: {
             b: relationship({ ref: 'B.a', many: true }),
@@ -135,7 +135,7 @@ test('when specifying relationName on both sides of a many to many relationship,
   await expect(
     getPrismaSchema(
       apiTestConfig({
-        lists: {
+        models: {
           A: list({
             fields: {
               b: relationship({ ref: 'B.a', many: true, db: { relationName: 'blah' } }),
@@ -159,7 +159,7 @@ test('when specifying relationName on the many side of a one to many relationshi
   await expect(
     getPrismaSchema(
       apiTestConfig({
-        lists: {
+        models: {
           A: list({
             fields: {
               b: relationship({ ref: 'B.a', many: true, db: { relationName: 'blah' } }),

--- a/tests/api-tests/relationships/shared-names.test.ts
+++ b/tests/api-tests/relationships/shared-names.test.ts
@@ -93,7 +93,7 @@ const createInitialData = async (context: KeystoneContext) => {
 
 const runner = setupTestRunner({
   config: apiTestConfig({
-    lists: {
+    models: {
       Employee: list({
         fields: {
           name: text(),

--- a/tests/sandbox/configs/7590-add-item-to-relationship-in-hook-cards-ui.ts
+++ b/tests/sandbox/configs/7590-add-item-to-relationship-in-hook-cards-ui.ts
@@ -2,7 +2,7 @@ import { list, config } from '@keystone-6/core';
 import { relationship, text } from '@keystone-6/core/fields';
 import { dbConfig } from '../utils';
 
-export const lists = {
+export const models = {
   User: list({
     fields: {
       name: text(),
@@ -35,4 +35,4 @@ export const lists = {
   }),
 };
 
-export default config({ db: dbConfig, lists });
+export default config({ db: dbConfig, models });

--- a/tests/sandbox/configs/7591-body-parser-options.ts
+++ b/tests/sandbox/configs/7591-body-parser-options.ts
@@ -20,7 +20,7 @@ function makeQuery(size = 0) {
   return `{ ${' '.repeat(padding)} ${query} }`;
 }
 
-export const lists = {
+export const models = {
   Thing: list({
     fields: {
       value: text(),
@@ -60,5 +60,5 @@ export default config({
       limit: '10mb',
     },
   },
-  lists,
+  models,
 });

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -23,7 +23,7 @@ import { dbConfig, localStorageConfig, trackingFields } from '../utils';
 const description =
   'Some thing to describe to test the length of the text for width, blah blah blah blah blah blah blah blah blah';
 
-export const lists = {
+export const models = {
   Thing: list({
     fields: {
       checkbox: checkbox({ ui: { description } }),
@@ -148,5 +148,5 @@ export const lists = {
 export default config({
   db: dbConfig,
   storage: localStorageConfig,
-  lists,
+  models,
 });

--- a/tests/test-projects/basic/keystone.ts
+++ b/tests/test-projects/basic/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./test.db',
   },
-  lists,
+  models,
 });

--- a/tests/test-projects/basic/schema.ts
+++ b/tests/test-projects/basic/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     fields: {
       label: text({ validation: { isRequired: true } }),

--- a/tests/test-projects/crud-notifications/keystone.ts
+++ b/tests/test-projects/crud-notifications/keystone.ts
@@ -1,10 +1,10 @@
 import { config } from '@keystone-6/core';
-import { lists } from './schema';
+import { models } from './schema';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./test.db',
   },
-  lists,
+  models,
 });

--- a/tests/test-projects/crud-notifications/schema.ts
+++ b/tests/test-projects/crud-notifications/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core';
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields';
 import { select } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Task: list({
     access: {
       item: {

--- a/tests/test-projects/live-reloading/keystone.ts
+++ b/tests/test-projects/live-reloading/keystone.ts
@@ -1,12 +1,12 @@
 import { config } from '@keystone-6/core';
-import { lists, extendGraphqlSchema } from './schemas';
+import { models, extendGraphqlSchema } from './schemas';
 
 export default config({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./test.db',
   },
-  lists,
+  models,
   extendGraphqlSchema,
   ui: {
     getAdditionalFiles: [

--- a/tests/test-projects/live-reloading/schemas/changed-prisma-schema.ts
+++ b/tests/test-projects/live-reloading/schemas/changed-prisma-schema.ts
@@ -1,7 +1,7 @@
 import { graphQLSchemaExtension, list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Something: list({
     fields: {
       text: text({ label: 'Initial Label For Text' }),

--- a/tests/test-projects/live-reloading/schemas/initial.ts
+++ b/tests/test-projects/live-reloading/schemas/initial.ts
@@ -1,7 +1,7 @@
 import { graphQLSchemaExtension, list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Something: list({
     fields: {
       text: text({ label: 'Initial Label For Text' }),

--- a/tests/test-projects/live-reloading/schemas/second.ts
+++ b/tests/test-projects/live-reloading/schemas/second.ts
@@ -1,7 +1,7 @@
 import { graphql, graphQLSchemaExtension, list } from '@keystone-6/core';
 import { text, virtual } from '@keystone-6/core/fields';
 
-export const lists = {
+export const models = {
   Something: list({
     fields: {
       text: text({ label: 'Very Important Text' }),


### PR DESCRIPTION
This pull request introduces [Singletons](https://en.wikipedia.org/wiki/Singleton_pattern) as a new feature for configuring global, editable database entries when it's not necessary to have more than one representation of the schema (aka, not a normal list).

Singletons can be useful for things like: 

- System Settings
- Homepage Layout
- Site Navigation

Before this feature, developers could write a typical schema for a list, and then using Keystone hooks limit the number of items within that list to approximate this functionality.
Unfortunately the GraphQL schema didn't reflect these constraints,  and neither did the AdminUI.

This pull requests brings that functionality native to Keystone's schema configuration as a first class primitive.

### Tasks
- [ ] Add enforcement of the databases (where able) to ensure that the singleton list only ever has one item
- [x] Alter the graphql layer so that queries on singletons make more sense (remove querying for multiple items, remove the ‘where’ query on fetching a single item, as there will only ever be one)
- [x] Update the Admin UI - mostly subtractive changes to give a good experience for singletons where navigating items UI is removed, removing clicks