### PR TITLE
Skip running tests when making changes to docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           filters: |
             shouldRunTests:
-              - '!{{design-system}/**,**/*.md}'
+              - '!{{design-system}/**,**/*.md,docs/**}'
 
       - run: echo "SHOULD_RUN_TESTS=$SHOULD_RUN" >> $GITHUB_ENV
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This will still run linting and etc. just not the tests that are purely Keystone itself