### PR TITLE
Refactor types for lists

### DIFF
--- a/.changeset/fifty-kids-pay.md
+++ b/.changeset/fifty-kids-pay.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Refactor the types-for-list file to add some extra clarity

--- a/packages/core/src/lib/core/prisma-schema.ts
+++ b/packages/core/src/lib/core/prisma-schema.ts
@@ -1,5 +1,5 @@
 import { ScalarDBField, ScalarDBFieldDefault, DatabaseProvider } from '../../types';
-import { ResolvedDBField, ListsWithResolvedRelations } from './resolve-relationships';
+import { ResolvedDBField } from './resolve-relationships';
 import { InitialisedList } from './types-for-lists';
 import { getDBFieldKeyForFieldOnMultiField } from './utils';
 
@@ -54,7 +54,7 @@ function printField(
   fieldPath: string,
   field: Exclude<ResolvedDBField, { kind: 'none' }>,
   datasourceName: string,
-  lists: ListsWithResolvedRelations
+  lists: Record<string, InitialisedList>
 ): string {
   if (field.kind === 'scalar') {
     const nativeType = printNativeType(field.nativeType, datasourceName);
@@ -112,7 +112,7 @@ function printField(
   return assertNever(field);
 }
 
-function collectEnums(lists: ListsWithResolvedRelations) {
+function collectEnums(lists: Record<string, InitialisedList>) {
   const enums: Record<string, { values: readonly string[]; firstDefinedByRef: string }> = {};
   for (const [listKey, { resolvedDbFields }] of Object.entries(lists)) {
     for (const [fieldPath, field] of Object.entries(resolvedDbFields)) {

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -16,10 +16,7 @@ export type ResolvedRelationDBField =
       foreignIdField: { kind: 'none' } | { kind: 'owned' | 'owned-unique'; map: string };
     });
 
-export type ListsWithResolvedRelations = Record<
-  string,
-  { resolvedDbFields: FieldsWithResolvedRelations }
->;
+export type ListsWithResolvedRelations = Record<string, FieldsWithResolvedRelations>;
 
 export type ResolvedDBField =
   | ResolvedRelationDBField
@@ -288,7 +285,7 @@ export function resolveRelationships(
       );
       // then we add the opposites to one-sided relations
       Object.assign(resolvedDbFields, outOfOrderDbFields);
-      return [listKey, { resolvedDbFields }];
+      return [listKey, resolvedDbFields];
     })
   );
 }

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -90,7 +90,7 @@ function getIsEnabled(listsConfig: KeystoneConfig['lists']) {
       // when defining these values. We avoid duck-typing here as this is security related
       // and we want to make it hard to write incorrect code.
       throwIfNotAFilter(defaultIsFilterable, listKey, 'defaultIsFilterable');
-      throwIfNotAFilter(defaultIsFilterable, listKey, 'defaultIsFilterable');
+      throwIfNotAFilter(defaultIsOrderable, listKey, 'defaultIsOrderable');
     }
     if (omit === true) {
       isEnabled[listKey] = {

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -71,7 +71,7 @@ type IsEnabled = {
   orderBy: boolean | ((args: FilterOrderArgs<BaseListTypeInfo>) => MaybePromise<boolean>);
 };
 
-function throwIfNotAFilter (x: unknown, listKey: string, fieldKey: string) {
+function throwIfNotAFilter(x: unknown, listKey: string, fieldKey: string) {
   if (['boolean', 'undefined', 'function'].includes(typeof x)) return;
 
   throw new Error(

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -81,6 +81,14 @@ type IsEnabled = Record<
   }
 >;
 
+function throwIfNotAFilter (x: unknown, listKey: string, fieldKey: string) {
+  if (['boolean', 'undefined', 'function'].includes(typeof x)) return;
+
+  throw new Error(
+    `Configuration option '${listKey}.${fieldKey}' must be either a boolean value or a function. Received'${x}'.`
+  );
+}
+
 function getIsEnabled(listsConfig: KeystoneConfig['lists']) {
   const isEnabled: IsEnabled = {};
 
@@ -91,16 +99,8 @@ function getIsEnabled(listsConfig: KeystoneConfig['lists']) {
       // We explicity check for boolean/function values here to ensure the dev hasn't made a mistake
       // when defining these values. We avoid duck-typing here as this is security related
       // and we want to make it hard to write incorrect code.
-      if (!['boolean', 'undefined', 'function'].includes(typeof defaultIsFilterable)) {
-        throw new Error(
-          `Configuration option '${listKey}.defaultIsFilterable' must be either a boolean value or a function. Recieved '${typeof defaultIsFilterable}'.`
-        );
-      }
-      if (!['boolean', 'undefined', 'function'].includes(typeof defaultIsOrderable)) {
-        throw new Error(
-          `Configuration option '${listKey}.defaultIsOrderable' must be either a boolean value or a function. Recieved '${typeof defaultIsOrderable}'.`
-        );
-      }
+      throwIfNotAFilter(defaultIsFilterable, listKey, 'defaultIsFilterable');
+      throwIfNotAFilter(defaultIsFilterable, listKey, 'defaultIsFilterable');
     }
     if (omit === true) {
       isEnabled[listKey] = {
@@ -166,16 +166,8 @@ function getListsWithInitialisedFields(
             // We explicity check for boolean values here to ensure the dev hasn't made a mistake
             // when defining these values. We avoid duck-typing here as this is security related
             // and we want to make it hard to write incorrect code.
-            if (!['boolean', 'function', 'undefined'].includes(typeof f.isFilterable)) {
-              throw new Error(
-                `Configuration option '${listKey}.${fieldKey}.isFilterable' must be either a boolean value or a function. Recieved '${typeof f.isFilterable}'.`
-              );
-            }
-            if (!['boolean', 'function', 'undefined'].includes(typeof f.isOrderable)) {
-              throw new Error(
-                `Configuration option '${listKey}.${fieldKey}.isOrderable' must be either a boolean value or a function. Recieved '${typeof f.isOrderable}'.`
-              );
-            }
+            throwIfNotAFilter(f.isFilterable, listKey, 'isFilterable');
+            throwIfNotAFilter(f.isFilterable, listKey, 'isOrderable');
 
             const _isEnabled = {
               read,

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -157,7 +157,7 @@ function getListsWithInitialisedFields(
             // when defining these values. We avoid duck-typing here as this is security related
             // and we want to make it hard to write incorrect code.
             throwIfNotAFilter(f.isFilterable, listKey, 'isFilterable');
-            throwIfNotAFilter(f.isFilterable, listKey, 'isOrderable');
+            throwIfNotAFilter(f.isOrderable, listKey, 'isOrderable');
 
             const _isEnabled = {
               read,

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -75,7 +75,7 @@ function throwIfNotAFilter(x: unknown, listKey: string, fieldKey: string) {
   if (['boolean', 'undefined', 'function'].includes(typeof x)) return;
 
   throw new Error(
-    `Configuration option '${listKey}.${fieldKey}' must be either a boolean value or a function. Received'${x}'.`
+    `Configuration option '${listKey}.${fieldKey}' must be either a boolean value or a function. Received '${x}'.`
   );
 }
 

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -256,7 +256,7 @@ function getListGraphqlTypes(
       pluralGraphQLName: getNamesFromList(listKey, listConfig).pluralGraphQLName,
     });
 
-    let output = graphql.object<BaseItem>()({
+    const output = graphql.object<BaseItem>()({
       name: names.outputTypeName,
       fields: () => {
         const { fields } = lists[listKey];
@@ -445,7 +445,7 @@ function getListGraphqlTypes(
       });
     }
 
-    const types: ListGraphQLTypes = {
+    graphQLTypes[listKey] = {
       types: {
         output,
         uniqueWhere,
@@ -471,8 +471,6 @@ function getListGraphqlTypes(
         },
       },
     };
-
-    graphQLTypes[listKey] = types;
   }
 
   return graphQLTypes;


### PR DESCRIPTION
Types for lists had a bunch of very complicated inline for-loops, some of which depended on previous items on the function, and some of which mutated previous generated items.

New pattern is we are building up the object over time, and where possible bounding using functions again, hopefully making it more understandable