### PR TITLE
Support body-parser options when configuring GraphQL

### DIFF
--- a/.changeset/cute-quokkas-dance.md
+++ b/.changeset/cute-quokkas-dance.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add optional `.graphql.bodyParser` options object for changing `body-parser` options when configuring GraphQL

--- a/packages/core/src/lib/server/createExpressServer.ts
+++ b/packages/core/src/lib/server/createExpressServer.ts
@@ -48,6 +48,7 @@ const addApolloServer = async ({
     app: server,
     path: config.graphql?.path || '/api/graphql',
     cors: false,
+    bodyParserConfig: config.graphql?.bodyParser === undefined ? true : config.graphql?.bodyParser,
   });
   return apolloServer;
 };

--- a/packages/core/src/lib/server/createExpressServer.ts
+++ b/packages/core/src/lib/server/createExpressServer.ts
@@ -48,7 +48,7 @@ const addApolloServer = async ({
     app: server,
     path: config.graphql?.path || '/api/graphql',
     cors: false,
-    bodyParserConfig: config.graphql?.bodyParser === undefined ? true : config.graphql?.bodyParser,
+    bodyParserConfig: config.graphql?.bodyParser,
   });
   return apolloServer;
 };

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -3,6 +3,7 @@ import type { Config } from 'apollo-server-express';
 import { CorsOptions } from 'cors';
 import express from 'express';
 import type { GraphQLSchema } from 'graphql';
+import type { Options as BodyParserOptions } from 'body-parser';
 
 import type { AssetMode, CreateRequestContext, BaseKeystoneTypeInfo, KeystoneContext } from '..';
 
@@ -183,6 +184,7 @@ export type GraphQLConfig = {
   // The CORS configuration to use on the GraphQL API endpoint.
   // Default: { origin: 'https://studio.apollographql.com', credentials: true }
   cors?: CorsOptions;
+  bodyParser?: BodyParserOptions;
   queryLimits?: {
     maxTotalResults?: number;
   };

--- a/tests/api-tests/body-parser.test.ts
+++ b/tests/api-tests/body-parser.test.ts
@@ -1,0 +1,101 @@
+import fetch from 'node-fetch';
+import { text } from '@keystone-6/core/fields';
+import { list } from '@keystone-6/core';
+import { setupTestRunner } from '@keystone-6/core/testing';
+import type { Options as BodyParserOptions } from 'body-parser';
+import { apiTestConfig } from './utils';
+
+function makeQuery (size = 0) {
+  const query = JSON.stringify({
+    variables:{
+      data:{
+        value: `Test ${Date.now()}`
+      }
+    },
+    query: `mutation ($data: ThingCreateInput!) {
+      item: createThing(data: $data) {
+        id
+      }
+    }`
+  }).slice(1, -1);
+  const padding = Math.max(0, size - (query.length + 3));
+  return `{ ${' '.repeat(padding)} ${query} }`;
+}
+
+async function tryRequest (size: number) {
+  const res = await fetch('http://localhost:3000/api/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: makeQuery(size)
+  });
+  if (res.status !== 200) return { res };
+  const { data, errors } = await res.json();
+  return { res, data, errors };
+}
+
+function setup(options?: BodyParserOptions) {
+  return setupTestRunner({
+    config: apiTestConfig({
+      lists: {
+        Thing: list({
+          fields: {
+            value: text(),
+          },
+        }),
+      },
+      graphql: {
+        bodyParser: {
+          // limit: '100kb', // the body-parser default
+          ...options
+        }
+      },
+    }),
+  });
+}
+
+describe('Configuring .graphql.bodyParser', () => {
+  test('defaults limits to 100KiB', setup()(async () => {
+    // <100KiB
+    {
+    const { res } = await tryRequest(1024);
+    expect(res.status).toEqual(200);
+    }
+
+    // === 100KiB
+    {
+    const { res } = await tryRequest(100*1024);
+    expect(res.status).toEqual(413);
+    }
+
+    // > 100KiB
+    {
+    const { res } = await tryRequest(100*1024 + 1);
+    expect(res.status).toEqual(413);
+    }
+  }));
+
+  test.only('supports changing the limit', setup({
+    // actually 10MiB
+    limit: '10mb'
+  })(async () => {
+    // <10MiB
+    {
+    const { res } = await tryRequest(1024);
+    expect(res.status).toEqual(200);
+    }
+
+    // === 10MiB
+    {
+    const { res } = await tryRequest(10*1024*1024);
+    expect(res.status).toEqual(413);
+    }
+
+    // > 10MiB
+    {
+    const { res } = await tryRequest(10*1024*1024 + 1);
+    expect(res.status).toEqual(413);
+    }
+  }));
+});

--- a/tests/api-tests/body-parser.test.ts
+++ b/tests/api-tests/body-parser.test.ts
@@ -1,38 +1,36 @@
-import fetch from 'node-fetch';
 import { text } from '@keystone-6/core/fields';
 import { list } from '@keystone-6/core';
+import express from 'express';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import type { Options as BodyParserOptions } from 'body-parser';
+import supertest from 'supertest';
 import { apiTestConfig } from './utils';
 
-function makeQuery (size = 0) {
+function makeQuery(size = 0) {
   const query = JSON.stringify({
-    variables:{
-      data:{
-        value: `Test ${Date.now()}`
-      }
+    variables: {
+      data: {
+        value: `Test ${Date.now()}`,
+      },
     },
     query: `mutation ($data: ThingCreateInput!) {
       item: createThing(data: $data) {
         id
       }
-    }`
+    }`,
   }).slice(1, -1);
   const padding = Math.max(0, size - (query.length + 3));
   return `{ ${' '.repeat(padding)} ${query} }`;
 }
 
-async function tryRequest (size: number) {
-  const res = await fetch('http://localhost:3000/api/graphql', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: makeQuery(size)
-  });
-  if (res.status !== 200) return { res };
-  const { data, errors } = await res.json();
-  return { res, data, errors };
+async function tryRequest(app: express.Express, size: number) {
+  const res = await supertest(app)
+    .post('/api/graphql')
+    .send(makeQuery(size))
+    .set('Accept', 'application/json')
+    .set('Content-Type', 'application/json');
+
+  return res;
 }
 
 function setup(options?: BodyParserOptions) {
@@ -48,54 +46,60 @@ function setup(options?: BodyParserOptions) {
       graphql: {
         bodyParser: {
           // limit: '100kb', // the body-parser default
-          ...options
-        }
+          ...options,
+        },
       },
     }),
   });
 }
 
 describe('Configuring .graphql.bodyParser', () => {
-  test('defaults limits to 100KiB', setup()(async () => {
-    // <100KiB
-    {
-    const { res } = await tryRequest(1024);
-    expect(res.status).toEqual(200);
-    }
+  test(
+    'defaults limits to 100KiB',
+    setup()(async ({ app }) => {
+      // <100KiB
+      {
+        const { status } = await tryRequest(app, 1024);
+        expect(status).toEqual(200);
+      }
 
-    // === 100KiB
-    {
-    const { res } = await tryRequest(100*1024);
-    expect(res.status).toEqual(413);
-    }
+      // === 100KiB
+      {
+        const { status } = await tryRequest(app, 100 * 1024);
+        expect(status).toEqual(413);
+      }
 
-    // > 100KiB
-    {
-    const { res } = await tryRequest(100*1024 + 1);
-    expect(res.status).toEqual(413);
-    }
-  }));
+      // > 100KiB
+      {
+        const { status } = await tryRequest(app, 100 * 1024 + 1);
+        expect(status).toEqual(413);
+      }
+    })
+  );
 
-  test.only('supports changing the limit', setup({
-    // actually 10MiB
-    limit: '10mb'
-  })(async () => {
-    // <10MiB
-    {
-    const { res } = await tryRequest(1024);
-    expect(res.status).toEqual(200);
-    }
+  test(
+    'supports changing the limit',
+    setup({
+      // actually 10MiB
+      limit: '10mb',
+    })(async ({ app }) => {
+      // <10MiB
+      {
+        const { status } = await tryRequest(app, 1024);
+        expect(status).toEqual(200);
+      }
 
-    // === 10MiB
-    {
-    const { res } = await tryRequest(10*1024*1024);
-    expect(res.status).toEqual(413);
-    }
+      // === 10MiB
+      {
+        const { status } = await tryRequest(app, 10 * 1024 * 1024);
+        expect(status).toEqual(413);
+      }
 
-    // > 10MiB
-    {
-    const { res } = await tryRequest(10*1024*1024 + 1);
-    expect(res.status).toEqual(413);
-    }
-  }));
+      // > 10MiB
+      {
+        const { status } = await tryRequest(app, 10 * 1024 * 1024 + 1);
+        expect(status).toEqual(413);
+      }
+    })
+  );
 });

--- a/tests/sandbox/configs/7591-body-parser-options.ts
+++ b/tests/sandbox/configs/7591-body-parser-options.ts
@@ -1,0 +1,57 @@
+import http from 'http';
+import { list, config } from '@keystone-6/core';
+import { text } from '@keystone-6/core/fields';
+import { dbConfig } from '../utils';
+
+export const lists = {
+  Thing: list({
+    fields: {
+      value: text(),
+    },
+  }),
+};
+
+const query = JSON.stringify({
+  variables:{
+    data:{
+      value: `Test ${Date.now()}`
+    }
+  },
+  query: `mutation ($data: ThingCreateInput!) {
+    item: createThing(data: $data) {
+      id
+    }
+  }`
+});
+
+export default config({
+  db: {
+    ...dbConfig,
+    onConnect: async () => {
+      // try something ~2MiB
+      const json = `{  ${' '.repeat(2*1024*1024)}   ${query.slice(1, -1)}   }`;
+      const req = http.request({
+        method: 'POST',
+        host: 'localhost',
+        port: 3000,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': json.length
+        },
+        path: '/api/graphql',
+      }, (res) => {
+        const { statusCode, headers } = res;
+        console.error({ statusCode, headers });
+        res.on('data', (data) => console.error(data.toString('utf8')));
+      });
+
+      req.end(json);
+    }
+  },
+  graphql: {
+    bodyParser: {
+      limit: '10mb'
+    }
+  },
+  lists
+});

--- a/tests/sandbox/configs/7591-body-parser-options.ts
+++ b/tests/sandbox/configs/7591-body-parser-options.ts
@@ -3,18 +3,18 @@ import { list, config } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { dbConfig } from '../utils';
 
-function makeQuery (size = 0) {
+function makeQuery(size = 0) {
   const query = JSON.stringify({
-    variables:{
-      data:{
-        value: `Test ${Date.now()}`
-      }
+    variables: {
+      data: {
+        value: `Test ${Date.now()}`,
+      },
     },
     query: `mutation ($data: ThingCreateInput!) {
       item: createThing(data: $data) {
         id
       }
-    }`
+    }`,
   }).slice(1, -1);
   const padding = Math.max(0, size - (query.length + 3));
   return `{ ${' '.repeat(padding)} ${query} }`;
@@ -33,29 +33,32 @@ export default config({
     ...dbConfig,
     onConnect: async () => {
       // try something ~2MiB
-      const json = makeQuery(2*1024*1024);
-      const req = http.request({
-        method: 'POST',
-        host: 'localhost',
-        port: 3000,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': json.length
+      const json = makeQuery(2 * 1024 * 1024);
+      const req = http.request(
+        {
+          method: 'POST',
+          host: 'localhost',
+          port: 3000,
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': json.length,
+          },
+          path: '/api/graphql',
         },
-        path: '/api/graphql',
-      }, (res) => {
-        const { statusCode, headers } = res;
-        console.error({ statusCode, headers });
-        res.on('data', (data) => console.error(data.toString('utf8')));
-      });
+        res => {
+          const { statusCode, headers } = res;
+          console.error({ statusCode, headers });
+          res.on('data', data => console.error(data.toString('utf8')));
+        }
+      );
 
       req.end(json);
-    }
+    },
   },
   graphql: {
     bodyParser: {
-      limit: '10mb'
-    }
+      limit: '10mb',
+    },
   },
-  lists
+  lists,
 });

--- a/tests/sandbox/configs/7591-body-parser-options.ts
+++ b/tests/sandbox/configs/7591-body-parser-options.ts
@@ -3,6 +3,23 @@ import { list, config } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { dbConfig } from '../utils';
 
+function makeQuery (size = 0) {
+  const query = JSON.stringify({
+    variables:{
+      data:{
+        value: `Test ${Date.now()}`
+      }
+    },
+    query: `mutation ($data: ThingCreateInput!) {
+      item: createThing(data: $data) {
+        id
+      }
+    }`
+  }).slice(1, -1);
+  const padding = Math.max(0, size - (query.length + 3));
+  return `{ ${' '.repeat(padding)} ${query} }`;
+}
+
 export const lists = {
   Thing: list({
     fields: {
@@ -11,25 +28,12 @@ export const lists = {
   }),
 };
 
-const query = JSON.stringify({
-  variables:{
-    data:{
-      value: `Test ${Date.now()}`
-    }
-  },
-  query: `mutation ($data: ThingCreateInput!) {
-    item: createThing(data: $data) {
-      id
-    }
-  }`
-});
-
 export default config({
   db: {
     ...dbConfig,
     onConnect: async () => {
       // try something ~2MiB
-      const json = `{  ${' '.repeat(2*1024*1024)}   ${query.slice(1, -1)}   }`;
+      const json = makeQuery(2*1024*1024);
       const req = http.request({
         method: 'POST',
         host: 'localhost',


### PR DESCRIPTION
Following the discussion in https://github.com/keystonejs/keystone/discussions/7582

[`body-parser`](https://www.npmjs.com/package/body-parser) has a number of configuration options that may be useful for developers to configure themselves. It looks like [Apollo 4 will be changing](https://github.com/apollographql/apollo-server/commit/81c7f7b2692d57bb45e3755dc44e7e3bfe1a03c4) how express interacts with user code in future so we'll need to do this anyway; might as well do it now. 