### PR TITLE
Ensure Prisma engines exist before attempting to format a Prisma schema

### DIFF
--- a/.changeset/dirty-apples-build.md
+++ b/.changeset/dirty-apples-build.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-The Prisma binaries are now downloaded just before they're needed if the Prisma's install script to download them fails. Note this will never happen in production, they will always be downloaded before.
+The Prisma binaries are now downloaded just before they're needed if Prisma's install script to download them fails. Note this will never happen in production, they will always be downloaded before.

--- a/.changeset/dirty-apples-build.md
+++ b/.changeset/dirty-apples-build.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+The Prisma binaries are now downloaded just before they're needed if the Prisma's install script to download them fails. Note this will never happen in production, they will always be downloaded before.


### PR DESCRIPTION
This should resolve the issues discussed in https://github.com/keystonejs/keystone/discussions/7461.

This will also make Keystone work when using `--ignore-scripts` with a package manager.

Note we always format the schema before attempting to do migrations and generate a Prisma client so this will ensure the engines will exist whenever they're necessary.