### PR TITLE
Fix Admin UI crash when saving an item with a cards relationship field when another item is added to the relationship since the item was initially loaded

### DIFF
--- a/.changeset/two-cameras-relate.md
+++ b/.changeset/two-cameras-relate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed the Admin UI crashing when saving an item with a relationship field using the cards display mode when another item is added to the relationship (e.g. by another user or a hook) since the item was initially loaded

--- a/packages/core/src/fields/types/relationship/views/cards/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/index.tsx
@@ -154,6 +154,9 @@ export function Cards({
       >
         {[...value.currentIds].map((id, index) => {
           const itemGetter = items[id];
+          if (!itemGetter) {
+            return null;
+          }
           const isEditMode = !!(onChange !== undefined) && value.itemsBeingEdited.has(id);
           return (
             <CardContainer role="status" mode={isEditMode ? 'edit' : 'view'} key={id}>

--- a/tests/sandbox/configs/7590-add-item-to-relationship-in-hook-cards-ui.ts
+++ b/tests/sandbox/configs/7590-add-item-to-relationship-in-hook-cards-ui.ts
@@ -1,0 +1,38 @@
+import { list, config } from '@keystone-6/core';
+import { relationship, text } from '@keystone-6/core/fields';
+import { dbConfig } from '../utils';
+
+export const lists = {
+  User: list({
+    fields: {
+      name: text(),
+      numbers: relationship({
+        ref: 'Number.user',
+        many: true,
+        ui: {
+          displayMode: 'cards',
+          cardFields: ['value'],
+        },
+        hooks: {
+          // every time you save, add a random number
+          async resolveInput(args) {
+            return {
+              ...args.resolvedData[args.fieldKey],
+              create: {
+                value: Math.floor(Math.random() * 100000).toString(),
+              },
+            };
+          },
+        },
+      }),
+    },
+  }),
+  Number: list({
+    fields: {
+      user: relationship({ ref: 'User.numbers' }),
+      value: text({ validation: { isRequired: true } }),
+    },
+  }),
+};
+
+export default config({ db: dbConfig, lists });


### PR DESCRIPTION
Closes #7590