### PR TITLE
Export more cloudinary fields

### DIFF
--- a/.changeset/khaki-singers-sip.md
+++ b/.changeset/khaki-singers-sip.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/cloudinary': patch
+---
+
+Export cloudinary image output type for custom usage e.g. in virtual fields.

--- a/.changeset/khaki-singers-sip.md
+++ b/.changeset/khaki-singers-sip.md
@@ -2,4 +2,4 @@
 '@keystone-6/cloudinary': patch
 ---
 
-Export cloudinary image output type for custom usage e.g. in virtual fields.
+Added an export for the Cloudinary image GraphQL output type for developer usage e.g. in virtual fields.

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -84,7 +84,7 @@ type CloudinaryImage_File = {
   }) => string | null;
 };
 
-const outputType = graphql.object<CloudinaryImage_File>()({
+export const outputType = graphql.object<CloudinaryImage_File>()({
   name: 'CloudinaryImage_File',
   fields: {
     id: graphql.field({ type: graphql.ID }),


### PR DESCRIPTION
It's currently not possible to use the cloudinary image type in e.g. a virtual fields that resolves a single image of a relationship.

E.g. (Pseudocode) this would not be possible without this PR

```js
import { outputType as CloudinaryOutputType } from '@keystone-6/cloudinary';
export const lists = {
  Gallery: list({
    fields: {
      title: text({ validation: { isRequired: true } }),
      galleryImages: relationship(
        ref: 'GalleryImage.gallery',
        many: true,
      ),
      fooGalleryImage: virtual({
        field: graphql.field({ 
          type: CloudinaryOutputType,
          resolve => image // resolve the first foo image
        })
      })
    },
  }),
  GalleryImage: list({
    fields: {
      gallery: relationship({
        ref: 'Gallery.galleryImages',
      }),
      image: cloudinaryImage(),
      type: select({
        type: 'enum',
        isIndexed: true,
        options: ['Foo', 'Bar'],
      }),
    },
  }),
};
```