### PR TITLE
Use form elements on inline create and edit forms on relationship fields using the cards display mode

### DIFF
--- a/.changeset/unlucky-parents-wait.md
+++ b/.changeset/unlucky-parents-wait.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed inline create and edit forms on relationship fields using the cards display mode not using form elements.

--- a/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { jsx, Stack } from '@keystone-ui/core';
 import isDeepEqual from 'fast-deep-equal';
 import { useToasts } from '@keystone-ui/toast';
@@ -56,7 +56,8 @@ export function InlineCreate({
 
   const [forceValidation, setForceValidation] = useState(false);
 
-  const onCreateClick = () => {
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     const newForceValidation = invalidFields.size !== 0;
     setForceValidation(newForceValidation);
 
@@ -105,32 +106,28 @@ export function InlineCreate({
   };
 
   return (
-    <Stack gap="xlarge">
-      {error && (
-        <GraphQLErrorNotice networkError={error?.networkError} errors={error?.graphQLErrors} />
-      )}
-      <Fields
-        fieldModes={null}
-        fields={fields}
-        forceValidation={forceValidation}
-        invalidFields={invalidFields}
-        onChange={setValue}
-        value={value}
-      />
-      <Stack gap="small" across>
-        <Button
-          isLoading={loading}
-          size="small"
-          tone="positive"
-          weight="bold"
-          onClick={onCreateClick}
-        >
-          Create {list.singular}
-        </Button>
-        <Button size="small" weight="none" onClick={onCancel}>
-          Cancel
-        </Button>
+    <form onSubmit={onSubmit}>
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice networkError={error?.networkError} errors={error?.graphQLErrors} />
+        )}
+        <Fields
+          fieldModes={null}
+          fields={fields}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={setValue}
+          value={value}
+        />
+        <Stack gap="small" across>
+          <Button isLoading={loading} size="small" tone="positive" weight="bold" type="submit">
+            Create {list.singular}
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
       </Stack>
-    </Stack>
+    </form>
   );
 }

--- a/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
@@ -5,7 +5,6 @@ import { Button } from '@keystone-ui/button';
 import { jsx, Stack } from '@keystone-ui/core';
 import { useToasts } from '@keystone-ui/toast';
 import { useCallback, useState } from 'react';
-import { Tooltip } from '@keystone-ui/tooltip';
 import { ListMeta } from '../../../../../types';
 import {
   deserializeValue,
@@ -66,94 +65,84 @@ export function InlineEdit({
 
   const [forceValidation, setForceValidation] = useState(false);
   const toasts = useToasts();
-  const saveButtonProps = {
-    isLoading: loading,
-    weight: 'bold',
-    size: 'small',
-    tone: 'active',
-    onClick: () => {
-      const newForceValidation = invalidFields.size !== 0;
-      setForceValidation(newForceValidation);
-      if (newForceValidation) return;
 
-      update({
-        variables: {
-          data: dataForUpdate,
-          id: itemGetter.get('id').data,
-        },
-      })
-        .then(({ data, errors }) => {
-          // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
-          // which are handled seperately and do not indicate a failure to update the item
-          const error = errors?.find(x => x.path?.length === 1);
-          if (error) {
+  return (
+    <form
+      onSubmit={event => {
+        event.preventDefault();
+        if (changedFields.size === 0) {
+          onCancel();
+          return;
+        }
+        const newForceValidation = invalidFields.size !== 0;
+        setForceValidation(newForceValidation);
+        if (newForceValidation) return;
+
+        update({
+          variables: {
+            data: dataForUpdate,
+            id: itemGetter.get('id').data,
+          },
+        })
+          .then(({ data, errors }) => {
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            const error = errors?.find(x => x.path?.length === 1);
+            if (error) {
+              toasts.addToast({
+                title: 'Failed to update item',
+                tone: 'negative',
+                message: error.message,
+              });
+            } else {
+              toasts.addToast({
+                title: data.item[list.labelField] || data.item.id,
+                tone: 'positive',
+                message: 'Saved successfully',
+              });
+              onSave(makeDataGetter(data, errors).get('item'));
+            }
+          })
+          .catch(err => {
             toasts.addToast({
               title: 'Failed to update item',
               tone: 'negative',
-              message: error.message,
+              message: err.message,
             });
-          } else {
-            toasts.addToast({
-              title: data.item[list.labelField] || data.item.id,
-              tone: 'positive',
-              message: 'Saved successfully',
-            });
-            onSave(makeDataGetter(data, errors).get('item'));
-          }
-        })
-        .catch(err => {
-          toasts.addToast({
-            title: 'Failed to update item',
-            tone: 'negative',
-            message: err.message,
           });
-        });
-    },
-    children: 'Save',
-  } as const;
-
-  return (
-    <Stack gap="xlarge">
-      {error && (
-        <GraphQLErrorNotice
-          networkError={error?.networkError}
-          // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
-          // which are handled seperately and do not indicate a failure to update the item
-          errors={error?.graphQLErrors.filter(x => x.path?.length === 1)}
+      }}
+    >
+      <Stack gap="xlarge">
+        {error && (
+          <GraphQLErrorNotice
+            networkError={error?.networkError}
+            // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+            // which are handled seperately and do not indicate a failure to update the item
+            errors={error?.graphQLErrors.filter(x => x.path?.length === 1)}
+          />
+        )}
+        <Fields
+          fieldModes={null}
+          fields={fieldsObj}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          onChange={useCallback(
+            value => {
+              setValue(state => ({ item: state.item, value: value(state.value) }));
+            },
+            [setValue]
+          )}
+          value={state.value}
         />
-      )}
-      <Fields
-        fieldModes={null}
-        fields={fieldsObj}
-        forceValidation={forceValidation}
-        invalidFields={invalidFields}
-        onChange={useCallback(
-          value => {
-            setValue(state => ({ item: state.item, value: value(state.value) }));
-          },
-          [setValue]
-        )}
-        value={state.value}
-      />
-      <Stack across gap="small">
-        {changedFields.size ? (
-          <Button {...saveButtonProps} />
-        ) : (
-          <Tooltip content="No fields have been modified so you cannot save changes">
-            {props => (
-              <Button
-                {...props}
-                {...saveButtonProps}
-                // making onClick undefined instead of making the button disabled so the button can be focussed so keyboard users can see the tooltip
-                onClick={undefined}
-              />
-            )}
-          </Tooltip>
-        )}
-        <Button size="small" weight="none" onClick={onCancel}>
-          Cancel
-        </Button>
+        <Stack across gap="small">
+          <Button isLoading={loading} weight="bold" size="small" tone="active" type="submit">
+            Save
+          </Button>
+          <Button size="small" weight="none" onClick={onCancel}>
+            Cancel
+          </Button>
+        </Stack>
       </Stack>
-    </Stack>
+    </form>
   );
 }


### PR DESCRIPTION
This pull request fixes the semantic-based browser input behaviour for inline create and edit forms on relationship fields when using the cards display mode, as they were not previously using form elements.

I was going to also make the whole item form use a form element too but that doesn't seem great since nested forms seem to be a No and pressing enter in some nested thing(e.g. editing a component block) and that saving the whole item seems unexpected.