### PR TITLE
Only run browser tests on chromium

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -390,11 +390,11 @@ jobs:
 
       - name: Install Dependencies of Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install-deps
+        run: npx playwright install-deps chromium
 
       - name: Install Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install
+        run: npx playwright install chromium
 
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
@@ -427,11 +427,11 @@ jobs:
 
       - name: Install Dependencies of Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        uses: microsoft/playwright-github-action@v1
+        run: npx playwright install-deps chromium
 
-      - name: Install Browsers for Playwright
+      - name: Install Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: node ./node_modules/playwright/install.js
+        run: npx playwright install chromium
 
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -390,11 +390,11 @@ jobs:
 
       - name: Install Dependencies of Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install-deps chromium
+        run: yarn playwright install-deps chromium
 
       - name: Install Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install chromium
+        run: yarn playwright install chromium
 
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
@@ -427,11 +427,11 @@ jobs:
 
       - name: Install Dependencies of Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install-deps chromium
+        run: yarn playwright install-deps chromium
 
       - name: Install Browsers
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'
-        run: npx playwright install chromium
+        run: yarn playwright install chromium
 
       - name: Unit tests
         if: needs.should_run_tests.outputs.shouldRunTests == 'true'

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -132,10 +132,12 @@ export const adminUITests = (
       });
     }
 
-    beforeAll(async () => {
-      await deleteAllData(projectDir);
+    describe('browser tests', () => {
+      beforeAll(async () => {
+        await deleteAllData(projectDir);
+      });
+      tests(playwright.chromium);
     });
-    tests(playwright.chromium);
   });
 };
 

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -132,20 +132,10 @@ export const adminUITests = (
       });
     }
 
-    describe.each([
-      'chromium',
-      'firefox',
-      // we don't run the tests on webkit in production
-      // because unlike chromium and firefox
-      // webkit doesn't treat localhost as a secure context
-      // and we enable secure cookies in production
-      ...(mode === 'prod' ? [] : (['webkit'] as const)),
-    ] as const)('%s', browserName => {
-      beforeAll(async () => {
-        await deleteAllData(projectDir);
-      });
-      tests(playwright[browserName]);
+    beforeAll(async () => {
+      await deleteAllData(projectDir);
     });
+    tests(playwright.chromium);
   });
 };
 

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -139,19 +139,9 @@ export const exampleProjectTests = (
       });
     }
 
-    describe.each([
-      'chromium',
-      'firefox',
-      // we don't run the tests on webkit in production
-      // because unlike chromium and firefox
-      // webkit doesn't treat localhost as a secure context
-      // and we enable secure cookies in production
-      ...(mode === 'prod' ? [] : (['webkit'] as const)),
-    ] as const)('%s', browserName => {
-      beforeAll(async () => {
-        await deleteAllData(projectDir);
-      });
-      tests(playwright[browserName], mode);
+    beforeAll(async () => {
+      await deleteAllData(projectDir);
     });
+    tests(playwright.chromium, mode);
   });
 };

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -139,9 +139,11 @@ export const exampleProjectTests = (
       });
     }
 
-    beforeAll(async () => {
-      await deleteAllData(projectDir);
+    describe('browser tests', () => {
+      beforeAll(async () => {
+        await deleteAllData(projectDir);
+      });
+      tests(playwright.chromium, mode);
     });
-    tests(playwright.chromium, mode);
   });
 };


### PR DESCRIPTION
As nice as it is to run our browser tests on multiple browsers, it's not really providing us a benefit. In the more than a year that we've had these tests running across browsers, I don't believe we've had a single case of something legitimately failing on only a particular browser found by these tests and webkit and firefox seem to be more flakey than chromium so I'm inclined to only run these on chromium.