### PR TITLE
Hide clear for segmented-control

### DIFF
--- a/.changeset/forty-stingrays-destroy.md
+++ b/.changeset/forty-stingrays-destroy.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Hide the clear button if is-required is true for segmented-control

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -75,7 +75,7 @@ export const Field = ({
                 setHasChanged(true);
               }}
             />
-            {value.value !== null && onChange !== undefined && (
+            {value.value !== null && onChange !== undefined && !field.isRequired && (
               <Button
                 onClick={() => {
                   onChange({ ...value, value: null });


### PR DESCRIPTION
Fix #7413 

Hide the clear button if is-required is true for segmented-control.

I confirmed that this fix works as expected in sandbox, but if you find a problem, please comment.