### PR TITLE
Add calendarDay field

### DIFF
--- a/.changeset/strange-panthers-eat.md
+++ b/.changeset/strange-panthers-eat.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Added `calendarDay` field to store a date without a time or timezone attached

--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -657,6 +657,57 @@ export default config({
 });
 ```
 
+### calendarDay
+
+A `calendarDay` field represents a date value only in ISO8601 format.
+
+On PostgreSQL and MySQL this is represented with the native date type.
+On SQLite this is represented as a string.
+
+Options:
+
+- `defaultValue` (default: `undefined`): Can be a string value with a date string in ISO8601 format.
+  This value will be used for the field when creating items if no explicit value is set.
+- `db.map`: Adds a [Prisma `@map`](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#map) attribute to this field which changes the column name in the database
+- `db.isNullable` (default: `validation.isRequired ? false : true`): If `false` then this field will be made non-nullable in the database and it will never be possible to set as `null`.
+- `validation.isRequired` (default: `false`): If `true` then this field can never be set to `null`.
+  It validate this when creating and updating an item through the GraphQL API or the Admin UI.
+  It will also default `db.isNullable` to false.
+- `isIndexed` (default: `false`)
+  - If `true` then this field will be indexed by the database.
+  - If `'unique'` then all values of this field must be unique.
+- `graphql.read.isNonNull` (default: `false`): If you have no read access control and you don't intend to add any in the future,
+  you can set this to true and the output field will be non-nullable. This is only allowed when you have no read access control because otherwise,
+  when access is denied, `null` will be returned which will cause an error since the field is non-nullable and the error
+  will propagate up until a nullable field is found which means the entire item will be unreadable and when doing an `items` query, all the items will be unreadable.
+- `graphql.create.isNonNull` (default: `false`): If you have no create access control and you want to explicitly show that this is field is non-nullable in the create input
+  you can set this to true and the create field will be non-nullable and have a default value at the GraphQL level.
+  This is only allowed when you have no create access control because otherwise, the item will always fail access control
+  if a user doesn't have access to create the particular field regardless of whether or not they specify the field in the create.
+
+```typescript
+import { config, list } from '@keystone-6/core';
+import { calendarDay } from '@keystone-6/core/fields';
+
+export default config({
+  lists: {
+    ListName: list({
+      fields: {
+        fieldName: calendarDay({
+          defaultValue: '1970-01-01',
+          db: { map: 'my_date' },
+          validation: { isRequired: true },
+          isIndexed: 'unique',
+        }),
+        /* ... */
+      },
+    }),
+    /* ... */
+  },
+  /* ... */
+});
+```
+
 ## Relationship type
 
 ### relationship

--- a/packages/core/fields/types/calendarDay/views/package.json
+++ b/packages/core/fields/types/calendarDay/views/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystone-6-core-fields-types-calendarDay-views.cjs.js",
+  "module": "dist/keystone-6-core-fields-types-calendarDay-views.esm.js"
+}

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -26,3 +26,5 @@ export { timestamp } from './types/timestamp';
 export type { TimestampFieldConfig } from './types/timestamp';
 export { virtual } from './types/virtual';
 export type { VirtualFieldConfig } from './types/virtual';
+export { calendarDay } from './types/calendarDay';
+export type { CalendarDayFieldConfig } from './types/calendarDay';

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -138,7 +138,7 @@ export const calendarDay =
           : graphql.CalendarDay,
         resolve({ value }) {
           if (value instanceof Date) {
-            return value.toISOString().slice(0, 10)
+            return value.toISOString().slice(0, 10);
           }
           return value;
         },

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -1,0 +1,210 @@
+import { humanize } from '../../../lib/utils';
+import {
+  BaseListTypeInfo,
+  fieldType,
+  FieldTypeFunc,
+  CommonFieldConfig,
+  orderDirectionEnum,
+  filters,
+} from '../../../types';
+import { graphql } from '../../..';
+import {
+  assertCreateIsNonNullAllowed,
+  assertReadIsNonNullAllowed,
+  getResolvedIsNullable,
+} from '../../non-null-graphql';
+import { resolveView } from '../../resolve-view';
+import { CalendarDayFieldMeta } from './views';
+
+export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
+  CommonFieldConfig<ListTypeInfo> & {
+    isIndexed?: boolean | 'unique';
+    validation?: {
+      isRequired?: boolean;
+    };
+    defaultValue?: string;
+    graphql?: {
+      create?: { isNonNull?: boolean };
+      read?: { isNonNull?: boolean };
+    };
+    db?: {
+      isNullable?: boolean;
+      map?: string;
+    };
+  };
+
+export const calendarDay =
+  <ListTypeInfo extends BaseListTypeInfo>({
+    isIndexed,
+    validation,
+    defaultValue,
+    ...config
+  }: CalendarDayFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> =>
+  meta => {
+    if (typeof defaultValue === 'string') {
+      try {
+        graphql.CalendarDay.graphQLType.parseValue(defaultValue);
+      } catch (err) {
+        throw new Error(
+          `The calendarDay field at ${meta.listKey}.${meta.fieldKey} specifies defaultValue: ${defaultValue} but values must be provided as a full-date ISO8601 string such as 1970-01-01`
+        );
+      }
+    }
+
+    const resolvedIsNullable = getResolvedIsNullable(validation, config.db);
+
+    assertReadIsNonNullAllowed(meta, config, resolvedIsNullable);
+
+    assertCreateIsNonNullAllowed(meta, config);
+
+    const mode = resolvedIsNullable === false ? 'required' : 'optional';
+
+    const fieldLabel = config.label ?? humanize(meta.fieldKey);
+
+    const usesNativeDateType = meta.provider === 'postgresql' || meta.provider === 'mysql';
+
+    const resolveInput = (value: null | undefined | string) => {
+      if (meta.provider === 'sqlite' || value == null) {
+        return value;
+      }
+      return dateStringToDateObjectInUTC(value);
+    };
+
+    const commonResolveFilter = mode === 'optional' ? filters.resolveCommon : <T>(x: T) => x;
+
+    return fieldType({
+      kind: 'scalar',
+      mode,
+      scalar: usesNativeDateType ? 'DateTime' : 'String',
+      index: isIndexed === true ? 'index' : isIndexed || undefined,
+      default:
+        typeof defaultValue === 'string'
+          ? {
+              kind: 'literal',
+              value: defaultValue,
+            }
+          : undefined,
+      map: config.db?.map,
+      nativeType: usesNativeDateType ? 'Date' : undefined,
+    })({
+      ...config,
+      hooks: {
+        ...config.hooks,
+        async validateInput(args) {
+          const value = args.resolvedData[meta.fieldKey];
+          if ((validation?.isRequired || resolvedIsNullable === false) && value === null) {
+            args.addValidationError(`${fieldLabel} is required`);
+          }
+
+          await config.hooks?.validateInput?.(args);
+        },
+      },
+      input: {
+        uniqueWhere:
+          isIndexed === 'unique'
+            ? {
+                arg: graphql.arg({ type: graphql.CalendarDay }),
+                resolve: usesNativeDateType ? dateStringToDateObjectInUTC : undefined,
+              }
+            : undefined,
+        where: {
+          arg: graphql.arg({
+            type: mode === 'optional' ? CalendarDayNullableFilter : CalendarDayFilter,
+          }),
+          resolve: usesNativeDateType
+            ? value => commonResolveFilter(transformFilterDateStringsToDateObjects(value))
+            : commonResolveFilter,
+        },
+        create: {
+          arg: graphql.arg({
+            type: config.graphql?.create?.isNonNull
+              ? graphql.nonNull(graphql.CalendarDay)
+              : graphql.CalendarDay,
+            defaultValue: config.graphql?.create?.isNonNull ? defaultValue : undefined,
+          }),
+          resolve(val: string | null | undefined) {
+            if (val === undefined) {
+              val = defaultValue ?? null;
+            }
+            return resolveInput(val);
+          },
+        },
+        update: { arg: graphql.arg({ type: graphql.CalendarDay }), resolve: resolveInput },
+        orderBy: { arg: graphql.arg({ type: orderDirectionEnum }) },
+      },
+      output: graphql.field({
+        type: config.graphql?.read?.isNonNull
+          ? graphql.nonNull(graphql.CalendarDay)
+          : graphql.CalendarDay,
+        resolve({ value }) {
+          if (value instanceof Date) {
+            return value.toISOString().slice(0, 10)
+          }
+          return value;
+        },
+      }),
+      views: resolveView('calendarDay/views'),
+      getAdminMeta(): CalendarDayFieldMeta {
+        return {
+          defaultValue: defaultValue ?? null,
+          isRequired: validation?.isRequired ?? false,
+        };
+      },
+    });
+  };
+
+const dateStringToDateObjectInUTC = (value: string) => new Date(`${value}T00:00Z`);
+
+type CalendarDayFilterType = graphql.InputObjectType<{
+  equals: graphql.Arg<typeof graphql.CalendarDay>;
+  in: graphql.Arg<graphql.ListType<graphql.NonNullType<typeof graphql.CalendarDay>>>;
+  notIn: graphql.Arg<graphql.ListType<graphql.NonNullType<typeof graphql.CalendarDay>>>;
+  lt: graphql.Arg<typeof graphql.CalendarDay>;
+  lte: graphql.Arg<typeof graphql.CalendarDay>;
+  gt: graphql.Arg<typeof graphql.CalendarDay>;
+  gte: graphql.Arg<typeof graphql.CalendarDay>;
+  not: graphql.Arg<CalendarDayFilterType>;
+}>;
+
+function transformFilterDateStringsToDateObjects(
+  filter: graphql.InferValueFromInputType<CalendarDayFilterType>
+): Parameters<typeof filters.resolveCommon>[0] {
+  if (filter === null) {
+    return filter;
+  }
+  return Object.fromEntries(
+    Object.entries(filter).map(([key, value]) => {
+      if (value == null) {
+        return [key, value];
+      }
+      if (Array.isArray(value)) {
+        return [key, value.map(dateStringToDateObjectInUTC)];
+      }
+      if (typeof value === 'object') {
+        return [key, transformFilterDateStringsToDateObjects(value)];
+      }
+      return [key, dateStringToDateObjectInUTC(value)];
+    })
+  );
+}
+
+const filterFields = (nestedType: CalendarDayFilterType) => ({
+  equals: graphql.arg({ type: graphql.CalendarDay }),
+  in: graphql.arg({ type: graphql.list(graphql.nonNull(graphql.CalendarDay)) }),
+  notIn: graphql.arg({ type: graphql.list(graphql.nonNull(graphql.CalendarDay)) }),
+  lt: graphql.arg({ type: graphql.CalendarDay }),
+  lte: graphql.arg({ type: graphql.CalendarDay }),
+  gt: graphql.arg({ type: graphql.CalendarDay }),
+  gte: graphql.arg({ type: graphql.CalendarDay }),
+  not: graphql.arg({ type: nestedType }),
+});
+
+const CalendarDayNullableFilter: CalendarDayFilterType = graphql.inputObject({
+  name: 'CalendarDayNullableFilter',
+  fields: () => filterFields(CalendarDayNullableFilter),
+});
+
+const CalendarDayFilter: CalendarDayFilterType = graphql.inputObject({
+  name: 'CalendarDayNullableFilter',
+  fields: () => filterFields(CalendarDayFilter),
+});

--- a/packages/core/src/fields/types/calendarDay/tests/non-null/test-fixtures.ts
+++ b/packages/core/src/fields/types/calendarDay/tests/non-null/test-fixtures.ts
@@ -1,0 +1,34 @@
+import { calendarDay } from '../..';
+
+export const name = 'calendarDay with isNullable: false';
+export const typeFunction = (x: any) => calendarDay({ ...x, db: { ...x?.db, isNullable: false } });
+export const exampleValue = () => '1990-12-31';
+export const exampleValue2 = () => '2000-01-20';
+export const supportsUnique = true;
+export const supportsGraphQLIsNonNull = true;
+export const supportsDbMap = true;
+export const fieldName = 'lastOnline';
+
+export const getTestFields = () => ({ lastOnline: calendarDay({ db: { isNullable: false } }) });
+
+export const initItems = () => {
+  return [
+    { name: 'person1', lastOnline: '1979-04-12' },
+    { name: 'person2', lastOnline: '1980-10-01' },
+    { name: 'person3', lastOnline: '1990-12-31' },
+    { name: 'person4', lastOnline: '2000-01-20' },
+    { name: 'person5', lastOnline: '2020-06-10' },
+    { name: 'person6', lastOnline: '2020-06-10' },
+    { name: 'person7', lastOnline: '2020-06-10' },
+  ];
+};
+
+export const storedValues = () => [
+  { name: 'person1', lastOnline: '1979-04-12' },
+  { name: 'person2', lastOnline: '1980-10-01' },
+  { name: 'person3', lastOnline: '1990-12-31' },
+  { name: 'person4', lastOnline: '2000-01-20' },
+  { name: 'person5', lastOnline: '2020-06-10' },
+  { name: 'person6', lastOnline: '2020-06-10' },
+  { name: 'person7', lastOnline: '2020-06-10' },
+];

--- a/packages/core/src/fields/types/calendarDay/tests/test-fixtures.ts
+++ b/packages/core/src/fields/types/calendarDay/tests/test-fixtures.ts
@@ -1,0 +1,34 @@
+import { calendarDay } from '..';
+
+export const name = 'calendarDay';
+export const typeFunction = calendarDay;
+export const exampleValue = () => '1990-12-31';
+export const exampleValue2 = () => '2000-01-20';
+export const supportsNullInput = true;
+export const supportsUnique = true;
+export const supportsDbMap = true;
+export const fieldName = 'lastOnline';
+
+export const getTestFields = () => ({ lastOnline: calendarDay() });
+
+export const initItems = () => {
+  return [
+    { name: 'person1', lastOnline: '1979-04-12' },
+    { name: 'person2', lastOnline: '1980-10-01' },
+    { name: 'person3', lastOnline: '1990-12-31' },
+    { name: 'person4', lastOnline: '2000-01-20' },
+    { name: 'person5', lastOnline: '2020-06-10' },
+    { name: 'person6', lastOnline: null },
+    { name: 'person7' },
+  ];
+};
+
+export const storedValues = () => [
+  { name: 'person1', lastOnline: '1979-04-12' },
+  { name: 'person2', lastOnline: '1980-10-01' },
+  { name: 'person3', lastOnline: '1990-12-31' },
+  { name: 'person4', lastOnline: '2000-01-20' },
+  { name: 'person5', lastOnline: '2020-06-10' },
+  { name: 'person6', lastOnline: null },
+  { name: 'person7', lastOnline: null },
+];

--- a/packages/core/src/fields/types/calendarDay/views/index.tsx
+++ b/packages/core/src/fields/types/calendarDay/views/index.tsx
@@ -1,0 +1,140 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { useState } from 'react';
+
+import { jsx, Inline, Stack, Text } from '@keystone-ui/core';
+import { FieldContainer, FieldLabel, DatePicker, FieldDescription } from '@keystone-ui/fields';
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+} from '../../../../types';
+import { CellContainer, CellLink } from '../../../../admin-ui/components';
+
+export type Value =
+  | { kind: 'create'; value: string | null }
+  | { kind: 'update'; value: string | null; initial: string | null };
+
+export const Field = ({
+  field,
+  value,
+  onChange,
+  forceValidation,
+}: FieldProps<typeof controller>) => {
+  const [touchedInput, setTouchedInput] = useState(false);
+  const showValidation = touchedInput || forceValidation;
+
+  const validationMessage = showValidation
+    ? validate(value, field.fieldMeta, field.label)
+    : undefined;
+
+  return (
+    <FieldContainer>
+      <Stack>
+        <FieldLabel>{field.label}</FieldLabel>
+        <FieldDescription id={`${field.path}-description`}>{field.description}</FieldDescription>
+        {onChange ? (
+          <Inline gap="small">
+            <Stack>
+              <DatePicker
+                onUpdate={date => {
+                  onChange({
+                    ...value,
+                    value: date,
+                  });
+                }}
+                onClear={() => {
+                  onChange({ ...value, value: null });
+                }}
+                onBlur={() => setTouchedInput(true)}
+                value={value.value ?? ''}
+              />
+              {validationMessage && (
+                <Text color="red600" size="small">
+                  {validationMessage}
+                </Text>
+              )}
+            </Stack>
+          </Inline>
+        ) : (
+          value.value !== null && <Text>{formatOutput(value.value)}</Text>
+        )}
+      </Stack>
+    </FieldContainer>
+  );
+};
+
+function validate(value: Value, fieldMeta: CalendarDayFieldMeta, label: string): string | undefined {
+  // if we recieve null initially on the item view and the current value is null,
+  // we should always allow saving it because:
+  // - the value might be null in the database and we don't want to prevent saving the whole item because of that
+  // - we might have null because of an access control error
+  if (value.kind === 'update' && value.initial === null && value.value === null) {
+    return undefined;
+  }
+
+  if (fieldMeta.isRequired && value.value === null) {
+    return `${label} is required`;
+  }
+  return undefined;
+}
+
+export const Cell: CellComponent = ({ item, field, linkTo }) => {
+  let value = item[field.path];
+  return linkTo ? (
+    <CellLink {...linkTo}>{formatOutput(value)}</CellLink>
+  ) : (
+    <CellContainer>{formatOutput(value)}</CellContainer>
+  );
+};
+Cell.supportsLinkTo = true;
+
+export const CardValue: CardValueComponent = ({ item, field }) => {
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {formatOutput(item[field.path])}
+    </FieldContainer>
+  );
+};
+
+function formatOutput(isoDateString: string | null) {
+  if (!isoDateString) {
+    return null;
+  }
+  const date = new Date(`${isoDateString}T00:00Z`);
+  const dateInLocalTimezone = new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate()
+  );
+  return dateInLocalTimezone.toLocaleDateString();
+}
+
+export type CalendarDayFieldMeta = {
+  defaultValue: string | null;
+  isRequired: boolean;
+};
+
+export const controller = (
+  config: FieldControllerConfig<CalendarDayFieldMeta>
+): FieldController<Value, string> & { fieldMeta: CalendarDayFieldMeta } => {
+  return {
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: config.path,
+    fieldMeta: config.fieldMeta,
+    defaultValue: { kind: 'create', value: null },
+    deserialize: data => {
+      const value = data[config.path];
+      return { kind: 'update', initial: value, value };
+    },
+    serialize: ({ value }) => {
+      return { [config.path]: value };
+    },
+    validate: value => validate(value, config.fieldMeta, config.label) === undefined,
+  };
+};

--- a/packages/core/src/fields/types/calendarDay/views/index.tsx
+++ b/packages/core/src/fields/types/calendarDay/views/index.tsx
@@ -66,7 +66,11 @@ export const Field = ({
   );
 };
 
-function validate(value: Value, fieldMeta: CalendarDayFieldMeta, label: string): string | undefined {
+function validate(
+  value: Value,
+  fieldMeta: CalendarDayFieldMeta,
+  label: string
+): string | undefined {
   // if we recieve null initially on the item view and the current value is null,
   // we should always allow saving it because:
   // - the value might be null in the database and we don't want to prevent saving the whole item because of that

--- a/packages/core/src/types/schema/graphql-ts-schema.ts
+++ b/packages/core/src/types/schema/graphql-ts-schema.ts
@@ -168,7 +168,9 @@ const RFC_3339_FULL_DATE_REGEX = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]
 
 function validateCalendarDay(input: string) {
   if (!RFC_3339_FULL_DATE_REGEX.test(input)) {
-    throw new GraphQLError('CalendarDay scalars must be in the form of a full-date ISO 8601 string');
+    throw new GraphQLError(
+      'CalendarDay scalars must be in the form of a full-date ISO 8601 string'
+    );
   }
 }
 

--- a/packages/core/src/types/schema/graphql-ts-schema.ts
+++ b/packages/core/src/types/schema/graphql-ts-schema.ts
@@ -164,6 +164,41 @@ export const DateTime = graphqlTsSchema.graphql.scalar<Date>(
   })
 );
 
+const RFC_3339_FULL_DATE_REGEX = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
+
+function validateCalendarDay(input: string) {
+  if (!RFC_3339_FULL_DATE_REGEX.test(input)) {
+    throw new GraphQLError('CalendarDay scalars must be in the form of a full-date ISO 8601 string');
+  }
+}
+
+export const CalendarDay = graphqlTsSchema.graphql.scalar<string>(
+  new GraphQLScalarType({
+    name: 'CalendarDay',
+    specifiedByUrl: 'https://datatracker.ietf.org/doc/html/rfc3339#section-5.6',
+    serialize(value: unknown) {
+      if (typeof value !== 'string') {
+        throw new GraphQLError(`unexpected value provided to CalendarDay scalar: ${value}`);
+      }
+      return value;
+    },
+    parseLiteral(value) {
+      if (value.kind !== 'StringValue') {
+        throw new GraphQLError('CalendarDay only accepts values as strings');
+      }
+      validateCalendarDay(value.value);
+      return value.value;
+    },
+    parseValue(value: unknown) {
+      if (typeof value !== 'string') {
+        throw new GraphQLError('CalendarDay only accepts values as strings');
+      }
+      validateCalendarDay(value);
+      return value;
+    },
+  })
+);
+
 export type NullableType = graphqlTsSchema.NullableType<Context>;
 export type Type = graphqlTsSchema.Type<Context>;
 export type NullableOutputType = graphqlTsSchema.NullableOutputType<Context>;

--- a/tests/api-tests/fields/types/calendarDay.test.ts
+++ b/tests/api-tests/fields/types/calendarDay.test.ts
@@ -1,0 +1,12 @@
+import { calendarDay } from '@keystone-6/core/fields';
+import { orderableFilterTests, filterTests, uniqueEqualityFilterTest } from './utils';
+
+for (const isNullable of [true, false]) {
+  describe(`calendarDay with isNullable: ${isNullable}`, () => {
+    const values = ['1979-04-12', '1980-10-01', '1990-12-31', '2000-01-20', '2020-06-10'] as const;
+    filterTests(calendarDay({ db: { isNullable } }), match => {
+      orderableFilterTests(match, values, isNullable);
+    });
+    uniqueEqualityFilterTest(calendarDay({ db: { isNullable }, isIndexed: 'unique' }), values);
+  });
+}

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -13,6 +13,7 @@ import {
   image,
   float,
   bigInt,
+  calendarDay,
 } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { componentBlocks } from '../component-blocks';
@@ -55,6 +56,7 @@ export const lists = {
       }),
       text: text({ ui: { description } }),
       timestamp: timestamp({ ui: { description } }),
+      calendarDay: calendarDay({ ui: { description } }),
       randomNumberVirtual: virtual({
         ui: { description },
         field: graphql.field({

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -23,6 +23,7 @@ type Thing {
   toManyRelationshipCardCount(where: TodoWhereInput! = {}): Int
   text: String
   timestamp: DateTime
+  calendarDay: CalendarDay
   randomNumberVirtual: Float
   select: String
   selectSegmentedControl: String
@@ -40,6 +41,9 @@ type PasswordState {
 }
 
 scalar DateTime
+  @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
+
+scalar CalendarDay
   @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
 
 scalar BigInt
@@ -87,6 +91,7 @@ input ThingWhereInput {
   toManyRelationshipCard: TodoManyRelationFilter
   text: StringFilter
   timestamp: DateTimeNullableFilter
+  calendarDay: CalendarDayNullableFilter
   select: StringNullableFilter
   selectSegmentedControl: StringNullableFilter
   integer: IntNullableFilter
@@ -159,6 +164,17 @@ input DateTimeNullableFilter {
   not: DateTimeNullableFilter
 }
 
+input CalendarDayNullableFilter {
+  equals: CalendarDay
+  in: [CalendarDay!]
+  notIn: [CalendarDay!]
+  lt: CalendarDay
+  lte: CalendarDay
+  gt: CalendarDay
+  gte: CalendarDay
+  not: CalendarDayNullableFilter
+}
+
 input StringNullableFilter {
   equals: String
   in: [String!]
@@ -225,6 +241,7 @@ input ThingOrderByInput {
   checkbox: OrderDirection
   text: OrderDirection
   timestamp: OrderDirection
+  calendarDay: OrderDirection
   select: OrderDirection
   selectSegmentedControl: OrderDirection
   integer: OrderDirection
@@ -246,6 +263,7 @@ input ThingUpdateInput {
   toManyRelationshipCard: TodoRelateToManyForUpdateInput
   text: String
   timestamp: DateTime
+  calendarDay: CalendarDay
   select: String
   selectSegmentedControl: String
   json: JSON
@@ -297,6 +315,7 @@ input ThingCreateInput {
   toManyRelationshipCard: TodoRelateToManyForCreateInput
   text: String
   timestamp: DateTime
+  calendarDay: CalendarDay
   select: String
   selectSegmentedControl: String
   json: JSON

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -24,6 +24,7 @@ model Thing {
   toManyRelationshipCard  Todo[]    @relation("Thing_toManyRelationshipCard")
   text                    String    @default("")
   timestamp               DateTime?
+  calendarDay             String?
   select                  String?
   selectSegmentedControl  String?
   json                    String?


### PR DESCRIPTION
This adds a new field type which store a date without a time or timezone. 
On PostgreSQL and MySQL this is represented with the native date type.
On SQLite this is represented as a string.
- https://github.com/keystonejs/keystone/discussions/7473

~The naming of `plainDate` is based on [the PlainDate type in the Temporal proposal ](https://tc39.es/proposal-temporal/docs/plaindate.html).~