### PR TITLE
Cleanup db config docs

### DIFF
--- a/docs/pages/docs/apis/config.mdx
+++ b/docs/pages/docs/apis/config.mdx
@@ -62,15 +62,9 @@ It has a TypeScript type of `DatabaseConfig`.
 Keystone supports the database types **PostgreSQL**, **MySQL** and **SQLite**.
 These database types are powered by their corresponding Prisma database providers; `postgresql`, `mysql` and `sqlite`.
 
-All database providers require the `url` argument, which defines the connection URL for your database.
-They also all have an optional `onConnect` async function, which takes a [`KeystoneContext`](./context) object, and lets perform any actions you might need at startup, such as data seeding.
-
-As well as these common options, each provider supports a number of optional advanced configuration options.
-
-### postgresql
-
-Advanced configuration:
-
+- `kind`: The database provider to use, it can be one of `postgresql`, `mysql` or `sqlite`.
+- `url`: The connection URL for your database
+- `onConnect`: which takes a [`KeystoneContext`](./context) object, and lets perform any actions you might need at startup, such as data seeding
 - `enableLogging` (default: `false`): Enable logging from the Prisma client.
 - `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
 - `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
@@ -78,6 +72,8 @@ Advanced configuration:
   If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 - `prismaPreviewFeatures` (default: `[]`): Enable [Prisma preview features](https://www.prisma.io/docs/concepts/components/preview-features) by providing an array of strings.
 - `shadowDatabaseUrl` (default: `undefined`): Enable [shadow databases](https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database#cloud-hosted-shadow-databases-must-be-created-manually) for some cloud providers.
+
+### postgresql
 
 ```typescript
 export default config({
@@ -97,15 +93,6 @@ export default config({
 
 ### mysql
 
-Advanced configuration:
-
-- `enableLogging` (default: `false`): Enable logging from the Prisma client.
-- `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
-- `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
-  This can also be customised at the list level `db.idField`.
-  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
-- `prismaPreviewFeatures` (default: `[]`): Enable [Prisma preview features](https://www.prisma.io/docs/concepts/components/preview-features) by providing an array of strings.
-
 ```typescript
 export default config({
   db: {
@@ -122,14 +109,6 @@ export default config({
 ```
 
 ### sqlite
-
-Advanced configuration:
-
-- `enableLogging` (default: `false`): Enable logging from the Prisma client.
-- `useMigrations` (default: `false`): Determines whether to use migrations or automatically force-update the database with the latest schema and potentially lose data.
-- `idField` (default: `{ kind: "cuid" }`): The kind of id field to use, it can be one of: `cuid`, `uuid` or `autoincrement`.
-  This can also be customised at the list level `db.idField`.
-  If you are using `autoincrement`, you can also specify `type: 'BigInt'` on PostgreSQL and MySQL to use BigInts.
 
 ```typescript
 export default config({


### PR DESCRIPTION
This was weirdly duplicated and made it seem like there's db specific config here when there isn't.

Excepting things like `db.idField: { kind: 'autoincrement', type: 'BigInt' }`,  which are mentioned explicitly and in reference to the supporting databases.