### PR TITLE
Update ambiguous plural changeset

### DIFF
--- a/.changeset/six-poems-appear.md
+++ b/.changeset/six-poems-appear.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Added support for changing the auto-generated names of lists used in the Admin UI with `ui.label`, `ui.singular`, `ui.plural` and `ui.path`
+Adds the ability to set ambiguous plurals - like `Firmware` or `Shrimp` - as list names without receiving an error. This builds on the existing `graphql.plural` configuration by adding the configuration options of `ui.label`, `ui.singular`, `ui.plural` and `ui.path` to change the auto-generated names of lists used in the Admin UI


### PR DESCRIPTION
Update ambiguous plural change set to be more clear about the outcome and reason.

Now reads

Adds the ability to set ambiguous plurals - like `Firmware` or `Shrimp` - as list names without receiving an error. This builds on the existing `graphql.plural` configuration by adding the configuration options of `ui.label`, `ui.singular`, `ui.plural` and `ui.path` to change the auto-generated names of lists used in the Admin UI