### PR TITLE
Minimal support for adding new fields to component blocks with existing data

### DIFF
--- a/.changeset/yellow-houses-doubt.md
+++ b/.changeset/yellow-houses-doubt.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+When new fields are added to an object field in a component block, the GraphQL will no longer error when returning data where some fields are missing in the saved data and the Admin UI will add the missing fields when a item is opened. Note that the missing fields won't be automatically added when fetched from the GraphQL, you will still have to handle the field being missing when consuming the data from the GraphQL API.

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
@@ -46,7 +46,10 @@ const componentBlocks = {
 test('delete backward at start', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElements" props={{ prop: '' }}>
+      <component-block
+        component="withChildElements"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-block-prop propPath={['block']}>
           <paragraph>
             <text>
@@ -91,7 +94,10 @@ test('delete backward at start', () => {
 test('insert break in last (inline) child prop', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElements" props={{ prop: '' }}>
+      <component-block
+        component="withChildElements"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-block-prop propPath={['block']}>
           <paragraph>
             <text>some text</text>
@@ -117,6 +123,8 @@ test('insert break in last (inline) child prop', () => {
         component="withChildElements"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -164,7 +172,10 @@ test('insert break in last (inline) child prop', () => {
 test('insert break in first (block) child prop in empty paragraph', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElements" props={{ prop: '' }}>
+      <component-block
+        component="withChildElements"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-block-prop propPath={['block']}>
           <paragraph>
             <text>some text</text>
@@ -192,6 +203,8 @@ test('insert break in first (block) child prop in empty paragraph', () => {
         component="withChildElements"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -234,7 +247,10 @@ test('insert break in first (block) child prop in empty paragraph', () => {
 test('insert break in last (block) child prop in empty paragraph', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElementsBlockLast" props={{ prop: '' }}>
+      <component-block
+        component="withChildElementsBlockLast"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-inline-prop propPath={['inline']}>
           <text>some more text</text>
         </component-inline-prop>
@@ -262,6 +278,8 @@ test('insert break in last (block) child prop in empty paragraph', () => {
         component="withChildElementsBlockLast"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -308,7 +326,10 @@ test('insert break in last (block) child prop in empty paragraph', () => {
 test('insert break in first (inline) child prop', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElementsBlockLast" props={{ prop: '' }}>
+      <component-block
+        component="withChildElementsBlockLast"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-inline-prop propPath={['inline']}>
           <text>
             some more
@@ -334,6 +355,8 @@ test('insert break in first (inline) child prop', () => {
         component="withChildElementsBlockLast"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
@@ -191,6 +191,7 @@ const makeEditorWithComplexComponentBlock = () =>
         component="complex"
         props={{
           object: {
+            block: null,
             conditional: {
               discriminant: false,
               value: null,
@@ -201,6 +202,7 @@ const makeEditorWithComplexComponentBlock = () =>
               discriminant: 'a',
               value: '',
             },
+            inline: null,
             many: [],
           },
         }}
@@ -311,6 +313,7 @@ test('preview props conditional change', () => {
         props={
           Object {
             "object": Object {
+              "block": null,
               "conditional": Object {
                 "discriminant": true,
                 "value": null,
@@ -319,6 +322,7 @@ test('preview props conditional change', () => {
                 "discriminant": "a",
                 "value": "",
               },
+              "inline": null,
               "many": Array [],
               "prop": "",
               "select": "a",

--- a/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
@@ -260,7 +260,10 @@ test('extra component props are removed', () => {
       <paragraph>
         <text />
       </paragraph>
-      <component-block component="withChildElements" props={{ prop: '' }}>
+      <component-block
+        component="withChildElements"
+        props={{ prop: '', block: null, inline: null }}
+      >
         <component-block-prop propPath={['block']}>
           <paragraph>
             <text>
@@ -297,6 +300,8 @@ test('extra component props are removed', () => {
         component="withChildElements"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -338,7 +343,7 @@ test('extra component props are removed', () => {
 test('missing component props are added', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withChildElements" props={{ prop: '' }}>
+      <component-block component="withChildElements" props={{ prop: '', block: null }}>
         <component-block-prop propPath={['block']}>
           <paragraph>
             <text>
@@ -359,6 +364,8 @@ test('missing component props are added', () => {
         component="withChildElements"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -423,6 +430,8 @@ test('prop with wrong type for a given prop path', () => {
         component="withChildElements"
         props={
           Object {
+            "block": null,
+            "inline": null,
             "prop": "",
           }
         }
@@ -465,7 +474,10 @@ test('prop with wrong type for a given prop path', () => {
 test('props in wrong order', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="withLotsOfChildElements" props={{}}>
+      <component-block
+        component="withLotsOfChildElements"
+        props={{ last: null, block: null, inline: null }}
+      >
         <component-block-prop propPath={['last']}>
           <paragraph>
             <text />
@@ -490,7 +502,13 @@ test('props in wrong order', () => {
     <editor>
       <component-block
         component="withLotsOfChildElements"
-        props={Object {}}
+        props={
+          Object {
+            "block": null,
+            "inline": null,
+            "last": null,
+          }
+        }
       >
         <component-block-prop
           propPath={
@@ -542,7 +560,7 @@ test('props in wrong order', () => {
 test('toggling to heading when in an inline prop', () => {
   const editor = makeEditor(
     <editor>
-      <component-block component="inline" props={{}}>
+      <component-block component="inline" props={{ child: null, other: null }}>
         <component-inline-prop propPath={['child']}>
           <text>
             some
@@ -578,7 +596,12 @@ test('toggling to heading when in an inline prop', () => {
     <editor>
       <component-block
         component="inline"
-        props={Object {}}
+        props={
+          Object {
+            "child": null,
+            "other": null,
+          }
+        }
       >
         <component-inline-prop
           propPath={
@@ -880,6 +903,55 @@ test('child field in array field deleteBackward in middle', () => {
         >
           <text>
             third
+          </text>
+        </component-inline-prop>
+      </component-block>
+      <paragraph>
+        <text>
+          
+        </text>
+      </paragraph>
+    </editor>
+  `);
+});
+
+test('normalization adds missing fields on object fields', () => {
+  const editor = makeEditor(
+    <editor>
+      <component-block component="basic" props={{ a: '' }}>
+        <component-inline-prop>
+          <text />
+        </component-inline-prop>
+      </component-block>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>,
+    {
+      normalization: 'normalize',
+      componentBlocks: {
+        basic: component({
+          preview: () => null,
+          label: 'Basic',
+          schema: { a: fields.text({ label: 'A' }), b: fields.checkbox({ label: 'B' }) },
+        }),
+      },
+    }
+  );
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <component-block
+        component="basic"
+        props={
+          Object {
+            "a": "",
+            "b": false,
+          }
+        }
+      >
+        <component-inline-prop>
+          <text>
+            
           </text>
         </component-inline-prop>
       </component-block>

--- a/packages/fields-document/src/DocumentEditor/insert-menu.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/insert-menu.test.tsx
@@ -373,8 +373,7 @@ test('insertMenu thing typing', () => {
       <paragraph>
         <text />
       </paragraph>
-    </editor>,
-    { normalization: 'normalize' }
+    </editor>
   );
   [...'/thing'].forEach(char => {
     editor.insertText(char);

--- a/packages/fields-document/src/DocumentEditor/markdown-link-shortcut.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/markdown-link-shortcut.test.tsx
@@ -249,7 +249,7 @@ test("link shortcut doesn't do anything when links are disabled globally in the 
 test("link shortcut doesn't do anything when inside of a component block with links disabled", () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="comp" props={{}}>
+      <component-block component="comp" props={{ child: null }}>
         <component-inline-prop propPath={['child']}>
           <text>
             [content](https://keystonejs.com
@@ -276,7 +276,11 @@ test("link shortcut doesn't do anything when inside of a component block with li
     <editor>
       <component-block
         component="comp"
-        props={Object {}}
+        props={
+          Object {
+            "child": null,
+          }
+        }
       >
         <component-inline-prop
           propPath={
@@ -302,7 +306,7 @@ test("link shortcut doesn't do anything when inside of a component block with li
 test('link shortcut works when inside of a component block with links option inherited', () => {
   let editor = makeEditor(
     <editor>
-      <component-block component="comp" props={{}}>
+      <component-block component="comp" props={{ child: null }}>
         <component-inline-prop propPath={['child']}>
           <text>
             [content](https://keystonejs.com
@@ -329,7 +333,11 @@ test('link shortcut works when inside of a component block with links option inh
     <editor>
       <component-block
         component="comp"
-        props={Object {}}
+        props={
+          Object {
+            "child": null,
+          }
+        }
       >
         <component-inline-prop
           propPath={

--- a/packages/fields-document/src/DocumentEditor/pasting/index.ts
+++ b/packages/fields-document/src/DocumentEditor/pasting/index.ts
@@ -63,8 +63,7 @@ export function withPasting(editor: Editor): Editor {
       }
     }
 
-    let html = data.getData('text/html');
-
+    const html = data.getData('text/html');
     if (html) {
       const fragment = deserializeHTML(html);
       insertFragmentButDifferent(editor, fragment);

--- a/packages/fields-document/src/relationship-data.tsx
+++ b/packages/fields-document/src/relationship-data.tsx
@@ -167,7 +167,14 @@ export async function addRelationshipDataToComponentProps(
         await Promise.all(
           Object.keys(schema.fields).map(async key => [
             key,
-            await addRelationshipDataToComponentProps(schema.fields[key], val[key], fetchData),
+            // if val[key] === undefined, we know a new field was added to the schema
+            // but there is old data in the database that doesn't have the new field
+            // we're intentionally not just magically adding it because we may want to
+            // have a more optimised strategy of hydrating relationships so we don't
+            // want to add something unrelated that requires the current "traverse everything" strategy
+            val[key] === undefined
+              ? undefined
+              : await addRelationshipDataToComponentProps(schema.fields[key], val[key], fetchData),
           ])
         )
       );

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -183,6 +183,7 @@ export const controller = (
       if (!documentFromServer) {
         return [{ type: 'paragraph', children: [{ text: '' }] }];
       }
+      // make a temporary editor to normalize the document
       const editor = createDocumentEditor(
         config.fieldMeta.documentFeatures,
         componentBlocks,

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -3,7 +3,7 @@
 
 import { jsx } from '@keystone-ui/core';
 import { FieldContainer, FieldDescription, FieldLabel } from '@keystone-ui/fields';
-import { Descendant, Node, Text } from 'slate';
+import { Descendant, Editor, Node, Text } from 'slate';
 import { DocumentRenderer } from '@keystone-6/document-renderer';
 
 import {
@@ -15,7 +15,7 @@ import {
 } from '@keystone-6/core/types';
 import weakMemoize from '@emotion/weak-memoize';
 import { CellContainer, CellLink } from '@keystone-6/core/admin-ui/components';
-import { DocumentEditor } from './DocumentEditor';
+import { createDocumentEditor, DocumentEditor } from './DocumentEditor';
 import { ComponentBlock } from './component-blocks';
 import { Relationships } from './DocumentEditor/relationship';
 import { clientSideValidateProp } from './DocumentEditor/component-blocks/utils';
@@ -179,7 +179,19 @@ export const controller = (
     relationships: config.fieldMeta.relationships,
     defaultValue: [{ type: 'paragraph', children: [{ text: '' }] }],
     deserialize: data => {
-      return data[config.path]?.document || [{ type: 'paragraph', children: [{ text: '' }] }];
+      const documentFromServer = data[config.path]?.document;
+      if (!documentFromServer) {
+        return [{ type: 'paragraph', children: [{ text: '' }] }];
+      }
+      const editor = createDocumentEditor(
+        config.fieldMeta.documentFeatures,
+        componentBlocks,
+        config.customViews.componentBlocks,
+        { current: false }
+      );
+      editor.children = documentFromServer;
+      Editor.normalize(editor, { force: true });
+      return editor.children;
     },
     serialize: value => ({
       [config.path]: value,

--- a/tests/sandbox/component-blocks.tsx
+++ b/tests/sandbox/component-blocks.tsx
@@ -563,4 +563,18 @@ export const componentBlocks = {
     },
     chromeless: true,
   }),
+  addingFieldsLater: component({
+    preview: () => null,
+    label: 'Adding Fields Later',
+    schema: {
+      someText: fields.text({ label: 'Some text' }),
+      // try
+      // 1. creating a document with this component blocks
+      // 2. uncommenting the lines below
+      // 3. view the document again and see if the fields are there
+      // someObject: fields.object({
+      //   someTextAddedLater: fields.text({ label: 'Some text added later' }),
+      // }),
+    },
+  }),
 };


### PR DESCRIPTION
This makes it possible to add new fields to component blocks when there is existing data in a database that doesn't have the new fields. It's not the ideal solution but it's a minimal solution so that developers aren't effectively blocked from adding new fields to component blocks over time.