### PR TITLE
Add multiselect field

### DIFF
--- a/.changeset/light-balloons-repair.md
+++ b/.changeset/light-balloons-repair.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds `multiselect` field

--- a/.changeset/light-balloons-repair.md
+++ b/.changeset/light-balloons-repair.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Adds `multiselect` field
+Adds a new `multiselect` field type

--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -544,6 +544,58 @@ export default config({
 });
 ```
 
+### multiselect
+
+A `multiselect` field represents the selection of a set of values from the defined `options`.
+Values can be either strings, integers, or enum values, as determined by the `type` option.
+This will determine their GraphQL data type.
+Unlike the `select` field, the `type` will not change the database type, `multiselect` fields are always stored as a json array in the database.
+
+Options:
+
+- `type` (default: `'string'`): Sets the type of the values of this field.
+  Must be one of `['string', 'enum', 'integer']`.
+- `options`: An array of `{ label, value }`.
+  `label` is a string to be displayed in the Admin UI.
+  `value` is either a `string` (for `{ type: 'string' }` or `{ type: 'enum' }`), or a `number` (for `{ type: 'integer' }`).
+  The `value` will be used in the GraphQL API and stored in the database.
+- `defaultValue` (default: `[]`): This value will be used for the field when creating items if no explicit value is set.
+- `db.map`: Adds a [Prisma `@map`](https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#map) attribute to this field which changes the column name in the database
+- `graphql.read.isNonNull` (default: `false`): If you have no read access control and you don't intend to add any in the future,
+  you can set this to true and the output field will be non-nullable. This is only allowed when you have no read access control because otherwise,
+  when access is denied, `null` will be returned which will cause an error since the field is non-nullable and the error
+  will propagate up until a nullable field is found which means the entire item will be unreadable and when doing an `items` query, all the items will be unreadable.
+- `graphql.create.isNonNull` (default: `false`): If you have no create access control and you want to explicitly show that this is field is non-nullable in the create input
+  you can set this to true and the create field will be non-nullable and have a default value at the GraphQL level.
+  This is only allowed when you have no create access control because otherwise, the item will always fail access control
+  if a user doesn't have access to create the particular field regardless of whether or not they specify the field in the create.
+
+```typescript
+import { config, list } from '@keystone-6/core';
+import { select } from '@keystone-6/core/fields';
+
+export default config({
+  lists: {
+    ListName: list({
+      fields: {
+        fieldName: multiselect({
+          type: 'enum',
+          options: [
+            { label: '...', value: '...' },
+            /* ... */
+          ],
+          defaultValue: ['...'],
+          db: { map: 'my_multiselect' },
+        }),
+        /* ... */
+      },
+    }),
+    /* ... */
+  },
+  /* ... */
+});
+```
+
 ### text
 
 A `text` field represents a string value.

--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -572,7 +572,7 @@ Options:
 
 ```typescript
 import { config, list } from '@keystone-6/core';
-import { select } from '@keystone-6/core/fields';
+import { multiselect } from '@keystone-6/core/fields';
 
 export default config({
   lists: {

--- a/packages/core/fields/types/multiselect/views/package.json
+++ b/packages/core/fields/types/multiselect/views/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystone-6-core-fields-types-multiselect-views.cjs.js",
+  "module": "dist/keystone-6-core-fields-types-multiselect-views.esm.js"
+}

--- a/packages/core/src/fields/index.ts
+++ b/packages/core/src/fields/index.ts
@@ -28,3 +28,5 @@ export { virtual } from './types/virtual';
 export type { VirtualFieldConfig } from './types/virtual';
 export { calendarDay } from './types/calendarDay';
 export type { CalendarDayFieldConfig } from './types/calendarDay';
+export { multiselect } from './types/multiselect';
+export type { MultiselectFieldConfig } from './types/multiselect';

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -1,0 +1,210 @@
+import inflection from 'inflection';
+import { humanize } from '../../../lib/utils';
+import {
+  BaseListTypeInfo,
+  FieldTypeFunc,
+  CommonFieldConfig,
+  FieldData,
+  jsonFieldTypePolyfilledForSQLite,
+} from '../../../types';
+import { graphql } from '../../..';
+import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
+import { resolveView } from '../../resolve-view';
+import { userInputError } from '../../../lib/core/graphql-errors';
+
+export type MultiselectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
+  CommonFieldConfig<ListTypeInfo> &
+    (
+      | {
+          /**
+           * When a value is provided as just a string, it will be formatted in the same way
+           * as field labels are to create the label.
+           */
+          options: readonly ({ label: string; value: string } | string)[];
+          /**
+           * If `enum` is provided on SQLite, it will use an enum in GraphQL but a string in the database.
+           */
+          type?: 'string' | 'enum';
+          defaultValue?: readonly string[];
+        }
+      | {
+          options: readonly { label: string; value: number }[];
+          type: 'integer';
+          defaultValue?: readonly number[];
+        }
+    ) & {
+      graphql?: {
+        create?: {
+          isNonNull?: boolean;
+        };
+        read?: {
+          isNonNull?: boolean;
+        };
+      };
+      db?: {
+        map?: string;
+      };
+    };
+
+// These are the max and min values available to a 32 bit signed integer
+const MAX_INT = 2147483647;
+const MIN_INT = -2147483648;
+
+export const multiselect =
+  <ListTypeInfo extends BaseListTypeInfo>({
+    ui,
+    defaultValue = [],
+    ...config
+  }: MultiselectFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
+  meta => {
+    if ((config as any).isIndexed === 'unique') {
+      throw Error("isIndexed: 'unique' is not a supported option for field type password");
+    }
+    const fieldLabel = config.label ?? humanize(meta.fieldKey);
+    assertReadIsNonNullAllowed(meta, config, false);
+
+    assertCreateIsNonNullAllowed(meta, config);
+
+    const output = <T extends graphql.NullableOutputType>(type: T) =>
+      config.graphql?.read?.isNonNull ? graphql.nonNull(nonNullList(type)) : nonNullList(type);
+
+    const create = <T extends graphql.NullableInputType>(type: T) => {
+      const list = nonNullList(type);
+      if (config.graphql?.read?.isNonNull) {
+        return graphql.arg({
+          type: graphql.nonNull(list),
+          defaultValue: defaultValue as any,
+        });
+      }
+      return graphql.arg({ type: list });
+    };
+
+    const resolveCreate = <T extends string | number>(val: T[] | null | undefined): T[] => {
+      const resolved = resolveUpdate(val);
+      if (resolved === undefined) {
+        return defaultValue as T[];
+      }
+      return resolved;
+    };
+    const resolveUpdate = <T extends string | number>(
+      val: T[] | null | undefined
+    ): T[] | undefined => {
+      if (val === null) {
+        throw userInputError('multiselect fields cannot be set to null');
+      }
+      return val;
+    };
+
+    const transformedConfig = configToOptionsAndGraphQLType(config, meta);
+
+    const possibleValues = new Set(transformedConfig.options.map(x => x.value));
+    if (possibleValues.size !== transformedConfig.options.length) {
+      throw new Error(
+        `The multiselect field at ${meta.listKey}.${meta.fieldKey} has duplicate options, this is not allowed`
+      );
+    }
+
+    return jsonFieldTypePolyfilledForSQLite(
+      meta.provider,
+      {
+        ui,
+        hooks: {
+          ...config.hooks,
+          async validateInput(args) {
+            const selectedValues: readonly (string | number)[] | undefined =
+              args.inputData[meta.fieldKey];
+            if (selectedValues !== undefined) {
+              for (const value of selectedValues) {
+                if (!possibleValues.has(value)) {
+                  args.addValidationError(`${value} is not a possible value for ${fieldLabel}`);
+                }
+              }
+              const uniqueValues = new Set(selectedValues);
+              if (uniqueValues.size !== selectedValues.length) {
+                args.addValidationError(`${fieldLabel} must have a unique set of options selected`);
+              }
+            }
+
+            await config.hooks?.validateInput?.(args);
+          },
+        },
+        views: resolveView('multiselect/views'),
+        getAdminMeta: () => ({
+          options: transformedConfig.options,
+          type: config.type ?? 'string',
+          defaultValue: [],
+        }),
+        input: {
+          create: { arg: create(transformedConfig.graphqlType), resolve: resolveCreate },
+          update: {
+            arg: graphql.arg({ type: nonNullList(transformedConfig.graphqlType) }),
+            resolve: resolveUpdate,
+          },
+        },
+        output: graphql.field({
+          type: output(transformedConfig.graphqlType),
+          resolve({ value }) {
+            return value as any;
+          },
+        }),
+      },
+      {
+        mode: 'required',
+        map: config?.db?.map,
+        default: { kind: 'literal', value: JSON.stringify(defaultValue) },
+      }
+    );
+  };
+
+function configToOptionsAndGraphQLType(
+  config: MultiselectFieldConfig<BaseListTypeInfo>,
+  meta: FieldData
+) {
+  if (config.type === 'integer') {
+    if (
+      config.options.some(
+        ({ value }) => !Number.isInteger(value) || value > MAX_INT || value < MIN_INT
+      )
+    ) {
+      throw new Error(
+        `The multiselect field at ${meta.listKey}.${meta.fieldKey} specifies integer values that are outside the range of a 32 bit signed integer`
+      );
+    }
+    return {
+      type: 'integer' as const,
+      graphqlType: graphql.Int,
+      options: config.options,
+    };
+  }
+
+  const options = config.options.map(option => {
+    if (typeof option === 'string') {
+      return {
+        label: humanize(option),
+        value: option,
+      };
+    }
+    return option;
+  });
+
+  if (config.type === 'enum') {
+    const enumName = `${meta.listKey}${inflection.classify(meta.fieldKey)}Type`;
+    const graphqlType = graphql.enum({
+      name: enumName,
+      values: graphql.enumValues(options.map(x => x.value)),
+    });
+    return {
+      type: 'enum' as const,
+      graphqlType,
+      options,
+    };
+  }
+  return {
+    type: 'string' as const,
+    graphqlType: graphql.String,
+    options,
+  };
+}
+
+const nonNullList = <T extends graphql.NullableType>(type: T) =>
+  graphql.list(graphql.nonNull(type));

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -58,7 +58,7 @@ export const multiselect =
   }: MultiselectFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
   meta => {
     if ((config as any).isIndexed === 'unique') {
-      throw Error("isIndexed: 'unique' is not a supported option for field type password");
+      throw Error("isIndexed: 'unique' is not a supported option for field type multiselect");
     }
     const fieldLabel = config.label ?? humanize(meta.fieldKey);
     assertReadIsNonNullAllowed(meta, config, false);

--- a/packages/core/src/fields/types/multiselect/tests/test-fixtures.ts
+++ b/packages/core/src/fields/types/multiselect/tests/test-fixtures.ts
@@ -1,0 +1,133 @@
+import { multiselect } from '..';
+
+type MatrixValue = typeof testMatrix[number];
+
+export const name = 'multiselect';
+export const typeFunction = multiselect;
+export const exampleValue = (matrixValue: MatrixValue) =>
+  matrixValue === 'enum'
+    ? ['thinkmill', 'atlassian']
+    : matrixValue === 'string'
+    ? ['something else', 'a string']
+    : [1, 3];
+export const exampleValue2 = (matrixValue: MatrixValue) =>
+  matrixValue === 'enum'
+    ? ['react', 'gelato']
+    : matrixValue === 'string'
+    ? ['a string', '1number']
+    : [2, 4];
+export const supportsNullInput = false;
+export const neverNull = true;
+export const supportsUnique = false;
+export const supportsDbMap = true;
+export const fieldConfig = (matrixValue: MatrixValue) => {
+  if (matrixValue === 'enum' || matrixValue === 'string') {
+    return {
+      type: matrixValue,
+      options:
+        matrixValue === 'enum'
+          ? [
+              { label: 'Thinkmill', value: 'thinkmill' },
+              { label: 'Atlassian', value: 'atlassian' },
+              { label: 'Thomas Walker Gelato', value: 'gelato' },
+              { label: 'Cete, or Seat, or Attend ¯\\_(ツ)_/¯', value: 'cete' },
+              { label: 'React', value: 'react' },
+            ]
+          : matrixValue === 'string'
+          ? [
+              { label: 'A string', value: 'a string' },
+              { label: 'Another string', value: 'another string' },
+              { label: '1number', value: '1number' },
+              { label: '@¯\\_(ツ)_/¯', value: '@¯\\_(ツ)_/¯' },
+              { label: 'something else', value: 'something else' },
+            ]
+          : [],
+    };
+  }
+  return {
+    type: matrixValue,
+    options: [
+      { label: 'One', value: 1 },
+      { label: 'Two', value: 2 },
+      { label: 'Three', value: 3 },
+      { label: 'Four', value: 4 },
+      { label: 'Five', value: 5 },
+    ],
+  };
+};
+export const fieldName = 'company';
+
+export const testMatrix = ['enum', 'string', 'integer'] as const;
+
+export const getTestFields = (matrixValue: MatrixValue) => ({
+  company: multiselect(fieldConfig(matrixValue)),
+});
+
+export const initItems = (matrixValue: MatrixValue) => {
+  if (matrixValue === 'enum') {
+    return [
+      { name: 'a', company: ['thinkmill', 'atlassian', 'gelato'] },
+      { name: 'b', company: ['atlassian', 'react'] },
+      { name: 'c', company: ['gelato'] },
+      { name: 'd', company: ['cete'] },
+      { name: 'e', company: ['react'] },
+      { name: 'f', company: [] },
+      { name: 'g' },
+    ];
+  } else if (matrixValue === 'string') {
+    return [
+      { name: 'a', company: ['a string', '@¯\\_(ツ)_/¯', '1number'] },
+      { name: 'b', company: ['@¯\\_(ツ)_/¯'] },
+      { name: 'c', company: ['another string'] },
+      { name: 'd', company: ['1number'] },
+      { name: 'e', company: ['something else'] },
+      { name: 'f', company: [] },
+      { name: 'g' },
+    ];
+  } else if (matrixValue === 'integer') {
+    return [
+      { name: 'a', company: [1, 2, 3] },
+      { name: 'b', company: [2] },
+      { name: 'c', company: [3] },
+      { name: 'd', company: [4] },
+      { name: 'e', company: [5] },
+      { name: 'f', company: [] },
+      { name: 'g' },
+    ];
+  }
+  return [];
+};
+
+export const storedValues = (matrixValue: MatrixValue) => {
+  if (matrixValue === 'enum') {
+    return [
+      { name: 'a', company: ['thinkmill', 'atlassian', 'gelato'] },
+      { name: 'b', company: ['atlassian', 'react'] },
+      { name: 'c', company: ['gelato'] },
+      { name: 'd', company: ['cete'] },
+      { name: 'e', company: ['react'] },
+      { name: 'f', company: [] },
+      { name: 'g', company: [] },
+    ];
+  } else if (matrixValue === 'string') {
+    return [
+      { name: 'a', company: ['a string', '@¯\\_(ツ)_/¯', '1number'] },
+      { name: 'b', company: ['@¯\\_(ツ)_/¯'] },
+      { name: 'c', company: ['another string'] },
+      { name: 'd', company: ['1number'] },
+      { name: 'e', company: ['something else'] },
+      { name: 'f', company: [] },
+      { name: 'g', company: [] },
+    ];
+  } else if (matrixValue === 'integer') {
+    return [
+      { name: 'a', company: [1, 2, 3] },
+      { name: 'b', company: [2] },
+      { name: 'c', company: [3] },
+      { name: 'd', company: [4] },
+      { name: 'e', company: [5] },
+      { name: 'f', company: [] },
+      { name: 'g', company: [] },
+    ];
+  }
+};

--- a/packages/core/src/fields/types/multiselect/tests/test-fixtures.ts
+++ b/packages/core/src/fields/types/multiselect/tests/test-fixtures.ts
@@ -20,6 +20,7 @@ export const supportsNullInput = false;
 export const neverNull = true;
 export const supportsUnique = false;
 export const supportsDbMap = true;
+export const skipRequiredTest = true;
 export const fieldConfig = (matrixValue: MatrixValue) => {
   if (matrixValue === 'enum' || matrixValue === 'string') {
     return {

--- a/packages/core/src/fields/types/multiselect/views/index.tsx
+++ b/packages/core/src/fields/types/multiselect/views/index.tsx
@@ -1,0 +1,113 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { Fragment } from 'react';
+import { jsx } from '@keystone-ui/core';
+import { FieldContainer, FieldDescription, FieldLabel, MultiSelect } from '@keystone-ui/fields';
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+} from '../../../../types';
+import { CellContainer, CellLink } from '../../../../admin-ui/components';
+
+export const Field = ({
+  field,
+  value,
+  onChange,
+  autoFocus,
+  forceValidation,
+}: FieldProps<typeof controller>) => {
+  return (
+    <FieldContainer>
+      <Fragment>
+        <FieldLabel htmlFor={field.path}>{field.label}</FieldLabel>
+        <FieldDescription id={`${field.path}-description`}>{field.description}</FieldDescription>
+        <MultiSelect
+          id={field.path}
+          isClearable
+          autoFocus={autoFocus}
+          options={field.options}
+          isDisabled={onChange === undefined}
+          onChange={newVal => {
+            onChange?.(newVal);
+          }}
+          value={value}
+          aria-describedby={field.description === null ? undefined : `${field.path}-description`}
+          portalMenu
+        />
+      </Fragment>
+    </FieldContainer>
+  );
+};
+
+export const Cell: CellComponent<typeof controller> = ({ item, field, linkTo }) => {
+  const value: readonly string[] | readonly number[] = item[field.path] ?? [];
+  const label = value.map(value => field.valuesToOptionsWithStringValues[value].label).join(', ');
+  return linkTo ? <CellLink {...linkTo}>{label}</CellLink> : <CellContainer>{label}</CellContainer>;
+};
+Cell.supportsLinkTo = true;
+
+export const CardValue: CardValueComponent<typeof controller> = ({ item, field }) => {
+  const value: readonly string[] | readonly number[] = item[field.path] ?? [];
+  const label = value.map(value => field.valuesToOptionsWithStringValues[value].label).join(', ');
+
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {label}
+    </FieldContainer>
+  );
+};
+
+export type AdminMultiSelectFieldMeta = {
+  options: readonly { label: string; value: string | number }[];
+  type: 'string' | 'integer' | 'enum';
+  defaultValue: string[] | number[];
+};
+
+type Config = FieldControllerConfig<AdminMultiSelectFieldMeta>;
+
+type Option = { label: string; value: string };
+
+type Value = readonly Option[];
+
+export const controller = (
+  config: Config
+): FieldController<Value, Option[]> & {
+  options: Option[];
+  type: 'string' | 'integer' | 'enum';
+  valuesToOptionsWithStringValues: Record<string, Option>;
+} => {
+  const optionsWithStringValues = config.fieldMeta.options.map(x => ({
+    label: x.label,
+    value: x.value.toString(),
+  }));
+
+  const valuesToOptionsWithStringValues = Object.fromEntries(
+    optionsWithStringValues.map(option => [option.value, option])
+  );
+
+  const parseValue = (value: string) =>
+    config.fieldMeta.type === 'integer' ? parseInt(value) : value;
+
+  return {
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: config.path,
+    defaultValue: config.fieldMeta.defaultValue.map(x => valuesToOptionsWithStringValues[x]),
+    type: config.fieldMeta.type,
+    options: optionsWithStringValues,
+    valuesToOptionsWithStringValues,
+    deserialize: data => {
+      // if we get null from the GraphQL API (which will only happen if field read access control failed)
+      // we'll just show it as nothing being selected for now.
+      const values: readonly string[] | readonly number[] = data[config.path] ?? [];
+      const selectedOptions = values.map(x => valuesToOptionsWithStringValues[x]);
+      return selectedOptions;
+    },
+    serialize: value => ({ [config.path]: value.map(x => parseValue(x.value)) }),
+  };
+};

--- a/packages/core/src/fields/types/multiselect/views/index.tsx
+++ b/packages/core/src/fields/types/multiselect/views/index.tsx
@@ -12,13 +12,7 @@ import {
 } from '../../../../types';
 import { CellContainer, CellLink } from '../../../../admin-ui/components';
 
-export const Field = ({
-  field,
-  value,
-  onChange,
-  autoFocus,
-  forceValidation,
-}: FieldProps<typeof controller>) => {
+export const Field = ({ field, value, onChange, autoFocus }: FieldProps<typeof controller>) => {
   return (
     <FieldContainer>
       <Fragment>

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -14,6 +14,7 @@ import {
   float,
   bigInt,
   calendarDay,
+  multiselect,
 } from '@keystone-6/core/fields';
 import { document } from '@keystone-6/fields-document';
 import { componentBlocks } from '../component-blocks';
@@ -81,6 +82,14 @@ export const lists = {
           { value: 'three', label: 'Three' },
         ],
         ui: { displayMode: 'segmented-control', description },
+      }),
+      multiselect: multiselect({
+        ui: { description },
+        options: [
+          { value: 'one', label: 'One' },
+          { value: 'two', label: 'Two' },
+          { value: 'three', label: 'Three' },
+        ],
       }),
       json: json({ ui: { description } }),
       integer: integer({ ui: { description } }),

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -27,6 +27,7 @@ type Thing {
   randomNumberVirtual: Float
   select: String
   selectSegmentedControl: String
+  multiselect: [String!]
   json: JSON
   integer: Int
   bigInt: BigInt
@@ -266,6 +267,7 @@ input ThingUpdateInput {
   calendarDay: CalendarDay
   select: String
   selectSegmentedControl: String
+  multiselect: [String!]
   json: JSON
   integer: Int
   bigInt: BigInt
@@ -318,6 +320,7 @@ input ThingCreateInput {
   calendarDay: CalendarDay
   select: String
   selectSegmentedControl: String
+  multiselect: [String!]
   json: JSON
   integer: Int
   bigInt: BigInt

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -27,6 +27,7 @@ model Thing {
   calendarDay             String?
   select                  String?
   selectSegmentedControl  String?
+  multiselect             String    @default("[]")
   json                    String?
   integer                 Int?
   bigInt                  BigInt?


### PR DESCRIPTION
This adds a `multiselect` field that mirrors the `select` field options. 

-  It is always non-nullable
- It is stored as a json array in databases

In this PR it does not have any filters and it is not orderable. It may change in the future PRs.
