### PR TITLE
Fix testing.mdx example imports

### DIFF
--- a/docs/pages/docs/guides/testing.mdx
+++ b/docs/pages/docs/guides/testing.mdx
@@ -34,7 +34,7 @@ You can then use this runner to wrap your test functions.
 
 ```typescript
 import { setupTestRunner } from '@keystone-6/core/testing';
-import { config } from './keystone';
+import config from './keystone';
 
 const runner = setupTestRunner({ config });
 


### PR DESCRIPTION
- Changing destructuring to direct import