### PR TITLE
Fixed inline relationships being removed when loading/saving an item in the Admin UI

### DIFF
--- a/.changeset/ten-apricots-nail.md
+++ b/.changeset/ten-apricots-nail.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': patch
 ---
 
-Fixes inline relationships being removed when loading/saving an item in the Admin UI.
+Fixes inline relationships being removed when loading/saving an item in the Admin UI (#7685)

--- a/.changeset/ten-apricots-nail.md
+++ b/.changeset/ten-apricots-nail.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes inline relationships being removed when loading/saving an item in the Admin UI.

--- a/packages/fields-document/src/views.tsx
+++ b/packages/fields-document/src/views.tsx
@@ -187,7 +187,7 @@ export const controller = (
       const editor = createDocumentEditor(
         config.fieldMeta.documentFeatures,
         componentBlocks,
-        config.customViews.componentBlocks
+        config.fieldMeta.relationships
       );
       editor.children = documentFromServer;
       Editor.normalize(editor, { force: true });


### PR DESCRIPTION
We were passing the component blocks to a place where relationships were expected and we didn't get a type error because what we were passing was any 😞

Closes #7685 