### PR TITLE
Add resize to document field

### DIFF
--- a/.changeset/tame-meals-guess.md
+++ b/.changeset/tame-meals-guess.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': minor
 ---
 
-Added resize to document field editor which allows to scroll through the content when it overflows in `item-view`.
+Changes the editors default overflow behaviour to align with other multi-line text inputs, supporting scrolling instead of an unbounded height for the field.

--- a/.changeset/tame-meals-guess.md
+++ b/.changeset/tame-meals-guess.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': minor
+---
+
+Added resize to document field editor which allows to scroll through the content when it overflows in `item-view`.

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -6,8 +6,7 @@ import { Toolbar } from '@keystone-6/fields-document/src/DocumentEditor/Toolbar'
 import { DocumentFeatures } from '@keystone-6/fields-document/views';
 import {
   createDocumentEditor,
-  DocumentEditorEditable,
-  DocumentEditorProvider,
+  DocumentEditor,
   Editor,
 } from '@keystone-6/fields-document/src/DocumentEditor';
 import {
@@ -276,19 +275,20 @@ export function DocumentFeaturesFormAndCode() {
 
 export const DocumentEditorDemo = () => {
   const [value, setValue] = useState(initialContent as any);
+  const [key, setKey] = useState(0);
   const { documentFeatures, formValue } = useContext(DocumentFeaturesContext);
 
-  const editor = useMemo(
-    () => createDocumentEditor(documentFeatures, componentBlocks, emptyObj),
-    [documentFeatures]
-  );
-
-  // this is why we're creating the editor ourselves and not using the DocumentEditor component
   useEffect(() => {
     // we want to force normalize when the document features change so
     // that no invalid things exist after a user changes something
+    const editor = createDocumentEditor(documentFeatures, componentBlocks, emptyObj);
+    editor.children = value;
     Editor.normalize(editor, { force: true });
-  }, [editor, documentFeatures]);
+    setValue(editor.children);
+    // slate looks like it's a controlled component but it actually isn't
+    // so we need to re-mount it so that it looks at the updated value
+    setKey(x => x + 1);
+  }, [documentFeatures]);
 
   return (
     <div
@@ -330,22 +330,14 @@ export const DocumentEditorDemo = () => {
           borderBottom: `1px var(--border) solid`,
         }}
       >
-        <DocumentEditorProvider
+        <DocumentEditor
+          key={key}
           value={value}
           onChange={setValue}
-          editor={editor}
           componentBlocks={componentBlocks}
           documentFeatures={documentFeatures}
           relationships={emptyObj}
-        >
-          {useMemo(
-            () => (
-              <Toolbar documentFeatures={documentFeatures} />
-            ),
-            [documentFeatures]
-          )}
-          <DocumentEditorEditable />
-        </DocumentEditorProvider>
+        />
       </div>
       <details css={{ marginBottom: 'var(--space-xlarge)' }}>
         <summary>View the Field Config</summary>

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -280,6 +280,8 @@ export const DocumentEditorDemo = () => {
   useEffect(() => {
     // we want to force normalize when the document features change so
     // that no invalid things exist after a user changes something
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const editor = createDocumentEditor(documentFeatures, componentBlocks, emptyObj);
     editor.children = value;
     Editor.normalize(editor, { force: true });

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -280,8 +280,6 @@ export const DocumentEditorDemo = () => {
   useEffect(() => {
     // we want to force normalize when the document features change so
     // that no invalid things exist after a user changes something
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const editor = createDocumentEditor(documentFeatures, componentBlocks, emptyObj);
     editor.children = value;
     Editor.normalize(editor, { force: true });
@@ -289,6 +287,7 @@ export const DocumentEditorDemo = () => {
     // slate looks like it's a controlled component but it actually isn't
     // so we need to re-mount it so that it looks at the updated value
     setKey(x => x + 1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [documentFeatures]);
 
   return (

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -2,7 +2,6 @@
 /** @jsx jsx */
 import { getInitialPropsValue } from '@keystone-6/fields-document/src/DocumentEditor/component-blocks/initial-values';
 import React, { ReactNode, useContext, useEffect, useMemo, useState } from 'react';
-import { Toolbar } from '@keystone-6/fields-document/src/DocumentEditor/Toolbar';
 import { DocumentFeatures } from '@keystone-6/fields-document/views';
 import {
   createDocumentEditor,

--- a/packages/fields-document/src/DocumentEditor/Toolbar.tsx
+++ b/packages/fields-document/src/DocumentEditor/Toolbar.tsx
@@ -182,8 +182,7 @@ const ToolbarContainer = ({ children }: { children: ReactNode }) => {
   return (
     <div
       css={{
-        backgroundColor: colors.background,
-        boxShadow: `0 1px ${colors.border}, 0 -1px ${colors.border}`,
+        borderBottom: `1px solid ${colors.border}`,
         paddingBottom: spacing.small,
         paddingTop: spacing.small,
         position: 'sticky',

--- a/packages/fields-document/src/DocumentEditor/Toolbar.tsx
+++ b/packages/fields-document/src/DocumentEditor/Toolbar.tsx
@@ -55,87 +55,83 @@ export function Toolbar({
   const relationship = useContext(DocumentFieldRelationshipsContext);
   const blockComponent = useContext(ComponentBlockContext);
   const hasBlockItems = Object.entries(relationship).length || Object.keys(blockComponent).length;
-
+  const hasMarks = Object.values(documentFeatures.formatting.inlineMarks).some(x => x);
   return (
     <ToolbarContainer>
-      {!!documentFeatures.formatting.headingLevels.length && (
-        <Fragment>
+      <ToolbarGroup>
+        {!!documentFeatures.formatting.headingLevels.length && (
           <HeadingMenu headingLevels={documentFeatures.formatting.headingLevels} />
-          <ToolbarSeparator />
-        </Fragment>
-      )}
-      {Object.values(documentFeatures.formatting.inlineMarks).some(x => x) && (
-        <Fragment>
-          <InlineMarks marks={documentFeatures.formatting.inlineMarks} />
-          <ToolbarSeparator />
-        </Fragment>
-      )}
-      {(documentFeatures.formatting.alignment.center ||
-        documentFeatures.formatting.alignment.end) && (
-        <TextAlignMenu alignment={documentFeatures.formatting.alignment} />
-      )}
-      {documentFeatures.formatting.listTypes.unordered && (
-        <Tooltip
-          content={
-            <Fragment>
-              Bullet List <KeyboardInTooltip>- </KeyboardInTooltip>
-            </Fragment>
-          }
-          weight="subtle"
-        >
-          {attrs => (
-            <ListButton type="unordered-list" {...attrs}>
-              <BulletListIcon />
-            </ListButton>
-          )}
-        </Tooltip>
-      )}
-      {documentFeatures.formatting.listTypes.ordered && (
-        <Tooltip
-          content={
-            <Fragment>
-              Numbered List <KeyboardInTooltip>1. </KeyboardInTooltip>
-            </Fragment>
-          }
-          weight="subtle"
-        >
-          {attrs => (
-            <ListButton type="ordered-list" {...attrs}>
-              <NumberedListIcon />
-            </ListButton>
-          )}
-        </Tooltip>
-      )}
-      {(documentFeatures.formatting.alignment.center ||
-        documentFeatures.formatting.alignment.end ||
-        documentFeatures.formatting.listTypes.unordered ||
-        documentFeatures.formatting.listTypes.ordered) && <ToolbarSeparator />}
+        )}
+        {hasMarks && <InlineMarks marks={documentFeatures.formatting.inlineMarks} />}
+        {hasMarks && <ToolbarSeparator />}
+        {(documentFeatures.formatting.alignment.center ||
+          documentFeatures.formatting.alignment.end) && (
+          <TextAlignMenu alignment={documentFeatures.formatting.alignment} />
+        )}
+        {documentFeatures.formatting.listTypes.unordered && (
+          <Tooltip
+            content={
+              <Fragment>
+                Bullet List <KeyboardInTooltip>- </KeyboardInTooltip>
+              </Fragment>
+            }
+            weight="subtle"
+          >
+            {attrs => (
+              <ListButton type="unordered-list" {...attrs}>
+                <BulletListIcon />
+              </ListButton>
+            )}
+          </Tooltip>
+        )}
+        {documentFeatures.formatting.listTypes.ordered && (
+          <Tooltip
+            content={
+              <Fragment>
+                Numbered List <KeyboardInTooltip>1. </KeyboardInTooltip>
+              </Fragment>
+            }
+            weight="subtle"
+          >
+            {attrs => (
+              <ListButton type="ordered-list" {...attrs}>
+                <NumberedListIcon />
+              </ListButton>
+            )}
+          </Tooltip>
+        )}
+        {(documentFeatures.formatting.alignment.center ||
+          documentFeatures.formatting.alignment.end ||
+          documentFeatures.formatting.listTypes.unordered ||
+          documentFeatures.formatting.listTypes.ordered) && <ToolbarSeparator />}
 
-      {documentFeatures.dividers && dividerButton}
-      {documentFeatures.links && linkButton}
-      {documentFeatures.formatting.blockTypes.blockquote && blockquoteButton}
-      {!!documentFeatures.layouts.length && <LayoutsButton layouts={documentFeatures.layouts} />}
-      {documentFeatures.formatting.blockTypes.code && codeButton}
-      {!!hasBlockItems && <InsertBlockMenu />}
-
-      <ToolbarSeparator />
+        {documentFeatures.dividers && dividerButton}
+        {documentFeatures.links && linkButton}
+        {documentFeatures.formatting.blockTypes.blockquote && blockquoteButton}
+        {!!documentFeatures.layouts.length && <LayoutsButton layouts={documentFeatures.layouts} />}
+        {documentFeatures.formatting.blockTypes.code && codeButton}
+        {!!hasBlockItems && <InsertBlockMenu />}
+      </ToolbarGroup>
       {useMemo(() => {
         const ExpandIcon = viewState?.expanded ? Minimize2Icon : Maximize2Icon;
         return (
           viewState && (
-            <Tooltip content={viewState.expanded ? 'Collapse' : 'Expand'} weight="subtle">
-              {attrs => (
-                <ToolbarButton
-                  onMouseDown={event => {
-                    event.preventDefault();
-                    viewState.toggle();
-                  }}
-                  {...attrs}
-                >
-                  <ExpandIcon size="small" />
-                </ToolbarButton>
-              )}
-            </Tooltip>
+            <ToolbarGroup>
+              <ToolbarSeparator />
+              <Tooltip content={viewState.expanded ? 'Collapse' : 'Expand'} weight="subtle">
+                {attrs => (
+                  <ToolbarButton
+                    onMouseDown={event => {
+                      event.preventDefault();
+                      viewState.toggle();
+                    }}
+                    {...attrs}
+                  >
+                    <ExpandIcon size="small" />
+                  </ToolbarButton>
+                )}
+              </Tooltip>
+            </ToolbarGroup>
           )
         );
       }, [viewState])}
@@ -183,14 +179,27 @@ const ToolbarContainer = ({ children }: { children: ReactNode }) => {
     <div
       css={{
         borderBottom: `1px solid ${colors.border}`,
-        paddingBottom: spacing.small,
-        paddingTop: spacing.small,
+        background: colors.background,
         position: 'sticky',
         top: 0,
         zIndex: 2,
+        borderTopLeftRadius: 'inherit',
+        borderTopRightRadius: 'inherit',
       }}
     >
-      <ToolbarGroup>{children}</ToolbarGroup>
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          height: 40,
+          paddingLeft: spacing.xsmall,
+          paddingRight: spacing.xsmall,
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
 };
@@ -486,7 +495,7 @@ function MoreFormattingDialog({
   return (
     <InlineDialog
       onMouseDown={event => {
-        if ((event.target as any).nodeName === 'BUTTON') {
+        if (event.target instanceof HTMLElement && event.target.closest('button')) {
           onCloseMenu();
         }
       }}

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -196,8 +196,6 @@ export function DocumentEditor({
     <div
       css={[
         {
-          // display: 'flex',
-          // flexDirection: 'column',
           border: `1px solid ${colors.border}`,
           borderRadius: radii.small,
         },
@@ -251,25 +249,23 @@ export function DocumentEditor({
         )}
 
         <DocumentEditorEditable
-          css={[
-            {
-              height: 270,
-              resize: 'vertical',
-              overflowY: 'auto',
-              minHeight: 120,
-              scrollbarGutter: 'stable',
-              paddingLeft: spacing.small,
-              paddingRight: spacing.small,
-            },
-            expanded && {
-              resize: 'none',
-              overflowY: 'hidden',
-              height: 'auto !important',
-              scrollbarGutter: 'unset',
-              paddingLeft: spacing.medium,
-              paddingRight: spacing.medium,
-            },
-          ]}
+          css={
+            expanded
+              ? {
+                  height: 'auto !important',
+                  paddingLeft: spacing.medium,
+                  paddingRight: spacing.medium,
+                }
+              : {
+                  height: 270,
+                  resize: 'vertical',
+                  overflowY: 'auto',
+                  minHeight: 120,
+                  scrollbarGutter: 'stable',
+                  paddingLeft: spacing.small,
+                  paddingRight: spacing.small,
+                }
+          }
           {...props}
           readOnly={onChange === undefined}
         />

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -185,7 +185,7 @@ export function DocumentEditor({
   relationships: Relationships;
   documentFeatures: DocumentFeatures;
 } & Omit<EditableProps, 'value' | 'onChange'>) {
-  const { radii, colors, spacing } = useTheme();
+  const { radii, colors, spacing, fields } = useTheme();
   const [expanded, setExpanded] = useState(false);
   const editor = useMemo(
     () => createDocumentEditor(documentFeatures, componentBlocks, relationships),
@@ -249,23 +249,36 @@ export function DocumentEditor({
         )}
 
         <DocumentEditorEditable
-          css={
+          css={[
+            {
+              borderRadius: 'inherit',
+              background: fields.inputBackground,
+              borderColor: fields.inputBorderColor,
+              paddingLeft: spacing.medium,
+              paddingRight: spacing.medium,
+              ':hover': {
+                background: fields.hover.inputBackground,
+              },
+              ':focus': {
+                background: fields.focus.inputBackground,
+              },
+              ':disabled': {
+                background: fields.disabled.inputBackground,
+              },
+            },
             expanded
               ? {
                   height: 'auto !important',
-                  paddingLeft: spacing.medium,
-                  paddingRight: spacing.medium,
+                  background: fields.focus.inputBackground,
                 }
               : {
-                  height: 270,
+                  height: 224,
                   resize: 'vertical',
                   overflowY: 'auto',
                   minHeight: 120,
                   scrollbarGutter: 'stable',
-                  paddingLeft: spacing.small,
-                  paddingRight: spacing.small,
-                }
-          }
+                },
+          ]}
           {...props}
           readOnly={onChange === undefined}
         />

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -185,7 +185,7 @@ export function DocumentEditor({
   relationships: Relationships;
   documentFeatures: DocumentFeatures;
 } & Omit<EditableProps, 'value' | 'onChange'>) {
-  const { colors, spacing } = useTheme();
+  const { radii, colors, spacing } = useTheme();
   const [expanded, setExpanded] = useState(false);
   const editor = useMemo(
     () => createDocumentEditor(documentFeatures, componentBlocks, relationships),
@@ -196,10 +196,13 @@ export function DocumentEditor({
     <div
       css={[
         {
-          display: 'flex',
-          flexDirection: 'column',
+          // display: 'flex',
+          // flexDirection: 'column',
+          border: `1px solid ${colors.border}`,
+          borderRadius: radii.small,
         },
         expanded && {
+          border: 'none',
           background: colors.background,
           bottom: 0,
           left: 0,
@@ -248,12 +251,25 @@ export function DocumentEditor({
         )}
 
         <DocumentEditorEditable
-          css={
+          css={[
+            {
+              height: 270,
+              resize: 'vertical',
+              overflowY: 'auto',
+              minHeight: 120,
+              scrollbarGutter: 'stable',
+              paddingLeft: spacing.small,
+              paddingRight: spacing.small,
+            },
             expanded && {
-              marginLeft: spacing.medium,
-              marginRight: spacing.medium,
-            }
-          }
+              resize: 'none',
+              overflowY: 'hidden',
+              height: 'auto !important',
+              scrollbarGutter: 'unset',
+              paddingLeft: spacing.medium,
+              paddingRight: spacing.medium,
+            },
+          ]}
           {...props}
           readOnly={onChange === undefined}
         />

--- a/packages/fields-document/src/DocumentEditor/primitives/toolbar.tsx
+++ b/packages/fields-document/src/DocumentEditor/primitives/toolbar.tsx
@@ -32,11 +32,12 @@ export const ToolbarSeparator = () => {
 // Groups
 // ------------------------------
 
-const autoFlowDirection = {
-  column: 'row',
-  row: 'column',
+type DirectionType = 'row' | 'column';
+
+const directionToAlignment = {
+  row: 'center',
+  column: 'start',
 };
-type DirectionType = keyof typeof autoFlowDirection;
 
 const ToolbarGroupContext = createContext<{ direction: DirectionType }>({ direction: 'row' });
 const useToolbarGroupContext = () => useContext(ToolbarGroupContext);
@@ -51,9 +52,12 @@ export const ToolbarGroup = forwardRefWithAs<'div', ToolbarGroupProps>(
         <Box
           ref={ref}
           css={{
-            display: 'inline-grid',
+            display: 'flex',
             gap: spacing.xxsmall,
-            gridAutoFlow: autoFlowDirection[direction],
+            flexDirection: direction,
+            justifyContent: 'start',
+            alignItems: directionToAlignment[direction],
+            height: '100%',
           }}
           {...props}
         >
@@ -146,6 +150,7 @@ export const ToolbarButton = forwardRefWithAs<'button', ToolbarButtonProps>(func
         '&[data-display-mode=column]': {
           paddingLeft: spacing.medium,
           paddingRight: spacing.medium,
+          width: '100%',
         },
       }}
       {...props}


### PR DESCRIPTION
This pull request changes the editors default overflow behaviour to align with other multi-line text inputs in the Item view, supporting scrolling instead of an unbounded height for the field.

#### Justification
Our justification for this is that the user is often burdened with the entire content of any given document field (or fields), and needs to scroll continuously to pass them. 

This changes that behaviour to contain their content inline with other fields, with two escape hatches:
- Click and drag the resize handle to the desired size
- Click the "Expand" button in the top right of the control bar to enter a full-screen mode

A video of the new behaviour

https://user-images.githubusercontent.com/28669082/180898856-4a126038-4030-42c2-af65-34484c806754.mov