### PR TITLE
Fix link in docs

### DIFF
--- a/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
+++ b/docs/pages/docs/walkthroughs/embedded-mode-with-sqlite-nextjs.mdx
@@ -58,7 +58,7 @@ Delete the `/pages/api` directory. We’ll add a GraphQL API later in the tutori
    └── index.tsx
 ```
 
-It is recommended that you use the same major version of `next` as used internally by [keystone](https://github.com/keystonejs/keystone/blob/main/packages/core/package.json#L107).
+It is recommended that you use the same major version of `next` as used internally by [keystone](https://github.com/keystonejs/keystone/blob/main/packages/core/package.json).
 
 ### Start your local server
 


### PR DESCRIPTION
Fixes a link in Keystone documentation that wasn't pointing to the right place in our Github repo.