### PR TITLE
Add radio button option to select

### DIFF
--- a/.changeset/metal-cars-breathe.md
+++ b/.changeset/metal-cars-breathe.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Add 'radio' button display mode option to select field.
+Adds `ui.displayMode: 'radio'` as an option for the select field.

--- a/.changeset/metal-cars-breathe.md
+++ b/.changeset/metal-cars-breathe.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add 'radio' button display mode option to select field.

--- a/docs/pages/docs/apis/fields.mdx
+++ b/docs/pages/docs/apis/fields.mdx
@@ -505,7 +505,7 @@ Options:
   - If `true` then this field will be indexed by the database.
   - If `'unique'` then all values of this field must be unique.
 - `ui.displayMode` (default: `'select'`): Configures the display mode of the field in the Admin UI.
-  Can be one of `['select', 'segmented-control']`.
+  Can be one of `['select', 'segmented-control', 'radio']`.
 - `graphql.read.isNonNull` (default: `false`): If you have no read access control and you don't intend to add any in the future,
   you can set this to true and the output field will be non-nullable. This is only allowed when you have no read access control because otherwise,
   when access is denied, `null` will be returned which will cause an error since the field is non-nullable and the error

--- a/packages/core/src/fields/types/select/index.ts
+++ b/packages/core/src/fields/types/select/index.ts
@@ -38,7 +38,7 @@ export type SelectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
         }
     ) & {
       ui?: {
-        displayMode?: 'select' | 'segmented-control';
+        displayMode?: 'select' | 'segmented-control' | 'radio';
       };
 
       validation?: {

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -65,6 +65,7 @@ export const Field = ({
           <Stack gap="small">
             {field.options.map(option => (
               <Radio
+                css={{ alignItems: 'center' }}
                 key={option.value}
                 value={option.value}
                 checked={value.value?.value === option.value}

--- a/packages/core/src/fields/types/select/views/index.tsx
+++ b/packages/core/src/fields/types/select/views/index.tsx
@@ -7,6 +7,7 @@ import {
   FieldDescription,
   FieldLabel,
   MultiSelect,
+  Radio,
   Select,
 } from '@keystone-ui/fields';
 import { SegmentedControl } from '@keystone-ui/segmented-control';
@@ -55,6 +56,39 @@ export const Field = ({
             aria-describedby={field.description === null ? undefined : `${field.path}-description`}
             portalMenu
           />
+          {validationMessage}
+        </Fragment>
+      ) : field.displayMode === 'radio' ? (
+        <Fragment>
+          <FieldLabel as="legend">{field.label}</FieldLabel>
+          <FieldDescription id={`${field.path}-description`}>{field.description}</FieldDescription>
+          <Stack gap="small">
+            {field.options.map(option => (
+              <Radio
+                key={option.value}
+                value={option.value}
+                checked={value.value?.value === option.value}
+                onChange={event => {
+                  if (event.target.checked) {
+                    onChange?.({ ...value, value: option });
+                    setHasChanged(true);
+                  }
+                }}
+              >
+                {option.label}
+              </Radio>
+            ))}
+            {value.value !== null && onChange !== undefined && !field.isRequired && (
+              <Button
+                onClick={() => {
+                  onChange({ ...value, value: null });
+                  setHasChanged(true);
+                }}
+              >
+                Clear
+              </Button>
+            )}
+          </Stack>
           {validationMessage}
         </Fragment>
       ) : (
@@ -115,7 +149,7 @@ export const CardValue: CardValueComponent<typeof controller> = ({ item, field }
 export type AdminSelectFieldMeta = {
   options: readonly { label: string; value: string | number }[];
   type: 'string' | 'integer' | 'enum';
-  displayMode: 'select' | 'segmented-control';
+  displayMode: 'select' | 'segmented-control' | 'radio';
   isRequired: boolean;
   defaultValue: string | number | null;
 };
@@ -145,7 +179,7 @@ export const controller = (
 ): FieldController<Value, Option[]> & {
   options: Option[];
   type: 'string' | 'integer' | 'enum';
-  displayMode: 'select' | 'segmented-control';
+  displayMode: 'select' | 'segmented-control' | 'radio';
   isRequired: boolean;
 } => {
   const optionsWithStringValues = config.fieldMeta.options.map(x => ({


### PR DESCRIPTION
A `radio` button `ui.displayMode` option is provided to configure the display of `select` field in the Admin UI. The displayMode options available to users are `['select', 'segmented-control', 'radio']`.

The `radio` displayMode is used for 
![Screenshot 2022-08-02 at 11 05 34 am](https://user-images.githubusercontent.com/28669082/182270171-82984a56-78d6-4483-9af5-427a2108f972.png)
single select fields.

 