### PR TITLE
Change markdown parsing when pasting plain text to be more conservative in the document editor

### DIFF
--- a/.changeset/fast-gorillas-build.md
+++ b/.changeset/fast-gorillas-build.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes pasting plain text in the document editor removing markdown link definition and usages 

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -45,7 +45,6 @@
     "io-ts-excess": "^1.0.1",
     "is-hotkey": "^0.2.0",
     "match-sorter": "^6.3.1",
-    "mdast-util-definitions": "^4.0.0",
     "mdast-util-from-markdown": "^0.8.5",
     "mdast-util-gfm-autolink-literal": "^0.1.3",
     "mdast-util-gfm-strikethrough": "^0.2.3",

--- a/packages/fields-document/src/DocumentEditor/pasting/markdown.ts
+++ b/packages/fields-document/src/DocumentEditor/pasting/markdown.ts
@@ -6,7 +6,6 @@ import autoLinkLiteralMarkdownSyntax from 'micromark-extension-gfm-autolink-lite
 // @ts-ignore
 import gfmStrikethroughFromMarkdownExtension from 'mdast-util-gfm-strikethrough/from-markdown';
 import gfmStrikethroughMarkdownSyntax from 'micromark-extension-gfm-strikethrough';
-import definitions from 'mdast-util-definitions';
 import { Descendant } from 'slate';
 import { getTextNodeForCurrentlyActiveMarks, addMarkToChildren } from './utils';
 
@@ -17,22 +16,19 @@ const markdownConfig = {
 
 export function deserializeMarkdown(markdown: string) {
   const root = mdASTUtilFromMarkdown(markdown, markdownConfig);
-  const getDefinition = definitions(root);
   let nodes = root.children;
   if (nodes.length === 1 && nodes[0].type === 'paragraph') {
     nodes = nodes[0].children;
   }
-  return deserializeChildren(nodes, getDefinition);
+  return deserializeChildren(nodes, markdown);
 }
-
-type GetDefinition = ReturnType<typeof definitions>;
 
 type MDNode = ReturnType<typeof mdASTUtilFromMarkdown>['children'][number];
 
-function deserializeChildren(nodes: MDNode[], getDefinition: GetDefinition) {
+function deserializeChildren(nodes: MDNode[], input: string) {
   const outputNodes: Descendant[] = [];
   for (const node of nodes) {
-    const result = deserializeMarkdownNode(node, getDefinition);
+    const result = deserializeMarkdownNode(node, input);
     if (result.length) {
       outputNodes.push(...result);
     }
@@ -43,26 +39,17 @@ function deserializeChildren(nodes: MDNode[], getDefinition: GetDefinition) {
   return outputNodes;
 }
 
-function deserializeMarkdownNode(node: MDNode, getDefinition: GetDefinition): Descendant[] {
+function deserializeMarkdownNode(node: MDNode, input: string): Descendant[] {
   switch (node.type) {
     case 'blockquote': {
-      return [{ type: 'blockquote', children: deserializeChildren(node.children, getDefinition) }];
-    }
-    case 'linkReference': {
-      return [
-        {
-          type: 'link',
-          href: getDefinition(node.identifier)?.url || '',
-          children: deserializeChildren(node.children, getDefinition),
-        },
-      ];
+      return [{ type: 'blockquote', children: deserializeChildren(node.children, input) }];
     }
     case 'link': {
       return [
         {
           type: 'link',
           href: node.url,
-          children: deserializeChildren(node.children, getDefinition),
+          children: deserializeChildren(node.children, input),
         },
       ];
     }
@@ -70,14 +57,14 @@ function deserializeMarkdownNode(node: MDNode, getDefinition: GetDefinition): De
       return [{ type: 'code', children: [{ text: node.value }] }];
     }
     case 'paragraph': {
-      return [{ type: 'paragraph', children: deserializeChildren(node.children, getDefinition) }];
+      return [{ type: 'paragraph', children: deserializeChildren(node.children, input) }];
     }
     case 'heading': {
       return [
         {
           type: 'heading',
           level: node.depth,
-          children: deserializeChildren(node.children, getDefinition),
+          children: deserializeChildren(node.children, input),
         },
       ];
     }
@@ -85,22 +72,12 @@ function deserializeMarkdownNode(node: MDNode, getDefinition: GetDefinition): De
       return [
         {
           type: node.ordered ? 'ordered-list' : 'unordered-list',
-          children: deserializeChildren(node.children, getDefinition),
+          children: deserializeChildren(node.children, input),
         },
       ];
     }
-    case 'imageReference': {
-      return [
-        getTextNodeForCurrentlyActiveMarks(
-          `![${node.alt || ''}](${getDefinition(node.identifier)?.url || ''})`
-        ),
-      ];
-    }
-    case 'image': {
-      return [getTextNodeForCurrentlyActiveMarks(`![${node.alt || ''}](${node.url})`)];
-    }
     case 'listItem': {
-      return [{ type: 'list-item', children: deserializeChildren(node.children, getDefinition) }];
+      return [{ type: 'list-item', children: deserializeChildren(node.children, input) }];
     }
     case 'thematicBreak': {
       return [{ type: 'divider', children: [{ text: '' }] }];
@@ -109,28 +86,29 @@ function deserializeMarkdownNode(node: MDNode, getDefinition: GetDefinition): De
       return [getTextNodeForCurrentlyActiveMarks('\n')];
     }
     case 'delete': {
-      return addMarkToChildren('strikethrough', () =>
-        deserializeChildren(node.children, getDefinition)
-      );
+      return addMarkToChildren('strikethrough', () => deserializeChildren(node.children, input));
     }
     case 'strong': {
-      return addMarkToChildren('bold', () => deserializeChildren(node.children, getDefinition));
+      return addMarkToChildren('bold', () => deserializeChildren(node.children, input));
     }
     case 'emphasis': {
-      return addMarkToChildren('italic', () => deserializeChildren(node.children, getDefinition));
+      return addMarkToChildren('italic', () => deserializeChildren(node.children, input));
     }
     case 'inlineCode': {
       return addMarkToChildren('code', () => [getTextNodeForCurrentlyActiveMarks(node.value)]);
     }
-    // while it would be nice if we parsed the html here
+    // while it might be nice if we parsed the html here
     // it's a bit more complicated than just parsing the html
     // because an html node might just be an opening/closing node
     // but we just have an opening/closing node here
     // not the opening and closing and children
-    case 'html':
     case 'text': {
       return [getTextNodeForCurrentlyActiveMarks(node.value)];
     }
   }
-  return [];
+  return [
+    getTextNodeForCurrentlyActiveMarks(
+      input.slice(node.position!.start.offset, node.position!.end.offset)
+    ),
+  ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9750,13 +9750,6 @@ mdast-util-compact@^1.0.0:
   dependencies:
     unist-util-visit "^1.1.0"
 
-mdast-util-definitions@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz#c5c1a84db799173b4dcf7643cda999e440c24db2"
-  integrity sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==
-  dependencies:
-    unist-util-visit "^2.0.0"
-
 mdast-util-definitions@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-5.1.1.tgz#2c1d684b28e53f84938bb06317944bee8efa79db"
@@ -13914,15 +13907,6 @@ unist-util-visit@^1.0.0, unist-util-visit@^1.1.0:
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
-
-unist-util-visit@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
-  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^4.0.0"
-    unist-util-visit-parents "^3.0.0"
 
 unist-util-visit@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
Why this change is good:

https://github.com/keystonejs/keystone/blob/f6901f0e2b76b5b538eb27d6768bca8d481d56ea/packages/fields-document/src/DocumentEditor/pasting/markdown.test.tsx#L409-L416

As an example, if you had `[1]: http://keystonejs.com/link-reference` on your clipboard (specifically as plain text), the new behaviour is that it will actually paste the text, and not parse that as markdown.