### PR TITLE
Improve printing in document editor snapshot tests

### DIFF
--- a/packages/fields-document/src/DocumentEditor/blockquote.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/blockquote.test.tsx
@@ -27,9 +27,7 @@ test('inserting a blockquote with a shortcut works', () => {
         </paragraph>
       </blockquote>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -62,9 +60,7 @@ test('backspace at start of blockquote', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -97,9 +93,7 @@ test('enter on empty line at end of blockquote exits blockquote', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -150,9 +144,7 @@ test('enter on empty line in middle splits the blockquote', () => {
         </paragraph>
       </blockquote>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/code-block.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/code-block.test.tsx
@@ -27,9 +27,7 @@ test('inserting a code block with a shortcut works', () => {
         </text>
       </code>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -65,9 +63,7 @@ test('insertBreak inserts a soft break', () => {
         </text>
       </code>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -130,14 +126,10 @@ test('non-text is removed from code blocks', () => {
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -161,25 +153,23 @@ test('insertBreak when at end with \n as last character exits code block', () =>
   editor.insertBreak();
 
   expect(editor).toMatchInlineSnapshot(`
-      <editor>
-        <code>
-          <text>
-            asdkjnajsndakjndkjnaksdjn
-      asdasdasd
-          </text>
-        </code>
-        <paragraph>
-          <text>
-            <cursor />
-          </text>
-        </paragraph>
-        <paragraph>
-          <text>
-            
-          </text>
-        </paragraph>
-      </editor>
-    `);
+    <editor>
+      <code>
+        <text>
+          asdkjnajsndakjndkjnaksdjn
+    asdasdasd
+        </text>
+      </code>
+      <paragraph>
+        <text>
+          <cursor />
+        </text>
+      </paragraph>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>
+  `);
 });
 
 test('insertBreak in the middle of the text when there is a break at the end of the text', () => {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/array-field.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/array-field.test.tsx
@@ -146,9 +146,7 @@ test('inserting a break at the end of a child field creates a new item with fres
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -226,9 +224,7 @@ test('inserting a break splits the text and uses the values from the first entry
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -297,9 +293,7 @@ test('inserting a break in an empty child removes the element and inserts a para
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -415,9 +409,7 @@ test('deleting a range of nodes removes them', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -467,15 +459,11 @@ test('inserting an item from empty works', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -512,15 +500,11 @@ test('removing an item using the preview props works', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
@@ -311,9 +311,7 @@ test('mark disabled in inline prop', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -354,9 +352,7 @@ test('mark enabled in inline prop', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -399,9 +395,7 @@ test('mark disabled in block prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -446,9 +440,7 @@ test('mark enabled in block prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -491,9 +483,7 @@ test('heading disabled in block prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -537,9 +527,7 @@ test('heading enabled in block prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insert-break-and-delete.test.tsx
@@ -83,9 +83,7 @@ test('delete backward at start', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -161,9 +159,7 @@ test('insert break in last (inline) child prop', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -236,9 +232,7 @@ test('insert break in first (block) child prop in empty paragraph', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -315,9 +309,7 @@ test('insert break in last (block) child prop in empty paragraph', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -393,9 +385,7 @@ test('insert break in first (inline) child prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/insertion-and-preview-props.test.tsx
@@ -95,9 +95,7 @@ test('inserting a void component block', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -161,15 +159,11 @@ test('inserting a complex component block', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -352,9 +346,7 @@ test('preview props conditional change', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-block-prop
           propPath={
@@ -366,16 +358,12 @@ test('preview props conditional change', () => {
           }
         >
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/multi-child-field-in-array-field.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/multi-child-field-in-array-field.test.tsx
@@ -139,9 +139,7 @@ test('deleting all child fields in an array field element when there are multipl
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -152,9 +150,7 @@ test('deleting all child fields in an array field element when there are multipl
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -165,9 +161,7 @@ test('deleting all child fields in an array field element when there are multipl
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -184,9 +178,7 @@ test('deleting all child fields in an array field element when there are multipl
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -248,9 +240,7 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -261,9 +251,7 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -274,9 +262,7 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -287,9 +273,7 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -300,9 +284,7 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-inline-prop
           propPath={
@@ -313,15 +295,11 @@ test('when the wrong children exist, the children are normalized based on the pr
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/nested-array-field.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/nested-array-field.test.tsx
@@ -90,9 +90,7 @@ test('child field in nested array', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -228,9 +226,7 @@ test('multiple in child field in nested array', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -376,9 +372,7 @@ test('add to multiple in child field in nested array', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
@@ -58,14 +58,10 @@ test('component-inline-prop and component-block-prop outside of component-block 
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <paragraph>
         <text>
@@ -105,9 +101,7 @@ test('non component block prop in component-block', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
@@ -153,9 +147,7 @@ test('content inside of void child prop', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
@@ -203,9 +195,7 @@ test('prop path for old fake void prop is removed', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
@@ -246,9 +236,7 @@ test('inserting a void component block', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -292,9 +280,7 @@ test('extra component props are removed', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <component-block
         component="withChildElements"
@@ -326,15 +312,11 @@ test('extra component props are removed', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -390,15 +372,11 @@ test('missing component props are added', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -463,9 +441,7 @@ test('prop with wrong type for a given prop path', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -518,9 +494,7 @@ test('props in wrong order', () => {
           }
         >
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </component-block-prop>
         <component-inline-prop
@@ -530,9 +504,7 @@ test('props in wrong order', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-block-prop
           propPath={
@@ -542,16 +514,12 @@ test('props in wrong order', () => {
           }
         >
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -610,9 +578,7 @@ test('toggling to heading when in an inline prop', () => {
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
         <component-block-prop
           propPath={
@@ -630,9 +596,7 @@ test('toggling to heading when in an inline prop', () => {
         </component-block-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -718,9 +682,7 @@ test('child field in array field insertBreak', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -801,9 +763,7 @@ test('child field in array field deleteBackward at end', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -907,9 +867,7 @@ test('child field in array field deleteBackward in middle', () => {
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -950,15 +908,11 @@ test('normalization adds missing fields on object fields', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/divider.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/divider.test.tsx
@@ -21,9 +21,7 @@ test('inserting a divider with a shortcut works', () => {
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <paragraph>
         <text>
@@ -31,9 +29,7 @@ test('inserting a divider with a shortcut works', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/heading.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/heading.test.tsx
@@ -26,9 +26,7 @@ test('inserting a heading with a shortcut works', () => {
         </text>
       </heading>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -65,9 +63,7 @@ test('inserting a break at the end of the heading exits the heading', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -107,9 +103,7 @@ test('inserting a break in the middle of the heading splits the text and does no
         </text>
       </heading>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -134,9 +128,7 @@ test('inserting a break at the start of the heading inserts a paragraph above th
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <heading
         level={1}
@@ -147,9 +139,7 @@ test('inserting a break at the start of the heading inserts a paragraph above th
         </text>
       </heading>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/insert-menu.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/insert-menu.test.tsx
@@ -398,9 +398,7 @@ test('insertMenu thing typing', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -420,9 +418,7 @@ test('insertMenu thing typing', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/layouts.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/layouts.test.tsx
@@ -65,16 +65,12 @@ test('layout with not enough layout-area are added', () => {
         </layout-area>
         <layout-area>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -123,9 +119,7 @@ test('layout with extra layout-areas that are empty are removed', () => {
       >
         <layout-area>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </layout-area>
         <layout-area>
@@ -137,9 +131,7 @@ test('layout with extra layout-areas that are empty are removed', () => {
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -198,9 +190,7 @@ test('the content of extra layout-areas are merged into the last layout-area', (
       >
         <layout-area>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </layout-area>
         <layout-area>
@@ -229,9 +219,7 @@ test('the content of extra layout-areas are merged into the last layout-area', (
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -274,24 +262,16 @@ test('enter in layout area never exits layout area', () => {
       >
         <layout-area>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
           <paragraph>
             <text>
@@ -301,9 +281,7 @@ test('enter in layout area never exits layout area', () => {
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -338,9 +316,7 @@ test('delete backward never deletes or exits in first layout area', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <layout
         layout={
@@ -358,9 +334,7 @@ test('delete backward never deletes or exits in first layout area', () => {
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -400,9 +374,7 @@ test('delete backward never deletes or exits in second layout area', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <layout
         layout={
@@ -414,9 +386,7 @@ test('delete backward never deletes or exits in second layout area', () => {
       >
         <layout-area>
           <paragraph>
-            <text>
-              
-            </text>
+            <text />
           </paragraph>
         </layout-area>
         <layout-area>
@@ -428,9 +398,7 @@ test('delete backward never deletes or exits in second layout area', () => {
         </layout-area>
       </layout>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/lists.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/lists.test.tsx
@@ -29,9 +29,7 @@ test('ordered list shortcut', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -62,9 +60,7 @@ test('unordered list shortcut - ', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -95,9 +91,7 @@ test('unordered list shortcut * ', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -214,9 +208,7 @@ test('inserting a break on end of list in empty list item exits list', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -278,9 +270,7 @@ test('inserting a break in empty list item in the middle of a list splits and ex
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -314,9 +304,7 @@ test('toggle list on empty line', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -352,9 +340,7 @@ test('toggle list on line with text', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -399,9 +385,7 @@ test('toggle list on line with text with marks', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -447,9 +431,7 @@ test('toggle list on list with text with marks', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -485,9 +467,7 @@ test('toggle ordered-list inside of ordered-list', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -551,9 +531,7 @@ test('toggle ordered-list inside of multi-item ordered-list', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -621,9 +599,7 @@ test('toggle unordered-list inside of single item in multi-item ordered-list', (
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -691,9 +667,7 @@ test('toggle unordered-list for all items in multi-item ordered-list', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -755,9 +729,7 @@ test('backspace at start of list only unwraps the first item', () => {
         </list-item>
       </ordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -808,9 +780,7 @@ test('nested list as direct child of list is moved to last list-item', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -871,9 +841,7 @@ test('nest list', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -941,9 +909,7 @@ test('nest list when previous thing is nested', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -989,9 +955,7 @@ test('inserting a break on end of list non-empty list item adds a new list item'
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -1046,9 +1010,7 @@ test('changing the type of a nested list', () => {
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -1119,9 +1081,7 @@ test('changing the type of a nested list to something which it is nested inside'
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -1188,9 +1148,7 @@ test('nesting a list item in an ordered list into an unordered list makes the it
         </list-item>
       </unordered-list>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/markdown-link-shortcut.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/markdown-link-shortcut.test.tsx
@@ -20,9 +20,7 @@ test('basic link shortcut', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -112,9 +110,7 @@ test('shortcut with whitespace in the middle of the content works', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -147,9 +143,7 @@ test('link shortcut then typing inserts text outside of the link', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -184,9 +178,7 @@ test('link shortcut with bold in some of the content works', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -296,9 +288,7 @@ test("link shortcut doesn't do anything when inside of a component block with li
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -346,9 +336,7 @@ test('link shortcut works when inside of a component block with links option inh
             ]
           }
         >
-          <text>
-            
-          </text>
+          <text />
           <link
             @@isInline={true}
             href="https://keystonejs.com"
@@ -363,9 +351,7 @@ test('link shortcut works when inside of a component block with links option inh
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -386,9 +372,7 @@ test('an undo only reverts to the whole shortcut text', () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -431,9 +415,7 @@ test("text after the markdown shortcut isn't included in the link text", () => {
   expect(editor).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"

--- a/packages/fields-document/src/DocumentEditor/marks.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/marks.test.tsx
@@ -540,9 +540,7 @@ test('inserting a break at the end of a block with a mark removes the mark', () 
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -589,9 +587,7 @@ test("inserting a break in the middle of text doesn't remove the mark", () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/pasting/html-from-other-editors.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/pasting/html-from-other-editors.test.tsx
@@ -137,9 +137,7 @@ test('confluence', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -148,16 +146,12 @@ test('confluence', () => {
             A link
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <unordered-list>
         <list-item>
@@ -247,9 +241,7 @@ test('confluence', () => {
         </text>
       </heading>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);
@@ -365,9 +357,7 @@ there is a break before this</p>
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com/"
@@ -376,16 +366,12 @@ there is a break before this</p>
             A link
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <unordered-list>
         <list-item>
@@ -535,9 +521,7 @@ test('dropbox paper', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -546,16 +530,12 @@ test('dropbox paper', () => {
             A link
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <unordered-list>
         <list-item>
@@ -710,9 +690,7 @@ test('google docs', () => {
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -721,26 +699,18 @@ test('google docs', () => {
             A link
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <unordered-list>
         <list-item>
@@ -826,9 +796,7 @@ test('google docs', () => {
         </text>
       </heading>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/pasting/markdown.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/pasting/markdown.test.tsx
@@ -161,9 +161,7 @@ there is a break before this
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -172,9 +170,7 @@ there is a break before this
             A link
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <paragraph>
         <text>
@@ -184,9 +180,7 @@ there is a break before this
       <divider
         @@isVoid={true}
       >
-        <text>
-          
-        </text>
+        <text />
       </divider>
       <unordered-list>
         <list-item>
@@ -253,9 +247,7 @@ there is a break before this
         </text>
       </paragraph>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="http://keystonejs.com/link-reference"
@@ -264,9 +256,7 @@ there is a break before this
             Link reference
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
       <paragraph>
         <text>
@@ -303,9 +293,7 @@ test('a link stays in the same block', () => {
   expect(deserializeMarkdown(`[link](https://keystonejs.com)`)).toMatchInlineSnapshot(`
     <editor>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
         <link
           @@isInline={true}
           href="https://keystonejs.com"
@@ -315,9 +303,7 @@ test('a link stays in the same block', () => {
             <cursor />
           </text>
         </link>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);

--- a/packages/fields-document/src/DocumentEditor/tests/utils.tsx
+++ b/packages/fields-document/src/DocumentEditor/tests/utils.tsx
@@ -320,7 +320,11 @@ function nodeToReactElement(
         });
       }
     }
-    return createElement('text', { children: text, ...marks });
+    return createElement('text', {
+      // we want to show empty text nodes as <text />
+      children: text === '' ? undefined : text,
+      ...marks,
+    });
   }
   let children = node.children.map((x, i) =>
     nodeToReactElement(editor, x, selection, path.concat(i))

--- a/packages/fields-document/src/validation.test.tsx
+++ b/packages/fields-document/src/validation.test.tsx
@@ -205,9 +205,7 @@ test('label and data in inline relationships are stripped', () => {
           }
           relationship="inline"
         >
-          <text>
-            
-          </text>
+          <text />
         </relationship>
         <text>
           something
@@ -258,15 +256,11 @@ test('label and data in relationship props are stripped', () => {
         }
       >
         <component-inline-prop>
-          <text>
-            
-          </text>
+          <text />
         </component-inline-prop>
       </component-block>
       <paragraph>
-        <text>
-          
-        </text>
+        <text />
       </paragraph>
     </editor>
   `);


### PR DESCRIPTION
Empty text nodes taking up three lines is annoying