### PR TITLE
use flag to more conservatively version peerdeps

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,5 +4,8 @@
   "commit": false,
   "baseBranch": "main",
   "linked": [],
-  "access": "public"
+  "access": "public",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
Currently, whenever `@keystone/core` publishes a new feature, this results in a major release of packages that rely on it as a `peerDependency` (such as `@keystone-6/auth`).

There are sound versioning reasons to do this, but with the style of monorepo `keystone` is, and the way keystone is maintained means that this is hurting consumers while providing us with coverage from a small error class.

The new plan is to *not* aggressively bump packages that have a peer dependency, and instead to, when new versions of them are published, ensure that they are using the latest version of `core` _at that time._