### PR TITLE
Updated redis tests to fail when redis is not running

### DIFF
--- a/.changeset/clever-numbers-swim.md
+++ b/.changeset/clever-numbers-swim.md
@@ -2,4 +2,4 @@
 '@keystone-6/session-store-redis': patch
 ---
 
-Errors will now be surfaced from the reddit client instead of swallowed
+Fixes errors not being thrown by your `@redis/client` on `connect`

--- a/.changeset/clever-numbers-swim.md
+++ b/.changeset/clever-numbers-swim.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/session-store-redis': patch
+---
+
+Errors will now be surfaced from the reddit client instead of swallowed

--- a/docs/pages/docs/apis/session.mdx
+++ b/docs/pages/docs/apis/session.mdx
@@ -77,14 +77,14 @@ A `SessionStore` object has the following interface:
 
 ```typescript
 const store = {
-  connect: () => { /* ... */ },
-  disconnect: () => { /* ... */ },
-  set: (sessionId, data) => { /* ... */ },
-  get: sessionId => {
+  connect: async () => { /* ... */ },
+  disconnect: async () => { /* ... */ },
+  set: async (sessionId, data) => { /* ... */ },
+  get: async (sessionId) => {
     /* ... */
     return data;
   },
-  delete: sessionId => { /* ... */ },
+  delete: async (sessionId) => { /* ... */ },
 };
 ```
 

--- a/packages/session-store-redis/src/index.ts
+++ b/packages/session-store-redis/src/index.ts
@@ -9,8 +9,6 @@ type Options = {
 export const redisSessionStore = ({ client }: Options): SessionStoreFunction => {
   return ({ maxAge }) => ({
     async connect() {
-      client.on('error', err => console.log('Redis Client Error', err));
-
       await client.connect();
     },
     async get(key) {

--- a/tests/api-tests/auth-stored-session.test.ts
+++ b/tests/api-tests/auth-stored-session.test.ts
@@ -7,6 +7,7 @@ import { createClient } from '@redis/client';
 import { createAuth } from '@keystone-6/auth';
 import type { KeystoneContext } from '@keystone-6/core/types';
 import { setupTestRunner, TestArgs } from '@keystone-6/core/testing';
+import fetch from 'node-fetch';
 import { apiTestConfig, expectAccessDenied, seed } from './utils';
 
 const initialData = {
@@ -99,6 +100,19 @@ async function login(
 }
 
 describe('Auth testing', () => {
+  beforeAll(async () => {
+    try {
+      await fetch('http:127.0.0.1:6379', {
+        method: 'post',
+        body: 'ping',
+      });
+    } catch (e) {
+      if ((e as Error).message.includes('ECONNREFUSED')) {
+        throw new Error('redis is not running on this computer so this test suite cannot be run');
+      }
+    }
+  });
+
   test(
     'Gives access denied when not logged in',
     setup()(async ({ context }) => {

--- a/tests/api-tests/auth-stored-session.test.ts
+++ b/tests/api-tests/auth-stored-session.test.ts
@@ -7,7 +7,6 @@ import { createClient } from '@redis/client';
 import { createAuth } from '@keystone-6/auth';
 import type { KeystoneContext } from '@keystone-6/core/types';
 import { setupTestRunner, TestArgs } from '@keystone-6/core/testing';
-import fetch from 'node-fetch';
 import { apiTestConfig, expectAccessDenied, seed } from './utils';
 
 const initialData = {
@@ -100,19 +99,6 @@ async function login(
 }
 
 describe('Auth testing', () => {
-  beforeAll(async () => {
-    try {
-      await fetch('http://127.0.0.1:6379', {
-        method: 'post',
-        body: 'ping',
-      });
-    } catch (e) {
-      if ((e as Error).message.includes('ECONNREFUSED')) {
-        throw new Error('redis not found: ECONNREFUSED');
-      }
-    }
-  });
-
   test(
     'Gives access denied when not logged in',
     setup()(async ({ context }) => {

--- a/tests/api-tests/auth-stored-session.test.ts
+++ b/tests/api-tests/auth-stored-session.test.ts
@@ -102,7 +102,7 @@ async function login(
 describe('Auth testing', () => {
   beforeAll(async () => {
     try {
-      await fetch('http:127.0.0.1:6379', {
+      await fetch('http://127.0.0.1:6379', {
         method: 'post',
         body: 'ping',
       });

--- a/tests/api-tests/auth-stored-session.test.ts
+++ b/tests/api-tests/auth-stored-session.test.ts
@@ -108,7 +108,7 @@ describe('Auth testing', () => {
       });
     } catch (e) {
       if ((e as Error).message.includes('ECONNREFUSED')) {
-        throw new Error('redis is not running on this computer so this test suite cannot be run');
+        throw new Error('redis not found: ECONNREFUSED');
       }
     }
   });


### PR DESCRIPTION
Previously they would just hang indefinitely