### PR TITLE
Fix long lines in code blocks in the document editor overflowing the editor

### DIFF
--- a/.changeset/fast-bears-attack.md
+++ b/.changeset/fast-bears-attack.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes long lines in code blocks in the document editor overflowing the editor

--- a/packages/fields-document/src/DocumentEditor/render-element.tsx
+++ b/packages/fields-document/src/DocumentEditor/render-element.tsx
@@ -99,6 +99,7 @@ const CodeElement = ({ attributes, children }: RenderElementProps) => {
         fontFamily: typography.fontFamily.monospace,
         fontSize: typography.fontSize.small,
         padding: `${spacing.small}px ${spacing.medium}px`,
+        overflowX: 'auto',
       }}
       {...attributes}
     >


### PR DESCRIPTION
This makes the code blocks horizontally scrollable instead of the editor itself (we could wrap instead but imo for code blocks, overflowing is the right choice)