### PR TITLE
Change view module resolution

### DIFF
--- a/.changeset/views-do-change.md
+++ b/.changeset/views-do-change.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Changes field `.views` module resolution, from a path, to a module path that can be resolved at the project's root directory

--- a/.changeset/views-do-change.md
+++ b/.changeset/views-do-change.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': major
 ---
 
-Changes field `.views` module resolution, from a path, to a module path that can be resolved at the project's root directory
+Changes field `.views` module resolution, from a path, to a module path that is resolved from where `keystone start` is run

--- a/docs/pages/docs/apis/fields.md
+++ b/docs/pages/docs/apis/fields.md
@@ -77,7 +77,7 @@ Options:
   See the [Hooks API](./hooks) for full details on the available hook options.
 - `label`: The label displayed for this field in the Admin UI. Defaults to a human readable version of the field name.
 - `ui`: Controls how the field is displayed in the Admin UI.
-  - `views`: A module specifier that will be resolved from the Keystone project's directory to a module containing code to replace or extend the default Admin UI components for this field. See the [Custom Field Views](../guides/custom-field-views) guide for details on how to use this option.
+  - `views`: A module path that is resolved from where `keystone start` is run, resolving to a module containing code to replace or extend the Admin UI components for this field. See the [Custom Field Views](../guides/custom-field-views) guide for details on how to use this option.
   - `createView.fieldMode` (default: `'edit'`): Controls the create view page of the Admin UI.
     Can be one of `['edit', 'hidden']`, or an async function with an argument `{ session, context }` that returns one of `['edit', 'hidden']`.
     Defaults to the list's `ui.createView.defaultFieldMode` config if defined.

--- a/docs/pages/docs/apis/fields.md
+++ b/docs/pages/docs/apis/fields.md
@@ -77,7 +77,7 @@ Options:
   See the [Hooks API](./hooks) for full details on the available hook options.
 - `label`: The label displayed for this field in the Admin UI. Defaults to a human readable version of the field name.
 - `ui`: Controls how the field is displayed in the Admin UI.
-  - `views`: A [resolved](https://nodejs.org/api/modules.html#modules_require_resolve_request_options) path to a module containing code to replace or extend the default Admin UI components for this field. See the [Custom Field Views](../guides/custom-field-views) guide for details on how to use this option.
+  - `views`: A module specifier that will be resolved from the Keystone project's directory to a module containing code to replace or extend the default Admin UI components for this field. See the [Custom Field Views](../guides/custom-field-views) guide for details on how to use this option.
   - `createView.fieldMode` (default: `'edit'`): Controls the create view page of the Admin UI.
     Can be one of `['edit', 'hidden']`, or an async function with an argument `{ session, context }` that returns one of `['edit', 'hidden']`.
     Defaults to the list's `ui.createView.defaultFieldMode` config if defined.
@@ -109,7 +109,7 @@ export default config({
           hooks: { /* ... */ },
           label: '...',
           ui: {
-            views: require.resolve('path/to/viewsModule.tsx'),
+            views: './path/to/viewsModule',
             createView: {
               fieldMode: ({ session, context }) => 'edit',
             },
@@ -1025,12 +1025,12 @@ export default config({
 ## Related resources
 
 {% related-content %}
-{% well 
+{% well
 heading="Schema API Reference"
 href="/docs/apis/schema" %}
-The API to configure your  options used with the `list()` function.
+The API to configure your options used with the `list()` function.
 {% /well %}
-{% well 
+{% well
 heading="GraphQL API Reference"
 href="/docs/apis/graphql" %}
 A complete CRUD (create, read, update, delete) GraphQL API derived from the list and field names you configure in your system.

--- a/docs/pages/docs/guides/custom-fields.md
+++ b/docs/pages/docs/guides/custom-fields.md
@@ -59,7 +59,7 @@ export const myInt =
         orderBy: { arg: graphql.arg({ type: orderDirectionEnum }) },
       },
       output: graphql.field({ type: graphql.Int }),
-      views: require.resolve('./view.tsx'),
+      views: './view',
     });
 ```
 
@@ -115,8 +115,10 @@ output: graphql.field({
 
 The frontend portion of a field must be in a seperate file that the backend implementation points to with the `views` option.
 
+The `views` option is resolved as though it is an import from some file in the project directory.
+
 ```
-views: require.resolve('./view.tsx'),
+views: './view',
 ```
 
 #### Controller
@@ -217,7 +219,7 @@ export const CardValue: CardValueComponent = ({ item, field }) => {
 ## Related resources
 
 {% related-content %}
-{% well 
+{% well
 heading="Example Project: Custom Fields"
 href="https://github.com/keystonejs/keystone/tree/main/examples/custom-field"
 target="_blank" %}

--- a/docs/pages/docs/guides/document-fields.md
+++ b/docs/pages/docs/guides/document-fields.md
@@ -364,7 +364,7 @@ export default config({
       fields: {
         fieldName: document({
           ui: {
-            views: require.resolve('./component-blocks')
+            views: './component-blocks'
           },
           componentBlocks,
         }),

--- a/examples/basic/schema.ts
+++ b/examples/basic/schema.ts
@@ -132,9 +132,6 @@ export const lists: Lists = {
   Post: list({
     fields: {
       title: text({ access: {} }),
-      // TODO: expand this out into a proper example project
-      // Enable this line to test custom field views
-      // test: text({ ui: { views: require.resolve('./admin/fieldViews/Test.tsx') } }),
       status: select({
         options: [
           { label: 'Published', value: 'published' },

--- a/examples/custom-field-view/README.md
+++ b/examples/custom-field-view/README.md
@@ -23,7 +23,7 @@ In this project we add a new JSON field to the `Task` list:
 ```typescript
 relatedLinks: json({
   ui: {
-      views: require.resolve('./fields/related-links/components.tsx'),
+      views: './fields/related-links/components',
       createView: { fieldMode: 'edit' },
       listView: { fieldMode: 'hidden' },
       itemView: { fieldMode: 'edit' },

--- a/examples/custom-field-view/schema.ts
+++ b/examples/custom-field-view/schema.ts
@@ -20,7 +20,7 @@ export const lists = {
       // We've added a json field which implements custom views in the Admin UI
       relatedLinks: json({
         ui: {
-          views: require.resolve('./fields/related-links/components.tsx'),
+          views: './fields/related-links/components',
           createView: { fieldMode: 'edit' },
           listView: { fieldMode: 'hidden' },
           itemView: { fieldMode: 'edit' },

--- a/examples/custom-field/1-text-field/index.ts
+++ b/examples/custom-field/1-text-field/index.ts
@@ -47,7 +47,7 @@ export function text<ListTypeInfo extends BaseListTypeInfo>({
           return value;
         },
       }),
-      views: require.resolve('./views.tsx'),
+      views: './1-text-field/views',
       getAdminMeta() {
         return {};
       },

--- a/examples/custom-field/2-stars-field/index.ts
+++ b/examples/custom-field/2-stars-field/index.ts
@@ -88,7 +88,7 @@ export const stars =
           return value;
         },
       }),
-      views: require.resolve('./views.tsx'),
+      views: './2-stars-field/views',
       getAdminMeta() {
         return { maxStars };
       },

--- a/examples/custom-field/3-pair-field/index.ts
+++ b/examples/custom-field/3-pair-field/index.ts
@@ -75,7 +75,7 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>({
           return resolveOutput(value);
         },
       }),
-      views: require.resolve('./views.tsx'),
+      views: './3-pair-field/views',
       getAdminMeta() {
         return {};
       },

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import {
   CommonFieldConfig,
   BaseListTypeInfo,
@@ -172,7 +171,7 @@ export const cloudinaryImage =
             };
           },
         }),
-        views: path.join(path.dirname(__dirname), 'views'),
+        views: '@keystone-6/cloudinary/views',
       },
       {
         map: config.db?.map,

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -171,13 +171,13 @@ export function createAdminMeta(
 function assertValidView(view: string, location: string) {
   if (view.includes('\\')) {
     throw new Error(
-      `${location} contains a backslash, which is not allowed. If you're using require.resolve or etc. remove the usage of it and provide a relative path from the root of the project instead.`
+      `${location} contains a backslash, which is invalid. You need to use a module path that can be resolved at the project's root directory (see https://github.com/keystonejs/keystone/pull/7805)`
     );
   }
 
   if (path.isAbsolute(view)) {
     throw new Error(
-      `${location} is an absolute path, which is not allowed, provide a path relative to the root of the project instead.`
+      `${location} is an absolute path, which is invalid. You need to use a module path that can be resolved at the project's root directory (see https://github.com/keystonejs/keystone/pull/7805)`
     );
   }
 }

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -171,13 +171,13 @@ export function createAdminMeta(
 function assertValidView(view: string, location: string) {
   if (view.includes('\\')) {
     throw new Error(
-      `${location} contains a backslash, which is invalid. You need to use a module path that can be resolved at the project's root directory (see https://github.com/keystonejs/keystone/pull/7805)`
+      `${location} contains a backslash, which is invalid. You need to use a module path that is resolved from where 'keystone start' is run (see https://github.com/keystonejs/keystone/pull/7805)`
     );
   }
 
   if (path.isAbsolute(view)) {
     throw new Error(
-      `${location} is an absolute path, which is invalid. You need to use a module path that can be resolved at the project's root directory (see https://github.com/keystonejs/keystone/pull/7805)`
+      `${location} is an absolute path, which is invalid. You need to use a module path that is resolved from where 'keystone start' is run (see https://github.com/keystonejs/keystone/pull/7805)`
     );
   }
 }

--- a/packages/core/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/core/src/admin-ui/system/generateAdminUI.ts
@@ -86,14 +86,7 @@ export const generateAdminUI = async (
 
   // Write out the built-in admin UI files. Don't overwrite any user-defined pages.
   const configFileExists = getDoesAdminConfigExist();
-  let adminFiles = writeAdminFiles(
-    config,
-    graphQLSchema,
-    adminMeta,
-    configFileExists,
-    projectAdminPath,
-    isLiveReload
-  );
+  let adminFiles = writeAdminFiles(config, graphQLSchema, adminMeta, configFileExists);
 
   // Add files to pages/ which point to any files which exist in admin/pages
   const adminConfigDir = Path.join(process.cwd(), 'admin');

--- a/packages/core/src/admin-ui/templates/index.ts
+++ b/packages/core/src/admin-ui/templates/index.ts
@@ -15,9 +15,7 @@ export const writeAdminFiles = (
   config: KeystoneConfig,
   graphQLSchema: GraphQLSchema,
   adminMeta: AdminMetaRootVal,
-  configFileExists: boolean,
-  projectAdminPath: string,
-  isLiveReload: boolean
+  configFileExists: boolean
 ): AdminFileToWrite[] => {
   if (
     config.experimental?.enableNextJsGraphqlApiEndpoint &&
@@ -44,9 +42,8 @@ export const writeAdminFiles = (
       src: appTemplate(
         adminMeta,
         graphQLSchema,
-        { configFileExists, projectAdminPath },
-        config.graphql?.path || '/api/graphql',
-        isLiveReload
+        { configFileExists },
+        config.graphql?.path || '/api/graphql'
       ),
       outputPath: 'pages/_app.js',
     },

--- a/packages/core/src/fields/resolve-view.ts
+++ b/packages/core/src/fields/resolve-view.ts
@@ -1,5 +1,0 @@
-import path from 'path';
-import { packagePath } from '../package-path';
-
-export const resolveView = (pathname: string) =>
-  path.join(packagePath, 'fields', 'types', pathname);

--- a/packages/core/src/fields/types/bigInt/index.ts
+++ b/packages/core/src/fields/types/bigInt/index.ts
@@ -13,7 +13,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type BigIntFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -173,7 +172,7 @@ export const bigInt =
       output: graphql.field({
         type: config.graphql?.read?.isNonNull ? graphql.nonNull(graphql.BigInt) : graphql.BigInt,
       }),
-      views: resolveView('bigInt/views'),
+      views: '@keystone-6/core/fields/types/bigInt/views',
       getAdminMeta() {
         return {
           validation: {

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -13,7 +13,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 import { CalendarDayFieldMeta } from './views';
 
 export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
@@ -143,7 +142,7 @@ export const calendarDay =
           return value;
         },
       }),
-      views: resolveView('calendarDay/views'),
+      views: '@keystone-6/core/fields/types/calendarDay/views',
       getAdminMeta(): CalendarDayFieldMeta {
         return {
           defaultValue: defaultValue ?? null,

--- a/packages/core/src/fields/types/checkbox/index.ts
+++ b/packages/core/src/fields/types/checkbox/index.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../types';
 import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type CheckboxFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -72,7 +71,7 @@ export const checkbox =
       output: graphql.field({
         type: config.graphql?.read?.isNonNull ? graphql.nonNull(graphql.Boolean) : graphql.Boolean,
       }),
-      views: resolveView('checkbox/views'),
+      views: '@keystone-6/core/fields/types/checkbox/views',
       getAdminMeta: () => ({ defaultValue }),
     });
   };

--- a/packages/core/src/fields/types/decimal/index.ts
+++ b/packages/core/src/fields/types/decimal/index.ts
@@ -10,7 +10,6 @@ import {
   FieldData,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 import {
   assertCreateIsNonNullAllowed,
   assertReadIsNonNullAllowed,
@@ -183,7 +182,7 @@ export const decimal =
           return val;
         },
       }),
-      views: resolveView('decimal/views'),
+      views: '@keystone-6/core/fields/types/decimal/views',
       getAdminMeta: (): import('./views').DecimalFieldMeta => ({
         defaultValue: defaultValue ?? null,
         precision,

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -7,7 +7,6 @@ import {
   FileMetadata,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 
 export type FileFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
   storage: string;
@@ -115,6 +114,6 @@ export const file =
           return { filename, filesize, storage: config.storage };
         },
       }),
-      views: resolveView('file/views'),
+      views: '@keystone-6/core/fields/types/file/views',
     });
   };

--- a/packages/core/src/fields/types/float/index.ts
+++ b/packages/core/src/fields/types/float/index.ts
@@ -14,7 +14,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type FloatFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -160,7 +159,7 @@ export const float =
       output: graphql.field({
         type: config.graphql?.read?.isNonNull ? graphql.nonNull(graphql.Float) : graphql.Float,
       }),
-      views: resolveView('float/views'),
+      views: '@keystone-6/core/fields/types/float/views',
       getAdminMeta() {
         return {
           validation: {

--- a/packages/core/src/fields/types/image/index.ts
+++ b/packages/core/src/fields/types/image/index.ts
@@ -8,7 +8,6 @@ import {
   KeystoneContext,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 import { SUPPORTED_IMAGE_EXTENSIONS } from './utils';
 
 export type ImageFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
@@ -152,6 +151,6 @@ export const image =
           };
         },
       }),
-      views: resolveView('image/views'),
+      views: '@keystone-6/core/fields/types/image/views',
     });
   };

--- a/packages/core/src/fields/types/integer/index.ts
+++ b/packages/core/src/fields/types/integer/index.ts
@@ -13,7 +13,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type IntegerFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -185,7 +184,7 @@ export const integer =
       output: graphql.field({
         type: config.graphql?.read?.isNonNull ? graphql.nonNull(graphql.Int) : graphql.Int,
       }),
-      views: resolveView('integer/views'),
+      views: '@keystone-6/core/fields/types/integer/views',
       getAdminMeta() {
         return {
           validation: {

--- a/packages/core/src/fields/types/json/index.ts
+++ b/packages/core/src/fields/types/json/index.ts
@@ -6,7 +6,6 @@ import {
   jsonFieldTypePolyfilledForSQLite,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 
 export type JsonFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -38,7 +37,7 @@ export const json =
           update: { arg: graphql.arg({ type: graphql.JSON }) },
         },
         output: graphql.field({ type: graphql.JSON }),
-        views: resolveView('json/views'),
+        views: '@keystone-6/core/fields/types/json/views',
         getAdminMeta: () => ({ defaultValue }),
       },
       {

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../types';
 import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 import { userInputError } from '../../../lib/core/graphql-errors';
 
 export type MultiselectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
@@ -128,7 +127,7 @@ export const multiselect =
             await config.hooks?.validateInput?.(args);
           },
         },
-        views: resolveView('multiselect/views'),
+        views: '@keystone-6/core/fields/types/multiselect/views',
         getAdminMeta: () => ({
           options: transformedConfig.options,
           type: config.type ?? 'string',

--- a/packages/core/src/fields/types/password/index.ts
+++ b/packages/core/src/fields/types/password/index.ts
@@ -5,7 +5,6 @@ import { userInputError } from '../../../lib/core/graphql-errors';
 import { humanize } from '../../../lib/utils';
 import { BaseListTypeInfo, fieldType, FieldTypeFunc, CommonFieldConfig } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 import { getResolvedIsNullable } from '../../non-null-graphql';
 import { PasswordFieldMeta } from './views';
 
@@ -184,7 +183,7 @@ export const password =
           resolve: inputResolver,
         },
       },
-      views: resolveView('password/views'),
+      views: '@keystone-6/core/fields/types/password/views',
       getAdminMeta: (): PasswordFieldMeta => ({
         isNullable,
         validation: {

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -6,7 +6,6 @@ import {
   AdminMetaRootVal,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 
 // This is the default display mode for Relationships
 type SelectDisplayConfig = {
@@ -86,7 +85,7 @@ export const relationship =
     const [foreignListKey, foreignFieldKey] = ref.split('.');
     const commonConfig = {
       ...config,
-      views: resolveView('relationship/views'),
+      views: '@keystone-6/core/fields/types/relationship/views',
       getAdminMeta: (
         adminMetaRoot: AdminMetaRootVal
       ): Parameters<typeof import('./views').controller>[0]['fieldMeta'] => {

--- a/packages/core/src/fields/types/select/index.ts
+++ b/packages/core/src/fields/types/select/index.ts
@@ -14,7 +14,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type SelectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> &
@@ -111,7 +110,7 @@ export const select =
             await config.hooks?.validateInput?.(args);
           },
         },
-        views: resolveView('select/views'),
+        views: '@keystone-6/core/fields/types/select/views',
         getAdminMeta: () => ({
           options,
           type: config.type ?? 'string',

--- a/packages/core/src/fields/types/text/index.ts
+++ b/packages/core/src/fields/types/text/index.ts
@@ -9,7 +9,6 @@ import {
 } from '../../../types';
 import { graphql } from '../../..';
 import { assertCreateIsNonNullAllowed, assertReadIsNonNullAllowed } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 
 export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
@@ -178,7 +177,7 @@ export const text =
       output: graphql.field({
         type: config.graphql?.read?.isNonNull ? graphql.nonNull(graphql.String) : graphql.String,
       }),
-      views: resolveView('text/views'),
+      views: '@keystone-6/core/fields/types/text/views',
       getAdminMeta(): TextFieldMeta {
         return {
           displayMode: config.ui?.displayMode ?? 'input',

--- a/packages/core/src/fields/types/timestamp/index.ts
+++ b/packages/core/src/fields/types/timestamp/index.ts
@@ -13,7 +13,6 @@ import {
   assertReadIsNonNullAllowed,
   getResolvedIsNullable,
 } from '../../non-null-graphql';
-import { resolveView } from '../../resolve-view';
 import { TimestampFieldMeta } from './views';
 
 export type TimestampFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
@@ -136,7 +135,7 @@ export const timestamp =
           ? graphql.nonNull(graphql.DateTime)
           : graphql.DateTime,
       }),
-      views: resolveView('timestamp/views'),
+      views: '@keystone-6/core/fields/types/timestamp/views',
       getAdminMeta(): TimestampFieldMeta {
         return {
           defaultValue: defaultValue ?? null,

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -9,7 +9,6 @@ import {
   getGqlNames,
 } from '../../../types';
 import { graphql } from '../../..';
-import { resolveView } from '../../resolve-view';
 
 type VirtualFieldGraphQLField<Item extends BaseItem> = graphql.Field<
   Item,
@@ -85,7 +84,7 @@ export const virtual =
           return usableField.resolve!(item as any, ...args);
         },
       }),
-      views: resolveView('virtual/views'),
+      views: '@keystone-6/core/fields/types/virtual/views',
       getAdminMeta: () => ({ query: config.ui?.query || '' }),
     });
   };

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { validate } from 'uuid';
 import { isCuid } from 'cuid';
 import {
@@ -9,13 +8,7 @@ import {
   orderDirectionEnum,
 } from '../types';
 import { graphql } from '..';
-import { packagePath } from '../package-path';
 import { userInputError } from './core/graphql-errors';
-
-const views = path.join(
-  packagePath,
-  '___internal-do-not-use-will-break-in-patch/admin-ui/id-field-view'
-);
 
 const idParsers = {
   autoincrement(val: string | null) {
@@ -145,7 +138,7 @@ export const idFieldType =
           return value.toString();
         },
       }),
-      views,
+      views: '@keystone-6/core/___internal-do-not-use-will-break-in-patch/admin-ui/id-field-view',
       getAdminMeta: () => ({ kind: config.kind }),
       ui: {
         createView: {

--- a/packages/core/src/package-path.ts
+++ b/packages/core/src/package-path.ts
@@ -1,8 +1,0 @@
-// DO NOT MOVE THIS FILE!!
-// this file is in the root of src so that in the built and dev versions of the package
-// __dirname resolves to a directory directly within the package directory
-// so path.dirname on it will get the package directory
-
-import path from 'path';
-
-export const packagePath = path.dirname(__dirname);

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { ApolloError } from 'apollo-server-errors';
 import {
   BaseListTypeInfo,
@@ -71,8 +70,6 @@ export type DocumentFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
     layouts?: readonly (readonly [number, ...number[]])[];
     db?: { map?: string };
   };
-
-const views = path.join(path.dirname(__dirname), 'views');
 
 export const document =
   <ListTypeInfo extends BaseListTypeInfo>({
@@ -160,7 +157,7 @@ export const document =
             return { document: value };
           },
         }),
-        views,
+        views: '@keystone-6/fields-document/views',
         getAdminMeta(): Parameters<typeof import('./views').controller>[0]['fieldMeta'] {
           return {
             relationships,

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -98,7 +98,7 @@ export const lists = {
       image: image({ ui: { description }, storage: 'images' }),
       file: file({ ui: { description }, storage: 'files' }),
       document: document({
-        ui: { views: require.resolve('../component-blocks.tsx') },
+        ui: { views: './component-blocks' },
         relationships: { mention: { label: 'Mention', listKey: 'User' } },
         formatting: true,
         layouts: [


### PR DESCRIPTION
This pull request changes field type `.views` resolution from being path based to a module path.
This means instead of using `require.resolve(...)` to resolve your custom views, you will now use a path as though it was resolving from where `keystone dev` is run.

This additionally means you can use typical modules or packages without needing relative or absolute pathing workarounds.

For example, if you wanted to use the `@keystone-6` text field views for your custom field type, you can now do that through canonical module resolution:

```typescript
  fieldType({ ... })({
    input: { ... },
    output: graphql.field({ ... }),
    views: '@keystone-6/core/fields/types/text/views',
  })
```