### PR TITLE
Define Singleton Admin Meta GraphQL API 

### DIFF
--- a/.changeset/fair-terms-beg.md
+++ b/.changeset/fair-terms-beg.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/core': patch
+'@keystone-6/fields-document': patch
+---
+
+Updates admin meta GraphQL schema to support singletons

--- a/examples/assets-local/schema.graphql
+++ b/examples/assets-local/schema.graphql
@@ -294,14 +294,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -312,12 +311,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -373,4 +372,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/assets-s3/schema.graphql
+++ b/examples/assets-s3/schema.graphql
@@ -294,14 +294,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -312,12 +311,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -373,4 +372,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/auth/schema.graphql
+++ b/examples/auth/schema.graphql
@@ -172,14 +172,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -190,12 +189,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -251,4 +250,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -463,14 +463,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -481,12 +480,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -542,6 +541,46 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }
 
 type RandomNumber {

--- a/examples/blog/schema.graphql
+++ b/examples/blog/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-admin-ui-logo/schema.graphql
+++ b/examples/custom-admin-ui-logo/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-admin-ui-navigation/schema.graphql
+++ b/examples/custom-admin-ui-navigation/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-admin-ui-pages/schema.graphql
+++ b/examples/custom-admin-ui-pages/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-field-view/schema.graphql
+++ b/examples/custom-field-view/schema.graphql
@@ -256,14 +256,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -274,12 +273,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -335,4 +334,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-field/schema.graphql
+++ b/examples/custom-field/schema.graphql
@@ -133,14 +133,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -151,12 +150,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -212,4 +211,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/custom-session-validation/schema.graphql
+++ b/examples/custom-session-validation/schema.graphql
@@ -301,14 +301,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -319,12 +318,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -380,4 +379,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/default-values/schema.graphql
+++ b/examples/default-values/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -268,14 +268,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -286,12 +285,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -347,4 +346,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/ecommerce/schema.graphql
+++ b/examples/ecommerce/schema.graphql
@@ -933,14 +933,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -951,12 +950,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -1012,4 +1011,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/embedded-nextjs/schema.graphql
+++ b/examples/embedded-nextjs/schema.graphql
@@ -124,14 +124,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -142,12 +141,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -203,4 +202,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/extend-graphql-schema-graphql-ts/schema.graphql
+++ b/examples/extend-graphql-schema-graphql-ts/schema.graphql
@@ -262,14 +262,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -280,12 +279,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -341,4 +340,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/extend-graphql-schema-nexus/schema.graphql
+++ b/examples/extend-graphql-schema-nexus/schema.graphql
@@ -255,14 +255,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -273,12 +272,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -334,6 +333,46 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }
 
 type NexusPost {

--- a/examples/extend-graphql-schema/schema.graphql
+++ b/examples/extend-graphql-schema/schema.graphql
@@ -277,14 +277,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -295,12 +294,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -356,6 +355,46 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }
 
 """

--- a/examples/extend-graphql-subscriptions/schema.graphql
+++ b/examples/extend-graphql-subscriptions/schema.graphql
@@ -258,14 +258,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -276,12 +275,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -337,6 +336,46 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }
 
 type Time {

--- a/examples/graphql-api-endpoint/schema.graphql
+++ b/examples/graphql-api-endpoint/schema.graphql
@@ -407,14 +407,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -425,12 +424,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -481,4 +480,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/json/schema.graphql
+++ b/examples/json/schema.graphql
@@ -222,14 +222,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -240,12 +239,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -301,4 +300,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/rest-api/schema.graphql
+++ b/examples/rest-api/schema.graphql
@@ -254,14 +254,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -272,12 +271,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -333,4 +332,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/roles/schema.graphql
+++ b/examples/roles/schema.graphql
@@ -386,14 +386,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -404,12 +403,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -465,4 +464,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/task-manager/schema.graphql
+++ b/examples/task-manager/schema.graphql
@@ -254,14 +254,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -272,12 +271,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -333,4 +332,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/testing/schema.graphql
+++ b/examples/testing/schema.graphql
@@ -296,14 +296,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -314,12 +313,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -375,4 +374,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/virtual-field/schema.graphql
+++ b/examples/virtual-field/schema.graphql
@@ -264,14 +264,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -282,12 +281,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -343,4 +342,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/examples/with-auth/schema.graphql
+++ b/examples/with-auth/schema.graphql
@@ -296,14 +296,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -314,12 +313,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -375,4 +374,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/index.tsx
@@ -112,9 +112,12 @@ export const HomePage = () => {
     query {
       keystone {
         adminMeta {
-          lists {
+          models {
+            __typename
             key
-            hideCreate
+            ... on KeystoneAdminUIListMeta {
+              hideCreate
+            }
           }
         }
       }
@@ -169,7 +172,7 @@ export const HomePage = () => {
                       : { type: 'loading' }
                   }
                   hideCreate={
-                    data?.keystone.adminMeta.lists.find((list: any) => list.key === key)
+                    data?.keystone.adminMeta.models.find((list: any) => list.key === key)
                       ?.hideCreate ?? false
                   }
                   key={key}

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -294,13 +294,15 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
           }
           keystone {
             adminMeta {
-              list(key: $listKey) {
-                hideCreate
-                hideDelete
-                fields {
-                  path
-                  itemView(id: $id) {
-                    fieldMode
+              list: model(key: $listKey) {
+                ... on KeystoneAdminUIListMeta {
+                  hideCreate
+                  hideDelete
+                  fields {
+                    path
+                    itemView(id: $id) {
+                      fieldMode
+                    }
                   }
                 }
               }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -45,7 +45,7 @@ let listMetaGraphqlQuery: TypedDocumentNode<
   {
     keystone: {
       adminMeta: {
-        list: {
+        model: {
           hideCreate: boolean;
           hideDelete: boolean;
           fields: FetchedFieldMeta[];
@@ -58,15 +58,17 @@ let listMetaGraphqlQuery: TypedDocumentNode<
   query ($listKey: String!) {
     keystone {
       adminMeta {
-        list(key: $listKey) {
-          hideDelete
-          hideCreate
-          fields {
-            path
-            isOrderable
-            isFilterable
-            listView {
-              fieldMode
+        model(key: $listKey) {
+          ... on KeystoneAdminUIListMeta {
+            hideDelete
+            hideCreate
+            fields {
+              path
+              isOrderable
+              isFilterable
+              listView {
+                fieldMode
+              }
             }
           }
         }
@@ -147,7 +149,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
     const listViewFieldModesByField: Record<string, 'read' | 'hidden'> = {};
     const orderableFields = new Set<string>();
     const filterableFields = new Set<string>();
-    for (const field of metaQuery.data?.keystone.adminMeta.list?.fields || []) {
+    for (const field of metaQuery.data?.keystone.adminMeta.model?.fields || []) {
       listViewFieldModesByField[field.path] = field.listView.fieldMode;
       if (field.isOrderable) {
         orderableFields.add(field.path);
@@ -158,7 +160,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
     }
 
     return { listViewFieldModesByField, orderableFields, filterableFields };
-  }, [metaQuery.data?.keystone.adminMeta.list?.fields]);
+  }, [metaQuery.data?.keystone.adminMeta.model?.fields]);
 
   const sort = useSort(list, orderableFields);
 
@@ -238,7 +240,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
   }
 
   const theme = useTheme();
-  const showCreate = !(metaQuery.data?.keystone.adminMeta.list?.hideCreate ?? true) || null;
+  const showCreate = !(metaQuery.data?.keystone.adminMeta.model?.hideCreate ?? true) || null;
 
   return (
     <PageContainer header={<ListPageHeader listKey={listKey} />} title={list.label}>
@@ -274,7 +276,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
                         <span css={{ marginRight: theme.spacing.small }}>
                           Selected {selectedItemsCount} of {data.items.length}
                         </span>
-                        {!(metaQuery.data?.keystone.adminMeta.list?.hideDelete ?? true) && (
+                        {!(metaQuery.data?.keystone.adminMeta.model?.hideDelete ?? true) && (
                           <DeleteManyButton
                             list={list}
                             selectedItems={selectedItems}

--- a/packages/core/src/admin-ui/admin-meta-graphql.ts
+++ b/packages/core/src/admin-ui/admin-meta-graphql.ts
@@ -7,24 +7,25 @@ export const staticAdminMetaQuery = gql`
       __typename
       adminMeta {
         __typename
-        lists {
+        models {
           __typename
           key
-          itemQueryName
-          listQueryName
-          initialSort {
-            __typename
-            field
-            direction
-          }
           path
           label
           singular
-          plural
           description
-          initialColumns
-          pageSize
-          labelField
+          ... on KeystoneAdminUIListMeta {
+            graphqlPlural
+            initialSort {
+              __typename
+              field
+              direction
+            }
+            plural
+            initialColumns
+            pageSize
+            labelField
+          }
           fields {
             __typename
             path
@@ -33,7 +34,9 @@ export const staticAdminMetaQuery = gql`
             fieldMeta
             viewsIndex
             customViewsIndex
-            search
+            ... on KeystoneAdminUIListFieldMeta {
+              search
+            }
             itemView {
               fieldMode
             }
@@ -50,55 +53,78 @@ export const staticAdminMetaQuery = gql`
 //     plugins:
 //       - typescript-operations:
 //           namingConvention: keep
+//           noExport: true
+//           avoidOptionals: true
+//           scalars:
+//             JSON: JSONValue
 //       - typescript:
 //           enumsAsTypes: true
 //           nonOptionalTypename: true
 //           namingConvention: keep
 //           noExport: true
 //           avoidOptionals: true
-//           scalars:
-//             JSON: JSONValue
-
-type Maybe<T> = T | null;
 
 export type StaticAdminMetaQuery = {
+  __typename?: 'Query';
   keystone: {
     __typename: 'KeystoneMeta';
     adminMeta: {
       __typename: 'KeystoneAdminMeta';
-      lists: Array<{
-        __typename: 'KeystoneAdminUIListMeta';
-        key: string;
-        itemQueryName: string;
-        listQueryName: string;
-        path: string;
-        label: string;
-        singular: string;
-        plural: string;
-        description: Maybe<string>;
-        initialColumns: Array<string>;
-        pageSize: number;
-        labelField: string;
-        initialSort: Maybe<{
-          __typename: 'KeystoneAdminUISort';
-          field: string;
-          direction: KeystoneAdminUISortDirection;
-        }>;
-        fields: Array<{
-          __typename: 'KeystoneAdminUIFieldMeta';
-          path: string;
-          label: string;
-          description: Maybe<string>;
-          fieldMeta: Maybe<JSONValue>;
-          viewsIndex: number;
-          customViewsIndex: Maybe<number>;
-          search: Maybe<QueryMode>;
-          itemView: Maybe<{
-            __typename: 'KeystoneAdminUIFieldMetaItemView';
-            fieldMode: Maybe<KeystoneAdminUIFieldMetaItemViewFieldMode>;
-          }>;
-        }>;
-      }>;
+      models: Array<
+        | {
+            __typename: 'KeystoneAdminUIListMeta';
+            graphqlPlural: string;
+            plural: string;
+            initialColumns: Array<string>;
+            pageSize: number;
+            labelField: string;
+            key: string;
+            path: string;
+            label: string;
+            singular: string;
+            description: string | null;
+            initialSort: {
+              __typename: 'KeystoneAdminUISort';
+              field: string;
+              direction: KeystoneAdminUISortDirection;
+            } | null;
+            fields: Array<{
+              __typename: 'KeystoneAdminUIListFieldMeta';
+              search: QueryMode | null;
+              path: string;
+              label: string;
+              description: string | null;
+              fieldMeta: JSONValue | null;
+              viewsIndex: number;
+              customViewsIndex: number | null;
+              itemView: {
+                __typename?: 'KeystoneAdminUIFieldMetaItemView';
+                fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode | null;
+              } | null;
+            }>;
+          }
+        | {
+            __typename: 'KeystoneAdminUISingletonMeta';
+            key: string;
+            path: string;
+            label: string;
+            singular: string;
+            description: string | null;
+            fields: Array<{
+              __typename: 'KeystoneAdminUISingletonFieldMeta';
+              path: string;
+              label: string;
+              description: string | null;
+              fieldMeta: JSONValue | null;
+              viewsIndex: number;
+              customViewsIndex: number | null;
+              itemView: {
+                __typename?: 'KeystoneAdminUIFieldMetaItemView';
+                fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode | null;
+              } | null;
+            }>;
+          }
+      >;
     };
   };
 };

--- a/packages/core/src/admin-ui/utils/useAdminMeta.tsx
+++ b/packages/core/src/admin-ui/utils/useAdminMeta.tsx
@@ -3,6 +3,7 @@ import hashString from '@emotion/hash';
 import { AdminMeta, FieldViews, getGqlNames } from '../../types';
 import { useLazyQuery } from '../apollo';
 import { StaticAdminMetaQuery, staticAdminMetaQuery } from '../admin-meta-graphql';
+import { assertUnhandledSingletonCase } from '../../lib/utils';
 
 const expectedExports = new Set(['Cell', 'Field', 'controller', 'CardValue']);
 
@@ -66,10 +67,13 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
     const runtimeAdminMeta: AdminMeta = {
       lists: {},
     };
-    adminMeta.lists.forEach(list => {
+    adminMeta.models.forEach(list => {
+      if (list.__typename === 'KeystoneAdminUISingletonMeta') {
+        assertUnhandledSingletonCase();
+      }
       runtimeAdminMeta.lists[list.key] = {
         ...list,
-        gqlNames: getGqlNames({ listKey: list.key, pluralGraphQLName: list.listQueryName }),
+        gqlNames: getGqlNames({ listKey: list.key, pluralGraphQLName: list.graphqlPlural }),
         fields: {},
       };
       list.fields.forEach(field => {

--- a/packages/core/src/admin-ui/utils/useLazyMetadata.tsx
+++ b/packages/core/src/admin-ui/utils/useLazyMetadata.tsx
@@ -28,7 +28,7 @@ export function useLazyMetadata(query: DocumentNode): {
           | { __typename: string };
         keystone: {
           adminMeta: {
-            lists: {
+            models: {
               key: string;
               isHidden: boolean;
               fields: { path: string; createView: { fieldMode: 'edit' | 'hidden' } }[];
@@ -67,7 +67,7 @@ function getCreateViewFieldModes(
   }
   if (data) {
     const lists: Record<string, Record<string, 'edit' | 'hidden'>> = {};
-    data.keystone.adminMeta.lists.forEach((list: any) => {
+    data.keystone.adminMeta.models.forEach((list: any) => {
       lists[list.key] = {};
       list.fields.forEach((field: any) => {
         lists[list.key][field.path] = field.createView.fieldMode;
@@ -88,7 +88,7 @@ function getVisibleLists(
   }
   if (data) {
     const lists = new Set<string>();
-    data.keystone.adminMeta.lists.forEach((list: any) => {
+    data.keystone.adminMeta.models.forEach((list: any) => {
       if (!list.isHidden) {
         lists.add(list.key);
       }

--- a/packages/core/src/lib/core/graphql-schema.ts
+++ b/packages/core/src/lib/core/graphql-schema.ts
@@ -1,5 +1,6 @@
 import { GraphQLNamedType, GraphQLSchema } from 'graphql';
 import { graphql } from '../..';
+import { adminMetaTypes } from '../../admin-ui/system/adminMetaSchema';
 import { InitialisedList } from './types-for-lists';
 
 import { getMutationsForList } from './mutations';
@@ -38,8 +39,12 @@ export function getGraphQLSchema(
   const graphQLSchema = new GraphQLSchema({
     query: query.graphQLType,
     mutation: mutation.graphQLType,
-    // not about behaviour, only ordering
-    types: [...collectTypes(lists, updateManyByList), mutation.graphQLType],
+    types: [
+      ...collectTypes(lists, updateManyByList),
+      mutation.graphQLType,
+      query.graphQLType,
+      ...adminMetaTypes,
+    ],
   });
   return graphQLSchema;
 }

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -19,3 +19,7 @@ export const humanize = (str: string) => {
     .map(upcase)
     .join(' ');
 };
+
+export function assertUnhandledSingletonCase(): never {
+  throw new Error('unhandled singleton case');
+}

--- a/packages/core/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages/core/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -114,14 +114,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -132,12 +131,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -193,4 +192,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/packages/fields-document/src/relationship-data.tsx
+++ b/packages/fields-document/src/relationship-data.tsx
@@ -204,9 +204,11 @@ const document = parse(`
   query {
     keystone {
       adminMeta {
-        lists {
+        models {
           key
-          labelField
+          ... on KeystoneAdminUIListMeta {
+            labelField
+          }
         }
       }
     }
@@ -224,7 +226,10 @@ export const getLabelFieldsForLists = weakMemoize(function getLabelFieldsForList
   if (errors?.length) {
     throw errors[0];
   }
+  type Data = { keystone: { adminMeta: { models: { key: string; labelField?: string }[] } } };
   return Object.fromEntries(
-    data!.keystone.adminMeta.lists.map((x: any) => [x.key, x.labelField as string])
+    (data as Data).keystone.adminMeta.models.flatMap(x =>
+      x.labelField ? [[x.key, x.labelField]] : []
+    )
   );
 });

--- a/tests/api-tests/access-control/schema.test.ts
+++ b/tests/api-tests/access-control/schema.test.ts
@@ -261,11 +261,13 @@ describe(`Public schema`, () => {
               query q($listName: String!) {
                 keystone {
                   adminMeta {
-                    list(key: $listName) {
-                      fields {
-                        path
-                        isFilterable
-                        isOrderable
+                    model(key: $listName) {
+                      ... on KeystoneAdminUIListMeta {
+                        fields {
+                          path
+                          isFilterable
+                          isOrderable
+                        }
                       }
                     }
                   }
@@ -275,7 +277,7 @@ describe(`Public schema`, () => {
             const { data, errors } = await context.graphql.raw({ query, variables });
             expect(errors).toBe(undefined);
 
-            const field = data!.keystone.adminMeta.list.fields.filter(
+            const field = data!.keystone.adminMeta.model.fields.filter(
               (f: any) => f.path === getFieldName(config)
             )[0];
             if (config.omit === true || config.omit?.includes('read')) {
@@ -315,13 +317,15 @@ describe(`Public schema`, () => {
               query q($listName: String!) {
                 keystone {
                   adminMeta {
-                    list(key: $listName) {
+                    model(key: $listName) {
                       key
-                      fields {
-                        path
-                        createView { fieldMode }
-                        listView { fieldMode }
-                        itemView(id: "blah") { fieldMode }
+                      ... on KeystoneAdminUIListMeta {
+                        fields {
+                          path
+                          createView { fieldMode }
+                          listView { fieldMode }
+                          itemView(id: "blah") { fieldMode }
+                        }
                       }
                     }
                   }
@@ -334,7 +338,7 @@ describe(`Public schema`, () => {
               .graphql.raw({ query, variables });
             expect(errors).toBe(undefined);
 
-            const field = data!.keystone.adminMeta.list.fields.filter(
+            const field = data!.keystone.adminMeta.model.fields.filter(
               (f: any) => f.path === getFieldName(config)
             )[0];
 

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -127,10 +127,12 @@ test(
         query {
           keystone {
             adminMeta {
-              list(key: "Test") {
+              model(key: "Test") {
                 label
                 singular
-                plural
+                ... on KeystoneAdminUIListMeta {
+                  plural
+                }
                 path
               }
             }
@@ -138,6 +140,6 @@ test(
         }
       `,
     });
-    expect(res.data!.keystone.adminMeta.list).toEqual(names);
+    expect(res.data!.keystone.adminMeta.model).toEqual(names);
   })
 );

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -37,13 +37,13 @@ test(
         __typename: 'KeystoneMeta',
         adminMeta: {
           __typename: 'KeystoneAdminMeta',
-          lists: [
+          models: [
             {
               __typename: 'KeystoneAdminUIListMeta',
               description: null,
               fields: [
                 {
-                  __typename: 'KeystoneAdminUIFieldMeta',
+                  __typename: 'KeystoneAdminUIListFieldMeta',
                   customViewsIndex: null,
                   description: null,
                   fieldMeta: {
@@ -58,7 +58,7 @@ test(
                   viewsIndex: 0,
                 },
                 {
-                  __typename: 'KeystoneAdminUIFieldMeta',
+                  __typename: 'KeystoneAdminUIListFieldMeta',
                   customViewsIndex: null,
                   description: null,
                   fieldMeta: {
@@ -84,13 +84,12 @@ test(
                   viewsIndex: 1,
                 },
               ],
+              graphqlPlural: 'Users',
               initialColumns: ['name'],
               initialSort: null,
-              itemQueryName: 'User',
               key: 'User',
               label: 'Users',
               labelField: 'name',
-              listQueryName: 'Users',
               pageSize: 50,
               path: 'users',
               plural: 'Users',

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -536,14 +536,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -554,12 +553,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -615,4 +614,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -310,14 +310,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -328,12 +327,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -389,4 +388,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/tests/test-projects/crud-notifications/schema.graphql
+++ b/tests/test-projects/crud-notifications/schema.graphql
@@ -253,14 +253,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -271,12 +270,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -332,4 +331,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }

--- a/tests/test-projects/live-reloading/schema.graphql
+++ b/tests/test-projects/live-reloading/schema.graphql
@@ -118,14 +118,13 @@ type KeystoneMeta {
 }
 
 type KeystoneAdminMeta {
-  lists: [KeystoneAdminUIListMeta!]!
-  list(key: String!): KeystoneAdminUIListMeta
+  models: [KeystoneAdminUIModelMeta!]!
+  model(key: String!): KeystoneAdminUIModelMeta
 }
 
-type KeystoneAdminUIListMeta {
+type KeystoneAdminUIListMeta implements KeystoneAdminUIModelMeta {
   key: String!
-  itemQueryName: String!
-  listQueryName: String!
+  graphqlPlural: String!
   hideCreate: Boolean!
   hideDelete: Boolean!
   path: String!
@@ -136,12 +135,12 @@ type KeystoneAdminUIListMeta {
   initialColumns: [String!]!
   pageSize: Int!
   labelField: String!
-  fields: [KeystoneAdminUIFieldMeta!]!
+  fields: [KeystoneAdminUIListFieldMeta!]!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
 }
 
-type KeystoneAdminUIFieldMeta {
+type KeystoneAdminUIListFieldMeta implements KeystoneAdminUIModelFieldMeta {
   path: String!
   label: String!
   description: String
@@ -197,4 +196,44 @@ type KeystoneAdminUISort {
 enum KeystoneAdminUISortDirection {
   ASC
   DESC
+}
+
+type KeystoneAdminUISingletonMeta implements KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUISingletonFieldMeta!]!
+}
+
+type KeystoneAdminUISingletonFieldMeta implements KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
+}
+
+interface KeystoneAdminUIModelMeta {
+  key: String!
+  path: String!
+  label: String!
+  singular: String!
+  description: String
+  isHidden: Boolean!
+  fields: [KeystoneAdminUIModelFieldMeta!]!
+}
+
+interface KeystoneAdminUIModelFieldMeta {
+  path: String!
+  label: String!
+  description: String
+  fieldMeta: JSON
+  viewsIndex: Int!
+  customViewsIndex: Int
+  itemView(id: ID): KeystoneAdminUIFieldMetaItemView
 }


### PR DESCRIPTION
This defines the GraphQL types needed for singletons in the admin meta and updates the usages to continue working for lists. The implementation assumes singletons are never actually used. The Admin UI and the back-end portions of singletons can be properly implemented independently after this.

Based on #7845