### PR TITLE
fix(fields): fix calendarDay non-nullable input type name

### DIFF
--- a/.changeset/tasty-lies-move.md
+++ b/.changeset/tasty-lies-move.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed CalendarDayFilter Graphql InputType name

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -204,6 +204,6 @@ const CalendarDayNullableFilter: CalendarDayFilterType = graphql.inputObject({
 });
 
 const CalendarDayFilter: CalendarDayFilterType = graphql.inputObject({
-  name: 'CalendarDayNullableFilter',
+  name: 'CalendarDayFilter',
   fields: () => filterFields(CalendarDayFilter),
 });


### PR DESCRIPTION
fixes #7865 (I think)

I'm relatively certain this will fix the issue I reported in #7865, but there could be other reasons it was occurring. This just appeared to be the most obvious one.