### PR TITLE
Only setup express server when necessary in tests

### DIFF
--- a/.changeset/fair-bugs-tease.md
+++ b/.changeset/fair-bugs-tease.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes `app`, `server` and `graphQLRequest` from `TestArgs` in `@keystone-6/core/testing`

--- a/examples/testing/example.test.ts
+++ b/examples/testing/example.test.ts
@@ -23,26 +23,6 @@ describe('Example tests using test runner', () => {
   );
 
   test(
-    'Create a Person using a hand-crafted GraphQL query sent over HTTP',
-    runner(async ({ graphQLRequest }) => {
-      // We can use the graphQLRequest argument provided by the test runner
-      // to execute HTTP requests to our GraphQL API and get a supertest
-      // "Test" object back. https://github.com/visionmedia/supertest
-      const { body } = await graphQLRequest({
-        query: `mutation {
-          createPerson(data: { name: "Alice", email: "alice@example.com", password: "super-secret" }) {
-            id name email password { isSet }
-          }
-        }`,
-      }).expect(200);
-      const person = body.data.createPerson;
-      expect(person.name).toEqual('Alice');
-      expect(person.email).toEqual('alice@example.com');
-      expect(person.password.isSet).toEqual(true);
-    })
-  );
-
-  test(
     'Check that trying to create user with no name (required field) fails',
     runner(async ({ context }) => {
       // The context.graphql.raw API is useful when we expect to recieve an

--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -3,8 +3,9 @@ import { list } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
 import type { KeystoneContext } from '@keystone-6/core/types';
-import { setupTestRunner, TestArgs, setupTestEnv } from '@keystone-6/core/testing';
+import { setupTestRunner, setupTestEnv } from '@keystone-6/core/testing';
 import { apiTestConfig, expectAccessDenied, seed } from './utils';
+import { GraphQLRequest, withServer } from './with-server';
 
 const initialData = {
   User: [
@@ -25,40 +26,42 @@ function setup(options?: any) {
     ...options,
   });
 
-  return setupTestRunner({
-    config: auth.withAuth(
-      apiTestConfig({
-        lists: {
-          Post: list({
-            fields: {
-              title: text(),
-              postedAt: timestamp(),
-            },
-          }),
-          User: list({
-            fields: {
-              name: text(),
-              email: text({ isIndexed: 'unique' }),
-              password: password(),
-            },
-            access: {
-              operation: {
-                create: defaultAccess,
-                query: defaultAccess,
-                update: defaultAccess,
-                delete: defaultAccess,
+  return withServer(
+    setupTestRunner({
+      config: auth.withAuth(
+        apiTestConfig({
+          lists: {
+            Post: list({
+              fields: {
+                title: text(),
+                postedAt: timestamp(),
               },
-            },
-          }),
-        },
-        session: statelessSessions({ secret: COOKIE_SECRET }),
-      })
-    ),
-  });
+            }),
+            User: list({
+              fields: {
+                name: text(),
+                email: text({ isIndexed: 'unique' }),
+                password: password(),
+              },
+              access: {
+                operation: {
+                  create: defaultAccess,
+                  query: defaultAccess,
+                  update: defaultAccess,
+                  delete: defaultAccess,
+                },
+              },
+            }),
+          },
+          session: statelessSessions({ secret: COOKIE_SECRET }),
+        })
+      ),
+    })
+  );
 }
 
 async function login(
-  graphQLRequest: TestArgs['graphQLRequest'],
+  graphQLRequest: GraphQLRequest,
   email: string,
   password: string
 ): Promise<{ sessionToken: string; item: { id: any } }> {

--- a/tests/api-tests/auth.test.ts
+++ b/tests/api-tests/auth.test.ts
@@ -2,8 +2,9 @@ import { text, password } from '@keystone-6/core/fields';
 import { list } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';
-import { setupTestRunner, TestArgs } from '@keystone-6/core/testing';
+import { setupTestRunner } from '@keystone-6/core/testing';
 import { apiTestConfig, expectInternalServerError, expectValidationError, seed } from './utils';
+import { GraphQLRequest, withServer } from './with-server';
 
 const initialData = {
   User: [
@@ -43,25 +44,27 @@ const auth = createAuth({
   },
 });
 
-const runner = setupTestRunner({
-  config: auth.withAuth(
-    apiTestConfig({
-      lists: {
-        User: list({
-          fields: {
-            name: text(),
-            email: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
-            password: password(),
-          },
-        }),
-      },
-      session: statelessSessions({ secret: COOKIE_SECRET }),
-    })
-  ),
-});
+const runner = withServer(
+  setupTestRunner({
+    config: auth.withAuth(
+      apiTestConfig({
+        lists: {
+          User: list({
+            fields: {
+              name: text(),
+              email: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
+              password: password(),
+            },
+          }),
+        },
+        session: statelessSessions({ secret: COOKIE_SECRET }),
+      })
+    ),
+  })
+);
 
 async function authenticateWithPassword(
-  graphQLRequest: TestArgs['graphQLRequest'],
+  graphQLRequest: GraphQLRequest,
   email: string,
   password: string
 ) {

--- a/tests/api-tests/body-parser.test.ts
+++ b/tests/api-tests/body-parser.test.ts
@@ -5,6 +5,7 @@ import { setupTestRunner } from '@keystone-6/core/testing';
 import type { Options as BodyParserOptions } from 'body-parser';
 import supertest from 'supertest';
 import { apiTestConfig } from './utils';
+import { withServer } from './with-server';
 
 function makeQuery(size = 0) {
   const query = JSON.stringify({
@@ -34,23 +35,25 @@ async function tryRequest(app: express.Express, size: number) {
 }
 
 function setup(options?: BodyParserOptions) {
-  return setupTestRunner({
-    config: apiTestConfig({
-      lists: {
-        Thing: list({
-          fields: {
-            value: text(),
-          },
-        }),
-      },
-      graphql: {
-        bodyParser: {
-          // limit: '100kb', // the body-parser default
-          ...options,
+  return withServer(
+    setupTestRunner({
+      config: apiTestConfig({
+        lists: {
+          Thing: list({
+            fields: {
+              value: text(),
+            },
+          }),
         },
-      },
-    }),
-  });
+        graphql: {
+          bodyParser: {
+            // limit: '100kb', // the body-parser default
+            ...options,
+          },
+        },
+      }),
+    })
+  );
 }
 
 describe('Configuring .graphql.bodyParser', () => {

--- a/tests/api-tests/extend-express-app.test.ts
+++ b/tests/api-tests/extend-express-app.test.ts
@@ -3,19 +3,22 @@ import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import supertest from 'supertest';
 import { apiTestConfig } from './utils';
+import { withServer } from './with-server';
 
-const runner = setupTestRunner({
-  config: apiTestConfig({
-    lists: { User: list({ fields: { name: text() } }) },
-    server: {
-      extendExpressApp: app => {
-        app.get('/magic', (req, res) => {
-          res.json({ magic: true });
-        });
+const runner = withServer(
+  setupTestRunner({
+    config: apiTestConfig({
+      lists: { User: list({ fields: { name: text() } }) },
+      server: {
+        extendExpressApp: app => {
+          app.get('/magic', (req, res) => {
+            res.json({ magic: true });
+          });
+        },
       },
-    },
-  }),
-});
+    }),
+  })
+);
 
 test(
   'basic extension',

--- a/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema/extend-graphql-schema.test.ts
@@ -2,6 +2,7 @@ import { list, graphQLSchemaExtension, gql } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import { apiTestConfig, expectInternalServerError } from '../utils';
+import { withServer } from '../with-server';
 
 const falseFn: (...args: any) => boolean = () => false;
 
@@ -70,7 +71,7 @@ describe('extendGraphqlSchema', () => {
   );
   it(
     'Denies access acording to access control',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: `
           query {

--- a/tests/api-tests/extend-http-server.test.ts
+++ b/tests/api-tests/extend-http-server.test.ts
@@ -4,19 +4,22 @@ import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import supertest from 'supertest';
 import { apiTestConfig } from './utils';
+import { withServer } from './with-server';
 
-const runner = setupTestRunner({
-  config: apiTestConfig({
-    lists: { User: list({ fields: { name: text() } }) },
-    server: {
-      extendHttpServer: server => {
-        server.prependListener('request', (req: IncomingMessage, res: ServerResponse) => {
-          res.setHeader('test-header', 'test-header-value');
-        });
+const runner = withServer(
+  setupTestRunner({
+    config: apiTestConfig({
+      lists: { User: list({ fields: { name: text() } }) },
+      server: {
+        extendHttpServer: server => {
+          server.prependListener('request', (req: IncomingMessage, res: ServerResponse) => {
+            res.setHeader('test-header', 'test-header-value');
+          });
+        },
       },
-    },
-  }),
-});
+    }),
+  })
+);
 
 test(
   'server extension',

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -5,6 +5,7 @@ import { setupTestEnv, setupTestRunner } from '@keystone-6/core/testing';
 import { KeystoneContext } from '@keystone-6/core/types';
 import { component, fields } from '@keystone-6/fields-document/component-blocks';
 import { apiTestConfig, expectInternalServerError } from '../../utils';
+import { withServer } from '../../with-server';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -252,7 +253,7 @@ describe('Document field type', () => {
 
   test(
     'hydrateRelationships: true - selection has bad fields',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       const { alice } = await initData({ context });
       const badBob = await context.query.Author.createOne({
         data: {

--- a/tests/api-tests/healthcheck.test.ts
+++ b/tests/api-tests/healthcheck.test.ts
@@ -3,14 +3,17 @@ import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import supertest from 'supertest';
 import { apiTestConfig } from './utils';
+import { withServer } from './with-server';
 
 const makeRunner = (healthCheck: any) =>
-  setupTestRunner({
-    config: apiTestConfig({
-      lists: { User: list({ fields: { name: text() } }) },
-      server: { healthCheck },
-    }),
-  });
+  withServer(
+    setupTestRunner({
+      config: apiTestConfig({
+        lists: { User: list({ fields: { name: text() } }) },
+        server: { healthCheck },
+      }),
+    })
+  );
 
 test(
   'No health check',

--- a/tests/api-tests/hooks/hook-errors.test.ts
+++ b/tests/api-tests/hooks/hook-errors.test.ts
@@ -1,112 +1,115 @@
 import { relationship, text } from '@keystone-6/core/fields';
 import { list } from '@keystone-6/core';
-import { GraphQLRequest, setupTestRunner } from '@keystone-6/core/testing';
+import { setupTestRunner } from '@keystone-6/core/testing';
 import { KeystoneContext } from '@keystone-6/core/types';
 import { apiTestConfig, expectExtensionError, unpackErrors } from '../utils';
+import { GraphQLRequest, withServer } from '../with-server';
 
 const runner = (debug: boolean | undefined) =>
-  setupTestRunner({
-    config: apiTestConfig({
-      lists: {
-        User: list({
-          fields: { name: text() },
-          hooks: {
-            beforeOperation: ({ resolvedData, operation, item }) => {
-              if (operation === 'delete') {
-                if (item.name === 'trigger before delete') {
-                  throw new Error('Simulated error: beforeOperation');
+  withServer(
+    setupTestRunner({
+      config: apiTestConfig({
+        lists: {
+          User: list({
+            fields: { name: text() },
+            hooks: {
+              beforeOperation: ({ resolvedData, operation, item }) => {
+                if (operation === 'delete') {
+                  if (item.name === 'trigger before delete') {
+                    throw new Error('Simulated error: beforeOperation');
+                  }
+                } else {
+                  if (resolvedData?.name === 'trigger before') {
+                    throw new Error('Simulated error: beforeOperation');
+                  }
                 }
-              } else {
-                if (resolvedData?.name === 'trigger before') {
-                  throw new Error('Simulated error: beforeOperation');
+              },
+              afterOperation: ({ resolvedData, operation, originalItem }) => {
+                if (operation === 'delete') {
+                  if (originalItem.name === 'trigger after delete') {
+                    throw new Error('Simulated error: afterOperation');
+                  }
+                } else {
+                  if (resolvedData?.name === 'trigger after') {
+                    throw new Error('Simulated error: afterOperation');
+                  }
                 }
-              }
+              },
             },
-            afterOperation: ({ resolvedData, operation, originalItem }) => {
-              if (operation === 'delete') {
-                if (originalItem.name === 'trigger after delete') {
-                  throw new Error('Simulated error: afterOperation');
-                }
-              } else {
-                if (resolvedData?.name === 'trigger after') {
-                  throw new Error('Simulated error: afterOperation');
-                }
-              }
+          }),
+          Post: list({
+            fields: {
+              title: text({
+                hooks: {
+                  beforeOperation: ({ resolvedData, operation, item }) => {
+                    if (operation === 'delete') {
+                      if (item.title === 'trigger before delete') {
+                        throw new Error('Simulated error: title: beforeOperation');
+                      }
+                    } else {
+                      if (resolvedData?.title === 'trigger before') {
+                        throw new Error('Simulated error: title: beforeOperation');
+                      }
+                    }
+                  },
+                  afterOperation: ({ resolvedData, operation, originalItem }) => {
+                    if (operation === 'delete') {
+                      if (originalItem.title === 'trigger after delete') {
+                        throw new Error('Simulated error: title: afterOperation');
+                      }
+                    } else {
+                      if (resolvedData?.title === 'trigger after') {
+                        throw new Error('Simulated error: title: afterOperation');
+                      }
+                    }
+                  },
+                },
+              }),
+              content: text({
+                hooks: {
+                  beforeOperation: ({ resolvedData, operation, item }) => {
+                    if (operation === 'delete') {
+                      if (item.content === 'trigger before delete') {
+                        throw new Error('Simulated error: content: beforeOperation');
+                      }
+                    } else {
+                      if (resolvedData?.content === 'trigger before') {
+                        throw new Error('Simulated error: content: beforeOperation');
+                      }
+                    }
+                  },
+                  afterOperation: ({ resolvedData, operation, originalItem }) => {
+                    if (operation === 'delete') {
+                      if (originalItem.content === 'trigger after delete') {
+                        throw new Error('Simulated error: content: afterOperation');
+                      }
+                    } else {
+                      if (resolvedData?.content === 'trigger after') {
+                        throw new Error('Simulated error: content: afterOperation');
+                      }
+                    }
+                  },
+                },
+              }),
             },
-          },
-        }),
-        Post: list({
-          fields: {
-            title: text({
-              hooks: {
-                beforeOperation: ({ resolvedData, operation, item }) => {
-                  if (operation === 'delete') {
-                    if (item.title === 'trigger before delete') {
-                      throw new Error('Simulated error: title: beforeOperation');
-                    }
-                  } else {
-                    if (resolvedData?.title === 'trigger before') {
-                      throw new Error('Simulated error: title: beforeOperation');
-                    }
-                  }
+          }),
+          BadResolveInput: list({
+            fields: {
+              badResolveInput: relationship({
+                ref: 'Post',
+                hooks: {
+                  resolveInput() {
+                    return { blah: true };
+                  },
                 },
-                afterOperation: ({ resolvedData, operation, originalItem }) => {
-                  if (operation === 'delete') {
-                    if (originalItem.title === 'trigger after delete') {
-                      throw new Error('Simulated error: title: afterOperation');
-                    }
-                  } else {
-                    if (resolvedData?.title === 'trigger after') {
-                      throw new Error('Simulated error: title: afterOperation');
-                    }
-                  }
-                },
-              },
-            }),
-            content: text({
-              hooks: {
-                beforeOperation: ({ resolvedData, operation, item }) => {
-                  if (operation === 'delete') {
-                    if (item.content === 'trigger before delete') {
-                      throw new Error('Simulated error: content: beforeOperation');
-                    }
-                  } else {
-                    if (resolvedData?.content === 'trigger before') {
-                      throw new Error('Simulated error: content: beforeOperation');
-                    }
-                  }
-                },
-                afterOperation: ({ resolvedData, operation, originalItem }) => {
-                  if (operation === 'delete') {
-                    if (originalItem.content === 'trigger after delete') {
-                      throw new Error('Simulated error: content: afterOperation');
-                    }
-                  } else {
-                    if (resolvedData?.content === 'trigger after') {
-                      throw new Error('Simulated error: content: afterOperation');
-                    }
-                  }
-                },
-              },
-            }),
-          },
-        }),
-        BadResolveInput: list({
-          fields: {
-            badResolveInput: relationship({
-              ref: 'Post',
-              hooks: {
-                resolveInput() {
-                  return { blah: true };
-                },
-              },
-            }),
-          },
-        }),
-      },
-      graphql: { debug },
-    }),
-  });
+              }),
+            },
+          }),
+        },
+        graphql: { debug },
+      }),
+    })
+  );
 
 [true, false].map(useHttp => {
   const runQuery = async (

--- a/tests/api-tests/queries/cache-hints.test.ts
+++ b/tests/api-tests/queries/cache-hints.test.ts
@@ -4,6 +4,7 @@ import { list, graphQLSchemaExtension } from '@keystone-6/core';
 import { KeystoneContext } from '@keystone-6/core/types';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import { apiTestConfig } from '../utils';
+import { withServer } from '../with-server';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -97,7 +98,7 @@ const addFixtures = async (context: KeystoneContext) => {
 describe('cache hints', () => {
   test(
     'users',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await addFixtures(context);
 
       // Basic query
@@ -190,7 +191,7 @@ describe('cache hints', () => {
 
   test(
     'posts',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await addFixtures(context);
       // The Post list has a static cache hint
 
@@ -284,7 +285,7 @@ describe('cache hints', () => {
 
   test(
     'mutations',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       const { posts } = await addFixtures(context);
 
       // Mutation responses shouldn't be cached.
@@ -307,7 +308,7 @@ describe('cache hints', () => {
 
   test(
     'extendGraphQLSchemaQueries',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await addFixtures(context);
 
       // Basic query
@@ -329,7 +330,7 @@ describe('cache hints', () => {
 
   test(
     'extendGraphQLSchemaMutations',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await addFixtures(context);
 
       // Mutation responses shouldn't be cached.

--- a/tests/api-tests/queries/filters.test.ts
+++ b/tests/api-tests/queries/filters.test.ts
@@ -9,6 +9,7 @@ import {
   expectGraphQLValidationError,
   expectFilterDenied,
 } from '../utils';
+import { withServer } from '../with-server';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -274,7 +275,7 @@ describe('searching by unique fields', () => {
 describe('isFilterable', () => {
   test(
     'isFilterable: false',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: '{ users(where: { filterFalse: { equals: 10 } }) { id } }',
       });
@@ -396,7 +397,7 @@ describe('defaultIsFilterable', () => {
 
   test(
     'defaultIsFilterable: false',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: '{ defaultFilterFalses(where: { a: { equals: 10 } }) { id } }',
       });

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -2,38 +2,41 @@ import { text, integer, relationship } from '@keystone-6/core/fields';
 import { list } from '@keystone-6/core';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import { apiTestConfig, expectGraphQLValidationError, expectLimitsExceededError } from '../utils';
+import { withServer } from '../with-server';
 import { depthLimit, definitionLimit, fieldLimit } from './validation';
 
-const runner = setupTestRunner({
-  config: apiTestConfig({
-    lists: {
-      Post: list({
-        fields: {
-          title: text(),
-          author: relationship({ ref: 'User.posts', many: true }),
-        },
-      }),
-      User: list({
-        fields: {
-          name: text(),
-          favNumber: integer(),
-          posts: relationship({ ref: 'Post.author', many: true }),
-        },
-        graphql: {
-          queryLimits: {
-            maxResults: 2,
+const runner = withServer(
+  setupTestRunner({
+    config: apiTestConfig({
+      lists: {
+        Post: list({
+          fields: {
+            title: text(),
+            author: relationship({ ref: 'User.posts', many: true }),
           },
-        },
-      }),
-    },
-    graphql: {
-      queryLimits: { maxTotalResults: 6 },
-      apolloConfig: {
-        validationRules: [depthLimit(3), definitionLimit(3), fieldLimit(8)],
+        }),
+        User: list({
+          fields: {
+            name: text(),
+            favNumber: integer(),
+            posts: relationship({ ref: 'Post.author', many: true }),
+          },
+          graphql: {
+            queryLimits: {
+              maxResults: 2,
+            },
+          },
+        }),
       },
-    },
-  }),
-});
+      graphql: {
+        queryLimits: { maxTotalResults: 6 },
+        apolloConfig: {
+          validationRules: [depthLimit(3), definitionLimit(3), fieldLimit(8)],
+        },
+      },
+    }),
+  })
+);
 
 describe('maxResults Limit', () => {
   describe('Basic querying', () => {

--- a/tests/api-tests/queries/orderBy.test.ts
+++ b/tests/api-tests/queries/orderBy.test.ts
@@ -9,6 +9,7 @@ import {
   expectGraphQLValidationError,
   expectFilterDenied,
 } from '../utils';
+import { withServer } from '../with-server';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -345,7 +346,7 @@ describe('Ordering by Multiple', () => {
 describe('isOrderable', () => {
   test(
     'isOrderable: false',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await initialiseData({ context });
       const { body } = await graphQLRequest({
         query: '{ users(orderBy: [{orderFalse: asc}]) { id } }',
@@ -470,7 +471,7 @@ describe('defaultIsOrderable', () => {
 
   test(
     'defaultIsOrderable: false',
-    runner(async ({ context, graphQLRequest }) => {
+    withServer(runner)(async ({ context, graphQLRequest }) => {
       await initialiseData({ context });
       const { body } = await graphQLRequest({
         query: '{ defaultOrderFalses(orderBy: [{a: asc}]) { id } }',

--- a/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/create-singular.test.ts
@@ -7,6 +7,7 @@ import {
   expectGraphQLValidationError,
   expectSingleRelationshipError,
 } from '../../utils';
+import { withServer } from '../../with-server';
 
 const runner = setupTestRunner({
   config: apiTestConfig({
@@ -230,7 +231,7 @@ describe('with access control', () => {
       } else {
         test(
           'throws error when creating nested within create mutation',
-          runner(async ({ context, graphQLRequest }) => {
+          withServer(runner)(async ({ context, graphQLRequest }) => {
             const alphaNumGenerator = gen.alphaNumString.notEmpty();
             const eventName = sampleOne(alphaNumGenerator);
             const groupName = sampleOne(alphaNumGenerator);
@@ -286,7 +287,7 @@ describe('with access control', () => {
 
         test(
           'throws error when creating nested within update mutation',
-          runner(async ({ context, graphQLRequest }) => {
+          withServer(runner)(async ({ context, graphQLRequest }) => {
             const groupName = sampleOne(gen.alphaNumString.notEmpty());
 
             // Create an item to update

--- a/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-many.test.ts
@@ -7,6 +7,7 @@ import {
   expectGraphQLValidationError,
   expectSingleRelationshipError,
 } from '../../utils';
+import { withServer } from '../../with-server';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -93,7 +94,7 @@ describe('no access control', () => {
 
   test(
     'causes a validation error if used during create',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: `
           mutation {

--- a/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/disconnect-singular.test.ts
@@ -3,6 +3,7 @@ import { text, relationship } from '@keystone-6/core/fields';
 import { list } from '@keystone-6/core';
 import { setupTestRunner } from '@keystone-6/core/testing';
 import { apiTestConfig, expectGraphQLValidationError } from '../../utils';
+import { withServer } from '../../with-server';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -77,7 +78,7 @@ describe('no access control', () => {
 
   test(
     'causes a validation error if used during create',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: `
           mutation {

--- a/tests/api-tests/relationships/nested-mutations/set-many.test.ts
+++ b/tests/api-tests/relationships/nested-mutations/set-many.test.ts
@@ -7,6 +7,7 @@ import {
   expectGraphQLValidationError,
   expectSingleRelationshipError,
 } from '../../utils';
+import { withServer } from '../../with-server';
 
 const alphanumGenerator = gen.alphaNumString.notEmpty();
 
@@ -155,7 +156,7 @@ describe('no access control', () => {
 
   test(
     'causes a validation error if used during create',
-    runner(async ({ graphQLRequest }) => {
+    withServer(runner)(async ({ graphQLRequest }) => {
       const { body } = await graphQLRequest({
         query: `
           mutation {

--- a/tests/api-tests/with-server.ts
+++ b/tests/api-tests/with-server.ts
@@ -1,0 +1,63 @@
+import { Server } from 'http';
+import express from 'express';
+import { TestArgs } from '@keystone-6/core/testing';
+import { createExpressServer } from '@keystone-6/core/system';
+import supertest, { Test } from 'supertest';
+
+export type GraphQLRequest = (arg: {
+  query: string;
+  variables?: Record<string, any>;
+  operationName?: string;
+}) => Test;
+
+type TestArgsWithServer = TestArgs & {
+  graphQLRequest: GraphQLRequest;
+  app: express.Express;
+  server: Server;
+};
+
+async function getTestArgsWithServer(testArgs: TestArgs): Promise<{
+  disconnect: () => Promise<void>;
+  args: TestArgsWithServer;
+}> {
+  const {
+    expressServer: app,
+    apolloServer,
+    httpServer: server,
+  } = await createExpressServer(
+    testArgs.config,
+    testArgs.context.graphql.schema,
+    testArgs.createContext
+  );
+
+  const graphQLRequest: GraphQLRequest = ({ query, variables = undefined, operationName }) =>
+    supertest(app)
+      .post(testArgs.config.graphql?.path || '/api/graphql')
+      .send({ query, variables, operationName })
+      .set('Accept', 'application/json');
+
+  return {
+    disconnect: () => apolloServer.stop(),
+    args: {
+      ...testArgs,
+      app,
+      graphQLRequest,
+      server,
+    },
+  };
+}
+
+export function withServer(
+  runner: (testFn: (testArgs: TestArgs) => Promise<void>) => () => Promise<void>
+) {
+  return (testFn: (testArgs: TestArgsWithServer) => Promise<void>) => () => {
+    return runner(async baseTestArgs => {
+      const { disconnect, args } = await getTestArgsWithServer(baseTestArgs);
+      try {
+        await testFn(args);
+      } finally {
+        await disconnect();
+      }
+    })();
+  };
+}


### PR DESCRIPTION
This is because setting up the express server is somewhat expensive but most tests don't need it. The documentation updates for this will be in a separate PR.