### PR TITLE
Remove validation in `executeGraphQLFieldToRootVal`

### DIFF
--- a/packages/core/src/lib/context/executeGraphQLFieldToRootVal.ts
+++ b/packages/core/src/lib/context/executeGraphQLFieldToRootVal.ts
@@ -5,7 +5,6 @@ import {
   GraphQLArgumentConfig,
   GraphQLSchema,
   DocumentNode,
-  validate,
   execute,
   GraphQLField,
   VariableDefinitionNode,
@@ -192,13 +191,9 @@ export function executeGraphQLFieldToRootVal(field: GraphQLField<any, any>) {
         [field.name]: fieldConfig,
       },
     }),
+    assumeValid: true,
   });
 
-  const validationErrors = validate(schema, document);
-
-  if (validationErrors.length > 0) {
-    throw validationErrors[0];
-  }
   return async (
     args: Record<string, any>,
     context: KeystoneContext,


### PR DESCRIPTION
The entire schema is already validated separately and the query is written by us and accepts no user input so we can assume it's valid and save the cost of validating this again. (no changeset because it doesn't impact users, it can be released whenever)