### PR TITLE
Fix rate limiting in CI

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Setup Node.js LTS
       uses: actions/setup-node@v3
       with:
-        # ideally we would use lts/* but GitHub hits API limits when trying to query that
+        # preferably lts/*, but we hit API limits when querying that
         node-version: 16
 
     - name: Get yarn cache directory path

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -5,6 +5,7 @@ runs:
     - name: Setup Node.js LTS
       uses: actions/setup-node@v3
       with:
+        # ideally we would use lts/* but GitHub hits API limits when trying to query that
         node-version: 16
 
     - name: Get yarn cache directory path

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Setup Node.js LTS
       uses: actions/setup-node@v3
       with:
-        node-version: lts/*
+        node-version: 16
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path


### PR DESCRIPTION
I think this should fix the rate limiting we're seeing because if you look at the logs, it always fails in `actions/setup-node` right after it logs `Attempt to resolve LTS alias from manifest...`(https://github.com/actions/setup-node/blob/c2dfe2df9884bf1033e0ee352d86309105ea6cf0/src/installer.ts#L44) that leads to https://github.com/actions/toolkit/blob/500d0b42fee2552ae9eeb5933091fe2fbf14e72d/packages/tool-cache/src/tool-cache.ts#L589 which does a GitHub API call so getting a rate limit error from GitHub makes sense.

So I think we can fix it by writing a version rather than use `lts/*`, from a cursory reading of the code in `actions/setup-node` doesn't try to do a call to GitHub's API when using a version range like `16`. Updating our CI every time there is a new active Node LTS seems fine.