### PR TITLE
Add `cache: "bounded"` and `persistedQueries: false` to default Apollo Server config

### DIFF
--- a/.changeset/many-bulldogs-scream.md
+++ b/.changeset/many-bulldogs-scream.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Adds `cache: "bounded"` and `persistedQueries: false` to default Apollo Server config.

--- a/.changeset/many-bulldogs-scream.md
+++ b/.changeset/many-bulldogs-scream.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': major
 ---
 
-Adds `cache: "bounded"` and `persistedQueries: false` to default Apollo Server config.
+Changes default Apollo Server configuration to use `cache: "bounded"` and `persistedQueries: false`

--- a/packages/core/src/lib/server/createApolloServer.ts
+++ b/packages/core/src/lib/server/createApolloServer.ts
@@ -5,6 +5,7 @@ import { ApolloServer as ApolloServerExpress } from 'apollo-server-express';
 import {
   ApolloServerPluginLandingPageDisabled,
   ApolloServerPluginLandingPageGraphQLPlayground,
+  Config,
 } from 'apollo-server-core';
 import type { CreateContext, GraphQLConfig, SessionStrategy } from '../../types';
 import { createSessionContext } from '../../session';
@@ -63,13 +64,15 @@ const _createApolloServerConfig = ({
 }: {
   graphQLSchema: GraphQLSchema;
   graphqlConfig?: GraphQLConfig;
-}) => {
+}): Config => {
   const apolloConfig = graphqlConfig?.apolloConfig;
   const playgroundOption = graphqlConfig?.playground ?? process.env.NODE_ENV !== 'production';
 
   return {
     schema: graphQLSchema,
     debug: graphqlConfig?.debug, // If undefined, use Apollo default of NODE_ENV !== 'production'
+    cache: 'bounded',
+    persistedQueries: false,
     ...apolloConfig,
     plugins:
       playgroundOption === 'apollo'

--- a/tests/api-tests/utils.ts
+++ b/tests/api-tests/utils.ts
@@ -7,13 +7,10 @@ let prevConsoleWarn = console.warn;
 console.warn = function (...args: unknown[]) {
   if (
     typeof args[0] === 'string' &&
-    (args[0].endsWith(
+    args[0].endsWith(
       // this is expected
       'There are already 10 instances of Prisma Client actively running.'
-    ) ||
-      // we should really enforce a safe default for this though
-      args[0] ===
-        'Persisted queries are enabled and are using an unbounded cache. Your server is vulnerable to denial of service attacks via memory exhaustion. Set `cache: "bounded"` or `persistedQueries: false` in your ApolloServer constructor, or see https://go.apollo.dev/s/cache-backends for other alternatives.')
+    )
   ) {
     return;
   }


### PR DESCRIPTION
This PR changes the default of `cache` in Apollo Server to `"bounded"` to ensure that an attacker cannot fill Apollo's automatic persisted queries cache to the point of memory exhaustion. This will be default in a future version of Apollo Server: https://www.apollographql.com/docs/apollo-server/performance/cache-backends#ensuring-a-bounded-cache.

This _also_ sets `persistedQueries: false`. While setting `cache: "bounded"` ensures that an attacker cannot exhaust a server's memory, an attacker could still send a large number of different queries constantly to fill up the cache rendering automatic persisted queries pointless and actually degrade performance because trusted actors would have to frequently send a second request since the server would have replaced the queries from trusted actors in the cache with malicious queries and the client would have to send the actual query text in a second request. A safer and more predictable approach would be to persist queries at compile time from the actual applications the server is meant to serve such as [what Relay suggests](https://relay.dev/docs/guides/persisted-queries/#compile-time-push).

If you're aware of the above caveats of persisted queries, you can re-enable persisted queries with `config.graphql.apolloConfig`.