### PR TITLE
Remove `adminMeta` argument to `getAdminMeta` function in custom field types and the associated types for it

### DIFF
--- a/.changeset/poor-dogs-exercise.md
+++ b/.changeset/poor-dogs-exercise.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes `adminMeta` argument to `getAdminMeta` function in custom field types and the associated types for it

--- a/.changeset/poor-dogs-exercise.md
+++ b/.changeset/poor-dogs-exercise.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': major
 ---
 
-Removes `adminMeta` argument to `getAdminMeta` function in custom field types and the associated types for it
+Removes the parameters for `getAdminMeta` when writing field types, and the respective types `AdminMetaRootVal`, `ListMetaRootVal` and `FieldMetaRootVal` therein.

--- a/packages/core/src/admin-ui/system/adminMetaSchema.ts
+++ b/packages/core/src/admin-ui/system/adminMetaSchema.ts
@@ -1,15 +1,8 @@
 import { GraphQLResolveInfo } from 'graphql';
 import { ScalarType, EnumType, EnumValue } from '@graphql-ts/schema';
-import {
-  QueryMode,
-  KeystoneContext,
-  AdminMetaRootVal,
-  ListMetaRootVal,
-  FieldMetaRootVal,
-  BaseItem,
-  MaybePromise,
-} from '../../types';
+import { QueryMode, KeystoneContext, BaseItem, MaybePromise } from '../../types';
 import { graphql as graphqlBoundToKeystoneContext } from '../..';
+import { FieldMetaRootVal, ListMetaRootVal, AdminMetaRootVal } from './createAdminMeta';
 
 type Context = KeystoneContext | { isAdminUIBuildProcess: true };
 

--- a/packages/core/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/core/src/admin-ui/system/generateAdminUI.ts
@@ -4,9 +4,10 @@ import fs from 'fs-extra';
 import resolve from 'resolve';
 import { GraphQLSchema } from 'graphql';
 import { Entry, walk as _walk } from '@nodelib/fs.walk';
-import type { KeystoneConfig, AdminMetaRootVal, AdminFileToWrite } from '../../types';
+import type { KeystoneConfig, AdminFileToWrite } from '../../types';
 import { writeAdminFiles } from '../templates';
 import { serializePathForImport } from '../utils/serializePathForImport';
+import { AdminMetaRootVal } from './createAdminMeta';
 
 const walk = promisify(_walk);
 

--- a/packages/core/src/admin-ui/templates/app.ts
+++ b/packages/core/src/admin-ui/templates/app.ts
@@ -11,8 +11,8 @@ import {
   ExecutionResult,
   Kind,
 } from 'graphql';
-import { AdminMetaRootVal } from '../../types';
 import { staticAdminMetaQuery, StaticAdminMetaQuery } from '../admin-meta-graphql';
+import { AdminMetaRootVal } from '../system/createAdminMeta';
 
 type AppTemplateOptions = { configFileExists: boolean };
 

--- a/packages/core/src/admin-ui/templates/index.ts
+++ b/packages/core/src/admin-ui/templates/index.ts
@@ -1,6 +1,7 @@
 import * as Path from 'path';
 import { GraphQLSchema } from 'graphql';
-import type { AdminMetaRootVal, KeystoneConfig, AdminFileToWrite } from '../../types';
+import type { KeystoneConfig, AdminFileToWrite } from '../../types';
+import { AdminMetaRootVal } from '../system/createAdminMeta';
 import { appTemplate } from './app';
 import { homeTemplate } from './home';
 import { listTemplate } from './list';

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,11 +1,6 @@
-import {
-  BaseListTypeInfo,
-  FieldTypeFunc,
-  CommonFieldConfig,
-  fieldType,
-  AdminMetaRootVal,
-} from '../../../types';
+import { BaseListTypeInfo, FieldTypeFunc, CommonFieldConfig, fieldType } from '../../../types';
 import { graphql } from '../../..';
+import { getAdminMetaForRelationshipField } from '../../../admin-ui/system/createAdminMeta';
 
 // This is the default display mode for Relationships
 type SelectDisplayConfig = {
@@ -86,9 +81,8 @@ export const relationship =
     const commonConfig = {
       ...config,
       views: '@keystone-6/core/fields/types/relationship/views',
-      getAdminMeta: (
-        adminMetaRoot: AdminMetaRootVal
-      ): Parameters<typeof import('./views').controller>[0]['fieldMeta'] => {
+      getAdminMeta: (): Parameters<typeof import('./views').controller>[0]['fieldMeta'] => {
+        const adminMetaRoot = getAdminMetaForRelationshipField();
         if (!meta.lists[foreignListKey]) {
           throw new Error(
             `The ref [${ref}] on relationship [${meta.listKey}.${meta.fieldKey}] is invalid`

--- a/packages/core/src/lib/createGraphQLSchema.ts
+++ b/packages/core/src/lib/createGraphQLSchema.ts
@@ -1,6 +1,7 @@
-import type { KeystoneConfig, AdminMetaRootVal } from '../types';
+import type { KeystoneConfig } from '../types';
 import { KeystoneMeta } from '../admin-ui/system';
 import { graphql } from '../types/schema';
+import { AdminMetaRootVal } from '../admin-ui/system/createAdminMeta';
 import { InitialisedList } from './core/types-for-lists';
 import { getGraphQLSchema } from './core/graphql-schema';
 

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -23,10 +23,11 @@ import {
   requirePrismaClient,
 } from '../../artifacts';
 import { ExitError, getAdminPath, getBuiltConfigPath } from '../utils';
-import { AdminMetaRootVal, CreateContext, KeystoneConfig } from '../../types';
+import { CreateContext, KeystoneConfig } from '../../types';
 import { initialiseLists } from '../../lib/core/types-for-lists';
 import { printPrismaSchema } from '../../lib/core/prisma-schema';
 import { createSessionContext } from '../../lib/context/session';
+import { AdminMetaRootVal } from '../../admin-ui/system/createAdminMeta';
 
 const devLoadingHTMLFilepath = path.join(
   path.dirname(require.resolve('@keystone-6/core/package.json')),

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -1,9 +1,6 @@
 import { GraphQLError } from 'graphql';
 import type { ReactElement } from 'react';
-import { MaybeItemFunction } from './config';
-import { KeystoneContext } from './context';
-import { BaseListTypeInfo } from './type-info';
-import { GqlNames, JSONValue, MaybePromise } from './utils';
+import { GqlNames, JSONValue } from './utils';
 
 export type NavigationProps = {
   authenticatedItem: AuthenticatedItem;
@@ -158,51 +155,3 @@ export type CardValueComponent<
     any
   >
 > = (props: { item: Record<string, any>; field: ReturnType<FieldControllerFn> }) => ReactElement;
-
-export type ContextFunction<Return> = (context: KeystoneContext) => MaybePromise<Return>;
-
-// Types used on the server by the Admin UI schema resolvers
-export type FieldMetaRootVal = {
-  path: string;
-  label: string;
-  description: string | null;
-  fieldMeta: JSONValue | null;
-  viewsIndex: number;
-  customViewsIndex: number | null;
-  listKey: string;
-  search: 'default' | 'insensitive' | null;
-  isOrderable: ContextFunction<boolean>;
-  isFilterable: ContextFunction<boolean>;
-  createView: { fieldMode: ContextFunction<'edit' | 'hidden'> };
-  // itemView is intentionally special because static values are special cased
-  // and fetched when fetching the static admin ui
-  itemView: { fieldMode: MaybeItemFunction<'edit' | 'read' | 'hidden', BaseListTypeInfo> };
-  listView: { fieldMode: ContextFunction<'read' | 'hidden'> };
-};
-
-export type ListMetaRootVal = {
-  key: string;
-  path: string;
-  label: string;
-  singular: string;
-  plural: string;
-  initialColumns: string[];
-  pageSize: number;
-  labelField: string;
-  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null;
-  fields: Array<FieldMetaRootVal>;
-  itemQueryName: string;
-  listQueryName: string;
-  description: string | null;
-  isHidden: ContextFunction<boolean>;
-  hideCreate: ContextFunction<boolean>;
-  hideDelete: ContextFunction<boolean>;
-  isSingleton: boolean;
-};
-
-export type AdminMetaRootVal = {
-  lists: Array<ListMetaRootVal>;
-  listsByKey: Record<string, ListMetaRootVal>;
-  views: string[];
-  isAccessAllowed: undefined | ((context: KeystoneContext) => MaybePromise<boolean>);
-};

--- a/packages/core/src/types/next-fields.ts
+++ b/packages/core/src/types/next-fields.ts
@@ -3,7 +3,7 @@ import { graphql } from '..';
 import { BaseListTypeInfo } from './type-info';
 import { CommonFieldConfig } from './config';
 import { DatabaseProvider } from './core';
-import { AdminMetaRootVal, JSONValue, KeystoneContext, MaybePromise, StorageConfig } from '.';
+import { JSONValue, KeystoneContext, MaybePromise, StorageConfig } from '.';
 
 export { Decimal };
 
@@ -387,7 +387,7 @@ export type FieldTypeWithoutDBField<
   output: FieldTypeOutputField<TDBField>;
   views: string;
   extraOutputFields?: Record<string, FieldTypeOutputField<TDBField>>;
-  getAdminMeta?: (adminMeta: AdminMetaRootVal) => JSONValue;
+  getAdminMeta?: () => JSONValue;
   unreferencedConcreteInterfaceImplementations?: readonly graphql.ObjectType<any>[];
 } & CommonFieldConfig<ListTypeInfo>;
 


### PR DESCRIPTION
This pull request removes the parameters for `getAdminMeta` when writing field types, and the respective types `AdminMetaRootVal`, `ListMetaRootVal` and `FieldMetaRootVal` therein.