### PR TITLE
Fix missing fields inside of a conditional field in a component block creating a broken structure

### DIFF
--- a/.changeset/brave-beers-applaud.md
+++ b/.changeset/brave-beers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes missing fields inside of conditional field in a component block creating a broken structure

--- a/.changeset/brave-beers-applaud.md
+++ b/.changeset/brave-beers-applaud.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': patch
 ---
 
-Fixes missing fields inside of conditional field in a component block creating a broken structure
+Fixes a broken code path for conditional component-blocks when fields are missing - this previously resulted in invalid data structures within the document editor

--- a/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
@@ -917,3 +917,74 @@ test('normalization adds missing fields on object fields', () => {
     </editor>
   `);
 });
+
+test('normalization adds missing fields for conditional fields', () => {
+  const editor = makeEditor(
+    <editor>
+      <component-block
+        component="basic"
+        props={{ a: { discriminant: 'a', value: { something: '' } } }}
+      >
+        <component-inline-prop>
+          <text />
+        </component-inline-prop>
+      </component-block>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>,
+    {
+      normalization: 'normalize',
+      componentBlocks: {
+        basic: component({
+          preview: () => null,
+          label: 'Basic',
+          schema: {
+            a: fields.conditional(
+              fields.select({
+                defaultValue: 'a',
+                label: '',
+                options: [
+                  { value: 'a', label: 'a' },
+                  { value: 'b', label: 'b' },
+                ],
+              }),
+              {
+                a: fields.object({
+                  something: fields.text({ label: '' }),
+                  new: fields.text({ label: '' }),
+                }),
+                b: fields.object({}),
+              }
+            ),
+          },
+        }),
+      },
+    }
+  );
+  expect(editor).toMatchInlineSnapshot(`
+    <editor>
+      <component-block
+        component="basic"
+        props={
+          {
+            "a": {
+              "discriminant": "a",
+              "value": {
+                "new": "",
+                "something": "",
+              },
+            },
+          }
+        }
+      >
+        <component-inline-prop>
+          <text />
+        </component-inline-prop>
+      </component-block>
+      <paragraph>
+        <text />
+      </paragraph>
+    </editor>
+  `);
+});

--- a/packages/fields-document/src/DocumentEditor/component-blocks/with-component-blocks.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/with-component-blocks.tsx
@@ -527,7 +527,7 @@ function addMissingFields(value: unknown, schema: ComponentSchema): unknown {
     if (updatedInnerValue === conditionalValue.value) {
       return value;
     }
-    return { discriminant: conditionalValue.value, value: updatedInnerValue };
+    return { discriminant: conditionalValue.discriminant, value: updatedInnerValue };
   }
   if (schema.kind === 'array') {
     const arrValue = value as unknown[];


### PR DESCRIPTION
This pull request fixes a broken code path for conditional component-blocks when the fields are missing from the database value.

This previously resulted in invalid data structures within the document editor.