### PR TITLE
Fix expand/collapse button in the document editor

### DIFF
--- a/.changeset/hot-lemons-clean.md
+++ b/.changeset/hot-lemons-clean.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes expand/collapse button in the editor

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -194,23 +194,10 @@ export function DocumentEditor({
 
   return (
     <div
-      css={[
-        {
-          border: `1px solid ${colors.border}`,
-          borderRadius: radii.small,
-        },
-        expanded && {
-          border: 'none',
-          background: colors.background,
-          bottom: 0,
-          left: 0,
-          overflowY: 'auto', // required to keep the toolbar stuck in place
-          position: 'absolute',
-          right: 0,
-          top: 0,
-          zIndex: 100,
-        },
-      ]}
+      css={{
+        border: `1px solid ${colors.border}`,
+        borderRadius: radii.small,
+      }}
     >
       <DocumentEditorProvider
         componentBlocks={componentBlocks}
@@ -252,32 +239,17 @@ export function DocumentEditor({
           css={[
             {
               borderRadius: 'inherit',
-              background: fields.inputBackground,
+              background: fields.focus.inputBackground,
               borderColor: fields.inputBorderColor,
               paddingLeft: spacing.medium,
               paddingRight: spacing.medium,
-              ':hover': {
-                background: fields.hover.inputBackground,
-              },
-              ':focus': {
-                background: fields.focus.inputBackground,
-              },
-              ':disabled': {
-                background: fields.disabled.inputBackground,
-              },
+              minHeight: 120,
+              scrollbarGutter: 'stable',
+              // the !important is necessary to override the width set by resizing as an inline style
+              height: expanded ? 'auto !important' : 224,
+              resize: expanded ? undefined : 'vertical',
+              overflowY: 'auto',
             },
-            expanded
-              ? {
-                  height: 'auto !important',
-                  background: fields.focus.inputBackground,
-                }
-              : {
-                  height: 224,
-                  resize: 'vertical',
-                  overflowY: 'auto',
-                  minHeight: 120,
-                  scrollbarGutter: 'stable',
-                },
           ]}
           {...props}
           readOnly={onChange === undefined}


### PR DESCRIPTION
Because of some problems with the current expanded view in the document editor (the auto-scrolling of the editor on selection changes scrolls to a broken position, the save button is hidden, etc.), this PR changes the expand/collapse button to switch between re-sizable to full height (while still being in the normal document flow).

This also reverts previous changes to the background colour based on focus because they don't work well since the editor can be conceptually focused (e.g. while updating where a link goes to, editing a form in a component block or etc.) even though the contenteditable element is not literally focused which creates a very strange experience of the editor looking blurred while you're still doing something inside of it.

Before: https://keystone-next-docs-3hjwvrtn8-thinkmill.vercel.app/docs/guides/document-field-demo
After: https://keystone-next-docs-82foenqiv-thinkmill.vercel.app/docs/guides/document-field-demo