### PR TITLE
Fix filter `input` types for integer, bigInt, decimal and float fields in the UI

### DIFF
--- a/.changeset/thirty-grapes-laugh.md
+++ b/.changeset/thirty-grapes-laugh.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Change input type to `text` instead of `number` in `number` and `bigInt` fields to allow for comma in fields filtering

--- a/.changeset/thirty-grapes-laugh.md
+++ b/.changeset/thirty-grapes-laugh.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Change input type to `text` instead of `number` in `number` and `bigInt` fields to allow for comma in fields filtering
+Fix `in` and `not_in` filter views for `integer`, `bigInt`, `decimal` and `float` fields

--- a/packages/core/src/fields/types/bigInt/views/index.tsx
+++ b/packages/core/src/fields/types/bigInt/views/index.tsx
@@ -227,19 +227,18 @@ export const controller = (
     validate: value =>
       validate(value, validation, config.label, hasAutoIncrementDefault) === undefined,
     filter: {
-      Filter(props) {
+      Filter({ autoFocus, type, onChange, value }) {
         return (
           <TextInput
-            // this should not be type=number since it shoud allow commas so the one of/not one of
-            // filters work but really the whole filtering UI needs to be fixed and just removing type=number
-            // while doing nothing else would probably make it worse since anything would be allowed in the input
-            // so when a user applies the filter, the query would return an error
-            type="text"
             onChange={event => {
-              props.onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
+              if (type in ['in', 'not_in']) {
+                onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
+                return;
+              }
+              onChange(event.target.value.replace(/[^\d\s-]/g, ''));
             }}
-            value={props.value}
-            autoFocus={props.autoFocus}
+            value={value}
+            autoFocus={autoFocus}
           />
         );
       },
@@ -248,8 +247,8 @@ export const controller = (
         const valueWithoutWhitespace = value.replace(/\s/g, '');
         const parsed =
           type === 'in' || type === 'not_in'
-            ? valueWithoutWhitespace.split(',').map(x => BigInt(x))
-            : BigInt(valueWithoutWhitespace);
+            ? valueWithoutWhitespace.split(',')
+            : valueWithoutWhitespace;
         if (type === 'not') {
           return { [config.path]: { not: { equals: parsed } } };
         }

--- a/packages/core/src/fields/types/bigInt/views/index.tsx
+++ b/packages/core/src/fields/types/bigInt/views/index.tsx
@@ -231,7 +231,7 @@ export const controller = (
         return (
           <TextInput
             onChange={event => {
-              if (type in ['in', 'not_in']) {
+              if (type === 'in' || type === 'not_in') {
                 onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
                 return;
               }

--- a/packages/core/src/fields/types/bigInt/views/index.tsx
+++ b/packages/core/src/fields/types/bigInt/views/index.tsx
@@ -234,7 +234,7 @@ export const controller = (
             // filters work but really the whole filtering UI needs to be fixed and just removing type=number
             // while doing nothing else would probably make it worse since anything would be allowed in the input
             // so when a user applies the filter, the query would return an error
-            type="number"
+            type="text"
             onChange={event => {
               props.onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
             }}

--- a/packages/core/src/fields/types/decimal/views/index.tsx
+++ b/packages/core/src/fields/types/decimal/views/index.tsx
@@ -197,14 +197,19 @@ export const controller = (
     }),
     validate: val => validate(val, validation, config.label) === undefined,
     filter: {
-      Filter(props) {
+      Filter({ autoFocus, type, onChange, value }) {
         return (
           <TextInput
             onChange={event => {
-              props.onChange(event.target.value.replace(/[^\d\.,\s-]/g, ''));
+              if (type in ['in', 'not_in']) {
+                onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
+                return;
+              }
+
+              onChange(event.target.value.replace(/[^\d\s-]/g, ''));
             }}
-            value={props.value}
-            autoFocus={props.autoFocus}
+            value={value}
+            autoFocus={autoFocus}
           />
         );
       },

--- a/packages/core/src/fields/types/decimal/views/index.tsx
+++ b/packages/core/src/fields/types/decimal/views/index.tsx
@@ -201,7 +201,7 @@ export const controller = (
         return (
           <TextInput
             onChange={event => {
-              if (type in ['in', 'not_in']) {
+              if (type === 'in' || type === 'not_in') {
                 onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
                 return;
               }

--- a/packages/core/src/fields/types/float/views/index.tsx
+++ b/packages/core/src/fields/types/float/views/index.tsx
@@ -194,14 +194,18 @@ export const controller = (
     serialize: value => ({ [config.path]: value.value }),
     validate: value => validate(value, config.fieldMeta.validation, config.label) === undefined,
     filter: {
-      Filter(props) {
+      Filter({ autoFocus, type, onChange, value }) {
         return (
           <TextInput
             onChange={event => {
-              props.onChange(event.target.value.replace(/[^\d\.,\s-]/g, ''));
+              if (type in ['in', 'not_in']) {
+                onChange(event.target.value.replace(/[^\d\.,\s-]/g, ''));
+                return;
+              }
+              onChange(event.target.value.replace(/[^\d\.\s-]/g, ''));
             }}
-            value={props.value}
-            autoFocus={props.autoFocus}
+            value={value}
+            autoFocus={autoFocus}
           />
         );
       },

--- a/packages/core/src/fields/types/float/views/index.tsx
+++ b/packages/core/src/fields/types/float/views/index.tsx
@@ -198,7 +198,7 @@ export const controller = (
         return (
           <TextInput
             onChange={event => {
-              if (type in ['in', 'not_in']) {
+              if (type === 'in' || type === 'not_in') {
                 onChange(event.target.value.replace(/[^\d\.,\s-]/g, ''));
                 return;
               }

--- a/packages/core/src/fields/types/integer/views/index.tsx
+++ b/packages/core/src/fields/types/integer/views/index.tsx
@@ -212,7 +212,7 @@ export const controller = (
           <TextInput
             type="text"
             onChange={event => {
-              if (type in ['in', 'not_in']) {
+              if (type === 'in' || type === 'not_in') {
                 onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
                 return;
               }

--- a/packages/core/src/fields/types/integer/views/index.tsx
+++ b/packages/core/src/fields/types/integer/views/index.tsx
@@ -207,19 +207,20 @@ export const controller = (
         config.fieldMeta.defaultValue === 'autoincrement'
       ) === undefined,
     filter: {
-      Filter(props) {
+      Filter({ autoFocus, type, onChange, value }) {
         return (
           <TextInput
-            // this should not be type=number since it shoud allow commas so the one of/not one of
-            // filters work but really the whole filtering UI needs to be fixed and just removing type=number
-            // while doing nothing else would probably make it worse since anything would be allowed in the input
-            // so when a user applies the filter, the query would return an error
             type="text"
             onChange={event => {
-              props.onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
+              if (type in ['in', 'not_in']) {
+                onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
+                return;
+              }
+
+              onChange(event.target.value.replace(/[^\d\s-]/g, ''));
             }}
-            value={props.value}
-            autoFocus={props.autoFocus}
+            value={value}
+            autoFocus={autoFocus}
           />
         );
       },

--- a/packages/core/src/fields/types/integer/views/index.tsx
+++ b/packages/core/src/fields/types/integer/views/index.tsx
@@ -214,7 +214,7 @@ export const controller = (
             // filters work but really the whole filtering UI needs to be fixed and just removing type=number
             // while doing nothing else would probably make it worse since anything would be allowed in the input
             // so when a user applies the filter, the query would return an error
-            type="number"
+            type="text"
             onChange={event => {
               props.onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
             }}


### PR DESCRIPTION
Closes https://github.com/keystonejs/keystone/issues/7638

In `integer` and `bigInt` fields I have changed the `TextInput` type to `text` (instead of `number`), this allows to enter commas, the filtering of the value (only digits, commas and minus sign) is already performed by a [regex on the `onChange` handler](https://github.com/keystonejs/keystone/blob/df88fe6c49c6e15acea45e00192a3c8d16a3d461/packages/core/src/fields/types/integer/views/index.tsx#L218-L220).
With this change the filtering works as expected.

There is a comment above the `TextInput` regarding the type change but I'm not sure this is an old comment (prior to the onChange regex) or if we want to have a more advanced input.

https://github.com/keystonejs/keystone/blob/df88fe6c49c6e15acea45e00192a3c8d16a3d461/packages/core/src/fields/types/integer/views/index.tsx#L213-L216

