### PR TITLE
Add support for writing conditional documentation on the docs site

### DIFF
--- a/docs/markdoc/config.ts
+++ b/docs/markdoc/config.ts
@@ -1,9 +1,24 @@
-import { Config, nodes, Tag, ValidationError, Node } from '@markdoc/markdoc';
+import {
+  Config,
+  nodes,
+  Tag,
+  ValidationError,
+  Node,
+  functions,
+  ConfigFunction,
+} from '@markdoc/markdoc';
 import slugify from '@sindresorhus/slugify';
 
 export type Pages = Map<string, { ids: Set<string> }>;
 
-export const markdocConfig: Config = {
+export const baseMarkdocConfig: Config = {
+  // an empty variables object makes Markdoc validate against missing variables
+  variables: {},
+  // we want to disable the built-in functions
+  functions: Object.fromEntries(
+    Object.keys(functions).map(key => [key, undefined as unknown as ConfigFunction])
+  ),
+  validation: { validateFunctions: true },
   tags: {
     emoji: {
       render: 'Emoji',

--- a/docs/markdoc/index.test.ts
+++ b/docs/markdoc/index.test.ts
@@ -1,5 +1,5 @@
-import React, { ReactNode } from 'react';
 import { RenderableTreeNode } from '@markdoc/markdoc';
+import React, { ReactNode } from 'react';
 import { transformDocContent } from '.';
 
 function renderableToReactElement(node: RenderableTreeNode, key = 1): ReactNode {
@@ -79,6 +79,23 @@ test('empty ids on headings are not allowed', () => {
     content.md:1: This heading has an empty id, change the heading content so that a non-empty id is generated or add {% #some-id %} after the heading
     content.md:2: This heading has an empty id, change the heading content so that a non-empty id is generated or add {% #some-id %} after the heading
     content.md:4: This heading has an empty id, change the heading content so that a non-empty id is generated or add {% #some-id %} after the heading
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯"
+  `);
+});
+
+test('built-in Markdoc functions are not allowed', () => {
+  const content = `
+{% if or(true, false) %}
+
+something
+
+{% /if %}
+
+`;
+  expect(() => transformDocContent('content.md', content)).toThrowErrorMatchingInlineSnapshot(`
+    "Errors in content.md:
+    ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+    content.md:2: Undefined function: 'or'
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯"
   `);
 });

--- a/docs/markdoc/index.ts
+++ b/docs/markdoc/index.ts
@@ -1,7 +1,7 @@
 // @markdoc/markdoc's declaration files depend on these global types
 import type {} from '@markdoc/markdoc/global';
 import fs from 'fs/promises';
-import Markdoc, { Config, Tag, ValidateError, tags } from '@markdoc/markdoc';
+import Markdoc, { Config, Tag, ValidateError } from '@markdoc/markdoc';
 import { isNonEmptyArray } from 'emery/guards';
 import { assert } from 'emery/assertions';
 import { load } from 'js-yaml';

--- a/docs/markdoc/index.ts
+++ b/docs/markdoc/index.ts
@@ -1,11 +1,11 @@
 // @markdoc/markdoc's declaration files depend on these global types
 import type {} from '@markdoc/markdoc/global';
 import fs from 'fs/promises';
-import Markdoc, { Tag, ValidateError } from '@markdoc/markdoc';
+import Markdoc, { Config, Tag, ValidateError, tags } from '@markdoc/markdoc';
 import { isNonEmptyArray } from 'emery/guards';
 import { assert } from 'emery/assertions';
 import { load } from 'js-yaml';
-import { markdocConfig } from './config';
+import { baseMarkdocConfig } from './config';
 
 export function printValidationError(error: ValidateError) {
   const location = error.error.location || error.location;
@@ -43,6 +43,13 @@ export async function readDocContent(filepath: string): Promise<DocContent> {
   const frontmatter = extractFrontmatter(content);
   return { content: transformDocContent(`docs/${filepath}`, content), ...frontmatter };
 }
+
+const markdocConfig: Config = {
+  ...baseMarkdocConfig,
+  variables: {
+    nextRelease: !!process.env.SHOW_NEXT_RELEASE,
+  },
+};
 
 export function transformDocContent(errorReportingFilepath: string, content: string): Tag {
   const node = Markdoc.parse(content, errorReportingFilepath);

--- a/docs/markdoc/load-all.ts
+++ b/docs/markdoc/load-all.ts
@@ -1,0 +1,14 @@
+import fs from 'fs/promises';
+import globby from 'globby';
+import Markdoc from '@markdoc/markdoc';
+
+export async function loadAllMarkdoc() {
+  const files = await globby('pages/docs/**/*.md');
+  return await Promise.all(
+    files.map(async file => {
+      const contents = await fs.readFile(file, 'utf8');
+      const root = Markdoc.parse(contents, file);
+      return { file, root };
+    })
+  );
+}

--- a/docs/markdoc/load-all.ts
+++ b/docs/markdoc/load-all.ts
@@ -7,8 +7,7 @@ export async function loadAllMarkdoc() {
   return await Promise.all(
     files.map(async file => {
       const contents = await fs.readFile(file, 'utf8');
-      const root = Markdoc.parse(contents, file);
-      return { file, root };
+      return { file, contents };
     })
   );
 }

--- a/docs/markdoc/load-all.ts
+++ b/docs/markdoc/load-all.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises';
 import globby from 'globby';
-import Markdoc from '@markdoc/markdoc';
 
 export async function loadAllMarkdoc() {
   const files = await globby('pages/docs/**/*.md');

--- a/docs/markdoc/remove-next-release-conditions.test.ts
+++ b/docs/markdoc/remove-next-release-conditions.test.ts
@@ -10,14 +10,13 @@ some content
 
 {% /if %}
   `;
-  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+  expect(removeNextReleaseConditions(content)).toMatchInlineSnapshot(`
     {
       "contents": "## Heading 1
-
     some content
 
     ## Some heading
-    ",
+      ",
       "errors": [],
     }
   `);
@@ -36,14 +35,13 @@ Content in else
 
 {% /if %}
   `;
-  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+  expect(removeNextReleaseConditions(content)).toMatchInlineSnapshot(`
     {
       "contents": "## Heading 1
-
     some content
 
     ## Some heading
-    ",
+      ",
       "errors": [],
     }
   `);
@@ -65,16 +63,16 @@ Content in else
 
 {% /if %}
   `;
-  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+  expect(removeNextReleaseConditions(content)).toMatchInlineSnapshot(`
     {
       "contents": "## Heading 1
 
     {% $nextRelease %}
-
+      
     some content
 
     ## Some heading
-    ",
+      ",
       "errors": [
         {
           "error": {

--- a/docs/markdoc/remove-next-release-conditions.test.ts
+++ b/docs/markdoc/remove-next-release-conditions.test.ts
@@ -1,4 +1,3 @@
-import Markdoc from '@markdoc/markdoc';
 import { removeNextReleaseConditions } from './remove-next-release-conditions';
 
 test('removes if', () => {

--- a/docs/markdoc/remove-next-release-conditions.test.ts
+++ b/docs/markdoc/remove-next-release-conditions.test.ts
@@ -1,0 +1,105 @@
+import Markdoc from '@markdoc/markdoc';
+import { removeNextReleaseConditions } from './remove-next-release-conditions';
+
+test('removes if', () => {
+  const content = `## Heading 1
+{% if $nextRelease %}
+some content
+
+## Some heading
+
+{% /if %}
+  `;
+  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+    {
+      "contents": "## Heading 1
+
+    some content
+
+    ## Some heading
+    ",
+      "errors": [],
+    }
+  `);
+});
+
+test('removes if with else', () => {
+  const content = `## Heading 1
+{% if $nextRelease %}
+some content
+
+## Some heading
+
+{% else /%}
+
+Content in else
+
+{% /if %}
+  `;
+  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+    {
+      "contents": "## Heading 1
+
+    some content
+
+    ## Some heading
+    ",
+      "errors": [],
+    }
+  `);
+});
+
+test('errors if nextRelease variables is still used', () => {
+  const content = `## Heading 1
+
+{% $nextRelease %}
+  
+{% if $nextRelease %}
+some content
+
+## Some heading
+
+{% else /%}
+
+Content in else
+
+{% /if %}
+  `;
+  expect(removeNextReleaseConditions(Markdoc.parse(content))).toMatchInlineSnapshot(`
+    {
+      "contents": "## Heading 1
+
+    {% $nextRelease %}
+
+    some content
+
+    ## Some heading
+    ",
+      "errors": [
+        {
+          "error": {
+            "id": "variable-undefined",
+            "level": "error",
+            "message": "Undefined variable: 'nextRelease'",
+          },
+          "lines": [
+            2,
+            3,
+          ],
+          "location": {
+            "end": {
+              "character": undefined,
+              "line": 3,
+            },
+            "file": undefined,
+            "start": {
+              "character": undefined,
+              "line": 2,
+            },
+          },
+          "type": "text",
+        },
+      ],
+    }
+  `);
+});

--- a/docs/markdoc/remove-next-release-conditions.ts
+++ b/docs/markdoc/remove-next-release-conditions.ts
@@ -15,19 +15,18 @@ function transform(node: Node): Node[] | Node {
   return elseTag === -1 ? node.children : node.children.slice(0, elseTag);
 }
 
-export function removeNextReleaseConditions(root: Node) {
-  const transformed = new Ast.Node(
-    root.type,
-    root.attributes,
-    root.children.flatMap(transform),
-    root.tag
-  );
-  const contents = Markdoc.__EXPERIMENTAL__format(transformed);
+const pattern =
+  /{%\s+if\s+\$nextRelease\s+%}\s*([^]+?)\s*(?:{%\s+else\s+\/%}[^]*?)?{%\s+\/if\s+%}/g;
 
-  // we parse it again before validating so that positions are correct
-  const reparsed = Markdoc.parse(contents);
+export function removeNextReleaseConditions(contents: string) {
+  // ideally this would be a transform
+  // but Markdoc's formatter is experimental and as of the time of writing this
+  // doesn't seem to break some of our content
+  const newContent = contents.replace(pattern, '$1');
+
   // this will report usages of variables in case the transform here is broken
-  const errors = Markdoc.validate(reparsed, baseMarkdocConfig);
+  const parsed = Markdoc.parse(newContent);
+  const errors = Markdoc.validate(parsed, baseMarkdocConfig);
 
-  return { contents, errors };
+  return { contents: newContent, errors };
 }

--- a/docs/markdoc/remove-next-release-conditions.ts
+++ b/docs/markdoc/remove-next-release-conditions.ts
@@ -1,19 +1,5 @@
-import Markdoc, { Ast, Node } from '@markdoc/markdoc';
+import Markdoc from '@markdoc/markdoc';
 import { baseMarkdocConfig } from './config';
-
-function transform(node: Node): Node[] | Node {
-  if (
-    node.type !== 'tag' ||
-    node.tag !== 'if' ||
-    !Ast.isVariable(node.attributes.primary) ||
-    node.attributes.primary.path.length !== 1 ||
-    node.attributes.primary.path[0] !== 'nextRelease'
-  ) {
-    return new Ast.Node(node.type, node.attributes, node.children.flatMap(transform), node.tag);
-  }
-  const elseTag = node.children.findIndex(child => child.type === 'tag' && child.tag === 'else');
-  return elseTag === -1 ? node.children : node.children.slice(0, elseTag);
-}
 
 const pattern =
   /{%\s+if\s+\$nextRelease\s+%}\s*([^]+?)\s*(?:{%\s+else\s+\/%}[^]*?)?{%\s+\/if\s+%}/g;

--- a/docs/markdoc/remove-next-release-conditions.ts
+++ b/docs/markdoc/remove-next-release-conditions.ts
@@ -1,0 +1,33 @@
+import Markdoc, { Ast, Node } from '@markdoc/markdoc';
+import { baseMarkdocConfig } from './config';
+
+function transform(node: Node): Node[] | Node {
+  if (
+    node.type !== 'tag' ||
+    node.tag !== 'if' ||
+    !Ast.isVariable(node.attributes.primary) ||
+    node.attributes.primary.path.length !== 1 ||
+    node.attributes.primary.path[0] !== 'nextRelease'
+  ) {
+    return new Ast.Node(node.type, node.attributes, node.children.flatMap(transform), node.tag);
+  }
+  const elseTag = node.children.findIndex(child => child.type === 'tag' && child.tag === 'else');
+  return elseTag === -1 ? node.children : node.children.slice(0, elseTag);
+}
+
+export function removeNextReleaseConditions(root: Node) {
+  const transformed = new Ast.Node(
+    root.type,
+    root.attributes,
+    root.children.flatMap(transform),
+    root.tag
+  );
+  const contents = Markdoc.__EXPERIMENTAL__format(transformed);
+
+  // we parse it again before validating so that positions are correct
+  const reparsed = Markdoc.parse(contents);
+  // this will report usages of variables in case the transform here is broken
+  const errors = Markdoc.validate(reparsed, baseMarkdocConfig);
+
+  return { contents, errors };
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,10 +5,12 @@
   "license": "MIT",
   "scripts": {
     "dev": "next -p 8000",
+    "next-release": "SHOW_NEXT_RELEASE=1 yarn dev",
     "build": "yarn validate-links && next build && yarn sitemap",
     "start": "next start -p 8000",
     "sitemap": "next-sitemap",
-    "validate-links": "tsx validate-links.ts"
+    "validate-links": "tsx validate-links.ts",
+    "remove-conditionals": "tsx remove-conditionals.ts"
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "dev": "next -p 8000",
-    "next-release": "SHOW_NEXT_RELEASE=1 yarn dev",
+    "dev": "SHOW_NEXT_RELEASE=1 next -p 8000",
+    "dev:live": "next -p 8000",
     "build": "yarn validate-links && next build && yarn sitemap",
     "start": "next start -p 8000",
     "sitemap": "next-sitemap",

--- a/docs/remove-conditionals.ts
+++ b/docs/remove-conditionals.ts
@@ -8,8 +8,8 @@ import { removeNextReleaseConditions } from './markdoc/remove-next-release-condi
   const docs = await loadAllMarkdoc();
   const allErrors: ValidateError[] = [];
   await Promise.all(
-    docs.map(({ file, root }) => {
-      const { contents, errors } = removeNextReleaseConditions(root);
+    docs.map(({ file, contents: initialContents }) => {
+      const { contents, errors } = removeNextReleaseConditions(initialContents);
       allErrors.push(...errors);
       return fs.writeFile(file, contents, 'utf8');
     })

--- a/docs/remove-conditionals.ts
+++ b/docs/remove-conditionals.ts
@@ -1,0 +1,28 @@
+import fs from 'fs/promises';
+import { ValidateError } from '@markdoc/markdoc';
+import { loadAllMarkdoc } from './markdoc/load-all';
+import { printValidationError } from './markdoc';
+import { removeNextReleaseConditions } from './markdoc/remove-next-release-conditions';
+
+(async () => {
+  const docs = await loadAllMarkdoc();
+  const allErrors: ValidateError[] = [];
+  await Promise.all(
+    docs.map(({ file, root }) => {
+      const { contents, errors } = removeNextReleaseConditions(root);
+      allErrors.push(...errors);
+      return fs.writeFile(file, contents, 'utf8');
+    })
+  );
+  if (allErrors.length) {
+    console.error('Errors occurred when validating docs after writing');
+    console.error("The errors likely say `Undefined variable: 'nextRelease'`");
+    console.error(
+      'That error means that the nextRelease variable is still used after the transform that should remove it'
+    );
+    for (const error of allErrors) {
+      console.error(printValidationError(error));
+    }
+    process.exitCode = 1;
+  }
+})();

--- a/docs/validate-links.ts
+++ b/docs/validate-links.ts
@@ -14,7 +14,8 @@ const NON_MARKDOWN_PAGES = [
 ];
 
 (async () => {
-  const parsedFiles = (await loadAllMarkdoc()).map(({ file, root }) => {
+  const parsedFiles = (await loadAllMarkdoc()).map(({ file, contents }) => {
+    const root = Markdoc.parse(contents, file);
     const ids = new Set<string>();
     for (const node of root.walk()) {
       if (node.type === 'heading') {

--- a/docs/validate-links.ts
+++ b/docs/validate-links.ts
@@ -1,5 +1,5 @@
 import Markdoc from '@markdoc/markdoc';
-import { getIdForHeading, baseMarkdocConfig as baseMarkdocConfig, Pages } from './markdoc/config';
+import { getIdForHeading, baseMarkdocConfig, Pages } from './markdoc/config';
 import { printValidationError } from './markdoc';
 import { loadAllMarkdoc } from './markdoc/load-all';
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "benchmark": "yarn workspace @keystone-6/benchmarks-legacy go",
     "changeset": "changeset",
     "publish-changed": "yarn build && changeset publish --public",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && cd docs && yarn remove-conditionals",
     "no-run-version-packages": "echo \"This workflow should not be run when there are changesets on main\" && exit 1",
     "build": "preconstruct build",
     "prepare": "patch-package && manypkg check && preconstruct dev && yarn run --silent contributing-guide && node scripts/generate-artifacts-for-projects && cd examples/graphql-ts-gql && yarn ts-gql build",


### PR DESCRIPTION
This will allow us to remove the `website_live` branch while still allowing us to document new features that will only be available in the next release. The conditionals are removed when doing a release. I was planning on removing them by transforming Markdoc's AST but Markdoc's formatter is experimental and seems to break on some of our content so this uses a regex. I was also planning to add conditionals around documentation on unreleased features but it seems as though there isn't any.

### New
```markdown
{% if $nextRelease %}
You can filter a post using `post (...)`
{% /if %}
```

### Updates
```markdown
{% if $nextRelease %}
You can filter a post using `post (...)`
{% else /%}
You cannot filter posts.
{% /if %}
```

### Removals
```markdown
{% if $nextRelease %}
{% else /%}
You cannot filter posts.
{% /if %}
```