### PR TITLE
Fallback to default AWS credential chain

### DIFF
--- a/.changeset/silver-shirts-remain.md
+++ b/.changeset/silver-shirts-remain.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Allow falling back to default AWS credential provider

--- a/packages/core/src/lib/assets/s3.ts
+++ b/packages/core/src/lib/assets/s3.ts
@@ -96,10 +96,13 @@ export function getS3AssetsEndpoint(storageConfig: StorageConfig & { kind: 's3' 
 
 function s3AssetsCommon(storageConfig: StorageConfig & { kind: 's3' }) {
   const s3 = new S3({
-    credentials: storageConfig.accessKeyId && storageConfig.secretAccessKey ? {
-      accessKeyId: storageConfig.accessKeyId,
-      secretAccessKey: storageConfig.secretAccessKey,
-    } : undefined,
+    credentials:
+      storageConfig.accessKeyId && storageConfig.secretAccessKey
+        ? {
+            accessKeyId: storageConfig.accessKeyId,
+            secretAccessKey: storageConfig.secretAccessKey,
+          }
+        : undefined,
     region: storageConfig.region,
     endpoint: storageConfig.endpoint,
     forcePathStyle: storageConfig.forcePathStyle,

--- a/packages/core/src/lib/assets/s3.ts
+++ b/packages/core/src/lib/assets/s3.ts
@@ -96,10 +96,10 @@ export function getS3AssetsEndpoint(storageConfig: StorageConfig & { kind: 's3' 
 
 function s3AssetsCommon(storageConfig: StorageConfig & { kind: 's3' }) {
   const s3 = new S3({
-    credentials: {
+    credentials: storageConfig.accessKeyId && storageConfig.secretAccessKey ? {
       accessKeyId: storageConfig.accessKeyId,
       secretAccessKey: storageConfig.secretAccessKey,
-    },
+    } : undefined,
     region: storageConfig.region,
     endpoint: storageConfig.endpoint,
     forcePathStyle: storageConfig.forcePathStyle,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -74,9 +74,9 @@ export type StorageConfig = (
       /** Your s3 instance's region */
       region: string;
       /** An access Key ID with write access to your S3 instance */
-      accessKeyId: string;
+      accessKeyId?: string;
       /** The secret access key that gives permissions to your access Key Id */
-      secretAccessKey: string;
+      secretAccessKey?: string;
       /** An endpoint to use - to be provided if you are not using AWS as your endpoint */
       endpoint?: string;
       /** If true, will force the 'old' S3 path style of putting bucket name at the start of the pathname of the URL  */


### PR DESCRIPTION
By setting the S3 Client credentials to undefined, the AWS SDK will fallback to a default credential chain, attempting to load credentials from the instance profile, .ini file, environment variables etc:
https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html

This allows users to follow AWS best practices by using temporary credentials:
https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html

To achieve this, I've made the s3Storage.accessKeyId and s3Storage.secretAccessKey configuration items optional.