### PR TITLE
Don't call db.onConnect with a sudo context

### DIFF
--- a/.changeset/binary-eats-grass.md
+++ b/.changeset/binary-eats-grass.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+`db.onConnect` is now called with an unprivileged context, **not sudo**.  Use `context.sudo()` if you need to bypass access control

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -78,6 +78,7 @@ export function createSystem(config: KeystoneConfig, isLiveReload?: boolean) {
         log: config.db.enableLogging ? ['query'] : undefined,
         datasources: { [config.db.provider]: { url: config.db.url } },
       });
+
       setWriteLimit(prismaClient, pLimit(config.db.provider === 'sqlite' ? 1 : Infinity));
       setPrismaNamespace(prismaClient, prismaModule.Prisma);
       prismaClient.$on('beforeExit', async () => {
@@ -103,12 +104,11 @@ export function createSystem(config: KeystoneConfig, isLiveReload?: boolean) {
         async connect() {
           if (!isLiveReload) {
             await prismaClient.$connect();
-            const context = createContext({ sudo: true });
+            const context = createContext();
             await config.db.onConnect?.(context);
           }
         },
         async disconnect() {
-          // Tests that use the stored session won't stop until the store connection is disconnected
           await config?.session?.disconnect?.();
           await prismaClient.$disconnect();
         },

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -102,11 +102,11 @@ export function createSystem(config: KeystoneConfig, isLiveReload?: boolean) {
 
       return {
         async connect() {
-          if (!isLiveReload) {
-            await prismaClient.$connect();
-            const context = createContext();
-            await config.db.onConnect?.(context);
-          }
+          if (isLiveReload) return;
+
+          await prismaClient.$connect();
+          const context = createContext();
+          await config.db.onConnect?.(context);
         },
         async disconnect() {
           await config?.session?.disconnect?.();


### PR DESCRIPTION
This pull request additionally stops `db.onConnect` being automatically called with a sudo context

I don't think this behaviour is intentional, it's rarely necessary.
None-the-less this is a **breaking change** to change.

For developers updating, if you need to bypass access control, you can use the following pattern to fix your code

```typescript
// ...
import { Context } from '.keystone/types'

export default config({
  db: {
    // ...
    async onConnect(context: Context) {
      const sudoContext = context.sudo() // .sudo() is all you need to revert to the previous behaviour
      // ...
      await doThingsWithoutAccessControl(sudoContext)
    },
  },
  // ...
})
```