### PR TITLE
Remove `isLiveReload` in `createSystem`

### DIFF
--- a/.changeset/less-system-pressure.md
+++ b/.changeset/less-system-pressure.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes `isLiveReload` flag from `createSystem`

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -61,7 +61,7 @@ function getSudoGraphQLSchema(config: KeystoneConfig) {
   return createGraphQLSchema(transformedConfig, lists, adminMeta);
 }
 
-export function createSystem(config: KeystoneConfig, isLiveReload?: boolean) {
+export function createSystem(config: KeystoneConfig) {
   const lists = initialiseLists(config);
 
   const adminMeta = createAdminMeta(config, lists);
@@ -102,8 +102,6 @@ export function createSystem(config: KeystoneConfig, isLiveReload?: boolean) {
 
       return {
         async connect() {
-          if (isLiveReload) return;
-
           await prismaClient.$connect();
           const context = createContext();
           await config.db.onConnect?.(context);

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -186,7 +186,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
           console.log('Your db config has changed, please restart Keystone');
           process.exit(1);
         }
-        const { graphQLSchema, getKeystone, adminMeta } = createSystem(newConfig, true);
+        const { graphQLSchema, getKeystone, adminMeta } = createSystem(newConfig);
         // we're not using generateCommittedArtifacts or any of the similar functions
         // because we will never need to write a new prisma schema here
         // and formatting the prisma schema leaves some listeners on the process
@@ -208,7 +208,6 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
           } as unknown as new (args: unknown) => any,
           Prisma: prismaClientModule.Prisma,
         });
-        await keystone.connect();
         const servers = await createExpressServer(newConfig, graphQLSchema, keystone.createContext);
 
         servers.expressServer.use(adminUIMiddleware);

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -14,7 +14,7 @@ const mode = process.argv.includes('update-schemas') ? 'generate' : 'validate';
 async function generateArtifactsForProjectDir(projectDir: string) {
   try {
     const config = await loadConfig(projectDir);
-    const { graphQLSchema } = createSystem(config, false);
+    const { graphQLSchema } = createSystem(config);
     if (mode === 'validate') {
       await validateCommittedArtifacts(graphQLSchema, config, projectDir);
     } else {


### PR DESCRIPTION
This flag was redundant, we didn't need to include it.

We can simply _not_ call `await keystone.connect()` in `keystone dev`.