### PR TITLE
Merge previous Version Packages

### DIFF
--- a/.changeset/brave-beers-applaud.md
+++ b/.changeset/brave-beers-applaud.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/fields-document': patch
----
-
-Fixes a broken code path for conditional component-blocks when fields are missing - this previously resulted in invalid data structures within the document editor

--- a/.changeset/five-spiders-hammer.md
+++ b/.changeset/five-spiders-hammer.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': minor
----
-
-Fixes return types for `context.graphql` so that correct types are returned when using a `TypedDocumentNode`

--- a/.changeset/hot-lemons-clean.md
+++ b/.changeset/hot-lemons-clean.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/fields-document': patch
----
-
-Fixes expand/collapse button in the editor

--- a/.changeset/oh-my-graphql.md
+++ b/.changeset/oh-my-graphql.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': patch
----
-
-Adds contextualised types when using the `graphql` export for GraphQL schema extensions

--- a/.changeset/slimy-snakes-jump.md
+++ b/.changeset/slimy-snakes-jump.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': patch
----
-
-Fixes types for `resolvedData`, and the return types for `resolveInput` hooks.

--- a/.changeset/tasty-lies-move.md
+++ b/.changeset/tasty-lies-move.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': patch
----
-
-Fixes nullable and non-nullable calendarDay fields existing in the same schema creating a GraphQL schema with two different types with the same name

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @keystone-6/core
 
+## 2.3.0
+
+### Minor Changes
+
+- [#7927](https://github.com/keystonejs/keystone/pull/7927) [`1edfbd516`](https://github.com/keystonejs/keystone/commit/1edfbd5162895af0ae66d32e36fa98a56604d80a) Thanks [@keystonejs-release-bot](https://github.com/keystonejs-release-bot)! - Fixes return types for `context.graphql` so that correct types are returned when using a `TypedDocumentNode`
+
+### Patch Changes
+
+- [#7927](https://github.com/keystonejs/keystone/pull/7927) [`59238990e`](https://github.com/keystonejs/keystone/commit/59238990e7e701a5d1a99d8ee829ee780d347d6f) Thanks [@keystonejs-release-bot](https://github.com/keystonejs-release-bot)! - Adds contextualised types when using the `graphql` export for GraphQL schema extensions
+
+* [#7927](https://github.com/keystonejs/keystone/pull/7927) [`9ad15484c`](https://github.com/keystonejs/keystone/commit/9ad15484c3e2f7534c8aab4714fa032dea9404fb) Thanks [@keystonejs-release-bot](https://github.com/keystonejs-release-bot)! - Fixes types for `resolvedData`, and the return types for `resolveInput` hooks.
+
+- [#7927](https://github.com/keystonejs/keystone/pull/7927) [`b7df30e92`](https://github.com/keystonejs/keystone/commit/b7df30e92c32064201c44e633630af438c9dca33) Thanks [@keystonejs-release-bot](https://github.com/keystonejs-release-bot)! - Fixes nullable and non-nullable calendarDay fields existing in the same schema creating a GraphQL schema with two different types with the same name
+
 ## 2.2.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keystone-6/core",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/core",
   "license": "MIT",
   "main": "dist/keystone-6-core.cjs.js",

--- a/packages/fields-document/CHANGELOG.md
+++ b/packages/fields-document/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-6/fields-document
 
+## 4.1.1
+
+### Patch Changes
+
+- [#7927](https://github.com/keystonejs/keystone/pull/7927) [`2f17c3ebd`](https://github.com/keystonejs/keystone/commit/2f17c3ebdb4aaaad6f573f89f340422e8a008802) Thanks [@keystonejs-release-bot](https://github.com/keystonejs-release-bot)! - Fixes expand/collapse button in the editor
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/fields-document/CHANGELOG.md
+++ b/packages/fields-document/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @keystone-6/fields-document
 
+## 4.1.2
+
+### Patch Changes
+
+- [`4fe98b20d`](https://github.com/keystonejs/keystone/commit/4fe98b20d7e3502d96e44c925e38f769722d86bc) Thanks [@mitchellhamilton](https://github.com/mitchellhamilton)! - Fixes a broken code path for conditional component-blocks when fields are missing - this previously resulted in invalid data structures within the document editor
+
 ## 4.1.1
 
 ### Patch Changes

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-6/fields-document",
   "description": "KeystoneJS Document Field Type",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "MIT",
   "main": "dist/keystone-6-fields-document.cjs.js",
   "module": "dist/keystone-6-fields-document.esm.js",

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@keystone-6/fields-document",
   "description": "KeystoneJS Document Field Type",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "main": "dist/keystone-6-fields-document.cjs.js",
   "module": "dist/keystone-6-fields-document.esm.js",


### PR DESCRIPTION
The following two releases were made from the `release` branch, which will be reset soon to `main`.
 
- https://github.com/keystonejs/keystone/releases/tag/2022-09-20
- https://github.com/keystonejs/keystone/releases/tag/2022-09-15

This pull request adds the changes from their respective version packages:
- https://github.com/keystonejs/keystone/pull/7927
- https://github.com/keystonejs/keystone/pull/7940

```bash
git cherry-pick 1e28e8e92 fbbc24c99
```