### PR TITLE
Fixes JSON field type view assuming the empty string is equivalent to `null`

### DIFF
--- a/.changeset/fix-json-null.md
+++ b/.changeset/fix-json-null.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes JSON field type view assuming the empty string is equivalent to `null`

--- a/packages/core/src/fields/types/json/views/index.tsx
+++ b/packages/core/src/fields/types/json/views/index.tsx
@@ -94,6 +94,7 @@ export const controller = (config: Config): FieldController<string, string> => {
     },
     deserialize: data => {
       const value = data[config.path];
+      // null is equivalent to Prisma.DbNull, and we show that as an empty input
       if (value === null) return '';
       return JSON.stringify(value, null, 2);
     },

--- a/packages/core/src/fields/types/json/views/index.tsx
+++ b/packages/core/src/fields/types/json/views/index.tsx
@@ -98,14 +98,12 @@ export const controller = (config: Config): FieldController<string, string> => {
       return JSON.stringify(value, null, 2);
     },
     serialize: value => {
-      let parsedValue;
-      if (!value) {
-        return { [config.path]: null };
-      }
+      if (!value) return { [config.path]: null };
       try {
-        parsedValue = JSON.parse(value);
-      } catch (e) {}
-      return { [config.path]: parsedValue };
+        return { [config.path]: JSON.parse(value) };
+      } catch (e) {
+        return { [config.path]: undefined };
+      }
     },
   };
 };

--- a/packages/core/src/fields/types/json/views/index.tsx
+++ b/packages/core/src/fields/types/json/views/index.tsx
@@ -94,7 +94,7 @@ export const controller = (config: Config): FieldController<string, string> => {
     },
     deserialize: data => {
       const value = data[config.path];
-      if (!value) return '';
+      if (value === null) return '';
       return JSON.stringify(value, null, 2);
     },
     serialize: value => {


### PR DESCRIPTION
When a JSON value is the empty JSON string `""` (not an empty input), the JSON field type view would de-serialize the value to an empty input.

It should have been de-serialized to `'""'` (an empty JSON string).

This pull request fixes that.