### PR TITLE
Add documentation for `isSingleton`

### DIFF
--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -33,7 +33,7 @@ This document will explain the configuration options which can be used with the 
 
 Options:
 
-- `isSingleton`: Setting this to `true` will make the list a single object list. Read more [here](#singleton).
+- `isSingleton`: This flag, when `true` changes the list to default to only supporting a single row. See [Singletons](#singleton) for details.
 - `defaultIsFilterable`: This value sets the default value to use for `isFilterable` for fields on this list.
 - `defaultIsOrderable`: This value sets the default value to use for `isOrderable` for fields on this list.
 
@@ -257,31 +257,34 @@ export default config({
 The `description` option defines a string that will be used as a description in the Admin UI and GraphQL API docs.
 This option can be individually overridden by the `graphql.description` or `ui.description` options.
 
-## singleton
+## Singleton
 
-`isSingleton` option converts a list into a single object list. It gives you a convenient syntax to work with entities that will always only have one item. Eg. website configuration, system settings, etc.
+The `isSingleton` flag changes a list to only have support for a single row with an `id` of `1`.
+The flag provides the developer with a convenient syntax and defaults when working with lists that should only have zero or one items.
+With this flag set, when an item is created it is given an `id` of `1`, and when an item is queried from a list, the GraphQL `where` filter defaults to `{ id: '1' }`.
 
-In singleton lists, Keystone makes sure when an item for the list is created, it is created with the `ID: '1'`. And when an item is queried from a list, a default where clause `where: { id: '1' }` is inserted into the query. This gives a convenient syntax sugar to work with.
+An example of when this might helpful is for editable data like your configuration options when it isn't suitable to be stored on the filesystem.
 
-Eg. In GraphQL, to query a singleton list named `config`, you would just write
+Abstracting singletons as a behavioural trait of lists instead of a distinct type helps developers build functions for lists without needing to know the underlying constraints, effectively ensuring that lists remain as functors.
+
+Using GraphQL, to query a list named `settings`, with `isSingleton` set, you can write the following
 
 ```
 query {
-  config {
+  settings {
     seoTitle
     seoDescription
   }
 }
 ```
 
-In the Admin UI, singleton lists don't have a list view and instead take you directly to the item view page.
+In the Admin UI, lists with `isSingleton` set do not have a list view, instead redirecting you to the item view page of the item with an `id` of `1`.
 
-Please remember that `isSingleton` is only a syntax sugar to conveniently work with single object entities. You will have to keep these things in mind when working with a singleton list —
+The following additional constraints should be kept in mind when lists that have `isSingleton` set —
 
-- Using `context` API, if you try to create a list item with `context.query` or `context.db` while an entry already exists, you will get a _unique constraint error_ because Keystone defaults the id to `1`.
-- You cannot have a relationship **to** a singleton. However you can have relationships **from** a singleton.
-- In the Admin UI, singleton lists don't have a _count_ because the list is limited to only one entry.
-- The plural query will still be available in the GraphQL API.
+- With `id: 1` injected into respective filters, the `id` unique constraint will fail for create operations if an item already exists
+- You cannot have relationships (`ref: 'Settings'`), if `Settings` is a list with `isSingleton` set
+- You can however, have relationship fields in the `Settings` list, like normal
 
 ## Related resources
 

--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -19,7 +19,9 @@ export default config({
       graphql: { /* ... */ },
       db: { /* ... */ },
       description: '...',
+      {% if $nextRelease %}
       isSingleton: false,
+      {% /if %}
       defaultIsFilterable: false,
       defaultIsOrderable: false,
     }),
@@ -33,7 +35,9 @@ This document will explain the configuration options which can be used with the 
 
 Options:
 
+{% if $nextRelease %}
 - `isSingleton`: This flag, when `true` changes the list to default to only supporting a single row. See [Singletons](#isSingleton) for details.
+{% /if %}
 - `defaultIsFilterable`: This value sets the default value to use for `isFilterable` for fields on this list.
 - `defaultIsOrderable`: This value sets the default value to use for `isOrderable` for fields on this list.
 
@@ -257,6 +261,7 @@ export default config({
 The `description` option defines a string that will be used as a description in the Admin UI and GraphQL API docs.
 This option can be individually overridden by the `graphql.description` or `ui.description` options.
 
+{% if $nextRelease %}
 ## isSingleton
 
 The `isSingleton` flag changes a list to only have support for a single row with an `id` of `1`.
@@ -292,6 +297,7 @@ The following additional constraints should be kept in mind when lists that have
 - With `id: 1` injected into respective filters, the `id` unique constraint will fail for create operations if an item already exists
 - You cannot have relationships (`ref: 'Settings'`), if `Settings` is a list with `isSingleton` set
 - You can however, have relationship fields in the `Settings` list, like normal
+{% /if %}
 
 ## Related resources
 

--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -33,7 +33,7 @@ This document will explain the configuration options which can be used with the 
 
 Options:
 
-- `isSingleton`: This flag, when `true` changes the list to default to only supporting a single row. See [Singletons](#singleton) for details.
+- `isSingleton`: This flag, when `true` changes the list to default to only supporting a single row. See [Singletons](#isSingleton) for details.
 - `defaultIsFilterable`: This value sets the default value to use for `isFilterable` for fields on this list.
 - `defaultIsOrderable`: This value sets the default value to use for `isOrderable` for fields on this list.
 
@@ -257,7 +257,7 @@ export default config({
 The `description` option defines a string that will be used as a description in the Admin UI and GraphQL API docs.
 This option can be individually overridden by the `graphql.description` or `ui.description` options.
 
-## Singleton
+## isSingleton
 
 The `isSingleton` flag changes a list to only have support for a single row with an `id` of `1`.
 The flag provides the developer with a convenient syntax and defaults when working with lists that should only have zero or one items.

--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -19,6 +19,7 @@ export default config({
       graphql: { /* ... */ },
       db: { /* ... */ },
       description: '...',
+      isSingleton: false,
       defaultIsFilterable: false,
       defaultIsOrderable: false,
     }),
@@ -32,6 +33,7 @@ This document will explain the configuration options which can be used with the 
 
 Options:
 
+- `isSingleton`: Setting this to `true` will make the list a single object list. Read more [here](#singleton).
 - `defaultIsFilterable`: This value sets the default value to use for `isFilterable` for fields on this list.
 - `defaultIsOrderable`: This value sets the default value to use for `isOrderable` for fields on this list.
 
@@ -254,6 +256,32 @@ export default config({
 
 The `description` option defines a string that will be used as a description in the Admin UI and GraphQL API docs.
 This option can be individually overridden by the `graphql.description` or `ui.description` options.
+
+## singleton
+
+`isSingleton` option converts a list into a single object list. It gives you a convenient syntax to work with entities that will always only have one item. Eg. website configuration, system settings, etc.
+
+In singleton lists, Keystone makes sure when an item for the list is created, it is created with the `ID: '1'`. And when an item is queried from a list, a default where clause `where: { id: '1' }` is inserted into the query. This gives a convenient syntax sugar to work with.
+
+Eg. In GraphQL, to query a singleton list named `config`, you would just write
+
+```
+query {
+  config {
+    seoTitle
+    seoDescription
+  }
+}
+```
+
+In the Admin UI, singleton lists don't have a list view and instead take you directly to the item view page.
+
+Please remember that `isSingleton` is only a syntax sugar to conveniently work with single object entities. You will have to keep these things in mind when working with a singleton list —
+
+- Using `context` API, if you try to create a list item with `context.query` or `context.db` while an entry already exists, you will get a _unique constraint error_ because Keystone defaults the id to `1`.
+- You cannot have a relationship **to** a singleton. However you can have relationships **from** a singleton.
+- In the Admin UI, singleton lists don't have a _count_ because the list is limited to only one entry.
+- The plural query will still be available in the GraphQL API.
 
 ## Related resources
 

--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -267,11 +267,18 @@ An example of when this might helpful is for editable data like your configurati
 
 Abstracting singletons as a behavioural trait of lists instead of a distinct type helps developers build functions for lists without needing to know the underlying constraints, effectively ensuring that lists remain as functors.
 
-Using GraphQL, to query a list named `settings`, with `isSingleton` set, you can write the following
+Using GraphQL, to query a list named `settings`, with `isSingleton` set, you can write any of the following queries
 
-```
+```graphql
 query {
+  # singular (null or an item)
   settings {
+    seoTitle
+    seoDescription
+  }
+
+  # plural (0 or 1 items)
+  settingsMany {
     seoTitle
     seoDescription
   }

--- a/docs/pages/docs/examples.tsx
+++ b/docs/pages/docs/examples.tsx
@@ -213,6 +213,15 @@ export default function Docs() {
         >
           Implements virtual fields in a Keystone list.
         </Well>
+        <Well
+          grad="grad1"
+          heading="Singleton"
+          href="https://github.com/keystonejs/keystone/tree/main/examples/singleton"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Demonstrates how to use singleton lists with Keystone.
+        </Well>
       </div>
 
       <Type as="h2" look="heading30" margin="2rem 0 1rem 0" id="end-to-end-examples">

--- a/docs/pages/docs/getting-started.md
+++ b/docs/pages/docs/getting-started.md
@@ -75,12 +75,12 @@ yarn dev
 
 This will generate the Admin UI pages via [Next.js](https://nextjs.org/) on <http://localhost:3000>. When you visit the Admin UI for the first time you will be presented with a handy screen that asks you to create a user:
 
-![The welcome screen giving you the ability the create a new user to log into the AdminUI](/assets/getting-started/welcome-screen.png)
+![The welcome screen giving you the ability the create a new user to log into the Admin UI](/assets/getting-started/welcome-screen.png)
 
 Go ahead and create your first user. The email address and password will be used to login to Keystone’s Admin UI. Once you've created your user, you’ll be logged in to a new Keystone Admin UI that comes with two [lists](/docs/config/config#lists).
 From here you can explore and interact with the data in your system, and understand how Keystone’s schema relates to your GraphQL API which you can explore at <http://localhost:3000/api/graphql>.
 
-![The AdminUI of Keystone showing the two lists: User and Posts](/assets/getting-started/adminui.png)
+![The Admin UI of Keystone showing the two lists: User and Posts](/assets/getting-started/adminui.png)
 
 ## Output
 

--- a/docs/pages/docs/walkthroughs/lesson-4.md
+++ b/docs/pages/docs/walkthroughs/lesson-4.md
@@ -53,7 +53,7 @@ While Keystone has very granular permissions controls, which you can read about 
 
 ## Add the Password field
 
-Keystone's [password](/docs/fields/password) field adheres to typical password security recommendations like hashing the password in the database, and masking the password for AdminUI input fields.
+Keystone's [password](/docs/fields/password) field adheres to typical password security recommendations like hashing the password in the database, and masking the password for Admin UI input fields.
 
 Let's add a password field to our `User` list so users can authenticate with Keystone:
 


### PR DESCRIPTION
Adds docs to the recently merged Singleton feature #7863 

- Added singleton example to the list of examples
- Added `isSingleton` option to `list` API
- Added a new `singleton` section to explain how singleton works to lists API page.

#### Related
- https://github.com/keystonejs/keystone/pull/7863


