### PR TITLE
Fix broken docs/api link

### DIFF
--- a/docs/redirects.js
+++ b/docs/redirects.js
@@ -147,6 +147,11 @@ const CURRENT = [
     permanent: false,
   },
   {
+    source: '/docs/apis',
+    destination: '/docs/config/overview',
+    permanent: false,
+  },
+  {
     source: '/docs/apis/config',
     destination: '/docs/config/config',
     permanent: false,


### PR DESCRIPTION
The API link is broken in our newsletter signup email and website footer. We don't have an API reference anymore since we moved the APIs to their own fields. So now we're redirecting the old links to `/config/overview` which has a set of links to all available APIs.