### PR TITLE
No automatic many-prefixing when isSingleton is set 

### DIFF
--- a/docs/pages/docs/config/lists.md
+++ b/docs/pages/docs/config/lists.md
@@ -277,15 +277,15 @@ Using GraphQL, to query a list named `settings`, with `isSingleton` set, you can
 ```graphql
 query {
   # singular (null or an item)
-  settings {
-    seoTitle
-    seoDescription
+  seoConfiguration {
+    title
+    description
   }
 
   # plural (0 or 1 items)
-  settingsMany {
-    seoTitle
-    seoDescription
+  seoConfigurations {
+    title
+    description
   }
 }
 ```

--- a/examples/singleton/schema.ts
+++ b/examples/singleton/schema.ts
@@ -11,6 +11,9 @@ export const lists = {
       copyrightText: text(),
       highlightedPosts: relationship({ ref: 'Post', many: true }),
     },
+    graphql: {
+      plural: 'ManySettings',
+    },
   }),
   Post: list({
     access: allowAll,

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -124,32 +124,33 @@ export function getNamesFromList(
   listKey: string,
   { graphql, ui, isSingleton }: KeystoneConfig['lists'][string]
 ) {
-  const computedSingular = humanize(listKey);
-  const computedPlural = pluralize.plural(computedSingular);
-  const computedLabel = isSingleton ? computedSingular : computedPlural;
-
-  const path = ui?.path || labelToPath(computedLabel);
-
   if (ui?.path !== undefined && !/^[a-z-_][a-z0-9-_]*$/.test(ui.path)) {
     throw new Error(
       `ui.path for ${listKey} is ${ui.path} but it must only contain lowercase letters, numbers, dashes, and underscores and not start with a number`
     );
   }
 
-  const adminUILabels = {
-    label: ui?.label || computedLabel,
-    singular: ui?.singular || computedSingular,
-    plural: ui?.plural || computedPlural,
-    path,
-  };
+  const computedSingular = humanize(listKey);
+  const computedPlural = pluralize.plural(computedSingular);
+  const computedLabel = isSingleton ? computedSingular : computedPlural;
+  const path = ui?.path || labelToPath(computedLabel);
 
-  let pluralGraphQLName = graphql?.plural || labelToClass(computedPlural);
+  const pluralGraphQLName = graphql?.plural || labelToClass(computedPlural);
   if (pluralGraphQLName === listKey) {
     throw new Error(
       `The list key and the plural name used in GraphQL must be different but the list key ${listKey} is the same as the plural GraphQL name, please specify graphql.plural`
     );
   }
-  return { pluralGraphQLName, adminUILabels };
+
+  return {
+    pluralGraphQLName,
+    adminUILabels: {
+      label: ui?.label || computedLabel,
+      singular: ui?.singular || computedSingular,
+      plural: ui?.plural || computedPlural,
+      path,
+    },
+  };
 }
 
 const labelToPath = (str: string) => str.split(' ').join('-').toLowerCase();

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -145,13 +145,9 @@ export function getNamesFromList(
 
   let pluralGraphQLName = graphql?.plural || labelToClass(computedPlural);
   if (pluralGraphQLName === listKey) {
-    if (isSingleton) {
-      pluralGraphQLName = 'Many' + listKey;
-    } else {
-      throw new Error(
-        `The list key and the plural name used in GraphQL must be different but the list key ${listKey} is the same as the plural GraphQL name, please specify graphql.plural`
-      );
-    }
+    throw new Error(
+      `The list key and the plural name used in GraphQL must be different but the list key ${listKey} is the same as the plural GraphQL name, please specify graphql.plural`
+    );
   }
   return { pluralGraphQLName, adminUILabels };
 }

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -154,6 +154,9 @@ export const lists = {
       websiteName: text(),
       copyrightText: text(),
     },
+    graphql: {
+      plural: 'ManySettings',
+    },
   }),
 };
 


### PR DESCRIPTION
This isn't intuitive, and we have a robust solution for resolving ambiguities already: `graphql.plural`

#### Related
- https://github.com/keystonejs/keystone/pull/7863