### PR TITLE
Fix multiselect field type not propagating common config options

### DIFF
--- a/.changeset/two-ghosts-jog.md
+++ b/.changeset/two-ghosts-jog.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Make multiselect field type use common config options like access, graphql.

--- a/.changeset/two-ghosts-jog.md
+++ b/.changeset/two-ghosts-jog.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Make multiselect field type use common config options like access, graphql.
+Fixes the multiselect field type not using the provided `label`, `access`, `graphql`, `isFilterable` or `isOrderable` configuration options

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -51,7 +51,6 @@ const MIN_INT = -2147483648;
 
 export const multiselect =
   <ListTypeInfo extends BaseListTypeInfo>({
-    ui,
     defaultValue = [],
     ...config
   }: MultiselectFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
@@ -106,7 +105,7 @@ export const multiselect =
     return jsonFieldTypePolyfilledForSQLite(
       meta.provider,
       {
-        ui,
+        ...config,
         hooks: {
           ...config.hooks,
           async validateInput(args) {


### PR DESCRIPTION
Currently multiselect field type completely ignores some common config options - most notably 'access' and 'graphql'.

This pull request fixes that by 'spreading' user config to final type.