### PR TITLE
Fix publish GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,9 @@ jobs:
 
       - run: yarn build
 
-      - name: npm publish, git tag, git push
-        uses: changesets/action@v1
-        with:
-          version: exit 1
-          publish: yarn changeset publish
-          createGithubReleases: false
+      - name: npm publish, git tag
+        run: yarn changeset publish --tag latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - run: git push origin --tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
 
       - run: yarn build
 
+      - run: |
+          git config --global user.name 'Keystonejs Release Bot'
+          git config --global user.email 'automation+keystonejs@thinkmill.com.au'
+
       - name: npm publish, git tag
         run: yarn changeset publish --tag latest
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,8 @@ jobs:
 
       - run: yarn build
 
-      - run: |
+      - name: git config
+        run: |
           git config --global user.name 'Keystonejs Release Bot'
           git config --global user.email 'automation+keystonejs@thinkmill.com.au'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: git push origin --tags
+      - run: git push origin --follow-tags


### PR DESCRIPTION
In trying to publish [`2022-10-19`](https://github.com/keystonejs/keystone/releases/tag/2022-10-19), I had to bypass `changeset/action` by updating the `publish.yml` to the following https://github.com/keystonejs/keystone/commit/26e4eada39aadcd6f5e72612d5adafb1b399fd86.
 This pull request is the formalization of that change.

The relevant workflow https://github.com/keystonejs/keystone/actions/runs/3277383457.

#### Other attempts
- https://github.com/keystonejs/keystone/actions/runs/3277109888
- https://github.com/keystonejs/keystone/actions/runs/3277211383
- https://github.com/keystonejs/keystone/actions/runs/3277270311
- https://github.com/keystonejs/keystone/actions/runs/3277303180