### PR TITLE
Fix selection for component blocks without child fields

### DIFF
--- a/.changeset/rich-tools-share.md
+++ b/.changeset/rich-tools-share.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes selection for component blocks without child fields

--- a/packages/fields-document/src/DocumentEditor/component-blocks/chromeful-element.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/chromeful-element.tsx
@@ -4,7 +4,7 @@ import { jsx, useTheme } from '@keystone-ui/core';
 import { Trash2Icon } from '@keystone-ui/icons/icons/Trash2Icon';
 import { Tooltip } from '@keystone-ui/tooltip';
 import { ReactNode, useMemo, useState, useCallback, Fragment } from 'react';
-import { RenderElementProps } from 'slate-react';
+import { RenderElementProps, useSelected } from 'slate-react';
 import { Stack } from '@keystone-ui/core';
 import { Button as KeystoneUIButton } from '@keystone-ui/button';
 import { ToolbarGroup, ToolbarButton, ToolbarSeparator } from '../primitives';
@@ -31,6 +31,7 @@ export function ChromefulComponentBlockElement(props: {
   onRemove: () => void;
   attributes: RenderElementProps['attributes'];
 }) {
+  const selected = useSelected();
   const { colors, fields, spacing, typography } = useTheme();
 
   const isValid = useMemo(
@@ -62,7 +63,11 @@ export function ChromefulComponentBlockElement(props: {
         position: 'relative',
         ':before': {
           content: '" "',
-          backgroundColor: editMode ? colors.linkColor : colors.border,
+          backgroundColor: selected
+            ? colors.focusRing
+            : editMode
+            ? colors.linkColor
+            : colors.border,
           borderRadius: 4,
           width: 4,
           position: 'absolute',
@@ -89,7 +94,11 @@ export function ChromefulComponentBlockElement(props: {
       {editMode ? (
         <Fragment>
           <FormValue isValid={isValid} props={props.previewProps} onClose={onCloseEditMode} />
-          <div css={{ display: 'none' }}>{props.children}</div>
+          <div
+            css={{ caretColor: 'transparent', '& ::selection': { backgroundColor: 'transparent' } }}
+          >
+            {props.children}
+          </div>
         </Fragment>
       ) : (
         <Fragment>

--- a/packages/fields-document/src/DocumentEditor/component-blocks/chromeful-element.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/chromeful-element.tsx
@@ -94,11 +94,7 @@ export function ChromefulComponentBlockElement(props: {
       {editMode ? (
         <Fragment>
           <FormValue isValid={isValid} props={props.previewProps} onClose={onCloseEditMode} />
-          <div
-            css={{ caretColor: 'transparent', '& ::selection': { backgroundColor: 'transparent' } }}
-          >
-            {props.children}
-          </div>
+          <div css={{ display: 'none' }}>{props.children}</div>
         </Fragment>
       ) : (
         <Fragment>

--- a/packages/fields-document/src/DocumentEditor/component-blocks/component-block-render.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/component-block-render.tsx
@@ -61,7 +61,11 @@ export function ComponentBlockRender({
         ),
         [previewProps, ComponentBlockPreview]
       )}
-      <span css={{ display: 'none' }}>{maybeChild}</span>
+      <span
+        css={{ caretColor: 'transparent', '& ::selection': { backgroundColor: 'transparent' } }}
+      >
+        {maybeChild}
+      </span>
     </ChildrenByPathContext.Provider>
   );
 }


### PR DESCRIPTION
Now you can actually put your text cursor in a component block (and therefore insert content below it or etc.) that doesn't have child fields and the bar on the side will change colour to indicate your selection is inside there.

Try navigating your caret to the carousel block on the docs site:
on this branch: https://keystone-next-docs-git-fix-selection-for-compo-824f49-thinkmill.vercel.app/docs/guides/document-field-demo
before this branch: https://keystone-next-docs-pm1f8fo8c-thinkmill.vercel.app/docs/guides/document-field-demo  