### PR TITLE
Default the document editor demo on the website to be expanded

### DIFF
--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -327,7 +327,6 @@ export const DocumentEditorDemo = () => {
         css={{
           marginTop: 'var(--space-xlarge)',
           marginBottom: 'var(--space-xlarge)',
-          borderBottom: `1px var(--border) solid`,
         }}
       >
         <DocumentEditor
@@ -337,6 +336,7 @@ export const DocumentEditorDemo = () => {
           componentBlocks={componentBlocks}
           documentFeatures={documentFeatures}
           relationships={emptyObj}
+          initialExpanded
         />
       </div>
       <details css={{ marginBottom: 'var(--space-xlarge)' }}>

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -177,6 +177,7 @@ export function DocumentEditor({
   componentBlocks,
   relationships,
   documentFeatures,
+  initialExpanded = false,
   ...props
 }: {
   onChange: undefined | ((value: Descendant[]) => void);
@@ -184,9 +185,10 @@ export function DocumentEditor({
   componentBlocks: Record<string, ComponentBlock>;
   relationships: Relationships;
   documentFeatures: DocumentFeatures;
+  initialExpanded?: boolean;
 } & Omit<EditableProps, 'value' | 'onChange'>) {
   const { radii, colors, spacing, fields } = useTheme();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(initialExpanded);
   const editor = useMemo(
     () => createDocumentEditor(documentFeatures, componentBlocks, relationships),
     [documentFeatures, componentBlocks, relationships]


### PR DESCRIPTION
The whole point of the page is to demo the editor so having it collapsed by default seems weird. Also removed a duplicate border.

(No changeset for the change to fields-document because it doesn't change anything that's visible externally)
