### PR TITLE
Fix admin meta not using custom controller

### DIFF
--- a/.changeset/nasty-snakes-explain.md
+++ b/.changeset/nasty-snakes-explain.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed issue where the custom field view `controller` was not being used. You should be able to override field `controller` when setting `ui.views` parameter in fields.

--- a/packages/core/src/admin-ui/utils/useAdminMeta.tsx
+++ b/packages/core/src/admin-ui/utils/useAdminMeta.tsx
@@ -111,7 +111,7 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
             fieldMode: field.itemView?.fieldMode ?? null,
           },
           views,
-          controller: fieldViews[field.viewsIndex].controller({
+          controller: views.controller({
             listKey: list.key,
             fieldMeta: field.fieldMeta,
             label: field.label,


### PR DESCRIPTION
I think this piece of code suggest that we should be able to override the `controller` 

https://github.com/gautamsi/keystone/blob/e08b866f57ba85e18a3cfd131a6bf945e700e11a/packages/core/src/admin-ui/utils/useAdminMeta.tsx#L100

but this specific line does not make is of overridden `controller`
https://github.com/gautamsi/keystone/blob/e08b866f57ba85e18a3cfd131a6bf945e700e11a/packages/core/src/admin-ui/utils/useAdminMeta.tsx#L114
