### PR TITLE
Fixed integer filter one-of and no one-of

### DIFF
--- a/.changeset/ten-pears-worry.md
+++ b/.changeset/ten-pears-worry.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixed `one of` and `not one of` filter for integer where the filter input did not allow multiple values separated by coma.

--- a/packages/core/src/fields/types/integer/views/index.tsx
+++ b/packages/core/src/fields/types/integer/views/index.tsx
@@ -214,7 +214,7 @@ export const controller = (
             // filters work but really the whole filtering UI needs to be fixed and just removing type=number
             // while doing nothing else would probably make it worse since anything would be allowed in the input
             // so when a user applies the filter, the query would return an error
-            type="number"
+            type={['in', 'not_in'].includes(props.type) ? 'text' : 'number'}
             onChange={event => {
               props.onChange(event.target.value.replace(/[^\d,\s-]/g, ''));
             }}


### PR DESCRIPTION
This has been annoying for long. 
I tried to fix it by minimal changes while preserving other case and concerns when other single values filters are used.

I also find that using regex already prevents the non numeric values.

this helps filtering on multiple integer values especially in case of auto-increment.