### PR TITLE
Add `exports` field to packages

### DIFF
--- a/.changeset/wild-lemons-yell.md
+++ b/.changeset/wild-lemons-yell.md
@@ -1,0 +1,22 @@
+---
+'@keystone-ui/button': patch
+'@keystone-ui/core': patch
+'@keystone-ui/fields': patch
+'@keystone-ui/icons': patch
+'@keystone-ui/loading': patch
+'@keystone-ui/modals': patch
+'@keystone-ui/notice': patch
+'@keystone-ui/options': patch
+'@keystone-ui/pill': patch
+'@keystone-ui/popover': patch
+'@keystone-ui/segmented-control': patch
+'@keystone-ui/toast': patch
+'@keystone-ui/tooltip': patch
+'@keystone-6/auth': patch
+'@keystone-6/cloudinary': patch
+'@keystone-6/core': patch
+'@keystone-6/document-renderer': patch
+'@keystone-6/fields-document': patch
+---
+
+Adds `exports` field to `package.json`

--- a/design-system/packages/button/package.json
+++ b/design-system/packages/button/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-button.cjs.js",
   "module": "dist/keystone-ui-button.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-button.esm.js",
+      "default": "./dist/keystone-ui-button.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9"
   },

--- a/design-system/packages/core/package.json
+++ b/design-system/packages/core/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-core.cjs.js",
   "module": "dist/keystone-ui-core.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-core.esm.js",
+      "default": "./dist/keystone-ui-core.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9",
     "react": "^18.1.0",

--- a/design-system/packages/fields/package.json
+++ b/design-system/packages/fields/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-fields.cjs.js",
   "module": "dist/keystone-ui-fields.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-fields.esm.js",
+      "default": "./dist/keystone-ui-fields.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9"
   },

--- a/design-system/packages/icons/package.json
+++ b/design-system/packages/icons/package.json
@@ -4,6 +4,1157 @@
   "license": "MIT",
   "main": "dist/keystone-ui-icons.cjs.js",
   "module": "dist/keystone-ui-icons.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-icons.esm.js",
+      "default": "./dist/keystone-ui-icons.cjs.js"
+    },
+    "./icons/XIcon": {
+      "module": "./icons/XIcon/dist/keystone-ui-icons-icons-XIcon.esm.js",
+      "default": "./icons/XIcon/dist/keystone-ui-icons-icons-XIcon.cjs.js"
+    },
+    "./icons/TvIcon": {
+      "module": "./icons/TvIcon/dist/keystone-ui-icons-icons-TvIcon.esm.js",
+      "default": "./icons/TvIcon/dist/keystone-ui-icons-icons-TvIcon.cjs.js"
+    },
+    "./icons/BoxIcon": {
+      "module": "./icons/BoxIcon/dist/keystone-ui-icons-icons-BoxIcon.esm.js",
+      "default": "./icons/BoxIcon/dist/keystone-ui-icons-icons-BoxIcon.cjs.js"
+    },
+    "./icons/CpuIcon": {
+      "module": "./icons/CpuIcon/dist/keystone-ui-icons-icons-CpuIcon.esm.js",
+      "default": "./icons/CpuIcon/dist/keystone-ui-icons-icons-CpuIcon.cjs.js"
+    },
+    "./icons/EyeIcon": {
+      "module": "./icons/EyeIcon/dist/keystone-ui-icons-icons-EyeIcon.esm.js",
+      "default": "./icons/EyeIcon/dist/keystone-ui-icons-icons-EyeIcon.cjs.js"
+    },
+    "./icons/KeyIcon": {
+      "module": "./icons/KeyIcon/dist/keystone-ui-icons-icons-KeyIcon.esm.js",
+      "default": "./icons/KeyIcon/dist/keystone-ui-icons-icons-KeyIcon.cjs.js"
+    },
+    "./icons/MapIcon": {
+      "module": "./icons/MapIcon/dist/keystone-ui-icons-icons-MapIcon.esm.js",
+      "default": "./icons/MapIcon/dist/keystone-ui-icons-icons-MapIcon.cjs.js"
+    },
+    "./icons/MehIcon": {
+      "module": "./icons/MehIcon/dist/keystone-ui-icons-icons-MehIcon.esm.js",
+      "default": "./icons/MehIcon/dist/keystone-ui-icons-icons-MehIcon.cjs.js"
+    },
+    "./icons/MicIcon": {
+      "module": "./icons/MicIcon/dist/keystone-ui-icons-icons-MicIcon.esm.js",
+      "default": "./icons/MicIcon/dist/keystone-ui-icons-icons-MicIcon.cjs.js"
+    },
+    "./icons/RssIcon": {
+      "module": "./icons/RssIcon/dist/keystone-ui-icons-icons-RssIcon.esm.js",
+      "default": "./icons/RssIcon/dist/keystone-ui-icons-icons-RssIcon.cjs.js"
+    },
+    "./icons/SunIcon": {
+      "module": "./icons/SunIcon/dist/keystone-ui-icons-icons-SunIcon.esm.js",
+      "default": "./icons/SunIcon/dist/keystone-ui-icons-icons-SunIcon.cjs.js"
+    },
+    "./icons/TagIcon": {
+      "module": "./icons/TagIcon/dist/keystone-ui-icons-icons-TagIcon.esm.js",
+      "default": "./icons/TagIcon/dist/keystone-ui-icons-icons-TagIcon.cjs.js"
+    },
+    "./icons/ZapIcon": {
+      "module": "./icons/ZapIcon/dist/keystone-ui-icons-icons-ZapIcon.esm.js",
+      "default": "./icons/ZapIcon/dist/keystone-ui-icons-icons-ZapIcon.cjs.js"
+    },
+    "./icons/BellIcon": {
+      "module": "./icons/BellIcon/dist/keystone-ui-icons-icons-BellIcon.esm.js",
+      "default": "./icons/BellIcon/dist/keystone-ui-icons-icons-BellIcon.cjs.js"
+    },
+    "./icons/BoldIcon": {
+      "module": "./icons/BoldIcon/dist/keystone-ui-icons-icons-BoldIcon.esm.js",
+      "default": "./icons/BoldIcon/dist/keystone-ui-icons-icons-BoldIcon.cjs.js"
+    },
+    "./icons/BookIcon": {
+      "module": "./icons/BookIcon/dist/keystone-ui-icons-icons-BookIcon.esm.js",
+      "default": "./icons/BookIcon/dist/keystone-ui-icons-icons-BookIcon.cjs.js"
+    },
+    "./icons/CastIcon": {
+      "module": "./icons/CastIcon/dist/keystone-ui-icons-icons-CastIcon.esm.js",
+      "default": "./icons/CastIcon/dist/keystone-ui-icons-icons-CastIcon.cjs.js"
+    },
+    "./icons/CodeIcon": {
+      "module": "./icons/CodeIcon/dist/keystone-ui-icons-icons-CodeIcon.esm.js",
+      "default": "./icons/CodeIcon/dist/keystone-ui-icons-icons-CodeIcon.cjs.js"
+    },
+    "./icons/CopyIcon": {
+      "module": "./icons/CopyIcon/dist/keystone-ui-icons-icons-CopyIcon.esm.js",
+      "default": "./icons/CopyIcon/dist/keystone-ui-icons-icons-CopyIcon.cjs.js"
+    },
+    "./icons/CropIcon": {
+      "module": "./icons/CropIcon/dist/keystone-ui-icons-icons-CropIcon.esm.js",
+      "default": "./icons/CropIcon/dist/keystone-ui-icons-icons-CropIcon.cjs.js"
+    },
+    "./icons/DiscIcon": {
+      "module": "./icons/DiscIcon/dist/keystone-ui-icons-icons-DiscIcon.esm.js",
+      "default": "./icons/DiscIcon/dist/keystone-ui-icons-icons-DiscIcon.cjs.js"
+    },
+    "./icons/EditIcon": {
+      "module": "./icons/EditIcon/dist/keystone-ui-icons-icons-EditIcon.esm.js",
+      "default": "./icons/EditIcon/dist/keystone-ui-icons-icons-EditIcon.cjs.js"
+    },
+    "./icons/FileIcon": {
+      "module": "./icons/FileIcon/dist/keystone-ui-icons-icons-FileIcon.esm.js",
+      "default": "./icons/FileIcon/dist/keystone-ui-icons-icons-FileIcon.cjs.js"
+    },
+    "./icons/FilmIcon": {
+      "module": "./icons/FilmIcon/dist/keystone-ui-icons-icons-FilmIcon.esm.js",
+      "default": "./icons/FilmIcon/dist/keystone-ui-icons-icons-FilmIcon.cjs.js"
+    },
+    "./icons/FlagIcon": {
+      "module": "./icons/FlagIcon/dist/keystone-ui-icons-icons-FlagIcon.esm.js",
+      "default": "./icons/FlagIcon/dist/keystone-ui-icons-icons-FlagIcon.cjs.js"
+    },
+    "./icons/GiftIcon": {
+      "module": "./icons/GiftIcon/dist/keystone-ui-icons-icons-GiftIcon.esm.js",
+      "default": "./icons/GiftIcon/dist/keystone-ui-icons-icons-GiftIcon.cjs.js"
+    },
+    "./icons/GridIcon": {
+      "module": "./icons/GridIcon/dist/keystone-ui-icons-icons-GridIcon.esm.js",
+      "default": "./icons/GridIcon/dist/keystone-ui-icons-icons-GridIcon.cjs.js"
+    },
+    "./icons/HashIcon": {
+      "module": "./icons/HashIcon/dist/keystone-ui-icons-icons-HashIcon.esm.js",
+      "default": "./icons/HashIcon/dist/keystone-ui-icons-icons-HashIcon.cjs.js"
+    },
+    "./icons/HomeIcon": {
+      "module": "./icons/HomeIcon/dist/keystone-ui-icons-icons-HomeIcon.esm.js",
+      "default": "./icons/HomeIcon/dist/keystone-ui-icons-icons-HomeIcon.cjs.js"
+    },
+    "./icons/InfoIcon": {
+      "module": "./icons/InfoIcon/dist/keystone-ui-icons-icons-InfoIcon.esm.js",
+      "default": "./icons/InfoIcon/dist/keystone-ui-icons-icons-InfoIcon.cjs.js"
+    },
+    "./icons/LinkIcon": {
+      "module": "./icons/LinkIcon/dist/keystone-ui-icons-icons-LinkIcon.esm.js",
+      "default": "./icons/LinkIcon/dist/keystone-ui-icons-icons-LinkIcon.cjs.js"
+    },
+    "./icons/ListIcon": {
+      "module": "./icons/ListIcon/dist/keystone-ui-icons-icons-ListIcon.esm.js",
+      "default": "./icons/ListIcon/dist/keystone-ui-icons-icons-ListIcon.cjs.js"
+    },
+    "./icons/LockIcon": {
+      "module": "./icons/LockIcon/dist/keystone-ui-icons-icons-LockIcon.esm.js",
+      "default": "./icons/LockIcon/dist/keystone-ui-icons-icons-LockIcon.cjs.js"
+    },
+    "./icons/MailIcon": {
+      "module": "./icons/MailIcon/dist/keystone-ui-icons-icons-MailIcon.esm.js",
+      "default": "./icons/MailIcon/dist/keystone-ui-icons-icons-MailIcon.cjs.js"
+    },
+    "./icons/MenuIcon": {
+      "module": "./icons/MenuIcon/dist/keystone-ui-icons-icons-MenuIcon.esm.js",
+      "default": "./icons/MenuIcon/dist/keystone-ui-icons-icons-MenuIcon.cjs.js"
+    },
+    "./icons/MoonIcon": {
+      "module": "./icons/MoonIcon/dist/keystone-ui-icons-icons-MoonIcon.esm.js",
+      "default": "./icons/MoonIcon/dist/keystone-ui-icons-icons-MoonIcon.cjs.js"
+    },
+    "./icons/MoveIcon": {
+      "module": "./icons/MoveIcon/dist/keystone-ui-icons-icons-MoveIcon.esm.js",
+      "default": "./icons/MoveIcon/dist/keystone-ui-icons-icons-MoveIcon.cjs.js"
+    },
+    "./icons/PlayIcon": {
+      "module": "./icons/PlayIcon/dist/keystone-ui-icons-icons-PlayIcon.esm.js",
+      "default": "./icons/PlayIcon/dist/keystone-ui-icons-icons-PlayIcon.cjs.js"
+    },
+    "./icons/PlusIcon": {
+      "module": "./icons/PlusIcon/dist/keystone-ui-icons-icons-PlusIcon.esm.js",
+      "default": "./icons/PlusIcon/dist/keystone-ui-icons-icons-PlusIcon.cjs.js"
+    },
+    "./icons/SaveIcon": {
+      "module": "./icons/SaveIcon/dist/keystone-ui-icons-icons-SaveIcon.esm.js",
+      "default": "./icons/SaveIcon/dist/keystone-ui-icons-icons-SaveIcon.cjs.js"
+    },
+    "./icons/SendIcon": {
+      "module": "./icons/SendIcon/dist/keystone-ui-icons-icons-SendIcon.esm.js",
+      "default": "./icons/SendIcon/dist/keystone-ui-icons-icons-SendIcon.cjs.js"
+    },
+    "./icons/StarIcon": {
+      "module": "./icons/StarIcon/dist/keystone-ui-icons-icons-StarIcon.esm.js",
+      "default": "./icons/StarIcon/dist/keystone-ui-icons-icons-StarIcon.cjs.js"
+    },
+    "./icons/ToolIcon": {
+      "module": "./icons/ToolIcon/dist/keystone-ui-icons-icons-ToolIcon.esm.js",
+      "default": "./icons/ToolIcon/dist/keystone-ui-icons-icons-ToolIcon.cjs.js"
+    },
+    "./icons/TypeIcon": {
+      "module": "./icons/TypeIcon/dist/keystone-ui-icons-icons-TypeIcon.esm.js",
+      "default": "./icons/TypeIcon/dist/keystone-ui-icons-icons-TypeIcon.cjs.js"
+    },
+    "./icons/UserIcon": {
+      "module": "./icons/UserIcon/dist/keystone-ui-icons-icons-UserIcon.esm.js",
+      "default": "./icons/UserIcon/dist/keystone-ui-icons-icons-UserIcon.cjs.js"
+    },
+    "./icons/WifiIcon": {
+      "module": "./icons/WifiIcon/dist/keystone-ui-icons-icons-WifiIcon.esm.js",
+      "default": "./icons/WifiIcon/dist/keystone-ui-icons-icons-WifiIcon.cjs.js"
+    },
+    "./icons/WindIcon": {
+      "module": "./icons/WindIcon/dist/keystone-ui-icons-icons-WindIcon.esm.js",
+      "default": "./icons/WindIcon/dist/keystone-ui-icons-icons-WindIcon.cjs.js"
+    },
+    "./icons/AwardIcon": {
+      "module": "./icons/AwardIcon/dist/keystone-ui-icons-icons-AwardIcon.esm.js",
+      "default": "./icons/AwardIcon/dist/keystone-ui-icons-icons-AwardIcon.cjs.js"
+    },
+    "./icons/CheckIcon": {
+      "module": "./icons/CheckIcon/dist/keystone-ui-icons-icons-CheckIcon.esm.js",
+      "default": "./icons/CheckIcon/dist/keystone-ui-icons-icons-CheckIcon.cjs.js"
+    },
+    "./icons/ClockIcon": {
+      "module": "./icons/ClockIcon/dist/keystone-ui-icons-icons-ClockIcon.esm.js",
+      "default": "./icons/ClockIcon/dist/keystone-ui-icons-icons-ClockIcon.cjs.js"
+    },
+    "./icons/CloudIcon": {
+      "module": "./icons/CloudIcon/dist/keystone-ui-icons-icons-CloudIcon.esm.js",
+      "default": "./icons/CloudIcon/dist/keystone-ui-icons-icons-CloudIcon.cjs.js"
+    },
+    "./icons/Edit2Icon": {
+      "module": "./icons/Edit2Icon/dist/keystone-ui-icons-icons-Edit2Icon.esm.js",
+      "default": "./icons/Edit2Icon/dist/keystone-ui-icons-icons-Edit2Icon.cjs.js"
+    },
+    "./icons/Edit3Icon": {
+      "module": "./icons/Edit3Icon/dist/keystone-ui-icons-icons-Edit3Icon.esm.js",
+      "default": "./icons/Edit3Icon/dist/keystone-ui-icons-icons-Edit3Icon.cjs.js"
+    },
+    "./icons/FigmaIcon": {
+      "module": "./icons/FigmaIcon/dist/keystone-ui-icons-icons-FigmaIcon.esm.js",
+      "default": "./icons/FigmaIcon/dist/keystone-ui-icons-icons-FigmaIcon.cjs.js"
+    },
+    "./icons/FrownIcon": {
+      "module": "./icons/FrownIcon/dist/keystone-ui-icons-icons-FrownIcon.esm.js",
+      "default": "./icons/FrownIcon/dist/keystone-ui-icons-icons-FrownIcon.cjs.js"
+    },
+    "./icons/GlobeIcon": {
+      "module": "./icons/GlobeIcon/dist/keystone-ui-icons-icons-GlobeIcon.esm.js",
+      "default": "./icons/GlobeIcon/dist/keystone-ui-icons-icons-GlobeIcon.cjs.js"
+    },
+    "./icons/HeartIcon": {
+      "module": "./icons/HeartIcon/dist/keystone-ui-icons-icons-HeartIcon.esm.js",
+      "default": "./icons/HeartIcon/dist/keystone-ui-icons-icons-HeartIcon.cjs.js"
+    },
+    "./icons/ImageIcon": {
+      "module": "./icons/ImageIcon/dist/keystone-ui-icons-icons-ImageIcon.esm.js",
+      "default": "./icons/ImageIcon/dist/keystone-ui-icons-icons-ImageIcon.cjs.js"
+    },
+    "./icons/InboxIcon": {
+      "module": "./icons/InboxIcon/dist/keystone-ui-icons-icons-InboxIcon.esm.js",
+      "default": "./icons/InboxIcon/dist/keystone-ui-icons-icons-InboxIcon.cjs.js"
+    },
+    "./icons/Link2Icon": {
+      "module": "./icons/Link2Icon/dist/keystone-ui-icons-icons-Link2Icon.esm.js",
+      "default": "./icons/Link2Icon/dist/keystone-ui-icons-icons-Link2Icon.cjs.js"
+    },
+    "./icons/LogInIcon": {
+      "module": "./icons/LogInIcon/dist/keystone-ui-icons-icons-LogInIcon.esm.js",
+      "default": "./icons/LogInIcon/dist/keystone-ui-icons-icons-LogInIcon.cjs.js"
+    },
+    "./icons/MinusIcon": {
+      "module": "./icons/MinusIcon/dist/keystone-ui-icons-icons-MinusIcon.esm.js",
+      "default": "./icons/MinusIcon/dist/keystone-ui-icons-icons-MinusIcon.cjs.js"
+    },
+    "./icons/MusicIcon": {
+      "module": "./icons/MusicIcon/dist/keystone-ui-icons-icons-MusicIcon.esm.js",
+      "default": "./icons/MusicIcon/dist/keystone-ui-icons-icons-MusicIcon.cjs.js"
+    },
+    "./icons/PauseIcon": {
+      "module": "./icons/PauseIcon/dist/keystone-ui-icons-icons-PauseIcon.esm.js",
+      "default": "./icons/PauseIcon/dist/keystone-ui-icons-icons-PauseIcon.cjs.js"
+    },
+    "./icons/PhoneIcon": {
+      "module": "./icons/PhoneIcon/dist/keystone-ui-icons-icons-PhoneIcon.esm.js",
+      "default": "./icons/PhoneIcon/dist/keystone-ui-icons-icons-PhoneIcon.cjs.js"
+    },
+    "./icons/PowerIcon": {
+      "module": "./icons/PowerIcon/dist/keystone-ui-icons-icons-PowerIcon.esm.js",
+      "default": "./icons/PowerIcon/dist/keystone-ui-icons-icons-PowerIcon.cjs.js"
+    },
+    "./icons/RadioIcon": {
+      "module": "./icons/RadioIcon/dist/keystone-ui-icons-icons-RadioIcon.esm.js",
+      "default": "./icons/RadioIcon/dist/keystone-ui-icons-icons-RadioIcon.cjs.js"
+    },
+    "./icons/ShareIcon": {
+      "module": "./icons/ShareIcon/dist/keystone-ui-icons-icons-ShareIcon.esm.js",
+      "default": "./icons/ShareIcon/dist/keystone-ui-icons-icons-ShareIcon.cjs.js"
+    },
+    "./icons/SlackIcon": {
+      "module": "./icons/SlackIcon/dist/keystone-ui-icons-icons-SlackIcon.esm.js",
+      "default": "./icons/SlackIcon/dist/keystone-ui-icons-icons-SlackIcon.cjs.js"
+    },
+    "./icons/SlashIcon": {
+      "module": "./icons/SlashIcon/dist/keystone-ui-icons-icons-SlashIcon.esm.js",
+      "default": "./icons/SlashIcon/dist/keystone-ui-icons-icons-SlashIcon.cjs.js"
+    },
+    "./icons/SmileIcon": {
+      "module": "./icons/SmileIcon/dist/keystone-ui-icons-icons-SmileIcon.esm.js",
+      "default": "./icons/SmileIcon/dist/keystone-ui-icons-icons-SmileIcon.cjs.js"
+    },
+    "./icons/TrashIcon": {
+      "module": "./icons/TrashIcon/dist/keystone-ui-icons-icons-TrashIcon.esm.js",
+      "default": "./icons/TrashIcon/dist/keystone-ui-icons-icons-TrashIcon.cjs.js"
+    },
+    "./icons/TruckIcon": {
+      "module": "./icons/TruckIcon/dist/keystone-ui-icons-icons-TruckIcon.esm.js",
+      "default": "./icons/TruckIcon/dist/keystone-ui-icons-icons-TruckIcon.cjs.js"
+    },
+    "./icons/UserXIcon": {
+      "module": "./icons/UserXIcon/dist/keystone-ui-icons-icons-UserXIcon.esm.js",
+      "default": "./icons/UserXIcon/dist/keystone-ui-icons-icons-UserXIcon.cjs.js"
+    },
+    "./icons/UsersIcon": {
+      "module": "./icons/UsersIcon/dist/keystone-ui-icons-icons-UsersIcon.esm.js",
+      "default": "./icons/UsersIcon/dist/keystone-ui-icons-icons-UsersIcon.cjs.js"
+    },
+    "./icons/VideoIcon": {
+      "module": "./icons/VideoIcon/dist/keystone-ui-icons-icons-VideoIcon.esm.js",
+      "default": "./icons/VideoIcon/dist/keystone-ui-icons-icons-VideoIcon.cjs.js"
+    },
+    "./icons/WatchIcon": {
+      "module": "./icons/WatchIcon/dist/keystone-ui-icons-icons-WatchIcon.esm.js",
+      "default": "./icons/WatchIcon/dist/keystone-ui-icons-icons-WatchIcon.cjs.js"
+    },
+    "./icons/AnchorIcon": {
+      "module": "./icons/AnchorIcon/dist/keystone-ui-icons-icons-AnchorIcon.esm.js",
+      "default": "./icons/AnchorIcon/dist/keystone-ui-icons-icons-AnchorIcon.cjs.js"
+    },
+    "./icons/AtSignIcon": {
+      "module": "./icons/AtSignIcon/dist/keystone-ui-icons-icons-AtSignIcon.esm.js",
+      "default": "./icons/AtSignIcon/dist/keystone-ui-icons-icons-AtSignIcon.cjs.js"
+    },
+    "./icons/CameraIcon": {
+      "module": "./icons/CameraIcon/dist/keystone-ui-icons-icons-CameraIcon.esm.js",
+      "default": "./icons/CameraIcon/dist/keystone-ui-icons-icons-CameraIcon.cjs.js"
+    },
+    "./icons/ChromeIcon": {
+      "module": "./icons/ChromeIcon/dist/keystone-ui-icons-icons-ChromeIcon.esm.js",
+      "default": "./icons/ChromeIcon/dist/keystone-ui-icons-icons-ChromeIcon.cjs.js"
+    },
+    "./icons/CircleIcon": {
+      "module": "./icons/CircleIcon/dist/keystone-ui-icons-icons-CircleIcon.esm.js",
+      "default": "./icons/CircleIcon/dist/keystone-ui-icons-icons-CircleIcon.cjs.js"
+    },
+    "./icons/CoffeeIcon": {
+      "module": "./icons/CoffeeIcon/dist/keystone-ui-icons-icons-CoffeeIcon.esm.js",
+      "default": "./icons/CoffeeIcon/dist/keystone-ui-icons-icons-CoffeeIcon.cjs.js"
+    },
+    "./icons/DeleteIcon": {
+      "module": "./icons/DeleteIcon/dist/keystone-ui-icons-icons-DeleteIcon.esm.js",
+      "default": "./icons/DeleteIcon/dist/keystone-ui-icons-icons-DeleteIcon.cjs.js"
+    },
+    "./icons/DivideIcon": {
+      "module": "./icons/DivideIcon/dist/keystone-ui-icons-icons-DivideIcon.esm.js",
+      "default": "./icons/DivideIcon/dist/keystone-ui-icons-icons-DivideIcon.cjs.js"
+    },
+    "./icons/EyeOffIcon": {
+      "module": "./icons/EyeOffIcon/dist/keystone-ui-icons-icons-EyeOffIcon.esm.js",
+      "default": "./icons/EyeOffIcon/dist/keystone-ui-icons-icons-EyeOffIcon.cjs.js"
+    },
+    "./icons/FilterIcon": {
+      "module": "./icons/FilterIcon/dist/keystone-ui-icons-icons-FilterIcon.esm.js",
+      "default": "./icons/FilterIcon/dist/keystone-ui-icons-icons-FilterIcon.cjs.js"
+    },
+    "./icons/FolderIcon": {
+      "module": "./icons/FolderIcon/dist/keystone-ui-icons-icons-FolderIcon.esm.js",
+      "default": "./icons/FolderIcon/dist/keystone-ui-icons-icons-FolderIcon.cjs.js"
+    },
+    "./icons/FramerIcon": {
+      "module": "./icons/FramerIcon/dist/keystone-ui-icons-icons-FramerIcon.esm.js",
+      "default": "./icons/FramerIcon/dist/keystone-ui-icons-icons-FramerIcon.cjs.js"
+    },
+    "./icons/GithubIcon": {
+      "module": "./icons/GithubIcon/dist/keystone-ui-icons-icons-GithubIcon.esm.js",
+      "default": "./icons/GithubIcon/dist/keystone-ui-icons-icons-GithubIcon.cjs.js"
+    },
+    "./icons/GitlabIcon": {
+      "module": "./icons/GitlabIcon/dist/keystone-ui-icons-icons-GitlabIcon.esm.js",
+      "default": "./icons/GitlabIcon/dist/keystone-ui-icons-icons-GitlabIcon.cjs.js"
+    },
+    "./icons/ItalicIcon": {
+      "module": "./icons/ItalicIcon/dist/keystone-ui-icons-icons-ItalicIcon.esm.js",
+      "default": "./icons/ItalicIcon/dist/keystone-ui-icons-icons-ItalicIcon.cjs.js"
+    },
+    "./icons/LayersIcon": {
+      "module": "./icons/LayersIcon/dist/keystone-ui-icons-icons-LayersIcon.esm.js",
+      "default": "./icons/LayersIcon/dist/keystone-ui-icons-icons-LayersIcon.cjs.js"
+    },
+    "./icons/LayoutIcon": {
+      "module": "./icons/LayoutIcon/dist/keystone-ui-icons-icons-LayoutIcon.esm.js",
+      "default": "./icons/LayoutIcon/dist/keystone-ui-icons-icons-LayoutIcon.cjs.js"
+    },
+    "./icons/LoaderIcon": {
+      "module": "./icons/LoaderIcon/dist/keystone-ui-icons-icons-LoaderIcon.esm.js",
+      "default": "./icons/LoaderIcon/dist/keystone-ui-icons-icons-LoaderIcon.cjs.js"
+    },
+    "./icons/LogOutIcon": {
+      "module": "./icons/LogOutIcon/dist/keystone-ui-icons-icons-LogOutIcon.esm.js",
+      "default": "./icons/LogOutIcon/dist/keystone-ui-icons-icons-LogOutIcon.cjs.js"
+    },
+    "./icons/MapPinIcon": {
+      "module": "./icons/MapPinIcon/dist/keystone-ui-icons-icons-MapPinIcon.esm.js",
+      "default": "./icons/MapPinIcon/dist/keystone-ui-icons-icons-MapPinIcon.cjs.js"
+    },
+    "./icons/MicOffIcon": {
+      "module": "./icons/MicOffIcon/dist/keystone-ui-icons-icons-MicOffIcon.esm.js",
+      "default": "./icons/MicOffIcon/dist/keystone-ui-icons-icons-MicOffIcon.cjs.js"
+    },
+    "./icons/PocketIcon": {
+      "module": "./icons/PocketIcon/dist/keystone-ui-icons-icons-PocketIcon.esm.js",
+      "default": "./icons/PocketIcon/dist/keystone-ui-icons-icons-PocketIcon.cjs.js"
+    },
+    "./icons/RepeatIcon": {
+      "module": "./icons/RepeatIcon/dist/keystone-ui-icons-icons-RepeatIcon.esm.js",
+      "default": "./icons/RepeatIcon/dist/keystone-ui-icons-icons-RepeatIcon.cjs.js"
+    },
+    "./icons/RewindIcon": {
+      "module": "./icons/RewindIcon/dist/keystone-ui-icons-icons-RewindIcon.esm.js",
+      "default": "./icons/RewindIcon/dist/keystone-ui-icons-icons-RewindIcon.cjs.js"
+    },
+    "./icons/SearchIcon": {
+      "module": "./icons/SearchIcon/dist/keystone-ui-icons-icons-SearchIcon.esm.js",
+      "default": "./icons/SearchIcon/dist/keystone-ui-icons-icons-SearchIcon.cjs.js"
+    },
+    "./icons/ServerIcon": {
+      "module": "./icons/ServerIcon/dist/keystone-ui-icons-icons-ServerIcon.esm.js",
+      "default": "./icons/ServerIcon/dist/keystone-ui-icons-icons-ServerIcon.cjs.js"
+    },
+    "./icons/Share2Icon": {
+      "module": "./icons/Share2Icon/dist/keystone-ui-icons-icons-Share2Icon.esm.js",
+      "default": "./icons/Share2Icon/dist/keystone-ui-icons-icons-Share2Icon.cjs.js"
+    },
+    "./icons/ShieldIcon": {
+      "module": "./icons/ShieldIcon/dist/keystone-ui-icons-icons-ShieldIcon.esm.js",
+      "default": "./icons/ShieldIcon/dist/keystone-ui-icons-icons-ShieldIcon.cjs.js"
+    },
+    "./icons/SquareIcon": {
+      "module": "./icons/SquareIcon/dist/keystone-ui-icons-icons-SquareIcon.esm.js",
+      "default": "./icons/SquareIcon/dist/keystone-ui-icons-icons-SquareIcon.cjs.js"
+    },
+    "./icons/SunsetIcon": {
+      "module": "./icons/SunsetIcon/dist/keystone-ui-icons-icons-SunsetIcon.esm.js",
+      "default": "./icons/SunsetIcon/dist/keystone-ui-icons-icons-SunsetIcon.cjs.js"
+    },
+    "./icons/TabletIcon": {
+      "module": "./icons/TabletIcon/dist/keystone-ui-icons-icons-TabletIcon.esm.js",
+      "default": "./icons/TabletIcon/dist/keystone-ui-icons-icons-TabletIcon.cjs.js"
+    },
+    "./icons/TargetIcon": {
+      "module": "./icons/TargetIcon/dist/keystone-ui-icons-icons-TargetIcon.esm.js",
+      "default": "./icons/TargetIcon/dist/keystone-ui-icons-icons-TargetIcon.cjs.js"
+    },
+    "./icons/Trash2Icon": {
+      "module": "./icons/Trash2Icon/dist/keystone-ui-icons-icons-Trash2Icon.esm.js",
+      "default": "./icons/Trash2Icon/dist/keystone-ui-icons-icons-Trash2Icon.cjs.js"
+    },
+    "./icons/TrelloIcon": {
+      "module": "./icons/TrelloIcon/dist/keystone-ui-icons-icons-TrelloIcon.esm.js",
+      "default": "./icons/TrelloIcon/dist/keystone-ui-icons-icons-TrelloIcon.cjs.js"
+    },
+    "./icons/TwitchIcon": {
+      "module": "./icons/TwitchIcon/dist/keystone-ui-icons-icons-TwitchIcon.esm.js",
+      "default": "./icons/TwitchIcon/dist/keystone-ui-icons-icons-TwitchIcon.cjs.js"
+    },
+    "./icons/UnlockIcon": {
+      "module": "./icons/UnlockIcon/dist/keystone-ui-icons-icons-UnlockIcon.esm.js",
+      "default": "./icons/UnlockIcon/dist/keystone-ui-icons-icons-UnlockIcon.cjs.js"
+    },
+    "./icons/UploadIcon": {
+      "module": "./icons/UploadIcon/dist/keystone-ui-icons-icons-UploadIcon.esm.js",
+      "default": "./icons/UploadIcon/dist/keystone-ui-icons-icons-UploadIcon.cjs.js"
+    },
+    "./icons/VolumeIcon": {
+      "module": "./icons/VolumeIcon/dist/keystone-ui-icons-icons-VolumeIcon.esm.js",
+      "default": "./icons/VolumeIcon/dist/keystone-ui-icons-icons-VolumeIcon.cjs.js"
+    },
+    "./icons/ZapOffIcon": {
+      "module": "./icons/ZapOffIcon/dist/keystone-ui-icons-icons-ZapOffIcon.esm.js",
+      "default": "./icons/ZapOffIcon/dist/keystone-ui-icons-icons-ZapOffIcon.cjs.js"
+    },
+    "./icons/ZoomInIcon": {
+      "module": "./icons/ZoomInIcon/dist/keystone-ui-icons-icons-ZoomInIcon.esm.js",
+      "default": "./icons/ZoomInIcon/dist/keystone-ui-icons-icons-ZoomInIcon.cjs.js"
+    },
+    "./icons/AirplayIcon": {
+      "module": "./icons/AirplayIcon/dist/keystone-ui-icons-icons-AirplayIcon.esm.js",
+      "default": "./icons/AirplayIcon/dist/keystone-ui-icons-icons-AirplayIcon.cjs.js"
+    },
+    "./icons/ArchiveIcon": {
+      "module": "./icons/ArchiveIcon/dist/keystone-ui-icons-icons-ArchiveIcon.esm.js",
+      "default": "./icons/ArchiveIcon/dist/keystone-ui-icons-icons-ArchiveIcon.cjs.js"
+    },
+    "./icons/ArrowUpIcon": {
+      "module": "./icons/ArrowUpIcon/dist/keystone-ui-icons-icons-ArrowUpIcon.esm.js",
+      "default": "./icons/ArrowUpIcon/dist/keystone-ui-icons-icons-ArrowUpIcon.cjs.js"
+    },
+    "./icons/BatteryIcon": {
+      "module": "./icons/BatteryIcon/dist/keystone-ui-icons-icons-BatteryIcon.esm.js",
+      "default": "./icons/BatteryIcon/dist/keystone-ui-icons-icons-BatteryIcon.cjs.js"
+    },
+    "./icons/BellOffIcon": {
+      "module": "./icons/BellOffIcon/dist/keystone-ui-icons-icons-BellOffIcon.esm.js",
+      "default": "./icons/BellOffIcon/dist/keystone-ui-icons-icons-BellOffIcon.cjs.js"
+    },
+    "./icons/CodepenIcon": {
+      "module": "./icons/CodepenIcon/dist/keystone-ui-icons-icons-CodepenIcon.esm.js",
+      "default": "./icons/CodepenIcon/dist/keystone-ui-icons-icons-CodepenIcon.cjs.js"
+    },
+    "./icons/ColumnsIcon": {
+      "module": "./icons/ColumnsIcon/dist/keystone-ui-icons-icons-ColumnsIcon.esm.js",
+      "default": "./icons/ColumnsIcon/dist/keystone-ui-icons-icons-ColumnsIcon.cjs.js"
+    },
+    "./icons/CommandIcon": {
+      "module": "./icons/CommandIcon/dist/keystone-ui-icons-icons-CommandIcon.esm.js",
+      "default": "./icons/CommandIcon/dist/keystone-ui-icons-icons-CommandIcon.cjs.js"
+    },
+    "./icons/CompassIcon": {
+      "module": "./icons/CompassIcon/dist/keystone-ui-icons-icons-CompassIcon.esm.js",
+      "default": "./icons/CompassIcon/dist/keystone-ui-icons-icons-CompassIcon.cjs.js"
+    },
+    "./icons/DropletIcon": {
+      "module": "./icons/DropletIcon/dist/keystone-ui-icons-icons-DropletIcon.esm.js",
+      "default": "./icons/DropletIcon/dist/keystone-ui-icons-icons-DropletIcon.cjs.js"
+    },
+    "./icons/FeatherIcon": {
+      "module": "./icons/FeatherIcon/dist/keystone-ui-icons-icons-FeatherIcon.esm.js",
+      "default": "./icons/FeatherIcon/dist/keystone-ui-icons-icons-FeatherIcon.cjs.js"
+    },
+    "./icons/HexagonIcon": {
+      "module": "./icons/HexagonIcon/dist/keystone-ui-icons-icons-HexagonIcon.esm.js",
+      "default": "./icons/HexagonIcon/dist/keystone-ui-icons-icons-HexagonIcon.cjs.js"
+    },
+    "./icons/MonitorIcon": {
+      "module": "./icons/MonitorIcon/dist/keystone-ui-icons-icons-MonitorIcon.esm.js",
+      "default": "./icons/MonitorIcon/dist/keystone-ui-icons-icons-MonitorIcon.cjs.js"
+    },
+    "./icons/OctagonIcon": {
+      "module": "./icons/OctagonIcon/dist/keystone-ui-icons-icons-OctagonIcon.esm.js",
+      "default": "./icons/OctagonIcon/dist/keystone-ui-icons-icons-OctagonIcon.cjs.js"
+    },
+    "./icons/PackageIcon": {
+      "module": "./icons/PackageIcon/dist/keystone-ui-icons-icons-PackageIcon.esm.js",
+      "default": "./icons/PackageIcon/dist/keystone-ui-icons-icons-PackageIcon.cjs.js"
+    },
+    "./icons/PenToolIcon": {
+      "module": "./icons/PenToolIcon/dist/keystone-ui-icons-icons-PenToolIcon.esm.js",
+      "default": "./icons/PenToolIcon/dist/keystone-ui-icons-icons-PenToolIcon.cjs.js"
+    },
+    "./icons/PercentIcon": {
+      "module": "./icons/PercentIcon/dist/keystone-ui-icons-icons-PercentIcon.esm.js",
+      "default": "./icons/PercentIcon/dist/keystone-ui-icons-icons-PercentIcon.cjs.js"
+    },
+    "./icons/PrinterIcon": {
+      "module": "./icons/PrinterIcon/dist/keystone-ui-icons-icons-PrinterIcon.esm.js",
+      "default": "./icons/PrinterIcon/dist/keystone-ui-icons-icons-PrinterIcon.cjs.js"
+    },
+    "./icons/ShuffleIcon": {
+      "module": "./icons/ShuffleIcon/dist/keystone-ui-icons-icons-ShuffleIcon.esm.js",
+      "default": "./icons/ShuffleIcon/dist/keystone-ui-icons-icons-ShuffleIcon.cjs.js"
+    },
+    "./icons/SidebarIcon": {
+      "module": "./icons/SidebarIcon/dist/keystone-ui-icons-icons-SidebarIcon.esm.js",
+      "default": "./icons/SidebarIcon/dist/keystone-ui-icons-icons-SidebarIcon.cjs.js"
+    },
+    "./icons/SlidersIcon": {
+      "module": "./icons/SlidersIcon/dist/keystone-ui-icons-icons-SlidersIcon.esm.js",
+      "default": "./icons/SlidersIcon/dist/keystone-ui-icons-icons-SlidersIcon.cjs.js"
+    },
+    "./icons/SpeakerIcon": {
+      "module": "./icons/SpeakerIcon/dist/keystone-ui-icons-icons-SpeakerIcon.esm.js",
+      "default": "./icons/SpeakerIcon/dist/keystone-ui-icons-icons-SpeakerIcon.cjs.js"
+    },
+    "./icons/SunriseIcon": {
+      "module": "./icons/SunriseIcon/dist/keystone-ui-icons-icons-SunriseIcon.esm.js",
+      "default": "./icons/SunriseIcon/dist/keystone-ui-icons-icons-SunriseIcon.cjs.js"
+    },
+    "./icons/TwitterIcon": {
+      "module": "./icons/TwitterIcon/dist/keystone-ui-icons-icons-TwitterIcon.esm.js",
+      "default": "./icons/TwitterIcon/dist/keystone-ui-icons-icons-TwitterIcon.cjs.js"
+    },
+    "./icons/Volume1Icon": {
+      "module": "./icons/Volume1Icon/dist/keystone-ui-icons-icons-Volume1Icon.esm.js",
+      "default": "./icons/Volume1Icon/dist/keystone-ui-icons-icons-Volume1Icon.cjs.js"
+    },
+    "./icons/Volume2Icon": {
+      "module": "./icons/Volume2Icon/dist/keystone-ui-icons-icons-Volume2Icon.esm.js",
+      "default": "./icons/Volume2Icon/dist/keystone-ui-icons-icons-Volume2Icon.cjs.js"
+    },
+    "./icons/VolumeXIcon": {
+      "module": "./icons/VolumeXIcon/dist/keystone-ui-icons-icons-VolumeXIcon.esm.js",
+      "default": "./icons/VolumeXIcon/dist/keystone-ui-icons-icons-VolumeXIcon.cjs.js"
+    },
+    "./icons/WifiOffIcon": {
+      "module": "./icons/WifiOffIcon/dist/keystone-ui-icons-icons-WifiOffIcon.esm.js",
+      "default": "./icons/WifiOffIcon/dist/keystone-ui-icons-icons-WifiOffIcon.cjs.js"
+    },
+    "./icons/XCircleIcon": {
+      "module": "./icons/XCircleIcon/dist/keystone-ui-icons-icons-XCircleIcon.esm.js",
+      "default": "./icons/XCircleIcon/dist/keystone-ui-icons-icons-XCircleIcon.cjs.js"
+    },
+    "./icons/XSquareIcon": {
+      "module": "./icons/XSquareIcon/dist/keystone-ui-icons-icons-XSquareIcon.esm.js",
+      "default": "./icons/XSquareIcon/dist/keystone-ui-icons-icons-XSquareIcon.cjs.js"
+    },
+    "./icons/YoutubeIcon": {
+      "module": "./icons/YoutubeIcon/dist/keystone-ui-icons-icons-YoutubeIcon.esm.js",
+      "default": "./icons/YoutubeIcon/dist/keystone-ui-icons-icons-YoutubeIcon.cjs.js"
+    },
+    "./icons/ZoomOutIcon": {
+      "module": "./icons/ZoomOutIcon/dist/keystone-ui-icons-icons-ZoomOutIcon.esm.js",
+      "default": "./icons/ZoomOutIcon/dist/keystone-ui-icons-icons-ZoomOutIcon.cjs.js"
+    },
+    "./icons/ActivityIcon": {
+      "module": "./icons/ActivityIcon/dist/keystone-ui-icons-icons-ActivityIcon.esm.js",
+      "default": "./icons/ActivityIcon/dist/keystone-ui-icons-icons-ActivityIcon.cjs.js"
+    },
+    "./icons/ApertureIcon": {
+      "module": "./icons/ApertureIcon/dist/keystone-ui-icons-icons-ApertureIcon.esm.js",
+      "default": "./icons/ApertureIcon/dist/keystone-ui-icons-icons-ApertureIcon.cjs.js"
+    },
+    "./icons/BarChartIcon": {
+      "module": "./icons/BarChartIcon/dist/keystone-ui-icons-icons-BarChartIcon.esm.js",
+      "default": "./icons/BarChartIcon/dist/keystone-ui-icons-icons-BarChartIcon.cjs.js"
+    },
+    "./icons/BookOpenIcon": {
+      "module": "./icons/BookOpenIcon/dist/keystone-ui-icons-icons-BookOpenIcon.esm.js",
+      "default": "./icons/BookOpenIcon/dist/keystone-ui-icons-icons-BookOpenIcon.cjs.js"
+    },
+    "./icons/BookmarkIcon": {
+      "module": "./icons/BookmarkIcon/dist/keystone-ui-icons-icons-BookmarkIcon.esm.js",
+      "default": "./icons/BookmarkIcon/dist/keystone-ui-icons-icons-BookmarkIcon.cjs.js"
+    },
+    "./icons/CalendarIcon": {
+      "module": "./icons/CalendarIcon/dist/keystone-ui-icons-icons-CalendarIcon.esm.js",
+      "default": "./icons/CalendarIcon/dist/keystone-ui-icons-icons-CalendarIcon.cjs.js"
+    },
+    "./icons/CloudOffIcon": {
+      "module": "./icons/CloudOffIcon/dist/keystone-ui-icons-icons-CloudOffIcon.esm.js",
+      "default": "./icons/CloudOffIcon/dist/keystone-ui-icons-icons-CloudOffIcon.cjs.js"
+    },
+    "./icons/DatabaseIcon": {
+      "module": "./icons/DatabaseIcon/dist/keystone-ui-icons-icons-DatabaseIcon.esm.js",
+      "default": "./icons/DatabaseIcon/dist/keystone-ui-icons-icons-DatabaseIcon.cjs.js"
+    },
+    "./icons/DownloadIcon": {
+      "module": "./icons/DownloadIcon/dist/keystone-ui-icons-icons-DownloadIcon.esm.js",
+      "default": "./icons/DownloadIcon/dist/keystone-ui-icons-icons-DownloadIcon.cjs.js"
+    },
+    "./icons/DribbbleIcon": {
+      "module": "./icons/DribbbleIcon/dist/keystone-ui-icons-icons-DribbbleIcon.esm.js",
+      "default": "./icons/DribbbleIcon/dist/keystone-ui-icons-icons-DribbbleIcon.cjs.js"
+    },
+    "./icons/FacebookIcon": {
+      "module": "./icons/FacebookIcon/dist/keystone-ui-icons-icons-FacebookIcon.esm.js",
+      "default": "./icons/FacebookIcon/dist/keystone-ui-icons-icons-FacebookIcon.cjs.js"
+    },
+    "./icons/FilePlusIcon": {
+      "module": "./icons/FilePlusIcon/dist/keystone-ui-icons-icons-FilePlusIcon.esm.js",
+      "default": "./icons/FilePlusIcon/dist/keystone-ui-icons-icons-FilePlusIcon.cjs.js"
+    },
+    "./icons/FileTextIcon": {
+      "module": "./icons/FileTextIcon/dist/keystone-ui-icons-icons-FileTextIcon.esm.js",
+      "default": "./icons/FileTextIcon/dist/keystone-ui-icons-icons-FileTextIcon.cjs.js"
+    },
+    "./icons/GitMergeIcon": {
+      "module": "./icons/GitMergeIcon/dist/keystone-ui-icons-icons-GitMergeIcon.esm.js",
+      "default": "./icons/GitMergeIcon/dist/keystone-ui-icons-icons-GitMergeIcon.cjs.js"
+    },
+    "./icons/LifeBuoyIcon": {
+      "module": "./icons/LifeBuoyIcon/dist/keystone-ui-icons-icons-LifeBuoyIcon.esm.js",
+      "default": "./icons/LifeBuoyIcon/dist/keystone-ui-icons-icons-LifeBuoyIcon.cjs.js"
+    },
+    "./icons/LinkedinIcon": {
+      "module": "./icons/LinkedinIcon/dist/keystone-ui-icons-icons-LinkedinIcon.esm.js",
+      "default": "./icons/LinkedinIcon/dist/keystone-ui-icons-icons-LinkedinIcon.cjs.js"
+    },
+    "./icons/MaximizeIcon": {
+      "module": "./icons/MaximizeIcon/dist/keystone-ui-icons-icons-MaximizeIcon.esm.js",
+      "default": "./icons/MaximizeIcon/dist/keystone-ui-icons-icons-MaximizeIcon.cjs.js"
+    },
+    "./icons/MinimizeIcon": {
+      "module": "./icons/MinimizeIcon/dist/keystone-ui-icons-icons-MinimizeIcon.esm.js",
+      "default": "./icons/MinimizeIcon/dist/keystone-ui-icons-icons-MinimizeIcon.cjs.js"
+    },
+    "./icons/PhoneOffIcon": {
+      "module": "./icons/PhoneOffIcon/dist/keystone-ui-icons-icons-PhoneOffIcon.esm.js",
+      "default": "./icons/PhoneOffIcon/dist/keystone-ui-icons-icons-PhoneOffIcon.cjs.js"
+    },
+    "./icons/PieChartIcon": {
+      "module": "./icons/PieChartIcon/dist/keystone-ui-icons-icons-PieChartIcon.esm.js",
+      "default": "./icons/PieChartIcon/dist/keystone-ui-icons-icons-PieChartIcon.cjs.js"
+    },
+    "./icons/RotateCwIcon": {
+      "module": "./icons/RotateCwIcon/dist/keystone-ui-icons-icons-RotateCwIcon.esm.js",
+      "default": "./icons/RotateCwIcon/dist/keystone-ui-icons-icons-RotateCwIcon.cjs.js"
+    },
+    "./icons/ScissorsIcon": {
+      "module": "./icons/ScissorsIcon/dist/keystone-ui-icons-icons-ScissorsIcon.esm.js",
+      "default": "./icons/ScissorsIcon/dist/keystone-ui-icons-icons-ScissorsIcon.cjs.js"
+    },
+    "./icons/SettingsIcon": {
+      "module": "./icons/SettingsIcon/dist/keystone-ui-icons-icons-SettingsIcon.esm.js",
+      "default": "./icons/SettingsIcon/dist/keystone-ui-icons-icons-SettingsIcon.cjs.js"
+    },
+    "./icons/SkipBackIcon": {
+      "module": "./icons/SkipBackIcon/dist/keystone-ui-icons-icons-SkipBackIcon.esm.js",
+      "default": "./icons/SkipBackIcon/dist/keystone-ui-icons-icons-SkipBackIcon.cjs.js"
+    },
+    "./icons/TerminalIcon": {
+      "module": "./icons/TerminalIcon/dist/keystone-ui-icons-icons-TerminalIcon.esm.js",
+      "default": "./icons/TerminalIcon/dist/keystone-ui-icons-icons-TerminalIcon.cjs.js"
+    },
+    "./icons/ThumbsUpIcon": {
+      "module": "./icons/ThumbsUpIcon/dist/keystone-ui-icons-icons-ThumbsUpIcon.esm.js",
+      "default": "./icons/ThumbsUpIcon/dist/keystone-ui-icons-icons-ThumbsUpIcon.cjs.js"
+    },
+    "./icons/TriangleIcon": {
+      "module": "./icons/TriangleIcon/dist/keystone-ui-icons-icons-TriangleIcon.esm.js",
+      "default": "./icons/TriangleIcon/dist/keystone-ui-icons-icons-TriangleIcon.cjs.js"
+    },
+    "./icons/UmbrellaIcon": {
+      "module": "./icons/UmbrellaIcon/dist/keystone-ui-icons-icons-UmbrellaIcon.esm.js",
+      "default": "./icons/UmbrellaIcon/dist/keystone-ui-icons-icons-UmbrellaIcon.cjs.js"
+    },
+    "./icons/UserPlusIcon": {
+      "module": "./icons/UserPlusIcon/dist/keystone-ui-icons-icons-UserPlusIcon.esm.js",
+      "default": "./icons/UserPlusIcon/dist/keystone-ui-icons-icons-UserPlusIcon.cjs.js"
+    },
+    "./icons/VideoOffIcon": {
+      "module": "./icons/VideoOffIcon/dist/keystone-ui-icons-icons-VideoOffIcon.esm.js",
+      "default": "./icons/VideoOffIcon/dist/keystone-ui-icons-icons-VideoOffIcon.cjs.js"
+    },
+    "./icons/XOctagonIcon": {
+      "module": "./icons/XOctagonIcon/dist/keystone-ui-icons-icons-XOctagonIcon.esm.js",
+      "default": "./icons/XOctagonIcon/dist/keystone-ui-icons-icons-XOctagonIcon.cjs.js"
+    },
+    "./icons/AlignLeftIcon": {
+      "module": "./icons/AlignLeftIcon/dist/keystone-ui-icons-icons-AlignLeftIcon.esm.js",
+      "default": "./icons/AlignLeftIcon/dist/keystone-ui-icons-icons-AlignLeftIcon.cjs.js"
+    },
+    "./icons/ArrowDownIcon": {
+      "module": "./icons/ArrowDownIcon/dist/keystone-ui-icons-icons-ArrowDownIcon.esm.js",
+      "default": "./icons/ArrowDownIcon/dist/keystone-ui-icons-icons-ArrowDownIcon.cjs.js"
+    },
+    "./icons/ArrowLeftIcon": {
+      "module": "./icons/ArrowLeftIcon/dist/keystone-ui-icons-icons-ArrowLeftIcon.esm.js",
+      "default": "./icons/ArrowLeftIcon/dist/keystone-ui-icons-icons-ArrowLeftIcon.cjs.js"
+    },
+    "./icons/BarChart2Icon": {
+      "module": "./icons/BarChart2Icon/dist/keystone-ui-icons-icons-BarChart2Icon.esm.js",
+      "default": "./icons/BarChart2Icon/dist/keystone-ui-icons-icons-BarChart2Icon.cjs.js"
+    },
+    "./icons/BluetoothIcon": {
+      "module": "./icons/BluetoothIcon/dist/keystone-ui-icons-icons-BluetoothIcon.esm.js",
+      "default": "./icons/BluetoothIcon/dist/keystone-ui-icons-icons-BluetoothIcon.cjs.js"
+    },
+    "./icons/BriefcaseIcon": {
+      "module": "./icons/BriefcaseIcon/dist/keystone-ui-icons-icons-BriefcaseIcon.esm.js",
+      "default": "./icons/BriefcaseIcon/dist/keystone-ui-icons-icons-BriefcaseIcon.cjs.js"
+    },
+    "./icons/CameraOffIcon": {
+      "module": "./icons/CameraOffIcon/dist/keystone-ui-icons-icons-CameraOffIcon.esm.js",
+      "default": "./icons/CameraOffIcon/dist/keystone-ui-icons-icons-CameraOffIcon.cjs.js"
+    },
+    "./icons/ChevronUpIcon": {
+      "module": "./icons/ChevronUpIcon/dist/keystone-ui-icons-icons-ChevronUpIcon.esm.js",
+      "default": "./icons/ChevronUpIcon/dist/keystone-ui-icons-icons-ChevronUpIcon.cjs.js"
+    },
+    "./icons/ClipboardIcon": {
+      "module": "./icons/ClipboardIcon/dist/keystone-ui-icons-icons-ClipboardIcon.esm.js",
+      "default": "./icons/ClipboardIcon/dist/keystone-ui-icons-icons-ClipboardIcon.cjs.js"
+    },
+    "./icons/CloudRainIcon": {
+      "module": "./icons/CloudRainIcon/dist/keystone-ui-icons-icons-CloudRainIcon.esm.js",
+      "default": "./icons/CloudRainIcon/dist/keystone-ui-icons-icons-CloudRainIcon.cjs.js"
+    },
+    "./icons/CloudSnowIcon": {
+      "module": "./icons/CloudSnowIcon/dist/keystone-ui-icons-icons-CloudSnowIcon.esm.js",
+      "default": "./icons/CloudSnowIcon/dist/keystone-ui-icons-icons-CloudSnowIcon.cjs.js"
+    },
+    "./icons/CrosshairIcon": {
+      "module": "./icons/CrosshairIcon/dist/keystone-ui-icons-icons-CrosshairIcon.esm.js",
+      "default": "./icons/CrosshairIcon/dist/keystone-ui-icons-icons-CrosshairIcon.cjs.js"
+    },
+    "./icons/FileMinusIcon": {
+      "module": "./icons/FileMinusIcon/dist/keystone-ui-icons-icons-FileMinusIcon.esm.js",
+      "default": "./icons/FileMinusIcon/dist/keystone-ui-icons-icons-FileMinusIcon.cjs.js"
+    },
+    "./icons/GitBranchIcon": {
+      "module": "./icons/GitBranchIcon/dist/keystone-ui-icons-icons-GitBranchIcon.esm.js",
+      "default": "./icons/GitBranchIcon/dist/keystone-ui-icons-icons-GitBranchIcon.cjs.js"
+    },
+    "./icons/GitCommitIcon": {
+      "module": "./icons/GitCommitIcon/dist/keystone-ui-icons-icons-GitCommitIcon.esm.js",
+      "default": "./icons/GitCommitIcon/dist/keystone-ui-icons-icons-GitCommitIcon.cjs.js"
+    },
+    "./icons/HardDriveIcon": {
+      "module": "./icons/HardDriveIcon/dist/keystone-ui-icons-icons-HardDriveIcon.esm.js",
+      "default": "./icons/HardDriveIcon/dist/keystone-ui-icons-icons-HardDriveIcon.cjs.js"
+    },
+    "./icons/InstagramIcon": {
+      "module": "./icons/InstagramIcon/dist/keystone-ui-icons-icons-InstagramIcon.esm.js",
+      "default": "./icons/InstagramIcon/dist/keystone-ui-icons-icons-InstagramIcon.cjs.js"
+    },
+    "./icons/Maximize2Icon": {
+      "module": "./icons/Maximize2Icon/dist/keystone-ui-icons-icons-Maximize2Icon.esm.js",
+      "default": "./icons/Maximize2Icon/dist/keystone-ui-icons-icons-Maximize2Icon.cjs.js"
+    },
+    "./icons/Minimize2Icon": {
+      "module": "./icons/Minimize2Icon/dist/keystone-ui-icons-icons-Minimize2Icon.esm.js",
+      "default": "./icons/Minimize2Icon/dist/keystone-ui-icons-icons-Minimize2Icon.cjs.js"
+    },
+    "./icons/PaperclipIcon": {
+      "module": "./icons/PaperclipIcon/dist/keystone-ui-icons-icons-PaperclipIcon.esm.js",
+      "default": "./icons/PaperclipIcon/dist/keystone-ui-icons-icons-PaperclipIcon.cjs.js"
+    },
+    "./icons/PhoneCallIcon": {
+      "module": "./icons/PhoneCallIcon/dist/keystone-ui-icons-icons-PhoneCallIcon.esm.js",
+      "default": "./icons/PhoneCallIcon/dist/keystone-ui-icons-icons-PhoneCallIcon.cjs.js"
+    },
+    "./icons/RefreshCwIcon": {
+      "module": "./icons/RefreshCwIcon/dist/keystone-ui-icons-icons-RefreshCwIcon.esm.js",
+      "default": "./icons/RefreshCwIcon/dist/keystone-ui-icons-icons-RefreshCwIcon.cjs.js"
+    },
+    "./icons/RotateCcwIcon": {
+      "module": "./icons/RotateCcwIcon/dist/keystone-ui-icons-icons-RotateCcwIcon.esm.js",
+      "default": "./icons/RotateCcwIcon/dist/keystone-ui-icons-icons-RotateCcwIcon.cjs.js"
+    },
+    "./icons/ShieldOffIcon": {
+      "module": "./icons/ShieldOffIcon/dist/keystone-ui-icons-icons-ShieldOffIcon.esm.js",
+      "default": "./icons/ShieldOffIcon/dist/keystone-ui-icons-icons-ShieldOffIcon.cjs.js"
+    },
+    "./icons/UnderlineIcon": {
+      "module": "./icons/UnderlineIcon/dist/keystone-ui-icons-icons-UnderlineIcon.esm.js",
+      "default": "./icons/UnderlineIcon/dist/keystone-ui-icons-icons-UnderlineIcon.cjs.js"
+    },
+    "./icons/UserCheckIcon": {
+      "module": "./icons/UserCheckIcon/dist/keystone-ui-icons-icons-UserCheckIcon.esm.js",
+      "default": "./icons/UserCheckIcon/dist/keystone-ui-icons-icons-UserCheckIcon.cjs.js"
+    },
+    "./icons/UserMinusIcon": {
+      "module": "./icons/UserMinusIcon/dist/keystone-ui-icons-icons-UserMinusIcon.esm.js",
+      "default": "./icons/UserMinusIcon/dist/keystone-ui-icons-icons-UserMinusIcon.cjs.js"
+    },
+    "./icons/VoicemailIcon": {
+      "module": "./icons/VoicemailIcon/dist/keystone-ui-icons-icons-VoicemailIcon.esm.js",
+      "default": "./icons/VoicemailIcon/dist/keystone-ui-icons-icons-VoicemailIcon.cjs.js"
+    },
+    "./icons/AlignRightIcon": {
+      "module": "./icons/AlignRightIcon/dist/keystone-ui-icons-icons-AlignRightIcon.esm.js",
+      "default": "./icons/AlignRightIcon/dist/keystone-ui-icons-icons-AlignRightIcon.cjs.js"
+    },
+    "./icons/ArrowRightIcon": {
+      "module": "./icons/ArrowRightIcon/dist/keystone-ui-icons-icons-ArrowRightIcon.esm.js",
+      "default": "./icons/ArrowRightIcon/dist/keystone-ui-icons-icons-ArrowRightIcon.cjs.js"
+    },
+    "./icons/ChevronsUpIcon": {
+      "module": "./icons/ChevronsUpIcon/dist/keystone-ui-icons-icons-ChevronsUpIcon.esm.js",
+      "default": "./icons/ChevronsUpIcon/dist/keystone-ui-icons-icons-ChevronsUpIcon.cjs.js"
+    },
+    "./icons/CreditCardIcon": {
+      "module": "./icons/CreditCardIcon/dist/keystone-ui-icons-icons-CreditCardIcon.esm.js",
+      "default": "./icons/CreditCardIcon/dist/keystone-ui-icons-icons-CreditCardIcon.cjs.js"
+    },
+    "./icons/DollarSignIcon": {
+      "module": "./icons/DollarSignIcon/dist/keystone-ui-icons-icons-DollarSignIcon.esm.js",
+      "default": "./icons/DollarSignIcon/dist/keystone-ui-icons-icons-DollarSignIcon.cjs.js"
+    },
+    "./icons/FolderPlusIcon": {
+      "module": "./icons/FolderPlusIcon/dist/keystone-ui-icons-icons-FolderPlusIcon.esm.js",
+      "default": "./icons/FolderPlusIcon/dist/keystone-ui-icons-icons-FolderPlusIcon.cjs.js"
+    },
+    "./icons/HeadphonesIcon": {
+      "module": "./icons/HeadphonesIcon/dist/keystone-ui-icons-icons-HeadphonesIcon.esm.js",
+      "default": "./icons/HeadphonesIcon/dist/keystone-ui-icons-icons-HeadphonesIcon.cjs.js"
+    },
+    "./icons/HelpCircleIcon": {
+      "module": "./icons/HelpCircleIcon/dist/keystone-ui-icons-icons-HelpCircleIcon.esm.js",
+      "default": "./icons/HelpCircleIcon/dist/keystone-ui-icons-icons-HelpCircleIcon.cjs.js"
+    },
+    "./icons/NavigationIcon": {
+      "module": "./icons/NavigationIcon/dist/keystone-ui-icons-icons-NavigationIcon.esm.js",
+      "default": "./icons/NavigationIcon/dist/keystone-ui-icons-icons-NavigationIcon.cjs.js"
+    },
+    "./icons/PlayCircleIcon": {
+      "module": "./icons/PlayCircleIcon/dist/keystone-ui-icons-icons-PlayCircleIcon.esm.js",
+      "default": "./icons/PlayCircleIcon/dist/keystone-ui-icons-icons-PlayCircleIcon.cjs.js"
+    },
+    "./icons/PlusCircleIcon": {
+      "module": "./icons/PlusCircleIcon/dist/keystone-ui-icons-icons-PlusCircleIcon.esm.js",
+      "default": "./icons/PlusCircleIcon/dist/keystone-ui-icons-icons-PlusCircleIcon.cjs.js"
+    },
+    "./icons/PlusSquareIcon": {
+      "module": "./icons/PlusSquareIcon/dist/keystone-ui-icons-icons-PlusSquareIcon.esm.js",
+      "default": "./icons/PlusSquareIcon/dist/keystone-ui-icons-icons-PlusSquareIcon.cjs.js"
+    },
+    "./icons/RefreshCcwIcon": {
+      "module": "./icons/RefreshCcwIcon/dist/keystone-ui-icons-icons-RefreshCcwIcon.esm.js",
+      "default": "./icons/RefreshCcwIcon/dist/keystone-ui-icons-icons-RefreshCcwIcon.cjs.js"
+    },
+    "./icons/SmartphoneIcon": {
+      "module": "./icons/SmartphoneIcon/dist/keystone-ui-icons-icons-SmartphoneIcon.esm.js",
+      "default": "./icons/SmartphoneIcon/dist/keystone-ui-icons-icons-SmartphoneIcon.cjs.js"
+    },
+    "./icons/StopCircleIcon": {
+      "module": "./icons/StopCircleIcon/dist/keystone-ui-icons-icons-StopCircleIcon.esm.js",
+      "default": "./icons/StopCircleIcon/dist/keystone-ui-icons-icons-StopCircleIcon.cjs.js"
+    },
+    "./icons/ThumbsDownIcon": {
+      "module": "./icons/ThumbsDownIcon/dist/keystone-ui-icons-icons-ThumbsDownIcon.esm.js",
+      "default": "./icons/ThumbsDownIcon/dist/keystone-ui-icons-icons-ThumbsDownIcon.cjs.js"
+    },
+    "./icons/ToggleLeftIcon": {
+      "module": "./icons/ToggleLeftIcon/dist/keystone-ui-icons-icons-ToggleLeftIcon.esm.js",
+      "default": "./icons/ToggleLeftIcon/dist/keystone-ui-icons-icons-ToggleLeftIcon.cjs.js"
+    },
+    "./icons/TrendingUpIcon": {
+      "module": "./icons/TrendingUpIcon/dist/keystone-ui-icons-icons-TrendingUpIcon.esm.js",
+      "default": "./icons/TrendingUpIcon/dist/keystone-ui-icons-icons-TrendingUpIcon.cjs.js"
+    },
+    "./icons/AlertCircleIcon": {
+      "module": "./icons/AlertCircleIcon/dist/keystone-ui-icons-icons-AlertCircleIcon.esm.js",
+      "default": "./icons/AlertCircleIcon/dist/keystone-ui-icons-icons-AlertCircleIcon.cjs.js"
+    },
+    "./icons/AlignCenterIcon": {
+      "module": "./icons/AlignCenterIcon/dist/keystone-ui-icons-icons-AlignCenterIcon.esm.js",
+      "default": "./icons/AlignCenterIcon/dist/keystone-ui-icons-icons-AlignCenterIcon.cjs.js"
+    },
+    "./icons/ArrowUpLeftIcon": {
+      "module": "./icons/ArrowUpLeftIcon/dist/keystone-ui-icons-icons-ArrowUpLeftIcon.esm.js",
+      "default": "./icons/ArrowUpLeftIcon/dist/keystone-ui-icons-icons-ArrowUpLeftIcon.cjs.js"
+    },
+    "./icons/CheckCircleIcon": {
+      "module": "./icons/CheckCircleIcon/dist/keystone-ui-icons-icons-CheckCircleIcon.esm.js",
+      "default": "./icons/CheckCircleIcon/dist/keystone-ui-icons-icons-CheckCircleIcon.cjs.js"
+    },
+    "./icons/CheckSquareIcon": {
+      "module": "./icons/CheckSquareIcon/dist/keystone-ui-icons-icons-CheckSquareIcon.esm.js",
+      "default": "./icons/CheckSquareIcon/dist/keystone-ui-icons-icons-CheckSquareIcon.cjs.js"
+    },
+    "./icons/ChevronDownIcon": {
+      "module": "./icons/ChevronDownIcon/dist/keystone-ui-icons-icons-ChevronDownIcon.esm.js",
+      "default": "./icons/ChevronDownIcon/dist/keystone-ui-icons-icons-ChevronDownIcon.cjs.js"
+    },
+    "./icons/ChevronLeftIcon": {
+      "module": "./icons/ChevronLeftIcon/dist/keystone-ui-icons-icons-ChevronLeftIcon.esm.js",
+      "default": "./icons/ChevronLeftIcon/dist/keystone-ui-icons-icons-ChevronLeftIcon.cjs.js"
+    },
+    "./icons/CodesandboxIcon": {
+      "module": "./icons/CodesandboxIcon/dist/keystone-ui-icons-icons-CodesandboxIcon.esm.js",
+      "default": "./icons/CodesandboxIcon/dist/keystone-ui-icons-icons-CodesandboxIcon.cjs.js"
+    },
+    "./icons/FastForwardIcon": {
+      "module": "./icons/FastForwardIcon/dist/keystone-ui-icons-icons-FastForwardIcon.esm.js",
+      "default": "./icons/FastForwardIcon/dist/keystone-ui-icons-icons-FastForwardIcon.cjs.js"
+    },
+    "./icons/FolderMinusIcon": {
+      "module": "./icons/FolderMinusIcon/dist/keystone-ui-icons-icons-FolderMinusIcon.esm.js",
+      "default": "./icons/FolderMinusIcon/dist/keystone-ui-icons-icons-FolderMinusIcon.cjs.js"
+    },
+    "./icons/MinusCircleIcon": {
+      "module": "./icons/MinusCircleIcon/dist/keystone-ui-icons-icons-MinusCircleIcon.esm.js",
+      "default": "./icons/MinusCircleIcon/dist/keystone-ui-icons-icons-MinusCircleIcon.cjs.js"
+    },
+    "./icons/MinusSquareIcon": {
+      "module": "./icons/MinusSquareIcon/dist/keystone-ui-icons-icons-MinusSquareIcon.esm.js",
+      "default": "./icons/MinusSquareIcon/dist/keystone-ui-icons-icons-MinusSquareIcon.cjs.js"
+    },
+    "./icons/Navigation2Icon": {
+      "module": "./icons/Navigation2Icon/dist/keystone-ui-icons-icons-Navigation2Icon.esm.js",
+      "default": "./icons/Navigation2Icon/dist/keystone-ui-icons-icons-Navigation2Icon.cjs.js"
+    },
+    "./icons/PauseCircleIcon": {
+      "module": "./icons/PauseCircleIcon/dist/keystone-ui-icons-icons-PauseCircleIcon.esm.js",
+      "default": "./icons/PauseCircleIcon/dist/keystone-ui-icons-icons-PauseCircleIcon.cjs.js"
+    },
+    "./icons/PhoneMissedIcon": {
+      "module": "./icons/PhoneMissedIcon/dist/keystone-ui-icons-icons-PhoneMissedIcon.esm.js",
+      "default": "./icons/PhoneMissedIcon/dist/keystone-ui-icons-icons-PhoneMissedIcon.cjs.js"
+    },
+    "./icons/ShoppingBagIcon": {
+      "module": "./icons/ShoppingBagIcon/dist/keystone-ui-icons-icons-ShoppingBagIcon.esm.js",
+      "default": "./icons/ShoppingBagIcon/dist/keystone-ui-icons-icons-ShoppingBagIcon.cjs.js"
+    },
+    "./icons/SkipForwardIcon": {
+      "module": "./icons/SkipForwardIcon/dist/keystone-ui-icons-icons-SkipForwardIcon.esm.js",
+      "default": "./icons/SkipForwardIcon/dist/keystone-ui-icons-icons-SkipForwardIcon.cjs.js"
+    },
+    "./icons/ThermometerIcon": {
+      "module": "./icons/ThermometerIcon/dist/keystone-ui-icons-icons-ThermometerIcon.esm.js",
+      "default": "./icons/ThermometerIcon/dist/keystone-ui-icons-icons-ThermometerIcon.cjs.js"
+    },
+    "./icons/ToggleRightIcon": {
+      "module": "./icons/ToggleRightIcon/dist/keystone-ui-icons-icons-ToggleRightIcon.esm.js",
+      "default": "./icons/ToggleRightIcon/dist/keystone-ui-icons-icons-ToggleRightIcon.cjs.js"
+    },
+    "./icons/UploadCloudIcon": {
+      "module": "./icons/UploadCloudIcon/dist/keystone-ui-icons-icons-UploadCloudIcon.esm.js",
+      "default": "./icons/UploadCloudIcon/dist/keystone-ui-icons-icons-UploadCloudIcon.cjs.js"
+    },
+    "./icons/AlertOctagonIcon": {
+      "module": "./icons/AlertOctagonIcon/dist/keystone-ui-icons-icons-AlertOctagonIcon.esm.js",
+      "default": "./icons/AlertOctagonIcon/dist/keystone-ui-icons-icons-AlertOctagonIcon.cjs.js"
+    },
+    "./icons/AlignJustifyIcon": {
+      "module": "./icons/AlignJustifyIcon/dist/keystone-ui-icons-icons-AlignJustifyIcon.esm.js",
+      "default": "./icons/AlignJustifyIcon/dist/keystone-ui-icons-icons-AlignJustifyIcon.cjs.js"
+    },
+    "./icons/ArrowUpRightIcon": {
+      "module": "./icons/ArrowUpRightIcon/dist/keystone-ui-icons-icons-ArrowUpRightIcon.esm.js",
+      "default": "./icons/ArrowUpRightIcon/dist/keystone-ui-icons-icons-ArrowUpRightIcon.cjs.js"
+    },
+    "./icons/ChevronRightIcon": {
+      "module": "./icons/ChevronRightIcon/dist/keystone-ui-icons-icons-ChevronRightIcon.esm.js",
+      "default": "./icons/ChevronRightIcon/dist/keystone-ui-icons-icons-ChevronRightIcon.cjs.js"
+    },
+    "./icons/ChevronsDownIcon": {
+      "module": "./icons/ChevronsDownIcon/dist/keystone-ui-icons-icons-ChevronsDownIcon.esm.js",
+      "default": "./icons/ChevronsDownIcon/dist/keystone-ui-icons-icons-ChevronsDownIcon.cjs.js"
+    },
+    "./icons/ChevronsLeftIcon": {
+      "module": "./icons/ChevronsLeftIcon/dist/keystone-ui-icons-icons-ChevronsLeftIcon.esm.js",
+      "default": "./icons/ChevronsLeftIcon/dist/keystone-ui-icons-icons-ChevronsLeftIcon.cjs.js"
+    },
+    "./icons/CloudDrizzleIcon": {
+      "module": "./icons/CloudDrizzleIcon/dist/keystone-ui-icons-icons-CloudDrizzleIcon.esm.js",
+      "default": "./icons/CloudDrizzleIcon/dist/keystone-ui-icons-icons-CloudDrizzleIcon.cjs.js"
+    },
+    "./icons/CornerLeftUpIcon": {
+      "module": "./icons/CornerLeftUpIcon/dist/keystone-ui-icons-icons-CornerLeftUpIcon.esm.js",
+      "default": "./icons/CornerLeftUpIcon/dist/keystone-ui-icons-icons-CornerLeftUpIcon.cjs.js"
+    },
+    "./icons/CornerUpLeftIcon": {
+      "module": "./icons/CornerUpLeftIcon/dist/keystone-ui-icons-icons-CornerUpLeftIcon.esm.js",
+      "default": "./icons/CornerUpLeftIcon/dist/keystone-ui-icons-icons-CornerUpLeftIcon.cjs.js"
+    },
+    "./icons/DivideCircleIcon": {
+      "module": "./icons/DivideCircleIcon/dist/keystone-ui-icons-icons-DivideCircleIcon.esm.js",
+      "default": "./icons/DivideCircleIcon/dist/keystone-ui-icons-icons-DivideCircleIcon.cjs.js"
+    },
+    "./icons/DivideSquareIcon": {
+      "module": "./icons/DivideSquareIcon/dist/keystone-ui-icons-icons-DivideSquareIcon.esm.js",
+      "default": "./icons/DivideSquareIcon/dist/keystone-ui-icons-icons-DivideSquareIcon.cjs.js"
+    },
+    "./icons/ExternalLinkIcon": {
+      "module": "./icons/ExternalLinkIcon/dist/keystone-ui-icons-icons-ExternalLinkIcon.esm.js",
+      "default": "./icons/ExternalLinkIcon/dist/keystone-ui-icons-icons-ExternalLinkIcon.cjs.js"
+    },
+    "./icons/MoreVerticalIcon": {
+      "module": "./icons/MoreVerticalIcon/dist/keystone-ui-icons-icons-MoreVerticalIcon.esm.js",
+      "default": "./icons/MoreVerticalIcon/dist/keystone-ui-icons-icons-MoreVerticalIcon.cjs.js"
+    },
+    "./icons/MousePointerIcon": {
+      "module": "./icons/MousePointerIcon/dist/keystone-ui-icons-icons-MousePointerIcon.esm.js",
+      "default": "./icons/MousePointerIcon/dist/keystone-ui-icons-icons-MousePointerIcon.cjs.js"
+    },
+    "./icons/ShoppingCartIcon": {
+      "module": "./icons/ShoppingCartIcon/dist/keystone-ui-icons-icons-ShoppingCartIcon.esm.js",
+      "default": "./icons/ShoppingCartIcon/dist/keystone-ui-icons-icons-ShoppingCartIcon.cjs.js"
+    },
+    "./icons/TrendingDownIcon": {
+      "module": "./icons/TrendingDownIcon/dist/keystone-ui-icons-icons-TrendingDownIcon.esm.js",
+      "default": "./icons/TrendingDownIcon/dist/keystone-ui-icons-icons-TrendingDownIcon.cjs.js"
+    },
+    "./icons/AlertTriangleIcon": {
+      "module": "./icons/AlertTriangleIcon/dist/keystone-ui-icons-icons-AlertTriangleIcon.esm.js",
+      "default": "./icons/AlertTriangleIcon/dist/keystone-ui-icons-icons-AlertTriangleIcon.cjs.js"
+    },
+    "./icons/ArrowDownLeftIcon": {
+      "module": "./icons/ArrowDownLeftIcon/dist/keystone-ui-icons-icons-ArrowDownLeftIcon.esm.js",
+      "default": "./icons/ArrowDownLeftIcon/dist/keystone-ui-icons-icons-ArrowDownLeftIcon.cjs.js"
+    },
+    "./icons/ArrowUpCircleIcon": {
+      "module": "./icons/ArrowUpCircleIcon/dist/keystone-ui-icons-icons-ArrowUpCircleIcon.esm.js",
+      "default": "./icons/ArrowUpCircleIcon/dist/keystone-ui-icons-icons-ArrowUpCircleIcon.cjs.js"
+    },
+    "./icons/ChevronsRightIcon": {
+      "module": "./icons/ChevronsRightIcon/dist/keystone-ui-icons-icons-ChevronsRightIcon.esm.js",
+      "default": "./icons/ChevronsRightIcon/dist/keystone-ui-icons-icons-ChevronsRightIcon.cjs.js"
+    },
+    "./icons/CornerRightUpIcon": {
+      "module": "./icons/CornerRightUpIcon/dist/keystone-ui-icons-icons-CornerRightUpIcon.esm.js",
+      "default": "./icons/CornerRightUpIcon/dist/keystone-ui-icons-icons-CornerRightUpIcon.cjs.js"
+    },
+    "./icons/CornerUpRightIcon": {
+      "module": "./icons/CornerUpRightIcon/dist/keystone-ui-icons-icons-CornerUpRightIcon.esm.js",
+      "default": "./icons/CornerUpRightIcon/dist/keystone-ui-icons-icons-CornerUpRightIcon.cjs.js"
+    },
+    "./icons/DownloadCloudIcon": {
+      "module": "./icons/DownloadCloudIcon/dist/keystone-ui-icons-icons-DownloadCloudIcon.esm.js",
+      "default": "./icons/DownloadCloudIcon/dist/keystone-ui-icons-icons-DownloadCloudIcon.cjs.js"
+    },
+    "./icons/MessageCircleIcon": {
+      "module": "./icons/MessageCircleIcon/dist/keystone-ui-icons-icons-MessageCircleIcon.esm.js",
+      "default": "./icons/MessageCircleIcon/dist/keystone-ui-icons-icons-MessageCircleIcon.cjs.js"
+    },
+    "./icons/MessageSquareIcon": {
+      "module": "./icons/MessageSquareIcon/dist/keystone-ui-icons-icons-MessageSquareIcon.esm.js",
+      "default": "./icons/MessageSquareIcon/dist/keystone-ui-icons-icons-MessageSquareIcon.cjs.js"
+    },
+    "./icons/PhoneIncomingIcon": {
+      "module": "./icons/PhoneIncomingIcon/dist/keystone-ui-icons-icons-PhoneIncomingIcon.esm.js",
+      "default": "./icons/PhoneIncomingIcon/dist/keystone-ui-icons-icons-PhoneIncomingIcon.cjs.js"
+    },
+    "./icons/PhoneOutgoingIcon": {
+      "module": "./icons/PhoneOutgoingIcon/dist/keystone-ui-icons-icons-PhoneOutgoingIcon.esm.js",
+      "default": "./icons/PhoneOutgoingIcon/dist/keystone-ui-icons-icons-PhoneOutgoingIcon.cjs.js"
+    },
+    "./icons/ArrowDownRightIcon": {
+      "module": "./icons/ArrowDownRightIcon/dist/keystone-ui-icons-icons-ArrowDownRightIcon.esm.js",
+      "default": "./icons/ArrowDownRightIcon/dist/keystone-ui-icons-icons-ArrowDownRightIcon.cjs.js"
+    },
+    "./icons/CloudLightningIcon": {
+      "module": "./icons/CloudLightningIcon/dist/keystone-ui-icons-icons-CloudLightningIcon.esm.js",
+      "default": "./icons/CloudLightningIcon/dist/keystone-ui-icons-icons-CloudLightningIcon.cjs.js"
+    },
+    "./icons/CornerDownLeftIcon": {
+      "module": "./icons/CornerDownLeftIcon/dist/keystone-ui-icons-icons-CornerDownLeftIcon.esm.js",
+      "default": "./icons/CornerDownLeftIcon/dist/keystone-ui-icons-icons-CornerDownLeftIcon.cjs.js"
+    },
+    "./icons/CornerLeftDownIcon": {
+      "module": "./icons/CornerLeftDownIcon/dist/keystone-ui-icons-icons-CornerLeftDownIcon.esm.js",
+      "default": "./icons/CornerLeftDownIcon/dist/keystone-ui-icons-icons-CornerLeftDownIcon.cjs.js"
+    },
+    "./icons/GitPullRequestIcon": {
+      "module": "./icons/GitPullRequestIcon/dist/keystone-ui-icons-icons-GitPullRequestIcon.esm.js",
+      "default": "./icons/GitPullRequestIcon/dist/keystone-ui-icons-icons-GitPullRequestIcon.cjs.js"
+    },
+    "./icons/MoreHorizontalIcon": {
+      "module": "./icons/MoreHorizontalIcon/dist/keystone-ui-icons-icons-MoreHorizontalIcon.esm.js",
+      "default": "./icons/MoreHorizontalIcon/dist/keystone-ui-icons-icons-MoreHorizontalIcon.cjs.js"
+    },
+    "./icons/PhoneForwardedIcon": {
+      "module": "./icons/PhoneForwardedIcon/dist/keystone-ui-icons-icons-PhoneForwardedIcon.esm.js",
+      "default": "./icons/PhoneForwardedIcon/dist/keystone-ui-icons-icons-PhoneForwardedIcon.cjs.js"
+    },
+    "./icons/ArrowDownCircleIcon": {
+      "module": "./icons/ArrowDownCircleIcon/dist/keystone-ui-icons-icons-ArrowDownCircleIcon.esm.js",
+      "default": "./icons/ArrowDownCircleIcon/dist/keystone-ui-icons-icons-ArrowDownCircleIcon.cjs.js"
+    },
+    "./icons/ArrowLeftCircleIcon": {
+      "module": "./icons/ArrowLeftCircleIcon/dist/keystone-ui-icons-icons-ArrowLeftCircleIcon.esm.js",
+      "default": "./icons/ArrowLeftCircleIcon/dist/keystone-ui-icons-icons-ArrowLeftCircleIcon.cjs.js"
+    },
+    "./icons/BatteryChargingIcon": {
+      "module": "./icons/BatteryChargingIcon/dist/keystone-ui-icons-icons-BatteryChargingIcon.esm.js",
+      "default": "./icons/BatteryChargingIcon/dist/keystone-ui-icons-icons-BatteryChargingIcon.cjs.js"
+    },
+    "./icons/CornerDownRightIcon": {
+      "module": "./icons/CornerDownRightIcon/dist/keystone-ui-icons-icons-CornerDownRightIcon.esm.js",
+      "default": "./icons/CornerDownRightIcon/dist/keystone-ui-icons-icons-CornerDownRightIcon.cjs.js"
+    },
+    "./icons/CornerRightDownIcon": {
+      "module": "./icons/CornerRightDownIcon/dist/keystone-ui-icons-icons-CornerRightDownIcon.esm.js",
+      "default": "./icons/CornerRightDownIcon/dist/keystone-ui-icons-icons-CornerRightDownIcon.cjs.js"
+    },
+    "./icons/ArrowRightCircleIcon": {
+      "module": "./icons/ArrowRightCircleIcon/dist/keystone-ui-icons-icons-ArrowRightCircleIcon.esm.js",
+      "default": "./icons/ArrowRightCircleIcon/dist/keystone-ui-icons-icons-ArrowRightCircleIcon.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "node build-icons.js"
   },

--- a/design-system/packages/loading/package.json
+++ b/design-system/packages/loading/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-loading.cjs.js",
   "module": "dist/keystone-ui-loading.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-loading.esm.js",
+      "default": "./dist/keystone-ui-loading.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9"
   },

--- a/design-system/packages/modals/package.json
+++ b/design-system/packages/modals/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-modals.cjs.js",
   "module": "dist/keystone-ui-modals.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-modals.esm.js",
+      "default": "./dist/keystone-ui-modals.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9"
   },

--- a/design-system/packages/notice/package.json
+++ b/design-system/packages/notice/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-notice.cjs.js",
   "module": "dist/keystone-ui-notice.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-notice.esm.js",
+      "default": "./dist/keystone-ui-notice.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9"
   },

--- a/design-system/packages/options/package.json
+++ b/design-system/packages/options/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-options.cjs.js",
   "module": "dist/keystone-ui-options.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-options.esm.js",
+      "default": "./dist/keystone-ui-options.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "react": "^18.1.0"
   },

--- a/design-system/packages/pill/package.json
+++ b/design-system/packages/pill/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-pill.cjs.js",
   "module": "dist/keystone-ui-pill.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-pill.esm.js",
+      "default": "./dist/keystone-ui-pill.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "react": "^18.1.0"
   },

--- a/design-system/packages/popover/package.json
+++ b/design-system/packages/popover/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-popover.cjs.js",
   "module": "dist/keystone-ui-popover.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-popover.esm.js",
+      "default": "./dist/keystone-ui-popover.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/design-system/packages/segmented-control/package.json
+++ b/design-system/packages/segmented-control/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-segmented-control.cjs.js",
   "module": "dist/keystone-ui-segmented-control.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-segmented-control.esm.js",
+      "default": "./dist/keystone-ui-segmented-control.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9",
     "react": "^18.1.0"

--- a/design-system/packages/toast/package.json
+++ b/design-system/packages/toast/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-toast.cjs.js",
   "module": "dist/keystone-ui-toast.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-toast.esm.js",
+      "default": "./dist/keystone-ui-toast.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "devDependencies": {
     "@types/react": "^18.0.9",
     "react": "^18.1.0"

--- a/design-system/packages/tooltip/package.json
+++ b/design-system/packages/tooltip/package.json
@@ -4,6 +4,13 @@
   "license": "MIT",
   "main": "dist/keystone-ui-tooltip.cjs.js",
   "module": "dist/keystone-ui-tooltip.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-ui-tooltip.esm.js",
+      "default": "./dist/keystone-ui-tooltip.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/docs/components/docs/DocumentEditorDemo.tsx
+++ b/docs/components/docs/DocumentEditorDemo.tsx
@@ -1,22 +1,21 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { getInitialPropsValue } from '@keystone-6/fields-document/src/DocumentEditor/component-blocks/initial-values';
 import React, { ReactNode, useContext, useEffect, useMemo, useState } from 'react';
 import { DocumentFeatures } from '@keystone-6/fields-document/views';
-import {
-  createDocumentEditor,
-  DocumentEditor,
-  Editor,
-} from '@keystone-6/fields-document/src/DocumentEditor';
 import {
   ComponentBlock,
   fields,
   InferRenderersForComponentBlocks,
 } from '@keystone-6/fields-document/component-blocks';
 import { Global, jsx } from '@emotion/react';
-
-import { FormValueContentFromPreviewProps } from '@keystone-6/fields-document/src/DocumentEditor/component-blocks/form-from-preview';
-import { createGetPreviewProps } from '@keystone-6/fields-document/src/DocumentEditor/component-blocks/preview-props';
+import { getInitialPropsValue } from '../../../packages/fields-document/src/DocumentEditor/component-blocks/initial-values';
+import {
+  createDocumentEditor,
+  DocumentEditor,
+  Editor,
+} from '../../../packages/fields-document/src/DocumentEditor';
+import { FormValueContentFromPreviewProps } from '../../../packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview';
+import { createGetPreviewProps } from '../../../packages/fields-document/src/DocumentEditor/component-blocks/preview-props';
 import { componentBlocks as componentBlocksInSandboxProject } from '../../../tests/sandbox/component-blocks';
 import { initialContent } from '../../lib/initialDocumentDemoContent';
 import { Code } from '../primitives/Code';

--- a/examples/custom-session-validation/keystone.ts
+++ b/examples/custom-session-validation/keystone.ts
@@ -1,5 +1,4 @@
-import { KeystoneConfig } from '@keystone-6/core/types';
-import { SessionStrategy } from '@keystone-6/core/src/types/session';
+import { KeystoneConfig, SessionStrategy } from '@keystone-6/core/types';
 import { config } from '@keystone-6/core';
 import { statelessSessions } from '@keystone-6/core/session';
 import { createAuth } from '@keystone-6/auth';

--- a/package.json
+++ b/package.json
@@ -93,7 +93,11 @@
       "design-system/packages/*",
       "prisma-utils",
       "scripts/*"
-    ]
+    ],
+    "exports": true,
+    "___experimentalFlags_WILL_CHANGE_IN_PATCH": {
+      "exports": true
+    }
   },
   "manypkg": {
     "defaultBranch": "main"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,6 +4,21 @@
   "license": "MIT",
   "main": "dist/keystone-6-auth.cjs.js",
   "module": "dist/keystone-6-auth.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-auth.esm.js",
+      "default": "./dist/keystone-6-auth.cjs.js"
+    },
+    "./pages/InitPage": {
+      "module": "./pages/InitPage/dist/keystone-6-auth-pages-InitPage.esm.js",
+      "default": "./pages/InitPage/dist/keystone-6-auth-pages-InitPage.cjs.js"
+    },
+    "./pages/SigninPage": {
+      "module": "./pages/SigninPage/dist/keystone-6-auth-pages-SigninPage.esm.js",
+      "default": "./pages/SigninPage/dist/keystone-6-auth-pages-SigninPage.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
     "@keystone-ui/button": "^7.0.1",

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -4,6 +4,17 @@
   "license": "MIT",
   "main": "dist/keystone-6-cloudinary.cjs.js",
   "module": "dist/keystone-6-cloudinary.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-cloudinary.esm.js",
+      "default": "./dist/keystone-6-cloudinary.cjs.js"
+    },
+    "./views": {
+      "module": "./views/dist/keystone-6-cloudinary-views.esm.js",
+      "default": "./views/dist/keystone-6-cloudinary-views.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/runtime": "^7.16.3",
     "@keystone-ui/button": "^7.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,193 @@
   "license": "MIT",
   "main": "dist/keystone-6-core.cjs.js",
   "module": "dist/keystone-6-core.esm.js",
+  "exports": {
+    "./next": {
+      "module": "./next/dist/keystone-6-core-next.esm.js",
+      "default": "./next/dist/keystone-6-core-next.cjs.js"
+    },
+    ".": {
+      "module": "./dist/keystone-6-core.esm.js",
+      "default": "./dist/keystone-6-core.cjs.js"
+    },
+    "./system": {
+      "module": "./system/dist/keystone-6-core-system.esm.js",
+      "default": "./system/dist/keystone-6-core-system.cjs.js"
+    },
+    "./context": {
+      "module": "./context/dist/keystone-6-core-context.esm.js",
+      "default": "./context/dist/keystone-6-core-context.cjs.js"
+    },
+    "./testing": {
+      "module": "./testing/dist/keystone-6-core-testing.esm.js",
+      "default": "./testing/dist/keystone-6-core-testing.cjs.js"
+    },
+    "./scripts/cli": {
+      "module": "./scripts/cli/dist/keystone-6-core-scripts-cli.esm.js",
+      "default": "./scripts/cli/dist/keystone-6-core-scripts-cli.cjs.js"
+    },
+    "./types": {
+      "module": "./types/dist/keystone-6-core-types.esm.js",
+      "default": "./types/dist/keystone-6-core-types.cjs.js"
+    },
+    "./access": {
+      "module": "./access/dist/keystone-6-core-access.esm.js",
+      "default": "./access/dist/keystone-6-core-access.cjs.js"
+    },
+    "./fields": {
+      "module": "./fields/dist/keystone-6-core-fields.esm.js",
+      "default": "./fields/dist/keystone-6-core-fields.cjs.js"
+    },
+    "./scripts": {
+      "module": "./scripts/dist/keystone-6-core-scripts.esm.js",
+      "default": "./scripts/dist/keystone-6-core-scripts.cjs.js"
+    },
+    "./session": {
+      "module": "./session/dist/keystone-6-core-session.esm.js",
+      "default": "./session/dist/keystone-6-core-session.cjs.js"
+    },
+    "./admin-ui/image": {
+      "module": "./admin-ui/image/dist/keystone-6-core-admin-ui-image.esm.js",
+      "default": "./admin-ui/image/dist/keystone-6-core-admin-ui-image.cjs.js"
+    },
+    "./admin-ui/apollo": {
+      "module": "./admin-ui/apollo/dist/keystone-6-core-admin-ui-apollo.esm.js",
+      "default": "./admin-ui/apollo/dist/keystone-6-core-admin-ui-apollo.cjs.js"
+    },
+    "./admin-ui/router": {
+      "module": "./admin-ui/router/dist/keystone-6-core-admin-ui-router.esm.js",
+      "default": "./admin-ui/router/dist/keystone-6-core-admin-ui-router.cjs.js"
+    },
+    "./admin-ui/context": {
+      "module": "./admin-ui/context/dist/keystone-6-core-admin-ui-context.esm.js",
+      "default": "./admin-ui/context/dist/keystone-6-core-admin-ui-context.cjs.js"
+    },
+    "./admin-ui/utils": {
+      "module": "./admin-ui/utils/dist/keystone-6-core-admin-ui-utils.esm.js",
+      "default": "./admin-ui/utils/dist/keystone-6-core-admin-ui-utils.cjs.js"
+    },
+    "./fields/types/image/utils": {
+      "module": "./fields/types/image/utils/dist/keystone-6-core-fields-types-image-utils.esm.js",
+      "default": "./fields/types/image/utils/dist/keystone-6-core-fields-types-image-utils.cjs.js"
+    },
+    "./admin-ui/components": {
+      "module": "./admin-ui/components/dist/keystone-6-core-admin-ui-components.esm.js",
+      "default": "./admin-ui/components/dist/keystone-6-core-admin-ui-components.cjs.js"
+    },
+    "./fields/types/file/views": {
+      "module": "./fields/types/file/views/dist/keystone-6-core-fields-types-file-views.esm.js",
+      "default": "./fields/types/file/views/dist/keystone-6-core-fields-types-file-views.cjs.js"
+    },
+    "./fields/types/json/views": {
+      "module": "./fields/types/json/views/dist/keystone-6-core-fields-types-json-views.esm.js",
+      "default": "./fields/types/json/views/dist/keystone-6-core-fields-types-json-views.cjs.js"
+    },
+    "./fields/types/text/views": {
+      "module": "./fields/types/text/views/dist/keystone-6-core-fields-types-text-views.esm.js",
+      "default": "./fields/types/text/views/dist/keystone-6-core-fields-types-text-views.cjs.js"
+    },
+    "./fields/types/float/views": {
+      "module": "./fields/types/float/views/dist/keystone-6-core-fields-types-float-views.esm.js",
+      "default": "./fields/types/float/views/dist/keystone-6-core-fields-types-float-views.cjs.js"
+    },
+    "./fields/types/image/views": {
+      "module": "./fields/types/image/views/dist/keystone-6-core-fields-types-image-views.esm.js",
+      "default": "./fields/types/image/views/dist/keystone-6-core-fields-types-image-views.cjs.js"
+    },
+    "./fields/types/bigInt/views": {
+      "module": "./fields/types/bigInt/views/dist/keystone-6-core-fields-types-bigInt-views.esm.js",
+      "default": "./fields/types/bigInt/views/dist/keystone-6-core-fields-types-bigInt-views.cjs.js"
+    },
+    "./fields/types/select/views": {
+      "module": "./fields/types/select/views/dist/keystone-6-core-fields-types-select-views.esm.js",
+      "default": "./fields/types/select/views/dist/keystone-6-core-fields-types-select-views.cjs.js"
+    },
+    "./fields/types/decimal/views": {
+      "module": "./fields/types/decimal/views/dist/keystone-6-core-fields-types-decimal-views.esm.js",
+      "default": "./fields/types/decimal/views/dist/keystone-6-core-fields-types-decimal-views.cjs.js"
+    },
+    "./fields/types/integer/views": {
+      "module": "./fields/types/integer/views/dist/keystone-6-core-fields-types-integer-views.esm.js",
+      "default": "./fields/types/integer/views/dist/keystone-6-core-fields-types-integer-views.cjs.js"
+    },
+    "./fields/types/virtual/views": {
+      "module": "./fields/types/virtual/views/dist/keystone-6-core-fields-types-virtual-views.esm.js",
+      "default": "./fields/types/virtual/views/dist/keystone-6-core-fields-types-virtual-views.cjs.js"
+    },
+    "./fields/types/checkbox/views": {
+      "module": "./fields/types/checkbox/views/dist/keystone-6-core-fields-types-checkbox-views.esm.js",
+      "default": "./fields/types/checkbox/views/dist/keystone-6-core-fields-types-checkbox-views.cjs.js"
+    },
+    "./fields/types/password/views": {
+      "module": "./fields/types/password/views/dist/keystone-6-core-fields-types-password-views.esm.js",
+      "default": "./fields/types/password/views/dist/keystone-6-core-fields-types-password-views.cjs.js"
+    },
+    "./fields/types/timestamp/views": {
+      "module": "./fields/types/timestamp/views/dist/keystone-6-core-fields-types-timestamp-views.esm.js",
+      "default": "./fields/types/timestamp/views/dist/keystone-6-core-fields-types-timestamp-views.cjs.js"
+    },
+    "./fields/types/calendarDay/views": {
+      "module": "./fields/types/calendarDay/views/dist/keystone-6-core-fields-types-calendarDay-views.esm.js",
+      "default": "./fields/types/calendarDay/views/dist/keystone-6-core-fields-types-calendarDay-views.cjs.js"
+    },
+    "./fields/types/multiselect/views": {
+      "module": "./fields/types/multiselect/views/dist/keystone-6-core-fields-types-multiselect-views.esm.js",
+      "default": "./fields/types/multiselect/views/dist/keystone-6-core-fields-types-multiselect-views.cjs.js"
+    },
+    "./fields/types/relationship/views": {
+      "module": "./fields/types/relationship/views/dist/keystone-6-core-fields-types-relationship-views.esm.js",
+      "default": "./fields/types/relationship/views/dist/keystone-6-core-fields-types-relationship-views.cjs.js"
+    },
+    "./fields/types/relationship/views/RelationshipSelect": {
+      "module": "./fields/types/relationship/views/RelationshipSelect/dist/keystone-6-core-fields-types-relationship-views-RelationshipSelect.esm.js",
+      "default": "./fields/types/relationship/views/RelationshipSelect/dist/keystone-6-core-fields-types-relationship-views-RelationshipSelect.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/artifacts": {
+      "module": "./___internal-do-not-use-will-break-in-patch/artifacts/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-artifacts.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/artifacts/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-artifacts.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/load-config": {
+      "module": "./___internal-do-not-use-will-break-in-patch/load-config/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-load-config.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/load-config/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-load-config.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/next-graphql": {
+      "module": "./___internal-do-not-use-will-break-in-patch/next-graphql/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-next-graphql.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/next-graphql/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-next-graphql.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/next-config": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/next-config/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-next-config.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/next-config/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-next-config.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/id-field-view": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/id-field-view/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-id-field-view.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/id-field-view/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-id-field-view.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/App": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/App/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-App.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/App/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-App.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-HomePage.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/HomePage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-HomePage.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-ItemPage.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-ItemPage.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-ListPage.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-ListPage.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/NoAccessPage": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/NoAccessPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-NoAccessPage.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/NoAccessPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-NoAccessPage.cjs.js"
+    },
+    "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage": {
+      "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-CreateItemPage.esm.js",
+      "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-CreateItemPage.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {
     "keystone": "bin/cli.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -190,7 +190,8 @@
       "module": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-CreateItemPage.esm.js",
       "default": "./___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/dist/keystone-6-core-___internal-do-not-use-will-break-in-patch-admin-ui-pages-CreateItemPage.cjs.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./bin/cli.js": "./bin/cli.js"
   },
   "bin": {
     "keystone": "bin/cli.js"
@@ -335,6 +336,11 @@
       "fields/types/{image,file}/utils.ts",
       "types/index.ts",
       "access/index.ts"
-    ]
+    ],
+    "exports": {
+      "extra": {
+        "./bin/cli.js": "./bin/cli.js"
+      }
+    }
   }
 }

--- a/packages/document-renderer/package.json
+++ b/packages/document-renderer/package.json
@@ -5,6 +5,13 @@
   "license": "MIT",
   "main": "dist/keystone-6-document-renderer.cjs.js",
   "module": "dist/keystone-6-document-renderer.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-document-renderer.esm.js",
+      "default": "./dist/keystone-6-document-renderer.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "react": "^16.14.0 || 17 || 18"
   },

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -5,6 +5,25 @@
   "license": "MIT",
   "main": "dist/keystone-6-fields-document.cjs.js",
   "module": "dist/keystone-6-fields-document.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-fields-document.esm.js",
+      "default": "./dist/keystone-6-fields-document.cjs.js"
+    },
+    "./views": {
+      "module": "./views/dist/keystone-6-fields-document-views.esm.js",
+      "default": "./views/dist/keystone-6-fields-document-views.cjs.js"
+    },
+    "./primitives": {
+      "module": "./primitives/dist/keystone-6-fields-document-primitives.esm.js",
+      "default": "./primitives/dist/keystone-6-fields-document-primitives.cjs.js"
+    },
+    "./component-blocks": {
+      "module": "./component-blocks/dist/keystone-6-fields-document-component-blocks.esm.js",
+      "default": "./component-blocks/dist/keystone-6-fields-document-component-blocks.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist",
     "component-blocks",

--- a/prisma-utils/package.json
+++ b/prisma-utils/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.2",
   "private": true,
   "main": "dist/keystone-6-prisma-utils.cjs.js",
+  "module": "dist/keystone-6-prisma-utils.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-prisma-utils.esm.js",
+      "default": "./dist/keystone-6-prisma-utils.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@prisma/generator-helper": "4.3.1",
     "@prisma/internals": "4.3.1",

--- a/scripts/generate-artifacts-for-projects/package.json
+++ b/scripts/generate-artifacts-for-projects/package.json
@@ -3,6 +3,14 @@
   "version": "0.0.3",
   "private": true,
   "main": "dist/keystone-6-generate-artifacts-for-projects.cjs.js",
+  "module": "dist/keystone-6-generate-artifacts-for-projects.esm.js",
+  "exports": {
+    ".": {
+      "module": "./dist/keystone-6-generate-artifacts-for-projects.esm.js",
+      "default": "./dist/keystone-6-generate-artifacts-for-projects.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@keystone-6/core": "^3.0.0"
   },

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -1,8 +1,8 @@
 import { list } from '@keystone-6/core';
 import { allowAll } from '@keystone-6/core/access';
 import { text } from '@keystone-6/core/fields';
-import { staticAdminMetaQuery } from '@keystone-6/core/src/admin-ui/admin-meta-graphql';
 import { setupTestRunner } from '@keystone-6/api-tests/test-runner';
+import { staticAdminMetaQuery } from '../../packages/core/src/admin-ui/admin-meta-graphql';
 import { apiTestConfig, dbProvider } from './utils';
 
 const runner = setupTestRunner({

--- a/tests/api-tests/fields/crud.test.ts
+++ b/tests/api-tests/fields/crud.test.ts
@@ -3,8 +3,8 @@ import { list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { KeystoneContext } from '@keystone-6/core/types';
 import { setupTestRunner } from '@keystone-6/api-tests/test-runner';
-import { humanize } from '@keystone-6/core/src/lib/utils';
 import { allowAll } from '@keystone-6/core/access';
+import { humanize } from '../../../packages/core/src/lib/utils';
 import { apiTestConfig, expectSingleResolverError, expectValidationError } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {

--- a/tests/api-tests/fields/required.test.ts
+++ b/tests/api-tests/fields/required.test.ts
@@ -5,8 +5,8 @@ import globby from 'globby';
 import { list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { setupTestRunner } from '@keystone-6/api-tests/test-runner';
-import { humanize } from '@keystone-6/core/src/lib/utils';
 import { allowAll } from '@keystone-6/core/access';
+import { humanize } from '../../../packages/core/src/lib/utils';
 import { apiTestConfig, expectValidationError } from '../utils';
 
 const testModules = globby.sync(`packages/**/src/**/test-fixtures.{js,ts}`, {

--- a/tests/api-tests/test-runner.ts
+++ b/tests/api-tests/test-runner.ts
@@ -24,7 +24,7 @@ import {
   PrismaModule,
 } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/artifacts';
 import prismaClientPackageJson from '@prisma/client/package.json';
-import { runMigrateWithDbUrl, withMigrate } from '@keystone-6/core/src/lib/migrations';
+import { runMigrateWithDbUrl, withMigrate } from '../../packages/core/src/lib/migrations';
 import { dbProvider, dbUrl, SQLITE_DATABASE_FILENAME } from './utils';
 
 export type TestArgs<TypeInfo extends BaseKeystoneTypeInfo> = {


### PR DESCRIPTION
This adds [the `exports` fields to the packages using Preconstruct](https://preconstruct.tools/configuration#exports), the only ways this really affects consumers is that:

- Entrypoints that are not at the root of a package can be imported from Node ESM (the root could be imported previously)
- In Node, some bundlers and TypeScript's `"moduleResolution": "nodenext"`, anything that isn't specified in the exports will not be allowed to be imported outside the package. For example, people won't be able to reach into the dist directory and import some random file. (Note this also applies in CommonJS, not only ESM)

For people who have seen the `exports` field before, you might be expecting to see the `import` condition used. We are intentionally not using it here as we don't ship ESM for Node. We do use the `module` condition though which is respected by some bundlers (but not Node).