### PR TITLE
Add labelField, searchFields support for relationship field

### DIFF
--- a/.changeset/thirty-apples-cry.md
+++ b/.changeset/thirty-apples-cry.md
@@ -1,5 +1,6 @@
 ---
 '@keystone-6/core': patch
+'@keystone-6/fields-document': patch
 ---
 
-Fix relationship fields not using their `ui.labelField` configuration
+Fix relationship fields not respecting their `ui.labelField` configuration

--- a/.changeset/thirty-apples-cry.md
+++ b/.changeset/thirty-apples-cry.md
@@ -3,4 +3,4 @@
 '@keystone-6/fields-document': patch
 ---
 
-Fix relationship fields not respecting their `ui.labelField` configuration
+Fix relationship fields not using their `ui.labelField` configuration

--- a/.changeset/thirty-strawberries-kick.md
+++ b/.changeset/thirty-strawberries-kick.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds `ui.searchFields` for the relationship field

--- a/docs/pages/docs/fields/relationship.md
+++ b/docs/pages/docs/fields/relationship.md
@@ -16,6 +16,9 @@ Read our [relationships guide](../guides/relationships) for details on Keystoneâ
   - `displayMode` (default: `'select'`): Controls the mode used to display the field in the item view. The mode `'select'` displays related items in a select component, while `'cards'` displays the related items in a card layout. Each display mode supports further configuration.
 - `ui.displayMode === 'select'` options:
   - `labelField`: The field path from the related list to use for item labels in the select. Defaults to the `labelField` configured on the related list.
+{% if $nextRelease %}
+  - `searchFields`: The fields used by the UI to search for this item, in context of this relationship field. Defaults to `searchFields` configured on the related list.
+{% /if %}
 - `ui.displayMode === 'cards'` options:
   - `cardFields`: A list of field paths from the related list to render in the card component. Defaults to `'id'` and the `labelField` configured on the related list.
   - `linkToItem` (default `false`): If `true`, the default card component will render as a link to navigate to the related item.
@@ -23,6 +26,11 @@ Read our [relationships guide](../guides/relationships) for details on Keystoneâ
   - `inlineCreate` (default: `null`): If not `null`, an object of the form `{ fields: [...] }`, where `fields` is a list of field paths from the related list should be provided. An inline `Create` button will be included in the cards allowing a new related item to be created based on the configured field paths.
   - `inlineEdit` (default: `null`): If not `null`, an object of the form `{ fields: [...] }`, where `fields` is a list of field paths from the related list should be provided. An `Edit` button will be included in each card, allowing the configured fields to be edited for each related item.
   - `inlineConnect` (default: `false`): If `true`, an inline `Link existing item` button will be present, allowing existing items of the related list to be connected in this field.
+{% if $nextRelease %}
+  Alternatively this can be an object with the properties:
+	- `labelField`: The field path from the related list to use for item labels in select. Defaults to the `labelField` configured on the related list.
+	- `searchFields`: The fields used by the UI to search for this item, in context of this relationship field. Defaults to `searchFields` configured on the related list.
+{% /if %}
 - `ui.displayMode === 'count'` only supports `many` relationships
 
 ```typescript

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -137,14 +137,14 @@ const ListPage = ({ listKey }: ListPageProps) => {
 
   const { resetToDefaults } = useQueryParamsFromLocalStorage(listKey);
 
-  let currentPage =
+  const currentPage =
     typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1;
-  let pageSize =
+  const pageSize =
     typeof query.pageSize === 'string' && !Number.isNaN(parseInt(query.pageSize))
       ? parseInt(query.pageSize)
       : list.pageSize;
 
-  let metaQuery = useQuery(listMetaGraphqlQuery, { variables: { listKey } });
+  const metaQuery = useQuery(listMetaGraphqlQuery, { variables: { listKey } });
 
   let { listViewFieldModesByField, filterableFields, orderableFields } = useMemo(() => {
     const listViewFieldModesByField: Record<string, 'read' | 'hidden'> = {};
@@ -166,13 +166,12 @@ const ListPage = ({ listKey }: ListPageProps) => {
   const sort = useSort(list, orderableFields);
   const filters = useFilters(list, filterableFields);
 
-  const searchFields = Object.values(list.fields)
-    .filter(({ search }) => search !== null)
-    .map(({ label }) => label);
+  const searchFields = Object.keys(list.fields).filter(key => list.fields[key].search);
+  const searchLabels = searchFields.map(key => list.fields[key].label);
 
   const searchParam = typeof query.search === 'string' ? query.search : '';
   const [searchString, updateSearchString] = useState(searchParam);
-  const search = useFilter(searchParam, list);
+  const search = useFilter(searchParam, list, searchFields);
 
   const updateSearch = (value: string) => {
     const { search, ...queries } = query;
@@ -283,7 +282,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
                   autoFocus
                   value={searchString}
                   onChange={e => updateSearchString(e.target.value)}
-                  placeholder={`Search by ${searchFields.length ? searchFields.join(', ') : 'ID'}`}
+                  placeholder={`Search by ${searchLabels.length ? searchLabels.join(', ') : 'ID'}`}
                 />
                 <Button css={{ borderRadius: '0px 4px 4px 0px' }} type="submit">
                   <SearchIcon />

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -191,16 +191,19 @@ export function createAdminMeta(
       // Disabling this entirely for now until we properly decide what the Admin UI
       // should do when `omit: ['read']` is used.
       if (field.graphql.isEnabled.read === false) continue;
-      let search = searchFields.has(fieldKey) ? possibleSearchFields.get(fieldKey) ?? null : null;
+
+      const search = searchFields.has(fieldKey) ? possibleSearchFields.get(fieldKey) ?? null : null;
       if (searchFields.has(fieldKey) && search === null) {
         throw new Error(
           `The ui.searchFields option on the ${key} list includes '${fieldKey}' but that field doesn't have a contains filter that accepts a GraphQL String`
         );
       }
+
       assertValidView(
         field.views,
         `The \`views\` on the implementation of the field type at lists.${key}.fields.${fieldKey}`
       );
+
       const baseOrderFilterArgs = { fieldKey, listKey: list.listKey };
       adminMetaRoot.listsByKey[key].fields.push({
         label: field.label ?? humanize(fieldKey),

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -90,7 +90,9 @@ export const relationship =
     const [foreignListKey, foreignFieldKey] = ref.split('.');
     const foreignList = lists[foreignListKey];
     if (!foreignList) {
-      throw new Error(`Unable to resolve list '${foreignListKey}' for ${listKey}.${fieldKey}`);
+      throw new Error(
+        `Unable to resolve list '${foreignListKey}' for field ${listKey}.${fieldKey}`
+      );
     }
     const foreignListTypes = foreignList.types;
 

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -30,7 +30,15 @@ type CardsDisplayConfig = {
     /** Configures inline edit mode for cards */
     inlineEdit?: { fields: readonly string[] };
     /** Configures whether a select to add existing items should be shown or not */
-    inlineConnect?: boolean;
+    inlineConnect?:
+      | boolean
+      | {
+          /**
+           * The path of the field to use from the related list for item labels in the inline connect
+           * Defaults to the labelField configured on the related list.
+           */
+          labelField: string;
+        };
   };
 };
 
@@ -129,8 +137,11 @@ export const relationship =
                 removeMode: config.ui.removeMode ?? 'disconnect',
                 inlineCreate: config.ui.inlineCreate ?? null,
                 inlineEdit: config.ui.inlineEdit ?? null,
-                inlineConnect: config.ui.inlineConnect ?? false,
-                refLabelField: adminMetaRoot.listsByKey[foreignListKey].labelField,
+                inlineConnect: config.ui.inlineConnect ? true : false,
+                refLabelField:
+                  typeof config.ui.inlineConnect === 'object'
+                    ? config.ui.inlineConnect.labelField
+                    : adminMetaRoot.listsByKey[foreignListKey].labelField,
               }
             : config.ui?.displayMode === 'count'
             ? { displayMode: 'count' }

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -12,6 +12,7 @@ type SelectDisplayConfig = {
      * Defaults to the labelField configured on the related list.
      */
     labelField?: string;
+    searchFields?: string[];
   };
 };
 
@@ -38,6 +39,7 @@ type CardsDisplayConfig = {
            * Defaults to the labelField configured on the related list.
            */
           labelField: string;
+          searchFields?: string[];
         };
   };
 };
@@ -141,14 +143,18 @@ export const relationship =
                 refLabelField:
                   typeof config.ui.inlineConnect === 'object'
                     ? config.ui.inlineConnect.labelField
-                    : adminMetaRoot.listsByKey[foreignListKey].labelField,
+                    : null,
+                refSearchFields:
+                  typeof config.ui.inlineConnect === 'object'
+                    ? config.ui.inlineConnect.searchFields ?? null
+                    : null,
               }
             : config.ui?.displayMode === 'count'
             ? { displayMode: 'count' }
             : {
                 displayMode: 'select',
-                refLabelField:
-                  config.ui?.labelField || adminMetaRoot.listsByKey[foreignListKey].labelField,
+                refLabelField: config.ui?.labelField ?? null,
+                refSearchFields: config.ui?.searchFields ?? null,
               }),
         };
       },

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -85,19 +85,25 @@ export const relationship =
     ref,
     ...config
   }: RelationshipFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
-  meta => {
-    const { fieldKey } = meta;
+  ({ fieldKey, listKey, lists }) => {
     const { many = false } = config;
     const [foreignListKey, foreignFieldKey] = ref.split('.');
+    const foreignList = lists[foreignListKey];
+    if (!foreignList) {
+      throw new Error(`Unable to resolve list '${foreignListKey}' for ${listKey}.${fieldKey}`);
+    }
+    const foreignListTypes = foreignList.types;
+
     const commonConfig = {
       ...config,
       views: '@keystone-6/core/fields/types/relationship/views',
       getAdminMeta: (): Parameters<typeof import('./views').controller>[0]['fieldMeta'] => {
         const adminMetaRoot = getAdminMetaForRelationshipField();
-        if (!meta.lists[foreignListKey]) {
-          throw new Error(
-            `The ref [${ref}] on relationship [${meta.listKey}.${meta.fieldKey}] is invalid`
-          );
+        const localListMeta = adminMetaRoot.listsByKey[listKey];
+        const foreignListMeta = adminMetaRoot.listsByKey[foreignListKey];
+
+        if (!foreignListMeta) {
+          throw new Error(`The ref [${ref}] on relationship [${listKey}.${fieldKey}] is invalid`);
         }
 
         if (config.ui?.displayMode === 'cards') {
@@ -105,13 +111,9 @@ export const relationship =
           // in newer versions of keystone, it will be there and it will not be there for older versions of keystone.
           // this is so that relationship fields doesn't break in confusing ways
           // if people are using a slightly older version of keystone
-          const currentField = adminMetaRoot.listsByKey[meta.listKey].fields.find(
-            x => x.key === meta.fieldKey
-          );
+          const currentField = localListMeta.fields.find(x => x.key === fieldKey);
           if (currentField) {
-            const allForeignFields = new Set(
-              adminMetaRoot.listsByKey[foreignListKey].fields.map(x => x.key)
-            );
+            const allForeignFields = new Set(foreignListMeta.fields.map(x => x.key));
             for (const [configOption, foreignFields] of [
               ['ui.cardFields', config.ui.cardFields],
               ['ui.inlineCreate.fields', config.ui.inlineCreate?.fields ?? []],
@@ -120,7 +122,7 @@ export const relationship =
               for (const foreignField of foreignFields) {
                 if (!allForeignFields.has(foreignField)) {
                   throw new Error(
-                    `The ${configOption} option on the relationship field at ${meta.listKey}.${meta.fieldKey} includes the "${foreignField}" field but that field does not exist on the "${foreignListKey}" list`
+                    `The ${configOption} option on the relationship field at ${listKey}.${fieldKey} includes the "${foreignField}" field but that field does not exist on the "${foreignListKey}" list`
                   );
                 }
               }
@@ -128,10 +130,9 @@ export const relationship =
           }
         }
 
-        const foreignList = adminMetaRoot.listsByKey[foreignListKey];
         const hideCreate = config.ui?.hideCreate ?? false;
-        const refLabelField: typeof foreignFieldKey = foreignList.labelField;
-        const refSearchFields: typeof foreignFieldKey[] = foreignList.fields
+        const refLabelField: typeof foreignFieldKey = foreignListMeta.labelField;
+        const refSearchFields: typeof foreignFieldKey[] = foreignListMeta.fields
           .filter(x => x.search)
           .map(x => x.key);
 
@@ -176,20 +177,20 @@ export const relationship =
           };
         }
 
-        if (!(refLabelField in foreignList.fieldsByKey)) {
+        if (!(refLabelField in foreignListMeta.fieldsByKey)) {
           throw new Error(
             `The ui.labelField option for field '${fieldKey}' uses '${refLabelField}' but that field doesn't exist.`
           );
         }
 
         for (const searchFieldKey of refSearchFields) {
-          if (!(searchFieldKey in foreignList.fieldsByKey)) {
+          if (!(searchFieldKey in foreignListMeta.fieldsByKey)) {
             throw new Error(
               `The ui.searchFields option for relationship field '${fieldKey}' includes '${searchFieldKey}' but that field doesn't exist.`
             );
           }
 
-          const field = foreignList.fieldsByKey[searchFieldKey];
+          const field = foreignListMeta.fieldsByKey[searchFieldKey];
           if (field.search) continue;
 
           throw new Error(
@@ -208,12 +209,7 @@ export const relationship =
         };
       },
     };
-    if (!meta.lists[foreignListKey]) {
-      throw new Error(
-        `Unable to resolve related list '${foreignListKey}' from ${meta.listKey}.${meta.fieldKey}`
-      );
-    }
-    const listTypes = meta.lists[foreignListKey].types;
+
     if (config.many) {
       return fieldType({
         kind: 'relation',
@@ -225,36 +221,39 @@ export const relationship =
         ...commonConfig,
         input: {
           where: {
-            arg: graphql.arg({ type: listTypes.relateTo.many.where }),
+            arg: graphql.arg({ type: foreignListTypes.relateTo.many.where }),
             resolve(value, context, resolve) {
               return resolve(value);
             },
           },
-          create: listTypes.relateTo.many.create && {
-            arg: graphql.arg({ type: listTypes.relateTo.many.create }),
+          create: foreignListTypes.relateTo.many.create && {
+            arg: graphql.arg({ type: foreignListTypes.relateTo.many.create }),
             async resolve(value, context, resolve) {
               return resolve(value);
             },
           },
-          update: listTypes.relateTo.many.update && {
-            arg: graphql.arg({ type: listTypes.relateTo.many.update }),
+          update: foreignListTypes.relateTo.many.update && {
+            arg: graphql.arg({ type: foreignListTypes.relateTo.many.update }),
             async resolve(value, context, resolve) {
               return resolve(value);
             },
           },
         },
         output: graphql.field({
-          args: listTypes.findManyArgs,
-          type: graphql.list(graphql.nonNull(listTypes.output)),
+          args: foreignListTypes.findManyArgs,
+          type: graphql.list(graphql.nonNull(foreignListTypes.output)),
           resolve({ value }, args) {
             return value.findMany(args);
           },
         }),
         extraOutputFields: {
-          [`${meta.fieldKey}Count`]: graphql.field({
+          [`${fieldKey}Count`]: graphql.field({
             type: graphql.Int,
             args: {
-              where: graphql.arg({ type: graphql.nonNull(listTypes.where), defaultValue: {} }),
+              where: graphql.arg({
+                type: graphql.nonNull(foreignListTypes.where),
+                defaultValue: {},
+              }),
             },
             resolve({ value }, args) {
               return value.count({
@@ -265,6 +264,7 @@ export const relationship =
         },
       });
     }
+
     return fieldType({
       kind: 'relation',
       mode: 'one',
@@ -275,27 +275,27 @@ export const relationship =
       ...commonConfig,
       input: {
         where: {
-          arg: graphql.arg({ type: listTypes.where }),
+          arg: graphql.arg({ type: foreignListTypes.where }),
           resolve(value, context, resolve) {
             return resolve(value);
           },
         },
-        create: listTypes.relateTo.one.create && {
-          arg: graphql.arg({ type: listTypes.relateTo.one.create }),
+        create: foreignListTypes.relateTo.one.create && {
+          arg: graphql.arg({ type: foreignListTypes.relateTo.one.create }),
           async resolve(value, context, resolve) {
             return resolve(value);
           },
         },
 
-        update: listTypes.relateTo.one.update && {
-          arg: graphql.arg({ type: listTypes.relateTo.one.update }),
+        update: foreignListTypes.relateTo.one.update && {
+          arg: graphql.arg({ type: foreignListTypes.relateTo.one.update }),
           async resolve(value, context, resolve) {
             return resolve(value);
           },
         },
       },
       output: graphql.field({
-        type: listTypes.output,
+        type: foreignListTypes.output,
         resolve({ value }) {
           return value();
         },

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -126,36 +126,62 @@ export const relationship =
           }
         }
 
+        const foreignList = adminMetaRoot.listsByKey[foreignListKey];
+        const hideCreate = config.ui?.hideCreate ?? false;
+        const refLabelField: typeof foreignFieldKey = foreignList.labelField;
+        const refSearchFields: typeof foreignFieldKey[] = foreignList.fields
+          .filter(x => x.search)
+          .map(x => x.path);
+
+        if (config.ui?.displayMode === 'select') {
+          return {
+            refFieldKey: foreignFieldKey,
+            refListKey: foreignListKey,
+            many,
+            hideCreate,
+            displayMode: 'select',
+
+            // prefer the local definition to the foreign list, if provided
+            refLabelField: config.ui.labelField || refLabelField,
+            refSearchFields: config.ui.searchFields || refSearchFields,
+          };
+        }
+
+        if (config.ui?.displayMode === 'cards') {
+          return {
+            refFieldKey: foreignFieldKey,
+            refListKey: foreignListKey,
+            many,
+            hideCreate,
+            displayMode: 'cards',
+            cardFields: config.ui.cardFields,
+            linkToItem: config.ui.linkToItem ?? false,
+            removeMode: config.ui.removeMode ?? 'disconnect',
+            inlineCreate: config.ui.inlineCreate ?? null,
+            inlineEdit: config.ui.inlineEdit ?? null,
+            inlineConnect: config.ui.inlineConnect ? true : false,
+
+            // prefer the local definition to the foreign list, if provided
+            ...(typeof config.ui.inlineConnect === 'object'
+              ? {
+                  refLabelField: config.ui.inlineConnect.labelField ?? refLabelField,
+                  refSearchFields: config.ui.inlineConnect?.searchFields ?? refSearchFields,
+                }
+              : {
+                  refLabelField,
+                  refSearchFields,
+                }),
+          };
+        }
+
         return {
           refFieldKey: foreignFieldKey,
           refListKey: foreignListKey,
           many,
-          hideCreate: config.ui?.hideCreate ?? false,
-          ...(config.ui?.displayMode === 'cards'
-            ? {
-                displayMode: 'cards',
-                cardFields: config.ui.cardFields,
-                linkToItem: config.ui.linkToItem ?? false,
-                removeMode: config.ui.removeMode ?? 'disconnect',
-                inlineCreate: config.ui.inlineCreate ?? null,
-                inlineEdit: config.ui.inlineEdit ?? null,
-                inlineConnect: config.ui.inlineConnect ? true : false,
-                refLabelField:
-                  typeof config.ui.inlineConnect === 'object'
-                    ? config.ui.inlineConnect.labelField
-                    : null,
-                refSearchFields:
-                  typeof config.ui.inlineConnect === 'object'
-                    ? config.ui.inlineConnect.searchFields ?? null
-                    : null,
-              }
-            : config.ui?.displayMode === 'count'
-            ? { displayMode: 'count' }
-            : {
-                displayMode: 'select',
-                refLabelField: config.ui?.labelField ?? null,
-                refSearchFields: config.ui?.searchFields ?? null,
-              }),
+          hideCreate,
+          displayMode: 'count',
+          refLabelField,
+          refSearchFields,
         };
       },
     };

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -98,17 +98,18 @@ export const relationship =
             `The ref [${ref}] on relationship [${meta.listKey}.${meta.fieldKey}] is invalid`
           );
         }
+
         if (config.ui?.displayMode === 'cards') {
           // we're checking whether the field which will be in the admin meta at the time that getAdminMeta is called.
           // in newer versions of keystone, it will be there and it will not be there for older versions of keystone.
           // this is so that relationship fields doesn't break in confusing ways
           // if people are using a slightly older version of keystone
           const currentField = adminMetaRoot.listsByKey[meta.listKey].fields.find(
-            x => x.path === meta.fieldKey
+            x => x.key === meta.fieldKey
           );
           if (currentField) {
             const allForeignFields = new Set(
-              adminMetaRoot.listsByKey[foreignListKey].fields.map(x => x.path)
+              adminMetaRoot.listsByKey[foreignListKey].fields.map(x => x.key)
             );
             for (const [configOption, foreignFields] of [
               ['ui.cardFields', config.ui.cardFields],
@@ -131,7 +132,7 @@ export const relationship =
         const refLabelField: typeof foreignFieldKey = foreignList.labelField;
         const refSearchFields: typeof foreignFieldKey[] = foreignList.fields
           .filter(x => x.search)
-          .map(x => x.path);
+          .map(x => x.key);
 
         if (config.ui?.displayMode === 'select') {
           return {

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -86,6 +86,7 @@ export const relationship =
     ...config
   }: RelationshipFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> =>
   meta => {
+    const { fieldKey } = meta;
     const { many = false } = config;
     const [foreignListKey, foreignFieldKey] = ref.split('.');
     const commonConfig = {
@@ -173,6 +174,27 @@ export const relationship =
                   refSearchFields,
                 }),
           };
+        }
+
+        if (!(refLabelField in foreignList.fieldsByKey)) {
+          throw new Error(
+            `The ui.labelField option for field '${fieldKey}' uses '${refLabelField}' but that field doesn't exist.`
+          );
+        }
+
+        for (const searchFieldKey of refSearchFields) {
+          if (!(searchFieldKey in foreignList.fieldsByKey)) {
+            throw new Error(
+              `The ui.searchFields option for relationship field '${fieldKey}' includes '${searchFieldKey}' but that field doesn't exist.`
+            );
+          }
+
+          const field = foreignList.fieldsByKey[searchFieldKey];
+          if (field.search) continue;
+
+          throw new Error(
+            `The ui.searchFields option for field '${fieldKey}' includes '${searchFieldKey}' but that field doesn't have a contains filter that accepts a GraphQL String`
+          );
         }
 
         return {

--- a/packages/core/src/fields/types/relationship/tests/implementation.test.ts
+++ b/packages/core/src/fields/types/relationship/tests/implementation.test.ts
@@ -135,7 +135,7 @@ describe('Type Generation', () => {
 describe('Referenced list errors', () => {
   test('throws when list not found', async () => {
     expect(() => getSchema(relationship({ ref: 'DoesNotExist' }))).toThrow(
-      "Unable to resolve related list 'DoesNotExist' from Test.foo"
+      "Unable to resolve list 'DoesNotExist' for field Test.foo"
     );
   });
 

--- a/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
+++ b/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
@@ -84,9 +84,9 @@ export function useFilter(search: string, list: ListMeta) {
   }, [search, list]);
 }
 
-const idField = '____id____';
+const idFieldAlias = '____id____';
 
-const labelField = '____label____';
+const labelFieldAlias = '____label____';
 
 const LoadingIndicatorContext = createContext<{
   count: number;
@@ -101,6 +101,7 @@ export const RelationshipSelect = ({
   controlShouldRenderValue,
   isDisabled,
   isLoading,
+  labelField,
   list,
   placeholder,
   portalMenu,
@@ -111,6 +112,7 @@ export const RelationshipSelect = ({
   controlShouldRenderValue: boolean;
   isDisabled: boolean;
   isLoading?: boolean;
+  labelField: string | null;
   list: ListMeta;
   placeholder?: string;
   portalMenu?: true | undefined;
@@ -135,13 +137,13 @@ export const RelationshipSelect = ({
   const [loadingIndicatorElement, setLoadingIndicatorElement] = useState<null | HTMLElement>(null);
 
   const QUERY: TypedDocumentNode<
-    { items: { [idField]: string; [labelField]: string | null }[]; count: number },
+    { items: { [idFieldAlias]: string; [labelFieldAlias]: string | null }[]; count: number },
     { where: Record<string, any>; take: number; skip: number }
   > = gql`
     query RelationshipSelect($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!) {
       items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip) {
-        ${idField}: id
-        ${labelField}: ${list.labelField}
+        ${idFieldAlias}: id
+        ${labelFieldAlias}: ${labelField}
         ${extraSelection}
       }
       count: ${list.gqlNames.listQueryCountName}(where: $where)
@@ -192,7 +194,7 @@ export const RelationshipSelect = ({
   const count = data?.count || 0;
 
   const options =
-    data?.items?.map(({ [idField]: value, [labelField]: label, ...data }) => ({
+    data?.items?.map(({ [idFieldAlias]: value, [labelFieldAlias]: label, ...data }) => ({
       value,
       label: label || value,
       data,
@@ -229,13 +231,13 @@ export const RelationshipSelect = ({
           lastFetchMore?.skip !== skip)
       ) {
         const QUERY: TypedDocumentNode<
-          { items: { [idField]: string; [labelField]: string | null }[] },
+          { items: { [idFieldAlias]: string; [labelFieldAlias]: string | null }[] },
           { where: Record<string, any>; take: number; skip: number }
         > = gql`
               query RelationshipSelectMore($where: ${list.gqlNames.whereInputName}!, $take: Int!, $skip: Int!) {
                 items: ${list.gqlNames.listQueryName}(where: $where, take: $take, skip: $skip) {
-                  ${labelField}: ${list.labelField}
-                  ${idField}: id
+                  ${labelFieldAlias}: ${labelField}
+                  ${idFieldAlias}: id
                   ${extraSelection}
                 }
               }

--- a/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
+++ b/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
@@ -56,7 +56,7 @@ function useDebouncedValue<T>(value: T, limitMs: number): T {
   return debouncedValue;
 }
 
-export function useFilter(search: string, list: ListMeta, searchFields: string[] | null) {
+export function useFilter(search: string, list: ListMeta, searchFields: string[]) {
   return useMemo(() => {
     if (!search.length) return { OR: [] };
 
@@ -69,12 +69,8 @@ export function useFilter(search: string, list: ListMeta, searchFields: string[]
       conditions.push({ id: { equals: trimmedSearch } });
     }
 
-    // prefer the relationship field's ui.searchFields before defaulting to the list definition
-    const _fields = searchFields
-      ? searchFields.map(x => list.fields[x])
-      : Object.values(list.fields).filter(x => x.search);
-
-    for (const field of _fields) {
+    for (const fieldKey of searchFields) {
+      const field = list.fields[fieldKey];
       conditions.push({
         [field.path]: {
           contains: trimmedSearch,
@@ -104,8 +100,8 @@ export const RelationshipSelect = ({
   controlShouldRenderValue,
   isDisabled,
   isLoading,
-  labelField = null,
-  searchFields = null,
+  labelField,
+  searchFields,
   list,
   placeholder,
   portalMenu,
@@ -116,8 +112,8 @@ export const RelationshipSelect = ({
   controlShouldRenderValue: boolean;
   isDisabled: boolean;
   isLoading?: boolean;
-  labelField?: string | null;
-  searchFields?: string[] | null;
+  labelField: string;
+  searchFields: string[];
   list: ListMeta;
   placeholder?: string;
   portalMenu?: true | undefined;

--- a/packages/core/src/fields/types/relationship/views/cards/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/index.tsx
@@ -294,6 +294,7 @@ export function Cards({
               autoFocus
               controlShouldRenderValue={isLoadingLazyItems}
               isDisabled={onChange === undefined}
+              labelField={field.refLabelField}
               list={foreignList}
               isLoading={isLoadingLazyItems}
               placeholder={`Select a ${foreignList.singular}`}

--- a/packages/core/src/fields/types/relationship/views/cards/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/index.tsx
@@ -294,8 +294,9 @@ export function Cards({
               autoFocus
               controlShouldRenderValue={isLoadingLazyItems}
               isDisabled={onChange === undefined}
-              labelField={field.refLabelField}
               list={foreignList}
+              labelField={field.refLabelField}
+              searchFields={field.refSearchFields}
               isLoading={isLoadingLazyItems}
               placeholder={`Select a ${foreignList.singular}`}
               portalMenu

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -132,6 +132,7 @@ export const Field = ({
             autoFocus={autoFocus}
             isDisabled={onChange === undefined}
             labelField={field.refLabelField}
+            searchFields={field.refSearchFields}
             list={foreignList}
             portalMenu
             state={
@@ -345,9 +346,10 @@ type RelationshipController = FieldController<
 > & {
   display: 'count' | 'cards-or-select';
   listKey: string;
-  refLabelField: string | null;
   refListKey: string;
   refFieldKey?: string;
+  refLabelField: string | null;
+  refSearchFields: string[] | null;
   hideCreate: boolean;
   many: boolean;
 };
@@ -362,7 +364,8 @@ export const controller = (
     } & (
       | {
           displayMode: 'select';
-          refLabelField: string;
+          refLabelField: string | null;
+          refSearchFields: string[] | null;
         }
       | {
           displayMode: 'cards';
@@ -372,7 +375,8 @@ export const controller = (
           inlineCreate: { fields: readonly string[] } | null;
           inlineEdit: { fields: readonly string[] } | null;
           inlineConnect: boolean;
-          refLabelField: string;
+          refLabelField: string | null;
+          refSearchFields: string[] | null;
         }
       | { displayMode: 'count' }
     )
@@ -399,6 +403,8 @@ export const controller = (
     description: config.description,
     display: config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
     refLabelField: config.fieldMeta.displayMode === 'count' ? null : config.fieldMeta.refLabelField,
+    refSearchFields:
+      config.fieldMeta.displayMode === 'count' ? null : config.fieldMeta.refSearchFields,
     refListKey: config.fieldMeta.refListKey,
     graphqlSelection:
       config.fieldMeta.displayMode === 'count'

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -348,8 +348,8 @@ type RelationshipController = FieldController<
   listKey: string;
   refListKey: string;
   refFieldKey?: string;
-  refLabelField: string | null;
-  refSearchFields: string[] | null;
+  refLabelField: string;
+  refSearchFields: string[];
   hideCreate: boolean;
   many: boolean;
 };
@@ -361,11 +361,11 @@ export const controller = (
       refListKey: string;
       many: boolean;
       hideCreate: boolean;
+      refLabelField: string;
+      refSearchFields: string[];
     } & (
       | {
           displayMode: 'select';
-          refLabelField: string | null;
-          refSearchFields: string[] | null;
         }
       | {
           displayMode: 'cards';
@@ -375,10 +375,10 @@ export const controller = (
           inlineCreate: { fields: readonly string[] } | null;
           inlineEdit: { fields: readonly string[] } | null;
           inlineConnect: boolean;
-          refLabelField: string | null;
-          refSearchFields: string[] | null;
         }
-      | { displayMode: 'count' }
+      | {
+          displayMode: 'count';
+        }
     )
   >
 ): RelationshipController => {
@@ -394,6 +394,9 @@ export const controller = (
         }
       : undefined;
 
+  const refLabelField = config.fieldMeta.refLabelField;
+  const refSearchFields = config.fieldMeta.refSearchFields;
+
   return {
     refFieldKey: config.fieldMeta.refFieldKey,
     many: config.fieldMeta.many,
@@ -402,16 +405,15 @@ export const controller = (
     label: config.label,
     description: config.description,
     display: config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
-    refLabelField: config.fieldMeta.displayMode === 'count' ? null : config.fieldMeta.refLabelField,
-    refSearchFields:
-      config.fieldMeta.displayMode === 'count' ? null : config.fieldMeta.refSearchFields,
+    refLabelField,
+    refSearchFields,
     refListKey: config.fieldMeta.refListKey,
     graphqlSelection:
       config.fieldMeta.displayMode === 'count'
         ? `${config.path}Count`
         : `${config.path} {
               id
-              label: ${config.fieldMeta.refLabelField}
+              label: ${refLabelField}
             }`,
     hideCreate: config.fieldMeta.hideCreate,
     // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
@@ -508,6 +510,8 @@ export const controller = (
           <RelationshipSelect
             controlShouldRenderValue
             list={foreignList}
+            labelField={refLabelField}
+            searchFields={refSearchFields}
             isLoading={loading}
             isDisabled={onChange === undefined}
             state={state}

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -131,6 +131,7 @@ export const Field = ({
             aria-describedby={field.description === null ? undefined : `${field.path}-description`}
             autoFocus={autoFocus}
             isDisabled={onChange === undefined}
+            labelField={field.refLabelField}
             list={foreignList}
             portalMenu
             state={
@@ -344,6 +345,7 @@ type RelationshipController = FieldController<
 > & {
   display: 'count' | 'cards-or-select';
   listKey: string;
+  refLabelField: string | null;
   refListKey: string;
   refFieldKey?: string;
   hideCreate: boolean;
@@ -396,6 +398,7 @@ export const controller = (
     label: config.label,
     description: config.description,
     display: config.fieldMeta.displayMode === 'count' ? 'count' : 'cards-or-select',
+    refLabelField: config.fieldMeta.displayMode === 'count' ? null : config.fieldMeta.refLabelField,
     refListKey: config.fieldMeta.refListKey,
     graphqlSelection:
       config.fieldMeta.displayMode === 'count'
@@ -630,7 +633,7 @@ function useRelationshipFilterValues({ value, list }: { value: string; list: Lis
   const query = gql`
     query FOREIGNLIST_QUERY($where: ${list.gqlNames.whereInputName}!) {
       items: ${list.gqlNames.listQueryName}(where: $where) {
-        id 
+        id
         ${list.labelField}
       }
     }

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -194,7 +194,7 @@ function getListsWithInitialisedFields(
 
     // Default the labelField to `name`, `label`, or `title` if they exist; otherwise fall back to `id`
     const labelField =
-      (list.ui?.labelField as string | undefined) ??
+      list.ui?.labelField ??
       (list.fields.label
         ? 'label'
         : list.fields.name

--- a/packages/core/src/lib/core/types-for-lists.ts
+++ b/packages/core/src/lib/core/types-for-lists.ts
@@ -1,7 +1,9 @@
 import { CacheHint } from 'apollo-server-types';
+import { GraphQLString, isInputObjectType } from 'graphql';
 import {
   BaseItem,
   GraphQLTypesForList,
+  QueryMode,
   getGqlNames,
   NextFieldType,
   BaseListTypeInfo,
@@ -53,6 +55,11 @@ export type InitialisedList = {
   adminUILabels: { label: string; singular: string; plural: string; path: string };
   cacheHint: ((args: CacheHintArgs) => CacheHint) | undefined;
   listKey: string;
+  ui: {
+    labelField: string;
+    searchFields: Set<string>;
+    searchableFields: Map<string, 'default' | 'insensitive' | null>;
+  };
   lists: Record<string, InitialisedList>;
   dbMap: string | undefined;
   graphql: {
@@ -185,6 +192,22 @@ function getListsWithInitialisedFields(
       };
     }
 
+    // Default the labelField to `name`, `label`, or `title` if they exist; otherwise fall back to `id`
+    const labelField =
+      (list.ui?.labelField as string | undefined) ??
+      (list.fields.label
+        ? 'label'
+        : list.fields.name
+        ? 'name'
+        : list.fields.title
+        ? 'title'
+        : 'id');
+
+    const searchFields = new Set(list.ui?.searchFields ?? []);
+    if (searchFields.has('id')) {
+      throw new Error(`${listKey}.ui.searchFields cannot include 'id'`);
+    }
+
     result[listKey] = {
       fields: resultFields,
       ...intermediateList,
@@ -193,6 +216,11 @@ function getListsWithInitialisedFields(
       dbMap: list.db?.map,
       types: listGraphqlTypes[listKey].types,
 
+      ui: {
+        labelField,
+        searchFields,
+        searchableFields: new Map<string, 'default' | 'insensitive' | null>(),
+      },
       hooks: list.hooks || {},
 
       listKey,
@@ -208,6 +236,38 @@ function getListsWithInitialisedFields(
   }
 
   return result;
+}
+
+function introspectGraphQLTypes(lists: Record<string, InitialisedList>) {
+  for (const [listKey, list] of Object.entries(lists)) {
+    const {
+      ui: { searchFields, searchableFields },
+    } = list;
+
+    if (searchFields.has('id')) {
+      throw new Error(
+        `The ui.searchFields option on the ${listKey} list includes 'id'. Lists can always be searched by an item's id so it must not be specified as a search field`
+      );
+    }
+
+    const whereInputFields = list.types.where.graphQLType.getFields();
+    for (const fieldKey of Object.keys(list.fields)) {
+      const filterType = whereInputFields[fieldKey]?.type;
+      const fieldFilterFields = isInputObjectType(filterType) ? filterType.getFields() : undefined;
+      if (fieldFilterFields?.contains?.type === GraphQLString) {
+        searchableFields.set(
+          fieldKey,
+          fieldFilterFields?.mode?.type === QueryMode.graphQLType ? 'insensitive' : 'default'
+        );
+      }
+    }
+
+    if (searchFields.size === 0) {
+      if (searchableFields.has(list.ui.labelField)) {
+        searchFields.add(list.ui.labelField);
+      }
+    }
+  }
 }
 
 function getListGraphqlTypes(
@@ -481,7 +541,7 @@ export function initialiseLists(config: KeystoneConfig): Record<string, Initiali
 
   /**
    * Lists is instantiated here so that it can be passed into the `getListGraphqlTypes` function
-   * This function attaches this list object to the various graphql functions
+   * This function binds the listsRef object to the various graphql functions
    *
    * The object will be populated at the end of this function, and the reference will be maintained
    */
@@ -495,9 +555,12 @@ export function initialiseLists(config: KeystoneConfig): Record<string, Initiali
   {
     const resolvedDBFieldsForLists = resolveRelationships(intermediateLists);
     intermediateLists = Object.fromEntries(
-      Object.entries(intermediateLists).map(([listKey, blah]) => [
+      Object.entries(intermediateLists).map(([listKey, list]) => [
         listKey,
-        { ...blah, resolvedDbFields: resolvedDBFieldsForLists[listKey] },
+        {
+          ...list,
+          resolvedDbFields: resolvedDBFieldsForLists[listKey],
+        },
       ])
     );
   }
@@ -539,19 +602,21 @@ export function initialiseLists(config: KeystoneConfig): Record<string, Initiali
     }
   }
 
-  /*
-    Error checking
-    */
+  // Error checking
   for (const [listKey, { fields }] of Object.entries(intermediateLists)) {
     assertFieldsValid({ listKey, fields });
   }
 
+  // Fixup the GraphQL refs
   for (const [listKey, intermediateList] of Object.entries(intermediateLists)) {
     listsRef[listKey] = {
       ...intermediateList,
       lists: listsRef,
     };
   }
+
+  // Do some introspection
+  introspectGraphQLTypes(listsRef);
 
   return listsRef;
 }

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -63,7 +63,7 @@ export type ListAdminUIConfig<
    * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.
    * @default 'label', if it exists, falling back to 'name', then 'title', and finally 'id', which is guaranteed to exist.
    */
-  labelField?: 'id' | keyof Fields;
+  labelField?: 'id' | Exclude<keyof Fields, number>;
   /**
    * The fields used by the Admin UI when searching this list.
    * It is always possible to search by id and `id` should not be specified in this option.

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "peerDependencies": {
-    "@keystone-6/core": "^3.0.0"
+    "@keystone-6/core": "^3.1.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.16.3",

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -54,6 +54,9 @@ function RelationshipFieldPreview({
   value,
 }: DefaultFieldProps<'relationship'>) {
   const keystone = useKeystone();
+  const list = keystone.adminMeta.lists[schema.listKey];
+  const searchFields = Object.keys(list.fields).filter(key => list.fields[key].search);
+
   return (
     <FieldContainer>
       <FieldLabel>{schema.label}</FieldLabel>
@@ -61,7 +64,9 @@ function RelationshipFieldPreview({
         autoFocus={autoFocus}
         controlShouldRenderValue
         isDisabled={false}
-        list={keystone.adminMeta.lists[schema.listKey]}
+        list={list}
+        labelField={list.labelField}
+        searchFields={searchFields}
         extraSelection={schema.selection || ''}
         portalMenu
         state={

--- a/packages/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages/fields-document/src/DocumentEditor/relationship.tsx
@@ -83,6 +83,9 @@ export function RelationshipElement({
   const editor = useStaticEditor();
   const relationships = useContext(DocumentFieldRelationshipsContext)!;
   const relationship = relationships[element.relationship];
+  const list = keystone.adminMeta.lists[relationship.listKey];
+  const searchFields = Object.keys(list.fields).filter(key => list.fields[key].search);
+
   return (
     <span
       {...attributes}
@@ -106,7 +109,9 @@ export function RelationshipElement({
           <RelationshipSelect
             controlShouldRenderValue
             isDisabled={false}
-            list={keystone.adminMeta.lists[relationship.listKey]}
+            list={list}
+            labelField={list.labelField}
+            searchFields={searchFields}
             portalMenu
             state={{
               kind: 'one',

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -32,9 +32,14 @@ export const lists = {
       password: password({ ui: { description } }),
       toOneRelationship: relationship({
         ref: 'User',
+        ui: { description },
+      }),
+      toOneRelationshipAlternateLabel: relationship({
+        ref: 'User',
         ui: {
           description,
           labelField: 'email',
+          searchFields: ['email', 'name'],
         },
       }),
       toManyRelationship: relationship({ ref: 'Todo', many: true, ui: { description } }),

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -44,7 +44,9 @@ export const lists = {
           description,
           displayMode: 'cards',
           cardFields: ['name', 'email'],
-          inlineConnect: true,
+          inlineConnect: {
+            labelField: 'email',
+          },
           inlineCreate: { fields: ['name', 'email'] },
           linkToItem: true,
           inlineEdit: { fields: ['name', 'email'] },

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -6,6 +6,7 @@ type Thing {
   checkbox: Boolean
   password: PasswordState
   toOneRelationship: User
+  toOneRelationshipAlternateLabel: User
   toManyRelationship(where: TodoWhereInput! = {}, orderBy: [TodoOrderByInput!]! = [], take: Int, skip: Int! = 0): [Todo!]
   toManyRelationshipCount(where: TodoWhereInput! = {}): Int
   toOneRelationshipCard: User
@@ -77,6 +78,7 @@ input ThingWhereInput {
   checkbox: BooleanFilter
   password: PasswordFilter
   toOneRelationship: UserWhereInput
+  toOneRelationshipAlternateLabel: UserWhereInput
   toManyRelationship: TodoManyRelationFilter
   toOneRelationshipCard: UserWhereInput
   toManyRelationshipCard: TodoManyRelationFilter
@@ -253,6 +255,7 @@ input ThingUpdateInput {
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForUpdateInput
+  toOneRelationshipAlternateLabel: UserRelateToOneForUpdateInput
   toManyRelationship: TodoRelateToManyForUpdateInput
   toOneRelationshipCard: UserRelateToOneForUpdateInput
   toManyRelationshipCard: TodoRelateToManyForUpdateInput
@@ -306,6 +309,7 @@ input ThingCreateInput {
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForCreateInput
+  toOneRelationshipAlternateLabel: UserRelateToOneForCreateInput
   toManyRelationship: TodoRelateToManyForCreateInput
   toOneRelationshipCard: UserRelateToOneForCreateInput
   toManyRelationshipCard: TodoRelateToManyForCreateInput

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -13,37 +13,40 @@ generator client {
 }
 
 model Thing {
-  id                       String    @id @default(cuid())
-  checkbox                 Boolean   @default(false)
-  password                 String?
-  toOneRelationship        User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])
-  toOneRelationshipId      String?   @map("toOneRelationship")
-  toManyRelationship       Todo[]    @relation("Thing_toManyRelationship")
-  toOneRelationshipCard    User?     @relation("Thing_toOneRelationshipCard", fields: [toOneRelationshipCardId], references: [id])
-  toOneRelationshipCardId  String?   @map("toOneRelationshipCard")
-  toManyRelationshipCard   Todo[]    @relation("Thing_toManyRelationshipCard")
-  text                     String    @default("")
-  timestamp                DateTime?
-  calendarDay              String?
-  select                   String?
-  selectOnSide             String?
-  selectOnSideItemViewOnly String?
-  selectSegmentedControl   String?
-  multiselect              String    @default("[]")
-  json                     String?
-  integer                  Int?
-  bigInt                   BigInt?
-  float                    Float?
-  image_filesize           Int?
-  image_extension          String?
-  image_width              Int?
-  image_height             Int?
-  image_id                 String?
-  file_filesize            Int?
-  file_filename            String?
-  document                 String    @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  id                                String    @id @default(cuid())
+  checkbox                          Boolean   @default(false)
+  password                          String?
+  toOneRelationship                 User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])
+  toOneRelationshipId               String?   @map("toOneRelationship")
+  toOneRelationshipAlternateLabel   User?     @relation("Thing_toOneRelationshipAlternateLabel", fields: [toOneRelationshipAlternateLabelId], references: [id])
+  toOneRelationshipAlternateLabelId String?   @map("toOneRelationshipAlternateLabel")
+  toManyRelationship                Todo[]    @relation("Thing_toManyRelationship")
+  toOneRelationshipCard             User?     @relation("Thing_toOneRelationshipCard", fields: [toOneRelationshipCardId], references: [id])
+  toOneRelationshipCardId           String?   @map("toOneRelationshipCard")
+  toManyRelationshipCard            Todo[]    @relation("Thing_toManyRelationshipCard")
+  text                              String    @default("")
+  timestamp                         DateTime?
+  calendarDay                       String?
+  select                            String?
+  selectOnSide                      String?
+  selectOnSideItemViewOnly          String?
+  selectSegmentedControl            String?
+  multiselect                       String    @default("[]")
+  json                              String?
+  integer                           Int?
+  bigInt                            BigInt?
+  float                             Float?
+  image_filesize                    Int?
+  image_extension                   String?
+  image_width                       Int?
+  image_height                      Int?
+  image_id                          String?
+  file_filesize                     Int?
+  file_filename                     String?
+  document                          String    @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
 
   @@index([toOneRelationshipId])
+  @@index([toOneRelationshipAlternateLabelId])
   @@index([toOneRelationshipCardId])
 }
 
@@ -63,15 +66,16 @@ model Todo {
 }
 
 model User {
-  id                               String   @id @default(cuid())
-  name                             String   @default("")
-  email                            String   @default("")
-  password                         String?
-  tasks                            Todo[]   @relation("Todo_assignedTo")
-  createdAt                        DateTime @default(now())
-  updatedAt                        DateTime @updatedAt
-  from_Thing_toOneRelationship     Thing[]  @relation("Thing_toOneRelationship")
-  from_Thing_toOneRelationshipCard Thing[]  @relation("Thing_toOneRelationshipCard")
+  id                                         String   @id @default(cuid())
+  name                                       String   @default("")
+  email                                      String   @default("")
+  password                                   String?
+  tasks                                      Todo[]   @relation("Todo_assignedTo")
+  createdAt                                  DateTime @default(now())
+  updatedAt                                  DateTime @updatedAt
+  from_Thing_toOneRelationship               Thing[]  @relation("Thing_toOneRelationship")
+  from_Thing_toOneRelationshipAlternateLabel Thing[]  @relation("Thing_toOneRelationshipAlternateLabel")
+  from_Thing_toOneRelationshipCard           Thing[]  @relation("Thing_toOneRelationshipCard")
 }
 
 model Settings {


### PR DESCRIPTION
Follow on from https://github.com/keystonejs/keystone/pull/8049, this feature was apparently completely undercooked.

I have now added `labelField` support for each of the instances that used that functionality, and consequently the `searchFields` feature which is required for functionality to adhere to UX expectations.