### PR TITLE
Adds `fieldPosition` to `ui.itemView` allowing fields to be moved to the sidebar

### DIFF
--- a/.changeset/five-owls-think.md
+++ b/.changeset/five-owls-think.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds `fieldPosition` to `ui.itemView` allowing fields to be moved to the sidebar

--- a/.changeset/five-owls-think.md
+++ b/.changeset/five-owls-think.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Adds `fieldPosition` to `ui.itemView` allowing fields to be moved to the sidebar
+Adds `fieldPosition` to field `ui.itemView`, for moving a field to the sidebar

--- a/docs/pages/docs/fields/overview.md
+++ b/docs/pages/docs/fields/overview.md
@@ -90,6 +90,10 @@ Options:
     Can be one of `['edit', 'read', 'hidden']`, or an async function with an argument `{ session, context, item }` that returns one of `['edit', 'read', 'hidden']`.
     Defaults to the list's `ui.itemView.defaultFieldMode` config if defined.
     See the [Lists API](../config/lists#ui) for details.
+    {% if $nextRelease %}
+  - `listView.fieldPosition` (default: `form`): Controls which side of the page the field is placed in the Admin UI.
+    Can be either `form` or `sidebar`. `form` or blank places the field on the left hand side of the item view. `sidebar` places the field on the right hand side under the ID field
+    {% /if %}
   - `listView.fieldMode` (default: `'read'`): Controls the list view page of the Admin UI.
     Can be one of `['read', 'hidden']`, or an async function with an argument `{ session, context }` that returns one of `['read', 'hidden']`.
     Defaults to the list's `ui.listView.defaultFieldMode` config if defined.

--- a/docs/pages/docs/fields/overview.md
+++ b/docs/pages/docs/fields/overview.md
@@ -90,10 +90,10 @@ Options:
     Can be one of `['edit', 'read', 'hidden']`, or an async function with an argument `{ session, context, item }` that returns one of `['edit', 'read', 'hidden']`.
     Defaults to the list's `ui.itemView.defaultFieldMode` config if defined.
     See the [Lists API](../config/lists#ui) for details.
-    {% if $nextRelease %}
-  - `listView.fieldPosition` (default: `form`): Controls which side of the page the field is placed in the Admin UI.
+{% if $nextRelease %}
+  - `itemView.fieldPosition` (default: `form`): Controls which side of the page the field is placed in the Admin UI.
     Can be either `form` or `sidebar`. `form` or blank places the field on the left hand side of the item view. `sidebar` places the field on the right hand side under the ID field
-    {% /if %}
+{% /if %}
   - `listView.fieldMode` (default: `'read'`): Controls the list view page of the Admin UI.
     Can be one of `['read', 'hidden']`, or an async function with an argument `{ session, context }` that returns one of `['read', 'hidden']`.
     Defaults to the list's `ui.listView.defaultFieldMode` config if defined.

--- a/examples/assets-local/schema.graphql
+++ b/examples/assets-local/schema.graphql
@@ -332,12 +332,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/assets-s3/schema.graphql
+++ b/examples/assets-s3/schema.graphql
@@ -332,12 +332,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/auth/schema.graphql
+++ b/examples/auth/schema.graphql
@@ -216,12 +216,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -486,12 +486,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/basic/schema.ts
+++ b/examples/basic/schema.ts
@@ -44,7 +44,15 @@ const User: Lists.User = list({
     /** The user's first and last name. */
     name: text({ validation: { isRequired: true } }),
     /** Email is used to log into the system. */
-    email: text({ isIndexed: 'unique', validation: { isRequired: true } }),
+    email: text({
+      isIndexed: 'unique',
+      validation: { isRequired: true },
+      ui: {
+        itemView: {
+          fieldPosition: 'sidebar',
+        },
+      },
+    }),
     /** Avatar upload for the users profile, stored locally */
     avatar: image({ storage: 'my_images' }),
     attachment: file({ storage: 'my_files' }),

--- a/examples/basic/schema.ts
+++ b/examples/basic/schema.ts
@@ -47,11 +47,6 @@ const User: Lists.User = list({
     email: text({
       isIndexed: 'unique',
       validation: { isRequired: true },
-      ui: {
-        itemView: {
-          fieldPosition: 'sidebar',
-        },
-      },
     }),
     /** Avatar upload for the users profile, stored locally */
     avatar: image({ storage: 'my_images' }),

--- a/examples/blog/schema.graphql
+++ b/examples/blog/schema.graphql
@@ -293,12 +293,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-admin-ui-logo/schema.graphql
+++ b/examples/custom-admin-ui-logo/schema.graphql
@@ -293,12 +293,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-admin-ui-navigation/schema.graphql
+++ b/examples/custom-admin-ui-navigation/schema.graphql
@@ -293,12 +293,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-admin-ui-pages/schema.graphql
+++ b/examples/custom-admin-ui-pages/schema.graphql
@@ -293,12 +293,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-field-view/schema.graphql
+++ b/examples/custom-field-view/schema.graphql
@@ -296,12 +296,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-field/schema.graphql
+++ b/examples/custom-field/schema.graphql
@@ -148,12 +148,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/custom-session-validation/schema.graphql
+++ b/examples/custom-session-validation/schema.graphql
@@ -334,12 +334,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/default-values/schema.graphql
+++ b/examples/default-values/schema.graphql
@@ -311,12 +311,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/document-field-customisation/keystone-server/schema.graphql
+++ b/examples/document-field-customisation/keystone-server/schema.graphql
@@ -284,12 +284,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -308,12 +308,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/e2e-boilerplate/keystone-server/schema.graphql
+++ b/examples/e2e-boilerplate/keystone-server/schema.graphql
@@ -284,12 +284,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/ecommerce/schema.graphql
+++ b/examples/ecommerce/schema.graphql
@@ -899,12 +899,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/embedded-nextjs/schema.graphql
+++ b/examples/embedded-nextjs/schema.graphql
@@ -175,12 +175,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/extend-graphql-schema-graphql-tools/schema.graphql
+++ b/examples/extend-graphql-schema-graphql-tools/schema.graphql
@@ -305,12 +305,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/extend-graphql-schema-graphql-ts/schema.graphql
+++ b/examples/extend-graphql-schema-graphql-ts/schema.graphql
@@ -302,12 +302,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/extend-graphql-schema-nexus/schema.graphql
+++ b/examples/extend-graphql-schema-nexus/schema.graphql
@@ -295,12 +295,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/extend-graphql-subscriptions/schema.graphql
+++ b/examples/extend-graphql-subscriptions/schema.graphql
@@ -296,12 +296,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/feature-boilerplate/schema.graphql
+++ b/examples/feature-boilerplate/schema.graphql
@@ -284,12 +284,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/graphql-ts-gql/schema.graphql
+++ b/examples/graphql-ts-gql/schema.graphql
@@ -304,12 +304,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/json/schema.graphql
+++ b/examples/json/schema.graphql
@@ -260,12 +260,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/limits/schema.graphql
+++ b/examples/limits/schema.graphql
@@ -165,12 +165,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/redis-session-store/schema.graphql
+++ b/examples/redis-session-store/schema.graphql
@@ -329,12 +329,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/rest-api/schema.graphql
+++ b/examples/rest-api/schema.graphql
@@ -294,12 +294,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/roles/schema.graphql
+++ b/examples/roles/schema.graphql
@@ -410,12 +410,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/script/schema.graphql
+++ b/examples/script/schema.graphql
@@ -183,12 +183,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/singleton/schema.graphql
+++ b/examples/singleton/schema.graphql
@@ -347,12 +347,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/task-manager/schema.graphql
+++ b/examples/task-manager/schema.graphql
@@ -294,12 +294,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/testing/schema.graphql
+++ b/examples/testing/schema.graphql
@@ -329,12 +329,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/virtual-field/schema.graphql
+++ b/examples/virtual-field/schema.graphql
@@ -304,12 +304,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/examples/with-auth/schema.graphql
+++ b/examples/with-auth/schema.graphql
@@ -329,12 +329,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -28,7 +28,7 @@ import { useRedirect } from '../lib/useFromRedirect';
 
 const signupURL = 'https://signup.keystonejs.cloud/api/newsletter-signup';
 
-const Welcome = ({ value }: { value: any }) => {
+function Welcome({ value }: { value: any }) {
   const [subscribe, setSubscribe] = useState<boolean>(false);
   const [email, setEmail] = useState<string>(guessEmailFromValue(value));
   const [error, setError] = useState<string | null>(null);
@@ -152,7 +152,7 @@ const Welcome = ({ value }: { value: any }) => {
       </form>
     </Stack>
   );
-};
+}
 
 type InitPageProps = {
   listKey: string;
@@ -160,9 +160,7 @@ type InitPageProps = {
   enableWelcome: boolean;
 };
 
-export const getInitPage = (props: InitPageProps) => () => <InitPage {...props} />;
-
-const InitPage = ({ fieldPaths, listKey, enableWelcome }: InitPageProps) => {
+function InitPage({ fieldPaths, listKey, enableWelcome }: InitPageProps) {
   const { adminMeta } = useKeystone();
   const fields = useMemo(() => {
     const fields: Record<string, FieldMeta> = {};
@@ -298,4 +296,6 @@ const InitPage = ({ fieldPaths, listKey, enableWelcome }: InitPageProps) => {
       <Welcome value={value} />
     </SigninContainer>
   );
-};
+}
+
+export const getInitPage = (props: InitPageProps) => () => <InitPage {...props} />;

--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -271,7 +271,6 @@ function InitPage({ fieldPaths, listKey, enableWelcome }: InitPageProps) {
           )}
           <Fields
             fields={fields}
-            fieldModes={null}
             forceValidation={forceValidation}
             invalidFields={invalidFields}
             onChange={setValue}

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -332,7 +332,7 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
   const id = useRouter().query.id as string;
 
   const { query, selectedFields } = useMemo(() => {
-    let selectedFields = Object.entries(list.fields)
+    const selectedFields = Object.entries(list.fields)
       .filter(
         ([fieldKey, field]) =>
           field.itemView.fieldMode !== 'hidden' ||
@@ -395,8 +395,8 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
     }>
   >(data, error?.graphQLErrors);
 
-  let itemViewFieldModesByField = useMemo(() => {
-    let itemViewFieldModesByField: Record<string, 'edit' | 'read' | 'hidden'> = {};
+  const itemViewFieldModesByField = useMemo(() => {
+    const itemViewFieldModesByField: Record<string, 'edit' | 'read' | 'hidden'> = {};
     dataGetter.data?.keystone?.adminMeta?.list?.fields?.forEach(field => {
       if (field !== null && field.path !== null && field?.itemView?.fieldMode != null) {
         itemViewFieldModesByField[field.path] = field.itemView.fieldMode;
@@ -405,8 +405,8 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
     return itemViewFieldModesByField;
   }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
 
-  let itemViewFieldPositionsByField = useMemo(() => {
-    let itemViewFieldPositionsByField: Record<string, 'form' | 'sidebar'> = {};
+  const itemViewFieldPositionsByField = useMemo(() => {
+    const itemViewFieldPositionsByField: Record<string, 'form' | 'sidebar'> = {};
     dataGetter.data?.keystone?.adminMeta?.list?.fields?.forEach(field => {
       if (field !== null && field.path !== null && field?.itemView?.fieldPosition != null) {
         itemViewFieldPositionsByField[field.path] = field.itemView.fieldPosition;

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -398,9 +398,8 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
   const itemViewFieldModesByField = useMemo(() => {
     const itemViewFieldModesByField: Record<string, 'edit' | 'read' | 'hidden'> = {};
     dataGetter.data?.keystone?.adminMeta?.list?.fields?.forEach(field => {
-      if (field !== null && field.path !== null && field?.itemView?.fieldMode != null) {
-        itemViewFieldModesByField[field.path] = field.itemView.fieldMode;
-      }
+      if (field === null || field.path === null || field?.itemView?.fieldMode == null) return;
+      itemViewFieldModesByField[field.path] = field.itemView.fieldMode;
     });
     return itemViewFieldModesByField;
   }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
@@ -408,14 +407,13 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
   const itemViewFieldPositionsByField = useMemo(() => {
     const itemViewFieldPositionsByField: Record<string, 'form' | 'sidebar'> = {};
     dataGetter.data?.keystone?.adminMeta?.list?.fields?.forEach(field => {
-      if (field !== null && field.path !== null && field?.itemView?.fieldPosition != null) {
-        itemViewFieldPositionsByField[field.path] = field.itemView.fieldPosition;
-      }
+      if (field === null || field.path === null || field?.itemView?.fieldPosition == null) return;
+      itemViewFieldPositionsByField[field.path] = field.itemView.fieldPosition;
     });
     return itemViewFieldPositionsByField;
   }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
-  const metaQueryErrors = dataGetter.get('keystone').errors;
 
+  const metaQueryErrors = dataGetter.get('keystone').errors;
   const pageTitle: string = list.isSingleton
     ? list.label
     : loading

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -64,15 +64,20 @@ function ItemForm({
   itemGetter,
   selectedFields,
   fieldModes,
+  fieldPositions,
   showDelete,
+  item,
 }: {
   listKey: string;
   itemGetter: DataGetter<ItemData>;
   selectedFields: string;
   fieldModes: Record<string, 'edit' | 'read' | 'hidden'>;
+  fieldPositions: Record<string, 'form' | 'sidebar'>;
   showDelete: boolean;
+  item: ItemData;
 }) {
   const list = useList(listKey);
+  const { spacing, typography } = useTheme();
 
   const [update, { loading, error, data }] = useMutation(
     gql`mutation ($data: ${list.gqlNames.updateInputName}!, $id: ID!) {
@@ -149,49 +154,102 @@ function ItemForm({
   const hasChangedFields = !!changedFields.size;
   usePreventNavigation(useMemo(() => ({ current: hasChangedFields }), [hasChangedFields]));
   return (
-    <Box marginTop="xlarge">
-      <GraphQLErrorNotice
-        networkError={error?.networkError}
-        // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
-        // which are handled seperately and do not indicate a failure to update the item
-        errors={error?.graphQLErrors.filter(x => x.path?.length === 1)}
-      />
-      <Fields
-        fieldModes={fieldModes}
-        fields={list.fields}
-        forceValidation={forceValidation}
-        invalidFields={invalidFields}
-        onChange={useCallback(
-          value => {
-            setValue(state => ({ item: state.item, value: value(state.value) }));
-          },
-          [setValue]
-        )}
-        value={state.value}
-      />
-      <Toolbar
-        onSave={onSave}
-        hasChangedFields={!!changedFields.size}
-        onReset={useEventCallback(() => {
-          setValue(state => ({
-            item: state.item,
-            value: deserializeValue(list.fields, state.item),
-          }));
-        })}
-        loading={loading}
-        deleteButton={useMemo(
-          () =>
-            showDelete ? (
-              <DeleteButton
-                list={list}
-                itemLabel={(labelFieldValue ?? itemId) as string}
-                itemId={itemId}
-              />
-            ) : undefined,
-          [showDelete, list, labelFieldValue, itemId]
-        )}
-      />
-    </Box>
+    <Fragment>
+      <Box marginTop="xlarge">
+        <GraphQLErrorNotice
+          networkError={error?.networkError}
+          // we're checking for path.length === 1 because errors with a path larger than 1 will be field level errors
+          // which are handled seperately and do not indicate a failure to update the item
+          errors={error?.graphQLErrors.filter(x => x.path?.length === 1)}
+        />
+        <Fields
+          fieldModes={fieldModes}
+          fields={list.fields}
+          forceValidation={forceValidation}
+          invalidFields={invalidFields}
+          position="form"
+          fieldPositions={fieldPositions}
+          onChange={useCallback(
+            value => {
+              setValue(state => ({ item: state.item, value: value(state.value) }));
+            },
+            [setValue]
+          )}
+          value={state.value}
+        />
+        <Toolbar
+          onSave={onSave}
+          hasChangedFields={!!changedFields.size}
+          onReset={useEventCallback(() => {
+            setValue(state => ({
+              item: state.item,
+              value: deserializeValue(list.fields, state.item),
+            }));
+          })}
+          loading={loading}
+          deleteButton={useMemo(
+            () =>
+              showDelete ? (
+                <DeleteButton
+                  list={list}
+                  itemLabel={(labelFieldValue ?? itemId) as string}
+                  itemId={itemId}
+                />
+              ) : undefined,
+            [showDelete, list, labelFieldValue, itemId]
+          )}
+        />
+      </Box>
+      <StickySidebar>
+        <FieldLabel>Item ID</FieldLabel>
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <TextInput
+            css={{
+              marginRight: spacing.medium,
+              fontFamily: typography.fontFamily.monospace,
+              fontSize: typography.fontSize.small,
+            }}
+            readOnly
+            value={item.id}
+          />
+          <Tooltip content="Copy ID">
+            {props => (
+              <Button
+                {...props}
+                aria-label="Copy ID"
+                onClick={() => {
+                  copyToClipboard(item.id);
+                }}
+              >
+                <ClipboardIcon size="small" />
+              </Button>
+            )}
+          </Tooltip>
+        </div>
+        <Box marginTop="xlarge">
+          <Fields
+            fieldModes={fieldModes}
+            fields={list.fields}
+            forceValidation={forceValidation}
+            invalidFields={invalidFields}
+            position="sidebar"
+            fieldPositions={fieldPositions}
+            onChange={useCallback(
+              value => {
+                setValue(state => ({ item: state.item, value: value(state.value) }));
+              },
+              [setValue]
+            )}
+            value={state.value}
+          />
+        </Box>
+      </StickySidebar>
+    </Fragment>
   );
 }
 
@@ -272,7 +330,6 @@ export const getItemPage = (props: ItemPageProps) => () => <ItemPage {...props} 
 const ItemPage = ({ listKey }: ItemPageProps) => {
   const list = useList(listKey);
   const id = useRouter().query.id as string;
-  const { spacing, typography } = useTheme();
 
   const { query, selectedFields } = useMemo(() => {
     let selectedFields = Object.entries(list.fields)
@@ -302,6 +359,7 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
                   path
                   itemView(id: $id) {
                     fieldMode
+                    fieldPosition
                   }
                 }
               }
@@ -323,7 +381,15 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
       item: ItemData;
       keystone: {
         adminMeta: {
-          list: { fields: { path: string; itemView: { fieldMode: 'edit' | 'read' | 'hidden' } }[] };
+          list: {
+            fields: {
+              path: string;
+              itemView: {
+                fieldMode: 'edit' | 'read' | 'hidden';
+                fieldPosition: 'form' | 'sidebar';
+              };
+            }[];
+          };
         };
       };
     }>
@@ -339,6 +405,15 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
     return itemViewFieldModesByField;
   }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
 
+  let itemViewFieldPositionsByField = useMemo(() => {
+    let itemViewFieldPositionsByField: Record<string, 'form' | 'sidebar'> = {};
+    dataGetter.data?.keystone?.adminMeta?.list?.fields?.forEach(field => {
+      if (field !== null && field.path !== null && field?.itemView?.fieldPosition != null) {
+        itemViewFieldPositionsByField[field.path] = field.itemView.fieldPosition;
+      }
+    });
+    return itemViewFieldPositionsByField;
+  }, [dataGetter.data?.keystone?.adminMeta?.list?.fields]);
   const metaQueryErrors = dataGetter.get('keystone').errors;
 
   const pageTitle: string = list.isSingleton
@@ -399,43 +474,13 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
             <Fragment>
               <ItemForm
                 fieldModes={itemViewFieldModesByField}
+                fieldPositions={itemViewFieldPositionsByField}
                 selectedFields={selectedFields}
                 showDelete={!data.keystone.adminMeta.list!.hideDelete}
                 listKey={listKey}
                 itemGetter={dataGetter.get('item') as DataGetter<ItemData>}
+                item={data.item}
               />
-              <StickySidebar>
-                <FieldLabel>Item ID</FieldLabel>
-                <div
-                  css={{
-                    display: 'flex',
-                    alignItems: 'center',
-                  }}
-                >
-                  <TextInput
-                    css={{
-                      marginRight: spacing.medium,
-                      fontFamily: typography.fontFamily.monospace,
-                      fontSize: typography.fontSize.small,
-                    }}
-                    readOnly
-                    value={data.item.id}
-                  />
-                  <Tooltip content="Copy ID">
-                    {props => (
-                      <Button
-                        {...props}
-                        aria-label="Copy ID"
-                        onClick={() => {
-                          copyToClipboard(data.item.id);
-                        }}
-                      >
-                        <ClipboardIcon size="small" />
-                      </Button>
-                    )}
-                  </Tooltip>
-                </div>
-              </StickySidebar>
             </Fragment>
           )}
         </ColumnLayout>

--- a/packages/core/src/admin-ui/admin-meta-graphql.ts
+++ b/packages/core/src/admin-ui/admin-meta-graphql.ts
@@ -98,7 +98,7 @@ export type StaticAdminMetaQuery = {
           itemView: Maybe<{
             __typename: 'KeystoneAdminUIFieldMetaItemView';
             fieldMode: Maybe<KeystoneAdminUIFieldMetaItemViewFieldMode>;
-            fieldposition: Maybe<KeystoneAdminUIFieldMetaItemViewFieldPosition>;
+            fieldPosition: Maybe<KeystoneAdminUIFieldMetaItemViewFieldPosition>;
           }>;
         }>;
       }>;

--- a/packages/core/src/admin-ui/admin-meta-graphql.ts
+++ b/packages/core/src/admin-ui/admin-meta-graphql.ts
@@ -98,6 +98,7 @@ export type StaticAdminMetaQuery = {
           itemView: Maybe<{
             __typename: 'KeystoneAdminUIFieldMetaItemView';
             fieldMode: Maybe<KeystoneAdminUIFieldMetaItemViewFieldMode>;
+            fieldposition: Maybe<KeystoneAdminUIFieldMetaItemViewFieldPosition>;
           }>;
         }>;
       }>;
@@ -108,5 +109,7 @@ export type StaticAdminMetaQuery = {
 type QueryMode = 'default' | 'insensitive';
 
 type KeystoneAdminUIFieldMetaItemViewFieldMode = 'edit' | 'read' | 'hidden';
+
+type KeystoneAdminUIFieldMetaItemViewFieldPosition = 'form' | 'sidebar';
 
 type KeystoneAdminUISortDirection = 'ASC' | 'DESC';

--- a/packages/core/src/admin-ui/system/adminMetaSchema.ts
+++ b/packages/core/src/admin-ui/system/adminMetaSchema.ts
@@ -60,10 +60,12 @@ const KeystoneAdminUIFieldMeta = graphql.object<FieldMetaRootVal>()({
         listKey,
         fieldMode: itemView.fieldMode,
         itemId: id ?? null,
+        fieldPosition: itemView.fieldPosition,
       }),
       type: graphql.object<{
         listKey: string;
         fieldMode: FieldMetaRootVal['itemView']['fieldMode'];
+        fieldPosition: FieldMetaRootVal['itemView']['fieldPosition'];
         itemId: string | null;
       }>()({
         name: 'KeystoneAdminUIFieldMetaItemView',
@@ -100,6 +102,39 @@ const KeystoneAdminUIFieldMeta = graphql.object<FieldMetaRootVal>()({
                   return 'hidden' as const;
                 }
                 return fieldMode({
+                  session: context.session,
+                  context,
+                  item,
+                });
+              });
+            },
+          }),
+          fieldPosition: graphql.field({
+            type: graphql.enum({
+              name: 'KeystoneAdminUIFieldMetaItemViewFieldPosition',
+              values: graphql.enumValues(['form', 'sidebar']),
+            }),
+            resolve(
+              { fieldPosition, itemId, listKey },
+              args,
+              context,
+              info
+            ): MaybePromise<'form' | 'sidebar' | null> {
+              if (itemId !== null) {
+                assertInRuntimeContext(context, info);
+              }
+              if (typeof fieldPosition === 'string') {
+                return fieldPosition;
+              }
+              if (itemId === null) {
+                return null;
+              }
+              assertInRuntimeContext(context, info);
+              return fetchItemForItemViewFieldMode(context)(listKey, itemId).then(item => {
+                if (item === null) {
+                  return 'form' as const;
+                }
+                return fieldPosition({
                   session: context.session,
                   context,
                   item,

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -30,7 +30,10 @@ export type FieldMetaRootVal = {
   createView: { fieldMode: ContextFunction<'edit' | 'hidden'> };
   // itemView is intentionally special because static values are special cased
   // and fetched when fetching the static admin ui
-  itemView: { fieldMode: MaybeItemFunction<'edit' | 'read' | 'hidden', BaseListTypeInfo> };
+  itemView: {
+    fieldMode: MaybeItemFunction<'edit' | 'read' | 'hidden', BaseListTypeInfo>;
+    fieldPosition: MaybeItemFunction<'form' | 'sidebar', BaseListTypeInfo>;
+  };
   listView: { fieldMode: ContextFunction<'read' | 'hidden'> };
 };
 
@@ -221,6 +224,7 @@ export function createAdminMeta(
           fieldMode: field.graphql.isEnabled.update
             ? field.ui?.itemView?.fieldMode ?? ('edit' as const)
             : 'read',
+          fieldPosition: field.ui?.itemView?.fieldPosition || 'form',
         },
         listView: {
           fieldMode: normalizeMaybeSessionFunction(field.ui?.listView?.fieldMode ?? 'read'),

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -40,8 +40,8 @@ type FieldsProps = {
   fields: Record<string, FieldMeta>;
   value: Value;
   forceValidation: boolean;
-  fieldPositions: Record<string, 'form' | 'sidebar'> | null;
-  position: 'form' | 'sidebar';
+  fieldPositions?: Record<string, 'form' | 'sidebar'> | null;
+  position?: 'form' | 'sidebar';
   invalidFields: ReadonlySet<string>;
   fieldModes: Record<string, 'hidden' | 'edit' | 'read'> | null;
   onChange(value: (value: Value) => Value): void;
@@ -59,9 +59,7 @@ export function Fields({
 }: FieldsProps) {
   const renderedFields = Object.keys(fields)
     .filter(fieldPath => fieldModes === null || fieldModes[fieldPath] !== 'hidden')
-    .filter(
-      fieldPath => fieldPositions === null || !position || fieldPositions[fieldPath] === position
-    )
+    .filter(fieldPath => !fieldPositions || !position || fieldPositions[fieldPath] === position)
     .map((fieldPath, index) => {
       const field = fields[fieldPath];
       const val = value[fieldPath];

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -40,6 +40,8 @@ type FieldsProps = {
   fields: Record<string, FieldMeta>;
   value: Value;
   forceValidation: boolean;
+  fieldPositions: Record<string, 'form' | 'sidebar'> | null;
+  position: 'form' | 'sidebar';
   invalidFields: ReadonlySet<string>;
   fieldModes: Record<string, 'hidden' | 'edit' | 'read'> | null;
   onChange(value: (value: Value) => Value): void;
@@ -51,10 +53,15 @@ export function Fields({
   fieldModes,
   forceValidation,
   invalidFields,
+  fieldPositions,
+  position,
   onChange,
 }: FieldsProps) {
   const renderedFields = Object.keys(fields)
     .filter(fieldPath => fieldModes === null || fieldModes[fieldPath] !== 'hidden')
+    .filter(
+      fieldPath => fieldPositions === null || !position || fieldPositions[fieldPath] === position
+    )
     .map((fieldPath, index) => {
       const field = fields[fieldPath];
       const val = value[fieldPath];

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -39,32 +39,33 @@ const RenderField = memo(function RenderField({
 type FieldsProps = {
   fields: Record<string, FieldMeta>;
   value: Value;
-  forceValidation: boolean;
+  fieldModes?: Record<string, 'hidden' | 'edit' | 'read'> | null;
   fieldPositions?: Record<string, 'form' | 'sidebar'> | null;
+  forceValidation: boolean;
   position?: 'form' | 'sidebar';
   invalidFields: ReadonlySet<string>;
-  fieldModes: Record<string, 'hidden' | 'edit' | 'read'> | null;
   onChange(value: (value: Value) => Value): void;
 };
 
 export function Fields({
   fields,
   value,
-  fieldModes,
+  fieldModes = null,
+  fieldPositions = null,
   forceValidation,
   invalidFields,
-  fieldPositions,
-  position,
+  position = 'form',
   onChange,
 }: FieldsProps) {
   const renderedFields = Object.keys(fields)
-    .filter(fieldPath => fieldModes === null || fieldModes[fieldPath] !== 'hidden')
-    .filter(fieldPath => !fieldPositions || !position || fieldPositions[fieldPath] === position)
     .map((fieldPath, index) => {
       const field = fields[fieldPath];
       const val = value[fieldPath];
       const fieldMode = fieldModes === null ? 'edit' : fieldModes[fieldPath];
+      const fieldPosition = fieldPositions === null ? 'form' : fieldPositions[fieldPath];
 
+      if (fieldMode === 'hidden') return null;
+      if (fieldPosition !== position) return null;
       if (val.kind === 'error') {
         return (
           <div>
@@ -72,6 +73,7 @@ export function Fields({
           </div>
         );
       }
+
       return (
         <RenderField
           key={fieldPath}
@@ -82,7 +84,9 @@ export function Fields({
           autoFocus={index === 0}
         />
       );
-    });
+    })
+    .filter(Boolean);
+
   return (
     <Stack gap="xlarge">
       {renderedFields}

--- a/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
@@ -112,7 +112,6 @@ export function InlineCreate({
           <GraphQLErrorNotice networkError={error?.networkError} errors={error?.graphQLErrors} />
         )}
         <Fields
-          fieldModes={null}
           fields={fields}
           forceValidation={forceValidation}
           invalidFields={invalidFields}

--- a/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
@@ -122,7 +122,6 @@ export function InlineEdit({
           />
         )}
         <Fields
-          fieldModes={null}
           fields={fieldsObj}
           forceValidation={forceValidation}
           invalidFields={invalidFields}

--- a/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -98,6 +98,10 @@ export type KeystoneAdminUIFieldMetaItemViewFieldMode =
   | "read"
   | "hidden";
 
+export type KeystoneAdminUIFieldMetaItemViewFieldPosition =
+  | "form"
+  | "sidebar";
+
 export type QueryMode =
   | "default"
   | "insensitive";

--- a/packages/core/src/scripts/tests/fixtures/basic-project/schema.graphql
+++ b/packages/core/src/scripts/tests/fixtures/basic-project/schema.graphql
@@ -165,12 +165,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -24,7 +24,10 @@ export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
     description?: string;
     views?: string;
     createView?: { fieldMode?: MaybeSessionFunction<'edit' | 'hidden', ListTypeInfo> };
-    itemView?: { fieldMode?: MaybeItemFunction<'edit' | 'read' | 'hidden', ListTypeInfo> };
+    itemView?: {
+      fieldMode?: MaybeItemFunction<'edit' | 'read' | 'hidden', ListTypeInfo>;
+      fieldPosition?: MaybeItemFunction<'form' | 'sidebar', ListTypeInfo>;
+    };
     listView?: { fieldMode?: MaybeSessionFunction<'read' | 'hidden', ListTypeInfo> };
   };
   graphql?: {

--- a/tests/examples-smoke-tests/basic.test.ts
+++ b/tests/examples-smoke-tests/basic.test.ts
@@ -10,24 +10,27 @@ exampleProjectTests('../examples/basic', (browserType, mode) => {
     page = await browser.newPage();
     await loadIndex(page);
   });
+
   initFirstItemTest(() => page);
+
   test('sign out and sign in', async () => {
     if (mode === 'dev') {
       await page.click('[aria-label="Links and signout"]');
     }
-    await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign out")')]);
+    await page.click('button:has-text("Sign out")');
     await page.fill('[placeholder="email"]', 'admin@keystonejs.com');
     await page.fill('[placeholder="password"]', 'password');
-    await Promise.all([page.waitForNavigation(), page.click('button:has-text("Sign In")')]);
+    await page.click('button:has-text("Sign In")');
   });
+
   test('update user', async () => {
     try {
       await page.goto('http://localhost:3000/users');
     } catch {
       await page.goto('http://localhost:3000/users');
     }
-    await Promise.all([page.waitForNavigation(), page.click('a:has-text("Admin")')]);
-    await page.type('label:has-text("Name") >> .. >> input', '1');
+    await page.click('a:has-text("Admin")');
+    await page.fill('label:has-text("Name") >> .. >> input', 'Admin2');
     await page.click('button:has-text("Save changes")');
     await page.waitForSelector('text=No changes');
   });
@@ -51,7 +54,7 @@ exampleProjectTests('../examples/basic', (browserType, mode) => {
     }).then(res => res.json());
     expect(usersResponse).toEqual({
       data: {
-        users: [{ id: expect.stringMatching(/\d+/), name: 'Admin1' }],
+        users: [{ id: expect.stringMatching(/\d+/), name: 'Admin2' }],
       },
     });
   });

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -68,7 +68,7 @@ export const initFirstItemTest = (getPage: () => playwright.Page) => {
     await page.fill('[placeholder="Confirm Password"]', 'password');
     await page.click('button:has-text("Get started")');
     await page.uncheck('input[type="checkbox"]', { force: true });
-    await Promise.all([page.waitForNavigation(), page.click('text=Continue')]);
+    await page.click('text=Continue');
     await page.waitForSelector('text=Signed in as Admin');
   });
 };
@@ -143,6 +143,7 @@ export const exampleProjectTests = (
       beforeAll(async () => {
         await deleteAllData(projectDir);
       });
+
       tests(playwright.chromium, mode);
     });
   });

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -83,6 +83,35 @@ export const lists = {
           { value: 'three', label: 'Three' },
         ],
       }),
+      selectOnSide: select({
+        ui: {
+          description,
+          itemView: {
+            fieldPosition: 'sidebar',
+          },
+        },
+        options: [
+          { value: 'one', label: 'One' },
+          { value: 'two', label: 'Two' },
+          { value: 'three', label: 'Three' },
+        ],
+      }),
+      selectOnSideItemViewOnly: select({
+        ui: {
+          description,
+          createView: {
+            fieldMode: 'hidden',
+          },
+          itemView: {
+            fieldPosition: 'sidebar',
+          },
+        },
+        options: [
+          { value: 'one', label: 'One' },
+          { value: 'two', label: 'Two' },
+          { value: 'three', label: 'Three' },
+        ],
+      }),
       selectSegmentedControl: select({
         options: [
           { value: 'one', label: 'One' },

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -607,12 +607,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -16,6 +16,8 @@ type Thing {
   calendarDay: CalendarDay
   randomNumberVirtual: Float
   select: String
+  selectOnSide: String
+  selectOnSideItemViewOnly: String
   selectSegmentedControl: String
   multiselect: [String!]
   json: JSON
@@ -82,6 +84,8 @@ input ThingWhereInput {
   timestamp: DateTimeNullableFilter
   calendarDay: CalendarDayNullableFilter
   select: StringNullableFilter
+  selectOnSide: StringNullableFilter
+  selectOnSideItemViewOnly: StringNullableFilter
   selectSegmentedControl: StringNullableFilter
   integer: IntNullableFilter
   bigInt: BigIntNullableFilter
@@ -232,6 +236,8 @@ input ThingOrderByInput {
   timestamp: OrderDirection
   calendarDay: OrderDirection
   select: OrderDirection
+  selectOnSide: OrderDirection
+  selectOnSideItemViewOnly: OrderDirection
   selectSegmentedControl: OrderDirection
   integer: OrderDirection
   bigInt: OrderDirection
@@ -254,6 +260,8 @@ input ThingUpdateInput {
   timestamp: DateTime
   calendarDay: CalendarDay
   select: String
+  selectOnSide: String
+  selectOnSideItemViewOnly: String
   selectSegmentedControl: String
   multiselect: [String!]
   json: JSON
@@ -305,6 +313,8 @@ input ThingCreateInput {
   timestamp: DateTime
   calendarDay: CalendarDay
   select: String
+  selectOnSide: String
+  selectOnSideItemViewOnly: String
   selectSegmentedControl: String
   multiselect: [String!]
   json: JSON

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -13,33 +13,35 @@ generator client {
 }
 
 model Thing {
-  id                      String    @id @default(cuid())
-  checkbox                Boolean   @default(false)
-  password                String?
-  toOneRelationship       User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])
-  toOneRelationshipId     String?   @map("toOneRelationship")
-  toManyRelationship      Todo[]    @relation("Thing_toManyRelationship")
-  toOneRelationshipCard   User?     @relation("Thing_toOneRelationshipCard", fields: [toOneRelationshipCardId], references: [id])
-  toOneRelationshipCardId String?   @map("toOneRelationshipCard")
-  toManyRelationshipCard  Todo[]    @relation("Thing_toManyRelationshipCard")
-  text                    String    @default("")
-  timestamp               DateTime?
-  calendarDay             String?
-  select                  String?
-  selectSegmentedControl  String?
-  multiselect             String    @default("[]")
-  json                    String?
-  integer                 Int?
-  bigInt                  BigInt?
-  float                   Float?
-  image_filesize          Int?
-  image_extension         String?
-  image_width             Int?
-  image_height            Int?
-  image_id                String?
-  file_filesize           Int?
-  file_filename           String?
-  document                String    @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
+  id                       String    @id @default(cuid())
+  checkbox                 Boolean   @default(false)
+  password                 String?
+  toOneRelationship        User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])
+  toOneRelationshipId      String?   @map("toOneRelationship")
+  toManyRelationship       Todo[]    @relation("Thing_toManyRelationship")
+  toOneRelationshipCard    User?     @relation("Thing_toOneRelationshipCard", fields: [toOneRelationshipCardId], references: [id])
+  toOneRelationshipCardId  String?   @map("toOneRelationshipCard")
+  toManyRelationshipCard   Todo[]    @relation("Thing_toManyRelationshipCard")
+  text                     String    @default("")
+  timestamp                DateTime?
+  calendarDay              String?
+  select                   String?
+  selectOnSide             String?
+  selectOnSideItemViewOnly String?
+  selectSegmentedControl   String?
+  multiselect              String    @default("[]")
+  json                     String?
+  integer                  Int?
+  bigInt                   BigInt?
+  float                    Float?
+  image_filesize           Int?
+  image_extension          String?
+  image_width              Int?
+  image_height             Int?
+  image_id                 String?
+  file_filesize            Int?
+  file_filename            String?
+  document                 String    @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")
 
   @@index([toOneRelationshipId])
   @@index([toOneRelationshipCardId])

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -342,12 +342,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/tests/test-projects/crud-notifications/schema.graphql
+++ b/tests/test-projects/crud-notifications/schema.graphql
@@ -293,12 +293,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {

--- a/tests/test-projects/live-reloading/schema.graphql
+++ b/tests/test-projects/live-reloading/schema.graphql
@@ -166,12 +166,18 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 
 type KeystoneAdminUIFieldMetaItemView {
   fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {
   edit
   read
   hidden
+}
+
+enum KeystoneAdminUIFieldMetaItemViewFieldPosition {
+  form
+  sidebar
 }
 
 enum QueryMode {


### PR DESCRIPTION
Adds the ability to set a field's `fieldPosition` in `ui.itemView` to either `form` (standard behaviour) or `sidebar` - places the field under the `id` field in the sidebar.