### PR TITLE
Log configured host

### DIFF
--- a/.changeset/loud-moose-hunt.md
+++ b/.changeset/loud-moose-hunt.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Log the configured host instead of localhost when starting Keystone.

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -285,9 +285,9 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
     // We start initialising Keystone after the dev server is ready,
-    console.log(`⭐️ Dev Server Starting on http://localhost:${httpOptions.port}`);
+    console.log(`⭐️ Dev Server Starting on http://${httpOptions.host}:${httpOptions.port}`);
     console.log(
-      `⭐️ GraphQL API Starting on http://localhost:${httpOptions.port}${
+      `⭐️ GraphQL API Starting on http://${httpOptions.host}:${httpOptions.port}${
         config.graphql?.path || '/api/graphql'
       }`
     );

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -60,6 +60,6 @@ export const start = async (cwd: string) => {
 
   httpServer.listen(options, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Server Ready on http://localhost:${options.port}`);
+    console.log(`⭐️ Server Ready on http://${options.host}:${options.port}`);
   });
 };


### PR DESCRIPTION
Log the configured host instead of localhost when starting Keystone.

I checked that the log has changed by sandbox.

This PR is related to #7852.

I searched [all codes that uses `localhost`](https://github.com/keystonejs/keystone/search?q=localhost), and it looks like there is no other code that needs fixing.
They were mostly example READMEs and test codes.
Also, #7852 reported that the Admin UI was broken, but now it seems to work.
Please let me know if I have overlooked anything.