### PR TITLE
fix ui.labelField use multiselect type throw label must be scalar types bug.

### DIFF
--- a/packages/core/src/admin-ui/templates/app.ts
+++ b/packages/core/src/admin-ui/templates/app.ts
@@ -3,6 +3,7 @@ import {
   executeSync,
   GraphQLNonNull,
   GraphQLScalarType,
+  GraphQLList,
   GraphQLSchema,
   GraphQLUnionType,
   parse,
@@ -119,6 +120,12 @@ function getLazyMetadataQuery(
           );
         }
         let labelGraphQLFieldType = labelGraphQLField.type;
+        // dongwenxiao 2022.11.11 fix
+        // fix ui.labelField use multiselect type throw label must be scalar types bug.
+        if(labelGraphQLFieldType instanceof GraphQLList){
+          labelGraphQLFieldType = labelGraphQLFieldType.ofType;
+        }
+        // 
         if (labelGraphQLFieldType instanceof GraphQLNonNull) {
           labelGraphQLFieldType = labelGraphQLFieldType.ofType;
         }


### PR DESCRIPTION
When I custom admin UI, I will use `authenticatedItem.label` from `NavigationProps`. 
It default use `name` field,But my logic need use array field, like `authenticatedItem.label` is `["student", "teacher"]`, so I set `ui.labelField` is `role`, like below 👇🏻

```ts
// my example code
const User = list({
  fields: {
    role: multiselect({ options: [ROLE.student, ROLE.teacher] }),
  },
  ui: {
    labelField: 'role',   // <== this use multiselect type, when you build code, it will throw 
  },
});
```
But, when I build code, throw theres errors 👇🏻

`Error: Label fields must be scalar GraphQL types but the labelField "role" on the list "User" is not a scalar type
    at getLazyMetadataQuery (/[PROJECT_PATH]/node_modules/@keystone-6/core/scripts/cli/dist/keystone-6-core-scripts-cli.cjs.dev.js:197:17)`

Then, I found the [scalar types](https://keystonejs.com/docs/fields/overview#scalar-types) include `multiselect`, so I think this is a bug and I want fix it.
<img width="338" alt="image" src="https://user-images.githubusercontent.com/4394559/201613850-13ae112e-4759-4da2-885d-0cee7780f68d.png">

