### PR TITLE
Fix `http` server not binding to '::' by default (regression)

### DIFF
--- a/.changeset/one-host-binds.md
+++ b/.changeset/one-host-binds.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix `http` server not binding to '::' by default (regression introduced by [#8078](https://github.com/keystonejs/keystone/pull/8078))

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -288,7 +288,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
 
     const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port})`
+      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );
     console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql'}`);
 

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -266,7 +266,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   });
 
   const httpOptions: ListenOptions = {
-    host: 'localhost',
+    host: '::', // the default for nodejs httpServer
     port: 3000,
   };
 

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -285,9 +285,12 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
 
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
-    // We start initialising Keystone after the dev server is ready,
-    console.log(`⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port}`);
-    console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql' }`);
+
+    const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
+    console.log(
+      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port})`
+    );
+    console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql'}`);
 
     // Don't start initialising Keystone until the dev server is ready,
     // otherwise it slows down the first response significantly

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -286,12 +286,9 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
     // We start initialising Keystone after the dev server is ready,
-    console.log(`⭐️ Dev Server Starting on http://${httpOptions.host}:${httpOptions.port}`);
-    console.log(
-      `⭐️ GraphQL API Starting on http://${httpOptions.host}:${httpOptions.port}${
-        config.graphql?.path || '/api/graphql'
-      }`
-    );
+    console.log(`⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port}`);
+    console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql' }`);
+
     // Don't start initialising Keystone until the dev server is ready,
     // otherwise it slows down the first response significantly
     initKeystone().catch(err => {

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -64,7 +64,7 @@ export const start = async (cwd: string) => {
 
     const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port})`
+      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );
   });
 };

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -42,7 +42,7 @@ export const start = async (cwd: string) => {
   }
 
   const options: ListenOptions = {
-    host: 'localhost',
+    host: '::', // the default for nodejs httpServer
     port: 3000,
   };
 

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -61,6 +61,6 @@ export const start = async (cwd: string) => {
 
   httpServer.listen(options, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Server Ready on http://${options.host}:${options.port}`);
+    console.log(`⭐️ Server listening on ${options.host}, port ${options.port}`);
   });
 };

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -41,26 +41,30 @@ export const start = async (cwd: string) => {
     console.log(`✅ Admin UI ready`);
   }
 
-  const options: ListenOptions = {
+  const httpOptions: ListenOptions = {
     host: '::', // the default for nodejs httpServer
     port: 3000,
   };
 
   if (config?.server && 'port' in config.server) {
-    options.port = config.server.port;
+    httpOptions.port = config.server.port;
   }
 
   if (config?.server && 'options' in config.server && config.server.options) {
-    Object.assign(options, config.server.options);
+    Object.assign(httpOptions, config.server.options);
   }
 
   // preference env.PORT if supplied
   if ('PORT' in process.env) {
-    options.port = parseInt(process.env.PORT || '');
+    httpOptions.port = parseInt(process.env.PORT || '');
   }
 
-  httpServer.listen(options, (err?: any) => {
+  httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
-    console.log(`⭐️ Server listening on ${options.host}, port ${options.port}`);
+
+    const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
+    console.log(
+      `⭐️ Server listening on ${httpOptions.host}, port ${httpOptions.port} (http://${easyHost}:${httpOptions.port})`
+    );
   });
 };

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -86,7 +86,7 @@ model Todo {
 `);
 
   expect(recording()).toEqual(`✨ Starting Keystone
-⭐️ Server listening on ::, port 3000
+⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
 ⭐️ GraphQL API available at /api/graphql
 ✨ Generating GraphQL and Prisma schemas
 ✨ sqlite database "app.db" created at file:./app.db
@@ -109,7 +109,7 @@ describe('useMigrations: false', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on ::, port 3000
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ The database is already in sync with the Prisma schema.

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -86,8 +86,8 @@ model Todo {
 `);
 
   expect(recording()).toEqual(`✨ Starting Keystone
-⭐️ Dev Server Starting on http://localhost:3000
-⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+⭐️ Server listening on ::, port 3000
+⭐️ GraphQL API available at /api/graphql
 ✨ Generating GraphQL and Prisma schemas
 ✨ sqlite database "app.db" created at file:./app.db
 ✨ Your database is now in sync with your schema. Done in 0ms
@@ -109,8 +109,8 @@ describe('useMigrations: false', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ The database is already in sync with the Prisma schema.
       ✨ Connecting to the database

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -146,8 +146,8 @@ describe('useMigrations: false', () => {
     `);
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
 
       ⚠️  Warnings:
@@ -189,8 +189,8 @@ describe('useMigrations: false', () => {
     `);
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
 
       ⚠️  Warnings:
@@ -217,8 +217,8 @@ describe('useMigrations: false', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database has been reset
       ✨ Your database is now in sync with your schema. Done in 0ms
@@ -265,8 +265,8 @@ CREATE TABLE "Todo" (
 `);
 
   expect(cleanOutputForApplyingMigration(recording(), migrationName)).toEqual(`✨ Starting Keystone
-⭐️ Dev Server Starting on http://localhost:3000
-⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+⭐️ GraphQL API available at /api/graphql
 ✨ Generating GraphQL and Prisma schemas
 ✨ sqlite database "app.db" created at file:./app.db
 ✨ There has been a change to your Keystone schema that requires a migration
@@ -339,8 +339,8 @@ describe('useMigrations: true', () => {
 
     expect(cleanOutputForApplyingMigration(recording(), migrationName)).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
 
@@ -412,8 +412,8 @@ describe('useMigrations: true', () => {
 
     expect(cleanOutputForApplyingMigration(recording(), migrationName)).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
 
@@ -476,8 +476,8 @@ describe('useMigrations: true', () => {
       )
     ).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       - Drift detected: Your database schema is not in sync with your migration history.
 
@@ -524,8 +524,8 @@ describe('useMigrations: true', () => {
 
     expect(recording().replace(oldMigrationName, 'old_migration_name')).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       - Drift detected: Your database schema is not in sync with your migration history.
 
@@ -596,8 +596,8 @@ describe('useMigrations: true', () => {
 
     expect(recording().replace(migrationName!, 'migration_name')).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
 
@@ -636,8 +636,8 @@ describe('useMigrations: true', () => {
     expect(recording().replace(new RegExp(migrationName, 'g'), 'migration_name'))
       .toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ sqlite database "app.db" created at file:./app.db
       Applying migration \`migration_name\`
@@ -672,8 +672,8 @@ describe('useMigrations: true', () => {
     expect(recording().replace(new RegExp(migrationName, 'g'), 'migration_name'))
       .toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database has been reset
       Applying migration \`migration_name\`
@@ -695,8 +695,8 @@ describe('useMigrations: true', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Dev Server Starting on http://localhost:3000
-      ⭐️ GraphQL API Starting on http://localhost:3000/api/graphql
+      ⭐️ Server listening on ::, port 3000 (http://localhost:3000/)
+      ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database is up to date, no migrations need to be created or applied
       ✨ Connecting to the database


### PR DESCRIPTION
This pull request fixes https://github.com/keystonejs/keystone/issues/8103, which outlined that `"@keystone-6/core": "3.1.1"` introduced a regression that accidentally changed that behaviour.

This pull request does not revert https://github.com/keystonejs/keystone/pull/8078, but instead fixes the regression by explicitly defaulting to `::`.