### PR TITLE
Fixes `initFirstItem` bypass when `ui.isAccessAllowed` is defined

### DIFF
--- a/.changeset/fix-busted-init.md
+++ b/.changeset/fix-busted-init.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Fixes `initFirstItem` bypass when `ui.isAccessAllowed` is defined

--- a/examples/auth/keystone.ts
+++ b/examples/auth/keystone.ts
@@ -64,7 +64,6 @@ export default withAuth(
       url: process.env.DATABASE_URL || 'file:./keystone-example.db',
     },
     lists,
-    ui: {},
     session:
       // Stateless sessions will store the listKey and itemId of the signed-in user in a cookie
       statelessSessions({

--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -35,6 +35,7 @@ export function getInitFirstItemSchema({
       name: gqlNames.CreateInitialInput,
     })
   );
+
   return {
     mutation: {
       [gqlNames.createInitialItem]: graphql.field({
@@ -46,6 +47,8 @@ export function getInitFirstItemSchema({
           }
 
           const dbItemAPI = context.sudo().db[listKey];
+
+          // should approximate hasInitFirstItemConditions
           const count = await dbItemAPI.count({});
           if (count !== 0) {
             throw new Error('Initial items can only be created when no items exist in that list');

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -213,7 +213,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   async function hasInitFirstItemConditions(context: KeystoneContext) {
     if (!initFirstItem) return false;
 
-    const count = await context.sudo().query[listKey].count({});
+    const count = await context.sudo().db[listKey].count({});
     return count === 0;
   }
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -109,9 +109,6 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
    * Must be added to the ui.publicPages config
    */
   const authPublicPages = ['/signin'];
-  if (initFirstItem) {
-    authPublicPages.push('/init');
-  }
 
   /**
    * extendGraphqlSchema

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -173,7 +173,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
    * withItemData
    *
    * Automatically injects a session.data value with the authenticated item
-  */
+   */
   const withItemData = (
     _sessionStrategy: SessionStrategy<Record<string, any>>
   ): SessionStrategy<{ listKey: string; itemId: string; data: any }> => {
@@ -210,21 +210,21 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     };
   };
 
-  async function hasInitFirstItemConditions (context: KeystoneContext) {
+  async function hasInitFirstItemConditions(context: KeystoneContext) {
     if (!initFirstItem) return false;
 
     const count = await context.sudo().query[listKey].count({});
     return count === 0;
   }
 
-  async function attemptRedirects ({
+  async function attemptRedirects({
     context,
     isAccessAllowed,
     publicPages,
   }: {
-    context: KeystoneContext,
-    isAccessAllowed: boolean,
-    publicPages: string[]
+    context: KeystoneContext;
+    isAccessAllowed: boolean;
+    publicPages: string[];
   }): Promise<{ kind: 'redirect'; to: string } | void> {
     const { req, session } = context;
     const { pathname } = new URL(req!.url!, 'http://_');
@@ -233,7 +233,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     if (pathname === '/__nextjs_original-stack-frame') return;
 
     // redirect to init if initFirstItem conditions are met
-    if (pathname !== '/init' && await hasInitFirstItemConditions(context)) {
+    if (pathname !== '/init' && (await hasInitFirstItemConditions(context))) {
       return { kind: 'redirect', to: '/init' };
     }
 
@@ -255,11 +255,11 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     if (pathname === '/') return { kind: 'redirect', to: '/signin' };
     return {
       kind: 'redirect',
-      to: `/signin?from=${encodeURIComponent(req!.url!)}`
+      to: `/signin?from=${encodeURIComponent(req!.url!)}`,
     };
-  };
+  }
 
-  function defaultAccessAllowed ({ session }: KeystoneContext) {
+  function defaultAccessAllowed({ session }: KeystoneContext) {
     return session !== undefined;
   }
 
@@ -279,25 +279,25 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
         getAdditionalFiles = [],
         isAccessAllowed = defaultAccessAllowed,
         pageMiddleware,
-        publicPages = []
+        publicPages = [],
       } = ui;
       ui = {
         ...ui,
         publicPages: [...publicPages, ...defaultPublicPages],
         getAdditionalFiles: [...getAdditionalFiles, defaultGetAdditionalFiles],
-        pageMiddleware: async (args) => {
+        pageMiddleware: async args => {
           const shouldRedirect = await attemptRedirects({
             ...args,
             isAccessAllowed: args.isValidSession,
-            publicPages: [...publicPages, ...defaultPublicPages]
-          })
+            publicPages: [...publicPages, ...defaultPublicPages],
+          });
           if (shouldRedirect) return shouldRedirect;
           return pageMiddleware?.(args);
         },
         isAccessAllowed: async (context: KeystoneContext) => {
           if (await hasInitFirstItemConditions(context)) return true;
           return isAccessAllowed(context);
-        }
+        },
       };
     }
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -253,7 +253,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     };
   }
 
-  function defaultIsAccessAllowed ({ session, sessionStrategy }: KeystoneContext) {
+  function defaultIsAccessAllowed({ session, sessionStrategy }: KeystoneContext) {
     return session !== undefined;
   }
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -223,7 +223,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     publicPages,
   }: {
     context: KeystoneContext;
-    isValidSession: boolean;
+    isValidSession: boolean; // TODO: rename "isValidSession" to "wasAccessAllowed"?
     publicPages: string[];
   }): Promise<{ kind: 'redirect'; to: string } | void> {
     const { req } = context;

--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -87,14 +87,15 @@ export const getSchemaExtension = ({
     // technically this will incorrectly error if someone has a schema extension that adds a field to the list output type
     // and then wants to fetch that field with `sessionData` but it's extremely unlikely someone will do that since if
     // they want to add a GraphQL field, they'll probably use a virtual field
-    let ast;
-    let query = `query($id: ID!) { ${
+    const query = `query($id: ID!) { ${
       getGqlNames({
         listKey,
         // this isn't used to get the itemQueryName and we don't know it here
         pluralGraphQLName: '',
       }).itemQueryName
     }(where: { id: $id }) { ${sessionData} } }`;
+
+    let ast;
     try {
       ast = parse(query);
     } catch (err) {

--- a/packages/core/src/admin-ui/context.tsx
+++ b/packages/core/src/admin-ui/context.tsx
@@ -113,13 +113,6 @@ export const useKeystone = (): {
     throw new Error('useKeystone must be called inside a KeystoneProvider component');
   }
   if (value.adminMeta.state === 'error') {
-    // If we get an "Access denied" error, it probably means the user doesn't have access to the
-    // adminMeta but has navigated (probably client-side) to a page that requires it. We reload
-    // the page so the server-side access control can run which should bounce them to the right
-    // place (or display the no-access page)
-    if (value.adminMeta.error.message === 'Access denied') {
-      window.location.reload();
-    }
     throw new Error('An error occurred when loading Admin Metadata');
   }
   return {

--- a/packages/core/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/core/src/lib/server/createAdminUIMiddleware.ts
@@ -46,6 +46,7 @@ export function createAdminUIMiddlewareWithNextApp(
         : session
         ? context.session !== undefined
         : true;
+
       const shouldRedirect = await ui?.pageMiddleware?.({ context, isValidSession });
       if (shouldRedirect) {
         res.header('Cache-Control', 'no-cache, max-age=0');

--- a/packages/core/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/core/src/lib/server/createAdminUIMiddleware.ts
@@ -50,7 +50,7 @@ export function createAdminUIMiddlewareWithNextApp(
 
     try {
       const userContext = await context.withRequest(req, res);
-      const isValidSession = await isAccessAllowed(userContext);
+      const isValidSession = await isAccessAllowed(userContext); // TODO: rename "isValidSession" to "wasAccessAllowed"?
       const shouldRedirect = await pageMiddleware?.({
         context,
         isValidSession,

--- a/packages/core/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/core/src/lib/server/createAdminUIMiddleware.ts
@@ -24,7 +24,7 @@ export async function getNextApp(dev: boolean, projectAdminPath: string): Promis
   return app;
 }
 
-function defaultIsAccessAllowed ({ session, sessionStrategy }: KeystoneContext) {
+function defaultIsAccessAllowed({ session, sessionStrategy }: KeystoneContext) {
   if (!sessionStrategy) return true;
   return session !== undefined;
 }
@@ -37,11 +37,7 @@ export function createAdminUIMiddlewareWithNextApp(
   const handle = nextApp.getRequestHandler();
 
   const {
-    ui: {
-      isAccessAllowed = defaultIsAccessAllowed,
-      pageMiddleware,
-      publicPages = [],
-    } = {}
+    ui: { isAccessAllowed = defaultIsAccessAllowed, pageMiddleware, publicPages = [] } = {},
   } = config;
 
   return async (req: express.Request, res: express.Response) => {
@@ -57,7 +53,7 @@ export function createAdminUIMiddlewareWithNextApp(
       const isValidSession = await isAccessAllowed(userContext);
       const shouldRedirect = await pageMiddleware?.({
         context,
-        isValidSession
+        isValidSession,
       });
 
       if (shouldRedirect) {

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -142,7 +142,7 @@ export type AdminUIConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
 
   pageMiddleware?: (args: {
     context: KeystoneContext<TypeInfo>;
-    isValidSession: boolean; // TODO: rename to isAccessAllowed
+    isValidSession: boolean; // TODO: rename "isValidSession" to "wasAccessAllowed"?
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -129,19 +129,20 @@ export type DatabaseConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
 export type AdminUIConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   /** Completely disables the Admin UI */
   isDisabled?: boolean;
+
   /** A function that can be run to validate that the current session should have access to the Admin UI */
   isAccessAllowed?: (context: KeystoneContext<TypeInfo>) => MaybePromise<boolean>;
+
   /** An array of page routes that can be accessed without passing the isAccessAllowed check */
   publicPages?: readonly string[];
-  /** The basePath for the Admin UI App */
-  // FIXME: currently unused
-  // path?: string;
+
   getAdditionalFiles?: readonly ((
     config: KeystoneConfig<TypeInfo>
   ) => MaybePromise<readonly AdminFileToWrite[]>)[];
+
   pageMiddleware?: (args: {
     context: KeystoneContext<TypeInfo>;
-    isValidSession: boolean;
+    isValidSession: boolean; // TODO: rename to isAccessAllowed
   }) => MaybePromise<{ kind: 'redirect'; to: string } | void>;
 };
 

--- a/tests/examples-smoke-tests/utils.ts
+++ b/tests/examples-smoke-tests/utils.ts
@@ -60,7 +60,7 @@ const promiseSignal = (): Promise<void> & { resolve: () => void } => {
 
 export const initFirstItemTest = (getPage: () => playwright.Page) => {
   test('init first item', async () => {
-    let page = getPage();
+    const page = getPage();
     await page.fill('label:has-text("Name") >> .. >> input', 'Admin');
     await page.fill('label:has-text("Email") >> .. >> input', 'admin@keystonejs.com');
     await page.click('button:has-text("Set Password")');


### PR DESCRIPTION
This pull request rewrites the `@keystone-6/auth` middleware and `isAccessAllowed` composition.

Fixes
- https://github.com/keystonejs/keystone/issues/7970
- https://github.com/keystonejs/keystone/issues/8085

Related
- https://github.com/keystonejs/keystone/issues/7662