### PR TITLE
Add RSS feed to Keystone Blog

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+public/feed.xml

--- a/docs/markdoc/index.ts
+++ b/docs/markdoc/index.ts
@@ -1,6 +1,7 @@
 // @markdoc/markdoc's declaration files depend on these global types
 import type {} from '@markdoc/markdoc/global';
 import fs from 'fs/promises';
+import isMatch from 'date-fns/isMatch';
 import Markdoc, { Config, Tag, ValidateError } from '@markdoc/markdoc';
 import { isNonEmptyArray } from 'emery/guards';
 import { assert } from 'emery/assertions';
@@ -150,6 +151,19 @@ export function extractBlogFrontmatter(content: string): BlogFrontmatter {
   }
   if (typeof obj.publishDate !== 'string') {
     throw new Error(`Expected frontmatter to contain publishDate`);
+  } else {
+    const publishDate = obj.publishDate;
+    // making sure months are always MM and not M, same with dd and d
+    // Eg. 2022-04-01 is correct
+    // 2022-4-1 is incorrect
+    // why do we do this manually? because date-fns isMatch doesn't validate this
+    if (publishDate.split('-').some(s => s.length < 2)) {
+      throw new Error(`Frontmatter publishDate format should be yyyy-MM-dd`);
+    }
+    const isValidDateFormat = isMatch(publishDate, 'yyyy-MM-dd');
+    if (!isValidDateFormat) {
+      throw new Error(`Frontmatter publishDate format should be yyyy-MM-dd`);
+    }
   }
   if (typeof obj.authorName !== 'string') {
     throw new Error(`Expected frontmatter to contain authorName`);

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "SHOW_NEXT_RELEASE=1 next -p 8000",
     "dev:live": "next -p 8000",
-    "build": "yarn validate-links && next build && yarn sitemap",
+    "build": "yarn validate-links && next build && yarn sitemap && yarn build:rss",
     "start": "next start -p 8000",
     "sitemap": "next-sitemap",
+    "build:rss": "tsx scripts/rss.ts",
     "validate-links": "tsx scripts/validate-links.ts",
     "remove-conditionals": "tsx scripts/replace-show-next-release/index.ts"
   },
@@ -50,10 +51,12 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-focus-lock": "^2.7.1",
+    "rss": "^1.2.2",
     "tsx": "^3.9.0"
   },
   "devDependencies": {
     "@types/lodash.debounce": "^4.0.6",
+    "@types/rss": "^0.0.29",
     "next-sitemap": "^3.0.0",
     "start-server-and-test": "^1.14.0",
     "typescript": "~4.7.4"

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -47,6 +47,12 @@ class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;900&display=swap"
             rel="stylesheet"
           />
+          <link
+            rel="alternate"
+            type="application/rss+xml"
+            title="Keystone Blog RSS Feed"
+            href="/feed.xml"
+          />
           <script async src="/assets/resize-observer-polyfill.js" />
           <script async src="/assets/focus-visible-polyfill.js" />
           <script

--- a/docs/pages/blog/customisable-admin-ui.md
+++ b/docs/pages/blog/customisable-admin-ui.md
@@ -1,7 +1,7 @@
 ---
 title: "Customisable Admin UI"
 description: "Custom navigation, pages and logo in this big Admin UI themed release."
-publishDate: "2021-7-29"
+publishDate: "2021-07-29"
 authorName: "Ronald Aveling"
 authorHandle: "https://twitter.com/ronaldaveling"
 metaImageUrl: ""

--- a/docs/pages/blog/index.tsx
+++ b/docs/pages/blog/index.tsx
@@ -34,7 +34,12 @@ export default function Docs(props: InferGetStaticPropsType<typeof getStaticProp
         formattedDateStr: formattedDateStr,
       };
     })
-    .sort((a, b) => (a.frontmatter.publishDate < b.frontmatter.publishDate ? 1 : -1));
+    .sort((a, b) => {
+      if (a.frontmatter.publishDate === b.frontmatter.publishDate) {
+        return a.frontmatter.title.localeCompare(b.frontmatter.title);
+      }
+      return a.frontmatter.publishDate.localeCompare(b.frontmatter.publishDate);
+    });
 
   return (
     <Page

--- a/docs/pages/blog/index.tsx
+++ b/docs/pages/blog/index.tsx
@@ -34,7 +34,7 @@ export default function Docs(props: InferGetStaticPropsType<typeof getStaticProp
         formattedDateStr: formattedDateStr,
       };
     })
-    .sort((a, b) => (a.parsedDate < b.parsedDate ? 1 : -1));
+    .sort((a, b) => (a.frontmatter.publishDate < b.frontmatter.publishDate ? 1 : -1));
 
   return (
     <Page

--- a/docs/pages/blog/introducing-keystone-blog.md
+++ b/docs/pages/blog/introducing-keystone-blog.md
@@ -1,7 +1,7 @@
 ---
 title: "Introducing the Keystone Blog"
 description: "We are launching the Keystone Blog, a one stop shop to all the latest news and announcements from the team."
-publishDate: "2022-11-2"
+publishDate: "2022-11-02"
 authorName: "Dinesh Pandiyan"
 authorHandle: "https://twitter.com/flexdinesh"
 metaImageUrl: ""

--- a/docs/pages/blog/keystone-tutorials.md
+++ b/docs/pages/blog/keystone-tutorials.md
@@ -1,7 +1,7 @@
 ---
 title: "Keystone learning series"
 description: "To help learn how Keystone works, we're introducing a new learning series that shows you how to turn an empty folder into a functioning blog backend with relationships, auth, and session data."
-publishDate: "2022-2-8"
+publishDate: "2022-02-08"
 authorName: "Ronald Aveling"
 authorHandle: "https://twitter.com/ronaldaveling"
 metaImageUrl: ""

--- a/docs/pages/blog/mysql-support.md
+++ b/docs/pages/blog/mysql-support.md
@@ -1,7 +1,7 @@
 ---
 title: "Keystone now supports MySQL"
 description: "We've added support for MySQL to Keystone's list of DB providers, bringing the total number of supported DB types to three."
-publishDate: "2022-6-30"
+publishDate: "2022-06-30"
 authorName: "Dinesh Pandiyan"
 authorHandle: "https://twitter.com/flexdinesh"
 metaImageUrl: ""

--- a/docs/pages/blog/prisma-day-2021.md
+++ b/docs/pages/blog/prisma-day-2021.md
@@ -1,7 +1,7 @@
 ---
 title: "Prisma Day 2021 Talk"
 description: "Jed Watson shared Keystone 6 with the world at Prisma Day conference in July 2021. His talk is a great way learn how Keystones combination of features and flexibility set it apart from other backend frameworks and Content Management Systems."
-publishDate: "2021-7-16"
+publishDate: "2021-07-16"
 authorName: "Ronald Aveling"
 authorHandle: "https://twitter.com/ronaldaveling"
 metaImageUrl: ""

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -21,7 +21,10 @@ async function getPosts() {
   );
 
   const reverseChronologicallySortedPosts = posts.sort((a, b) => {
-    return a.frontmatter.publishDate < b.frontmatter.publishDate ? 1 : -1;
+    if (a.frontmatter.publishDate === b.frontmatter.publishDate) {
+      return a.frontmatter.title.localeCompare(b.frontmatter.title);
+    }
+    return a.frontmatter.publishDate.localeCompare(b.frontmatter.publishDate);
   });
 
   return reverseChronologicallySortedPosts;

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -1,0 +1,65 @@
+import path from 'path';
+import fs from 'fs/promises';
+import parse from 'date-fns/parse';
+import RSS from 'rss';
+import globby from 'globby';
+import { extractBlogFrontmatter } from '../markdoc';
+import { siteBaseUrl } from '../lib/og-util';
+
+async function getPosts() {
+  const files = await globby('*.md', {
+    cwd: path.join(process.cwd(), 'pages/blog'),
+  });
+
+  const posts = await Promise.all(
+    files.map(async filename => {
+      const contents = await fs.readFile(path.join(process.cwd(), 'pages/blog', filename), 'utf8');
+      return {
+        slug: filename.replace(/\.md$/, ''),
+        frontmatter: extractBlogFrontmatter(contents),
+      };
+    })
+  );
+
+  const today = new Date();
+  const reverseChronologicallySortedPosts = posts.sort((a, b) => {
+    const parsedA = parse(a.frontmatter.publishDate, 'yyyy-M-d', today);
+    const parsedB = parse(b.frontmatter.publishDate, 'yyyy-M-d', today);
+
+    return parsedA < parsedB ? 1 : -1;
+  });
+
+  return reverseChronologicallySortedPosts;
+}
+export default async function generateRssFeed() {
+  const feedOptions = {
+    title: 'Keystone Blog | RSS Feed',
+    description: 'Blog posts from the team maintaining Keystone.',
+    site_url: `${siteBaseUrl}/blog`,
+    feed_url: `${siteBaseUrl}/rss.xml`,
+    image_url: `${siteBaseUrl}/assets/blog/the-keystone-blog-cover.png`,
+    pubDate: new Date(),
+    // TODO:
+    // copyright: `All rights reserved ${new Date().getFullYear()}, Thinkmill Labs`,
+  };
+
+  const feed = new RSS(feedOptions);
+  const posts = await getPosts();
+  posts.forEach(post => {
+    feed.item({
+      title: post.frontmatter.title,
+      description: post.frontmatter.description,
+      url: `${siteBaseUrl}/blog/${post.slug}`,
+      date: post.frontmatter.publishDate,
+    });
+  });
+
+  return fs.writeFile('./public/feed.xml', feed.xml({ indent: true }));
+}
+
+(async () => {
+  await generateRssFeed();
+})().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -31,14 +31,13 @@ async function getPosts() {
 }
 export default async function generateRssFeed() {
   const feedOptions = {
-    title: 'Keystone Blog | RSS Feed',
+    title: 'Keystone Blog',
     description: 'Blog posts from the team maintaining Keystone.',
     site_url: `${siteBaseUrl}/blog`,
     feed_url: `${siteBaseUrl}/rss.xml`,
-    image_url: `${siteBaseUrl}/assets/blog/the-keystone-blog-cover.png`,
+    image_url: `${siteBaseUrl}/favicon-32x32.png`,
     pubDate: new Date(),
-    // TODO:
-    // copyright: `All rights reserved ${new Date().getFullYear()}, Thinkmill Labs`,
+    copyright: `Thinkmill Labs Pty Ltd`,
   };
 
   const feed = new RSS(feedOptions);
@@ -49,6 +48,8 @@ export default async function generateRssFeed() {
       description: post.frontmatter.description,
       url: `${siteBaseUrl}/blog/${post.slug}`,
       date: post.frontmatter.publishDate,
+      // TODO: Render post as HTML for <content:encoded>
+      // custom_elements: [{'content:encoded': ''}]
     });
   });
 

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs/promises';
-import parse from 'date-fns/parse';
 import RSS from 'rss';
 import globby from 'globby';
 import { extractBlogFrontmatter } from '../markdoc';
@@ -21,12 +20,8 @@ async function getPosts() {
     })
   );
 
-  const today = new Date();
   const reverseChronologicallySortedPosts = posts.sort((a, b) => {
-    const parsedA = parse(a.frontmatter.publishDate, 'yyyy-M-d', today);
-    const parsedB = parse(b.frontmatter.publishDate, 'yyyy-M-d', today);
-
-    return parsedA < parsedB ? 1 : -1;
+    return a.frontmatter.publishDate < b.frontmatter.publishDate ? 1 : -1;
   });
 
   return reverseChronologicallySortedPosts;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4634,6 +4634,11 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/rss@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/rss/-/rss-0.0.29.tgz#1f2b37a863021c56398bf913fd02efad484123c8"
+  integrity sha512-9hAYKyOcoxWqkJMue6bi0fcNXxjJiRutVvqyImy732LmTCxRz9BYPmSmujG7uddK0ZEP/35K3QVZ0sfAVyPnQw==
+
 "@types/scheduler@*":
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
@@ -9859,6 +9864,18 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==
+  dependencies:
+    mime-db "~1.25.0"
+
 mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
@@ -11478,6 +11495,14 @@ rollup@^2.32.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -13096,6 +13121,11 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Changes:

- Add `<link rel='alternate' />` linking to the feed to all pages
- Generate RSS feed during build and export it as a static file in `public` dir
- Generate feed based on `*.md` posts