### PR TITLE
`ui.publicPages` should bypass `ui.isAccessAllowed` and `ui.pageMiddleware`

### DIFF
--- a/.changeset/goodbye-busted-context.md
+++ b/.changeset/goodbye-busted-context.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': major
 ---
 
-Removes `context.startSession` and `context.endSession` - use `context.sessionStrategy.*` directly if required
+Removes `context.startSession` and `context.endSession` - replace with `context.sessionStrategy.start` and `context.sessionStrategy.end` as required

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -109,9 +109,6 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
    * Must be added to the ui.publicPages config
    */
   const authPublicPages = ['/signin'];
-  if (initFirstItem) {
-    authPublicPages.push('/init');
-  }
 
   /**
    * extendGraphqlSchema

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -220,7 +220,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
 
   async function authMiddleware({
     context,
-    isValidSession,
+    isValidSession: wasAccessAllowed,
   }: {
     context: KeystoneContext;
     isValidSession: boolean; // TODO: rename "isValidSession" to "wasAccessAllowed"?
@@ -239,7 +239,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     }
 
     // don't redirect if we have access
-    if (isValidSession) return;
+    if (wasAccessAllowed) return;
 
     // otherwise, redirect to signin
     if (pathname === '/') return { kind: 'redirect', to: '/signin' };

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -211,7 +211,11 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   };
 
   async function hasInitFirstItemConditions(context: KeystoneContext) {
+    // do nothing if they aren't using this feature
     if (!initFirstItem) return false;
+
+    // if they have a session, there is no initialisation necessary
+    if (context.session) return false;
 
     const count = await context.sudo().db[listKey].count({});
     return count === 0;

--- a/packages/core/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/core/src/lib/server/createAdminUIMiddleware.ts
@@ -49,6 +49,12 @@ export function createAdminUIMiddlewareWithNextApp(
     }
 
     try {
+      // do nothing if this is a public page
+      if (publicPages.includes(pathname!)) {
+        handle(req, res);
+        return;
+      }
+
       const userContext = await context.withRequest(req, res);
       const isValidSession = await isAccessAllowed(userContext); // TODO: rename "isValidSession" to "wasAccessAllowed"?
       const shouldRedirect = await pageMiddleware?.({
@@ -64,11 +70,12 @@ export function createAdminUIMiddlewareWithNextApp(
         return;
       }
 
-      if (!isValidSession && !publicPages.includes(pathname!)) {
-        nextApp.render(req, res, '/no-access');
-      } else {
+      if (isValidSession) {
         handle(req, res);
+      } else {
+        nextApp.render(req, res, '/no-access');
       }
+
     } catch (e) {
       console.error('An error occurred handling a request for the Admin UI:', e);
       res.status(500);

--- a/packages/core/src/lib/server/createAdminUIMiddleware.ts
+++ b/packages/core/src/lib/server/createAdminUIMiddleware.ts
@@ -75,7 +75,6 @@ export function createAdminUIMiddlewareWithNextApp(
       } else {
         nextApp.render(req, res, '/no-access');
       }
-
     } catch (e) {
       console.error('An error occurred handling a request for the Admin UI:', e);
       res.status(500);


### PR DESCRIPTION
I think the previous behaviour was unintentionally misleading; and although https://github.com/keystonejs/keystone/pull/8115 resolved the behaviour as near to what existed before, I don't think this what developers are expecting.
 
Public pages shouldn't be redirected conditionally in respect to the session, they are public pages.

If they can be conditionally re-directed as a result of `ui.isAccessAllowed` or some other behaviour, then they aren't public pages, but conditional pages, and can be handled using `ui.pageMiddleware`.

This pull request resolves that ambiguity as a separate followup to https://github.com/keystonejs/keystone/pull/8115.

This pull request additionally restores a small optimization that we had which prevented `hasInitFirstItemConditions` calling the database for every request if a `session` already exists (and thereby, initialization already completed). 