### PR TITLE
Fix `access.filter.*` passing `listKey: undefined`

### DIFF
--- a/.changeset/fix-no-listkey.md
+++ b/.changeset/fix-no-listkey.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes `access.filter.*` passing `listKey: undefined`

--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -82,7 +82,6 @@ export async function getAccessFilters(
         listKey: list.listKey,
         context,
       });
-
     } else if (operation === 'update') {
       filters = await list.access.filter.update({
         operation,
@@ -90,7 +89,6 @@ export async function getAccessFilters(
         listKey: list.listKey,
         context,
       });
-
     } else if (operation === 'delete') {
       filters = await list.access.filter.delete({
         operation,

--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -101,7 +101,7 @@ export async function getAccessFilters(
     }
 
     if (typeof filters === 'boolean') return filters;
-    if (filters === undefined) return false; // shouldn't happen, but, Typescript
+    if (!filters) return false; // shouldn't happen, but, Typescript
 
     const schema = context.sudo().graphql.schema;
     const whereInput = assertInputObjectType(schema.getType(getGqlNames(list).whereInputName));

--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -71,17 +71,37 @@ export async function getOperationAccess(
 export async function getAccessFilters(
   list: InitialisedList,
   context: KeystoneContext,
-  operation: 'update' | 'query' | 'delete'
+  operation: keyof typeof list.access.filter
 ): Promise<boolean | InputFilter> {
-  const access = list.access.filter[operation];
   try {
-    const filters = await access({
-      operation,
-      session: context.session,
-      list: list.listKey,
-      context,
-    } as any); // TODO: FIXME
+    let filters;
+    if (operation === 'query') {
+      filters = await list.access.filter.query({
+        operation,
+        session: context.session,
+        listKey: list.listKey,
+        context,
+      });
+
+    } else if (operation === 'update') {
+      filters = await list.access.filter.update({
+        operation,
+        session: context.session,
+        listKey: list.listKey,
+        context,
+      });
+
+    } else if (operation === 'delete') {
+      filters = await list.access.filter.delete({
+        operation,
+        session: context.session,
+        listKey: list.listKey,
+        context,
+      });
+    }
+
     if (typeof filters === 'boolean') return filters;
+    if (filters === undefined) return false; // shouldn't happen, but, Typescript
 
     const schema = context.sudo().graphql.schema;
     const whereInput = assertInputObjectType(schema.getType(getGqlNames(list).whereInputName));


### PR DESCRIPTION
Fixes https://github.com/keystonejs/keystone/issues/8121 where `access.filter.*` operations were being passed `list: list.listKey` instead of `listKey: list.listKey`.

The typo fell through our types because we had an `as any` with the type being difficult to resolve.
Prior to c740ba630c we had `@ts-ignore` for this check:
https://github.com/keystonejs/keystone/blob/6c60565c940a9e27b8bb9b3e3e61260f22ee1e1a/packages/core/src/lib/core/access-control.ts#L63-L67

And then with #7914 we changed it to `as any` and introduced the regression (as shown in the pull request diff).

With this pull request, we resolve the types verbosely.  Not ideal, but, it's better than the alternative.