### PR TITLE
Prevent inline related item form from submitting the parent form

### DIFF
--- a/.changeset/early-days-thank.md
+++ b/.changeset/early-days-thank.md
@@ -1,0 +1,5 @@
+---
+"@keystone-ui/modals": patch
+---
+
+Fixes inline related item form submitting the parent form

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -234,6 +234,7 @@ jobs:
             'list-view-crud.test.ts',
             'navigation.test.ts',
             'live-reloading.test.ts',
+            'relations.test.ts',
           ]
       fail-fast: false
     steps:

--- a/.github/workflows/skip_core_tests.yml
+++ b/.github/workflows/skip_core_tests.yml
@@ -122,6 +122,7 @@ jobs:
             'list-view-crud.test.ts',
             'navigation.test.ts',
             'live-reloading.test.ts',
+            'relations.test.ts',
           ]
       fail-fast: false
     steps:

--- a/design-system/packages/modals/src/DrawerBase.tsx
+++ b/design-system/packages/modals/src/DrawerBase.tsx
@@ -76,6 +76,7 @@ export const DrawerBase = ({
     onSubmit = (event: any) => {
       if (!event.defaultPrevented) {
         event.preventDefault();
+        event.stopPropagation();
         oldOnSubmit();
       }
     };

--- a/tests/admin-ui-tests/relations.test.ts
+++ b/tests/admin-ui-tests/relations.test.ts
@@ -1,0 +1,27 @@
+import { Browser, Page } from 'playwright';
+import { adminUITests } from './utils';
+
+adminUITests('./tests/test-projects/basic', browserType => {
+  let browser: Browser = undefined as any;
+  let page: Page = undefined as any;
+
+  beforeAll(async () => {
+    browser = await browserType.launch();
+    page = await browser.newPage();
+  });
+
+  test('Creating relation items inline does not submit main form', async () => {
+    await page.goto('http://localhost:3000/tasks/create');
+    await page.fill('label:has-text("Label")', 'Buy beer');
+    await page.click('button:has-text("Create related Person")');
+    await page.waitForSelector('h1:has-text("Create Person")');
+    await page.fill('label:has-text("Name")', 'Max');
+    await page.click('button:has-text("Create Person")');
+    await page.waitForSelector('legend:has-text("Assigned To") ~ div:has-text("Max")');
+    expect(page.url()).toBe('http://localhost:3000/tasks/create');
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+});

--- a/tests/admin-ui-tests/relations.test.ts
+++ b/tests/admin-ui-tests/relations.test.ts
@@ -15,9 +15,9 @@ adminUITests('./tests/test-projects/basic', browserType => {
     await page.fill('label:has-text("Label")', 'Buy beer');
     await page.click('button:has-text("Create related Person")');
     await page.waitForSelector('h1:has-text("Create Person")');
-    await page.fill('label:has-text("Name")', 'Max');
+    await page.fill('label:has-text("Name")', 'Geralt');
     await page.click('button:has-text("Create Person")');
-    await page.waitForSelector('legend:has-text("Assigned To") ~ div:has-text("Max")');
+    await page.waitForSelector('legend:has-text("Assigned To") ~ div:has-text("Geralt")');
     expect(page.url()).toBe('http://localhost:3000/tasks/create');
   });
 


### PR DESCRIPTION
Inline related item creation is currently semi-broken, because the related item form in a drawer is submitting the main form as well. This results either in the main form showing validation errors just after the related item is created, or, if all the fields in the main form were filled correctly, in the main form being submitted automatically without any value in the relation field.

I think the https://github.com/keystonejs/keystone/pull/7594 introduced the regression, when a separate page started being used to create new items, instead of using the drawer component.

**Steps to reproduce the problem (using `tests/test-projects/basic`):**
1. Go to the new task page (http://localhost:3000/tasks/create);
2. Fill in the "Label" field to make the main form valid (it's the only required field);
3. Click "Create related Person" button to open the person form in a drawer;
4. Fill in any name and click "Create Person" to submit the form;
5. You should see that the Task form has been submitted as well, and the value of the "Assigned To" field isn't set.

I've created a test following these steps, which fails in the current `main` branch, and passes with my fix. The fix itself is very simple - stop form submit event propagation in the drawer component.