### PR TITLE
Fix Blog sort order

### DIFF
--- a/docs/pages/blog/index.tsx
+++ b/docs/pages/blog/index.tsx
@@ -38,7 +38,7 @@ export default function Docs(props: InferGetStaticPropsType<typeof getStaticProp
       if (a.frontmatter.publishDate === b.frontmatter.publishDate) {
         return a.frontmatter.title.localeCompare(b.frontmatter.title);
       }
-      return a.frontmatter.publishDate.localeCompare(b.frontmatter.publishDate);
+      return b.frontmatter.publishDate.localeCompare(a.frontmatter.publishDate);
     });
 
   return (

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -24,7 +24,7 @@ async function getPosts() {
     if (a.frontmatter.publishDate === b.frontmatter.publishDate) {
       return a.frontmatter.title.localeCompare(b.frontmatter.title);
     }
-    return a.frontmatter.publishDate.localeCompare(b.frontmatter.publishDate);
+    return b.frontmatter.publishDate.localeCompare(a.frontmatter.publishDate);
   });
 
   return reverseChronologicallySortedPosts;


### PR DESCRIPTION
Blog sort order got sorted chronologically instead of reverse chronologically in #8119. This PR fixes that.