### PR TITLE
Changes default `listen` to remove `host`

### DIFF
--- a/.changeset/fix-bind-again.md
+++ b/.changeset/fix-bind-again.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Reverts `::` as the default `config.server.options.host`, prefer `undefined` (the default for nodejs `httpServer`)

--- a/.changeset/honest-foxes-drum.md
+++ b/.changeset/honest-foxes-drum.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Host can be configured via the HOST environment variable

--- a/.changeset/honest-foxes-drum.md
+++ b/.changeset/honest-foxes-drum.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Host can be configured via the HOST environment variable
+Adds `HOST` as an environment variable for `keystone dev` and `keystone start`, with higher precedence than `config.server.options.host` 

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -282,7 +282,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = [undefined, '', '::', '0.0.0.0'].indexOf(httpOptions.host) !== -1 ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host) ? 'localhost' : httpOptions.host;
     console.log(
       `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -258,7 +258,6 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   });
 
   const httpOptions: ListenOptions = {
-    host: '::', // the default for nodejs httpServer
     port: 3000,
   };
 
@@ -275,12 +274,17 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
     httpOptions.port = parseInt(process.env.PORT || '');
   }
 
+  // preference env.HOST if supplied
+  if ('HOST' in process.env) {
+    httpOptions.host = process.env.HOST || '';
+  }
+
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].indexOf(httpOptions.host) !== -1 ? 'localhost' : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
+      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );
     console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql'}`);
 

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -282,9 +282,13 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
   const server = httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host) ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host)
+      ? 'localhost'
+      : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
+      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${
+        httpOptions.port
+      }/)`
     );
     console.log(`⭐️ GraphQL API available at ${config.graphql?.path || '/api/graphql'}`);
 

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -42,7 +42,6 @@ export const start = async (cwd: string) => {
   }
 
   const httpOptions: ListenOptions = {
-    host: '::', // the default for nodejs httpServer
     port: 3000,
   };
 
@@ -59,12 +58,17 @@ export const start = async (cwd: string) => {
     httpOptions.port = parseInt(process.env.PORT || '');
   }
 
+  // preference env.HOST if supplied
+  if ('HOST' in process.env) {
+    httpOptions.host = process.env.HOST || '';
+  }
+
   httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = httpOptions.host === '::' ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].indexOf(httpOptions.host) !== -1 ? 'localhost' : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
+      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );
   });
 };

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -66,7 +66,7 @@ export const start = async (cwd: string) => {
   httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = [undefined, '', '::', '0.0.0.0'].indexOf(httpOptions.host) !== -1 ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host) ? 'localhost' : httpOptions.host;
     console.log(
       `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
     );

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -66,9 +66,13 @@ export const start = async (cwd: string) => {
   httpServer.listen(httpOptions, (err?: any) => {
     if (err) throw err;
 
-    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host) ? 'localhost' : httpOptions.host;
+    const easyHost = [undefined, '', '::', '0.0.0.0'].includes(httpOptions.host)
+      ? 'localhost'
+      : httpOptions.host;
     console.log(
-      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${httpOptions.port}/)`
+      `⭐️ Server listening on ${httpOptions.host || ''}:${httpOptions.port} (http://${easyHost}:${
+        httpOptions.port
+      }/)`
     );
   });
 };

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -86,7 +86,7 @@ model Todo {
 `);
 
   expect(recording()).toEqual(`✨ Starting Keystone
-⭐️ Server listening on :::3000 (http://localhost:3000/)
+⭐️ Server listening on :3000 (http://localhost:3000/)
 ⭐️ GraphQL API available at /api/graphql
 ✨ Generating GraphQL and Prisma schemas
 ✨ sqlite database "app.db" created at file:./app.db
@@ -109,7 +109,7 @@ describe('useMigrations: false', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ The database is already in sync with the Prisma schema.
@@ -146,7 +146,7 @@ describe('useMigrations: false', () => {
     `);
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
 
@@ -189,7 +189,7 @@ describe('useMigrations: false', () => {
     `);
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
 
@@ -217,7 +217,7 @@ describe('useMigrations: false', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database has been reset
@@ -265,7 +265,7 @@ CREATE TABLE "Todo" (
 `);
 
   expect(cleanOutputForApplyingMigration(recording(), migrationName)).toEqual(`✨ Starting Keystone
-⭐️ Server listening on :::3000 (http://localhost:3000/)
+⭐️ Server listening on :3000 (http://localhost:3000/)
 ⭐️ GraphQL API available at /api/graphql
 ✨ Generating GraphQL and Prisma schemas
 ✨ sqlite database "app.db" created at file:./app.db
@@ -339,7 +339,7 @@ describe('useMigrations: true', () => {
 
     expect(cleanOutputForApplyingMigration(recording(), migrationName)).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
@@ -412,7 +412,7 @@ describe('useMigrations: true', () => {
 
     expect(cleanOutputForApplyingMigration(recording(), migrationName)).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
@@ -476,7 +476,7 @@ describe('useMigrations: true', () => {
       )
     ).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       - Drift detected: Your database schema is not in sync with your migration history.
@@ -524,7 +524,7 @@ describe('useMigrations: true', () => {
 
     expect(recording().replace(oldMigrationName, 'old_migration_name')).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       - Drift detected: Your database schema is not in sync with your migration history.
@@ -596,7 +596,7 @@ describe('useMigrations: true', () => {
 
     expect(recording().replace(migrationName!, 'migration_name')).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ There has been a change to your Keystone schema that requires a migration
@@ -636,7 +636,7 @@ describe('useMigrations: true', () => {
     expect(recording().replace(new RegExp(migrationName, 'g'), 'migration_name'))
       .toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ sqlite database "app.db" created at file:./app.db
@@ -672,7 +672,7 @@ describe('useMigrations: true', () => {
     expect(recording().replace(new RegExp(migrationName, 'g'), 'migration_name'))
       .toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database has been reset
@@ -695,7 +695,7 @@ describe('useMigrations: true', () => {
 
     expect(recording()).toMatchInlineSnapshot(`
       "✨ Starting Keystone
-      ⭐️ Server listening on :::3000 (http://localhost:3000/)
+      ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ Your database is up to date, no migrations need to be created or applied


### PR DESCRIPTION
This fixes #8131 by doing the following changes:

1. Removed the default `host` provided inside `start` and `dev` command
2. Added support to set `host` with the env variable `HOST`
3. Adjusted log message to resolve `undefined`, `''`. `'::'`, and `'0.0.0.0'` to the message `(http://localhost:3000/)`