### PR TITLE
Resolve config.telemetry check issue

### DIFF
--- a/.changeset/grumpy-cooks-poke.md
+++ b/.changeset/grumpy-cooks-poke.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Resolve `config.telemetry` check issue

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -147,7 +147,7 @@ export const dev = async (cwd: string, shouldDropDatabase: boolean) => {
     let lastPrintedGraphQLSchema = printSchema(graphQLSchema);
     let lastApolloServer = apolloServer;
 
-    if (!config.telemetry) {
+    if (config.telemetry !== false) {
       runTelemetry(cwd, initialisedLists, config.db.provider);
     }
 


### PR DESCRIPTION
The check on `config.telemetry` was incorrectly checking for the value to be not falsey where it whould skip when `telemetry === false`