### PR TITLE
Adds `KEYSTONE_TELEMETRY_DISABLED` to disable telemetry

### DIFF
--- a/.changeset/soft-emus-complain.md
+++ b/.changeset/soft-emus-complain.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Adds the ability to disable telemetry using environment variable `KEYSTONE_TELEMETRY_DISABLED`

--- a/docs/pages/docs/reference/telemetry.md
+++ b/docs/pages/docs/reference/telemetry.md
@@ -169,6 +169,11 @@ Keystone stores your telemetry preferences in a location defined by [env-paths](
 | Linux | ~/.config/keystonejs (or $XDG_CONFIG_HOME/keystonejs) |
 | Windows | %APPDATA%\keystonejs\Config (for example C:\Users\YOUR_USERNAME\AppData\Roaming\keystonejs\Config) |
 
+{% if $nextRelease %}
+**Environment Variable**
+You can opt-out of all telemetry by setting the `KEYSTONE_TELEMETRY_DISABLED` environment variable to `'1'`
+
+{% /if %}
 **Network-wide opt-out**
 
 If you have a network-wide firewall, you can opt-out of Keystone telemetry by not resolving the following domain: [telemetry.keystonejs.com](https://telemetry.keystonejs.com)

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -54,14 +54,15 @@ export function runTelemetry(
   dbProviderName: DatabaseProvider
 ) {
   try {
-    const { userConfig, telemetry } = getTelemetryConfig();
     if (
       ci.isCI || // Don't run in CI
       process.env.NODE_ENV === 'production' || // Don't run in production
-      telemetry === false // Don't run if the user has opted out
+      process.env.KEYSTONE_TELEMETRY_DISABLED === '1' // Don't run if the user has disabled it
     ) {
       return;
     }
+    const { userConfig, telemetry } = getTelemetryConfig();
+    if (telemetry === false) return; // Don't run if the user has opted out
     if (telemetry === undefined) {
       const newTelemetry: Configuration['telemetry'] = {
         device: { informedAt: new Date().toISOString() },


### PR DESCRIPTION
Adds the ability to disable telemetry by setting the `KEYSTONE_TELEMETRY_DISABLED` environment variable to `'1'`