### PR TITLE
Upgrade `@types/node` version

### DIFF
--- a/examples/document-field-customisation/nextjs-frontend/package.json
+++ b/examples/document-field-customisation/nextjs-frontend/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "18.7.2",
+    "@types/node": "18.11.14",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "typescript": "~4.9.4"

--- a/examples/e2e-boilerplate/nextjs-frontend/package.json
+++ b/examples/e2e-boilerplate/nextjs-frontend/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "18.7.2",
+    "@types/node": "18.11.14",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "typescript": "~4.9.4"

--- a/examples/nextjs-keystone/package.json
+++ b/examples/nextjs-keystone/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "18.7.2",
+    "@types/node": "18.11.14",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "typescript": "~4.9.4"

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
     ]
   },
   "resolutions": {
-    "**/@types/node": "^18.11.9"
+    "**/@types/node": "^18.11.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4614,10 +4614,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@18.7.2", "@types/node@>=8.1.0", "@types/node@^10.1.0", "@types/node@^12.7.1", "@types/node@^17.0.10", "@types/node@^18.11.9":
-  version "18.11.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.10.tgz#4c64759f3c2343b7e6c4b9caf761c7a3a05cee34"
-  integrity sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==
+"@types/node@*", "@types/node@18.11.14", "@types/node@>=8.1.0", "@types/node@^10.1.0", "@types/node@^12.7.1", "@types/node@^17.0.10", "@types/node@^18.11.14":
+  version "18.11.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.14.tgz#a8571b25f3a31e9ded14e3ab9488509adef831d8"
+  integrity sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ==
 
 "@types/nodemailer@^6.4.4":
   version "6.4.6"


### PR DESCRIPTION
This upgrade is needed to fix the build failures of `examples/nextjs-keystone` example in Vercel environment when deployed using the **Click to Deploy to Vercel** button in `README.md` file.