### PR TITLE
Fixes GraphQL errors when using `@keystone-6/auth`

### DIFF
--- a/.changeset/early-suns-knock.md
+++ b/.changeset/early-suns-knock.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Fixes GraphQL error when using `autoincrement` for auth list id

--- a/.changeset/good-monkeys-complain.md
+++ b/.changeset/good-monkeys-complain.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/auth': patch
+---
+
+Fixes GraphQL error when `sessionStrategy.start` returns null or undefined  
+

--- a/.changeset/good-monkeys-complain.md
+++ b/.changeset/good-monkeys-complain.md
@@ -2,5 +2,4 @@
 '@keystone-6/auth': patch
 ---
 
-Fixes GraphQL error when `sessionStrategy.start` returns null or undefined  
-
+Fixes GraphQL error when `sessionStrategy.start` returns null or undefined

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -54,7 +54,10 @@ export function getBaseAuthSchema<I extends string, S extends string>({
           resolveType: (root, context) => context.session?.listKey,
         }),
         resolve(root, args, { session, db }) {
-          if (typeof session?.itemId === 'string' && typeof session.listKey === 'string') {
+          if (
+            (typeof session?.itemId === 'string' || typeof session.itemId === 'number') &&
+            typeof session.listKey === 'string'
+          ) {
             return db[session.listKey].findOne({ where: { id: session.itemId } });
           }
           return null;

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -91,13 +91,17 @@ export function getBaseAuthSchema<I extends string, S extends string>({
           }
 
           // Update system state
-          const sessionToken = (await context.sessionStrategy.start({
+          const sessionToken = await context.sessionStrategy.start({
             data: {
               listKey,
               itemId: result.item.id,
             },
             context,
-          })) as string;
+          });
+          // return Failure if sessionStrategy.start() returns null
+          if (typeof sessionToken !== 'string' || sessionToken.length === 0) {
+            return { code: 'FAILURE', message: 'Failed to start session.' };
+          }
           return { sessionToken, item: result.item };
         },
       }),


### PR DESCRIPTION
Fixes #8163 - Allows for auth list id to be `autoincrement`
Fixes #8178 - Returns an authentication failure when `sessionStrategy.start` does not return a valid string. 