### PR TITLE
Fixes Document Editor Demo on the website

### DIFF
--- a/tests/sandbox/component-blocks.tsx
+++ b/tests/sandbox/component-blocks.tsx
@@ -499,7 +499,8 @@ export const componentBlocks = {
                 {attrs => (
                   <ToolbarButton
                     isSelected={props.fields.intent.value === opt.value}
-                    onClick={() => {
+                    onMouseDown={event => {
+                      event.preventDefault();
                       props.fields.intent.onChange(opt.value);
                     }}
                     {...attrs}
@@ -515,7 +516,14 @@ export const componentBlocks = {
 
           <Tooltip content="Remove" weight="subtle">
             {attrs => (
-              <ToolbarButton variant="destructive" onClick={onRemove} {...attrs}>
+              <ToolbarButton
+                variant="destructive"
+                onMouseDown={event => {
+                  event.preventDefault();
+                  onRemove();
+                }}
+                {...attrs}
+              >
                 <Trash2Icon size="small" />
               </ToolbarButton>
             )}


### PR DESCRIPTION
Fixes #8102

The editor would lose focus and stop showing the notice buttons before `onClick` was called, changing to `onMouseDown` resolves this issue. This is the default behaviour for using Chromeless custom components without a custom toolbar - see https://github.com/keystonejs/keystone/blob/6f6e2a150de667f1f72eb9abba1a9c86914189e3/packages/fields-document/src/DocumentEditor/component-blocks/chromeless-element.tsx#L57