### PR TITLE
Add missing documentation for `server.options` (`http.createServer` options)

### DIFF
--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -208,6 +208,7 @@ Options:
 - `cors` (default: `undefined`): Allows you to configure the [cors middleware](https://www.npmjs.com/package/cors#configuration-options) for your Express server.
   If left undefined `cors` will not be used.
 - `port` (default: `3000` ): The port your Express server will listen on.
+- `options` (default: `undefined`): The [`http.createServer`](https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener) options used by Node.
 - `maxFileSize` (default: `200 * 1024 * 1024`): The maximum file size allowed for uploads. If left undefined, defaults to `200 MiB`
 - `healthCheck` (default: `undefined`): Allows you to configure a health check endpoint on your server.
 - `extendExpressApp` (default: `undefined`): Allows you to extend the express app that Keystone creates.


### PR DESCRIPTION
As brought up by @fkrauthan and @mkastner in https://github.com/keystonejs/keystone/issues/8131#issuecomment-1368203105