### PR TITLE
Fixes Dataloader error when resolving relationships when access is `false` on related to-one item

### DIFF
--- a/.changeset/shy-falcons-think.md
+++ b/.changeset/shy-falcons-think.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes Dataloader error when resolving relationships when access is `false` on related to-one item

--- a/packages/core/src/lib/core/queries/output-field.ts
+++ b/packages/core/src/lib/core/queries/output-field.ts
@@ -102,12 +102,12 @@ async function fetchRelatedItems(
 ) {
   const operationAccess = await getOperationAccess(foreignList, context, 'query');
   if (!operationAccess) {
-    return [];
+    return toFetch.map(() => undefined);
   }
 
   const accessFilters = await getAccessFilters(foreignList, context, 'query');
   if (accessFilters === false) {
-    return [];
+    return toFetch.map(() => undefined);
   }
 
   const resolvedWhere = await accessControlledFilter(


### PR DESCRIPTION
Fixes #8191 