### PR TITLE
Update to node 16 in Codesandbox

### DIFF
--- a/examples/assets-local/sandbox.config.json
+++ b/examples/assets-local/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/auth/sandbox.config.json
+++ b/examples/auth/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/basic/sandbox.config.json
+++ b/examples/basic/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/blog/sandbox.config.json
+++ b/examples/blog/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/custom-admin-ui-logo/sandbox.config.json
+++ b/examples/custom-admin-ui-logo/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/custom-admin-ui-navigation/sandbox.config.json
+++ b/examples/custom-admin-ui-navigation/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/custom-admin-ui-pages/sandbox.config.json
+++ b/examples/custom-admin-ui-pages/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/custom-field-view/sandbox.config.json
+++ b/examples/custom-field-view/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/custom-field/sandbox.config.json
+++ b/examples/custom-field/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/default-values/sandbox.config.json
+++ b/examples/default-values/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/document-field-customisation/keystone-server/sandbox.config.json
+++ b/examples/document-field-customisation/keystone-server/sandbox.config.json
@@ -2,7 +2,7 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev --seed-data",
-    "node": "14"
+    "node": "16"
   },
   "hardReloadOnChange": true
 }

--- a/examples/document-field/sandbox.config.json
+++ b/examples/document-field/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/e2e-boilerplate/keystone-server/sandbox.config.json
+++ b/examples/e2e-boilerplate/keystone-server/sandbox.config.json
@@ -2,7 +2,7 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev --seed-data",
-    "node": "14"
+    "node": "16"
   },
   "hardReloadOnChange": true
 }

--- a/examples/ecommerce/sandbox.config.json
+++ b/examples/ecommerce/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/embedded-nextjs/sandbox.config.json
+++ b/examples/embedded-nextjs/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/extend-graphql-schema-graphql-tools/sandbox.config.json
+++ b/examples/extend-graphql-schema-graphql-tools/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/extend-graphql-schema-graphql-ts/sandbox.config.json
+++ b/examples/extend-graphql-schema-graphql-ts/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/extend-graphql-schema-nexus/sandbox.config.json
+++ b/examples/extend-graphql-schema-nexus/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/extend-graphql-subscriptions/sandbox.config.json
+++ b/examples/extend-graphql-subscriptions/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/feature-boilerplate/sandbox.config.json
+++ b/examples/feature-boilerplate/sandbox.config.json
@@ -2,7 +2,7 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev --seed-data",
-    "node": "14"
+    "node": "16"
   },
   "hardReloadOnChange": true
 }

--- a/examples/json/sandbox.config.json
+++ b/examples/json/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/limits/sandbox.config.json
+++ b/examples/limits/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/rest-api/sandbox.config.json
+++ b/examples/rest-api/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/roles/sandbox.config.json
+++ b/examples/roles/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/examples/singleton/sandbox.config.json
+++ b/examples/singleton/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "keystone dev",
-    "node": "14"
+    "node": "16"
   }
 }

--- a/tests/sandbox/sandbox.config.json
+++ b/tests/sandbox/sandbox.config.json
@@ -2,6 +2,6 @@
   "template": "node",
   "container": {
     "startScript": "sandbox",
-    "node": "14"
+    "node": "16"
   }
 }


### PR DESCRIPTION
Fixes #8230 
Codesandbox is not currently working, using node 14 gives the following error:
```
error @vercel/og@0.0.21: The engine "node" is incompatible with this module. Expected version ">=16". Got "14...
```
Bumping the node version 16
