### PR TITLE
Add missing CodeSandbox configs to examples

### DIFF
--- a/examples/custom-session-validation/sandbox.config.json
+++ b/examples/custom-session-validation/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/graphql-ts-gql/sandbox.config.json
+++ b/examples/graphql-ts-gql/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/script/sandbox.config.json
+++ b/examples/script/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/task-manager/sandbox.config.json
+++ b/examples/task-manager/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/testing/sandbox.config.json
+++ b/examples/testing/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/virtual-field/sandbox.config.json
+++ b/examples/virtual-field/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}

--- a/examples/with-auth/sandbox.config.json
+++ b/examples/with-auth/sandbox.config.json
@@ -1,0 +1,7 @@
+{
+  "template": "node",
+  "container": {
+    "startScript": "keystone dev",
+    "node": "16"
+  }
+}


### PR DESCRIPTION
A few examples have missing CodeSandbox configs leading to Codesandbox doing nothing. This adds configs to those that example where it makes sense