### PR TITLE
Resolve console errors on Signin

### DIFF
--- a/.changeset/gentle-wolves-travel.md
+++ b/.changeset/gentle-wolves-travel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Export `next/head` for use in auth package

--- a/.changeset/twenty-chefs-kick.md
+++ b/.changeset/twenty-chefs-kick.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Resolve `loading Admin Metadata` and `<head> cannot appear as a child of <div>` errors on signin

--- a/packages/auth/src/components/SigninContainer.tsx
+++ b/packages/auth/src/components/SigninContainer.tsx
@@ -4,6 +4,7 @@
 import { ReactNode } from 'react';
 
 import { jsx, Box, Center, useTheme } from '@keystone-ui/core';
+import { Head } from '@keystone-6/core/admin-ui/router';
 
 type SigninContainerProps = {
   children: ReactNode;
@@ -14,9 +15,9 @@ export const SigninContainer = ({ children, title }: SigninContainerProps) => {
   const { colors, shadow } = useTheme();
   return (
     <div>
-      <head>
+      <Head>
         <title>{title || 'Keystone'}</title>
-      </head>
+      </Head>
       <Center
         css={{
           minWidth: '100vw',

--- a/packages/auth/src/pages/SigninPage.tsx
+++ b/packages/auth/src/pages/SigninPage.tsx
@@ -99,7 +99,6 @@ export const SigninPage = ({
               return;
             }
             reinitContext();
-            router.push(redirect);
           }
         }}
       >

--- a/packages/core/src/admin-ui/router.tsx
+++ b/packages/core/src/admin-ui/router.tsx
@@ -18,3 +18,7 @@ import { AnchorHTMLAttributes } from 'react';
 export type LinkProps = NextLinkProps & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const Link = NextLink;
+
+import NextHead from 'next/head';
+
+export const Head = NextHead;


### PR DESCRIPTION
Fixes #8224 #8223 and #8211 

`router.push` was being called twice - once in the `onSubmit` and the other in the use effect this caused and `Abort fetching component for route` error and would sporadically cause the error seen in #8224 

Switched to use `<Head>` exported through `@keystone-6/core` to resolve #8211 