### PR TITLE
Fixes `<div> cannot appear as a dependant of <p>` error on List Page

### DIFF
--- a/.changeset/nervous-dogs-move.md
+++ b/.changeset/nervous-dogs-move.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Resolve `<div> cannot appear as a dependant of <p>` error on List Page

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -189,7 +189,6 @@ const ListPage = ({ listKey }: ListPageProps) => {
     data: newData,
     error: newError,
     refetch,
-    loading,
   } = useQuery(
     useMemo(() => {
       let selectedGqlFields = [...selectedFields]
@@ -337,9 +336,6 @@ const ListPage = ({ listKey }: ListPageProps) => {
                         list={list}
                         fieldModesByFieldPath={listViewFieldModesByField}
                       />{' '}
-                      {loading && (
-                        <LoadingDots label="Loading item data" size="small" tone="active" />
-                      )}
                     </Fragment>
                   );
                 })()}


### PR DESCRIPTION
Fixes #7596 

Remove extra `<LoadingDots>` that are a child of `<ResultsSummaryContainer>` which has `{children}` within a `<p>` 
Loading dots are still on this page, so these were extra ones.