### PR TITLE
Resolves error thrown when deleting item with a file that no longer exists

### DIFF
--- a/.changeset/gentle-poets-perform.md
+++ b/.changeset/gentle-poets-perform.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Resolves error when deleting an item that has a file or image that is no longer on the filesystem

--- a/packages/core/src/lib/assets/local.ts
+++ b/packages/core/src/lib/assets/local.ts
@@ -19,7 +19,15 @@ export function localImageAssetsAPI(
       await fs.writeFile(path.join(storageConfig.storagePath, `${id}.${extension}`), buffer);
     },
     async delete(id, extension) {
-      await fs.unlink(path.join(storageConfig.storagePath, `${id}.${extension}`));
+      try {
+        await fs.unlink(path.join(storageConfig.storagePath, `${id}.${extension}`));
+      } catch (e) {
+        const error = e as NodeJS.ErrnoException;
+        // If the file doesn't exist, we don't care
+        if (error.code !== 'ENOENT') {
+          throw e;
+        }
+      }
     },
   };
 }
@@ -51,7 +59,15 @@ export function localFileAssetsAPI(storageConfig: StorageConfig & { kind: 'local
       }
     },
     async delete(filename) {
-      await fs.unlink(path.join(storageConfig.storagePath, filename));
+      try {
+        await fs.unlink(path.join(storageConfig.storagePath, filename));
+      } catch (e) {
+        const error = e as NodeJS.ErrnoException;
+        // If the file doesn't exist, we don't care
+        if (error.code !== 'ENOENT') {
+          throw e;
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
Fixes #8071

Wraps the `fs.unlink` in a try/catch and checks for ENOENT code on error

The other option would be to just swallow all errors on the local `adapter.delete` if there are no errors we need to throw on.