### PR TITLE
Set `isFilterable` to `false` in examples where read access is false

### DIFF
--- a/examples/basic/schema.graphql
+++ b/examples/basic/schema.graphql
@@ -56,7 +56,6 @@ input UserWhereInput {
   name: StringFilter
   email: StringFilter
   password: PasswordFilter
-  isAdmin: BooleanFilter
   roles: StringFilter
   phoneNumbers: PhoneNumberManyRelationFilter
   posts: PostManyRelationFilter
@@ -103,11 +102,6 @@ input NestedStringFilter {
 
 input PasswordFilter {
   isSet: Boolean!
-}
-
-input BooleanFilter {
-  equals: Boolean
-  not: BooleanFilter
 }
 
 input PhoneNumberManyRelationFilter {

--- a/examples/basic/schema.ts
+++ b/examples/basic/schema.ts
@@ -60,6 +60,7 @@ const User: Lists.User = list({
         create: access.isAdmin,
         update: access.isAdmin,
       },
+      isFilterable: false,
       ui: {
         createView: {
           fieldMode: args => (access.isAdmin(args) ? 'edit' : 'hidden'),

--- a/examples/custom-session-validation/schema.graphql
+++ b/examples/custom-session-validation/schema.graphql
@@ -167,7 +167,6 @@ input PersonWhereInput {
   id: IDFilter
   name: StringFilter
   email: StringFilter
-  passwordChangedAt: DateTimeNullableFilter
   tasks: TaskManyRelationFilter
 }
 

--- a/examples/custom-session-validation/schema.ts
+++ b/examples/custom-session-validation/schema.ts
@@ -41,6 +41,7 @@ export const lists = {
       passwordChangedAt: timestamp({
         // Don't allow the passwordChangedAt field to be set by the user.
         access: () => false,
+        isFilterable: false,
         hooks: {
           resolveInput: ({ resolvedData }) => {
             // If the password has been changed, update the passwordChangedAt field to the current time.


### PR DESCRIPTION
Both the basic and custom-sesson-validation examples have fields with field-level access control that don't allow reads, this PR also sets those fields to `isFilterable: false`