### PR TITLE
Add missing access control for walkthrough documentation

### DIFF
--- a/docs/pages/docs/walkthroughs/lesson-1.md
+++ b/docs/pages/docs/walkthroughs/lesson-1.md
@@ -87,7 +87,7 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./keystone.db',
-  },
+  }
 });
 ```
 
@@ -105,6 +105,7 @@ We’re going to build a simple blog with **users** and **posts**. Let’s start
 
 ```js{2,9-15}[5-8]
 import { config, list } from '@keystone-6/core';
+import { allowAll } from '@keystone-6/core/access';
 import { text } from '@keystone-6/core/fields';
 
 export default config({
@@ -114,6 +115,7 @@ export default config({
   },
   lists: {
     User: list({
+      access: allowAll,
       fields: {
         name: text({ validation: { isRequired: true } }),
         email: text({ validation: { isRequired: true }, isIndexed: 'unique' }),

--- a/docs/pages/docs/walkthroughs/lesson-1.md
+++ b/docs/pages/docs/walkthroughs/lesson-1.md
@@ -87,7 +87,8 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./keystone.db',
-  }
+  },
+  lists: {} // ...
 });
 ```
 


### PR DESCRIPTION
This is required in recent versions of `keystone-6`, this amends the guide to reflect that.

Found while trying to reproduce https://github.com/keystonejs/keystone/issues/7636