### PR TITLE
Add `Apollo-Require-Preflight` to Apollo client header

### DIFF
--- a/.changeset/warm-rules-sort.md
+++ b/.changeset/warm-rules-sort.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes CSRF on image upload by adding `Apollo-Require-Preflight` to Apollo client header

--- a/.changeset/warm-rules-sort.md
+++ b/.changeset/warm-rules-sort.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': patch
----
-
-Fixes CSRF on image upload by adding `Apollo-Require-Preflight` to Apollo client header

--- a/packages/core/src/admin-ui/context.tsx
+++ b/packages/core/src/admin-ui/context.tsx
@@ -88,7 +88,10 @@ export const KeystoneProvider = (props: KeystoneProviderProps) => {
     () =>
       new ApolloClient({
         cache: new InMemoryCache(),
-        link: createUploadLink({ uri: props.apiPath }),
+        link: createUploadLink({
+          uri: props.apiPath,
+          headers: { 'Apollo-Require-Preflight': 'true' },
+        }),
       }),
     [props.apiPath]
   );


### PR DESCRIPTION
Fixes #7925

Also fixes image upload on main now Apollo 4 has CSRF protection enabled by default