### PR TITLE
Add acl option for s3 storage

### DIFF
--- a/.changeset/five-papayas-mate.md
+++ b/.changeset/five-papayas-mate.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/core': minor
+'@keystone-6/website': minor
+---
+
+Add acl option for s3 storage configuration.

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -483,6 +483,7 @@ S3 options:
 - `endpoint`: The endpoint to use - if provided, this endpoint will be used instead of the default amazon s3 endpoint
 - `forcePathStyle`: Force the old pathstyle of using the bucket name after the host
 - `signed.expiry`: Use S3 URL signing to keep S3 assets private. `expiry` is in seconds
+{% if $nextRelease %}
 - `acl`: Set the permissions for the uploaded asset. If not set, the permissions of the asset will depend on your S3 provider's default settings.
 These values are supported:
   - `'private'` No public assess.
@@ -494,6 +495,7 @@ These values are supported:
   - `'bucket-owner-full-control'` Bucket owner gets full control.
 
   See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl for more details.
+{% /if %}
 
 ```typescript
 import { config } from '@keystone-6/core';

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -483,6 +483,17 @@ S3 options:
 - `endpoint`: The endpoint to use - if provided, this endpoint will be used instead of the default amazon s3 endpoint
 - `forcePathStyle`: Force the old pathstyle of using the bucket name after the host
 - `signed.expiry`: Use S3 URL signing to keep S3 assets private. `expiry` is in seconds
+- `acl`: Set the permissions for the uploaded asset. If not set, the permissions of the asset will depend on your S3 provider's default settings.
+These values are supported:
+  - `'private'` No public assess.
+  - `'public-read'` Public read access.
+  - `'public-read-write'` Public read and write access.
+  - `'aws-exec-read'` Amazon EC2 gets read access.
+  - `'authenticated-read'` Authenticated users get access.
+  - `'bucket-owner-read'` Bucket owner gets read access.
+  - `'bucket-owner-full-control'` Bucket owner gets full control.
+
+  See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl for more details.
 
 ```typescript
 import { config } from '@keystone-6/core';

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -486,7 +486,7 @@ S3 options:
 {% if $nextRelease %}
 - `acl`: Set the permissions for the uploaded asset. If not set, the permissions of the asset will depend on your S3 provider's default settings.
 These values are supported:
-  - `'private'` No public assess.
+  - `'private'` No public access.
   - `'public-read'` Public read access.
   - `'public-read-write'` Public read and write access.
   - `'aws-exec-read'` Amazon EC2 gets read access.

--- a/packages/core/src/lib/assets/s3.ts
+++ b/packages/core/src/lib/assets/s3.ts
@@ -27,6 +27,7 @@ export function s3ImageAssetsAPI(storageConfig: StorageConfig & { kind: 's3' }):
             gif: 'image/gif',
             jpg: 'image/jpeg',
           }[extension],
+          ACL: storageConfig.acl,
         },
       });
       await upload.done();
@@ -63,6 +64,7 @@ export function s3FileAssetsAPI(storageConfig: StorageConfig & { kind: 's3' }): 
           Key: (storageConfig.pathPrefix || '') + filename,
           Body: stream,
           ContentType: 'application/octet-stream',
+          ACL: storageConfig.acl,
         },
       });
 

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -75,6 +75,20 @@ export type StorageConfig = (
       endpoint?: string;
       /** If true, will force the 'old' S3 path style of putting bucket name at the start of the pathname of the URL  */
       forcePathStyle?: boolean;
+      /** A string that sets permissions for the uploaded assets. Default is 'private'.
+       *
+       * Amazon S3 supports a set of predefined grants, known as canned ACLs.
+       * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+       * for more details.
+       */
+      acl?:
+        | 'private'
+        | 'public-read'
+        | 'public-read-write'
+        | 'aws-exec-read'
+        | 'authenticated-read'
+        | 'bucket-owner-read'
+        | 'bucket-owner-full-control';
     }
 ) &
   FileOrImage;


### PR DESCRIPTION
This PR adds ACL settings to the s3 storage config.

## Why

This change was necessary because on DigitalOcean I wasn't able to see my uploaded images publicly. Instead, I had to set them to public manually. 

DO does not let you set default permissions:
https://docs.digitalocean.com/products/spaces/how-to/set-file-permissions/

> By default, file permissions are set to Private. Some third-party tools provide support for changing the default permissions, but there is currently no way to do so in the control panel.

## Usage

```typescript
config({
  storage: {
    remote: {
      kind: 's3',
      type: 'image',
      bucketName,
      region,
      accessKeyId,
      secretAccessKey,
      endpoint,

      /** Optionally add one of the ACL options from AWS-SDK.
       * 
       * Example: 'private', 'public-read' or 'public-read-write'.
       * 
       * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
       * for more details.
       */
      acl: 'public-read'
    },    
  }
});
```