### PR TITLE
Add `access` key for Next.js embedded tutorial

### DIFF
--- a/docs/pages/blog/embedded-mode-with-sqlite-nextjs.md
+++ b/docs/pages/blog/embedded-mode-with-sqlite-nextjs.md
@@ -111,6 +111,7 @@ To create and edit blog records in Keystone's Admin UI, add a `keystone.ts` [con
 
 import { config, list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
+import { allowAll } from '@keystone-6/core/access';
 import { Lists } from '.keystone/types';
 
 const Post: Lists.Post = list({
@@ -119,6 +120,7 @@ const Post: Lists.Post = list({
     slug: text({ isIndexed: 'unique', isFilterable: true }),
     content: text(),
   },
+  access: allowAll
 });
 
 export default config({


### PR DESCRIPTION
Otherwise, it'll cryptically crash on launch.