### PR TITLE
Fix regression in authenticatedItem query

### DIFF
--- a/.changeset/twenty-parrots-rescue.md
+++ b/.changeset/twenty-parrots-rescue.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Fix regression in authenticatedItem query

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -55,7 +55,7 @@ export function getBaseAuthSchema<I extends string, S extends string>({
         }),
         resolve(root, args, { session, db }) {
           if (
-            (typeof session?.itemId === 'string' || typeof session.itemId === 'number') &&
+            (typeof session?.itemId === 'string' || typeof session?.itemId === 'number') &&
             typeof session.listKey === 'string'
           ) {
             return db[session.listKey].findOne({ where: { id: session.itemId } });


### PR DESCRIPTION
PR https://github.com/keystonejs/keystone/pull/8182 introduced regression that causes authenticatedItem query to return error when current user is unauthenticated (session is undefined).

Example query:
```graphql
query authenticate {
      authenticatedItem {
        __typename
        ... on User {
          id
          name
        }
      }
    }
```

Results in

```graphql
{
  "errors": [
    {
      "message": "Unexpected error.",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "authenticatedItem"
      ],
      "extensions": {
        "originalError": {
          "message": "Cannot read properties of undefined (reading 'itemId')",
          "stack": "TypeError: Cannot read properties of undefined (reading 'itemId')\n    at resolve (webpack-internal:///(api)/../../packages/auth/src/gql/getBaseAuthSchema.ts:56:80)\n    at executeField (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:294:24)\n    at executeFields (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:241:28)\n    at executeOperation (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:205:18)\n    at file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:62:37\n    at new ValueOrPromise (/home/exar/os/keystone/node_modules/value-or-promise/build/main/ValueOrPromise.js:14:21)\n    at executeImpl (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:62:12)\n    at execute (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/execute.js:48:12)\n    at file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/normalizedExecutor.js:12:37\n    at new ValueOrPromise (/home/exar/os/keystone/node_modules/value-or-promise/build/main/ValueOrPromise.js:14:21)\n    at normalizedExecutor (file:///home/exar/os/keystone/node_modules/@graphql-tools/executor/esm/execution/normalizedExecutor.js:12:12)\n    at file:///home/exar/os/keystone/node_modules/@envelop/core/esm/orchestrator.js:373:33\n    at async YogaServer.getResultForParams (file:///home/exar/os/keystone/node_modules/graphql-yoga/esm/server.js:262:26)\n    at async YogaServer.getResponse (file:///home/exar/os/keystone/node_modules/graphql-yoga/esm/server.js:328:23)\n    at async YogaServer.handle (file:///home/exar/os/keystone/node_modules/graphql-yoga/esm/server.js:38:34)\n    at async requestListener (file:///home/exar/os/keystone/node_modules/@whatwg-node/server/index.mjs:214:26)\n    at async Object.apiResolver (/home/exar/os/keystone/node_modules/next/dist/server/api-utils/node.js:363:9)\n    at async DevServer.runApi (/home/exar/os/keystone/node_modules/next/dist/server/next-server.js:487:9)\n    at async Object.fn (/home/exar/os/keystone/node_modules/next/dist/server/next-server.js:749:37)\n    at async Router.execute (/home/exar/os/keystone/node_modules/next/dist/server/router.js:253:36)\n    at async DevServer.run (/home/exar/os/keystone/node_modules/next/dist/server/base-server.js:384:29)\n    at async DevServer.run (/home/exar/os/keystone/node_modules/next/dist/server/dev/next-dev-server.js:741:20)\n    at async DevServer.handleRequest (/home/exar/os/keystone/node_modules/next/dist/server/base-server.js:322:20)"
        }
      }
    }
  ],
  "data": {
    "authenticatedItem": null
  }
}
```