### PR TITLE
Fix `inlineCreate` for `displayMode: 'cards'` with relationships

### DIFF
--- a/.changeset/few-chefs-help.md
+++ b/.changeset/few-chefs-help.md
@@ -1,0 +1,7 @@
+---
+'@keystone-6/test-projects-basic': patch
+'@keystone-6/admin-ui-tests': patch
+'@keystone-6/core': patch
+---
+
+Fixes inline-Card related item form submitting the parent form

--- a/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
@@ -58,6 +58,7 @@ export function InlineCreate({
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    event.stopPropagation();
     const newForceValidation = invalidFields.size !== 0;
     setForceValidation(newForceValidation);
 

--- a/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineEdit.tsx
@@ -70,6 +70,7 @@ export function InlineEdit({
     <form
       onSubmit={event => {
         event.preventDefault();
+        event.stopPropagation();
         if (changedFields.size === 0) {
           onCancel();
           return;

--- a/tests/admin-ui-tests/relations.test.ts
+++ b/tests/admin-ui-tests/relations.test.ts
@@ -10,7 +10,7 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
   });
 
-  test('Creating relation items inline does not submit main form', async () => {
+  test('Creating relation items using the drawer does not submit main form', async () => {
     await page.goto('http://localhost:3000/tasks/create');
     await page.fill('label:has-text("Label")', 'Buy beer');
     await page.click('button:has-text("Create related Person")');
@@ -19,6 +19,23 @@ adminUITests('./tests/test-projects/basic', browserType => {
     await page.click('button:has-text("Create Person")');
     await page.waitForSelector('legend:has-text("Assigned To") ~ div:has-text("Geralt")');
     expect(page.url()).toBe('http://localhost:3000/tasks/create');
+  });
+
+  test('Creating/Editing relation items inline does not submit main form', async () => {
+    await page.goto('http://localhost:3000/cats/create');
+    await page.fill('name:has-text("Name")', 'Whiskers');
+    await page.click('button:has-text("Create related Person")');
+    await page.waitForSelector('h1:has-text("Create Person")');
+    await page.fill('label:has-text("Name")', 'Geralt');
+    await page.click('button:has-text("Create Person")');
+
+    expect(page.url()).toBe('http://localhost:3000/cats/create');
+
+    await page.click('button:has-text("Edit")');
+    await page.fill('label:has-text("Name")', 'John');
+    await page.click('button:has-text("Save")');
+
+    expect(page.url()).toBe('http://localhost:3000/cats/create');
   });
 
   afterAll(async () => {

--- a/tests/admin-ui-tests/relations.test.ts
+++ b/tests/admin-ui-tests/relations.test.ts
@@ -10,7 +10,7 @@ adminUITests('./tests/test-projects/basic', browserType => {
     page = await browser.newPage();
   });
 
-  test('Creating relation items using the drawer does not submit main form', async () => {
+  test('Creating relation items using the inline drawer does not submit main form', async () => {
     await page.goto('http://localhost:3000/tasks/create');
     await page.fill('label:has-text("Label")', 'Buy beer');
     await page.click('button:has-text("Create related Person")');
@@ -21,7 +21,7 @@ adminUITests('./tests/test-projects/basic', browserType => {
     expect(page.url()).toBe('http://localhost:3000/tasks/create');
   });
 
-  test('Creating/Editing relation items inline does not submit main form', async () => {
+  test('Creating/Editing relation items using the inline card does not submit main form', async () => {
     await page.goto('http://localhost:3000/cats/create');
     await page.fill('name:has-text("Name")', 'Whiskers');
     await page.click('button:has-text("Create related Person")');

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -141,11 +141,52 @@ input PersonRelateToOneForCreateInput {
   connect: PersonWhereUniqueInput
 }
 
+type Cat {
+  id: ID!
+  name: String
+  owner: Person
+}
+
+input CatWhereUniqueInput {
+  id: ID
+}
+
+input CatWhereInput {
+  AND: [CatWhereInput!]
+  OR: [CatWhereInput!]
+  NOT: [CatWhereInput!]
+  id: IDFilter
+  name: StringFilter
+  owner: PersonWhereInput
+}
+
+input CatOrderByInput {
+  id: OrderDirection
+  name: OrderDirection
+}
+
+input CatUpdateInput {
+  name: String
+  owner: PersonRelateToOneForUpdateInput
+}
+
+input CatUpdateArgs {
+  where: CatWhereUniqueInput!
+  data: CatUpdateInput!
+}
+
+input CatCreateInput {
+  name: String
+  owner: PersonRelateToOneForCreateInput
+}
+
 type Person {
   id: ID!
   name: String
   tasks(where: TaskWhereInput! = {}, orderBy: [TaskOrderByInput!]! = [], take: Int, skip: Int! = 0): [Task!]
   tasksCount(where: TaskWhereInput! = {}): Int
+  cat(where: CatWhereInput! = {}, orderBy: [CatOrderByInput!]! = [], take: Int, skip: Int! = 0): [Cat!]
+  catCount(where: CatWhereInput! = {}): Int
 }
 
 input PersonWhereUniqueInput {
@@ -159,12 +200,19 @@ input PersonWhereInput {
   id: IDFilter
   name: StringFilter
   tasks: TaskManyRelationFilter
+  cat: CatManyRelationFilter
 }
 
 input TaskManyRelationFilter {
   every: TaskWhereInput
   some: TaskWhereInput
   none: TaskWhereInput
+}
+
+input CatManyRelationFilter {
+  every: CatWhereInput
+  some: CatWhereInput
+  none: CatWhereInput
 }
 
 input PersonOrderByInput {
@@ -175,6 +223,7 @@ input PersonOrderByInput {
 input PersonUpdateInput {
   name: String
   tasks: TaskRelateToManyForUpdateInput
+  cat: CatRelateToManyForUpdateInput
 }
 
 input TaskRelateToManyForUpdateInput {
@@ -182,6 +231,13 @@ input TaskRelateToManyForUpdateInput {
   set: [TaskWhereUniqueInput!]
   create: [TaskCreateInput!]
   connect: [TaskWhereUniqueInput!]
+}
+
+input CatRelateToManyForUpdateInput {
+  disconnect: [CatWhereUniqueInput!]
+  set: [CatWhereUniqueInput!]
+  create: [CatCreateInput!]
+  connect: [CatWhereUniqueInput!]
 }
 
 input PersonUpdateArgs {
@@ -192,11 +248,17 @@ input PersonUpdateArgs {
 input PersonCreateInput {
   name: String
   tasks: TaskRelateToManyForCreateInput
+  cat: CatRelateToManyForCreateInput
 }
 
 input TaskRelateToManyForCreateInput {
   create: [TaskCreateInput!]
   connect: [TaskWhereUniqueInput!]
+}
+
+input CatRelateToManyForCreateInput {
+  create: [CatCreateInput!]
+  connect: [CatWhereUniqueInput!]
 }
 
 type SecretPlan {
@@ -251,6 +313,12 @@ type Mutation {
   updateTasks(data: [TaskUpdateArgs!]!): [Task]
   deleteTask(where: TaskWhereUniqueInput!): Task
   deleteTasks(where: [TaskWhereUniqueInput!]!): [Task]
+  createCat(data: CatCreateInput!): Cat
+  createCats(data: [CatCreateInput!]!): [Cat]
+  updateCat(where: CatWhereUniqueInput!, data: CatUpdateInput!): Cat
+  updateCats(data: [CatUpdateArgs!]!): [Cat]
+  deleteCat(where: CatWhereUniqueInput!): Cat
+  deleteCats(where: [CatWhereUniqueInput!]!): [Cat]
   createPerson(data: PersonCreateInput!): Person
   createPeople(data: [PersonCreateInput!]!): [Person]
   updatePerson(where: PersonWhereUniqueInput!, data: PersonUpdateInput!): Person
@@ -269,6 +337,9 @@ type Query {
   tasks(where: TaskWhereInput! = {}, orderBy: [TaskOrderByInput!]! = [], take: Int, skip: Int! = 0): [Task!]
   task(where: TaskWhereUniqueInput!): Task
   tasksCount(where: TaskWhereInput! = {}): Int
+  cats(where: CatWhereInput! = {}, orderBy: [CatOrderByInput!]! = [], take: Int, skip: Int! = 0): [Cat!]
+  cat(where: CatWhereUniqueInput!): Cat
+  catsCount(where: CatWhereInput! = {}): Int
   people(where: PersonWhereInput! = {}, orderBy: [PersonOrderByInput!]! = [], take: Int, skip: Int! = 0): [Person!]
   person(where: PersonWhereUniqueInput!): Person
   peopleCount(where: PersonWhereInput! = {}): Int

--- a/tests/test-projects/basic/schema.prisma
+++ b/tests/test-projects/basic/schema.prisma
@@ -24,10 +24,20 @@ model Task {
   @@index([assignedToId])
 }
 
+model Cat {
+  id      String  @id @default(cuid())
+  name    String  @default("")
+  owner   Person? @relation("Cat_owner", fields: [ownerId], references: [id])
+  ownerId String? @map("owner")
+
+  @@index([ownerId])
+}
+
 model Person {
   id    String @id @default(cuid())
   name  String @default("")
   tasks Task[] @relation("Task_assignedTo")
+  cat   Cat[]  @relation("Cat_owner")
 }
 
 model SecretPlan {

--- a/tests/test-projects/basic/schema.ts
+++ b/tests/test-projects/basic/schema.ts
@@ -21,11 +21,29 @@ export const lists = {
       finishBy: timestamp(),
     },
   }),
+  Cat: list({
+    access: allowAll,
+    fields: {
+      name: text({ validation: { isRequired: true } }),
+      owner: relationship({
+        ref: 'Person.cat',
+        many: false ,
+        ui: {
+          displayMode: 'cards',
+          cardFields: ['name'],
+          inlineEdit: { fields: ['name'] },
+          inlineCreate: { fields: ['name'] },
+          linkToItem: true,
+        }
+      }),
+    },
+  }),
   Person: list({
     access: allowAll,
     fields: {
       name: text({ validation: { isRequired: true } }),
       tasks: relationship({ ref: 'Task.assignedTo', many: true }),
+      cat: relationship({ ref: 'Cat.owner', many: true, })
     },
   }),
   SecretPlan: list({


### PR DESCRIPTION
Inline related item creation using Cards submits the parent form too, see the following: 

![simplescreenrecorder-2023-02-04_23 20 19](https://user-images.githubusercontent.com/50421893/216801542-a06d7937-c331-4e8e-8632-a73b144b7f12.gif)


Steps to recreate:
- create a brand new keystone project with `yarn create keystone-app`, then try to add a tag while creating a post as in the video

this is the same issue as https://github.com/keystonejs/keystone/pull/8123

I wasn't able to get any of the tests in the repo working, I get the following error:

```

    Invalid `prisma.task.deleteMany()` invocation:


    error: Environment variable not found: DATABASE_URL.
      -->  schema.prisma:5
       | 
     4 | datasource sqlite {
     5 |   url               = env("DATABASE_URL")
       | 
```

This is my first time contributing so can you tell me what I am doing wrong!



