### PR TITLE
Fixes `keystone start` requiring Typescript by removing `tsconfig.json` from the generated AdminUI output

### DIFF
--- a/.changeset/ten-beers-heal.md
+++ b/.changeset/ten-beers-heal.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Allow Keystone to be run without installing Typescript by removing `tsconfig.json` from the generated output

--- a/.changeset/ten-beers-heal.md
+++ b/.changeset/ten-beers-heal.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-6/core': minor
+'@keystone-6/core': patch
 ---
 
-Allow Keystone to be run without installing Typescript by removing `tsconfig.json` from the generated output
+Fixes `keystone start` requiring Typescript by removing `tsconfig.json` from the generated AdminUI output

--- a/packages/core/src/admin-ui/templates/index.ts
+++ b/packages/core/src/admin-ui/templates/index.ts
@@ -18,10 +18,11 @@ export const writeAdminFiles = (
   configFileExists: boolean
 ): AdminFileToWrite[] => {
   return [
-    ...['next.config.js', 'tsconfig.json'].map(
-      outputPath =>
-        ({ mode: 'copy', inputPath: Path.join(pkgDir, 'static', outputPath), outputPath } as const)
-    ),
+    {
+      mode: 'copy',
+      inputPath: Path.join(pkgDir, 'static', 'next.config.js'),
+      outputPath: 'next.config.js',
+    },
     {
       mode: 'copy',
       inputPath: Path.join(pkgDir, 'static', 'favicon.ico'),


### PR DESCRIPTION
Removes admin UI `tsconfig.json` from being generated

Hopefully fixes https://github.com/keystonejs/keystone/issues/7636