### PR TITLE
Fix SignInPage capitalisation

### DIFF
--- a/packages/auth/src/pages/SigninPage.tsx
+++ b/packages/auth/src/pages/SigninPage.tsx
@@ -105,7 +105,7 @@ export const SigninPage = ({
   };
 
   return (
-    <SigninContainer title="Keystone - Sign In">
+    <SigninContainer title="Keystone - Sign in">
       <Stack gap="xlarge" as="form" onSubmit={onSubmit}>
         <H1>Sign In</H1>
         {error && (
@@ -168,7 +168,7 @@ export const SigninPage = ({
               }
               type="submit"
             >
-              Sign In
+              Sign in
             </Button>
             {/* Disabled until we come up with a complete password reset workflow */}
             {/* <Button weight="none" tone="active" onClick={() => setMode('forgot password')}>

--- a/tests/examples-smoke-tests/basic.test.ts
+++ b/tests/examples-smoke-tests/basic.test.ts
@@ -20,7 +20,7 @@ exampleProjectTests('../examples/basic', (browserType, mode) => {
     await page.click('button:has-text("Sign out")');
     await page.fill('[placeholder="email"]', 'admin@keystonejs.com');
     await page.fill('[placeholder="password"]', 'password');
-    await page.click('button:has-text("Sign In")');
+    await page.click('button:has-text("Sign in")');
   });
 
   test('update user', async () => {


### PR DESCRIPTION
We use `Sign out` for the `SignoutButton`, and `Sign In` for this page, we should align on one capitalization or the other.  