### PR TITLE
Fix undefined types when omitted from GraphQL

### DIFF
--- a/.changeset/nine-papayas-heal.md
+++ b/.changeset/nine-papayas-heal.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix undefined types when using `omit` for create or update

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -171,13 +171,21 @@ function printListTypeInfo<L extends InitialisedList>(listKey: string, list: L) 
     `    inputs: {`,
     `      where: ${whereInputName};`,
     `      uniqueWhere: ${whereUniqueInputName};`,
+    ...(list.graphql.isEnabled.create ? [
     `      create: ${createInputName};`,
+    ] : []),
+    ...(list.graphql.isEnabled.update ? [
     `      update: ${updateInputName};`,
+    ] : []),
     `      orderBy: ${listOrderName};`,
     `    };`,
     `    prisma: {`,
+    ...(list.graphql.isEnabled.create ? [
     `      create: Resolved${createInputName}`,
+    ] : []),
+    ...(list.graphql.isEnabled.update ? [
     `      update: Resolved${updateInputName}`,
+    ] : []),
     `    };`,
     `    all: __TypeInfo;`,
     `  };`,


### PR DESCRIPTION
As is, if you use `graphql.omit`, some printed Typescript types will not be defined, but they are still printed.
This pull request fixes that by not printing the types if they are not defined.