### PR TITLE
Reduce code complexity

### DIFF
--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -52,7 +52,6 @@ export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
           update?: boolean;
         };
   };
-  // Disabled by default...
   isFilterable?: boolean | ((args: FilterOrderArgs<ListTypeInfo>) => MaybePromise<boolean>);
   isOrderable?: boolean | ((args: FilterOrderArgs<ListTypeInfo>) => MaybePromise<boolean>);
 };

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -85,7 +85,7 @@ async function fetchData(tag) {
   const changes = {};
   for (const commit of revs) {
     let { user, pull } = await getInfo({ repo: 'keystonejs/keystone', commit });
-    pull = pull || gitCommitDescription(commit).match(/#([0-9]+)/)?.[1]
+    pull = pull || gitCommitDescription(commit).match(/#([0-9]+)/)?.[1];
 
     console.error(`commit ${commit}, user ${user}, pull #${pull}`);
     const change = { commit, user, pull };

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -85,7 +85,7 @@ async function fetchData(tag) {
   const changes = {};
   for (const commit of revs) {
     let { user, pull } = await getInfo({ repo: 'keystonejs/keystone', commit });
-    pull = pull || gitCommitDescription(commit).match(/#([0-9]+)/)[1];
+    pull = pull || gitCommitDescription(commit).match(/#([0-9]+)/)?.[1]
 
     console.error(`commit ${commit}, user ${user}, pull #${pull}`);
     const change = { commit, user, pull };


### PR DESCRIPTION
This pull request refactors `getDbAPIFactory` to not use complicated type resolution and casting, but instead rely on the return type.