### PR TITLE
Remove `keystone dev --reset-db`

### DIFF
--- a/.changeset/plenty-books-share.md
+++ b/.changeset/plenty-books-share.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes `--reset-db` from `keystone dev`, use `keystone prisma db push --force-reset` to reset your database

--- a/docs/pages/docs/guides/cli.md
+++ b/docs/pages/docs/guides/cli.md
@@ -129,17 +129,18 @@ We strongly recommend enabling migrations if you are going to run your app in pr
 
 ### Resetting the database
 
-From time to time, in development you may want to reset the database and recreate it from scratch. You can do this by passing the `--reset-db` flag:
+From time to time, in development you may want to reset the database and recreate it from scratch.
+You can do this by using Prisma:
 
 ```bash
-$ keystone dev --reset-db
+$ keystone prisma db push --force-reset
 ```
 
 {% hint kind="error" %}
 Doing this will destroy your database, including all data
 {% /hint %}
 
-This is mainly useful early in a project's development lifecycle, when you want to test database initialisation scripts or create a fresh set of test data.
+This is typically useful early in a project's development lifecycle, when you want to test database initialisation scripts or create a fresh set of test data.
 
 ## postinstall
 

--- a/packages/core/src/lib/migrations.ts
+++ b/packages/core/src/lib/migrations.ts
@@ -66,7 +66,7 @@ export async function pushPrismaSchemaToDatabase(
   shadowDbUrl: string | undefined,
   schema: string,
   schemaPath: string,
-  resetDb = false
+  resetDb: boolean
 ) {
   const before = Date.now();
   await ensureDatabaseExists(dbUrl, path.dirname(schemaPath));
@@ -181,7 +181,6 @@ export async function deployMigrations(dbUrl: string) {
   });
 }
 
-// TODO: don't have process.exit calls here
 export async function devMigrations(
   dbUrl: string,
   shadowDbUrl: string | undefined,

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -94,7 +94,7 @@ export async function cli(cwd: string, argv: string[]) {
   }
 
   if (command === 'prisma') {
-    return prisma(cwd, argv.slice(1), defaultFlags(flags, { frozen: false }).frozen);
+    return prisma(cwd, argv.slice(1), !!flags.frozen);
   }
 
   if (command === 'telemetry') return telemetry(cwd, argv[1]);

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -11,7 +11,6 @@ export type Flags = {
   fix: boolean; // TODO: remove, deprecated
   frozen: boolean;
   prisma: boolean;
-  resetDb: boolean;
   server: boolean;
   ui: boolean;
   withMigrations: boolean;
@@ -82,7 +81,7 @@ export async function cli(cwd: string, argv: string[]) {
   if (command === 'dev') {
     return dev(
       cwd,
-      defaultFlags(flags, { dbPush: true, prisma: true, resetDb: false, server: true, ui: true })
+      defaultFlags(flags, { dbPush: true, prisma: true, server: true, ui: true })
     );
   }
 

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -79,10 +79,7 @@ export async function cli(cwd: string, argv: string[]) {
 
   const command = input[0] || 'dev';
   if (command === 'dev') {
-    return dev(
-      cwd,
-      defaultFlags(flags, { dbPush: true, prisma: true, server: true, ui: true })
-    );
+    return dev(cwd, defaultFlags(flags, { dbPush: true, prisma: true, server: true, ui: true }));
   }
 
   if (command === 'build') {

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -94,7 +94,7 @@ export async function cli(cwd: string, argv: string[]) {
   }
 
   if (command === 'prisma') {
-    return prisma(cwd, argv.slice(1), !!flags.frozen);
+    return prisma(cwd, argv.slice(1), Boolean(flags.frozen));
   }
 
   if (command === 'telemetry') return telemetry(cwd, argv[1]);

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -77,12 +77,7 @@ type WatchBuildResult = { error: BuildFailure | null; result: BuildResult | null
 
 export async function dev(
   cwd: string,
-  {
-    dbPush,
-    prisma,
-    server,
-    ui,
-  }: Pick<Flags, 'dbPush' | 'prisma' | 'server' | 'ui'>
+  { dbPush, prisma, server, ui }: Pick<Flags, 'dbPush' | 'prisma' | 'server' | 'ui'>
 ) {
   console.log('✨ Starting Keystone');
   const app = server ? express() : null;

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -80,10 +80,9 @@ export async function dev(
   {
     dbPush,
     prisma,
-    resetDb,
     server,
     ui,
-  }: Pick<Flags, 'dbPush' | 'prisma' | 'resetDb' | 'server' | 'ui'>
+  }: Pick<Flags, 'dbPush' | 'prisma' | 'server' | 'ui'>
 ) {
   console.log('✨ Starting Keystone');
   const app = server ? express() : null;
@@ -135,7 +134,6 @@ export async function dev(
       server,
       prisma,
       dbPush,
-      resetDb,
     });
 
     if (configWithHTTP?.server?.extendHttpServer && httpServer && context) {
@@ -375,12 +373,11 @@ async function setupInitialKeystone(
   cwd: string,
   options: {
     dbPush: boolean;
-    resetDb: boolean;
     prisma: boolean;
     server: boolean;
   }
 ) {
-  const { dbPush, resetDb, prisma, server } = options;
+  const { dbPush, prisma, server } = options;
   const { graphQLSchema, adminMeta, getKeystone } = createSystem(config);
 
   // Make local storage folders if used
@@ -403,7 +400,7 @@ async function setupInitialKeystone(
         config.db.shadowDatabaseUrl,
         prismaSchema,
         getSchemaPaths(cwd).prisma,
-        resetDb
+        false
       );
     } else if (dbPush) {
       await pushPrismaSchemaToDatabase(
@@ -411,7 +408,7 @@ async function setupInitialKeystone(
         config.db.shadowDatabaseUrl,
         prismaSchema,
         getSchemaPaths(cwd).prisma,
-        resetDb
+        false
       );
     } else {
       console.log('⚠️ Skipping database schema push');

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -19,9 +19,9 @@ const dbUrl = 'file:./app.db';
 
 async function setupAndStopDevServerForMigrations(cwd: string, resetDb: boolean = false) {
   if (resetDb) {
-    await ((await runCommand(cwd, 'prisma db push --force-reset')) as () => Promise<void>)();
+    await runCommand(cwd, 'prisma db push --force-reset');
   }
-  await (((await runCommand(cwd, 'dev')) as () => Promise<void>)());
+  await ((await runCommand(cwd, 'dev')) as () => Promise<void>)();
 }
 
 function getPrismaClient(cwd: string) {
@@ -199,7 +199,7 @@ describe('useMigrations: false', () => {
       Push cancelled."
     `);
   });
-  test('--reset-db flag', async () => {
+  test('prisma db push --force-reset works', async () => {
     const tmp = await setupInitialProjectWithoutMigrations();
     {
       const prismaClient = await getPrismaClient(tmp);
@@ -219,8 +219,7 @@ describe('useMigrations: false', () => {
       ⭐️ Server listening on :3000 (http://localhost:3000/)
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
-      ✨ Your database has been reset
-      ✨ Your database is now in sync with your schema. Done in 0ms
+      ✨ The database is already in sync with the Prisma schema.
       ✨ Connecting to the database
       ✨ Creating server
       ✅ GraphQL API ready"
@@ -639,42 +638,6 @@ describe('useMigrations: true', () => {
       ⭐️ GraphQL API available at /api/graphql
       ✨ Generating GraphQL and Prisma schemas
       ✨ sqlite database "app.db" created at file:./app.db
-      Applying migration \`migration_name\`
-      ✨ The following migration(s) have been applied:
-
-      migrations/
-        └─ migration_name/
-          └─ migration.sql
-      ✨ Your migrations are up to date, no new migrations need to be created
-      ✨ Connecting to the database
-      ✨ Creating server
-      ✅ GraphQL API ready"
-    `);
-  });
-  test('--reset-db flag', async () => {
-    const tmp = await setupInitialProjectWithMigrations();
-    {
-      const prismaClient = await getPrismaClient(tmp);
-      await prismaClient.todo.create({ data: { title: 'something' } });
-      await prismaClient.$disconnect();
-    }
-    const recording = recordConsole();
-    await setupAndStopDevServerForMigrations(tmp, true);
-    {
-      const prismaClient = await getPrismaClient(tmp);
-      expect(await prismaClient.todo.findMany()).toHaveLength(0);
-      await prismaClient.$disconnect();
-    }
-
-    const { migrationName } = await getGeneratedMigration(tmp, 1, 'init');
-
-    expect(recording().replace(new RegExp(migrationName, 'g'), 'migration_name'))
-      .toMatchInlineSnapshot(`
-      "✨ Starting Keystone
-      ⭐️ Server listening on :3000 (http://localhost:3000/)
-      ⭐️ GraphQL API available at /api/graphql
-      ✨ Generating GraphQL and Prisma schemas
-      ✨ Your database has been reset
       Applying migration \`migration_name\`
       ✨ The following migration(s) have been applied:
 

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -21,7 +21,7 @@ async function setupAndStopDevServerForMigrations(cwd: string, resetDb: boolean 
   if (resetDb) {
     await runCommand(cwd, 'prisma db push --force-reset');
   }
-  await ((await runCommand(cwd, 'dev')) as () => Promise<void>)();
+  await runCommand(cwd, 'dev');
 }
 
 function getPrismaClient(cwd: string) {

--- a/packages/core/src/scripts/tests/migrations.test.ts
+++ b/packages/core/src/scripts/tests/migrations.test.ts
@@ -18,18 +18,16 @@ setSkipWatching();
 const dbUrl = 'file:./app.db';
 
 async function setupAndStopDevServerForMigrations(cwd: string, resetDb: boolean = false) {
-  const stopServer = (await runCommand(
-    cwd,
-    `dev${resetDb ? ' --reset-db' : ''}`
-  )) as () => Promise<void>;
-  await stopServer();
+  if (resetDb) {
+    await ((await runCommand(cwd, 'prisma db push --force-reset')) as () => Promise<void>)();
+  }
+  await (((await runCommand(cwd, 'dev')) as () => Promise<void>)());
 }
 
 function getPrismaClient(cwd: string) {
-  const prismaClient = new (requirePrismaClient(cwd).PrismaClient)({
+  return new (requirePrismaClient(cwd).PrismaClient)({
     datasources: { sqlite: { url: dbUrl } },
   });
-  return prismaClient;
 }
 
 async function getGeneratedMigration(

--- a/packages/core/src/scripts/tests/utils.tsx
+++ b/packages/core/src/scripts/tests/utils.tsx
@@ -137,7 +137,10 @@ async function getSymlinkType(targetPath: string): Promise<'dir' | 'file'> {
 
 export async function runCommand(cwd: string, args: string) {
   const argv = parseArgsStringToArgv(args);
-  return cli(cwd, argv);
+  const proc = await cli(cwd, argv);
+  if (typeof proc === 'function') {
+    await proc();
+  }
 }
 
 let dirsToRemove: string[] = [];


### PR DESCRIPTION
This pull request removes `--reset-db`.

This command was dangerous at the best of times and frustrating almost every other time you accidentally used it from your shell history.

Resetting your database in this way is not a typical way to work with a local development database.
We recommend using `keystone prisma db push --force-reset` for the limited number of occasions that you need this.

This pull request is part of the work from https://github.com/keystonejs/keystone/pull/8046 which cements the idea that `keystone dev` is about a workflow, and not about kicking off specific actions.

(review and merge https://github.com/keystonejs/keystone/pull/8046 before this pull request is rebased)