### PR TITLE
fix(website): broken link for GraphQL example

### DIFF
--- a/.changeset/heavy-vans-join.md
+++ b/.changeset/heavy-vans-join.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/website': patch
----
-
-Fix broken link for GraphQL example

--- a/.changeset/heavy-vans-join.md
+++ b/.changeset/heavy-vans-join.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/website': patch
+---
+
+Fix broken link for GraphQL example

--- a/docs/pages/for-developers.tsx
+++ b/docs/pages/for-developers.tsx
@@ -425,7 +425,7 @@ export default function ForDevelopers() {
             <li>
               <Button
                 as="a"
-                href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema"
+                href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-graphql-tools"
                 target="_blank"
                 rel="noopener noreferrer"
                 look="soft"


### PR DESCRIPTION
On the `For developers` page, one of the examples link is broken.
The example has been renamed in the keystone/examples in the repo.