### PR TITLE
Fix withRequest behavior without session strategy

### DIFF
--- a/.changeset/thin-turtles-beg.md
+++ b/.changeset/thin-turtles-beg.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix withRequest behavior when no session strategy is configured

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -75,14 +75,19 @@ export function makeCreateContext({
       return result.data as any;
     };
 
-    async function withRequest(req: IncomingMessage, res?: ServerResponse) {
-      contextToReturn.req = req;
-      contextToReturn.res = res;
-      if (!config.session) {
-        return contextToReturn;
+    async function withRequest(newReq: IncomingMessage, newRes?: ServerResponse) {
+      const newContext = createContext({
+        session,
+        sudo,
+        req: newReq,
+        res: newRes,
+      });
+
+      if (config.session) {
+        newContext.session = await config.session.get({ context: newContext });
       }
-      contextToReturn.session = await config.session.get({ context: contextToReturn });
-      return createContext({ session: contextToReturn.session, sudo, req, res });
+
+      return newContext;
     }
     const dbAPI: KeystoneContext['db'] = {};
     const itemAPI: KeystoneContext['query'] = {};


### PR DESCRIPTION
closes #8317
- previously, if no session strategy was configured in the Keystone config, the withRequest function would return early without calling `createContext`. If `sudo()` was called on the returned context from withRequest, the context object returned from sudo would have the req/res objects present on the initial context object (i.e. the one prior to withRequest being called)
- this change makes withRequest consistent with the other context 'change' functions (sudo/exitSudo/withSession)