### PR TITLE
Add the ability to pass custom log settings to Prisma

### DIFF
--- a/.changeset/dry-ghosts-joke.md
+++ b/.changeset/dry-ghosts-joke.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Adds the ability to pass custom log level settings to Prisma Client

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -75,7 +75,12 @@ export function createSystem(config: KeystoneConfig) {
     adminMeta,
     getKeystone: (prismaModule: PrismaModule) => {
       const prismaClient = new prismaModule.PrismaClient({
-        log: config.db.enableLogging === true ? ['query'] : config.db.enableLogging ?? undefined,
+        log:
+          config.db.enableLogging === true
+            ? ['query']
+            : config.db.enableLogging === false
+            ? undefined
+            : config.db.enableLogging,
         datasources: { [config.db.provider]: { url: config.db.url } },
       });
 

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -75,7 +75,7 @@ export function createSystem(config: KeystoneConfig) {
     adminMeta,
     getKeystone: (prismaModule: PrismaModule) => {
       const prismaClient = new prismaModule.PrismaClient({
-        log: config.db.enableLogging ? ['query'] : undefined,
+        log: config.db.enableLogging === true ? ['query'] : config.db.enableLogging ?? undefined,
         datasources: { [config.db.provider]: { url: config.db.url } },
       });
 

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -126,13 +126,21 @@ export type { ListSchemaConfig, ListConfig, BaseFields, MaybeSessionFunction, Ma
 
 // config.db
 
+// Copy of the Prisma's LogLevel types from `src/runtime/getLogLevel.ts`,
+// because they are not exported by Prisma.
+type PrismaLogLevel = 'info' | 'query' | 'warn' | 'error';
+type PrismaLogDefinition = {
+  level: PrismaLogLevel;
+  emit: 'stdout' | 'event';
+};
+
 export type DatabaseConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   url: string;
   shadowDatabaseUrl?: string;
   onConnect?: (args: KeystoneContext<TypeInfo>) => Promise<void>;
   /** @deprecated */
   useMigrations?: boolean;
-  enableLogging?: boolean;
+  enableLogging?: boolean | PrismaLogLevel | Array<PrismaLogLevel | PrismaLogDefinition>;
   idField?: IdFieldConfig;
   provider: DatabaseProvider;
 


### PR DESCRIPTION
Prisma has flexible settings for log level, here is the documentation: https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging 

For example, for our project, we also need to log the query timings, but can't do this with Keystone settings.

But Keystone now allows only a boolean setting:
```ts
export type DatabaseConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
...
  enableLogging?: boolean;
```
that just passes the `['query']` log level to Prisma:
```ts
    getKeystone: (prismaModule: PrismaModule) => {
      const prismaClient = new prismaModule.PrismaClient({
        log: config.db.enableLogging ? ['query'] : undefined,
        datasources: { [config.db.provider]: { url: config.db.url } },
      });
```

But in Prisma the log level is much more flexible:
```ts
type LogLevel = 'info' | 'query' | 'warn' | 'error'
type LogDefinition = {
  level: LogLevel
  emit: 'stdout' | 'event'
}
```

This PR adds the ability to pass a custom log level configuration to Prisma directly from Keystone config.

And here is an example:
```ts
export default config<TypeInfo>({
  db: {
    provider: 'sqlite',
    enableLogging: [
      {
        emit: 'stdout',
        level: 'query',
      },
      {
        emit: 'stdout',
        level: 'error',
      },
      {
        emit: 'stdout',
        level: 'info',
      },
      {
        emit: 'stdout',
        level: 'warn',
      },
    ],
    async onConnect(context) {
      context.prisma.$on('query', (e) => {
        console.log('Query: ' + e.query)
        console.log('Params: ' + e.params)
        console.log('Duration: ' + e.duration + 'ms')
      });
    },
    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
  },
  lists,
});
```