### PR TITLE
Rename `db.prismaPath` to `db.prismaClientPath`

### DIFF
--- a/.changeset/depend-on-me.md
+++ b/.changeset/depend-on-me.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': major
 ---
 
-Removes assumptions about `@prisma/client` output location, with a new `db.prismaPath` configuration option to set where to import the Prisma client from
+Removes assumptions about `@prisma/client` output location, with a new `db.prismaClientPath` configuration option to set where to import the Prisma client from

--- a/examples/example-utils.ts
+++ b/examples/example-utils.ts
@@ -6,5 +6,5 @@
 //   still use node_modules/... to skip the painful experience that is jest/babel
 //   transforms
 export const fixPrismaPath = {
-  prismaPath: 'node_modules/.myprisma/client',
+  prismaClientPath: 'node_modules/.myprisma/client',
 };

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -83,7 +83,9 @@ export function getSystemPaths(cwd: string, config: KeystoneConfig) {
     config: getBuiltKeystoneConfigurationPath(cwd),
     admin: path.join(cwd, '.keystone/admin'),
     keystone: path.join(cwd, 'node_modules/.keystone'),
-    prisma: config.db.prismaClientPath ? path.join(cwd, config.db.prismaClientPath) : '@prisma/client',
+    prisma: config.db.prismaClientPath
+      ? path.join(cwd, config.db.prismaClientPath)
+      : '@prisma/client',
     schema: {
       // types: // TODO
       prisma: path.join(cwd, 'schema.prisma'),

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -23,7 +23,7 @@ export async function getCommittedArtifacts(config: KeystoneConfig, graphQLSchem
   const lists = initialiseLists(config);
   const prismaSchema = printPrismaSchema(
     lists,
-    config.db.prismaPath,
+    config.db.prismaClientPath,
     config.db.provider,
     config.db.prismaPreviewFeatures,
     config.db.additionalPrismaDatasourceProperties,
@@ -83,7 +83,7 @@ export function getSystemPaths(cwd: string, config: KeystoneConfig) {
     config: getBuiltKeystoneConfigurationPath(cwd),
     admin: path.join(cwd, '.keystone/admin'),
     keystone: path.join(cwd, 'node_modules/.keystone'),
-    prisma: config.db.prismaPath ? path.join(cwd, config.db.prismaPath) : '@prisma/client',
+    prisma: config.db.prismaClientPath ? path.join(cwd, config.db.prismaClientPath) : '@prisma/client',
     schema: {
       // types: // TODO
       prisma: path.join(cwd, 'schema.prisma'),

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -122,7 +122,13 @@ function printInterimMultiFieldType({
       const prismaKey = `${fieldKey}_${subFieldKey}`;
       return (
         '  ' +
-        printInterimFieldType({ prismaClientPath, listKey, fieldKey: subFieldKey, prismaKey, operation })
+        printInterimFieldType({
+          prismaClientPath,
+          listKey,
+          fieldKey: subFieldKey,
+          prismaKey,
+          operation,
+        })
       );
     }),
     `  };`,

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -88,29 +88,29 @@ function printInputTypesFromSchema(schema: GraphQLSchema, scalars: Record<string
 }
 
 function printInterimFieldType({
-  prismaPath,
+  prismaClientPath,
   listKey,
   fieldKey,
   prismaKey,
   operation,
 }: {
-  prismaPath: string;
+  prismaClientPath: string;
   listKey: string;
   fieldKey: string;
   prismaKey: string;
   operation: string;
 }) {
-  return `  ${fieldKey}?: import('${prismaPath}').Prisma.${listKey}${operation}Input["${prismaKey}"];`;
+  return `  ${fieldKey}?: import('${prismaClientPath}').Prisma.${listKey}${operation}Input["${prismaKey}"];`;
 }
 
 function printInterimMultiFieldType({
-  prismaPath,
+  prismaClientPath,
   listKey,
   fieldKey,
   operation,
   fields,
 }: {
-  prismaPath: string;
+  prismaClientPath: string;
   listKey: string;
   fieldKey: string;
   operation: string;
@@ -122,7 +122,7 @@ function printInterimMultiFieldType({
       const prismaKey = `${fieldKey}_${subFieldKey}`;
       return (
         '  ' +
-        printInterimFieldType({ prismaPath, listKey, fieldKey: subFieldKey, prismaKey, operation })
+        printInterimFieldType({ prismaClientPath, listKey, fieldKey: subFieldKey, prismaKey, operation })
       );
     }),
     `  };`,
@@ -130,7 +130,7 @@ function printInterimMultiFieldType({
 }
 
 function printInterimType<L extends InitialisedList>(
-  prismaPath: string,
+  prismaClientPath: string,
   list: L,
   listKey: string,
   typename: string,
@@ -142,7 +142,7 @@ function printInterimType<L extends InitialisedList>(
       if (dbField.kind === 'none' || fieldKey === 'id') return `  ${fieldKey}?: undefined;`;
       if (dbField.kind === 'multi') {
         return printInterimMultiFieldType({
-          prismaPath,
+          prismaClientPath,
           listKey,
           fieldKey,
           operation,
@@ -151,7 +151,7 @@ function printInterimType<L extends InitialisedList>(
       }
 
       return printInterimFieldType({
-        prismaPath,
+        prismaClientPath,
         listKey,
         fieldKey,
         prismaKey: fieldKey,
@@ -163,7 +163,7 @@ function printInterimType<L extends InitialisedList>(
 }
 
 function printListTypeInfo<L extends InitialisedList>(
-  prismaPath: string,
+  prismaClientPath: string,
   listKey: string,
   list: L
 ) {
@@ -181,7 +181,7 @@ function printListTypeInfo<L extends InitialisedList>(
   return [
     `export type ${listKey} = import('@keystone-6/core').ListConfig<${listTypeInfoName}, any>;`,
     `namespace ${listKey} {`,
-    `  export type Item = import('${prismaPath}').${listKey};`,
+    `  export type Item = import('${prismaClientPath}').${listKey};`,
     `  export type TypeInfo = {`,
     `    key: "${listKey}";`,
     `    isSingleton: ${list.isSingleton};`,
@@ -215,7 +215,7 @@ function printListTypeInfo<L extends InitialisedList>(
 }
 
 export function printGeneratedTypes(
-  prismaPath: string,
+  prismaClientPath: string,
   graphQLSchema: GraphQLSchema,
   lists: Record<string, InitialisedList>
 ) {
@@ -229,18 +229,18 @@ export function printGeneratedTypes(
 
     if (list.graphql.isEnabled.create) {
       interimCreateUpdateTypes.push(
-        printInterimType(prismaPath, list, listKey, gqlNames.createInputName, 'Create')
+        printInterimType(prismaClientPath, list, listKey, gqlNames.createInputName, 'Create')
       );
     }
 
     if (list.graphql.isEnabled.update) {
       interimCreateUpdateTypes.push(
-        printInterimType(prismaPath, list, listKey, gqlNames.updateInputName, 'Update')
+        printInterimType(prismaClientPath, list, listKey, gqlNames.updateInputName, 'Update')
       );
     }
 
     listsTypeInfo.push(`    readonly ${listKey}: ${listTypeInfoName};`);
-    listsNamespaces.push(printListTypeInfo(prismaPath, listKey, list));
+    listsNamespaces.push(printListTypeInfo(prismaClientPath, listKey, list));
   }
 
   return [
@@ -265,7 +265,7 @@ export function printGeneratedTypes(
     `  lists: {`,
     ...listsTypeInfo,
     `  };`,
-    `  prisma: import('${prismaPath}').PrismaClient;`,
+    `  prisma: import('${prismaClientPath}').PrismaClient;`,
     `};`,
     ``,
     // we need to reference the `TypeInfo` above in another type that is also called `TypeInfo`

--- a/packages/core/src/scripts/run/dev.ts
+++ b/packages/core/src/scripts/run/dev.ts
@@ -153,7 +153,7 @@ export async function dev(
     const initialisedLists = initialiseLists(config);
     const originalPrismaSchema = printPrismaSchema(
       initialisedLists,
-      config.db.prismaPath,
+      config.db.prismaClientPath,
       config.db.provider,
       config.db.prismaPreviewFeatures,
       config.db.additionalPrismaDatasourceProperties,
@@ -179,7 +179,7 @@ export async function dev(
         if (prisma) {
           const newPrismaSchema = printPrismaSchema(
             initialiseLists(newConfig),
-            config.db.prismaPath,
+            config.db.prismaClientPath,
             newConfig.db.provider,
             newConfig.db.prismaPreviewFeatures,
             newConfig.db.additionalPrismaDatasourceProperties,

--- a/packages/core/src/scripts/tests/fixtures/basic-with-no-ui.ts
+++ b/packages/core/src/scripts/tests/fixtures/basic-with-no-ui.ts
@@ -6,7 +6,7 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./app.db',
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/log-node-env.ts
+++ b/packages/core/src/scripts/tests/fixtures/log-node-env.ts
@@ -8,7 +8,7 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./app.db',
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/no-fields-with-migrations.ts
+++ b/packages/core/src/scripts/tests/fixtures/no-fields-with-migrations.ts
@@ -6,7 +6,7 @@ export default config({
     provider: 'sqlite',
     url: 'file:./app.db',
     useMigrations: true,
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/no-fields.ts
+++ b/packages/core/src/scripts/tests/fixtures/no-fields.ts
@@ -5,7 +5,7 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./app.db',
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/one-field-with-migrations.ts
+++ b/packages/core/src/scripts/tests/fixtures/one-field-with-migrations.ts
@@ -7,7 +7,7 @@ export default config({
     provider: 'sqlite',
     url: 'file:./app.db',
     useMigrations: true,
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/two-fields-with-migrations.ts
+++ b/packages/core/src/scripts/tests/fixtures/two-fields-with-migrations.ts
@@ -7,7 +7,7 @@ export default config({
     provider: 'sqlite',
     url: 'file:./app.db',
     useMigrations: true,
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   ui: { isDisabled: true },
   lists: {

--- a/packages/core/src/scripts/tests/fixtures/with-ts.ts
+++ b/packages/core/src/scripts/tests/fixtures/with-ts.ts
@@ -8,7 +8,7 @@ export default config({
   db: {
     provider: 'sqlite',
     url: 'file:./app.db',
-    prismaPath: 'node_modules/.testprisma/client',
+    prismaClientPath: 'node_modules/.testprisma/client',
   },
   lists: {
     Todo: list({

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -141,7 +141,7 @@ export type DatabaseConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   /** @deprecated use extendPrismaSchema */
   additionalPrismaDatasourceProperties?: { [key: string]: string };
 
-  prismaPath?: string;
+  prismaClientPath?: string;
   extendPrismaSchema?: (schema: string) => string;
 };
 

--- a/tests/sandbox/utils.ts
+++ b/tests/sandbox/utils.ts
@@ -26,7 +26,7 @@ export const localStorageConfig: Record<string, StorageConfig> = {
 //   still use node_modules/... to skip the painful experience that is jest/babel
 //   transforms
 export const fixPrismaPath = {
-  prismaPath: 'node_modules/.testprisma/client',
+  prismaClientPath: 'node_modules/.testprisma/client',
 };
 
 export const dbConfig: DatabaseConfig<BaseKeystoneTypeInfo> = {


### PR DESCRIPTION
Reviewing https://github.com/keystonejs/keystone/pull/8307 with @borisno2, we think `prismaPath` could be ambiguous with the `schema.prisma` location.

For the removal of doubt, we have renamed this configuration option to `prismaClientPath`.