### PR TITLE
Fix packageManager specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/keystonejs/keystone",
   "homepage": "https://github.com/keystonejs/keystone",
-  "packageManager": "^yarn@1.22.19",
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "docs": "manypkg run @keystone-6/website dev",
     "coverage": "jest --coverage",


### PR DESCRIPTION
```
Usage Error: Unsupported package manager specification (^yarn@1.22.19,^yarn,1.22.19)
```