### PR TITLE
Remove `prismaClient.$on('beforeExit'...)` to assist with Prisma Data Proxy support

### DIFF
--- a/.changeset/strange-baboons-do.md
+++ b/.changeset/strange-baboons-do.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Removes `prismaClient.$on('beforeExit'...` as it is no longer required and blocked Prisma Data Proxy support

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -86,13 +86,17 @@ export function createSystem(config: KeystoneConfig) {
 
       setWriteLimit(prismaClient, pLimit(config.db.provider === 'sqlite' ? 1 : Infinity));
       setPrismaNamespace(prismaClient, prismaModule.Prisma);
-      prismaClient.$on('beforeExit', async () => {
-        // Prisma is failing to properly clean up its child processes
-        // https://github.com/keystonejs/keystone/issues/5477
-        // We explicitly send a SIGINT signal to the prisma child process on exit
-        // to ensure that the process is cleaned up appropriately.
-        prismaClient._engine.child?.kill('SIGINT');
-      });
+
+      // beforeExit event is not supported by Prisma Data Proxy
+      if (!prismaClient._dataProxy) {
+        prismaClient.$on('beforeExit', async () => {
+          // Prisma is failing to properly clean up its child processes
+          // https://github.com/keystonejs/keystone/issues/5477
+          // We explicitly send a SIGINT signal to the prisma child process on exit
+          // to ensure that the process is cleaned up appropriately.
+          prismaClient._engine.child?.kill('SIGINT');
+        });
+      }
 
       const context = makeCreateContext({
         graphQLSchema,

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -87,17 +87,6 @@ export function createSystem(config: KeystoneConfig) {
       setWriteLimit(prismaClient, pLimit(config.db.provider === 'sqlite' ? 1 : Infinity));
       setPrismaNamespace(prismaClient, prismaModule.Prisma);
 
-      // beforeExit event is not supported by Prisma Data Proxy
-      if (!prismaClient._dataProxy) {
-        prismaClient.$on('beforeExit', async () => {
-          // Prisma is failing to properly clean up its child processes
-          // https://github.com/keystonejs/keystone/issues/5477
-          // We explicitly send a SIGINT signal to the prisma child process on exit
-          // to ensure that the process is cleaned up appropriately.
-          prismaClient._engine.child?.kill('SIGINT');
-        });
-      }
-
       const context = makeCreateContext({
         graphQLSchema,
         sudoGraphQLSchema,


### PR DESCRIPTION
`prismaClient.$on('beforeExit'...)` was initially added to resolve a prisma issue (see #5477) however I am unable to replicate this issue anymore with this code removed.

Thanks to @mmachatschek from the initial PR #8274 to add support for Prisma Data Proxy  