### PR TITLE
Fix behavior of `keystone start --with-migrations`

### DIFF
--- a/.changeset/tidy-keys-own.md
+++ b/.changeset/tidy-keys-own.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix behavior of `keystone start --with-migrations`

--- a/.changeset/tidy-keys-own.md
+++ b/.changeset/tidy-keys-own.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fix behavior of `keystone start --with-migrations`
+Fixes behavior of `keystone start --with-migrations`

--- a/packages/core/src/lib/migrations.ts
+++ b/packages/core/src/lib/migrations.ts
@@ -165,8 +165,8 @@ function logWarnings(warnings: string[]) {
   }
 }
 
-export async function deployMigrations(dbUrl: string) {
-  return withMigrate(process.cwd(), async migrate => {
+export async function deployMigrations(schemaPath: string, dbUrl: string) {
+  return withMigrate(schemaPath, async migrate => {
     const before = Date.now();
     const migration = await runMigrateWithDbUrl(dbUrl, undefined, () => migrate.applyMigrations());
     if (migration.appliedMigrationNames.length === 0) {

--- a/packages/core/src/scripts/run/start.ts
+++ b/packages/core/src/scripts/run/start.ts
@@ -34,7 +34,7 @@ export const start = async (
   await keystone.connect();
   if (withMigrations) {
     console.log('✨ Applying database migrations');
-    await deployMigrations(config.db.url);
+    await deployMigrations(paths.schema.prisma, config.db.url);
   }
 
   console.log('✨ Creating server');


### PR DESCRIPTION
This pull request updates the `deployMigrations` function to take `schemaPath` (similar to devMigrations function), which was exiting when it should have migrated and then stayed open.

Closes #8353 
