### PR TITLE
Update schema-type-printer to output "never" for omitted GraphQL types

### DIFF
--- a/.changeset/lemon-cougars-peel.md
+++ b/.changeset/lemon-cougars-peel.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Update schema type printer to output `never` for omitted types.
+Fixes schema type printer to output `never` for omitted types.

--- a/.changeset/lemon-cougars-peel.md
+++ b/.changeset/lemon-cougars-peel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Update schema type printer to output `never` for omitted types.

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -196,21 +196,13 @@ function printListTypeInfo<L extends InitialisedList>(
     `    inputs: {`,
     `      where: ${whereInputName};`,
     `      uniqueWhere: ${whereUniqueInputName};`,
-    ...(list.graphql.isEnabled.create ? [
-    `      create: ${createInputName};`,
-    ] : []),
-    ...(list.graphql.isEnabled.update ? [
-    `      update: ${updateInputName};`,
-    ] : []),
+    `      create: ${list.graphql.isEnabled.create ? createInputName : 'never'};`,
+    `      update: ${list.graphql.isEnabled.update ? updateInputName : 'never'};`,
     `      orderBy: ${listOrderName};`,
     `    };`,
     `    prisma: {`,
-    ...(list.graphql.isEnabled.create ? [
-    `      create: Resolved${createInputName}`,
-    ] : []),
-    ...(list.graphql.isEnabled.update ? [
-    `      update: Resolved${updateInputName}`,
-    ] : []),
+    `      create: ${list.graphql.isEnabled.create ? `Resolved${createInputName}` : 'never'};`,
+    `      update: ${list.graphql.isEnabled.update ? `Resolved${updateInputName}` : 'never'};`,
     `    };`,
     `    all: __TypeInfo;`,
     `  };`,

--- a/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
+++ b/packages/core/src/scripts/tests/__snapshots__/artifacts.test.ts.snap
@@ -142,8 +142,8 @@ export declare namespace Lists {
         orderBy: TodoOrderByInput;
       };
       prisma: {
-        create: ResolvedTodoCreateInput
-        update: ResolvedTodoUpdateInput
+        create: ResolvedTodoCreateInput;
+        update: ResolvedTodoUpdateInput;
       };
       all: __TypeInfo;
     };


### PR DESCRIPTION
closes #8349

Originally, this PR marked the `create`/`update` fields of the BaseListTypeInfo type as "optional", since that seemed like the easiest approach to fix the typing issues in #8349. However, that approach broke a number of the built in keystone tests.

After evaluating a couple of other options, having the schema type printer output "never" seems like the best approach to fix the issue - it still satisfies the "extends BaseListTypeInfo" constraint, but if anyone attempts to actually _use_ a value of that type, they'll get a typescript compile error.