### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/pages/docs/guides/auth-and-access-control.md
+++ b/docs/pages/docs/guides/auth-and-access-control.md
@@ -8,7 +8,7 @@ Keystone comes with several features that work together to control access to the
 - **Session Management** – a set of APIs for starting and ending user sessions, as well as initialising the session data for each request ([docs](../config/session))
 - **The `auth` package** – an opinionated implementation of authentication features for Keystone apps ([docs](../config/auth))
 - **Access Control** – a powerful framework for restricting access to specific lists, operations, and fields ([docs](../config/access-control))
-- **Dynamic UI Config and Field Modes** – options for the Admin UI that work similarly to Access Control, and let you dyamically configure the Admin UI based on user permissions ([docs](../config/lists#ui))
+- **Dynamic UI Config and Field Modes** – options for the Admin UI that work similarly to Access Control, and let you dynamically configure the Admin UI based on user permissions ([docs](../config/lists#ui))
 
 Session Management and Auth are extremely flexible in Keystone, and it's possible to replace the default implementations we provide with your own (or integrate an entirely separate auth system), but in this guide we'll focus on how all these features are designed to work together.
 

--- a/docs/pages/docs/guides/custom-admin-ui-pages.md
+++ b/docs/pages/docs/guides/custom-admin-ui-pages.md
@@ -149,7 +149,7 @@ With all that in place, our custom Admin UI page is now navigable from the Admin
 There are other styling considerations when adding a custom page to the Admin UI that go beyond making it _look_ and _feel_ like an Admin UI page.
 For this, we recommend using the `jsx` runtime export from the `@keystone-ui/core` package, as this will ensure that the version of [emotion](https://emotion.sh/docs/introduction) you're using conforms with the version of emotion used internally used by Keystone.
 
-The snippet below uses the emotion `jsx` runtime exported from `@keystone-ui/core` to help add some basic allignment and layout styling to the contents of our Admin UI custom page.
+The snippet below uses the emotion `jsx` runtime exported from `@keystone-ui/core` to help add some basic alignment and layout styling to the contents of our Admin UI custom page.
 
 ```tsx
 // admin/pages/custom-page.tsx

--- a/examples/nextjs-keystone/next.config.js
+++ b/examples/nextjs-keystone/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
   /*
       next@13 automatically bundles server code for server components.
       This causes a problem for the prisma binary built by Keystone.
-      We need to explicity ask Next.js to opt-out from bundling
+      We need to explicitly ask Next.js to opt-out from bundling
       dependencies that use native Node.js APIs.
 
       More here: https://beta.nextjs.org/docs/api-reference/next.config.js#servercomponentsexternalpackages

--- a/examples/script/README.md
+++ b/examples/script/README.md
@@ -2,7 +2,7 @@
 
 This project demonstrates how to write code to interact with Keystone without using the standard `@keystone-6/core/scripts/cli` tools.
 
-The `getContext` function does not ahdere to the typical Keystone entry-point and requires that your Prisma schema has been previously built by Keystone.
+The `getContext` function does not adhere to the typical Keystone entry-point and requires that your Prisma schema has been previously built by Keystone.
 
 ## Instructions
 

--- a/packages/core/src/admin-ui/TODO.md
+++ b/packages/core/src/admin-ui/TODO.md
@@ -21,7 +21,7 @@
 - [ ] Check in on custom pages
 - [ ] Add an option to hide the GitHub and GraphQL links in the nav
 - [ ] Generate Nav, and allow overrides in client-side config
-- [ ] Add a SignOut page, as an esacape hatch if you need to sign out and don't have a button
+- [ ] Add a SignOut page, as an escape hatch if you need to sign out and don't have a button
 - [ ] Validate the user can access the admin when you sign in, for a smoother error experience
 
 ## Design System Components


### PR DESCRIPTION
There are small typos in:
- docs/pages/docs/guides/auth-and-access-control.md
- docs/pages/docs/guides/custom-admin-ui-pages.md
- examples/nextjs-keystone/next.config.js
- examples/script/README.md
- packages/core/src/admin-ui/TODO.md

Fixes:
- Should read `explicitly` rather than `explicity`.
- Should read `escape` rather than `esacape`.
- Should read `dynamically` rather than `dyamically`.
- Should read `alignment` rather than `allignment`.
- Should read `adhere` rather than `ahdere`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md