### PR TITLE
Add newline compatibility to description text in admin ui

### DIFF
--- a/.changeset/late-birds-clean.md
+++ b/.changeset/late-birds-clean.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/fields': minor
+---
+
+Add newline compatibility to description text in admin ui

--- a/design-system/packages/fields/src/FieldDescription.tsx
+++ b/design-system/packages/fields/src/FieldDescription.tsx
@@ -19,6 +19,7 @@ export const FieldDescription = (props: FieldDescriptionProps) => {
         color: palette.neutral700,
         marginBottom: spacing.small,
         minWidth: 120,
+        whiteSpace: 'pre-wrap'
       }}
       {...props}
     />

--- a/design-system/packages/fields/src/FieldDescription.tsx
+++ b/design-system/packages/fields/src/FieldDescription.tsx
@@ -19,7 +19,7 @@ export const FieldDescription = (props: FieldDescriptionProps) => {
         color: palette.neutral700,
         marginBottom: spacing.small,
         minWidth: 120,
-        whiteSpace: 'pre-wrap'
+        whiteSpace: 'pre-wrap',
       }}
       {...props}
     />


### PR DESCRIPTION
Added a simple `white-space: pre-wrap` to field description to allow usage of `\n` in description string