### PR TITLE
Generate Prisma Data Proxy client based on `db.url` provided

### DIFF
--- a/.changeset/cool-cycles-exist.md
+++ b/.changeset/cool-cycles-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds `--data-proxy` flag to `dev`,`build` and `prisma` commands to allow generating the Prisma client for the Prisma Data Proxy

--- a/.changeset/cool-cycles-exist.md
+++ b/.changeset/cool-cycles-exist.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Generates the Prisma client for the Prisma Data Proxy if a URL starting with `prisma:` is provided to `db.url`
+Adds support for Prisma Data Proxy client generation, automatically enabled for `db.url`'s with a `prisma:` prefix

--- a/.changeset/cool-cycles-exist.md
+++ b/.changeset/cool-cycles-exist.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Adds `--data-proxy` flag to `dev`,`build` and `prisma` commands to allow generating the Prisma client for the Prisma Data Proxy
+Generates the Prisma client for the Prisma Data Proxy if a URL starting with `prisma:` is provided to `db.url`

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -191,8 +191,7 @@ export async function generateNodeModulesArtifacts(
   ]);
 }
 
-async function generatePrismaClient(prismaSchemaPath: string, dataProxyFlag: boolean) {
-  const dataProxy = dataProxyFlag || process.env.PRISMA_GENERATE_DATAPROXY === 'true';
+async function generatePrismaClient(prismaSchemaPath: string, dataProxy: boolean) {
   const generator = await getGenerator({
     schemaPath: prismaSchemaPath,
     dataProxy,

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -181,17 +181,21 @@ export async function generateNodeModulesArtifacts(
   graphQLSchema: GraphQLSchema
 ) {
   const paths = getSystemPaths(cwd, config);
-
+  const dataProxy = config.db.url.startsWith('prisma:');
+  if (dataProxy === true) {
+    console.log('✨ Generating Prisma Client (data proxy)');
+  }
   await Promise.all([
-    generatePrismaClient(paths.schema.prisma),
+    generatePrismaClient(paths.schema.prisma, dataProxy),
     generateNodeModulesArtifactsWithoutPrismaClient(cwd, config, graphQLSchema),
   ]);
 }
 
-async function generatePrismaClient(prismaSchemaPath: string) {
+async function generatePrismaClient(prismaSchemaPath: string, dataProxyFlag: boolean) {
+  const dataProxy = dataProxyFlag || process.env.PRISMA_GENERATE_DATAPROXY === 'true';
   const generator = await getGenerator({
     schemaPath: prismaSchemaPath,
-    dataProxy: false,
+    dataProxy,
   });
   try {
     await generator.generate();

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -21,7 +21,7 @@ async function generateArtifactsForProjectDir(projectDir: string) {
     } else {
       await generateCommittedArtifacts(projectDir, config, graphQLSchema);
     }
-    await generateNodeModulesArtifacts(projectDir, config, graphQLSchema);
+    await generateNodeModulesArtifacts(projectDir, config, graphQLSchema, false);
   } catch (err) {
     throw new Error(
       `An error occurred generating/validating the artifacts for the project at ${projectDir}:\n${format(

--- a/scripts/generate-artifacts-for-projects/src/index.ts
+++ b/scripts/generate-artifacts-for-projects/src/index.ts
@@ -21,7 +21,7 @@ async function generateArtifactsForProjectDir(projectDir: string) {
     } else {
       await generateCommittedArtifacts(projectDir, config, graphQLSchema);
     }
-    await generateNodeModulesArtifacts(projectDir, config, graphQLSchema, false);
+    await generateNodeModulesArtifacts(projectDir, config, graphQLSchema);
   } catch (err) {
     throw new Error(
       `An error occurred generating/validating the artifacts for the project at ${projectDir}:\n${format(


### PR DESCRIPTION
Generated the Prisma Client for data proxy based on the URL provided. If a `prisma://` URL is provided to `db.url` the Client is generated for the Prisma Data Proxy.

https://www.prisma.io/docs/data-platform/data-proxy/deploy 