### PR TITLE
Resolves type error in generated types when using `db.prismaClientPath` on windows

### DIFF
--- a/.changeset/early-garlics-double.md
+++ b/.changeset/early-garlics-double.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes generated types when usins `db.prismaSchemaPath` on Windows

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -220,6 +220,7 @@ export function printGeneratedTypes(
   const interimCreateUpdateTypes = [];
   const listsTypeInfo = [];
   const listsNamespaces = [];
+  prismaClientPath = JSON.stringify(prismaClientPath).slice(1, -1);
 
   for (const [listKey, list] of Object.entries(lists)) {
     const gqlNames = getGqlNames(list);


### PR DESCRIPTION
Escapes the `prismaClientPath` using `JSON.stringify` and strips the `"` in the schema type printer to get the correct imports on Windows