### PR TITLE
fix(docs): replace non-existing migrate command

### DIFF
--- a/docs/pages/docs/guides/database-migration.md
+++ b/docs/pages/docs/guides/database-migration.md
@@ -24,7 +24,7 @@ Running `keystone dev --no-db-push` will return GraphQL runtime errors if tables
 ## Keystone Prisma Migrate CLI
 
 Keystone offers the following three commonly used commands through Prisma to help manage your migrations.
-- `keystone prisma migrate generate` - Generates the migration files to run to set up your production database - these files should be committed to source control and accessible by the `deploy` step. This command is helpful if you want to either leave `keystone dev` as the default behaviour for rapid schema iteration and generate the migrations once you are ready to submit a PR.
+- `keystone prisma migrate dev` - Generates the migration files to run to set up your production database - these files should be committed to source control and accessible by the `deploy` step. This command is helpful if you want to either leave `keystone dev` as the default behaviour for rapid schema iteration and generate the migrations once you are ready to submit a PR.
 - `keystone prisma migrate deploy` - Runs the generated migrations - this command can only be run after a `build` step, and is generally run in the deploy step of your app or before running `keystone start`.
 - `keystone start --with-migrations` - Runs the generated migrations then starts Keystone.
 ## Prisma CLI


### PR DESCRIPTION
The command `keystone migrate generate` does not seem to exist. The described behavior can be achieved with `keystone migrate dev` according to the Prisma documentation: https://www.prisma.io/docs/reference/api-reference/command-reference#migrate-dev