### PR TITLE
fixes minor formatting issue in telemetry.md

### DIFF
--- a/docs/pages/docs/reference/telemetry.md
+++ b/docs/pages/docs/reference/telemetry.md
@@ -171,8 +171,8 @@ Keystone stores your telemetry preferences in a location defined by [env-paths](
 
 **Environment Variable**
 You can opt-out of all telemetry by setting the `KEYSTONE_TELEMETRY_DISABLED` environment variable to `'1'`
-**Network-wide opt-out**
 
+**Network-wide opt-out**
 If you have a network-wide firewall, you can opt-out of Keystone telemetry by not resolving the following domain: [telemetry.keystonejs.com](https://telemetry.keystonejs.com)
 
 ---


### PR DESCRIPTION
This just fixes a very minor issue with the formatting on the [telemetry privacy policy page](https://keystonejs.com/docs/reference/telemetry#how-to-opt-out) where headings aren't clear.

<img width="792" alt="Screenshot 2023-03-15 at 9 04 36 PM" src="https://user-images.githubusercontent.com/1199820/225483260-da841e02-b206-481c-b638-68e286165a45.png">
