### PR TITLE
Fix Document editor with `"use client"` for `getContext` in NextJS App Directory

### DIFF
--- a/.changeset/short-impalas-hide.md
+++ b/.changeset/short-impalas-hide.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Adds `"use client"` to Document field files that allow it to be used in the Next App Dorectory

--- a/packages/fields-document/src/DocumentEditor/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/utils.ts
@@ -1,3 +1,4 @@
+"use client"
 import React, { useCallback, useEffect, useRef, useState, useContext } from 'react';
 import {
   Editor,

--- a/packages/fields-document/src/DocumentEditor/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/utils.ts
@@ -1,4 +1,4 @@
-"use client"
+'use client';
 import React, { useCallback, useEffect, useRef, useState, useContext } from 'react';
 import {
   Editor,

--- a/packages/fields-document/src/validation.ts
+++ b/packages/fields-document/src/validation.ts
@@ -1,4 +1,4 @@
-"use client"
+'use client';
 import { Text, Editor } from 'slate';
 import { createDocumentEditor } from './DocumentEditor';
 import { ComponentBlock, ComponentSchema } from './DocumentEditor/component-blocks/api';

--- a/packages/fields-document/src/validation.ts
+++ b/packages/fields-document/src/validation.ts
@@ -1,3 +1,4 @@
+"use client"
 import { Text, Editor } from 'slate';
 import { createDocumentEditor } from './DocumentEditor';
 import { ComponentBlock, ComponentSchema } from './DocumentEditor/component-blocks/api';


### PR DESCRIPTION
Currently, if you add the document field to a project and use `getContext` in the NextJs app directory, the next build will fail due to how the document editor validates the schema on the server side - the result being `useState` in a server-side component. This PR marks two files with `"use client"` so Next knows these are client-side files.

Thanks to @gautamsi for working this one out - see comment on #8371 
