### PR TITLE
use pnpm for GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: ./.github/actions/ci-setup
 
-      - run: yarn build
+      - run: pnpm build
 
       - name: git config
         run: |
@@ -24,7 +24,7 @@ jobs:
           git config --global user.email 'automation+keystonejs@thinkmill.com.au'
 
       - name: npm publish, git tag
-        run: yarn changeset publish --tag latest
+        run: pnpm changeset publish --tag latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/version_packages.yml
+++ b/.github/workflows/version_packages.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: changesets/action@v1
         with:
-          version: yarn ci:version-packages
+          version: pnpm ci:version-packages
         env:
           # use a different GitHub account to have the CI run on push
           GITHUB_TOKEN: ${{ secrets.KEYSTONE_RELEASE_BOT_GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,14 +30,14 @@ For more information on the reasoning behind using certain tooling, please refer
 
 ### Version management
 
-Keystone uses @noviny's [@changesets/cli](https://github.com/noviny/changesets) to track package versions and publish packages.
+Keystone uses @noviny's [@changesets/cli](https://github.com/changesets/changesets) to track package versions and publish packages.
 This tool allows each PR to indicate which packages need a version bump along with a changelog snippet.
 This information is then collated when performing a release to update package versions and `CHANGELOG.md` files.
 
 #### What all contributors need to do
 
 - Make your changes (as per usual)
-- Before you make a Pull Request, run the `yarn changeset` command and answer the questions that are asked. It will want to know:
+- Before you make a Pull Request, run the `pnpm changeset` command and answer the questions that are asked. It will want to know:
   - which packages you want to publish
   - what version you are releasing them at
   - a message to summarise the changes (this message will be written to the changelog of bumped packages)


### PR DESCRIPTION
Watching https://github.com/keystonejs/keystone/commits/main, our Version Packages updates are [failing](https://github.com/keystonejs/keystone/actions/runs/4537789825/jobs/7996003592).

```
Usage Error: This project is configured to use pnpm

$ yarn ...
Error: The process '/usr/local/bin/yarn' failed with exit code 1
```

We didn't catch all the usages of `yarn` in https://github.com/keystonejs/keystone/pull/8398
 