### PR TITLE
Always use POSIX path separator when printing types

### DIFF
--- a/.github/workflows/tests_ci_windows.yml
+++ b/.github/workflows/tests_ci_windows.yml
@@ -1,10 +1,6 @@
 name: CI - Windows
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tests_ci_windows.yml
+++ b/.github/workflows/tests_ci_windows.yml
@@ -1,0 +1,33 @@
+name: CI - Windows
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: always-tests-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linting:
+    name: Linting
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ./.github/actions/ci-setup
+
+      - name: TypeScript
+        run: pnpm lint:types
+
+  unit_tests:
+    name: Package Unit Tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ./.github/actions/ci-setup
+
+      - name: Unit tests
+        run: pnpm jest --ci --runInBand --testPathIgnorePatterns=admin-ui-tests --testPathIgnorePatterns=api-tests --testPathIgnorePatterns=examples-smoke-tests --testPathIgnorePatterns=examples/testing

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -78,6 +78,10 @@ export function getBuiltKeystoneConfigurationPath(cwd: string) {
   return path.join(cwd, '.keystone/config.js');
 }
 
+function posixify(s: string) {
+  return s.split(path.sep).join('/');
+}
+
 export function getSystemPaths(cwd: string, config: KeystoneConfig) {
   const prismaClientPath = config.db.prismaClientPath
     ? path.join(cwd, config.db.prismaClientPath)
@@ -88,7 +92,7 @@ export function getSystemPaths(cwd: string, config: KeystoneConfig) {
     : path.join(cwd, 'node_modules/.keystone/types.ts');
 
   const relativePrismaPath = prismaClientPath
-    ? `./${path.relative(path.dirname(builtTypesPath), prismaClientPath)}`
+    ? `./${posixify(path.relative(path.dirname(builtTypesPath), prismaClientPath))}`
     : '@prisma/client';
 
   return {


### PR DESCRIPTION
#8381 added the ability to set an output path for Keystone types to be generated.
The generated types printed a relative path to the Prisma client when a `prismaClientPath` is provided.

On Windows, this would use `\\` as the path separator, compared to `/` on POSIX operating systems.
Windows is interoperable with either.  Using `\\` resulted in unreadable path strings for Windows users.

This pull request changes the behaviour to always use a POSIX path separator (`/`), ensuring if types are committed to source control they are readable on both platforms, without any change in behaviour.