### PR TITLE
Import `getPrismaClient` in tests from `@prisma/client/runtime/library`

### DIFF
--- a/tests/api-tests/test-runner.ts
+++ b/tests/api-tests/test-runner.ts
@@ -9,7 +9,7 @@ import {
   parseEnvValue,
   printConfigWarnings,
 } from '@prisma/internals';
-import { getPrismaClient, objectEnumValues } from '@prisma/client/runtime';
+import { getPrismaClient, objectEnumValues } from '@prisma/client/runtime/library';
 // @ts-ignore
 import { externalToInternalDmmf } from '@prisma/client/generator-build';
 import { initConfig, createSystem } from '@keystone-6/core/system';


### PR DESCRIPTION
Since the Prisma 4.11 update the tests have been getting the following warning:
```
console.warn
      imports from "@prisma/client/runtime" are deprecated.

      37 | // because we're only going to run this on a reasonably small number of schemas and then exit
      38 | const generatedPrismaModules = new Map<string, PrismaModule>();
    > 39 |
         | ^
....
    console.warn
      Use "@prisma/client/runtime/library",  "@prisma/client/runtime/data-proxy" or  "@prisma/client/runtime/binary"
```
This updates API tests to import `getPrismaClient` from `@prisma/client/runtime/library` instead of `@prisma/client/runtime`