### PR TITLE
Fix regression from #8073, `.sudo` now retains the `context.session`

### DIFF
--- a/.changeset/session-went-far.md
+++ b/.changeset/session-went-far.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes regression from #8073, `.sudo` now retains the `context.session`

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -91,8 +91,8 @@ export function createContext({
       graphql: { raw: rawGraphQL, run: runGraphQL, schema },
       prisma: prismaClient,
 
-      sudo: () => construct({ sudo: true, req, res }),
-      exitSudo: () => construct({ sudo: false, req, res }), // TODO: remove, deprecated
+      sudo: () => construct({ session, sudo: true, req, res }),
+      exitSudo: () => construct({ session, sudo: false, req, res }), // TODO: remove, deprecated
 
       req,
       res,


### PR DESCRIPTION
#8073 unintentionally removed the `session` from the new context when calling `context.sudo()`.
This pull request restores the previous functionality that `session` should be retained when calling `context.sudo()`. 

Reviewing this part of the code as part of https://github.com/keystonejs/keystone/pull/8438 brought up many questions about whether this should actually be the functionality; **but we are opting to retain the previous behaviour for now.**

As part of #8438, we decided that `context.exitSudo()` should be deprecated.

In future work we might introduce a new `KeystoneSudoContext` type, we would support `prisma` and other context-free functionality. This would allow us to limit contextualised functionality (like `withRequest` or `withSession`) to a normal `KeystoneContext`, possibly with some recursion prevention.  For example, `context.withSession(...).withSession(...)` is not reasonable usage and the expectations are confusing.

Food for thought, but for now, this pull request fixes the existing behaviour to what users might have expected when upgrading previously.