### PR TITLE
Fix nextjs-keystone example deploy to Vercel

### DIFF
--- a/examples/nextjs-keystone/keystone.ts
+++ b/examples/nextjs-keystone/keystone.ts
@@ -1,5 +1,4 @@
 import { config } from '@keystone-6/core';
-import { fixPrismaPath } from './../example-utils';
 import { lists } from './src/keystone/schema';
 import { withAuth, session } from './src/keystone/auth';
 import { seedDemoData } from './src/keystone/seed';
@@ -17,7 +16,7 @@ export default withAuth(
       },
 
       // WARNING: this is only needed for our monorepo examples, dont do this
-      ...fixPrismaPath,
+      prismaClientPath: 'node_modules/.myprisma/client',
     },
     lists,
     session,


### PR DESCRIPTION
Fixes #8430 

The Deploy to Vercel button for the nextjs-keystone example just clones that one folder and therefore when deployed does not have access to files outside that directory. To simplify the solution this PR just sets the `prismaClientPath` in the config directly instead of importing `example-utils.ts`    