### PR TITLE
Fixes #8046 regression which prevented other command line arguments from being used

### DIFF
--- a/.changeset/large-yaks-eat.md
+++ b/.changeset/large-yaks-eat.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes regression in supplying extra flags to the CLI

--- a/.changeset/large-yaks-eat.md
+++ b/.changeset/large-yaks-eat.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixes regression in supplying extra flags to the CLI
+Fixes #8046 regression which prevented other command line arguments from being used

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -21,7 +21,9 @@ function defaultFlags(flags: Partial<Flags>, defaults: Partial<Flags>) {
 
   for (const [key, value] of Object.entries(flags)) {
     if (value !== undefined && !(key in defaults)) {
-      throw new Error(`Option '${key}' is unsupported for this command`);
+      // Readd support for extra CLI flags for now
+      //throw new Error(`Option '${key}' is unsupported for this command`);
+      continue;
     }
 
     const defaultValue = defaults[key as keyof Flags];

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -21,7 +21,7 @@ function defaultFlags(flags: Partial<Flags>, defaults: Partial<Flags>) {
 
   for (const [key, value] of Object.entries(flags)) {
     if (value !== undefined && !(key in defaults)) {
-      // Readd support for extra CLI flags for now
+      // TODO: maybe we should prevent other flags?
       //throw new Error(`Option '${key}' is unsupported for this command`);
       continue;
     }


### PR DESCRIPTION
Our recent changes in #8046 added some extra CLI flags, including a new feature that would throw (exit the process early) if any unsupported flags were passed to the CLI. 

Unfortunately this broken expected behaviour for anyone using `process.argv` for other purposes in their code.

For example, if a user was using something like `--seed-data` as a flag for their `onConnect` function.
No one has reported this bug to date, which is good insofar as the blast radius of that breaking change, but, we'll nonetheless revert the change for now to the previous behaviour.