### PR TITLE
Resolve Next build errors in Next example

### DIFF
--- a/examples/nextjs-keystone/package.json
+++ b/examples/nextjs-keystone/package.json
@@ -9,7 +9,7 @@
     "keystone:start": "keystone start",
     "next:dev": "next dev -p 4000",
     "next:build": "next build",
-    "build": "keystone build && next build",
+    "build": "keystone build --no-ui && next build",
     "postinstall": "keystone postinstall",
     "start": "next start"
   },
@@ -19,6 +19,7 @@
     "@keystone-6/fields-document": "^7.0.0",
     "@preconstruct/next": "^4.0.0",
     "@prisma/client": "^4.12.0",
+    "graphql": "^16.6.0",
     "graphql-request": "^5.0.0",
     "graphql-yoga": "^3.1.0",
     "next": "13.2.2",

--- a/examples/nextjs-keystone/tsconfig.json
+++ b/examples/nextjs-keystone/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": false,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,6 +1239,9 @@ importers:
       '@prisma/client':
         specifier: ^4.12.0
         version: 4.12.0(prisma@4.12.0)
+      graphql:
+        specifier: ^16.6.0
+        version: 16.6.0
       graphql-request:
         specifier: ^5.0.0
         version: 5.2.0(graphql@16.6.0)


### PR DESCRIPTION
This pull request fixes the `nextjs-keystone` example deployment for Vercel, as it had a number of build issues.