### PR TITLE
Fix structured JSON output types

### DIFF
--- a/.changeset/shiny-dolphins-move.md
+++ b/.changeset/shiny-dolphins-move.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': patch
 ---
 
-Fixes structured JSON output types when using `structure`
+Fixes the JSON output type values for the structure field

--- a/.changeset/shiny-dolphins-move.md
+++ b/.changeset/shiny-dolphins-move.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': patch
+---
+
+Fixes structured JSON output types when using `structure`

--- a/packages/fields-document/src/structure-graphql-output.tsx
+++ b/packages/fields-document/src/structure-graphql-output.tsx
@@ -62,7 +62,7 @@ function getOutputGraphQLFieldInner(
   meta: FieldData
 ): OutputField {
   if (schema.kind === 'form') {
-    return wrapGraphQLFieldInResolver(schema.graphql.output, x => x);
+    return wrapGraphQLFieldInResolver(schema.graphql.output, x => x.value);
   }
   if (schema.kind === 'object') {
     return graphql.field({


### PR DESCRIPTION
When using the structured JSON field with `structure` in GraphQL the return value was `{value: someValue}` but the GraphQL did not line up with this which caused a GraphQL runtime error. This PR makes fixes this so it returns `x.value`. 