### PR TITLE
Deploy documentation as needed

### DIFF
--- a/.github/workflows/vercel_preview.yml
+++ b/.github/workflows/vercel_preview.yml
@@ -1,23 +1,39 @@
 name: Vercel (Preview)
 
 on:
+  pull_request:
+    paths:
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:
   deploy:
-    name: Deploy
     runs-on: ubuntu-latest
-    environment: vercel
+    environment:
+      name: Vercel
+      url: ${{ steps.deploy.outputs.url }}
     env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@main
 
-      - run: npm install --global vercel@canary
+      - run: corepack enable
+
+      - uses: actions/setup-node@main
+        with:
+          # preferably lts/*, but we hit API limits when querying that
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - run: pnpm install -w vercel@canary
 
       - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
-      - run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vercel_production.yml
+++ b/.github/workflows/vercel_production.yml
@@ -8,19 +8,32 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
     runs-on: ubuntu-latest
-    environment: vercel
+    environment:
+      name: Vercel
+      url: ${{ steps.deploy.outputs.url }}
     env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@main
 
-      - run: npm install --global vercel@canary
+      - run: corepack enable
+
+      - uses: actions/setup-node@main
+        with:
+          # preferably lts/*, but we hit API limits when querying that
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - run: pnpm install -w vercel@canary
 
       - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
-      - run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/website_preview.yml
+++ b/.github/workflows/website_preview.yml
@@ -1,7 +1,6 @@
 name: Website (Preview)
 
 on:
-  push:
   pull_request:
     paths:
       - 'docs/**'

--- a/.github/workflows/website_preview.yml
+++ b/.github/workflows/website_preview.yml
@@ -1,6 +1,7 @@
-name: Vercel (Preview)
+name: Website (Preview)
 
 on:
+  push:
   pull_request:
     paths:
       - 'docs/**'
@@ -8,31 +9,20 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
     environment:
-      name: Vercel
+      name: Website
       url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - uses: ./.github/actions/ci-setup
 
-      - run: corepack enable
-
-      - uses: actions/setup-node@main
-        with:
-          # preferably lts/*, but we hit API limits when querying that
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - run: pnpm install -w vercel@canary
-
+      - run: pnpm install -w vercel@canary --ignore-scripts
       - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
       - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
       - id: deploy
         run: |
           url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})

--- a/.github/workflows/website_production.yml
+++ b/.github/workflows/website_production.yml
@@ -1,4 +1,4 @@
-name: Vercel (Production)
+name: Website (Production)
 
 on:
   push:
@@ -8,31 +8,20 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
     environment:
-      name: Vercel
+      name: Website
       url: ${{ steps.deploy.outputs.url }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - uses: ./.github/actions/ci-setup
 
-      - run: corepack enable
-
-      - uses: actions/setup-node@main
-        with:
-          # preferably lts/*, but we hit API limits when querying that
-          node-version: 18
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
-      - run: pnpm install -w vercel@canary
-
+      - run: pnpm install -w vercel@canary --ignore-scripts
       - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
       - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
       - id: deploy
         run: |
           url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})

--- a/design-system/website/next.config.js
+++ b/design-system/website/next.config.js
@@ -1,3 +1,4 @@
+// you don't need this if you're building something outside of the Keystone repo
 const withPreconstruct = require('@preconstruct/next');
 
 module.exports = withPreconstruct();

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,37 +1,16 @@
+// you don't need this if you're building something outside of the Keystone repo
 const withPreconstruct = require('@preconstruct/next');
-const withPlugins = require('next-compose-plugins');
 
-const redirectRoutes = require('./redirects.js');
-const redirects = {
-  async redirects() {
-    return redirectRoutes;
+module.exports = withPreconstruct({
+  env: {
+    siteUrl: 'https://keystonejs.com',
   },
-};
-
-module.exports = withPlugins([
-  withPreconstruct,
-  nextConfig => {
-    nextConfig.env = {
-      siteUrl: 'https://keystonejs.com',
-    };
-    nextConfig.eslint = { ignoreDuringBuilds: true };
-    nextConfig.typescript = {
-      ...nextConfig.typescript,
-      // we run TS elsewhere, Next runs against a different TS config which it insists on existing
-      // this is easier than making this the local TS config correct
-      // + type checking slows down vercel deploys
-      ignoreBuildErrors: true,
-    };
-    const webpack = nextConfig.webpack;
-    nextConfig.webpack = (_config, args) => {
-      const config = webpack ? webpack(_config, args) : _config;
-      const { isServer } = args;
-      if (!isServer) {
-        config.resolve.fallback.fs = false;
-      }
-      return config;
-    };
-    return nextConfig;
+  eslint: {
+    ignoreDuringBuilds: true,
   },
-  redirects,
-]);
+  typescript: {
+    // next attempts to use Typescript, but it's not using our configuration
+    //   we check Typescript elsewhere
+    ignoreBuildErrors: true,
+  },
+});

--- a/examples/nextjs-keystone/next.config.js
+++ b/examples/nextjs-keystone/next.config.js
@@ -1,27 +1,4 @@
-/* You don't need this if you are building something outside of the Keystone repo */
+// you don't need this if you're building something outside of the Keystone repo
 const withPreconstruct = require('@preconstruct/next');
 
-const nextConfig = {
-  /*
-      next@13 automatically bundles server code for server components.
-      This causes a problem for the prisma binary built by Keystone.
-      We need to explicitly ask Next.js to opt-out from bundling
-      dependencies that use native Node.js APIs.
-
-      More here: https://beta.nextjs.org/docs/api-reference/next.config.js#servercomponentsexternalpackages
-    */
-  webpack: config => {
-    config.externals = [...(config.externals || []), '.myprisma/client'];
-    // Important: return the modified config
-    return config;
-  },
-};
-
-/*
-    If you are running this example outside the Keystone repo
-    you can export the next config directly
-*/
-// module.exports = nextConfig;
-
-/* withPreconstruct() is a special export for the keystone monorepo */
-module.exports = withPreconstruct(nextConfig);
+module.exports = withPreconstruct();


### PR DESCRIPTION
Previously the documentation only deployed with a `workflow_dispatch`, but it would be nice if it was deploying when any changes are made to `docs/`.

The GitHub deployment environment was missing a `url` too, which I have added using `GITHUB_OUTPUT` in this pull request.