### PR TITLE
Fix broken link in README Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## Contents
 
-- [Usage & Documentation](#documentation)
+- [Usage & Documentation](#usage--documentation)
 - [Version Control](#version-control)
 - [Code of Conduct](#code-of-conduct)
 - [License](#license)


### PR DESCRIPTION
The existing link to "Usage & Documentation" in the TOC wasn't working. This change fixes that.