### PR TITLE
Revert "Change preview deployment trigger to pull_request_target"

### DIFF
--- a/.github/workflows/website_preview.yml
+++ b/.github/workflows/website_preview.yml
@@ -1,7 +1,7 @@
 name: Website (Preview)
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/website_preview.yml
+++ b/.github/workflows/website_preview.yml
@@ -1,9 +1,6 @@
 name: Website (Preview)
 
 on:
-  pull_request:
-    paths:
-      - 'docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Reverts keystonejs/keystone#8470, we'll use `workflow_dispatch` for now