### PR TITLE
Fix documentation website redirects

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -13,4 +13,5 @@ module.exports = withPreconstruct({
     //   we check Typescript elsewhere
     ignoreBuildErrors: true,
   },
+  redirects: require('./redirects.js'),
 });

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,7 +1,8 @@
 // you don't need this if you're building something outside of the Keystone repo
-const withPreconstruct = require('@preconstruct/next');
+import withPreconstruct from '@preconstruct/next';
+import redirects from './redirects.mjs';
 
-module.exports = withPreconstruct({
+export default withPreconstruct({
   env: {
     siteUrl: 'https://keystonejs.com',
   },
@@ -13,5 +14,5 @@ module.exports = withPreconstruct({
     //   we check Typescript elsewhere
     ignoreBuildErrors: true,
   },
-  redirects: require('./redirects.js'),
+  redirects,
 });

--- a/docs/redirects.mjs
+++ b/docs/redirects.mjs
@@ -276,4 +276,12 @@ const CURRENT = [
   },
 ];
 
-module.exports = [...SPLITBEE, ...CURRENT, ...ORIGINAL_NEXT, ...KEYSTONE_5, ...KEYSTONE_4];
+export default async function redirects() {
+  return [
+    ...SPLITBEE,
+    ...CURRENT,
+    ...ORIGINAL_NEXT,
+    ...KEYSTONE_5,
+    ...KEYSTONE_4
+  ];
+}


### PR DESCRIPTION
The redirects were unintentionally dropped in https://github.com/keystonejs/keystone/pull/8459, this pull request restores them