### PR TITLE
Revert getGqlNames type change

### DIFF
--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -90,7 +90,7 @@ export const getSchemaExtension = ({
     // and then wants to fetch that field with `sessionData` but it's extremely unlikely someone will do that since if
     // they want to add a GraphQL field, they'll probably use a virtual field
     const query = `query($id: ID!) { ${
-      getGqlNames(listKey, '').itemQueryName
+      getGqlNames({ listKey, pluralGraphQLName: '' }).itemQueryName
     }(where: { id: $id }) { ${sessionData} } }`;
 
     let ast;

--- a/packages/core/src/admin-ui/admin-meta-graphql.ts
+++ b/packages/core/src/admin-ui/admin-meta-graphql.ts
@@ -75,31 +75,14 @@ export type StaticAdminMetaQuery = {
       lists: Array<{
         __typename: 'KeystoneAdminUIListMeta';
         key: string;
-        itemQueryName: string;
-        listQueryName: string;
         path: string;
+        description: string | null;
+
         label: string;
+        labelField: string;
         singular: string;
         plural: string;
-        description: string | null;
-        initialColumns: Array<string>;
-        pageSize: number;
-        labelField: string;
-        isSingleton: boolean;
-        initialSort: {
-          __typename: 'KeystoneAdminUISort';
-          field: string;
-          direction: KeystoneAdminUISortDirection;
-        } | null;
-        groups: Array<{
-          __typename: 'KeystoneAdminUIFieldGroupMeta';
-          label: string;
-          description: string | null;
-          fields: Array<{
-            __typename: 'KeystoneAdminUIFieldMeta';
-            path: string;
-          }>;
-        }>;
+
         fields: Array<{
           __typename: 'KeystoneAdminUIFieldMeta';
           path: string;
@@ -116,6 +99,28 @@ export type StaticAdminMetaQuery = {
             fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode | null;
           } | null;
         }>;
+        groups: Array<{
+          __typename: 'KeystoneAdminUIFieldGroupMeta';
+          label: string;
+          description: string | null;
+          fields: Array<{
+            __typename: 'KeystoneAdminUIFieldMeta';
+            path: string;
+          }>;
+        }>;
+
+        pageSize: number;
+        initialColumns: Array<string>;
+        initialSort: {
+          __typename: 'KeystoneAdminUISort';
+          field: string;
+          direction: KeystoneAdminUISortDirection;
+        } | null;
+        isSingleton: boolean;
+
+        // TODO: probably remove this
+        itemQueryName: string;
+        listQueryName: string;
       }>;
     };
   };

--- a/packages/core/src/admin-ui/system/createAdminMeta.ts
+++ b/packages/core/src/admin-ui/system/createAdminMeta.ts
@@ -49,23 +49,28 @@ export type FieldGroupMeta = {
 export type ListMetaRootVal = {
   key: string;
   path: string;
+  description: string | null;
+
   label: string;
+  labelField: string;
   singular: string;
   plural: string;
-  initialColumns: string[];
-  pageSize: number;
-  labelField: string;
-  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null;
+
   fields: FieldMetaRootVal[];
   fieldsByKey: Record<string, FieldMetaRootVal>;
   groups: Array<FieldGroupMeta>;
+
+  pageSize: number;
+  initialColumns: string[];
+  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null;
+  isSingleton: boolean;
+
+  // TODO: probably remove this
   itemQueryName: string;
   listQueryName: string;
-  description: string | null;
   isHidden: ContextFunction<boolean>;
   hideCreate: ContextFunction<boolean>;
   hideDelete: ContextFunction<boolean>;
-  isSingleton: boolean;
 };
 
 export type AdminMetaRootVal = {
@@ -120,26 +125,29 @@ export function createAdminMeta(
 
     adminMetaRoot.listsByKey[listKey] = {
       key: listKey,
-      labelField: list.ui.labelField,
+      path: list.ui.labels.path,
       description: listConfig.ui?.description ?? listConfig.description ?? null,
+
       label: list.ui.labels.label,
+      labelField: list.ui.labelField,
       singular: list.ui.labels.singular,
       plural: list.ui.labels.plural,
-      path: list.ui.labels.path,
+
       fields: [],
       fieldsByKey: {},
       groups: [],
+
       pageSize: maximumPageSize,
       initialColumns,
       initialSort:
         (listConfig.ui?.listView?.initialSort as
           | { field: string; direction: 'ASC' | 'DESC' }
           | undefined) ?? null,
+      isSingleton: list.isSingleton,
 
-      // TODO: probably remove this from the GraphQL schema and here
+      // TODO: probably remove this
       itemQueryName: listKey,
       listQueryName: list.graphql.namePlural, // TODO: remove
-
       hideCreate: normalizeMaybeSessionFunction(
         list.graphql.isEnabled.create ? listConfig.ui?.hideCreate ?? false : false
       ),
@@ -147,10 +155,11 @@ export function createAdminMeta(
         list.graphql.isEnabled.delete ? listConfig.ui?.hideDelete ?? false : false
       ),
       isHidden: normalizeMaybeSessionFunction(listConfig.ui?.isHidden ?? false),
-      isSingleton: list.isSingleton,
     };
+
     adminMetaRoot.lists.push(adminMetaRoot.listsByKey[listKey]);
   }
+
   let uniqueViewCount = -1;
   const stringViewsToIndex: Record<string, number> = {};
   function getViewId(view: string) {

--- a/packages/core/src/admin-ui/utils/useAdminMeta.tsx
+++ b/packages/core/src/admin-ui/utils/useAdminMeta.tsx
@@ -71,7 +71,7 @@ export function useAdminMeta(adminMetaHash: string, fieldViews: FieldViews) {
       runtimeAdminMeta.lists[list.key] = {
         ...list,
         groups: [],
-        gqlNames: getGqlNames(list.key, list.listQueryName), // TODO: remove
+        gqlNames: getGqlNames({ listKey: list.key, pluralGraphQLName: list.listQueryName }), // TODO: replace with an object
         fields: {},
       };
 

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -66,7 +66,9 @@ export const virtual =
           `Either set ui.query with what the Admin UI should fetch or hide the field from the Admin UI by setting ui.listView.fieldMode and ui.itemView.fieldMode to 'hidden'.\n` +
           `When setting ui.query, it is interpolated into a GraphQL query like this:\n` +
           `query {\n` +
-          `  ${getGqlNames({ listKey: meta.listKey, pluralGraphQLName: '' }).itemQueryName}(where: { id: "..." }) {\n` +
+          `  ${
+            getGqlNames({ listKey: meta.listKey, pluralGraphQLName: '' }).itemQueryName
+          }(where: { id: "..." }) {\n` +
           `    ${meta.fieldKey}\${ui.query}\n` +
           `  }\n` +
           `}`

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -66,7 +66,7 @@ export const virtual =
           `Either set ui.query with what the Admin UI should fetch or hide the field from the Admin UI by setting ui.listView.fieldMode and ui.itemView.fieldMode to 'hidden'.\n` +
           `When setting ui.query, it is interpolated into a GraphQL query like this:\n` +
           `query {\n` +
-          `  ${getGqlNames(meta.listKey, '').itemQueryName}(where: { id: "..." }) {\n` +
+          `  ${getGqlNames({ listKey: meta.listKey, pluralGraphQLName: '' }).itemQueryName}(where: { id: "..." }) {\n` +
           `    ${meta.fieldKey}\${ui.query}\n` +
           `  }\n` +
           `}`

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -146,7 +146,7 @@ export function getNamesFromList(
 
   return {
     graphql: {
-      names: getGqlNames(listKey, pluralGraphQLName),
+      names: getGqlNames({ listKey, pluralGraphQLName }),
       namePlural: pluralGraphQLName,
     },
     ui: {

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -105,18 +105,22 @@ export type FieldGroupMeta = {
 export type ListMeta = {
   key: string;
   path: string;
+  description: string | null;
+
   label: string;
+  labelField: string;
   singular: string;
   plural: string;
-  description: string | null;
+
   /** @deprecated */
   gqlNames: InitialisedList['graphql']['names'];
-  initialColumns: string[];
-  pageSize: number;
-  labelField: string;
-  initialSort: null | { direction: 'ASC' | 'DESC'; field: string };
+
   fields: { [path: string]: FieldMeta };
   groups: FieldGroupMeta[];
+
+  pageSize: number;
+  initialColumns: string[];
+  initialSort: null | { direction: 'ASC' | 'DESC'; field: string };
   isSingleton: boolean;
 };
 

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -8,7 +8,13 @@ export type JSONValue =
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export function getGqlNames(listKey: string, pluralGraphQLName: string) {
+export function getGqlNames({
+  listKey,
+  pluralGraphQLName,
+}: {
+  listKey: string;
+  pluralGraphQLName: string;
+}) {
   const lowerPluralName = pluralGraphQLName.slice(0, 1).toLowerCase() + pluralGraphQLName.slice(1);
   const lowerSingularName = listKey.slice(0, 1).toLowerCase() + listKey.slice(1);
   return {

--- a/tests/api-tests/access-control/schema.test.ts
+++ b/tests/api-tests/access-control/schema.test.ts
@@ -80,8 +80,8 @@ describe(`Public schema`, () => {
   describe('config', () => {
     listConfigVariables.forEach(config => {
       test(JSON.stringify(config), async () => {
-        const name = getListName(config);
-        const gqlNames = getGqlNames(name, `${name}s`);
+        const listKey = getListName(config);
+        const gqlNames = getGqlNames({ listKey, pluralGraphQLName: `${listKey}s` });
         // The type is used in all the queries and mutations as a return type.
         if (config.omit === true) {
           expect(types).not.toContain(gqlNames.outputTypeName);
@@ -401,8 +401,8 @@ describe(`Sudo schema`, () => {
   describe('config', () => {
     listConfigVariables.forEach(config => {
       test(JSON.stringify(config), async () => {
-        const name = getListName(config);
-        const gqlNames = getGqlNames(name, `${name}s`);
+        const listKey = getListName(config);
+        const gqlNames = getGqlNames({ listKey, pluralGraphQLName: `${listKey}s` });
         expect(types).toContain(gqlNames.outputTypeName);
         expect(types).toContain(gqlNames.whereUniqueInputName);
         expect(types).toContain(gqlNames.relateToManyForCreateInputName);


### PR DESCRIPTION
As part of https://github.com/keystonejs/keystone/pull/8438 (unreleased), I changed the type signature of `getGqlNames`, not  recognizing that it is a commonly used function as part of our public exports.

This pull request reverts that unreleased change, as we don't actually want to end up with a major upgrade for something so trivial.
Thanks to Paul Andrew Ciocan for notifying us about this in our release candidate.