### PR TITLE
Remove `fetch-depth: 0` for `actions/checkout` for Publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 0
           persist-credentials: true # needed for git push
 
       - uses: ./.github/actions/ci-setup

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 0
           persist-credentials: true # needed for git push
 
       - uses: ./.github/actions/ci-setup


### PR DESCRIPTION
I don't think we actually need this, trying in this pull request anyway