### PR TITLE
Add a new `graphql.typeName` for the `structure` field to support deduplication of GraphQL types

### DIFF
--- a/.changeset/early-feet-heal.md
+++ b/.changeset/early-feet-heal.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': minor
+---
+
+Allow the global Graphql Types for Structured JSON

--- a/.changeset/early-feet-heal.md
+++ b/.changeset/early-feet-heal.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': minor
 ---
 
-Allow the global Graphql Types for Structured JSON
+Add a new `graphql.typeName` for the `structure` field to support deduplication of GraphQL types

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -35,6 +35,12 @@ export const lists = {
       timestamp: timestamp({ ui: { description } }),
       structure: structure({ schema: structureSchema, ui: { views: './structure' } }),
       structureNested: structure({
+        graphql: { typeName: 'StructureNested' },
+        schema: structureNestedSchema,
+        ui: { views: './structure-nested' },
+      }),
+      structureNested2: structure({
+        graphql: { typeName: 'StructureNested' },
         schema: structureNestedSchema,
         ui: { views: './structure-nested' },
       }),

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -6,9 +6,9 @@ type Thing {
   text: String
   timestamp: DateTime
   structure: ThingStructureOutput
-  structureRelationships: ThingStructureRelationshipsOutput
   structureNested: StructureNestedOutput
   structureNested2: StructureNestedOutput
+  structureRelationships: ThingStructureRelationshipsOutput
   checkbox: Boolean
   password: PasswordState
   toOneRelationship: User
@@ -46,8 +46,8 @@ type ThingStructure {
   array: [Int]
 }
 
-type ThingStructureNestedOutput {
-  structure: [ThingStructureNested]
+type StructureNestedOutput {
+  structure: [StructureNested]
   json(hydrateRelationships: Boolean! = false): JSON
 }
 
@@ -303,10 +303,9 @@ input ThingUpdateInput {
   text: String
   timestamp: DateTime
   structure: ThingStructureUpdateInput
-  structureNested: [ThingStructureNestedUpdateInput]
-  structureRelationships: [ThingRelateToOneForUpdateInput]
   structureNested: [StructureNestedUpdateInput]
   structureNested2: [StructureNestedUpdateInput]
+  structureRelationships: [ThingRelateToOneForUpdateInput]
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForUpdateInput
@@ -334,9 +333,9 @@ input ThingStructureUpdateInput {
   array: [Int]
 }
 
-input ThingStructureNestedUpdateInput {
-  leaf: ThingStructureNestedLeafUpdateInput
-  group: ThingStructureNestedGroupUpdateInput
+input StructureNestedUpdateInput {
+  leaf: StructureNestedLeafUpdateInput
+  group: StructureNestedGroupUpdateInput
 }
 
 input StructureNestedLeafUpdateInput {
@@ -388,10 +387,9 @@ input ThingCreateInput {
   text: String
   timestamp: DateTime
   structure: ThingStructureCreateInput
-  structureNested: [ThingStructureNestedCreateInput]
-  structureRelationships: [ThingRelateToOneForCreateInput]
   structureNested: [StructureNestedCreateInput]
   structureNested2: [StructureNestedCreateInput]
+  structureRelationships: [ThingRelateToOneForCreateInput]
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForCreateInput
@@ -419,9 +417,9 @@ input ThingStructureCreateInput {
   array: [Int]
 }
 
-input ThingStructureNestedCreateInput {
-  leaf: ThingStructureNestedLeafCreateInput
-  group: ThingStructureNestedGroupCreateInput
+input StructureNestedCreateInput {
+  leaf: StructureNestedLeafCreateInput
+  group: StructureNestedGroupCreateInput
 }
 
 input StructureNestedLeafCreateInput {

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -6,8 +6,9 @@ type Thing {
   text: String
   timestamp: DateTime
   structure: ThingStructureOutput
-  structureNested: ThingStructureNestedOutput
   structureRelationships: ThingStructureRelationshipsOutput
+  structureNested: StructureNestedOutput
+  structureNested2: StructureNestedOutput
   checkbox: Boolean
   password: PasswordState
   toOneRelationship: User
@@ -50,7 +51,7 @@ type ThingStructureNestedOutput {
   json(hydrateRelationships: Boolean! = false): JSON
 }
 
-interface ThingStructureNested {
+interface StructureNested {
   discriminant: String
 }
 
@@ -97,24 +98,24 @@ input ThingWhereUniqueInput {
   id: ID
 }
 
-type ThingStructureNestedLeaf implements ThingStructureNested {
+type StructureNestedLeaf implements StructureNested {
   discriminant: String
-  value: ThingStructureNestedLeafValue
+  value: StructureNestedLeafValue
 }
 
-type ThingStructureNestedLeafValue {
+type StructureNestedLeafValue {
   label: String
   url: String
 }
 
-type ThingStructureNestedGroup implements ThingStructureNested {
+type StructureNestedGroup implements StructureNested {
   discriminant: String
-  value: ThingStructureNestedGroupValue
+  value: StructureNestedGroupValue
 }
 
-type ThingStructureNestedGroupValue {
+type StructureNestedGroupValue {
   label: String
-  children: [ThingStructureNested]
+  children: [StructureNested]
 }
 
 input ThingWhereInput {
@@ -304,6 +305,8 @@ input ThingUpdateInput {
   structure: ThingStructureUpdateInput
   structureNested: [ThingStructureNestedUpdateInput]
   structureRelationships: [ThingRelateToOneForUpdateInput]
+  structureNested: [StructureNestedUpdateInput]
+  structureNested2: [StructureNestedUpdateInput]
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForUpdateInput
@@ -336,14 +339,14 @@ input ThingStructureNestedUpdateInput {
   group: ThingStructureNestedGroupUpdateInput
 }
 
-input ThingStructureNestedLeafUpdateInput {
+input StructureNestedLeafUpdateInput {
   label: String
   url: String
 }
 
-input ThingStructureNestedGroupUpdateInput {
+input StructureNestedGroupUpdateInput {
   label: String
-  children: [ThingStructureNestedUpdateInput]
+  children: [StructureNestedUpdateInput]
 }
 
 input ThingRelateToOneForUpdateInput {
@@ -387,6 +390,8 @@ input ThingCreateInput {
   structure: ThingStructureCreateInput
   structureNested: [ThingStructureNestedCreateInput]
   structureRelationships: [ThingRelateToOneForCreateInput]
+  structureNested: [StructureNestedCreateInput]
+  structureNested2: [StructureNestedCreateInput]
   checkbox: Boolean
   password: String
   toOneRelationship: UserRelateToOneForCreateInput
@@ -419,14 +424,14 @@ input ThingStructureNestedCreateInput {
   group: ThingStructureNestedGroupCreateInput
 }
 
-input ThingStructureNestedLeafCreateInput {
+input StructureNestedLeafCreateInput {
   label: String
   url: String
 }
 
-input ThingStructureNestedGroupCreateInput {
+input StructureNestedGroupCreateInput {
   label: String
-  children: [ThingStructureNestedCreateInput]
+  children: [StructureNestedCreateInput]
 }
 
 input ThingRelateToOneForCreateInput {

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -18,8 +18,8 @@ model Thing {
   timestamp                         DateTime?
   structure                         String    @default("{\"integer\":0,\"array\":[]}")
   structureNested                   String    @default("[]")
-  structureRelationships            String    @default("[]")
   structureNested2                  String    @default("[]")
+  structureRelationships            String    @default("[]")
   checkbox                          Boolean   @default(false)
   password                          String?
   toOneRelationship                 User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -19,6 +19,7 @@ model Thing {
   structure                         String    @default("{\"integer\":0,\"array\":[]}")
   structureNested                   String    @default("[]")
   structureRelationships            String    @default("[]")
+  structureNested2                  String    @default("[]")
   checkbox                          Boolean   @default(false)
   password                          String?
   toOneRelationship                 User?     @relation("Thing_toOneRelationship", fields: [toOneRelationshipId], references: [id])


### PR DESCRIPTION
Adds `graphql.typeName` to structured JSON field to allow structured JSON to have global types 
Note if the types don't match it will cause GraphQL runtime errors, this will also not work with relationships