### PR TITLE
Add additional custom-field examples, showing nesting and JSON

### DIFF
--- a/examples/custom-field/3-pair-field-json/views.tsx
+++ b/examples/custom-field/3-pair-field-json/views.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { FieldContainer, FieldDescription, FieldLabel, TextInput } from '@keystone-ui/fields';
+import { CellLink, CellContainer } from '@keystone-6/core/admin-ui/components';
+
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+} from '@keystone-6/core/types';
+
+export function Field({ field, value, onChange, autoFocus }: FieldProps<typeof controller>) {
+  const disabled = onChange === undefined;
+  const { left = null, right = null } = value ?? {};
+
+  return (
+    <>
+      <FieldContainer as="fieldset">
+        <FieldLabel>{field.label} (Left)</FieldLabel>
+        <FieldDescription id={`${field.path}-description-left`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          <TextInput
+            type="text"
+            onChange={event => {
+              onChange?.({ left: event.target.value, right });
+            }}
+            disabled={disabled}
+            value={left || ''}
+            autoFocus={autoFocus}
+          />
+        </div>
+      </FieldContainer>
+      <FieldContainer as="fieldset">
+        <FieldLabel>{field.label} (Right)</FieldLabel>
+        <FieldDescription id={`${field.path}-description-right`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          <TextInput
+            type="text"
+            onChange={event => {
+              onChange?.({ left, right: event.target.value });
+            }}
+            disabled={disabled}
+            value={right || ''}
+            autoFocus={autoFocus}
+          />
+        </div>
+      </FieldContainer>
+    </>
+  );
+}
+
+export const Cell: CellComponent = ({ item, field, linkTo }) => {
+  let value = item[field.path] + '';
+  return linkTo ? <CellLink {...linkTo}>{value}</CellLink> : <CellContainer>{value}</CellContainer>;
+};
+Cell.supportsLinkTo = true;
+
+export const CardValue: CardValueComponent = ({ item, field }) => {
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {item[field.path]}
+    </FieldContainer>
+  );
+};
+
+export const controller = (
+  config: FieldControllerConfig<{}>
+): FieldController<
+  {
+    left: string | null;
+    right: string | null;
+  } | null,
+  string
+> => {
+  return {
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: `${config.path} {
+        left
+        right
+      }`,
+    defaultValue: null,
+    deserialize: data => {
+      const value = data[config.path];
+      return typeof value === 'object' ? value : null;
+    },
+    serialize: value => ({ [config.path]: value }),
+  };
+};

--- a/examples/custom-field/3-pair-field-nested/index.ts
+++ b/examples/custom-field/3-pair-field-nested/index.ts
@@ -9,16 +9,34 @@ import { graphql } from '@keystone-6/core';
 export type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo>;
 
-type PairInput = string;
-type PairOutput = string;
+type PairInput = {
+  left: string | null | undefined;
+  right: string | null | undefined;
+};
+type PairOutput = PairInput;
 
-const PairInput = graphql.String;
-const PairOutput = graphql.String;
+const PairInput = graphql.inputObject({
+  name: 'PairNestedInput',
+  fields: {
+    left: graphql.arg({ type: graphql.String }),
+    right: graphql.arg({ type: graphql.String }),
+  },
+});
+
+const PairOutput = graphql.object<PairOutput>()({
+  name: 'PairNestedOutput',
+  fields: {
+    left: graphql.field({ type: graphql.String }),
+    right: graphql.field({ type: graphql.String }),
+  },
+});
 
 const PairFilter = graphql.inputObject({
-  name: 'PairFilter',
+  name: 'PairNestedFilter',
   fields: {
-    equals: graphql.arg({ type: graphql.String }),
+    equals: graphql.arg({
+      type: PairInput,
+    }),
   },
 });
 
@@ -26,21 +44,15 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
   config: PairFieldConfig<ListTypeInfo> = {}
 ): FieldTypeFunc<ListTypeInfo> {
   function resolveInput(value: PairInput | null | undefined) {
-    if (!value) return { left: value, right: value };
-    const [left = '', right = ''] = value.split(' ', 2);
-    return {
-      left,
-      right,
-    };
+    const { left = null, right = null } = value ?? {};
+    return { left, right };
   }
 
-  function resolveOutput(value: { left: string | null; right: string | null }) {
-    const { left, right } = value;
-    if (left === null || right === null) return null;
-    return `${left} ${right}`;
+  function resolveOutput(value: PairOutput) {
+    return value;
   }
 
-  function resolveWhere(value: null | { equals: string | null | undefined }) {
+  function resolveWhere(value: null | { equals: PairInput | null | undefined }) {
     if (value === null) {
       throw new Error('PairFilter cannot be null');
     }
@@ -102,7 +114,7 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
           return resolveOutput(value);
         },
       }),
-      views: './3-pair-field/views',
+      views: './3-pair-field-nested/views',
       getAdminMeta() {
         return {};
       },

--- a/examples/custom-field/3-pair-field-nested/views.tsx
+++ b/examples/custom-field/3-pair-field-nested/views.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { FieldContainer, FieldDescription, FieldLabel, TextInput } from '@keystone-ui/fields';
+import { CellLink, CellContainer } from '@keystone-6/core/admin-ui/components';
+
+import {
+  CardValueComponent,
+  CellComponent,
+  FieldController,
+  FieldControllerConfig,
+  FieldProps,
+} from '@keystone-6/core/types';
+
+export function Field({ field, value, onChange, autoFocus }: FieldProps<typeof controller>) {
+  const disabled = onChange === undefined;
+  const { left = null, right = null } = value ?? {};
+
+  return (
+    <>
+      <FieldContainer as="fieldset">
+        <FieldLabel>{field.label} (Left)</FieldLabel>
+        <FieldDescription id={`${field.path}-description-left`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          <TextInput
+            type="text"
+            onChange={event => {
+              onChange?.({ left: event.target.value, right });
+            }}
+            disabled={disabled}
+            value={left || ''}
+            autoFocus={autoFocus}
+          />
+        </div>
+      </FieldContainer>
+      <FieldContainer as="fieldset">
+        <FieldLabel>{field.label} (Right)</FieldLabel>
+        <FieldDescription id={`${field.path}-description-right`}>
+          {field.description}
+        </FieldDescription>
+        <div>
+          <TextInput
+            type="text"
+            onChange={event => {
+              onChange?.({ left, right: event.target.value });
+            }}
+            disabled={disabled}
+            value={right || ''}
+            autoFocus={autoFocus}
+          />
+        </div>
+      </FieldContainer>
+    </>
+  );
+}
+
+export const Cell: CellComponent = ({ item, field, linkTo }) => {
+  let value = item[field.path] + '';
+  return linkTo ? <CellLink {...linkTo}>{value}</CellLink> : <CellContainer>{value}</CellContainer>;
+};
+Cell.supportsLinkTo = true;
+
+export const CardValue: CardValueComponent = ({ item, field }) => {
+  return (
+    <FieldContainer>
+      <FieldLabel>{field.label}</FieldLabel>
+      {item[field.path]}
+    </FieldContainer>
+  );
+};
+
+export const controller = (
+  config: FieldControllerConfig<{}>
+): FieldController<
+  {
+    left: string | null;
+    right: string | null;
+  } | null,
+  string
+> => {
+  return {
+    path: config.path,
+    label: config.label,
+    description: config.description,
+    graphqlSelection: `${config.path} {
+        left
+        right
+      }`,
+    defaultValue: null,
+    deserialize: data => {
+      const value = data[config.path];
+      return typeof value === 'object' ? value : null;
+    },
+    serialize: value => ({ [config.path]: value }),
+  };
+};

--- a/examples/custom-field/schema.graphql
+++ b/examples/custom-field/schema.graphql
@@ -6,6 +6,18 @@ type Post {
   content: String
   rating: Int
   pair: String
+  pairNested: PairNestedOutput
+  pairJson: PairJsonOutput
+}
+
+type PairNestedOutput {
+  left: String
+  right: String
+}
+
+type PairJsonOutput {
+  left: String
+  right: String
 }
 
 input PostWhereUniqueInput {
@@ -18,6 +30,8 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   id: IDFilter
   pair: PairFilter
+  pairNested: PairNestedFilter
+  pairJson: PairJsonFilter
 }
 
 input IDFilter {
@@ -35,6 +49,24 @@ input PairFilter {
   equals: String
 }
 
+input PairNestedFilter {
+  equals: PairNestedInput
+}
+
+input PairNestedInput {
+  left: String
+  right: String
+}
+
+input PairJsonFilter {
+  equals: PairJsonInput
+}
+
+input PairJsonInput {
+  left: String
+  right: String
+}
+
 input PostOrderByInput {
   id: OrderDirection
   content: OrderDirection
@@ -50,6 +82,8 @@ input PostUpdateInput {
   content: String
   rating: Int
   pair: String
+  pairNested: PairNestedInput
+  pairJson: PairJsonInput
 }
 
 input PostUpdateArgs {
@@ -61,6 +95,8 @@ input PostCreateInput {
   content: String
   rating: Int
   pair: String
+  pairNested: PairNestedInput
+  pairJson: PairJsonInput
 }
 
 """

--- a/examples/custom-field/schema.prisma
+++ b/examples/custom-field/schema.prisma
@@ -13,9 +13,12 @@ generator client {
 }
 
 model Post {
-  id         String  @id @default(cuid())
-  content    String?
-  rating     Int?
-  pair_left  String?
-  pair_right String?
+  id               String  @id @default(cuid())
+  content          String?
+  rating           Int?
+  pair_left        String?
+  pair_right       String?
+  pairNested_left  String?
+  pairNested_right String?
+  pairJson         String?
 }

--- a/examples/custom-field/schema.ts
+++ b/examples/custom-field/schema.ts
@@ -4,6 +4,8 @@ import { allowAll } from '@keystone-6/core/access';
 import { text } from './1-text-field';
 import { stars } from './2-stars-field';
 import { pair } from './3-pair-field';
+import { pair as pairNested } from './3-pair-field-nested';
+import { pair as pairJson } from './3-pair-field-json';
 
 import { Lists } from '.keystone/types';
 
@@ -23,9 +25,19 @@ export const lists: Lists = {
       }),
       pair: pair({
         ui: {
-          description: 'Two words split by a space',
+          description: 'One string, two database string fields',
         },
-      }), // TODO: this example is a bit abstract, should be contextualised
+      }),
+      pairNested: pairNested({
+        ui: {
+          description: 'Two strings, two database string fields',
+        },
+      }),
+      pairJson: pairJson({
+        ui: {
+          description: 'Two strings, one database JSON field',
+        },
+      }),
     },
     hooks: {
       // TODO: this is  an example of how hooks interact with custom multiple-column fields,
@@ -41,6 +53,14 @@ export const lists: Lists = {
             right: resolvedData.pair?.right,
           },
         };
+      },
+
+      validateInput: async ({ resolvedData, operation, inputData, item, addValidationError }) => {
+        console.log('Post.hooks.validateInput', { resolvedData, operation, inputData, item });
+
+        if (Math.random() > 0.95) {
+          addValidationError('oh oh, try again, this is part of the example');
+        }
       },
     },
   }),


### PR DESCRIPTION
This pull request adds alternative approaches for the `3-pair` example in the `custom-field` demonstration.
Two additional custom fields have been added, resulting in the `3-pair-*` suite containing the following:

- `3-pair` - a field with one Admin UI input field, one GraphQL type, and two columns in the database
- `3-pair-nested` - a field with two Admin UI input fields, distinct GraphQL fields, and two columns in the database
- `3-pair-json` - a field with two Admin UI input fields, distinct GraphQL fields, and one column in the database

This helped me answer some questions I had, hopefully it helps others too.