### PR TITLE
chore(deps): include all `@keystone-6/core` files inside npm package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -188,23 +188,6 @@
   "bin": {
     "keystone": "bin/cli.js"
   },
-  "files": [
-    "session",
-    "bin",
-    "___internal-do-not-use-will-break-in-patch",
-    "next",
-    "schema",
-    "scripts",
-    "dist",
-    "static",
-    "admin-ui",
-    "testing",
-    "fields",
-    "types",
-    "system",
-    "context",
-    "access"
-  ],
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.2",
     "@apollo/client": "^3.7.0",


### PR DESCRIPTION
Currently, we don't have an `src` folder, `CHANGELOG.md`, and so on ...

Related to https://github.com/keystonejs/keystone/discussions/8487