### PR TITLE
Add declarationMap for source mapping

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    "target": "esnext" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
-    "noEmit": true /* Do not emit outputs. */,
-    "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-    "strict": true /* Enable all strict type-checking options. */,
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+    "declaration": true,
+    "declarationMap": true, // Enables 'Go to Definition'
+    "esModuleInterop": true, // Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'
+    "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file
+    "isolatedModules": true, // Transpile each file as a separate module (similar to 'ts.transpileModule')
+    "jsx": "react", // Specify JSX code generation: 'preserve', 'react-native', or 'react'
+    "module": "esnext", // Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'
+    "moduleResolution": "node", // Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6)
+    "noEmit": true, // Do not emit outputs
     "noUnusedLocals": true,
-    "types": ["@types/jest"],
-    "typeRoots": [],
-    "skipLibCheck": true,
     "resolveJsonModule": true,
-    "declaration": true
+    "skipLibCheck": true,
+    "strict": true, // Enable all strict type-checking options.
+    "target": "esnext", // Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'
+    "typeRoots": [],
+    "types": ["@types/jest"]
   },
   "include": ["**/*"],
   "exclude": ["**/node_modules/**/*"]


### PR DESCRIPTION
Follow up to https://github.com/keystonejs/keystone/pull/8488, one of the benefits of having the source available, is we can actually reference that instead of the compiled bundles.

This pull request adds `"declarationMap": true`, and then sorts the fields in the `tsconfig.json` lexicographically.