### PR TITLE
Add field labels for structured JSON array fields

### DIFF
--- a/.changeset/neat-guests-design.md
+++ b/.changeset/neat-guests-design.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-6/fields-document': minor
+'@keystone-6/fields-document': major
 ---
 
 Adds `fieldLabel` to array field for Structured JSON

--- a/.changeset/neat-guests-design.md
+++ b/.changeset/neat-guests-design.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/fields-document': minor
+---
+
+Adds `fieldLabel` to array field for Structured JSON

--- a/.changeset/neat-guests-design.md
+++ b/.changeset/neat-guests-design.md
@@ -2,4 +2,4 @@
 '@keystone-6/fields-document': major
 ---
 
-Adds `fieldLabel` to array field for Structured JSON
+Changes `fields.array({ label: ...` to `fields.array({ itemLabel: ...`, and adds `fields.array({ label: string`, aligned with other document fields

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -118,6 +118,7 @@ export type ArrayField<ElementField extends ComponentSchema> = {
   element: ElementField;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
   label?(props: unknown): string;
+  fieldLabel?: string;
 };
 
 export type RelationshipField<Many extends boolean> = {
@@ -152,6 +153,7 @@ type ArrayFieldInComponentSchema = {
   element: ComponentSchema;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
   label?(props: unknown): string;
+  fieldLabel?: string;
 };
 
 export type ComponentSchema =
@@ -168,6 +170,7 @@ type ArrayFieldInComponentSchemaForGraphQL = {
   element: ComponentSchemaForGraphQL;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
   label?(props: unknown): string;
+  fieldLabel?: string;
 };
 
 export type ComponentSchemaForGraphQL =
@@ -552,9 +555,12 @@ export const fields = {
   },
   array<ElementField extends ComponentSchema>(
     element: ElementField,
-    opts?: { label?: (props: GenericPreviewProps<ElementField, unknown>) => string }
+    opts?: {
+      label?: (props: GenericPreviewProps<ElementField, unknown>) => string;
+      fieldLabel?: string;
+    }
   ): ArrayField<ElementField> {
-    return { kind: 'array', element, label: opts?.label };
+    return { kind: 'array', element, label: opts?.label, fieldLabel: opts?.fieldLabel };
   },
 };
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -117,8 +117,8 @@ export type ArrayField<ElementField extends ComponentSchema> = {
   kind: 'array';
   element: ElementField;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
-  label?(props: unknown): string;
-  fieldLabel?: string;
+  itemLabel?(props: unknown): string;
+  label?: string;
 };
 
 export type RelationshipField<Many extends boolean> = {
@@ -152,8 +152,8 @@ type ArrayFieldInComponentSchema = {
   kind: 'array';
   element: ComponentSchema;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
-  label?(props: unknown): string;
-  fieldLabel?: string;
+  itemLabel?(props: unknown): string;
+  label?: string;
 };
 
 export type ComponentSchema =
@@ -169,8 +169,8 @@ type ArrayFieldInComponentSchemaForGraphQL = {
   kind: 'array';
   element: ComponentSchemaForGraphQL;
   // this is written with unknown to avoid typescript being annoying about circularity or variance things
-  label?(props: unknown): string;
-  fieldLabel?: string;
+  itemLabel?(props: unknown): string;
+  label?: string;
 };
 
 export type ComponentSchemaForGraphQL =
@@ -556,11 +556,11 @@ export const fields = {
   array<ElementField extends ComponentSchema>(
     element: ElementField,
     opts?: {
-      label?: (props: GenericPreviewProps<ElementField, unknown>) => string;
-      fieldLabel?: string;
+      itemLabel?: (props: GenericPreviewProps<ElementField, unknown>) => string;
+      label?: string;
     }
   ): ArrayField<ElementField> {
-    return { kind: 'array', element, label: opts?.label, fieldLabel: opts?.fieldLabel };
+    return { kind: 'array', element, itemLabel: opts?.itemLabel, label: opts?.label };
   },
 };
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -34,6 +34,7 @@ type DefaultFieldProps<Key> = GenericPreviewProps<
 function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
   return (
     <Stack gap="medium">
+      {props.schema.fieldLabel && <FieldLabel>{props.schema.fieldLabel}</FieldLabel>}
       <OrderableList {...props}>
         {props.elements.map(val => {
           return (

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -34,13 +34,13 @@ type DefaultFieldProps<Key> = GenericPreviewProps<
 function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
   return (
     <Stack gap="medium">
-      {props.schema.fieldLabel && <FieldLabel>{props.schema.fieldLabel}</FieldLabel>}
+      {props.schema.label && <FieldLabel>{props.schema.label}</FieldLabel>}
       <OrderableList {...props}>
         {props.elements.map(val => {
           return (
             <OrderableItemInForm
               elementKey={val.key}
-              label={props.schema.label?.(val) ?? 'Item'}
+              label={props.schema.itemLabel?.(val) ?? 'Item'}
               {...val}
             />
           );

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -36,8 +36,13 @@ type Thing {
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
 
 type ThingStructureOutput {
-  structure: [Int]
+  structure: ThingStructure
   json(hydrateRelationships: Boolean! = false): JSON
+}
+
+type ThingStructure {
+  integer: Int
+  array: [Int]
 }
 
 type ThingStructureNestedOutput {
@@ -296,7 +301,7 @@ enum OrderDirection {
 input ThingUpdateInput {
   text: String
   timestamp: DateTime
-  structure: [Int]
+  structure: ThingStructureUpdateInput
   structureNested: [ThingStructureNestedUpdateInput]
   structureRelationships: [ThingRelateToOneForUpdateInput]
   checkbox: Boolean
@@ -319,6 +324,11 @@ input ThingUpdateInput {
   image: ImageFieldInput
   file: FileFieldInput
   document: JSON
+}
+
+input ThingStructureUpdateInput {
+  integer: Int
+  array: [Int]
 }
 
 input ThingStructureNestedUpdateInput {
@@ -374,7 +384,7 @@ input ThingUpdateArgs {
 input ThingCreateInput {
   text: String
   timestamp: DateTime
-  structure: [Int]
+  structure: ThingStructureCreateInput
   structureNested: [ThingStructureNestedCreateInput]
   structureRelationships: [ThingRelateToOneForCreateInput]
   checkbox: Boolean
@@ -397,6 +407,11 @@ input ThingCreateInput {
   image: ImageFieldInput
   file: FileFieldInput
   document: JSON
+}
+
+input ThingStructureCreateInput {
+  integer: Int
+  array: [Int]
 }
 
 input ThingStructureNestedCreateInput {

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -16,7 +16,7 @@ model Thing {
   id                                String    @id @default(cuid())
   text                              String    @default("")
   timestamp                         DateTime?
-  structure                         String    @default("[]")
+  structure                         String    @default("{\"integer\":0,\"array\":[]}")
   structureNested                   String    @default("[]")
   structureRelationships            String    @default("[]")
   checkbox                          Boolean   @default(false)

--- a/tests/sandbox/structure-nested.tsx
+++ b/tests/sandbox/structure-nested.tsx
@@ -28,7 +28,7 @@ export const schema: ArrayField<ComponentSchemaForGraphQL> = fields.array(
     }
   ),
   {
-    label: props =>
+    itemLabel: props =>
       `${
         props.schema.discriminant.options.find(option => props.discriminant === option.value)?.label
       } - ${props.value.fields.label.value}${

--- a/tests/sandbox/structure-relationships.tsx
+++ b/tests/sandbox/structure-relationships.tsx
@@ -11,7 +11,7 @@ export const schema: ArrayField<ComponentSchemaForGraphQL> = fields.array(
     many: false,
   }),
   {
-    label: props => {
+    itemLabel: props => {
       return `${props.value?.label}`;
     },
   }

--- a/tests/sandbox/structure.tsx
+++ b/tests/sandbox/structure.tsx
@@ -3,8 +3,8 @@ import { fields } from '@keystone-6/fields-document/component-blocks';
 export const schema = fields.object({
   integer: fields.integer({ label: 'My integer units' }),
   array: fields.array(fields.integer({ label: 'My integer units' }), {
-    fieldLabel: 'My array of integers',
-    label: props => {
+    label: 'My array of integers',
+    itemLabel: props => {
       return `${props.value} units`;
     },
   }),

--- a/tests/sandbox/structure.tsx
+++ b/tests/sandbox/structure.tsx
@@ -1,14 +1,11 @@
-import {
-  ArrayField,
-  ComponentSchemaForGraphQL,
-  fields,
-} from '@keystone-6/fields-document/component-blocks';
+import { fields } from '@keystone-6/fields-document/component-blocks';
 
-export const schema: ArrayField<ComponentSchemaForGraphQL> = fields.array(
-  fields.integer({ label: 'My integer units' }),
-  {
+export const schema = fields.object({
+  integer: fields.integer({ label: 'My integer units' }),
+  array: fields.array(fields.integer({ label: 'My integer units' }), {
+    fieldLabel: 'My array of integers',
     label: props => {
       return `${props.value} units`;
     },
-  }
-);
+  }),
+});


### PR DESCRIPTION
Currently, a nested array field does not have a heading label so looks like this:
<img width="422" alt="Screenshot 2023-04-18 at 1 29 42 pm" src="https://user-images.githubusercontent.com/8251494/232663910-df1ce6f5-243b-4cad-a8a4-9a1ea81d5fa6.png">
This makes it hard to distinguish between nested array fields until an item is added.

The current `label` is really just an `itemLabel` field, so only is visible after an item is added:

<img width="757" alt="Screenshot 2023-04-18 at 1 33 14 pm" src="https://user-images.githubusercontent.com/8251494/232664330-88cfe0bf-cd1e-4cb7-947d-f71862acd8ef.png">

This PR adds changes the current `label` to `itemLabel` and `label` is now the field label and displays that above the array
<img width="774" alt="Screenshot 2023-04-18 at 1 35 11 pm" src="https://user-images.githubusercontent.com/8251494/232664485-7c7690e9-728a-4282-81f8-59561affe834.png">
