### PR TITLE
Fix Auth example project link in documentation

### DIFF
--- a/docs/pages/docs/config/auth.md
+++ b/docs/pages/docs/config/auth.md
@@ -459,7 +459,7 @@ The authenticated item will be returned as `item`.
 {% related-content %}
 {% well
 heading="Example Project: Authentication"
-href="<https://github.com/keystonejs/keystone/tree/main/examples/with-auth>" %}
+href="https://github.com/keystonejs/keystone/tree/main/examples/with-auth" %}
 Adds password-based authentication to the Task Manager starter project.
 {% /well %}
 {% /related-content %}

--- a/docs/pages/docs/config/auth.md
+++ b/docs/pages/docs/config/auth.md
@@ -459,7 +459,7 @@ The authenticated item will be returned as `item`.
 {% related-content %}
 {% well
 heading="Example Project: Authentication"
-href="https://github.com/keystonejs/keystone/tree/main/examples/with-auth" %}
+href="https://github.com/keystonejs/keystone/tree/main/examples/auth" %}
 Adds password-based authentication to the Task Manager starter project.
 {% /well %}
 {% /related-content %}


### PR DESCRIPTION
Link to Example Project is currently broken 404