### PR TITLE
Revert "Remove env.SKIP_PROMPTS for CLI"

### DIFF
--- a/.changeset/no-skip-prompts.md
+++ b/.changeset/no-skip-prompts.md
@@ -1,5 +1,0 @@
----
-'@keystone-6/core': major
----
-
-Removes CLI environment variable `SKIP_PROMPTS`

--- a/packages/core/src/lib/prompts.ts
+++ b/packages/core/src/lib/prompts.ts
@@ -28,7 +28,8 @@ async function textPromptImpl(message: string): Promise<string> {
   return value;
 }
 
-export let shouldPrompt = process.stdout.isTTY;
+export let shouldPrompt = process.stdout.isTTY && !process.env.SKIP_PROMPTS;
+
 export let confirmPrompt = confirmPromptImpl;
 export let textPrompt = textPromptImpl;
 

--- a/packages/core/src/scripts/tests/utils.tsx
+++ b/packages/core/src/scripts/tests/utils.tsx
@@ -67,7 +67,6 @@ export function recordConsole(promptResponses?: Record<string, string | boolean>
 
     return answer;
   };
-
   mockPrompts({
     confirm: async message => {
       const answer = getPromptAnswer(message);


### PR DESCRIPTION
Reverts keystonejs/keystone#8517 for now, we don't want to trigger a `major` for the upcoming release, nor do we want to branch around