### PR TITLE
Remove env.SKIP_PROMPTS for CLI

### DIFF
--- a/.changeset/no-skip-prompts.md
+++ b/.changeset/no-skip-prompts.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes CLI environment variable `SKIP_PROMPTS`

--- a/packages/core/src/lib/prompts.ts
+++ b/packages/core/src/lib/prompts.ts
@@ -28,8 +28,7 @@ async function textPromptImpl(message: string): Promise<string> {
   return value;
 }
 
-export let shouldPrompt = process.stdout.isTTY && !process.env.SKIP_PROMPTS;
-
+export let shouldPrompt = process.stdout.isTTY;
 export let confirmPrompt = confirmPromptImpl;
 export let textPrompt = textPromptImpl;
 

--- a/packages/core/src/scripts/tests/utils.tsx
+++ b/packages/core/src/scripts/tests/utils.tsx
@@ -67,6 +67,7 @@ export function recordConsole(promptResponses?: Record<string, string | boolean>
 
     return answer;
   };
+
   mockPrompts({
     confirm: async message => {
       const answer = getPromptAnswer(message);


### PR DESCRIPTION
Duplicate of https://github.com/keystonejs/keystone/pull/8517 (reverted temporarily in https://github.com/keystonejs/keystone/pull/8520)

---

Previously added in https://github.com/keystonejs/keystone/pull/5758, this is being removed.
If you don't want an interactive CLI, don't run the command in an interactive CLI.

For example, using the same format as the [node documentation](https://nodejs.org/api/tty.html#tty):

```bash
keystone/examples/auth $ pn postinstall

Your Prisma schema is not up to date
Replace the Prisma schema? … (Y/n)
...

keystone/examples/auth $ pn postinstall | cat

Your Prisma schema is not up to date
Use keystone dev to update the Prisma schema
... ELIFECYCLE  Command failed with exit code 1.
```