### PR TITLE
Fixes for Version Packages

### DIFF
--- a/.changeset/cool-cycles-exist.md
+++ b/.changeset/cool-cycles-exist.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds support for Prisma Data Proxy client generation, automatically enabled for `db.url`'s with a `prisma:` prefix

--- a/.changeset/early-garlics-double.md
+++ b/.changeset/early-garlics-double.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes the `.keystone/types` import paths when using `db.prismaSchemaPath` on Windows

--- a/.changeset/late-birds-clean.md
+++ b/.changeset/late-birds-clean.md
@@ -1,0 +1,5 @@
+---
+'@keystone-ui/fields': minor
+---
+
+Add newline compatibility to description text in admin ui

--- a/.changeset/late-birds-clean.md
+++ b/.changeset/late-birds-clean.md
@@ -2,4 +2,4 @@
 '@keystone-ui/fields': minor
 ---
 
-Add newline compatibility to description text in admin ui
+Adds newline compatibility to description text in admin ui

--- a/.changeset/tough-moles-heal.md
+++ b/.changeset/tough-moles-heal.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Update Prisma version to `4.12.0`
+Updates Prisma version to `4.12.0`

--- a/.changeset/types-can-upgrade.md
+++ b/.changeset/types-can-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes the printed output when using `keystone telemetry reset`

--- a/.changeset/types-can-walk.md
+++ b/.changeset/types-can-walk.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Adds a new `.types.path` configuration option, for specifying where your Keystone types are built

--- a/.github/workflows/version_packages.yml
+++ b/.github/workflows/version_packages.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@main
         with:
-          fetch-depth: 0
           persist-credentials: false
 
       - uses: ./.github/actions/ci-setup

--- a/design-system/packages/fields/CHANGELOG.md
+++ b/design-system/packages/fields/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @keystone-ui/fields
 
-## 7.2.0
-
-### Minor Changes
-
-- [#8369](https://github.com/keystonejs/keystone/pull/8369) [`1af39b913`](https://github.com/keystonejs/keystone/commit/1af39b9133ef6a8d48c55f09c79a7d2f853346ad) Thanks [@DiesIrae](https://github.com/DiesIrae)! - Add newline compatibility to description text in admin ui
-
 ## 7.1.2
 
 ### Patch Changes

--- a/design-system/packages/fields/package.json
+++ b/design-system/packages/fields/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keystone-ui/fields",
-  "version": "7.2.0",
+  "version": "7.1.2",
   "license": "MIT",
   "main": "dist/keystone-ui-fields.cjs.js",
   "module": "dist/keystone-ui-fields.esm.js",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@babel/preset-typescript": "^7.21.0",
     "@changesets/changelog-github": "^0.4.1",
     "@changesets/cli": "^2.18.0",
+    "@changesets/get-github-info": "^0.5.2",
+    "@changesets/get-release-plan": "^3.0.16",
     "@manypkg/cli": "^0.20.0",
     "@preconstruct/cli": "2.5.0",
     "@types/jest": "^29.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,22 +1,5 @@
 # @keystone-6/core
 
-## 5.2.0
-
-### Minor Changes
-
-- [#8370](https://github.com/keystonejs/keystone/pull/8370) [`730ee7948`](https://github.com/keystonejs/keystone/commit/730ee79489cd5c7cf74553a86d5de8433d32ebeb) Thanks [@borisno2](https://github.com/borisno2)! - Adds support for Prisma Data Proxy client generation, automatically enabled for `db.url`'s with a `prisma:` prefix
-
-- [#8381](https://github.com/keystonejs/keystone/pull/8381) [`6b338c46a`](https://github.com/keystonejs/keystone/commit/6b338c46a5f9c4ab71939f3632dfccae27ffb56e) Thanks [@dcousens](https://github.com/dcousens)! - Adds a new `.types.path` configuration option, for specifying where your Keystone types are built
-
-### Patch Changes
-
-- [#8373](https://github.com/keystonejs/keystone/pull/8373) [`c6c9078d5`](https://github.com/keystonejs/keystone/commit/c6c9078d5cdeab968d563c340904717ebc36b1a3) Thanks [@borisno2](https://github.com/borisno2)! - Fixes the `.keystone/types` import paths when using `db.prismaSchemaPath` on Windows
-
-- [#8400](https://github.com/keystonejs/keystone/pull/8400) [`7cfe118bb`](https://github.com/keystonejs/keystone/commit/7cfe118bb68b0a2420a82fe78849ee9f7b9f6fb2) Thanks [@renovate](https://github.com/apps/renovate)! - Fixes the printed output when using `keystone telemetry reset`
-
-- Updated dependencies [[`1af39b913`](https://github.com/keystonejs/keystone/commit/1af39b9133ef6a8d48c55f09c79a7d2f853346ad)]:
-  - @keystone-ui/fields@7.2.0
-
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keystone-6/core",
-  "version": "5.2.0",
+  "version": "5.1.0",
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/core",
   "license": "MIT",
   "main": "dist/keystone-6-core.cjs.js",
@@ -204,7 +204,7 @@
     "@hapi/iron": "^7.0.0",
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/core": "^5.0.2",
-    "@keystone-ui/fields": "^7.2.0",
+    "@keystone-ui/fields": "^7.1.2",
     "@keystone-ui/icons": "^6.0.2",
     "@keystone-ui/loading": "^6.0.2",
     "@keystone-ui/modals": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.18.0
         version: 2.18.0
+      '@changesets/get-github-info':
+        specifier: ^0.5.2
+        version: 0.5.2
+      '@changesets/get-release-plan':
+        specifier: ^3.0.16
+        version: 3.0.16
       '@manypkg/cli':
         specifier: ^0.20.0
         version: 0.20.0
@@ -2649,7 +2655,7 @@ packages:
       '@babel/core': 7.21.4
       '@babel/generator': 7.21.4
       '@babel/parser': 7.21.4
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       '@babel/traverse': 7.21.4
       '@babel/types': 7.21.4
       babel-preset-fbjs: 3.4.0(@babel/core@7.21.4)
@@ -6403,7 +6409,7 @@ packages:
     resolution: {integrity: sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==}
     dependencies:
       dataloader: 1.4.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.9
     transitivePeerDependencies:
       - encoding
     dev: true
@@ -7825,11 +7831,11 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
-      globby: 11.0.4
+      globby: 11.1.0
       read-yaml-file: 1.1.0
     dev: true
 
@@ -7846,7 +7852,7 @@ packages:
     engines: {node: '>=14.18.0'}
     dependencies:
       fs-extra: 8.1.0
-      globby: 11.0.4
+      globby: 11.1.0
       jju: 1.4.0
       read-yaml-file: 1.1.0
     dev: true
@@ -8677,7 +8683,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -8749,7 +8755,7 @@ packages:
     peerDependencies:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || 14 || 15 || 16
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       find-pkg-json-field-up: 1.0.1
       graphql: 16.6.0
       lazy-require.macro: 0.1.0
@@ -10076,7 +10082,7 @@ packages:
   /babel-plugin-macros@2.8.0:
     resolution: {integrity: sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       cosmiconfig: 6.0.0
       resolve: 1.20.0
     dev: false
@@ -10085,7 +10091,7 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       cosmiconfig: 7.1.0
       resolve: 1.22.1
     dev: false
@@ -11454,7 +11460,7 @@ packages:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
     engines: {node: '>=10'}
     dependencies:
-      globby: 11.0.4
+      globby: 11.1.0
       graceful-fs: 4.2.11
       is-glob: 4.0.3
       is-path-cwd: 2.2.0
@@ -13189,6 +13195,7 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
 
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -17568,7 +17575,7 @@ packages:
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
 
   /regex-not@1.0.2:
     resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
@@ -17658,7 +17665,7 @@ packages:
   /relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
     dependencies:
-      '@babel/runtime': 7.16.3
+      '@babel/runtime': 7.21.0
       fbjs: 3.0.4
       invariant: 2.2.4
     transitivePeerDependencies:

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -15,37 +15,18 @@ const publicPackages = [
   '@keystone-6/core',
   '@keystone-6/document-renderer',
   '@keystone-6/fields-document',
-  '@keystone-6/session-store-redis',
 ];
 
 const cves = [
-  {
-    id: 'CVE-2022-36313',
-    href: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-36313',
-    upstream: true,
-    description: `
-      An upstream transitive dependency \`file-type\` is vulnerable to a ReDoS.
-      We have upgraded to a version of \`file-type\` that is fixed.
-    `,
-  },
-  {
-    id: 'CVE-2023-23936',
-    href: 'https://github.com/advisories/GHSA-5r9g-qh6m-jxff',
-    upstream: true,
-    description: `
-      An upstream transitive dependency \`undici\` is vulnerable to a HTTP header CRLF injection vulnerability.
-      We have upgraded to a version of \`@prisma/core\` that uses a fixed \`undici\`.
-    `,
-  },
-  {
-    id: 'CVE-2023-24807',
-    href: 'https://github.com/advisories/GHSA-r6ch-mqf9-qc9w',
-    upstream: true,
-    description: `
-      An upstream transitive dependency \`undici\` is vulnerable to a ReDoS.
-      We have upgraded to a version of \`@prisma/core\` that uses a fixed \`undici\`.
-    `,
-  },
+//    {
+//      id: 'CVE-2023-23936',
+//      href: 'https://github.com/advisories/GHSA-5r9g-qh6m-jxff',
+//      upstream: true,
+//      description: `
+//        An upstream transitive dependency \`undici\` is vulnerable to a HTTP header CRLF injection vulnerability.
+//        We have upgraded to a version of \`@prisma/core\` that uses a fixed \`undici\`.
+//      `,
+//    },
 ];
 
 function gitCommitsSince(tag) {

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -18,15 +18,15 @@ const publicPackages = [
 ];
 
 const cves = [
-//    {
-//      id: 'CVE-2023-23936',
-//      href: 'https://github.com/advisories/GHSA-5r9g-qh6m-jxff',
-//      upstream: true,
-//      description: `
-//        An upstream transitive dependency \`undici\` is vulnerable to a HTTP header CRLF injection vulnerability.
-//        We have upgraded to a version of \`@prisma/core\` that uses a fixed \`undici\`.
-//      `,
-//    },
+  //    {
+  //      id: 'CVE-2023-23936',
+  //      href: 'https://github.com/advisories/GHSA-5r9g-qh6m-jxff',
+  //      upstream: true,
+  //      description: `
+  //        An upstream transitive dependency \`undici\` is vulnerable to a HTTP header CRLF injection vulnerability.
+  //        We have upgraded to a version of \`@prisma/core\` that uses a fixed \`undici\`.
+  //      `,
+  //    },
 ];
 
 function gitCommitsSince(tag) {


### PR DESCRIPTION
Version Packages [is failing with a bad `pnpm-lock.yaml`](https://github.com/keystonejs/keystone/actions/runs/4815658013), this should fix that and a few other small changes for preparing the release.

This reverts #8374, fixes the problem, and then we'll follow up with a fixed version package merge.