### PR TITLE
fix(docs): Updated url to Next.js example

### DIFF
--- a/docs/pages/docs/examples.tsx
+++ b/docs/pages/docs/examples.tsx
@@ -252,7 +252,7 @@ export default function Docs() {
         <Well
           grad="grad2"
           heading="Next.js + Keystone"
-          href="https://github.com/keystonejs/keystone/blob/main/examples/example-framework-nextjs-app-directory"
+          href="https://github.com/keystonejs/keystone/tree/main/examples/framework-nextjs-app-directory"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Fixed url  on https://keystonejs.com/docs/examples page in End-to-End Examples section