### PR TITLE
Fix `keystone dev` errors for `next@^13.4.0`

### DIFF
--- a/.changeset/small-games-bathe.md
+++ b/.changeset/small-games-bathe.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-set appdir to false in next config
+Change next `experimental.appDir: false` for now, until resolution found for internal React issues

--- a/.changeset/small-games-bathe.md
+++ b/.changeset/small-games-bathe.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+set appdir to false in next config

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/next-config.ts
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/next-config.ts
@@ -3,6 +3,9 @@ import Path from 'path';
 import withPreconstruct from '@preconstruct/next';
 
 export const config = withPreconstruct({
+  experimental: {
+    appDir: false,
+  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
This resolves: #8553 

On next version 13.4.0 and higher setting the appDir to false is mandatory in the next config file.
Ref: https://github.com/vercel/next.js/issues/49261 and https://github.com/vercel/next.js/discussions/49251