### PR TITLE
Updated MySQL code example default port

### DIFF
--- a/docs/pages/blog/mysql-support.md
+++ b/docs/pages/blog/mysql-support.md
@@ -15,7 +15,7 @@ Here's an example `db.config` to work with MySQL database.
 export default config({
   db: {
     provider: 'mysql',
-    url: 'mysql://dbuser:dbpass@localhost:5432/keystone',
+    url: 'mysql://dbuser:dbpass@localhost:3306/keystone',
     idField: { kind: 'uuid' },
   },
   ...

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -94,7 +94,7 @@ export default config({
 export default config({
   db: {
     provider: 'mysql',
-    url: 'mysql://dbuser:dbpass@localhost:5432/keystone',
+    url: 'mysql://dbuser:dbpass@localhost:3306/keystone',
     onConnect: async context => { /* ... */ },
     // Optional advanced configuration
     enableLogging: true,


### PR DESCRIPTION
Updated MySQL code examples to use the correct MySQL port `3306` instead of PostgreSQL port `5432`, to prevent configuration errors for beginners.