### PR TITLE
Fix hanging process when multiple Prisma generators are defined

### DIFF
--- a/.changeset/chatty-dryers-smash.md
+++ b/.changeset/chatty-dryers-smash.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes hanging process when multiple Prisma generators are defined


### PR DESCRIPTION
closes #8586
- getGenerator only works when one generator is defined, by switching to getGenerators we ensure that all the generators are used & handled correctly

I applied this fix via patch-package in one of my projects and it fixed the issue 😄 