### PR TITLE
(website) Enterprise page, outbound links, typo fixes 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This is for information on how use the keystone website. Please check out the [s
 
 ## Running the docs site in dev
 
-Run `pnpm docs` from the root of the repository
+Run `pnpm dev` from the `/docs` directory
 
 ## How is the website built?
 

--- a/docs/components/ContactForm.tsx
+++ b/docs/components/ContactForm.tsx
@@ -86,7 +86,7 @@ export function ContactForm({ autoFocus, stacked, children, ...props }: ContactF
           block={stacked}
           css={{
             justifyItems: stacked ? 'baseline' : undefined,
-            gap: '1rem',
+            gap: '1.75rem',
           }}
         >
           <Field

--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -224,7 +224,11 @@ export function Footer() {
           </Type> */}
           <Type look="body14" as="p" css={{ justifySelf: 'start' }}>
             Made in Australia <Emoji symbol="🇦🇺" alt="Australia" /> by{' '}
-            <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www.thinkmill.com.au?utm_source=keystone-site"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Thinkmill
             </a>
             . Contributed to around the world <Emoji symbol="🌏" alt="Globe" />
@@ -276,7 +280,11 @@ export function DocsFooter() {
       >
         <Type look="body14" as="p" css={{ justifySelf: 'start' }}>
           Made in Australia <Emoji symbol="🇦🇺" alt="Australia" /> by{' '}
-          <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
+          <a
+            href="https://www.thinkmill.com.au?utm_source=keystone-site"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Thinkmill
           </a>
           , with contributions from around the world <Emoji symbol="🌏" alt="Globe" />

--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -107,20 +107,12 @@ export function Footer() {
             </Type>
             <List>
               <li>
-                <a
-                  href="https://github.com/keystonejs/keystone"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href="https://github.com/keystonejs/keystone" target="_blank" rel="noreferrer">
                   Keystone on GitHub
                 </a>
               </li>
               <li>
-                <a
-                  href="https://community.keystonejs.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href="https://community.keystonejs.com/" target="_blank" rel="noreferrer">
                   Join our Slack
                 </a>
               </li>
@@ -128,7 +120,7 @@ export function Footer() {
                 <a
                   href="https://github.com/keystonejs/keystone/blob/main/CONTRIBUTING.md"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 >
                   Contribution Guide
                 </a>
@@ -137,7 +129,7 @@ export function Footer() {
                 <a
                   href="https://github.com/keystonejs/keystone/blob/main/CODE-OF-CONDUCT.md"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 >
                   Code of Conduct
                 </a>
@@ -227,7 +219,7 @@ export function Footer() {
             <a
               href="https://www.thinkmill.com.au?utm_source=keystone-site"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               Thinkmill
             </a>
@@ -283,7 +275,7 @@ export function DocsFooter() {
           <a
             href="https://www.thinkmill.com.au?utm_source=keystone-site"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Thinkmill
           </a>

--- a/docs/components/Footer.tsx
+++ b/docs/components/Footer.tsx
@@ -224,7 +224,7 @@ export function Footer() {
           </Type> */}
           <Type look="body14" as="p" css={{ justifySelf: 'start' }}>
             Made in Australia <Emoji symbol="🇦🇺" alt="Australia" /> by{' '}
-            <a href="https://www.thinkmill.com.au" target="_blank" rel="noopener noreferrer">
+            <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
               Thinkmill
             </a>
             . Contributed to around the world <Emoji symbol="🌏" alt="Globe" />
@@ -276,7 +276,7 @@ export function DocsFooter() {
       >
         <Type look="body14" as="p" css={{ justifySelf: 'start' }}>
           Made in Australia <Emoji symbol="🇦🇺" alt="Australia" /> by{' '}
-          <a href="https://www.thinkmill.com.au" target="_blank" rel="noopener noreferrer">
+          <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
             Thinkmill
           </a>
           , with contributions from around the world <Emoji symbol="🌏" alt="Globe" />

--- a/docs/components/Header.tsx
+++ b/docs/components/Header.tsx
@@ -448,7 +448,7 @@ export function Header() {
         <a
           href="https://github.com/keystonejs/keystone"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           css={mq({
             display: ['none', null, 'inline-flex'],
             padding: 0,

--- a/docs/components/Socials.tsx
+++ b/docs/components/Socials.tsx
@@ -22,7 +22,7 @@ export function Socials(props: HTMLAttributes<HTMLElement>) {
       <a
         href="https://twitter.com/keystonejs"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
         css={{
           display: 'inline-flex',
           padding: 0,
@@ -41,7 +41,7 @@ export function Socials(props: HTMLAttributes<HTMLElement>) {
       <a
         href="https://community.keystonejs.com/"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
         css={{
           display: 'inline-flex',
           padding: 0,
@@ -71,7 +71,7 @@ export function Socials(props: HTMLAttributes<HTMLElement>) {
       {/* <a
         href="https://www.youtube.com/channel/UClWScN0YMgpN7swHVaEPKuQ"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
         css={{
           display: 'inline-flex',
           padding: 0,

--- a/docs/components/content/AdvancedReactCta.tsx
+++ b/docs/components/content/AdvancedReactCta.tsx
@@ -107,7 +107,7 @@ export function AdvancedReactCta(props: HTMLAttributes<HTMLElement>) {
             size="small"
             href="https://advancedreact.com/friend/KEYSTONE"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Course details <ArrowR />
           </Button>

--- a/docs/components/content/CommunityCta.tsx
+++ b/docs/components/content/CommunityCta.tsx
@@ -67,7 +67,7 @@ export function CommunityCta(props: HTMLAttributes<HTMLElement>) {
           as="a"
           href="https://community.keystonejs.com"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
           css={{
             marginTop: '1rem',
           }}

--- a/docs/components/content/TweetBox.tsx
+++ b/docs/components/content/TweetBox.tsx
@@ -38,7 +38,7 @@ export function TweetBox({ user, img, grad, children, ...props }: TweetBoxProps)
       <a
         href={`https://twitter.com/${user}`}
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
         css={{
           display: 'flex',
           alignItems: 'center',

--- a/docs/components/docs/CommunitySlackCTA.tsx
+++ b/docs/components/docs/CommunitySlackCTA.tsx
@@ -23,7 +23,7 @@ export function CommunitySlackCTA() {
         size="small"
         href="https://community.keystonejs.com/"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Community Slack <ArrowR />
       </Button>

--- a/docs/components/docs/ExamplesList.tsx
+++ b/docs/components/docs/ExamplesList.tsx
@@ -21,7 +21,7 @@ export function Examples() {
         heading="Blog"
         href="https://github.com/keystonejs/keystone/blob/main/examples/usecase-blog"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         A basic Blog schema with Posts and Authors. Use this as a starting place for learning how to
         use Keystone. It’s also a starter for other feature projects.
@@ -31,7 +31,7 @@ export function Examples() {
         heading="Task Manager"
         href="https://github.com/keystonejs/keystone/blob/main/examples/usecase-todo"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         A basic Task Management app, with Tasks and People who can be assigned to tasks. Great for
         learning how to use Keystone. It’s also a starter for other feature projects.
@@ -41,7 +41,7 @@ export function Examples() {
         heading="Extend GraphQL Schema"
         href="https://github.com/keystonejs/keystone/blob/main/examples/extend-graphql-schema"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Shows you how to extend the Keystone GraphQL API with custom queries and mutations. Builds
         upon the Blog starter project.
@@ -51,7 +51,7 @@ export function Examples() {
         heading="Default Values"
         href="https://github.com/keystonejs/keystone/blob/main/examples/default-values"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Demonstrates how to use default values for fields. Builds upon the Task Manager starter
         project.
@@ -61,7 +61,7 @@ export function Examples() {
         heading="Virtual fields"
         href="https://github.com/keystonejs/keystone/tree/main/examples/virtual-field"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Implements virtual fields in a Keystone list. Builds on the Blog starter project.
       </Well>
@@ -70,7 +70,7 @@ export function Examples() {
         heading="Document field"
         href="https://github.com/keystonejs/keystone/tree/main/examples/document-field"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Illustrates how to configure <InlineCode>document</InlineCode> fields in your Keystone
         system and render their data in a frontend application. Builds on the Blog starter project.
@@ -80,7 +80,7 @@ export function Examples() {
         heading="Testing"
         href="https://github.com/keystonejs/keystone/tree/main/examples/testing"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Shows you how to write tests against the GraphQL API to your Keystone system. Builds on the
         Authentication example project.
@@ -90,7 +90,7 @@ export function Examples() {
         heading="Authentication"
         href="https://github.com/keystonejs/keystone/tree/main/examples/auth"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Adds password-based authentication to the Task Manager starter project.
       </Well>
@@ -99,7 +99,7 @@ export function Examples() {
         heading="JSON Field"
         href="https://github.com/keystonejs/keystone/tree/main/examples/json"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Illustrates how to use the <InlineCode>json</InlineCode> field type.
       </Well>
@@ -108,7 +108,7 @@ export function Examples() {
         heading="Custom Field View"
         href="https://github.com/keystonejs/keystone/blob/main/examples/custom-field-view"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Adds a custom Admin UI view to a <InlineCode>json</InlineCode> field which provides a
         customised editing experience for users.
@@ -118,7 +118,7 @@ export function Examples() {
         heading="Custom Field Type"
         href="https://github.com/keystonejs/keystone/blob/main/examples/custom-field"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Adds a custom field type based on the <InlineCode>integer</InlineCode> field type which lets
         users rate items on a 5-star scale.
@@ -128,7 +128,7 @@ export function Examples() {
         heading="Custom Admin UI Pages"
         href="https://github.com/keystonejs/keystone/blob/main/examples/custom-admin-ui-pages"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Adds a custom page in the Admin UI.
       </Well>
@@ -137,7 +137,7 @@ export function Examples() {
         heading="Custom Admin UI Logo"
         href="https://github.com/keystonejs/keystone/blob/main/examples/custom-admin-ui-logo"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Adds a custom logo component in the Admin UI.
       </Well>

--- a/docs/components/docs/GitHubExamplesCTA.tsx
+++ b/docs/components/docs/GitHubExamplesCTA.tsx
@@ -23,7 +23,7 @@ export function GitHubExamplesCTA() {
         size="small"
         href="https://github.com/keystonejs/keystone/tree/main/examples"
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         Keystone GitHub repo <ArrowR />
       </Button>

--- a/docs/components/docs/Keystone5DocsCTA.tsx
+++ b/docs/components/docs/Keystone5DocsCTA.tsx
@@ -14,7 +14,7 @@ export function Keystone5DocsCTA() {
         }}
       >
         Using <strong>Keystone 5</strong>? Find the docs at{' '}
-        <a href="https://v5.keystonejs.com/documentation" target="_blank" rel="noopener noreferrer">
+        <a href="https://v5.keystonejs.com/documentation" target="_blank" rel="noreferrer">
           v5.keystonejs.com
         </a>
       </span>

--- a/docs/components/primitives/EditButton.tsx
+++ b/docs/components/primitives/EditButton.tsx
@@ -31,7 +31,7 @@ export function EditButton({
       look="text"
       size="xsmall"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noreferrer"
       css={{
         textTransform: 'uppercase',
       }}

--- a/docs/components/primitives/Field.tsx
+++ b/docs/components/primitives/Field.tsx
@@ -28,7 +28,7 @@ export const Field = ({
       }}
     >
       {label && (
-        <Type look="body14" as="label" htmlFor={id}>
+        <Type look="body18" as="label" htmlFor={id}>
           {label}
         </Type>
       )}
@@ -72,6 +72,9 @@ export const Field = ({
             background: 'var(--border)',
             color: 'var(--code)',
             pointerEvents: 'none',
+          },
+          '::placeholder': {
+            color: 'var(--muted)',
           },
         }}
         aria-disabled={disabled ? true : undefined}

--- a/docs/components/primitives/GitHubButton.tsx
+++ b/docs/components/primitives/GitHubButton.tsx
@@ -48,7 +48,7 @@ export function GitHubButton({ repo, ...props }: GitHubButtonProps) {
         }}
         href={`https://github.com/${repo}`}
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
       >
         <svg
           version="1.1"
@@ -82,7 +82,7 @@ export function GitHubButton({ repo, ...props }: GitHubButtonProps) {
         look="body12"
         href={`https://github.com/${repo}/stargazers`}
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noreferrer"
         css={{
           display: 'inline-block',
           borderLeft: '1px solid var(--border)',

--- a/docs/pages/branding.tsx
+++ b/docs/pages/branding.tsx
@@ -46,7 +46,7 @@ export default function Brand() {
           <a
             href="https://keystonejs.s3.amazonaws.com/framework-assets/211123-KeystoneJS-logos.zip"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
             download
             css={{
               display: 'block',
@@ -192,7 +192,7 @@ export default function Brand() {
             size="small"
             href="https://community.keystonejs.com/"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Community Slack <ArrowR />
           </Button>

--- a/docs/pages/docs/examples.tsx
+++ b/docs/pages/docs/examples.tsx
@@ -56,7 +56,7 @@ export default function Docs() {
           heading="Blog"
           href="https://github.com/keystonejs/keystone/blob/main/examples/usecase-blog"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           A basic Blog schema with Posts and Authors. Use this as a starting place for learning how
           to use Keystone.
@@ -66,7 +66,7 @@ export default function Docs() {
           heading="Task Manager"
           href="https://github.com/keystonejs/keystone/blob/main/examples/usecase-todo"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           A basic Task Management app, with Tasks and People who can be assigned to tasks. Great for
           learning how to use Keystone.
@@ -77,7 +77,7 @@ export default function Docs() {
           heading="Authentication"
           href="https://github.com/keystonejs/keystone/tree/main/examples/auth"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Adds password-based authentication to the Task Manager starter project.
         </Well>
@@ -86,7 +86,7 @@ export default function Docs() {
           heading="Custom Admin UI Logo"
           href="https://github.com/keystonejs/keystone/blob/main/examples/custom-admin-ui-logo"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Adds a custom logo component in the Admin UI.
         </Well>
@@ -102,7 +102,7 @@ export default function Docs() {
           heading="Custom Admin UI Pages"
           href="https://github.com/keystonejs/keystone/blob/main/examples/custom-admin-ui-pages"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Adds a custom page in the Admin UI.
         </Well>
@@ -111,7 +111,7 @@ export default function Docs() {
           heading="Custom Field Type"
           href="https://github.com/keystonejs/keystone/blob/main/examples/custom-field"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Adds a custom field type based on the <InlineCode>integer</InlineCode> field type which
           lets users rate items on a 5-star scale.
@@ -121,7 +121,7 @@ export default function Docs() {
           heading="Custom Field View"
           href="https://github.com/keystonejs/keystone/blob/main/examples/custom-field-view"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Adds a custom Admin UI view to a <InlineCode>json</InlineCode> field which provides a
           customised editing experience for users.
@@ -131,7 +131,7 @@ export default function Docs() {
           heading="Default Values"
           href="https://github.com/keystonejs/keystone/blob/main/examples/default-values"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Demonstrates how to use default values for fields.
         </Well>
@@ -140,7 +140,7 @@ export default function Docs() {
           heading="Document field"
           href="https://github.com/keystonejs/keystone/tree/main/examples/document-field"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Illustrates how to configure <InlineCode>document</InlineCode> fields in your Keystone
           system and render their data in a frontend application.
@@ -150,7 +150,7 @@ export default function Docs() {
           heading="Extend GraphQL Schema"
           href="https://github.com/keystonejs/keystone/blob/main/examples/extend-graphql-schema"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Shows you how to extend the Keystone GraphQL API with custom queries and mutations.
         </Well>
@@ -159,7 +159,7 @@ export default function Docs() {
           heading="Extend GraphQL Schema with GraphQL TS"
           href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-graphql-ts"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Demonstrates how to extend the GraphQL API provided by Keystone with custom queries and
           mutations using graphql-ts.
@@ -169,7 +169,7 @@ export default function Docs() {
           heading="Extend GraphQL API with Nexus"
           href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-nexus"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Shows you how to use <strong>Nexus</strong> to extend the GraphQL API provided by Keystone
           with custom queries and mutations.
@@ -180,7 +180,7 @@ export default function Docs() {
           heading="JSON Field"
           href="https://github.com/keystonejs/keystone/tree/main/examples/json"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Illustrates how to use the <InlineCode>json</InlineCode> field type. Builds on the Task
           Manager starter project.
@@ -199,7 +199,7 @@ export default function Docs() {
           heading="Testing"
           href="https://github.com/keystonejs/keystone/tree/main/examples/testing"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Shows you how to write tests against the GraphQL API to your Keystone system.
         </Well>
@@ -208,7 +208,7 @@ export default function Docs() {
           heading="Virtual fields"
           href="https://github.com/keystonejs/keystone/tree/main/examples/virtual-field"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Implements virtual fields in a Keystone list.
         </Well>
@@ -217,7 +217,7 @@ export default function Docs() {
           heading="Singleton"
           href="https://github.com/keystonejs/keystone/tree/main/examples/singleton"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Demonstrates how to use singleton lists with Keystone.
         </Well>
@@ -244,7 +244,7 @@ export default function Docs() {
           heading="Document Field Customisation"
           href="https://github.com/keystonejs/keystone/blob/main/examples/usecase-blog"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Example to demonstrate customisation of Keystone's document field and document renderer.
         </Well>
@@ -254,7 +254,7 @@ export default function Docs() {
           heading="Next.js + Keystone"
           href="https://github.com/keystonejs/keystone/tree/main/examples/framework-nextjs-app-directory"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Shows you how to use Keystone as a data engine within Next.js applications.
         </Well>
@@ -282,7 +282,7 @@ export default function Docs() {
           heading="Heroku"
           href="https://github.com/keystonejs/keystone-6-heroku-example"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Based on the <InlineCode>with-auth</InlineCode> project, this example deploys a simple app
           backend to Heroku. Includes a <strong>one-click deployment</strong> for Heroku account
@@ -294,7 +294,7 @@ export default function Docs() {
           badge="Community"
           href="https://github.com/aaronpowell/keystone-6-azure-example"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Deploys a Keystone app backend to Microsoft Azure. Based on the{' '}
           <InlineCode>with-auth</InlineCode> project. <strong>One-click deployment</strong>{' '}
@@ -305,7 +305,7 @@ export default function Docs() {
           heading="Railway"
           href="https://github.com/keystonejs/keystone-6-railway-example"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           Deploys a Keystone app backend to Railway. Based on the <InlineCode>with-auth</InlineCode>{' '}
           project. <strong>One-click deployment</strong> included.

--- a/docs/pages/docs/guides/document-field-demo.tsx
+++ b/docs/pages/docs/guides/document-field-demo.tsx
@@ -76,7 +76,7 @@ export default function DocumentFieldDemo() {
               heading="Example Project: Document Field"
               href="https://github.com/keystonejs/keystone/tree/main/examples/document-field"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               Illustrates how to configure <InlineCode>document</InlineCode> fields in your Keystone
               system and render their data in a frontend application. Builds on the Blog starter

--- a/docs/pages/docs/index.tsx
+++ b/docs/pages/docs/index.tsx
@@ -89,7 +89,7 @@ export default function Docs() {
               backgroundImage: `linear-gradient(116.01deg, var(--grad1-2), var(--grad1-1))`,
             }}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             <Video />
             <Type
@@ -330,7 +330,7 @@ export default function Docs() {
         <a
           href="https://github.com/keystonejs/keystone/tree/main/examples"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noreferrer"
         >
           View on Github &rarr;
         </a>

--- a/docs/pages/ds.tsx
+++ b/docs/pages/ds.tsx
@@ -238,7 +238,7 @@ export default function DS() {
             fontFamily: `var(${name})`,
           }}
         >
-          {name} aAgGzZij
+          {name}
           <br />
           {stack}
         </span>

--- a/docs/pages/enterprise.tsx
+++ b/docs/pages/enterprise.tsx
@@ -26,12 +26,19 @@ const customers = [
     icon: VocalLogo,
     title: 'Vocal',
     copy: 'Large scale platform for content creators.',
-    learnMoreHref: 'https://www.thinkmill.com.au/work/vocal',
+    learnMoreHref: 'https://www.thinkmill.com.au/work/vocal?utm_source=keystone-site',
   },
   {
-    icon: PJohnsonLogo,
-    title: 'PJohnson Tailors',
-    copy: 'Custom garment order & production management system.',
+    icon: RugbyAuLogo,
+    title: 'Rugby Australia',
+    copy: 'Headless CMS to power 3000 websites.',
+    learnMoreHref: 'https://www.thinkmill.com.au/work/rugby?utm_source=keystone-site',
+  },
+  {
+    icon: EnliticLogo,
+    title: 'Enlitic',
+    copy: 'Medical Annotation Platform & PACS.',
+    learnMoreHref: 'https://www.thinkmill.com.au/work/enlitic?utm_source=keystone-site',
   },
   {
     icon: DFATLogo,
@@ -40,15 +47,9 @@ const customers = [
     copy: 'Australia’s Free Trade Agreements website.',
   },
   {
-    icon: EnliticLogo,
-    title: 'Enlitic',
-    copy: 'Medical Annotation Platform & PACS.',
-    learnMoreHref: 'https://www.thinkmill.com.au/work/enlitic',
-  },
-  {
-    icon: RugbyAuLogo,
-    title: 'Rugby Australia',
-    copy: 'Headless CMS to power Rugby’s many websites.',
+    icon: PJohnsonLogo,
+    title: 'PJohnson Tailors',
+    copy: 'Custom garment order & production management system.',
   },
   {
     icon: WestpacLogo,
@@ -58,7 +59,7 @@ const customers = [
   {
     icon: PrintBarLogo,
     title: 'The Print Bar',
-    copy: 'Application backend for a custom design and ordering plaform.',
+    copy: 'Application backend for a custom design and ordering platform.',
   },
 ];
 
@@ -67,7 +68,7 @@ export default function ForOrganisations() {
 
   return (
     <Page
-      title={'KeystoneJS for Content Management'}
+      title={'KeystoneJS for Enterprise'}
       description={
         'Discover how Keystone’s Admin UI is a natural extension of how you work in code, and has the flexibility you need to enable content creatives.'
       }
@@ -80,9 +81,17 @@ export default function ForOrganisations() {
             Keystone support <Highlight look="grad6">from the people who built it</Highlight>{' '}
           </IntroHeading>
           <IntroLead>
-            Keystone is developed and maintained by Thinkmill, an Australian software design and
-            development consultancy. Thinkmill has been building and scaling Keystone apps since
-            2013 and can provide flexible, tailored, and hands-on support for your Keystone project.
+            Keystone is developed and maintained by{' '}
+            <a
+              href="https://thinkmill.com.au?utm_source=keystone-site"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Thinkmill
+            </a>{' '}
+            , an Australian software design and development consultancy. We’ve been building and
+            scaling Keystone apps since 2013 and can provide flexible, tailored, and hands-on
+            support for your Keystone project.
           </IntroLead>
         </IntroWrapper>
 
@@ -129,7 +138,10 @@ export default function ForOrganisations() {
                       <Stack gap={0}>
                         {copy}
                         <div>
-                          <Link href={learnMoreHref}>Learn more</Link>.
+                          <a href={learnMoreHref} target="_blank">
+                            Learn more
+                          </a>
+                          .
                         </div>
                       </Stack>
                     ) : (
@@ -158,7 +170,7 @@ export default function ForOrganisations() {
 
         <div
           css={{
-            maxWidth: '33.75rem',
+            maxWidth: '50rem',
             margin: '5rem auto 0',
           }}
         >

--- a/docs/pages/enterprise.tsx
+++ b/docs/pages/enterprise.tsx
@@ -138,7 +138,7 @@ export default function ForOrganisations() {
                       <Stack gap={0}>
                         {copy}
                         <div>
-                          <a href={learnMoreHref} target="_blank">
+                          <a href={learnMoreHref} target="_blank" rel="noreferrer">
                             Learn more
                           </a>
                           .

--- a/docs/pages/enterprise.tsx
+++ b/docs/pages/enterprise.tsx
@@ -1,7 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx  */
 import { jsx } from '@emotion/react';
-import Link from 'next/link';
 import { useMediaQuery } from '../lib/media';
 import { Highlight } from '../components/primitives/Highlight';
 import { MWrapper } from '../components/content/MWrapper';

--- a/docs/pages/enterprise.tsx
+++ b/docs/pages/enterprise.tsx
@@ -85,7 +85,7 @@ export default function ForOrganisations() {
             <a
               href="https://thinkmill.com.au?utm_source=keystone-site"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               Thinkmill
             </a>{' '}

--- a/docs/pages/for-developers.tsx
+++ b/docs/pages/for-developers.tsx
@@ -394,7 +394,7 @@ export default function ForDevelopers() {
                 as="a"
                 href="https://github.com/keystonejs/keystone/tree/main/examples/usecase-blog"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noreferrer"
                 look="soft"
               >
                 Blog <ArrowR />
@@ -405,7 +405,7 @@ export default function ForDevelopers() {
                 as="a"
                 href="https://github.com/keystonejs/keystone/tree/main/examples/usecase-todo"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noreferrer"
                 look="soft"
               >
                 Task Manager app <ArrowR />
@@ -416,7 +416,7 @@ export default function ForDevelopers() {
                 as="a"
                 href="https://github.com/keystonejs/keystone/tree/main/examples/default-values"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noreferrer"
                 look="soft"
               >
                 Default field values <ArrowR />
@@ -427,7 +427,7 @@ export default function ForDevelopers() {
                 as="a"
                 href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-graphql-tools"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noreferrer"
                 look="soft"
               >
                 Extend GraphQL schema <ArrowR />
@@ -471,7 +471,7 @@ export default function ForDevelopers() {
               focused on building the UI <Emoji symbol="😍" alt="Love" />
             </TweetBox>
             <TweetBox user="divslingerx" img="/assets/divslingerx.jpg" grad="grad3">
-              <a href="https://twitter.com/keystonejs" target="_blank" rel="noopener noreferrer">
+              <a href="https://twitter.com/keystonejs" target="_blank" rel="noreferrer">
                 @KeystoneJS
               </a>{' '}
               is almost too good to be open source. I can’t stress enough how awesome the dev
@@ -488,7 +488,7 @@ export default function ForDevelopers() {
             </TweetBox>
             <TweetBox user="mxstbr" img="/assets/mxstbr.jpg" grad="grad3">
               The new{' '}
-              <a href="https://twitter.com/keystonejs" target="_blank" rel="noopener noreferrer">
+              <a href="https://twitter.com/keystonejs" target="_blank" rel="noreferrer">
                 @KeystoneJS
               </a>{' '}
               rich text editor has incredible inline React component support, including editing
@@ -500,11 +500,11 @@ export default function ForDevelopers() {
             </TweetBox>
             <TweetBox user="BenAPatton" img="/assets/benapatton.jpg" grad="grad3">
               My mind is being blown today! Combining{' '}
-              <a href="https://twitter.com/keystonejs" target="_blank" rel="noopener noreferrer">
+              <a href="https://twitter.com/keystonejs" target="_blank" rel="noreferrer">
                 @KeystoneJS
               </a>{' '}
               with{' '}
-              <a href="https://twitter.com/supabase_io" target="_blank" rel="noopener noreferrer">
+              <a href="https://twitter.com/supabase_io" target="_blank" rel="noreferrer">
                 @supabase_io
               </a>{' '}
               and the experience is just magical.

--- a/docs/pages/for-organisations.tsx
+++ b/docs/pages/for-organisations.tsx
@@ -226,7 +226,7 @@ export default function ForOrganisations() {
             <a
               href="https://www.thinkmill.com.au?utm_source=keystone-site"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               Thinkmill
             </a>

--- a/docs/pages/for-organisations.tsx
+++ b/docs/pages/for-organisations.tsx
@@ -223,7 +223,7 @@ export default function ForOrganisations() {
             }}
           >
             Built by{' '}
-            <a href="https://www.thinkmill.com.au" target="_blank" rel="noopener noreferrer">
+            <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
               Thinkmill
             </a>
             , an internationally recognised design & development consultancy. Keystone is proven in

--- a/docs/pages/for-organisations.tsx
+++ b/docs/pages/for-organisations.tsx
@@ -223,7 +223,11 @@ export default function ForOrganisations() {
             }}
           >
             Built by{' '}
-            <a href="https://www.thinkmill.com.au?utm_source=keystone-site" target="_blank" rel="noopener noreferrer">
+            <a
+              href="https://www.thinkmill.com.au?utm_source=keystone-site"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Thinkmill
             </a>
             , an internationally recognised design & development consultancy. Keystone is proven in

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -176,11 +176,7 @@ export default function IndexPage() {
           </TweetBox>
           <TweetBox user="wesbos" img="/assets/wesbos-square.jpg" grad="grad2">
             I use Keystone in my{' '}
-            <a
-              href="https://advancedreact.com/friend/KEYSTONE"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href="https://advancedreact.com/friend/KEYSTONE" target="_blank" rel="noreferrer">
               Advanced React
             </a>{' '}
             course because it’s super quick to get my content types up and running, add custom

--- a/docs/pages/updates/index.tsx
+++ b/docs/pages/updates/index.tsx
@@ -153,7 +153,7 @@ export default function WhatsNew() {
           What are we working on next?{' '}
           <span>
             See our{' '}
-            <Button as="a" href="/roadmap" rel="noopener noreferrer">
+            <Button as="a" href="/roadmap" rel="noreferrer">
               Roadmap <ArrowR />
             </Button>
           </span>
@@ -435,12 +435,12 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema-nexus"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             This example
           </a>{' '}
           uses{' '}
-          <a href="https://nexusjs.org/" target="_blank" rel="noopener noreferrer">
+          <a href="https://nexusjs.org/" target="_blank" rel="noreferrer">
             Nexus
           </a>{' '}
           — a declarative, code-first and strongly typed GraphQL schema construction for TypeScript
@@ -477,7 +477,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/aaronpowell/keystone-6-azure-example"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             This example
           </a>{' '}
@@ -490,7 +490,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone/tree/main/examples/rest-api"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             This example
           </a>{' '}
@@ -503,7 +503,7 @@ export default function WhatsNew() {
             <a
               href="https://www.youtube.com/watch?v=r1IJh-iHm1c"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               <img
                 width="100%"
@@ -514,7 +514,7 @@ export default function WhatsNew() {
             <a
               href="https://www.youtube.com/watch?v=r1IJh-iHm1c"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               <img
                 width="100%"
@@ -527,7 +527,7 @@ export default function WhatsNew() {
             <a
               href="https://www.youtube.com/watch?v=r1IJh-iHm1c"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               <img
                 width="100%"
@@ -538,7 +538,7 @@ export default function WhatsNew() {
             <a
               href="https://www.youtube.com/watch?v=r1IJh-iHm1c"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noreferrer"
             >
               <img
                 width="100%"
@@ -552,7 +552,7 @@ export default function WhatsNew() {
           <a
             href="https://www.youtube.com/watch?v=r1IJh-iHm1c"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Watch it online here
           </a>
@@ -571,7 +571,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone-6-heroku-example"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Heroku
           </a>{' '}
@@ -579,7 +579,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone-6-railway-example"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Railway
           </a>
@@ -589,7 +589,7 @@ export default function WhatsNew() {
         <Box heading="Prisma Meetup Korea">
           Jed spoke at Prisma Meetup Korea, covering V6 general availability, user-facing
           management, UI authentication, access control, business logic integrations and more.{' '}
-          <a href="https://youtu.be/qKqSRTtOlmw?t=4101" target="_blank" rel="noopener noreferrer">
+          <a href="https://youtu.be/qKqSRTtOlmw?t=4101" target="_blank" rel="noreferrer">
             Watch it online here
           </a>
           .
@@ -713,7 +713,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/prisma-day-2021-workshop"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             Follow along in with the repo
           </a>{' '}
@@ -740,7 +740,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone/tree/main/examples/custom-field-view"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             custom field view
           </a>{' '}
@@ -841,7 +841,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone/tree/main/examples/json"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             example project
           </a>
@@ -867,7 +867,7 @@ export default function WhatsNew() {
           <a
             href="https://github.com/keystonejs/keystone/tree/main/examples"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             collection of example projects
           </a>{' '}
@@ -910,12 +910,7 @@ export default function WhatsNew() {
         >
           Need answers to Keystone questions? Get help in our
         </span>
-        <Button
-          as="a"
-          href="https://community.keystonejs.com/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <Button as="a" href="https://community.keystonejs.com/" target="_blank" rel="noreferrer">
           Community Slack <ArrowR />
         </Button>
       </Alert>

--- a/docs/pages/updates/roadmap.tsx
+++ b/docs/pages/updates/roadmap.tsx
@@ -307,15 +307,15 @@ export default function Roadmap() {
       </Type>
       <Type as="p" look="body18" margin="1rem 0">
         At{' '}
-        <a href="https://thinkmill.com.au" target="_blank" rel="noopener noreferrer">
+        <a href="https://thinkmill.com.au" target="_blank" rel="noreferrer">
           Thinkmill
         </a>
         , we have a longstanding commitment to open source that includes the likes of{' '}
-        <a href="https://react-select.com" target="_blank" rel="noopener noreferrer">
+        <a href="https://react-select.com" target="_blank" rel="noreferrer">
           react select
         </a>
         ,{' '}
-        <a href="https://github.com/JedWatson/classnames" target="_blank" rel="noopener noreferrer">
+        <a href="https://github.com/JedWatson/classnames" target="_blank" rel="noreferrer">
           classnames
         </a>
         , and of course Keystone <Emoji symbol="🙂" alt="Smile" />. Now that Keystone 6 is stable
@@ -467,19 +467,19 @@ export default function Roadmap() {
         </Type>
         <Type as="p" margin=".5rem 0 0">
           Join the Keystone conversation on{' '}
-          <a href="https://community.keystonejs.com" target="_blank" rel="noopener noreferrer">
+          <a href="https://community.keystonejs.com" target="_blank" rel="noreferrer">
             Slack
           </a>
           ,{' '}
           <a
             href="https://github.com/keystonejs/keystone/discussions"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noreferrer"
           >
             GitHub
           </a>
           , and{' '}
-          <a href="https://twitter.com/keystonejs" target="_blank" rel="noopener noreferrer">
+          <a href="https://twitter.com/keystonejs" target="_blank" rel="noreferrer">
             Twitter
           </a>
           .

--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -62,7 +62,11 @@ export default function WhyKeystonePage() {
           <div>
             <Type as="p" look="body18" color="var(--muted)" margin="0 0 1rem 0">
               Keystone is a{' '}
-              <a href="https://thinkmill.com.au" target="_blank" rel="noopener noreferrer">
+              <a
+                href="https://thinkmill.com.au?utm_source=keystone-site"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Thinkmill
               </a>{' '}
               product. We’ve spent years shipping sophisticated solutions for large companies like

--- a/docs/pages/why-keystone.tsx
+++ b/docs/pages/why-keystone.tsx
@@ -65,7 +65,7 @@ export default function WhyKeystonePage() {
               <a
                 href="https://thinkmill.com.au?utm_source=keystone-site"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noreferrer"
               >
                 Thinkmill
               </a>{' '}
@@ -362,7 +362,7 @@ export default function WhyKeystonePage() {
                 <a
                   href="https://github.com/keystonejs/keystone/tree/main/examples/extend-graphql-schema"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 >
                   Try the example →
                 </a>
@@ -550,7 +550,7 @@ export default function WhyKeystonePage() {
                 <a
                   href="https://github.com/keystonejs/keystone/tree/main/examples/usecase-todo"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 >
                   Try the Task Manager example →
                 </a>
@@ -573,7 +573,7 @@ export default function WhyKeystonePage() {
                 <a
                   href="https://github.com/keystonejs/keystone/tree/main/examples/usecase-blog"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noreferrer"
                 >
                   Try the Blog example →
                 </a>


### PR DESCRIPTION
1. Added a link to the [new Rugby/Keystone case study](https://www.thinkmill.com.au/work/rugby) from the Keystone `/enterprise` page
3. Fixed content typos on `/enterprise` and `/ds pages`
4. Added `utm_source` parameter for all links pointing to the Thinkmill site
5. Made all links to the Thinkmill ite `target="_blank"` (I changed some from <Link> component to <a> not sure if this is right?)
6. Improved styling and layout of Field and ContactForm components (placeholder text was not inheriting text color form existing tokens)
7. Updated `.README` in `/docs` to reflect the current approach to running the docs site locally