### PR TITLE
Fix db usage in onConnect when combined with migrations

### DIFF
--- a/.changeset/flat-spoons-learn.md
+++ b/.changeset/flat-spoons-learn.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixes onConnect database usage with database migrations
+Fixes `db.onConnect` for `keystone start` to run _after_ migrations are completed 

--- a/.changeset/flat-spoons-learn.md
+++ b/.changeset/flat-spoons-learn.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixes `db.onConnect` for `keystone start` to run _after_ migrations are completed 
+Fixes `db.onConnect`, with `keystone start --with-migrations`, to run  _after_ migrations complete

--- a/.changeset/flat-spoons-learn.md
+++ b/.changeset/flat-spoons-learn.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes onConnect database usage with database migrations

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -34,12 +34,13 @@ export const start = async (
   const prismaClient = require(paths.prisma);
   const keystone = getKeystone(prismaClient);
 
-  console.log('✨ Connecting to the database');
-  await keystone.connect();
   if (withMigrations) {
     console.log('✨ Applying database migrations');
     await deployMigrations(paths.schema.prisma, config.db.url);
   }
+
+  console.log('✨ Connecting to the database');
+  await keystone.connect();
 
   console.log('✨ Creating server');
   const { expressServer, httpServer } = await createExpressServer(

--- a/tests/cli-tests/migrations.test.ts
+++ b/tests/cli-tests/migrations.test.ts
@@ -760,10 +760,10 @@ describe('start --with-migrations', () => {
         .replace(/[^ -~\n]+/g, '?')
     ).toMatchInlineSnapshot(`
       "? Starting Keystone
-      ? Connecting to the database
       ? Applying database migrations
       Applying migration \`migration_name\`
       ? Your database is now in sync with your migrations
+      ? Connecting to the database
       ? Creating server
       ? GraphQL API ready
       ? Server listening on :3000 (http://localhost:3000/)
@@ -777,9 +777,9 @@ describe('start --with-migrations', () => {
 
     expect(output.replace(/[^ -~\n]+/g, '?')).toMatchInlineSnapshot(`
       "? Starting Keystone
-      ? Connecting to the database
       ? Applying database migrations
       ? The database is already in sync with your migrations
+      ? Connecting to the database
       ? Creating server
       ? GraphQL API ready
       ? Server listening on :3000 (http://localhost:3000/)


### PR DESCRIPTION
closes #8611
- reorders database connection to occur after migrations, to ensure that onConnect hooks are run after the database migrations are run

this seemed to work fine when I tested it locally with the reproduction repo from #8611, but I'm not sure if there are other consequences of reordering these statements