### PR TITLE
Removes redirect functionality from `/signin` page to prevent open redirection CVE

### DIFF
--- a/.changeset/no-redirect.md
+++ b/.changeset/no-redirect.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Removes `?from` redirect from `/signin` page to prevent open redirection.

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -30,13 +30,13 @@ function ConstructionIllustration() {
   );
 }
 
-// Modifying this code may have security implications
-// See.. https://github.com/keystonejs/keystone/pull/6411#issuecomment-906085389
+// modifying this code may have security implications
+//   see https://github.com/keystonejs/keystone/pull/6411#issuecomment-906085389
 const v5PathList = ['/tutorials', '/guides', '/keystonejs', '/api', '/discussions'];
 
 export default function NotFoundPage() {
   const { asPath } = useRouter();
-  const tryV5Link = asPath.startsWith('/') && v5PathList.some(i => asPath.startsWith(i));
+  const tryV5Link = v5PathList.some(x => asPath.startsWith(x));
   return (
     <Page title={'Page Not Found (404)'} description={'Page Not Found (404)'}>
       <div

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -70,8 +70,8 @@ export function getBaseAuthSchema<I extends string, S extends string>({
 
           return context.db[listKey].findOne({
             where: {
-              id: session.itemId
-            }
+              id: session.itemId,
+            },
           });
         },
       }),

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -53,6 +53,7 @@ export function getBaseAuthSchema<I extends string, S extends string>({
       return gqlNames.ItemAuthenticationWithPasswordFailure;
     },
   });
+
   const extension = {
     query: {
       authenticatedItem: graphql.field({
@@ -61,14 +62,17 @@ export function getBaseAuthSchema<I extends string, S extends string>({
           types: [base.object(listKey) as graphql.ObjectType<BaseItem>],
           resolveType: (root, context) => context.session?.listKey,
         }),
-        resolve(root, args, { session, db }) {
-          if (
-            (typeof session?.itemId === 'string' || typeof session?.itemId === 'number') &&
-            typeof session.listKey === 'string'
-          ) {
-            return db[session.listKey].findOne({ where: { id: session.itemId } });
-          }
-          return null;
+        resolve(root, args, context) {
+          const { session } = context;
+          if (!session) return null;
+          if (!session.itemId) return null;
+          if (session.listKey !== listKey) return null;
+
+          return context.db[listKey].findOne({
+            where: {
+              id: session.itemId
+            }
+          });
         },
       }),
     },
@@ -106,10 +110,12 @@ export function getBaseAuthSchema<I extends string, S extends string>({
             },
             context,
           });
+
           // return Failure if sessionStrategy.start() returns null
           if (typeof sessionToken !== 'string' || sessionToken.length === 0) {
             return { code: 'FAILURE', message: 'Failed to start session.' };
           }
+
           return { sessionToken, item: result.item };
         },
       }),

--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -1,8 +1,8 @@
 import { graphql } from '@keystone-6/core';
-import { BaseItem } from '@keystone-6/core/types';
+import type { BaseItem } from '@keystone-6/core/types';
 import { assertInputObjectType, GraphQLInputObjectType, GraphQLSchema } from 'graphql';
 
-import { AuthGqlNames, InitFirstItemConfig } from '../types';
+import type { AuthGqlNames, InitFirstItemConfig } from '../types';
 
 export function getInitFirstItemSchema({
   listKey,

--- a/packages/auth/src/gql/getMagicAuthLinkSchema.ts
+++ b/packages/auth/src/gql/getMagicAuthLinkSchema.ts
@@ -1,6 +1,6 @@
 import type { BaseItem } from '@keystone-6/core/types';
 import { graphql } from '@keystone-6/core';
-import { AuthGqlNames, AuthTokenTypeConfig, SecretFieldImpl } from '../types';
+import type { AuthGqlNames, AuthTokenTypeConfig, SecretFieldImpl } from '../types';
 
 import { createAuthToken } from '../lib/createAuthToken';
 import { validateAuthToken } from '../lib/validateAuthToken';

--- a/packages/auth/src/gql/getPasswordResetSchema.ts
+++ b/packages/auth/src/gql/getPasswordResetSchema.ts
@@ -1,5 +1,5 @@
 import { graphql } from '@keystone-6/core';
-import { AuthGqlNames, AuthTokenTypeConfig, SecretFieldImpl } from '../types';
+import type { AuthGqlNames, AuthTokenTypeConfig, SecretFieldImpl } from '../types';
 
 import { createAuthToken } from '../lib/createAuthToken';
 import { validateAuthToken } from '../lib/validateAuthToken';

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -138,38 +138,26 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
    *
    * Validates the provided auth config; optional step when integrating auth
    */
-  function validateConfig<TypeInfo extends BaseKeystoneTypeInfo>(config: KeystoneConfig<TypeInfo>) {
-    const listConfig = config.lists[listKey];
-    if (listConfig === undefined) {
-      const msg = `A createAuth() invocation specifies the list "${listKey}" but no list with that key has been defined.`;
-      throw new Error(msg);
+  function throwIfInvalidConfig<TypeInfo extends BaseKeystoneTypeInfo>(config: KeystoneConfig<TypeInfo>) {
+    if (!(listKey in config.lists)) {
+      throw new Error(`withAuth cannot find the list "${listKey}"`)
     }
 
-    // TODO: Check for String-like typing for identityField? How?
-    // TODO: Validate that the identifyField is unique.
-    // TODO: If this field isn't required, what happens if I try to log in as `null`?
-    const identityFieldConfig = listConfig.fields[identityField];
-    if (identityFieldConfig === undefined) {
-      const i = JSON.stringify(identityField);
-      const msg = `A createAuth() invocation for the "${listKey}" list specifies ${i} as its identityField but no field with that key exists on the list.`;
-      throw new Error(msg);
+    // TODO: verify that the identity field is unique
+    // TODO: verify that the field is required
+    const list = config.lists[listKey];
+    if (!(identityField in list.fields)) {
+      throw new Error(`withAuth cannot find the identity field "${listKey}.${identityField}"`);
     }
 
-    // TODO: We could make the secret field optional to disable the standard id/secret auth and password resets (ie. magic links only)
-    const secretFieldConfig = listConfig.fields[secretField];
-    if (secretFieldConfig === undefined) {
-      const s = JSON.stringify(secretField);
-      const msg = `A createAuth() invocation for the "${listKey}" list specifies ${s} as its secretField but no field with that key exists on the list.`;
-      throw new Error(msg);
+    if (!(secretField in list.fields)) {
+      throw new Error(`withAuth cannot find the secret field "${listKey}.${secretField}"`);
     }
 
-    // TODO: Could also validate initFirstItem.itemData keys?
-    for (const field of initFirstItem?.fields || []) {
-      if (listConfig.fields[field] === undefined) {
-        const f = JSON.stringify(field);
-        const msg = `A createAuth() invocation for the "${listKey}" list specifies the field ${f} in initFirstItem.fields array but no field with that key exist on the list.`;
-        throw new Error(msg);
-      }
+    for (const fieldKey of initFirstItem?.fields || []) {
+      if (fieldKey in list.fields) continue;
+
+      throw new Error(`initFirstItem.fields has unknown field "${listKey}.${fieldKey}"`);
     }
   }
 
@@ -184,19 +172,13 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
       get: async ({ context }) => {
         const session = await get({ context });
         const sudoContext = context.sudo();
-        if (
-          !session ||
-          !session.listKey ||
-          session.listKey !== listKey ||
-          !session.itemId ||
-          !sudoContext.query[session.listKey]
-        ) {
-          return;
-        }
+        if (!session) return;
+        if (!session.itemId) return;
+        if (listKey !== session.listKey) return;
 
         try {
           const data = await sudoContext.query[listKey].findOne({
-            where: { id: session.itemId as any }, // TODO: fix this
+            where: { id: session.itemId },
             query: sessionData,
           });
           if (!data) return;
@@ -267,7 +249,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   function withAuth<TypeInfo extends BaseKeystoneTypeInfo>(
     config: KeystoneConfig<TypeInfo>
   ): KeystoneConfig<TypeInfo> {
-    validateConfig(config);
+    throwIfInvalidConfig(config);
     let { ui } = config;
     if (!ui?.isDisabled) {
       const {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -72,16 +72,19 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
       listView: { fieldMode: 'hidden' },
     },
   } as const;
-  // These field names have to follow this format so that for e.g
-  // validateAuthToken() behaves correctly.
-  const tokenFields = (tokenType: 'passwordReset' | 'magicAuth') => ({
-    [`${tokenType}Token`]: password({ ...fieldConfig }),
-    [`${tokenType}IssuedAt`]: timestamp({ ...fieldConfig }),
-    [`${tokenType}RedeemedAt`]: timestamp({ ...fieldConfig }),
-  });
-  const fields = {
-    ...(passwordResetLink && tokenFields('passwordReset')),
-    ...(magicAuthLink && tokenFields('magicAuth')),
+
+  const authFields = {
+    ...(passwordResetLink ? {
+      [`passwordResetToken`]: password({ ...fieldConfig }),
+      [`passwordResetIssuedAt`]: timestamp({ ...fieldConfig }),
+      [`passwordResetRedeemedAt`]: timestamp({ ...fieldConfig }),
+    } : null),
+
+    ...(magicAuthLink ? {
+      [`magicAuthToken`]: password({ ...fieldConfig }),
+      [`magicAuthIssuedAt`]: timestamp({ ...fieldConfig }),
+      [`magicAuthRedeemedAt`]: timestamp({ ...fieldConfig }),
+    } : null),
   };
 
   /**
@@ -287,7 +290,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
           ...authListConfig,
           fields: {
             ...authListConfig.fields,
-            ...fields,
+            ...authFields,
           },
         },
       },

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -174,7 +174,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
         const sudoContext = context.sudo();
         if (!session) return;
         if (!session.itemId) return;
-        if (listKey !== session.listKey) return;
+        if (session.listKey !== listKey) return;
 
         try {
           const data = await sudoContext.query[listKey].findOne({
@@ -185,7 +185,8 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
 
           return { ...session, itemId: session.itemId, listKey, data };
         } catch (e) {
-          // TODO: the assumption is this should only be from an invalid sessionData configuration
+          console.error(e);
+          // TODO: the assumption is this could only be from an invalid sessionData configuration
           //   it could be something else though, either way, result is a bad session
           return;
         }

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -133,11 +133,6 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     sessionData,
   });
 
-  /**
-   * validateConfig
-   *
-   * Validates the provided auth config; optional step when integrating auth
-   */
   function throwIfInvalidConfig<TypeInfo extends BaseKeystoneTypeInfo>(config: KeystoneConfig<TypeInfo>) {
     if (!(listKey in config.lists)) {
       throw new Error(`withAuth cannot find the list "${listKey}"`)

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -74,17 +74,21 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   } as const;
 
   const authFields = {
-    ...(passwordResetLink ? {
-      [`passwordResetToken`]: password({ ...fieldConfig }),
-      [`passwordResetIssuedAt`]: timestamp({ ...fieldConfig }),
-      [`passwordResetRedeemedAt`]: timestamp({ ...fieldConfig }),
-    } : null),
+    ...(passwordResetLink
+      ? {
+          passwordResetToken: password({ ...fieldConfig }),
+          passwordResetIssuedAt: timestamp({ ...fieldConfig }),
+          passwordResetRedeemedAt: timestamp({ ...fieldConfig }),
+        }
+      : null),
 
-    ...(magicAuthLink ? {
-      [`magicAuthToken`]: password({ ...fieldConfig }),
-      [`magicAuthIssuedAt`]: timestamp({ ...fieldConfig }),
-      [`magicAuthRedeemedAt`]: timestamp({ ...fieldConfig }),
-    } : null),
+    ...(magicAuthLink
+      ? {
+          magicAuthToken: password({ ...fieldConfig }),
+          magicAuthIssuedAt: timestamp({ ...fieldConfig }),
+          magicAuthRedeemedAt: timestamp({ ...fieldConfig }),
+        }
+      : null),
   };
 
   /**
@@ -136,9 +140,11 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     sessionData,
   });
 
-  function throwIfInvalidConfig<TypeInfo extends BaseKeystoneTypeInfo>(config: KeystoneConfig<TypeInfo>) {
+  function throwIfInvalidConfig<TypeInfo extends BaseKeystoneTypeInfo>(
+    config: KeystoneConfig<TypeInfo>
+  ) {
     if (!(listKey in config.lists)) {
-      throw new Error(`withAuth cannot find the list "${listKey}"`)
+      throw new Error(`withAuth cannot find the list "${listKey}"`);
     }
 
     // TODO: verify that the identity field is unique

--- a/packages/auth/src/lib/useFromRedirect.ts
+++ b/packages/auth/src/lib/useFromRedirect.ts
@@ -1,16 +1,6 @@
 import { useMemo } from 'react';
-import { useRouter } from '@keystone-6/core/admin-ui/router';
 
-export const useRedirect = () => {
-  const router = useRouter();
-  const redirect = useMemo(() => {
-    const { from } = router.query;
-    if (typeof from !== 'string') return '/';
-    if (!from.startsWith('/')) return '/';
-    if (from === '/no-access') return '/';
-
-    return from;
-  }, [router]);
-
-  return redirect;
-};
+// TODO: remove or fix
+export function useRedirect() {
+  return useMemo(() => '/', []);
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -65,5 +65,5 @@ export type AuthTokenRedemptionErrorCode = 'FAILURE' | 'TOKEN_EXPIRED' | 'TOKEN_
 
 export type SecretFieldImpl = {
   generateHash: (secret: string) => Promise<string>;
-  compare: (secret: string, hash: string) => Promise<string>;
+  compare: (secret: string, hash: string) => Promise<boolean>;
 };

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -12,7 +12,7 @@ export type BaseListTypeInfo = {
     create: GraphQLInput;
     update: GraphQLInput;
     where: GraphQLInput;
-    uniqueWhere: { readonly id?: string | null } & GraphQLInput;
+    uniqueWhere: { readonly id?: string | number | null } & GraphQLInput;
     orderBy: Record<string, 'asc' | 'desc' | null>;
   };
   /**


### PR DESCRIPTION
Thanks to @scgajge12 for reporting https://github.com/keystonejs/keystone/security/advisories/GHSA-jqxr-vjvv-899m, for now there is no straight forward resolution.

It is my understanding that the best approach we could take here would be to only allow redirecting to routes accepted by the AdminUI, but that functionality did not appear to be easy to implement quickly.

Although this is a breaking change, I have opted to mark this as a `patch`, as users will likely prefer the security resolution in a patch compared to an upgrade.

@borisno2 and I intend to fix this in newer versions of this package.