### PR TITLE
Fix three-pair-field example (part of #8664) 

### DIFF
--- a/examples/custom-field/3-pair-field-json/index.ts
+++ b/examples/custom-field/3-pair-field-json/index.ts
@@ -65,7 +65,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
     return { equals: json };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return meta =>
     fieldType({
       kind: 'scalar',
@@ -78,21 +77,18 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       input: {
         where: {
           arg: graphql.arg({ type: PairFilter }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveWhere(value);
           },
         },
         create: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
         },
         update: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
@@ -100,7 +96,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       },
       output: graphql.field({
         type: PairOutput,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         resolve({ value, item }, args, context, info) {
           return resolveOutput(value);
         },

--- a/examples/custom-field/3-pair-field-nested/index.ts
+++ b/examples/custom-field/3-pair-field-nested/index.ts
@@ -44,7 +44,7 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
   config: PairFieldConfig<ListTypeInfo> = {}
 ): FieldTypeFunc<ListTypeInfo> {
   function resolveInput(value: PairInput | null | undefined) {
-    if (value === undefined) return undefined;
+    if (!value) return { left: value, right: value };
     const { left = null, right = null } = value ?? {};
     return { left, right };
   }
@@ -67,7 +67,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return meta =>
     fieldType({
       kind: 'multi',
@@ -88,21 +87,18 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       input: {
         where: {
           arg: graphql.arg({ type: PairFilter }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveWhere(value);
           },
         },
         create: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
         },
         update: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
@@ -110,7 +106,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       },
       output: graphql.field({
         type: PairOutput,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         resolve({ value, item }, args, context, info) {
           return resolveOutput(value);
         },

--- a/examples/custom-field/3-pair-field/index.ts
+++ b/examples/custom-field/3-pair-field/index.ts
@@ -26,7 +26,7 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
   config: PairFieldConfig<ListTypeInfo> = {}
 ): FieldTypeFunc<ListTypeInfo> {
   function resolveInput(value: PairInput | null | undefined) {
-    if (value === undefined) return undefined;
+    if (!value) return { left: value, right: value };
     const [left = '', right = ''] = value.split(' ', 2);
     return {
       left,
@@ -54,7 +54,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return meta =>
     fieldType({
       kind: 'multi',
@@ -75,21 +74,18 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       input: {
         where: {
           arg: graphql.arg({ type: PairFilter }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveWhere(value);
           },
         },
         create: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
         },
         update: {
           arg: graphql.arg({ type: PairInput }),
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           resolve(value, context) {
             return resolveInput(value);
           },
@@ -97,7 +93,6 @@ export function pair<ListTypeInfo extends BaseListTypeInfo>(
       },
       output: graphql.field({
         type: PairOutput,
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         resolve({ value, item }, args, context, info) {
           return resolveOutput(value);
         },

--- a/examples/custom-field/schema.ts
+++ b/examples/custom-field/schema.ts
@@ -53,17 +53,17 @@ export const lists: Lists = {
       }),
       pair: pair({
         ui: {
-          description: 'One string, two database string fields',
+          description: 'One string, two database string fields (e.g "foo bar")',
         },
       }),
       pairNested: pairNested({
         ui: {
-          description: 'Two strings, two database string fields',
+          description: 'Two strings, two database string fields (e.g "foo", "bar")',
         },
       }),
       pairJson: pairJson({
         ui: {
-          description: 'Two strings, one database JSON field',
+          description: 'Two strings, one database JSON field (e.g "foo", "bar")',
         },
       }),
     },


### PR DESCRIPTION
Follow up to https://github.com/keystonejs/keystone/pull/8664, @gathanase the types were wrong and failing our CI.
Testing locally, the `3-pair-field` and `3-pair-field-nested` examples need to return `{ left: null, right: null }` or `{ left: undefined, right: undefined }` for a multi-column field update.

This is not the case for the `3-pair-field-json` example which is only one column.