### PR TITLE
Changes session secret to a secure random default when not provided

### DIFF
--- a/.changeset/twelve-garlics-shave.md
+++ b/.changeset/twelve-garlics-shave.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Changes session secret to a secure random default if no session secret is provided

--- a/.changeset/twelve-garlics-shave.md
+++ b/.changeset/twelve-garlics-shave.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Changes session secret to a secure random default if no session secret is provided
+Changes session secret to a secure random default when not provided

--- a/examples/custom-session-invalidation/keystone.ts
+++ b/examples/custom-session-invalidation/keystone.ts
@@ -9,14 +9,6 @@ import type { Config, Context, TypeInfo } from '.keystone/types';
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-// WARNING: you need to change this
-const sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
-
-// statelessSessions uses cookies for session tracking
-//   these cookies have an expiry, in seconds
-//   we use an expiry of 30 days for this example
-const sessionMaxAge = 60 * 60 * 24 * 30;
-
 // withAuth is a function we can use to wrap our base configuration
 const { withAuth } = createAuth({
   // this is the list that contains our users
@@ -86,12 +78,7 @@ export default withSessionInvalidation(
       },
       lists,
       // you can find out more at https://keystonejs.com/docs/apis/session#session-api
-      session: statelessSessions<Session>({
-        // the maxAge option controls how long session cookies are valid for before they expire
-        maxAge: sessionMaxAge,
-        // the session secret is used to encrypt cookie data
-        secret: sessionSecret,
-      }),
+      session: statelessSessions<Session>(),
     })
   )
 );

--- a/examples/custom-session-redis/keystone.ts
+++ b/examples/custom-session-redis/keystone.ts
@@ -10,14 +10,6 @@ import type { TypeInfo } from '.keystone/types';
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-// WARNING: you need to change this
-const sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
-
-// statelessSessions uses cookies for session tracking
-//   these cookies have an expiry, in seconds
-//   we use an expiry of 30 days for this example
-const sessionMaxAge = 60 * 60 * 24 * 30;
-
 // withAuth is a function we can use to wrap our base configuration
 const { withAuth } = createAuth({
   // this is the list that contains our users
@@ -45,12 +37,7 @@ const redis = createClient();
 function redisSessionStrategy() {
   // you can find out more at https://keystonejs.com/docs/apis/session#session-api
   return storedSessions<Session>({
-    // the maxAge option controls how long session cookies are valid for before they expire
-    maxAge: sessionMaxAge,
-    // the session secret is used to encrypt cookie data
-    secret: sessionSecret,
-
-    store: () => ({
+    store: ({ maxAge }) => ({
       async get(sessionId) {
         const result = await redis.get(sessionId);
         if (!result) return;
@@ -60,7 +47,7 @@ function redisSessionStrategy() {
 
       async set(sessionId, data) {
         // we use redis for our Session data, in JSON
-        await redis.setEx(sessionId, sessionMaxAge, JSON.stringify(data));
+        await redis.setEx(sessionId, maxAge, JSON.stringify(data));
       },
 
       async delete(sessionId) {

--- a/examples/testing/keystone.ts
+++ b/examples/testing/keystone.ts
@@ -10,9 +10,6 @@ import type { TypeInfo } from '.keystone/types';
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-// WARNING: you need to change this
-const sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
-
 // withAuth is a function we can use to wrap our base configuration
 const { withAuth } = createAuth({
   // this is the list that contains our users
@@ -46,9 +43,6 @@ export default withAuth(
     },
     lists,
     // you can find out more at https://keystonejs.com/docs/apis/session#session-api
-    session: statelessSessions({
-      // the session secret is used to encrypt cookie data
-      secret: sessionSecret,
-    }),
+    session: statelessSessions(),
   })
 );

--- a/examples/usecase-roles/keystone.ts
+++ b/examples/usecase-roles/keystone.ts
@@ -8,14 +8,6 @@ import { lists } from './schema';
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-// WARNING: you need to change this
-const sessionSecret = '-- DEV COOKIE SECRET; CHANGE ME --';
-
-// statelessSessions uses cookies for session tracking
-//   these cookies have an expiry, in seconds
-//   we use an expiry of 30 days for this example
-const sessionMaxAge = 60 * 60 * 24 * 30;
-
 // withAuth is a function we can use to wrap our base configuration
 const { withAuth } = createAuth({
   // this is the list that contains our users
@@ -88,11 +80,6 @@ export default withAuth(
       },
     },
     // you can find out more at https://keystonejs.com/docs/apis/session#session-api
-    session: statelessSessions({
-      // the maxAge option controls how long session cookies are valid for before they expire
-      maxAge: sessionMaxAge,
-      // the session secret is used to encrypt cookie data
-      secret: sessionSecret,
-    }),
+    session: statelessSessions(),
   })
 );

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -60,18 +60,16 @@ type StatelessSessionsOptions = {
   sameSite?: true | false | 'lax' | 'strict' | 'none';
 };
 
-const MAX_AGE = 60 * 60 * 8; // 8 hours
-
 export function statelessSessions<Session>({
   secret = randomBytes(32).toString('base64url'),
-  maxAge = MAX_AGE,
+  maxAge = 60 * 60 * 8, // 8 hours,
   cookieName = 'keystonejs-session',
   path = '/',
   secure = process.env.NODE_ENV === 'production',
   ironOptions = Iron.defaults,
   domain,
   sameSite = 'lax',
-}: StatelessSessionsOptions): SessionStrategy<Session, any> {
+}: StatelessSessionsOptions = {}): SessionStrategy<Session, any> {
   if (secret.length < 32) {
     throw new Error('The session secret must be at least 32 characters long');
   }
@@ -128,7 +126,7 @@ export function statelessSessions<Session>({
 /** @deprecated */
 export function storedSessions<Session>({
   store: storeFn,
-  maxAge = MAX_AGE,
+  maxAge = 60 * 60 * 8, // 8 hours
   ...statelessSessionsOptions
 }: {
   store: SessionStoreFunction<Session>;

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,8 +1,8 @@
+import { randomBytes } from 'crypto';
 import * as cookie from 'cookie';
 import Iron from '@hapi/iron';
 import { sync as uid } from 'uid-safe';
 import type { SessionStrategy, SessionStoreFunction } from '../types';
-import { randomBytes } from 'crypto';
 
 // should we also accept httpOnly?
 type StatelessSessionsOptions = {

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -2,6 +2,7 @@ import * as cookie from 'cookie';
 import Iron from '@hapi/iron';
 import { sync as uid } from 'uid-safe';
 import type { SessionStrategy, SessionStoreFunction } from '../types';
+import { randomBytes } from 'crypto';
 
 // should we also accept httpOnly?
 type StatelessSessionsOptions = {
@@ -62,7 +63,7 @@ type StatelessSessionsOptions = {
 const MAX_AGE = 60 * 60 * 8; // 8 hours
 
 export function statelessSessions<Session>({
-  secret,
+  secret = randomBytes(32).toString('base64url'),
   maxAge = MAX_AGE,
   cookieName = 'keystonejs-session',
   path = '/',
@@ -71,9 +72,6 @@ export function statelessSessions<Session>({
   domain,
   sameSite = 'lax',
 }: StatelessSessionsOptions): SessionStrategy<Session, any> {
-  if (!secret) {
-    throw new Error('You must specify a session secret to use sessions');
-  }
   if (secret.length < 32) {
     throw new Error('The session secret must be at least 32 characters long');
   }

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -9,7 +9,7 @@ type StatelessSessionsOptions = {
   /**
    * Secret used by https://github.com/hapijs/iron for encapsulating data. Must be at least 32 characters long
    */
-  secret: string;
+  secret?: string;
   /**
    * Iron seal options for customizing the key derivation algorithm used to generate encryption and integrity verification keys as well as the algorithms and salt sizes used.
    * See https://hapi.dev/module/iron/api/?v=6.0.0#options for available options.


### PR DESCRIPTION
This PR defaults the session secret to a secure random string, using `crypto.randomBytes` when no session secret is provided. This will enable Keystone to build without a session secret being provided while being a more secure by default. 

If no session secret is provided, the session secret will reset on every process restart forcing all sessions to become invalid. Developers are still encouraged to provide a secure option in production so that sessions remain alive between restarts.