### PR TITLE
Update slate dependencies

### DIFF
--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -78,7 +78,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "scroll-into-view-if-needed": "^3.0.0",
-    "slate": "^0.81.1",
+    "slate": "^0.94.1",
     "slate-history": "^0.66.0",
     "slate-react": "^0.97.1"
   },

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -79,7 +79,7 @@
     "react-dom": "^18.2.0",
     "scroll-into-view-if-needed": "^3.0.0",
     "slate": "^0.94.1",
-    "slate-history": "^0.66.0",
+    "slate-history": "^0.93.0",
     "slate-react": "^0.97.1"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/fields-document",

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -90,6 +90,6 @@
     "array.prototype.flat": "^1.2.5",
     "jest-diff": "^29.0.0",
     "pretty-format": "^29.0.0",
-    "slate-hyperscript": "^0.67.0"
+    "slate-hyperscript": "^0.81.3"
   }
 }

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -80,7 +80,7 @@
     "scroll-into-view-if-needed": "^3.0.0",
     "slate": "^0.81.1",
     "slate-history": "^0.66.0",
-    "slate-react": "^0.81.0"
+    "slate-react": "^0.97.1"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/fields-document",
   "devDependencies": {

--- a/packages/fields-document/src/DocumentEditor/block-markdown-shortcuts.ts
+++ b/packages/fields-document/src/DocumentEditor/block-markdown-shortcuts.ts
@@ -160,7 +160,7 @@ export function withBlockMarkdownShortcuts(
         return;
       }
       // so that this starts a new undo group
-      editor.history.undos.push([]);
+      editor.writeHistory('undos', { operations: [], selectionBefore: null });
       Transforms.select(editor, range);
       Transforms.delete(editor);
       shortcut.insert();

--- a/packages/fields-document/src/DocumentEditor/block-markdown-shortcuts.ts
+++ b/packages/fields-document/src/DocumentEditor/block-markdown-shortcuts.ts
@@ -1,4 +1,4 @@
-import { Editor, Transforms, Range } from 'slate';
+import { Element, Editor, Transforms, Range } from 'slate';
 import { DocumentFeatures } from '../views';
 import { ComponentBlock } from './component-blocks/api';
 import { insertDivider } from './divider';
@@ -53,7 +53,7 @@ export function withBlockMarkdownShortcuts(
       Transforms.wrapNodes(
         editor,
         { type: 'ordered-list', children: [] },
-        { match: n => Editor.isBlock(editor, n) }
+        { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
       );
     },
     features => features.formatting.listTypes.ordered
@@ -65,7 +65,7 @@ export function withBlockMarkdownShortcuts(
       Transforms.wrapNodes(
         editor,
         { type: 'unordered-list', children: [] },
-        { match: n => Editor.isBlock(editor, n) }
+        { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
       );
     },
     features => features.formatting.listTypes.unordered
@@ -76,7 +76,7 @@ export function withBlockMarkdownShortcuts(
       Transforms.wrapNodes(
         editor,
         { type: 'unordered-list', children: [] },
-        { match: n => Editor.isBlock(editor, n) }
+        { match: n => Element.isElement(n) && Editor.isBlock(editor, n) }
       );
     },
     features => features.formatting.listTypes.unordered
@@ -135,7 +135,7 @@ export function withBlockMarkdownShortcuts(
     if (shortcutsForTrigger && editor.selection && Range.isCollapsed(editor.selection)) {
       const { anchor } = editor.selection;
       const block = Editor.above(editor, {
-        match: node => Editor.isBlock(editor, node),
+        match: node => Element.isElement(node) && Editor.isBlock(editor, node),
       });
       if (!block || (block[0].type !== 'paragraph' && block[0].type !== 'heading')) return;
 

--- a/packages/fields-document/src/DocumentEditor/code-block.tsx
+++ b/packages/fields-document/src/DocumentEditor/code-block.tsx
@@ -13,7 +13,7 @@ export function withCodeBlock(editor: Editor): Editor {
 
   editor.insertBreak = () => {
     const [node, path] = Editor.above(editor, {
-      match: n => Editor.isBlock(editor, n),
+      match: n => Element.isElement(n) && Editor.isBlock(editor, n),
     }) || [editor, []];
     if (node.type === 'code' && Text.isText(node.children[0])) {
       const text = node.children[0].text;

--- a/packages/fields-document/src/DocumentEditor/component-blocks/with-component-blocks.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/with-component-blocks.tsx
@@ -29,7 +29,8 @@ import { getKeysForArrayValue, getNewArrayElementKey, setKeysForArrayValue } fro
 function getAncestorComponentBlock(editor: Editor) {
   if (editor.selection) {
     const ancestorEntry = Editor.above(editor, {
-      match: node => Editor.isBlock(editor, node) && node.type !== 'paragraph',
+      match: node =>
+        Element.isElement(node) && Editor.isBlock(editor, node) && node.type !== 'paragraph',
     });
     if (
       ancestorEntry &&

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -553,12 +553,12 @@ function withBlocksSchema(editor: Editor): Editor {
       if (
         info.kind === 'blocks' &&
         node.children.length !== 0 &&
-        node.children.every(child => !Editor.isBlock(editor, child))
+        node.children.every(child => !(Element.isElement(child) && Editor.isBlock(editor, child)))
       ) {
         Transforms.wrapNodes(
           editor,
           { type: info.blockToWrapInlinesIn, children: [] },
-          { at: path, match: node => !Editor.isBlock(editor, node) }
+          { at: path, match: node => !(Element.isElement(node) && Editor.isBlock(editor, node)) }
         );
         return;
       }
@@ -566,13 +566,20 @@ function withBlocksSchema(editor: Editor): Editor {
       for (const [index, childNode] of node.children.entries()) {
         const childPath = [...path, index];
         if (info.kind === 'inlines') {
-          if (!Text.isText(childNode) && !Editor.isInline(editor, childNode)) {
+          if (
+            !Text.isText(childNode) &&
+            !Editor.isInline(editor, childNode) &&
+            // these checks are implicit in Editor.isBlock
+            // but that isn't encoded in types so these will make TS happy
+            childNode.type !== 'link' &&
+            childNode.type !== 'relationship'
+          ) {
             handleNodeInInvalidPosition(editor, [childNode, childPath], path);
             return;
           }
         } else {
           if (
-            !Editor.isBlock(editor, childNode) ||
+            !(Element.isElement(childNode) && Editor.isBlock(editor, childNode)) ||
             // these checks are implicit in Editor.isBlock
             // but that isn't encoded in types so these will make TS happy
             childNode.type === 'link' ||
@@ -585,7 +592,11 @@ function withBlocksSchema(editor: Editor): Editor {
             );
             return;
           }
-          if (!info.allowedChildren.has(childNode.type)) {
+          if (
+            Element.isElement(childNode) &&
+            Editor.isBlock(editor, childNode) &&
+            !info.allowedChildren.has(childNode.type)
+          ) {
             handleNodeInInvalidPosition(editor, [childNode, childPath], path);
             return;
           }

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -289,7 +289,7 @@ export function DocumentEditorProvider({
       // this fixes issues with Slate crashing when a fast refresh occcurs
       key={identity}
       editor={editor}
-      value={value}
+      initialValue={value}
       onChange={value => {
         onChange(value);
         // this fixes a strange issue in Safari where the selection stays inside of the editor

--- a/packages/fields-document/src/DocumentEditor/insert-menu.tsx
+++ b/packages/fields-document/src/DocumentEditor/insert-menu.tsx
@@ -3,7 +3,7 @@
 import { jsx, Portal } from '@keystone-ui/core';
 import { useControlledPopover } from '@keystone-ui/popover';
 import { Fragment, ReactNode, useContext, useEffect, useRef, useState } from 'react';
-import { Transforms, Text, Editor, Path, Point, Node } from 'slate';
+import { Element, Transforms, Text, Editor, Path, Point, Node } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { matchSorter } from 'match-sorter';
 import scrollIntoView from 'scroll-into-view-if-needed';
@@ -346,7 +346,9 @@ export function withInsertMenu(editor: Editor): Editor {
     if (editor.selection && text === '/') {
       const startOfBlock = Editor.start(
         editor,
-        Editor.above(editor, { match: node => Editor.isBlock(editor, node) })![1]
+        Editor.above(editor, {
+          match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+        })![1]
       );
       const before = Editor.before(editor, editor.selection.anchor, { unit: 'character' });
       if (

--- a/packages/fields-document/src/DocumentEditor/link.tsx
+++ b/packages/fields-document/src/DocumentEditor/link.tsx
@@ -269,7 +269,7 @@ export function withLink(
       // by doing this, the insertText(')') above will happen in a different undo than the link replacement
       // so that means that when someone does an undo after this
       // it will undo to the state of "[content](link)" rather than "[content](link" (note the missing closing bracket)
-      editor.history.undos.push([]);
+      editor.writeHistory('undos', { operations: [], selectionBefore: null });
       const startOfShortcut =
         match.index === 0
           ? startOfBlock

--- a/packages/fields-document/src/DocumentEditor/link.tsx
+++ b/packages/fields-document/src/DocumentEditor/link.tsx
@@ -2,7 +2,7 @@
 /** @jsx jsx */
 
 import { ReactEditor, RenderElementProps, useFocused, useSelected } from 'slate-react';
-import { Editor, Node, Range, Transforms, Text } from 'slate';
+import { Element, Editor, Node, Range, Transforms, Text } from 'slate';
 import { forwardRef, memo, useEffect, useMemo, useState } from 'react';
 
 import { jsx, useTheme } from '@keystone-ui/core';
@@ -245,7 +245,9 @@ export function withLink(
       if (text !== ')' || !editor.selection) return;
       const startOfBlock = Editor.start(
         editor,
-        Editor.above(editor, { match: node => Editor.isBlock(editor, node) })![1]
+        Editor.above(editor, {
+          match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+        })![1]
       );
 
       const startOfBlockToEndOfShortcutString = Editor.string(editor, {

--- a/packages/fields-document/src/DocumentEditor/lists.tsx
+++ b/packages/fields-document/src/DocumentEditor/lists.tsx
@@ -30,7 +30,10 @@ export const toggleList = (editor: Editor, format: 'ordered-list' | 'unordered-l
       Transforms.wrapNodes(
         editor,
         { type: format, children: [] },
-        { match: x => x.type !== 'list-item-content' && Editor.isBlock(editor, x) }
+        {
+          match: x =>
+            x.type !== 'list-item-content' && Element.isElement(x) && Editor.isBlock(editor, x),
+        }
       );
     }
   });
@@ -121,6 +124,7 @@ export function withList(editor: Editor): Editor {
           node.type === 'list-item' &&
           childNode.type !== 'list-item-content' &&
           index === 0 &&
+          Element.isElement(childNode) &&
           Editor.isBlock(editor, childNode)
         ) {
           if (path[path.length - 1] !== 0) {
@@ -182,7 +186,7 @@ export const ListButton = forwardRef<
 
 export function nestList(editor: Editor) {
   const block = Editor.above(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
   });
 
   if (!block || block[0].type !== 'list-item-content') {
@@ -223,7 +227,7 @@ export function nestList(editor: Editor) {
 
 export function unnestList(editor: Editor) {
   const block = Editor.above(editor, {
-    match: n => Editor.isBlock(editor, n),
+    match: n => Element.isElement(n) && Editor.isBlock(editor, n),
   });
 
   if (block && block[0].type === 'list-item-content') {

--- a/packages/fields-document/src/DocumentEditor/marks.tsx
+++ b/packages/fields-document/src/DocumentEditor/marks.tsx
@@ -1,4 +1,4 @@
-import { Editor, Transforms, Range, Text, Point, Node, Path } from 'slate';
+import { Element, Editor, Transforms, Range, Text, Point, Node, Path } from 'slate';
 import { DocumentFeatures } from '../views';
 import { ComponentBlock } from './component-blocks/api';
 import { getAncestorComponentChildFieldDocumentFeatures } from './toolbar-state';
@@ -48,7 +48,9 @@ export function withMarks(
     insertBreak();
     const marksAfterInsertBreak = Editor.marks(editor);
     if (!marksAfterInsertBreak || !editor.selection) return;
-    const parentBlock = Editor.above(editor, { match: node => Editor.isBlock(editor, node) });
+    const parentBlock = Editor.above(editor, {
+      match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+    });
     if (!parentBlock) return;
     const point = EditorAfterButIgnoringingPointsWithNoContent(editor, editor.selection.anchor);
     const marksAfterInsertBreakArr = Object.keys(
@@ -193,6 +195,8 @@ export function withMarks(
 function getStartOfBlock(editor: Editor) {
   return Editor.start(
     editor,
-    Editor.above(editor, { match: node => Editor.isBlock(editor, node) })![1]
+    Editor.above(editor, {
+      match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+    })![1]
   );
 }

--- a/packages/fields-document/src/DocumentEditor/marks.tsx
+++ b/packages/fields-document/src/DocumentEditor/marks.tsx
@@ -13,7 +13,7 @@ export const allMarkdownShortcuts = {
 
 function applyMark(editor: Editor, mark: string, shortcutText: string, startOfStartPoint: Point) {
   // so that this starts a new undo group
-  editor.history.undos.push([]);
+  editor.writeHistory('undos', { operations: [], selectionBefore: null });
   const startPointRef = Editor.pointRef(editor, startOfStartPoint);
 
   Transforms.delete(editor, {

--- a/packages/fields-document/src/DocumentEditor/pasting/pasting-from-other-slate-editor.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/pasting/pasting-from-other-slate-editor.test.tsx
@@ -31,7 +31,7 @@ function OtherEditor({ editor }: { editor: Editor }) {
       ] as any
   );
   return (
-    <Slate editor={editor} onChange={setVal} value={val}>
+    <Slate editor={editor} onChange={setVal} initialValue={val}>
       <Editable
         renderElement={({ element, attributes, children }) => {
           return (element as any).isHeading ? (

--- a/packages/fields-document/src/DocumentEditor/shortcuts.ts
+++ b/packages/fields-document/src/DocumentEditor/shortcuts.ts
@@ -1,4 +1,4 @@
-import { Range, Editor, Transforms, Path } from 'slate';
+import { Element, Range, Editor, Transforms, Path } from 'slate';
 
 export const shortcuts: Record<string, string> = {
   '...': '…',
@@ -15,7 +15,9 @@ export function withShortcuts(editor: Editor): Editor {
     insertText(text);
     if (text === ' ' && editor.selection && Range.isCollapsed(editor.selection)) {
       const selectionPoint = editor.selection.anchor;
-      const ancestorBlock = Editor.above(editor, { match: node => Editor.isBlock(editor, node) });
+      const ancestorBlock = Editor.above(editor, {
+        match: node => Element.isElement(node) && Editor.isBlock(editor, node),
+      });
       if (ancestorBlock) {
         Object.keys(shortcuts).forEach(shortcut => {
           const pointBefore = Editor.before(editor, selectionPoint, {

--- a/packages/fields-document/src/DocumentEditor/shortcuts.ts
+++ b/packages/fields-document/src/DocumentEditor/shortcuts.ts
@@ -28,7 +28,7 @@ export function withShortcuts(editor: Editor): Editor {
             const range = { anchor: selectionPoint, focus: pointBefore };
             const str = Editor.string(editor, range);
             if (str.slice(0, shortcut.length) === shortcut) {
-              editor.history.undos.push([]);
+              editor.writeHistory('undos', { operations: [], selectionBefore: null });
               Transforms.select(editor, range);
               editor.insertText(shortcuts[shortcut] + ' ');
             }

--- a/packages/fields-document/src/DocumentEditor/tests/utils.tsx
+++ b/packages/fields-document/src/DocumentEditor/tests/utils.tsx
@@ -162,7 +162,7 @@ function EditorComp({
 }) {
   const [val, setVal] = useState(editor.children);
   return (
-    <Slate editor={editor} value={val} onChange={setVal}>
+    <Slate editor={editor} initialValue={val} onChange={setVal}>
       <ToolbarStateProvider
         componentBlocks={componentBlocks}
         editorDocumentFeatures={documentFeatures}

--- a/packages/fields-document/src/DocumentEditor/toolbar-state.tsx
+++ b/packages/fields-document/src/DocumentEditor/toolbar-state.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useContext } from 'react';
-import { Editor, Range, Text } from 'slate';
+import { Element, Editor, Range, Text } from 'slate';
 import { useSlate } from 'slate-react';
 import { DocumentFeatures } from '../views';
 import { ComponentBlockContext } from './component-blocks';
@@ -118,7 +118,7 @@ export const createToolbarState = (
     };
 
   let [maybeCodeBlockEntry] = Editor.nodes(editor, {
-    match: node => node.type !== 'code' && Editor.isBlock(editor, node),
+    match: node => node.type !== 'code' && Element.isElement(node) && Editor.isBlock(editor, node),
   });
   const editorMarks = Editor.marks(editor) || {};
   const marks = Object.fromEntries(

--- a/packages/fields-document/src/DocumentEditor/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/utils.ts
@@ -64,7 +64,7 @@ export function moveChildren(
 ) {
   const parentPath = Path.isPath(parent) ? parent : parent[1];
   const parentNode = Path.isPath(parent) ? Node.get(editor, parentPath) : parent[0];
-  if (!Editor.isBlock(editor, parentNode)) return;
+  if (!(Element.isElement(parentNode) && Editor.isBlock(editor, parentNode))) return;
 
   for (let i = parentNode.children.length - 1; i >= 0; i--) {
     if (shouldMoveNode(parentNode.children[i])) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2278,8 +2278,8 @@ importers:
         specifier: ^29.0.0
         version: 29.0.0
       slate-hyperscript:
-        specifier: ^0.67.0
-        version: 0.67.0(slate@0.81.1)
+        specifier: ^0.81.3
+        version: 0.81.3(slate@0.81.1)
 
   prisma-utils:
     dependencies:
@@ -21885,8 +21885,8 @@ packages:
       slate: 0.81.1
     dev: false
 
-  /slate-hyperscript@0.67.0(slate@0.81.1):
-    resolution: {integrity: sha512-3c+d2ePTUk5J7wMjs2CZIJPhb1/VnTltel+qnQarOWlXtJng7oRc8BNaYbNfkl2ecT9W5bpxpsy1r6x5ICXucQ==}
+  /slate-hyperscript@0.81.3(slate@0.81.1):
+    resolution: {integrity: sha512-A/jvoLTAgeRcJaUPQCYOikCJxSws6+/jkL7mM+QuZljNd7EA5YqafGA7sVBJRFpcoSsDRUIah1yNiC/7vxZPYg==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2256,8 +2256,8 @@ importers:
         specifier: ^0.66.0
         version: 0.66.0(slate@0.81.1)
       slate-react:
-        specifier: ^0.81.0
-        version: 0.81.0(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1)
+        specifier: ^0.97.1
+        version: 0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1)
     devDependencies:
       '@keystone-6/core':
         specifier: '*'
@@ -8984,6 +8984,10 @@ packages:
 
   /@js-joda/core@5.5.3:
     resolution: {integrity: sha512-7dqNYwG8gCt4hfg5PKgM7xLEcgSBcx/UgC92OMnhMmvAnq11QzDFPrxUkNR/u5kn17WWLZ8beZ4A3Qrz4pZcmQ==}
+    dev: false
+
+  /@juggle/resize-observer@3.4.0:
+    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: false
 
   /@ljharb/has-package-exports-patterns@0.0.2:
@@ -21894,13 +21898,14 @@ packages:
       slate: 0.81.1
     dev: true
 
-  /slate-react@0.81.0(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1):
-    resolution: {integrity: sha512-bwryad4EvOmc7EFKb8aGg9DWNDh3KvToaggGieIgGTTbHJYHc9ADFC3A87Ittlpd5XUVopR0MpChQ3g3ODyvqw==}
+  /slate-react@0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1):
+    resolution: {integrity: sha512-+1LMIVusBwduzBOsoX0u6ah7qgpOIlVOdbVpUrowSc5uZTXViBvAQnvSD6edOjtRUI62IFtPSvDAoHRm+E55+g==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
       slate: '>=0.65.3'
     dependencies:
+      '@juggle/resize-observer': 3.4.0
       '@types/is-hotkey': 0.1.7
       '@types/lodash': 4.14.195
       direction: 1.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2250,14 +2250,14 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       slate:
-        specifier: ^0.81.1
-        version: 0.81.1
+        specifier: ^0.94.1
+        version: 0.94.1
       slate-history:
         specifier: ^0.66.0
-        version: 0.66.0(slate@0.81.1)
+        version: 0.66.0(slate@0.94.1)
       slate-react:
         specifier: ^0.97.1
-        version: 0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1)
+        version: 0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
     devDependencies:
       '@keystone-6/core':
         specifier: '*'
@@ -2279,7 +2279,7 @@ importers:
         version: 29.0.0
       slate-hyperscript:
         specifier: ^0.81.3
-        version: 0.81.3(slate@0.81.1)
+        version: 0.81.3(slate@0.94.1)
 
   prisma-utils:
     dependencies:
@@ -2702,7 +2702,7 @@ packages:
       subscriptions-transport-ws:
         optional: true
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.2(graphql@16.6.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.6.0)
       '@wry/context': 0.7.3
       '@wry/equality': 0.5.6
       '@wry/trie': 0.3.2
@@ -21880,25 +21880,25 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
-  /slate-history@0.66.0(slate@0.81.1):
+  /slate-history@0.66.0(slate@0.94.1):
     resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.81.1
+      slate: 0.94.1
     dev: false
 
-  /slate-hyperscript@0.81.3(slate@0.81.1):
+  /slate-hyperscript@0.81.3(slate@0.94.1):
     resolution: {integrity: sha512-A/jvoLTAgeRcJaUPQCYOikCJxSws6+/jkL7mM+QuZljNd7EA5YqafGA7sVBJRFpcoSsDRUIah1yNiC/7vxZPYg==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:
       is-plain-object: 5.0.0
-      slate: 0.81.1
+      slate: 0.94.1
     dev: true
 
-  /slate-react@0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.81.1):
+  /slate-react@0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1):
     resolution: {integrity: sha512-+1LMIVusBwduzBOsoX0u6ah7qgpOIlVOdbVpUrowSc5uZTXViBvAQnvSD6edOjtRUI62IFtPSvDAoHRm+E55+g==}
     peerDependencies:
       react: '>=16.8.0'
@@ -21915,12 +21915,12 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       scroll-into-view-if-needed: 2.2.31
-      slate: 0.81.1
+      slate: 0.94.1
       tiny-invariant: 1.0.6
     dev: false
 
-  /slate@0.81.1:
-    resolution: {integrity: sha512-nmqphQb2qnlJpPMKsoxeWShpa+pOlKfy6XVdmlTuOtgWeGethM6SMPSRTrhh5UF/G+3/IoXhfbKF7o3iDZCbWw==}
+  /slate@0.94.1:
+    resolution: {integrity: sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==}
     dependencies:
       immer: 9.0.21
       is-plain-object: 5.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2253,8 +2253,8 @@ importers:
         specifier: ^0.94.1
         version: 0.94.1
       slate-history:
-        specifier: ^0.66.0
-        version: 0.66.0(slate@0.94.1)
+        specifier: ^0.93.0
+        version: 0.93.0(slate@0.94.1)
       slate-react:
         specifier: ^0.97.1
         version: 0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
@@ -21880,8 +21880,8 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
-  /slate-history@0.66.0(slate@0.94.1):
-    resolution: {integrity: sha512-6MWpxGQZiMvSINlCbMW43E2YBSVMCMCIwQfBzGssjWw4kb0qfvj0pIdblWNRQZD0hR6WHP+dHHgGSeVdMWzfng==}
+  /slate-history@0.93.0(slate@0.94.1):
+    resolution: {integrity: sha512-Gr1GMGPipRuxIz41jD2/rbvzPj8eyar56TVMyJBvBeIpQSSjNISssvGNDYfJlSWM8eaRqf6DAcxMKzsLCYeX6g==}
     peerDependencies:
       slate: '>=0.65.3'
     dependencies:


### PR DESCRIPTION
This is an attempt to update the slate dependencies to its latest version.

Tests were run in form of executing type checks. I did not test this yet in the browser or with a running instance of keystone

I updated each slate dependency in a separate commit so it can be followed which code changes have been made to solve type issues with each package update