### PR TITLE
Fix misleading error when `db.url` is `undefined`

### DIFF
--- a/.changeset/better-errors-please.md
+++ b/.changeset/better-errors-please.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes misleading error when `db.url` is `undefined`

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -187,6 +187,7 @@ export async function generateTypescriptTypesAndPrisma(
   if (dataProxy === true) {
     console.log('✨ Generating Prisma Client (data proxy)');
   }
+
   await Promise.all([
     generatePrismaClient(paths.schema.prisma, dataProxy),
     generateTypescriptTypes(cwd, config, graphQLSchema),

--- a/packages/core/src/lib/config.ts
+++ b/packages/core/src/lib/config.ts
@@ -92,11 +92,15 @@ function applyIdFieldDefaults(config: KeystoneConfig): KeystoneConfig['lists'] {
 
 export function initConfig(config: KeystoneConfig) {
   if (!['postgresql', 'sqlite', 'mysql'].includes(config.db.provider)) {
-    throw new Error(
+    throw new TypeError(
       'Invalid db configuration. Please specify db.provider as either "sqlite", "postgresql" or "mysql"'
     );
   }
 
+  // WARNING: Typescript should prevent this, but empty string is useful for Prisma errors
+  config.db.url ??= 'postgres://';
+
+  // TODO: use zod or something if want to follow this path
   return {
     ...config,
     lists: applyIdFieldDefaults(config),

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -140,22 +140,22 @@ type PrismaLogDefinition = {
 };
 
 export type DatabaseConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
+  provider: DatabaseProvider;
   url: string;
+
   shadowDatabaseUrl?: string;
   onConnect?: (args: KeystoneContext<TypeInfo>) => Promise<void>;
-  /** @deprecated */
-  useMigrations?: boolean;
   enableLogging?: boolean | PrismaLogLevel | Array<PrismaLogLevel | PrismaLogDefinition>;
   idField?: IdFieldConfig;
-  provider: DatabaseProvider;
+  prismaClientPath?: string;
+  extendPrismaSchema?: (schema: string) => string;
 
+  /** @deprecated */
+  useMigrations?: boolean;
   /** @deprecated use extendPrismaSchema */
   prismaPreviewFeatures?: readonly string[]; // https://www.prisma.io/docs/concepts/components/preview-features
   /** @deprecated use extendPrismaSchema */
   additionalPrismaDatasourceProperties?: { [key: string]: string };
-
-  prismaClientPath?: string;
-  extendPrismaSchema?: (schema: string) => string;
 };
 
 // config.ui


### PR DESCRIPTION
When `config.db.url` was `undefined` - although not allowed by our types - users were faced with the following error:
```typescript
TypeError: Cannot read properties of undefined (reading 'startsWith')
```

This can happen if, for example, someone used `db.url: process.env.DATABASE_URL!`.
You shouldn't do this, but, the error doesn't need to be terrible, when the alternative is that Prisma will inform you that your connection url is empty.

Some day, we should use something like `zod` to validate a users configuration. 