### PR TITLE
fix(cli): regenerate prisma schema during `keystone prisma ..` commands

### DIFF
--- a/.changeset/fix-frozen-prisma.md
+++ b/.changeset/fix-frozen-prisma.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Changes `keystone prisma` behaviour to not generate Typescript types and prisma schema when using `--frozen`

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -19,7 +19,6 @@ export async function prisma(cwd: string, args: string[], frozen: boolean) {
   // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
   const config = getBuiltKeystoneConfiguration(cwd);
   const { graphQLSchema } = createSystem(config);
-  await validatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema);
   await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema);
 
   const result = await execa('node', [require.resolve('prisma'), ...args], {

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -5,6 +5,7 @@ import {
   getBuiltKeystoneConfiguration,
   generateTypescriptTypesAndPrisma,
   generatePrismaAndGraphQLSchemas,
+  validatePrismaAndGraphQLSchemas
 } from '../artifacts';
 import { getEsbuildConfig } from '../lib/esbuild';
 import { ExitError } from './utils';

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -4,7 +4,7 @@ import { createSystem } from '../lib/createSystem';
 import {
   getBuiltKeystoneConfiguration,
   generateTypescriptTypesAndPrisma,
-  validatePrismaAndGraphQLSchemas,
+  generatePrismaAndGraphQLSchemas,
 } from '../artifacts';
 import { getEsbuildConfig } from '../lib/esbuild';
 import { ExitError } from './utils';
@@ -19,6 +19,8 @@ export async function prisma(cwd: string, args: string[], frozen: boolean) {
   // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
   const config = getBuiltKeystoneConfiguration(cwd);
   const { graphQLSchema } = createSystem(config);
+  console.log('✨ Generating GraphQL and Prisma schemas');
+  await generatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema);
   await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema);
 
   const result = await execa('node', [require.resolve('prisma'), ...args], {

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -19,9 +19,15 @@ export async function prisma(cwd: string, args: string[], frozen: boolean) {
   // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
   const config = getBuiltKeystoneConfiguration(cwd);
   const { graphQLSchema } = createSystem(config);
-  console.log('✨ Generating GraphQL and Prisma schemas');
-  await generatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema);
-  await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema);
+
+  if (frozen) {
+    await validatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema);
+    console.log('✨ GraphQL and Prisma schemas are up to date');
+  } else {
+    await generatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema); // TODO: rename to generateSchemas (or similar)
+    console.log('✨ Generated GraphQL and Prisma schemas');
+    await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema); // TODO: generate PrismaClientAndTypes (or similar)
+  }
 
   const result = await execa('node', [require.resolve('prisma'), ...args], {
     cwd,

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -26,7 +26,7 @@ export async function prisma(cwd: string, args: string[], frozen: boolean) {
   } else {
     await generatePrismaAndGraphQLSchemas(cwd, config, graphQLSchema); // TODO: rename to generateSchemas (or similar)
     console.log('✨ Generated GraphQL and Prisma schemas');
-    await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema); // TODO: generate PrismaClientAndTypes (or similar)
+    await generateTypescriptTypesAndPrisma(cwd, config, graphQLSchema); // TODO: rename to generatePrismaClientAndTypes (or similar)
   }
 
   const result = await execa('node', [require.resolve('prisma'), ...args], {


### PR DESCRIPTION
We also want to disable GrpahQL validations because it's not so important for the prisma command.