### PR TITLE
Adds responsive AdminUI menu for smaller device widths

### DIFF
--- a/.changeset/fix-responsive-ui.md
+++ b/.changeset/fix-responsive-ui.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/admin-ui': minor
+---
+
+Adds responsive AdminUI menu for smaller device widths

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/common.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/common.tsx
@@ -78,8 +78,12 @@ export function ColumnLayout(props: HTMLAttributes<HTMLDivElement>) {
         css={{
           alignItems: 'start',
           display: 'grid',
-          gap: spacing.xlarge,
-          gridTemplateColumns: `2fr 1fr`,
+          gap: spacing.none,
+          gridTemplateColumns: `100vw`,
+          '@media (min-width: 576px)': {
+            gridTemplateColumns: `2fr 1fr`,
+            gap: spacing.xlarge,
+          },
         }}
         {...props}
       />

--- a/packages/core/src/admin-ui/components/PageContainer.tsx
+++ b/packages/core/src/admin-ui/components/PageContainer.tsx
@@ -2,7 +2,8 @@
 /** @jsx jsx */
 
 import { jsx, useTheme } from '@keystone-ui/core';
-import { Fragment, HTMLAttributes, ReactNode } from 'react';
+import { Dispatch, Fragment, HTMLAttributes, ReactNode, SetStateAction, useState } from 'react';
+import { MenuIcon, XCircleIcon } from '@keystone-ui/icons';
 
 import { Navigation } from './Navigation';
 import { Logo } from './Logo';
@@ -25,10 +26,14 @@ const PageWrapper = (props: HTMLAttributes<HTMLElement>) => {
         css={{
           // background: colors.background,
           display: 'grid',
-          gridTemplateColumns: `minmax(300px, 1fr) 4fr`,
-          gridTemplateRows: `${HEADER_HEIGHT}px auto`,
+          gridTemplateColumns: `minmax(300px, 1fr)`,
+          gridTemplateRows: `repeat(2,${HEADER_HEIGHT}px) auto`,
           height: '100vh',
           isolation: 'isolate',
+          '@media (min-width: 576px)': {
+            gridTemplateColumns: `minmax(300px, 1fr) 4fr`,
+            gridTemplateRows: `${HEADER_HEIGHT}px auto`,
+          },
         }}
         {...props}
       />
@@ -36,19 +41,52 @@ const PageWrapper = (props: HTMLAttributes<HTMLElement>) => {
   );
 };
 
-const Sidebar = (props: HTMLAttributes<HTMLElement>) => {
+const Sidebar = ({
+  isSidebarOpen,
+  ...props
+}: HTMLAttributes<HTMLElement> & {
+  isSidebarOpen: boolean;
+  setIsSidebarOpen: Dispatch<SetStateAction<boolean>>;
+}) => {
   // const { colors } = useTheme();
 
   return (
-    <aside
+    <div
       css={{
-        // borderRight: `1px solid ${colors.border}`,
-        minWidth: 0, // resolves collapsing issues in children
-        overflowY: 'auto',
-        WebkitOverflowScrolling: 'touch',
+        gridColumn: '1/2',
+        gridRow: '1/4',
+        display: isSidebarOpen ? 'block' : 'none',
+        height: '100vh',
+        '@media (min-width: 576px)': {
+          gridColumn: '1/2',
+          gridRow: '2/3',
+          display: 'block',
+          height: '100%',
+        },
       }}
-      {...props}
-    />
+    >
+      <div
+        onClick={() => {
+          props.setIsSidebarOpen(!isSidebarOpen);
+        }}
+        css={{
+          float: 'right',
+          padding: '10px',
+          display: 'block',
+          '@media (min-width: 576px)': { display: 'none' },
+        }}
+      >
+        <XCircleIcon />
+      </div>
+      <aside
+        css={{
+          // borderRight: `1px solid ${colors.border}`,
+          minWidth: 0, // resolves collapsing issues in children
+          WebkitOverflowScrolling: 'touch',
+        }}
+        {...props}
+      />
+    </div>
   );
 };
 
@@ -74,6 +112,7 @@ const Content = (props: HTMLAttributes<HTMLElement>) => {
 
 export const PageContainer = ({ children, header, title }: PageContainerProps) => {
   const { colors, spacing } = useTheme();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   return (
     <PageWrapper>
       <div
@@ -88,6 +127,14 @@ export const PageContainer = ({ children, header, title }: PageContainerProps) =
         }}
       >
         <Logo />
+        <div
+          onClick={() => {
+            setIsSidebarOpen(!isSidebarOpen);
+          }}
+          css={{ display: 'block', '@media (min-width: 576px)': { display: 'none' } }}
+        >
+          <MenuIcon />
+        </div>
       </div>
       <header
         css={{
@@ -102,9 +149,10 @@ export const PageContainer = ({ children, header, title }: PageContainerProps) =
         }}
       >
         <title>{title ? `Keystone - ${title}` : 'Keystone'}</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         {header}
       </header>
-      <Sidebar>
+      <Sidebar isSidebarOpen={isSidebarOpen} setIsSidebarOpen={setIsSidebarOpen}>
         <Navigation />
       </Sidebar>
       <Content>{children}</Content>

--- a/packages/fields-document/src/DocumentEditor/primitives/toolbar.tsx
+++ b/packages/fields-document/src/DocumentEditor/primitives/toolbar.tsx
@@ -58,6 +58,7 @@ export const ToolbarGroup = forwardRefWithAs<'div', ToolbarGroupProps>(
             justifyContent: 'start',
             alignItems: directionToAlignment[direction],
             height: '100%',
+            overflowX: 'auto',
           }}
           {...props}
         >


### PR DESCRIPTION
Before: 

<img width="490" alt="image" src="https://github.com/keystonejs/keystone/assets/102274194/1ce38bd9-86a3-4e41-bcd7-3314ae71e619">

After:
<img width="344" alt="image" src="https://github.com/keystonejs/keystone/assets/102274194/e505c49c-e537-409b-a5fd-6e33037db854">

This pull request introduced a responsive sidebar for rudimentary support for mobile devices in Keystone admin UI. 

