### PR TITLE
Don't prevent navigation for `NODE_ENV === 'development'`

### DIFF
--- a/examples/custom-admin-ui-navigation/admin/config.ts
+++ b/examples/custom-admin-ui-navigation/admin/config.ts
@@ -1,5 +1,7 @@
 import { AdminConfig } from '@keystone-6/core/types';
 
+export const disablePreventNavigation = process.env.NODE_ENV === 'development';
+
 import { CustomNavigation } from './components/CustomNavigation';
 export const components: AdminConfig['components'] = {
   Navigation: CustomNavigation,

--- a/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
+++ b/packages/core/src/admin-ui/utils/usePreventNavigation.tsx
@@ -1,11 +1,17 @@
 import { useEffect } from 'react';
 import { useRouter } from '../router';
+import { useKeystone } from '../context';
 
 export function usePreventNavigation(shouldPreventNavigationRef: { current: boolean }) {
   const router = useRouter();
+  const keystone = useKeystone();
+
+  const disablePreventNavigation = keystone.adminConfig?.disablePreventNavigation || false;
 
   useEffect(() => {
     const clientSideRouteChangeHandler = () => {
+      if (disablePreventNavigation) return;
+
       if (
         shouldPreventNavigationRef.current &&
         !window.confirm('There are unsaved changes, are you sure you want to exit?')
@@ -18,7 +24,7 @@ export function usePreventNavigation(shouldPreventNavigationRef: { current: bool
     };
     router.events.on('routeChangeStart', clientSideRouteChangeHandler);
     const beforeUnloadHandler = (event: BeforeUnloadEvent) => {
-      if (shouldPreventNavigationRef.current) {
+      if (!disablePreventNavigation && shouldPreventNavigationRef.current) {
         event.preventDefault();
       }
     };
@@ -27,5 +33,5 @@ export function usePreventNavigation(shouldPreventNavigationRef: { current: bool
       router.events.off('routeChangeStart', clientSideRouteChangeHandler);
       window.removeEventListener('beforeunload', beforeUnloadHandler);
     };
-  }, [shouldPreventNavigationRef, router.events]);
+  }, [shouldPreventNavigationRef, router.events, disablePreventNavigation]);
 }

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -25,6 +25,7 @@ export type CreateViewFieldModes =
   | { state: 'error'; error: Error | readonly [GraphQLError, ...GraphQLError[]] };
 
 export type AdminConfig = {
+  disablePreventNavigation?: boolean;
   components?: {
     Logo?: (props: {}) => ReactElement;
     Navigation?: (props: NavigationProps) => ReactElement;


### PR DESCRIPTION
During development I found prevent navigation really annoying. There are cases when I change some files many times before getting back to browser and then I need to confirm many times that I want to reload page (over a dozen or more).

So, here's a little proposal for disabling prevent navigation.

I'd rather like to set this with `config.ui.disablePreventNavigation`, but as far I could find, config is not passed to KeystoneProvider and it would probably need many changes. Therefore here's quick example using AdminConfig (which seems reasonable for me as well).

And if you like this feature, but need to set this somewhere else, I'm gonna need some guidance.