### PR TITLE
Fix field width of grouped fields

### DIFF
--- a/.changeset/fix-field-widths.md
+++ b/.changeset/fix-field-widths.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/admin-ui': patch
+---
+
+Fix field width of grouped fields

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -178,18 +178,22 @@ function FieldGroup(props: { label: string; description: string | null; children
             </Text>
           </Stack>
         </summary>
-        <Stack across gap="medium">
-          <div css={{ width: buttonSize }} />
-          {divider}
-          <div>
+        <div css={{ display: 'flex' }}>
+          <div css={{ display: 'flex' }}>
+            <Stack across gap="medium">
+              <div css={{ width: buttonSize }} />
+              {divider}
+            </Stack>
+          </div>
+          <Stack marginLeft="medium" css={{ width: '100%' }}>
             {props.description !== null && (
               <FieldDescription id={descriptionId}>{props.description}</FieldDescription>
             )}
-            <Stack marginTop="xlarge" gap="xlarge">
+            <Stack marginTop="large" gap="xlarge">
               {props.children}
             </Stack>
-          </div>
-        </Stack>
+          </Stack>
+        </div>
       </details>
     </div>
   );


### PR DESCRIPTION
Fields within groups have incorrect width, And may be different for each group depends on fields .

This PR fixes this issue.

Example:
<img width="1098" alt="groups-width" src="https://github.com/keystonejs/keystone/assets/16906868/8d2ef265-fcfb-4a12-9232-feb41796aac4">

---
And here's another example, showing two groups with different widths. Before and after changes.

**Before:**
<img width="1411" alt="before" src="https://github.com/keystonejs/keystone/assets/16906868/ff50b40e-e9da-4d26-bea5-a4ccf24e9a2e">

---
**After**
<img width="1411" alt="after" src="https://github.com/keystonejs/keystone/assets/16906868/631ec544-4fd4-4d91-9f37-cd6b6a76e9c8">
