### PR TITLE
Deprecate `@keystone-6/system` and `server.healthCheck`

### DIFF
--- a/.changeset/less-systems-now.md
+++ b/.changeset/less-systems-now.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Deprecates `@keystone-6/system`, including `createSystem`, `createExpressServer` and `initConfig`
+Deprecates `@keystone-6/core/system`, including `createSystem`, `createExpressServer` and `initConfig`

--- a/.changeset/less-systems-now.md
+++ b/.changeset/less-systems-now.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Deprecates `@keystone-6/system`, including `createSystem`, `createExpressServer` and `initConfig`

--- a/.changeset/no-health-check.md
+++ b/.changeset/no-health-check.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Deprecates `config.server.healthCheck`, use `extendExpressApp`

--- a/docs/pages/blog/customisable-admin-ui.md
+++ b/docs/pages/blog/customisable-admin-ui.md
@@ -34,42 +34,6 @@ Dive into our [Custom Admin UI Logo guide](https://keystonejs.com/docs/guides/cu
 
 ![Animated logo screenshot](https://user-images.githubusercontent.com/737821/127438961-40bc6ddd-e34a-497d-ac6a-c135e88324d1.gif)
 
-## Health Check 💙
-
-We've added an optional `/_healthcheck` endpoint to Keystone's express server. You can use this endpoint to ensure your Keystone instance is up and running using website monitoring solutions.
-
-Enable it by setting `config.server.healthCheck: true`, by default it will respond with `{ status: 'pass', timestamp: Date.now() }`.
-
-You can also specify a custom path and JSON data:
-
-```js
-config({
-  server: {
-    healthCheck: {
-      path: '/my-health-check',
-      data: { status: 'healthy' },
-    },
-  },
-});
-```
-
-Or use a function for the `data` config to return real-time information:
-
-```js
-config({
-  server: {
-    healthCheck: {
-      path: '/my-health-check',
-      data: () => ({
-        status: 'healthy',
-        timestamp: Date.now(),
-        uptime: process.uptime(),
-      }),
-    },
-  },
-});
-```
-
 You can view the [verbose release notes](https://github.com/keystonejs/keystone/releases/tag/2021-07-29) on GitHub.
 
 If you like using Keystone, we'd appreciate a shout out in [Twitter](https://twitter.com/KeystoneJS) and a star in [GitHub](https://github.com/keystonejs/keystone).

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -208,7 +208,6 @@ Options:
 - `port` (default: `3000` ): The port your Express server will listen on.
 - `options` (default: `undefined`): The [`http.createServer`](https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener) options used by Node.
 - `maxFileSize` (default: `200 * 1024 * 1024`): The maximum file size allowed for uploads. If left undefined, defaults to `200 MiB`
-- `healthCheck` (default: `undefined`): Allows you to configure a health check endpoint on your server.
 - `extendExpressApp` (default: `undefined`): Allows you to extend the express app that Keystone creates.
 - `extendHttpServer` (default: `undefined`): Allows you to extend the node `http` server that runs Keystone.
 
@@ -218,46 +217,11 @@ export default config({
     cors: { origin: ['http://localhost:7777'], credentials: true },
     port: 3000,
     maxFileSize: 200 * 1024 * 1024,
-    healthCheck: true,
     extendExpressApp: (app, commonContext) => { /* ... */ },
     extendHttpServer: (httpServer, commonContext, graphQLSchema) => { /* ... */ },
   },
   /* ... */
 });
-```
-
-### healthCheck
-
-If set to `true`, a `/_healthcheck` endpoint will be added to your server which will respond with `{ status: 'pass', timestamp: Date.now() }`.
-
-You can configure the health check with a custom path and JSON data:
-
-```typescript
-config({
-  server: {
-    healthCheck: {
-      path: '/my-health-check',
-      data: { status: 'healthy' },
-    },
-  },
-})
-```
-
-Or use a function for the `data` config to return real-time information:
-
-```typescript
-config({
-  server: {
-    healthCheck: {
-      path: '/my-health-check',
-      data: () => ({
-        status: 'healthy',
-        timestamp: Date.now(),
-        uptime: process.uptime(),
-      }),
-    },
-  },
-})
 ```
 
 ### extendExpressApp

--- a/packages/core/src/lib/server/addHealthCheck.ts
+++ b/packages/core/src/lib/server/addHealthCheck.ts
@@ -6,9 +6,10 @@ import { healthCheckPath as defaultHealthCheckPath } from '../defaults';
 /** @deprecated */
 export async function addHealthCheck({
   config,
-  server
+  server,
 }: {
-  config: KeystoneConfig; server: Application
+  config: KeystoneConfig;
+  server: Application;
 }) {
   if (!config.server?.healthCheck) return;
 

--- a/packages/core/src/lib/server/addHealthCheck.ts
+++ b/packages/core/src/lib/server/addHealthCheck.ts
@@ -3,10 +3,13 @@ import type { KeystoneConfig } from '../../types';
 
 import { healthCheckPath as defaultHealthCheckPath } from '../defaults';
 
-type AddHealthCheckArgs = { config: KeystoneConfig; server: Application };
-
-// deprecated
-export async function addHealthCheck({ config, server }: AddHealthCheckArgs) {
+/** @deprecated */
+export async function addHealthCheck({
+  config,
+  server
+}: {
+  config: KeystoneConfig; server: Application
+}) {
   if (!config.server?.healthCheck) return;
 
   const healthCheck = config.server.healthCheck === true ? {} : config.server.healthCheck;

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -269,22 +269,20 @@ export async function dev(
   });
 
   if (app && httpServer) {
-    app.use('/__keystone_dev_status', (req, res) => {
-      res.json({ ready: isReady() ? true : false });
+    app.use('/__keystone/dev/status', (req, res) => {
+      res.status(isReady() ? 200 : 501).end();
     });
 
-    // Pass the request the express server, or serve the loading page
     app.use((req, res, next) => {
-      // If both the express server and Admin UI Middleware are ready, we're go!
       if (expressServer && hasAddedAdminUIMiddleware) {
         return expressServer(req, res, next);
       }
-      // Otherwise, we may be able to serve the GraphQL API
+
       const { pathname } = url.parse(req.url);
       if (expressServer && pathname === (config.graphql?.path || '/api/graphql')) {
         return expressServer(req, res, next);
       }
-      // Serve the loading page
+
       res.sendFile(devLoadingHTMLFilepath);
     });
 

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -11,7 +11,6 @@ import { generateAdminUI } from '../admin-ui/system';
 import { devMigrations, pushPrismaSchemaToDatabase } from '../lib/migrations';
 import { createSystem } from '../lib/createSystem';
 import { getEsbuildConfig } from '../lib/esbuild';
-import { healthCheckPath as defaultHealthCheckPath } from '../lib/defaults';
 import { createExpressServer } from '../lib/server/createExpressServer';
 import { createAdminUIMiddlewareWithNextApp } from '../lib/server/createAdminUIMiddleware';
 import { runTelemetry } from '../lib/telemetry';
@@ -260,21 +259,6 @@ export async function dev(
       }
     }
   };
-
-  // You shouldn't really be doing a healthcheck on the dev server, but we
-  // respond on the endpoint with the correct error code just in case. This
-  // doesn't send the configured data shape, because config doesn't allow
-  // for the "not ready" case but that's probably OK.
-  if (config.server?.healthCheck && app) {
-    const healthCheckPath =
-      config.server.healthCheck === true
-        ? defaultHealthCheckPath
-        : config.server.healthCheck.path || defaultHealthCheckPath;
-    app.use(healthCheckPath, (req, res, next) => {
-      if (expressServer) return next();
-      res.status(503).json({ status: 'fail', timestamp: Date.now() });
-    });
-  }
 
   // Serve the dev status page for the Admin UI
   let initKeystonePromiseResolve: () => void | undefined;

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -3,8 +3,13 @@ import next from 'next';
 import type { KeystoneConfig, KeystoneContext } from '../types';
 import { createAdminUIMiddlewareWithNextApp } from './lib/server/createAdminUIMiddleware';
 
+/** @deprecated */
 export { createSystem } from './lib/createSystem';
+
+/** @deprecated */
 export { createExpressServer } from './lib/server/createExpressServer';
+
+/** @deprecated */
 export { initConfig } from './lib/config';
 
 /** @deprecated */

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -190,24 +190,25 @@ export type AdminFileToWrite =
   | { mode: 'copy'; inputPath: string; outputPath: string };
 
 // config.server
-
-type HealthCheckConfig = {
-  path?: string;
-  data?: Record<string, any> | (() => Record<string, any>);
-};
-
 export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   /** Configuration options for the cors middleware. Set to `true` to use core Keystone defaults */
   cors?: CorsOptions | true;
   /** Maximum upload file size allowed (in bytes) */
   maxFileSize?: number;
-  /** Health check configuration. Set to `true` to add a basic `/_healthcheck` route, or specify the path and data explicitly */
-  healthCheck?: HealthCheckConfig | true;
-  /** Hook to extend the Express App that Keystone creates */
+
+  /** @deprecated */
+  healthCheck?: true | {
+    path?: string;
+    data?: Record<string, any> | (() => Record<string, any>);
+  };
+
+  /** extend the Express application used by Keystone */
   extendExpressApp?: (
     app: express.Express,
     context: KeystoneContext<TypeInfo>
   ) => void | Promise<void>;
+
+  /** extend the node:http server used by Keystone */
   extendHttpServer?: (
     server: Server,
     context: KeystoneContext<TypeInfo>,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -197,10 +197,12 @@ export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   maxFileSize?: number;
 
   /** @deprecated */
-  healthCheck?: true | {
-    path?: string;
-    data?: Record<string, any> | (() => Record<string, any>);
-  };
+  healthCheck?:
+    | true
+    | {
+        path?: string;
+        data?: Record<string, any> | (() => Record<string, any>);
+      };
 
   /** extend the Express application used by Keystone */
   extendExpressApp?: (

--- a/packages/core/static/dev-loading.html
+++ b/packages/core/static/dev-loading.html
@@ -116,7 +116,6 @@
       <p id="message">This page will reload when the server is ready</p>
     </div>
     <script>
-      const INTERVAL = 250;
       const statusEl = document.querySelector('#status');
       const messageEl = document.querySelector('#message');
       const loadingEl = document.querySelector('.loading-spinner');
@@ -127,28 +126,20 @@
         loadingEl.remove();
         throw err;
       }
+
       function onReady() {
         statusEl.innerHTML = 'Keystone is ready!';
         messageEl.innerHTML = 'Reloading the page...';
         location.reload(true);
       }
 
-      function checkStatus() {
-        fetch('/__keystone_dev_status', { headers: { Accept: 'application/json' } })
-          .then(result => result.json())
-          .then(status => {
-            if (status.ready) {
-              onReady();
-            } else {
-              setTimeout(checkStatus, INTERVAL);
-            }
-          })
-          .catch(error => {
-            onError();
-          });
+      async function checkStatus() {
+        const res = await fetch('/__keystone/dev/status');
+        if (res.status === 200) return onReady();
+        setTimeout(checkStatus, 400);
       }
 
-      const interval = setTimeout(checkStatus, 250);
+      checkStatus();
     </script>
   </body>
 </html>


### PR DESCRIPTION
This pull request deprecates `@keystone-6/system`, including each of the exports `createSystem`, `createExpressServer` and `initConfig`. Neither of these exports should be used by developers in new code, as we are slowly changing the way users interact with Keystone generally.  If you have a usecase for these functions, please comment on this pull request!

This pull request additionally deprecates `config.server.healthCheck`, with the new recommendation for developers to use `extendExpressApp` with a custom route that fits their use-case.   This configuration was highly opinionated and often unhelpful in different environments when you needed a very specific response format.
An implementation that wants to upgrade early could use the following:

```typescript
import { config } from '@keystone-6/core';
import { TypeInfo } from '.keystone/types';

export default config<TypeInfo>({
  ...
  server: {
    extendExpressApp: (app, commonContext) => {
      app.get('/status', async (req, res) => {
        res.status(200).json({ status: 'up' })
      })
    },
  },
})
``` 