### PR TITLE
Use console.error for Prisma errors

### DIFF
--- a/.changeset/more-errors-please.md
+++ b/.changeset/more-errors-please.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+`KS_PRISMA_ERRORS` are now logged with `console.error` on the server

--- a/packages/core/src/lib/core/graphql-errors.ts
+++ b/packages/core/src/lib/core/graphql-errors.ts
@@ -6,7 +6,9 @@ export const userInputError = (msg: string) =>
 export const accessDeniedError = (msg: string) =>
   new GraphQLError(`Access denied: ${msg}`, { extensions: { code: 'KS_ACCESS_DENIED' } });
 
-export const prismaError = (err: Error) => {
+export function prismaError(err: Error) {
+  console.error(err);
+
   if ((err as any).code === undefined) {
     return new GraphQLError(`Prisma error`, {
       extensions: {
@@ -23,7 +25,7 @@ export const prismaError = (err: Error) => {
       prisma: { ...err },
     },
   });
-};
+}
 
 export const validationFailureError = (messages: string[]) => {
   const s = messages.map(m => `  - ${m}`).join('\n');


### PR DESCRIPTION
This pull request changes `KS_PRISMA_ERRORS` to now be logged using `console.error` on the server.
This isn't a breaking change in any sense, but it might be a change of scope for what users expect from these errors if they output sensitive information.

I am open  to feedback on if this is acceptable or not as a `minor`.