### PR TITLE
Use base64url for cloudinary identifiers, not cuid2

### DIFF
--- a/.changeset/no-cuid-2-cloud.md
+++ b/.changeset/no-cuid-2-cloud.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/cloudinary': patch
+---
+
+Change cloudinary identifiers to use random base64url identifiers, not cuid2

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -21,10 +21,8 @@
     "@keystone-ui/core": "^5.0.2",
     "@keystone-ui/fields": "^7.1.2",
     "@keystone-ui/pill": "^7.0.2",
-    "@paralleldrive/cuid2": "^2.2.1",
     "@types/react": "^18.0.9",
     "cloudinary": "^1.27.1",
-    "cuid": "^2.1.8",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import {
   CommonFieldConfig,
   BaseListTypeInfo,
@@ -5,7 +6,6 @@ import {
   jsonFieldTypePolyfilledForSQLite,
 } from '@keystone-6/core/types';
 import { graphql } from '@keystone-6/core';
-import { createId as cuid2 } from '@paralleldrive/cuid2';
 import cloudinary from 'cloudinary';
 import { CloudinaryAdapter } from './cloudinary';
 
@@ -140,7 +140,7 @@ export const cloudinaryImage =
       const { id, filename, _meta } = await adapter.save({
         stream,
         filename: originalFilename,
-        id: cuid2(),
+        id: randomBytes(20).toString('base64url'),
       });
 
       return { id, filename, originalFilename, mimetype, encoding, _meta };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1836,18 +1836,12 @@ importers:
       '@keystone-ui/pill':
         specifier: ^7.0.2
         version: link:../../design-system/packages/pill
-      '@paralleldrive/cuid2':
-        specifier: ^2.2.1
-        version: 2.2.1
       '@types/react':
         specifier: ^18.0.9
         version: 18.0.25
       cloudinary:
         specifier: ^1.27.1
         version: 1.27.1
-      cuid:
-        specifier: ^2.1.8
-        version: 2.1.8
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -13505,6 +13499,7 @@ packages:
   /cuid@2.1.8:
     resolution: {integrity: sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==}
     deprecated: Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.
+    dev: true
 
   /data-uri-to-buffer@3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}


### PR DESCRIPTION
This pull request switches from `cuid2` (a dependency) to a `node:crypto` call that doesn't potentially fallback to `Math.random`.
To my knowledge, there is no requirement for Cloudinary to use `cuid` or similar, and we could drop this dependency easily.

`randomBytes(20).toString('base64url')` is url safe. 