### PR TITLE
Prefer `node:crypto` `randomBytes` with `base64url`

### DIFF
--- a/.changeset/use-node-crypto.md
+++ b/.changeset/use-node-crypto.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/core': patch
+'@keystone-6/auth': patch
+---
+
+Use `base64url` from `node:crypto` for random identifiers, drop `safe-uid` dependency

--- a/packages/auth/src/lib/createAuthToken.ts
+++ b/packages/auth/src/lib/createAuthToken.ts
@@ -1,15 +1,6 @@
 import { randomBytes } from 'crypto';
 import type { KeystoneDbAPI } from '@keystone-6/core/types';
 
-function generateToken(length: number): string {
-  return randomBytes(length) // Generates N*8 bits of data
-    .toString('base64') // Groups by 6-bits and encodes as ascii chars in [A-Za-z0-9+/] and '=' for padding (~8/6 * N chars)
-    .replace(/[^a-zA-Z0-9]/g, '') // Removes any '+', '/' (62, 63) and '=' chars as often require escaping (eg. in urls)
-    .slice(0, length); // Shortens the string, so we now have ~6*N bits of data (it's actually log2(62)*N = 5.954*N)
-}
-
-// TODO: Auth token mutations may leak user identities due to timing attacks :(
-// We don't (currently) make any effort to mitigate the time taken to record the new token or sent the email when successful
 export async function createAuthToken(
   identityField: string,
   identity: string,
@@ -17,10 +8,13 @@ export async function createAuthToken(
 ): Promise<
   { success: false } | { success: true; itemId: string | number | bigint; token: string }
 > {
+  // FIXME : identity lookups may leak information due to timing attacks
   const item = await dbItemAPI.findOne({ where: { [identityField]: identity } });
-  if (item) {
-    return { success: true, itemId: item.id, token: generateToken(20) };
-  } else {
-    return { success: false };
-  }
+  if (!item) return { success: false };
+
+  return {
+    success: true,
+    itemId: item.id,
+    token: randomBytes(16).toString('base64url').slice(0, 20), // (128 / Math.log2(64)) < 20
+  };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -224,7 +224,6 @@
     "@types/pluralize": "^0.0.30",
     "@types/prompts": "^2.0.14",
     "@types/react": "^18.0.9",
-    "@types/uid-safe": "^2.1.2",
     "@types/uuid": "^9.0.0",
     "apollo-upload-client": "^17.0.0",
     "bcryptjs": "^2.4.3",
@@ -264,7 +263,6 @@
     "react-dom": "^18.2.0",
     "resolve": "^1.20.0",
     "ts-toolbelt": "^9.6.0",
-    "uid-safe": "^2.1.5",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,7 +1,6 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 import * as cookie from 'cookie';
 import Iron from '@hapi/iron';
-import { sync as uid } from 'uid-safe';
 import type { SessionStrategy, SessionStoreFunction } from '../types';
 
 // should we also accept httpOnly?
@@ -142,7 +141,7 @@ export function storedSessions<Session>({
       return store.get(sessionId);
     },
     async start({ context, data }) {
-      const sessionId = uid(24);
+      const sessionId = randomBytes(24).toString('base64url');
       await store.set(sessionId, data);
       return stateless.start({ context, data: sessionId }) || '';
     },

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -69,9 +69,11 @@ export function statelessSessions<Session>({
   domain,
   sameSite = 'lax',
 }: StatelessSessionsOptions = {}): SessionStrategy<Session, any> {
+  // atleast 192-bit in base64
   if (secret.length < 32) {
     throw new Error('The session secret must be at least 32 characters long');
   }
+
   return {
     async get({ context }) {
       if (!context?.req) return;
@@ -141,7 +143,7 @@ export function storedSessions<Session>({
       return store.get(sessionId);
     },
     async start({ context, data }) {
-      const sessionId = randomBytes(24).toString('base64url');
+      const sessionId = randomBytes(24).toString('base64url'); // 192-bit
       await store.set(sessionId, data);
       return stateless.start({ context, data: sessionId }) || '';
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1996,9 +1996,6 @@ importers:
       '@types/react':
         specifier: ^18.0.9
         version: 18.0.25
-      '@types/uid-safe':
-        specifier: ^2.1.2
-        version: 2.1.2
       '@types/uuid':
         specifier: ^9.0.0
         version: 9.0.0
@@ -2116,9 +2113,6 @@ importers:
       ts-toolbelt:
         specifier: ^9.6.0
         version: 9.6.0
-      uid-safe:
-        specifier: ^2.1.5
-        version: 2.1.5
       uuid:
         specifier: ^9.0.0
         version: 9.0.0
@@ -11163,10 +11157,6 @@ packages:
   /@types/tough-cookie@4.0.2:
     resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
     dev: true
-
-  /@types/uid-safe@2.1.2:
-    resolution: {integrity: sha512-Qe3A73fQbbkyoCIZvumH3kGJe01aOeUjUjKW05QHAfkfyKa8FjlDR5dP05T27S/f1/qjCtI07pQJzo4SKQWFSQ==}
-    dev: false
 
   /@types/unist@2.0.7:
     resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
@@ -20773,11 +20763,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /random-bytes@1.0.0:
-    resolution: {integrity: sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==}
-    engines: {node: '>= 0.8'}
-    dev: false
-
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -23147,13 +23132,6 @@ packages:
   /ufo@1.2.0:
     resolution: {integrity: sha512-RsPyTbqORDNDxqAdQPQBpgqhWle1VcTSou/FraClYlHf6TZnQcGslpLcAphNR+sQW4q5lLWLbOsRlh9j24baQg==}
     dev: true
-
-  /uid-safe@2.1.5:
-    resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      random-bytes: 1.0.0
-    dev: false
 
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}


### PR DESCRIPTION
This pull request updates `@keystone-6/auth` and `@keystone-6/core` to use `node:crypto` and the `base64url` encoding instead of encoding to `base64`, or using the `safe-uid` dependency.

This is the recommended best practice and reduces our need on dependencies.