### PR TITLE
Fix `ui.isDisabled: true`

### DIFF
--- a/.changeset/fix-disable-uid.md
+++ b/.changeset/fix-disable-uid.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes `ui.isDisabled` condition for `keystone start`

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -50,7 +50,7 @@ export const start = async (
   );
 
   console.log(`✅ GraphQL API ready`);
-  if (!config.ui?.isDisabled || ui) {
+  if (!config.ui?.isDisabled && ui) {
     console.log('✨ Preparing Admin UI Next.js app');
     const nextApp = next({ dev: false, dir: paths.admin });
     await nextApp.prepare();


### PR DESCRIPTION
Fix incorrect condition around in `keystone start` when looking to start the admin UI. See #8732.

Pretty sure this is what was intended.