### PR TITLE
Fix broken context type narrowing for virtual field resolvers

### DIFF
--- a/.changeset/perfect-rats-cough.md
+++ b/.changeset/perfect-rats-cough.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes broken context type narrowing for virtual field resolvers

--- a/examples/virtual-field/README.md
+++ b/examples/virtual-field/README.md
@@ -1,6 +1,6 @@
 ## Feature Example - virtual field
 
-This project demonstrates how to add virtual fields to a Keystone list
+This project demonstrates how to add virtual fields to a Keystone list.
 It builds on the [Blog](../blog) starter project.
 
 ## Instructions
@@ -20,103 +20,6 @@ You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://
 
 This project demonstrates how to use virtual fields.
 It uses the `graphql` export from `@keystone-6/core` to define the GraphQL schema used by the virtual fields.
-
-### `isPublished`
-
-The `isPublished` field shows how to use the `virtual` field to return some derived data.
-
-```ts
-isPublished: virtual({
-  field: graphql.field({
-    type: graphql.Boolean,
-    resolve(item: any) {
-      return item.status === 'published';
-    },
-  }),
-}),
-```
-
-### `counts`
-
-The `counts` field shows how to return a GraphQL object rather than a scalar from a virtual field.
-
-```ts
-counts: virtual({
-  field: graphql.field({
-    type: graphql.object<{ content: string }>()({
-      name: 'PostCounts',
-      fields: {
-        words: graphql.field({
-          type: graphql.Int,
-          resolve({ content }) {
-            return content.split(' ').length;
-          },
-        }),
-        sentences: graphql.field({
-          type: graphql.Int,
-          resolve({ content }) {
-            return content.split('.').length;
-          },
-        }),
-        paragraphs: graphql.field({
-          type: graphql.Int,
-          resolve({ content }) {
-            return content.split('\n\n').length;
-          },
-        }),
-      },
-    }),
-    resolve(item: any) {
-      return { content: item.content || '' };
-    },
-  }),
-  ui: { query: '{ words sentences paragraphs }' },
-}),
-```
-
-### `excerpt`
-
-The `excerpt` field shows how to add GraphQL arguments to a virtual field.
-
-```ts
-excerpt: virtual({
-  field: graphql.field({
-    type: graphql.String,
-    args: {
-      length: graphql.arg({ type: graphql.nonNull(graphql.Int), defaultValue: 200 }),
-    },
-    resolve(item, { length }) {
-      if (!item.content) {
-        return null;
-      }
-      return (item.content as string).slice(0, length - 3) + '...';
-    },
-  }),
-}),
-```
-
-### `relatedPosts`
-
-The `relatedPosts` field shows how to use the GraphQL types defined by a Keystone list.
-
-```ts
-relatedPosts: virtual({
-  field: lists =>
-    graphql.field({
-      type: graphql.list(graphql.nonNull(lists.Post.types.output)),
-      resolve(item, args, context) {
-        // this could have some logic to get posts that are actually related to this one somehow
-        // this is a just a naive "get the three latest posts that aren't this one"
-        return context.db.Post.findMany({
-          take: 3,
-          where: { id_not: item.id, status: 'published' },
-          orderBy: [{ publishDate: 'desc' }],
-        });
-      },
-    }),
-  ui: { query: '{ title }' },
-}),
-```
 
 ## Try it out in CodeSandbox 🧪
 

--- a/examples/virtual-field/schema.graphql
+++ b/examples/virtual-field/schema.graphql
@@ -4,19 +4,12 @@
 type Post {
   id: ID!
   title: String
-  status: PostStatusType
-  isPublished: Boolean
   content: String
+  listed: Boolean
+  isActive: Boolean
   counts: PostCounts
-  excerpt(length: Int! = 200): String
-  publishDate: DateTime
-  author: Author
-  authorName: String
-}
-
-enum PostStatusType {
-  draft
-  published
+  excerpt(length: Int! = 50): String
+  related: [RelatedPosts]
 }
 
 type PostCounts {
@@ -25,7 +18,10 @@ type PostCounts {
   paragraphs: Int
 }
 
-scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
+type RelatedPosts {
+  id: String
+  title: String
+}
 
 input PostWhereUniqueInput {
   id: ID
@@ -37,10 +33,8 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   id: IDFilter
   title: StringFilter
-  status: PostStatusTypeNullableFilter
   content: StringFilter
-  publishDate: DateTimeNullableFilter
-  author: AuthorWhereInput
+  listed: BooleanFilter
 }
 
 input IDFilter {
@@ -82,30 +76,16 @@ input NestedStringFilter {
   not: NestedStringFilter
 }
 
-input PostStatusTypeNullableFilter {
-  equals: PostStatusType
-  in: [PostStatusType!]
-  notIn: [PostStatusType!]
-  not: PostStatusTypeNullableFilter
-}
-
-input DateTimeNullableFilter {
-  equals: DateTime
-  in: [DateTime!]
-  notIn: [DateTime!]
-  lt: DateTime
-  lte: DateTime
-  gt: DateTime
-  gte: DateTime
-  not: DateTimeNullableFilter
+input BooleanFilter {
+  equals: Boolean
+  not: BooleanFilter
 }
 
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
-  status: OrderDirection
   content: OrderDirection
-  publishDate: OrderDirection
+  listed: OrderDirection
 }
 
 enum OrderDirection {
@@ -115,16 +95,8 @@ enum OrderDirection {
 
 input PostUpdateInput {
   title: String
-  status: PostStatusType
   content: String
-  publishDate: DateTime
-  author: AuthorRelateToOneForUpdateInput
-}
-
-input AuthorRelateToOneForUpdateInput {
-  create: AuthorCreateInput
-  connect: AuthorWhereUniqueInput
-  disconnect: Boolean
+  listed: Boolean
 }
 
 input PostUpdateArgs {
@@ -134,80 +106,8 @@ input PostUpdateArgs {
 
 input PostCreateInput {
   title: String
-  status: PostStatusType
   content: String
-  publishDate: DateTime
-  author: AuthorRelateToOneForCreateInput
-}
-
-input AuthorRelateToOneForCreateInput {
-  create: AuthorCreateInput
-  connect: AuthorWhereUniqueInput
-}
-
-type Author {
-  id: ID!
-  name: String
-  email: String
-  posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
-  postsCount(where: PostWhereInput! = {}): Int
-  latestPost: Post
-}
-
-input AuthorWhereUniqueInput {
-  id: ID
-  email: String
-}
-
-input AuthorWhereInput {
-  AND: [AuthorWhereInput!]
-  OR: [AuthorWhereInput!]
-  NOT: [AuthorWhereInput!]
-  id: IDFilter
-  name: StringFilter
-  email: StringFilter
-  posts: PostManyRelationFilter
-}
-
-input PostManyRelationFilter {
-  every: PostWhereInput
-  some: PostWhereInput
-  none: PostWhereInput
-}
-
-input AuthorOrderByInput {
-  id: OrderDirection
-  name: OrderDirection
-  email: OrderDirection
-}
-
-input AuthorUpdateInput {
-  name: String
-  email: String
-  posts: PostRelateToManyForUpdateInput
-}
-
-input PostRelateToManyForUpdateInput {
-  disconnect: [PostWhereUniqueInput!]
-  set: [PostWhereUniqueInput!]
-  create: [PostCreateInput!]
-  connect: [PostWhereUniqueInput!]
-}
-
-input AuthorUpdateArgs {
-  where: AuthorWhereUniqueInput!
-  data: AuthorUpdateInput!
-}
-
-input AuthorCreateInput {
-  name: String
-  email: String
-  posts: PostRelateToManyForCreateInput
-}
-
-input PostRelateToManyForCreateInput {
-  create: [PostCreateInput!]
-  connect: [PostWhereUniqueInput!]
+  listed: Boolean
 }
 
 """
@@ -222,21 +122,12 @@ type Mutation {
   updatePosts(data: [PostUpdateArgs!]!): [Post]
   deletePost(where: PostWhereUniqueInput!): Post
   deletePosts(where: [PostWhereUniqueInput!]!): [Post]
-  createAuthor(data: AuthorCreateInput!): Author
-  createAuthors(data: [AuthorCreateInput!]!): [Author]
-  updateAuthor(where: AuthorWhereUniqueInput!, data: AuthorUpdateInput!): Author
-  updateAuthors(data: [AuthorUpdateArgs!]!): [Author]
-  deleteAuthor(where: AuthorWhereUniqueInput!): Author
-  deleteAuthors(where: [AuthorWhereUniqueInput!]!): [Author]
 }
 
 type Query {
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   post(where: PostWhereUniqueInput!): Post
   postsCount(where: PostWhereInput! = {}): Int
-  authors(where: AuthorWhereInput! = {}, orderBy: [AuthorOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: AuthorWhereUniqueInput): [Author!]
-  author(where: AuthorWhereUniqueInput!): Author
-  authorsCount(where: AuthorWhereInput! = {}): Int
   keystone: KeystoneMeta!
 }
 

--- a/examples/virtual-field/schema.prisma
+++ b/examples/virtual-field/schema.prisma
@@ -13,20 +13,8 @@ generator client {
 }
 
 model Post {
-  id          String    @id @default(cuid())
-  title       String    @default("")
-  status      String?
-  content     String    @default("")
-  publishDate DateTime?
-  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
-  authorId    String?   @map("author")
-
-  @@index([authorId])
-}
-
-model Author {
-  id    String @id @default(cuid())
-  name  String @default("")
-  email String @unique @default("")
-  posts Post[] @relation("Post_author")
+  id      String  @id @default(cuid())
+  title   String  @default("")
+  content String  @default("")
+  listed  Boolean @default(false)
 }

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -5,25 +5,24 @@ import {
   CommonFieldConfig,
   FieldTypeFunc,
   fieldType,
+  KeystoneContext,
   ListGraphQLTypes,
   getGqlNames,
 } from '../../../types';
 import { graphql } from '../../..';
 
-type VirtualFieldGraphQLField<Item extends BaseItem> = graphql.Field<
-  Item,
-  any,
-  graphql.OutputType,
-  string
->;
+type VirtualFieldGraphQLField<
+  Item extends BaseItem,
+  Context extends KeystoneContext
+> = graphql.Field<Item, any, graphql.OutputType, string, Context>;
 
 export type VirtualFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
   CommonFieldConfig<ListTypeInfo> & {
     field:
-      | VirtualFieldGraphQLField<ListTypeInfo['item']>
+      | VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>
       | ((
           lists: Record<string, ListGraphQLTypes>
-        ) => VirtualFieldGraphQLField<ListTypeInfo['item']>);
+        ) => VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>);
     unreferencedConcreteInterfaceImplementations?: readonly graphql.ObjectType<any>[];
     ui?: {
       /**

--- a/tests/examples-smoke-tests/virtual-field.test.ts
+++ b/tests/examples-smoke-tests/virtual-field.test.ts
@@ -10,8 +10,8 @@ exampleProjectTests('virtual-field', browserType => {
     await loadIndex(page);
   });
   test('Load list', async () => {
-    await Promise.all([page.waitForNavigation(), page.click('h3:has-text("Authors")')]);
-    await page.waitForSelector('a:has-text("Create Author")');
+    await Promise.all([page.waitForNavigation(), page.click('h3:has-text("Posts")')]);
+    await page.waitForSelector('a:has-text("Create Post")');
   });
   afterAll(async () => {
     await browser.close();


### PR DESCRIPTION
closes #8740

`graphql.Field` supports the context type as a passthrough, so this PR passes through the inferred Context type.

Tested this via patch-package, it fixed the issue I had in #8740, though I'm not sure if there are other side-effects this type passthrough would have 🤔 