### PR TITLE
Fixes `session` type as `any` when using `.keystone/types` `Lists` as your root type

### DIFF
--- a/.changeset/enable-sourcemap-esbuild.md
+++ b/.changeset/enable-sourcemap-esbuild.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Add sourcemap: true to esbuild configuration to enable debugging
+Add `sourcemap: true` to esbuild configuration to help with error debugging

--- a/.changeset/fix-session-types.md
+++ b/.changeset/fix-session-types.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes `session` type as `any` when using `.keystone/types` `Lists` as your root type

--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -147,7 +147,7 @@ type ResolvedPostUpdateInput = {
 };
 
 export declare namespace Lists {
-  export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>, any>;
+  export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>>;
   namespace Post {
     export type Item = import('./node_modules/.myprisma/client').Post;
     export type TypeInfo<Session = any> = {
@@ -175,7 +175,7 @@ export type Config<Session = any> = import('@keystone-6/core/types').KeystoneCon
 
 export type TypeInfo<Session = any> = {
   lists: {
-    readonly Post: Lists.Post.TypeInfo;
+    readonly Post: Lists.Post.TypeInfo<Session>;
   };
   prisma: import('./node_modules/.myprisma/client').PrismaClient;
   session: Session;
@@ -184,7 +184,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key], any>
-} & Record<string, import('@keystone-6/core').ListConfig<any, any>>;
+  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+} & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}

--- a/examples/custom-session/schema.ts
+++ b/examples/custom-session/schema.ts
@@ -25,7 +25,7 @@ function isAdminOrOnlySameUser({ session }: { session?: Session }) {
   };
 }
 
-export const lists: Lists = {
+export const lists: Lists<Session> = {
   Post: list({
     access: {
       operation: {

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -243,7 +243,7 @@ type ResolvedAuthorUpdateInput = {
 };
 
 export declare namespace Lists {
-  export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>, any>;
+  export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>>;
   namespace Post {
     export type Item = import('./node_modules/.myprisma/client').Post;
     export type TypeInfo<Session = any> = {
@@ -265,7 +265,7 @@ export declare namespace Lists {
       all: __TypeInfo<Session>;
     };
   }
-  export type Author<Session = any> = import('@keystone-6/core').ListConfig<Lists.Author.TypeInfo<Session>, any>;
+  export type Author<Session = any> = import('@keystone-6/core').ListConfig<Lists.Author.TypeInfo<Session>>;
   namespace Author {
     export type Item = import('./node_modules/.myprisma/client').Author;
     export type TypeInfo<Session = any> = {
@@ -293,8 +293,8 @@ export type Config<Session = any> = import('@keystone-6/core/types').KeystoneCon
 
 export type TypeInfo<Session = any> = {
   lists: {
-    readonly Post: Lists.Post.TypeInfo;
-    readonly Author: Lists.Author.TypeInfo;
+    readonly Post: Lists.Post.TypeInfo<Session>;
+    readonly Author: Lists.Author.TypeInfo<Session>;
   };
   prisma: import('./node_modules/.myprisma/client').PrismaClient;
   session: Session;
@@ -303,7 +303,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key], any>
-} & Record<string, import('@keystone-6/core').ListConfig<any, any>>;
+  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+} & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -303,7 +303,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}

--- a/examples/usecase-roles/schema.ts
+++ b/examples/usecase-roles/schema.ts
@@ -70,7 +70,7 @@ export const lists: Lists<Session> = {
         },
         hooks: {
           resolveInput({ operation, resolvedData, context }) {
-            if (operation === 'create' && !resolvedData.assignedTo) {
+            if (operation === 'create' && !resolvedData.assignedTo && context.session) {
               // Always default new todo items to the current user; this is important because users
               // without canManageAllTodos don't see this field when creating new items
               return { connect: { id: context.session.itemId } };
@@ -112,11 +112,13 @@ export const lists: Lists<Session> = {
       },
       itemView: {
         defaultFieldMode: ({ session, item }) => {
-          // People with canEditOtherPeople can always edit people
-          if (session.data.role?.canEditOtherPeople) return 'edit';
-          // People can also always edit themselves
-          else if (session.itemId === item.id) return 'edit';
-          // Otherwise, default all fields to read mode
+          // canEditOtherPeople can edit other people
+          if (session?.data.role?.canEditOtherPeople) return 'edit';
+
+          // edit themselves
+          if (session?.itemId === item.id) return 'edit';
+
+          // else, default all fields to read mode
           return 'read';
         },
       },
@@ -141,7 +143,7 @@ export const lists: Lists<Session> = {
         access: {
           read: denyAll, // TODO: is this required?
           update: ({ session, item }) =>
-            permissions.canManagePeople({ session }) || session.itemId === item.id,
+            permissions.canManagePeople({ session }) || session?.itemId === item.id,
         },
         validation: { isRequired: true },
       }),
@@ -163,11 +165,12 @@ export const lists: Lists<Session> = {
         ref: 'Todo.assignedTo',
         many: true,
         access: {
-          // Only people with canManageAllTodos can set this field when creating other users
+          // only people with canManageAllTodos can set this field when creating other users
           create: permissions.canManageAllTodos,
-          // You can only update this field with canManageAllTodos, or for yourself
+
+          // you can only update this field with canManageAllTodos, or for yourself
           update: ({ session, item }) =>
-            permissions.canManageAllTodos({ session }) || session.itemId === item.id,
+            permissions.canManageAllTodos({ session }) || session?.itemId === item.id,
         },
         ui: {
           createView: {

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -156,7 +156,7 @@ function printListTypeInfo<L extends InitialisedList>(
 
   // prettier-ignore
   return [
-    `export type ${listKey}<Session = any> = import('@keystone-6/core').ListConfig<${listTypeInfoName}<Session>, any>;`,
+    `export type ${listKey}<Session = any> = import('@keystone-6/core').ListConfig<${listTypeInfoName}<Session>>;`,
     `namespace ${listKey} {`,
     `  export type Item = import('${prismaClientPath}').${listKey};`,
     `  export type TypeInfo<Session = any> = {`,
@@ -194,7 +194,7 @@ export function printGeneratedTypes(
   prismaClientPath = stringify(prismaClientPath).replace(/'/g, `\\'`);
 
   for (const [listKey, list] of Object.entries(lists)) {
-    const listTypeInfoName = `Lists.${listKey}.TypeInfo`;
+    const listTypeInfoName = `Lists.${listKey}.TypeInfo<Session>`;
 
     if (list.graphql.isEnabled.create) {
       interimCreateUpdateTypes.push(
@@ -257,8 +257,8 @@ export function printGeneratedTypes(
     `type __TypeInfo<Session = any> = TypeInfo<Session>;`,
     ``,
     `export type Lists<Session = any> = {`,
-    `  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key], any>`,
-    `} & Record<string, import('@keystone-6/core').ListConfig<any, any>>;`,
+    `  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>`,
+    `} & Record<string, import('@keystone-6/core').ListConfig<any>>;`,
     ``,
     `export {}`,
     ``,

--- a/packages/core/src/lib/schema-type-printer.tsx
+++ b/packages/core/src/lib/schema-type-printer.tsx
@@ -257,7 +257,7 @@ export function printGeneratedTypes(
     `type __TypeInfo<Session = any> = TypeInfo<Session>;`,
     ``,
     `export type Lists<Session = any> = {`,
-    `  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>`,
+    `  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>`,
     `} & Record<string, import('@keystone-6/core').ListConfig<any>>;`,
     ``,
     `export {}`,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -12,7 +12,7 @@ export function config<TypeInfo extends BaseKeystoneTypeInfo>(config: KeystoneCo
 
 let i = 0;
 export function group<
-  __Fields extends BaseFields<ListTypeInfo>, // TODO: remove in breaking change
+  __Unused extends any, // TODO: remove in breaking change
   ListTypeInfo extends BaseListTypeInfo
 >(config: {
   label: string;
@@ -35,7 +35,7 @@ export function group<
 }
 
 export function list<
-  __Fields extends BaseFields<ListTypeInfo>, // TODO: remove in breaking change
+  __Unused extends any, // TODO: remove in breaking change
   ListTypeInfo extends BaseListTypeInfo
 >(config: ListConfig<ListTypeInfo>): ListConfig<ListTypeInfo> {
   return { ...config };

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -14,7 +14,7 @@ export type ListSchemaConfig<ListTypeInfo extends BaseListTypeInfo = BaseListTyp
 
 export type ListConfig<
   ListTypeInfo extends BaseListTypeInfo,
-  __Fields extends BaseFields<ListTypeInfo> = BaseFields<ListTypeInfo> // TODO: remove in breaking change
+  __Unused extends any = any // TODO: remove in breaking change
 > = {
   isSingleton?: boolean;
   fields: BaseFields<ListTypeInfo>;
@@ -50,7 +50,7 @@ export type ListConfig<
 
 export type ListAdminUIConfig<
   ListTypeInfo extends BaseListTypeInfo,
-  __Fields extends BaseFields<ListTypeInfo> = BaseFields<ListTypeInfo> // TODO: remove in breaking change
+  __Unused extends any = any // TODO: remove in breaking change
 > = {
   /**
    * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -3,7 +3,7 @@ import type { BaseItem } from './next-fields';
 
 type GraphQLInput = Record<string, any>;
 
-export type BaseListTypeInfo = {
+export type BaseListTypeInfo<Session = any> = {
   key: string;
   isSingleton: boolean;
   fields: string;
@@ -22,14 +22,14 @@ export type BaseListTypeInfo = {
     create: Record<string, any>;
     update: Record<string, any>;
   };
-  all: BaseKeystoneTypeInfo;
+  all: BaseKeystoneTypeInfo<Session>;
 };
 
 export type KeystoneContextFromListTypeInfo<ListTypeInfo extends BaseListTypeInfo> =
   KeystoneContext<ListTypeInfo['all']>;
 
-export type BaseKeystoneTypeInfo = {
-  lists: Record<string, BaseListTypeInfo>;
+export type BaseKeystoneTypeInfo<Session = any> = {
+  lists: Record<string, BaseListTypeInfo<Session>>;
   prisma: any;
   session: any;
 };

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -1,4 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+
 exports[`postinstall writes the correct node_modules files 1`] = `
 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/types.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 /* eslint-disable */
@@ -127,7 +128,7 @@ type ResolvedTodoUpdateInput = {
 };
 
 export declare namespace Lists {
-  export type Todo<Session = any> = import('@keystone-6/core').ListConfig<Lists.Todo.TypeInfo<Session>, any>;
+  export type Todo<Session = any> = import('@keystone-6/core').ListConfig<Lists.Todo.TypeInfo<Session>>;
   namespace Todo {
     export type Item = import('@prisma/client').Todo;
     export type TypeInfo<Session = any> = {
@@ -155,7 +156,7 @@ export type Config<Session = any> = import('@keystone-6/core/types').KeystoneCon
 
 export type TypeInfo<Session = any> = {
   lists: {
-    readonly Todo: Lists.Todo.TypeInfo;
+    readonly Todo: Lists.Todo.TypeInfo<Session>;
   };
   prisma: import('@prisma/client').PrismaClient;
   session: Session;
@@ -164,8 +165,8 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key], any>
-} & Record<string, import('@keystone-6/core').ListConfig<any, any>>;
+  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+} & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}
 

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -165,7 +165,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}


### PR DESCRIPTION
This pull request fixes `session` type becoming `any` when using `.keystone/types` `Lists` as your root type for your lists definition.
