### PR TITLE
Update generated `my-types.ts` in `custom-output-paths` example

### DIFF
--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -184,7 +184,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>;
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core').ListConfig<any>>;
 
 export {}


### PR DESCRIPTION
The generated types for the `custom-output-paths` example is out of date, this PR regenerates that file