### PR TITLE
Remove `context.exitSudo()`

### DIFF
--- a/.changeset/no-exit-sudo.md
+++ b/.changeset/no-exit-sudo.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Removes `context.exitSudo()` from a Keystone context, sudo() should not carry hidden state

--- a/docs/pages/docs/context/overview.md
+++ b/docs/pages/docs/context/overview.md
@@ -37,7 +37,6 @@ context = {
 
   // New context creators
   sudo,
-  exitSudo,
   withSession,
   withRequest,
 

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -92,7 +92,6 @@ export function createContext({
       prisma: prismaClient,
 
       sudo: () => construct({ session, sudo: true, req, res }),
-      exitSudo: () => construct({ session, sudo: false, req, res }), // TODO: remove, deprecated
 
       req,
       res,

--- a/packages/core/src/scripts/prisma.ts
+++ b/packages/core/src/scripts/prisma.ts
@@ -5,7 +5,7 @@ import {
   getBuiltKeystoneConfiguration,
   generateTypescriptTypesAndPrisma,
   generatePrismaAndGraphQLSchemas,
-  validatePrismaAndGraphQLSchemas
+  validatePrismaAndGraphQLSchemas,
 } from '../artifacts';
 import { getEsbuildConfig } from '../lib/esbuild';
 import { ExitError } from './utils';

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -13,7 +13,6 @@ export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystone
   query: KeystoneListsAPI<TypeInfo['lists']>;
   graphql: KeystoneGraphQLAPI;
   sudo: () => KeystoneContext<TypeInfo>;
-  exitSudo: () => KeystoneContext<TypeInfo>;
   withSession: (session?: TypeInfo['session']) => KeystoneContext<TypeInfo>;
   withRequest: (req: IncomingMessage, res?: ServerResponse) => Promise<KeystoneContext<TypeInfo>>;
   prisma: TypeInfo['prisma'];

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -36,21 +36,6 @@ const runner = setupTestRunner({
 });
 
 test(
-  'non-sudo context does not bypass isAccessAllowed for admin meta',
-  runner(async ({ context }) => {
-    const res = await context.exitSudo().graphql.raw({ query: staticAdminMetaQuery });
-    expect(res).toMatchInlineSnapshot(`
-      {
-        "data": null,
-        "errors": [
-          [GraphQLError: Access denied],
-        ],
-      }
-    `);
-  })
-);
-
-test(
   'sudo context bypasses isAccessAllowed for admin meta',
   runner(async ({ context }) => {
     const data = await context.sudo().graphql.run({ query: staticAdminMetaQuery });


### PR DESCRIPTION
This pull request removes `context.exitSudo`, which was deprecated in https://github.com/keystonejs/keystone/pull/8438.
Following discussion with @borisno2, it is our opinion that `exitSudo` is an anti-pattern and can result in scenarios where a developer might revert to calling `exitSudo` deep in their stacks to ensure they are not bypassing access control.

This is not best practice and `.sudo()` should be a 1-way consideration, if need the original context, you should pass that around instead and call `.sudo()` only when necessary.