### PR TITLE
Fix Prisma test using `--frozen`

### DIFF
--- a/tests/cli-tests/artifacts.test.ts
+++ b/tests/cli-tests/artifacts.test.ts
@@ -10,22 +10,38 @@ import {
   testdir,
 } from './utils';
 
-describe.each(['postinstall', ['build', '--frozen'], ['prisma', 'migrate', 'status']])(
-  '%s',
-  command => {
-    test('logs an error and exits with 1 when the schemas do not exist', async () => {
-      const tmp = await testdir({
-        ...symlinkKeystoneDeps,
-        'keystone.js': basicKeystoneConfig,
-      });
-      const recording = recordConsole();
-      await expect(runCommand(tmp, command)).rejects.toEqual(new ExitError(1));
-      expect(recording()).toMatchInlineSnapshot(
-        `"Your Prisma and GraphQL schemas are not up to date"`
-      );
+describe.each(['postinstall', ['build', '--frozen']])('%s', command => {
+  test('logs an error and exits with 1 when the schemas do not exist', async () => {
+    const tmp = await testdir({
+      ...symlinkKeystoneDeps,
+      'keystone.js': basicKeystoneConfig,
     });
-  }
-);
+    const recording = recordConsole();
+    await expect(runCommand(tmp, command)).rejects.toEqual(new ExitError(1));
+    expect(recording()).toMatchInlineSnapshot(
+      `"Your Prisma and GraphQL schemas are not up to date"`
+    );
+  });
+});
+
+describe('prisma migrate status', () => {
+  test('logs an error and exits with 1 when the schemas do not exist', async () => {
+    const tmp = await testdir({
+      ...symlinkKeystoneDeps,
+      'keystone.js': basicKeystoneConfig,
+    });
+    await expect(runCommand(tmp, ['build', '--no-ui', '--frozen'])).rejects.toEqual(
+      new ExitError(1)
+    );
+    const recording = recordConsole();
+    await expect(runCommand(tmp, ['prisma', '--frozen', 'migrate', 'status'])).rejects.toEqual(
+      new ExitError(1)
+    );
+    expect(recording()).toMatchInlineSnapshot(
+      `"Your Prisma and GraphQL schemas are not up to date"`
+    );
+  });
+});
 
 const schemasMatch = ['schema.prisma', 'schema.graphql'];
 

--- a/tests/cli-tests/migrations.test.ts
+++ b/tests/cli-tests/migrations.test.ts
@@ -248,7 +248,8 @@ describe('useMigrations: false', () => {
     }
 
     expect(recording()).toMatchInlineSnapshot(`
-      "? Starting Keystone
+      "? Generated GraphQL and Prisma schemas
+      ? Starting Keystone
       ? Server listening on :3000 (http://localhost:3000/)
       ? GraphQL API available at /api/graphql
       ? Generating GraphQL and Prisma schemas

--- a/tests/cli-tests/prisma.test.ts
+++ b/tests/cli-tests/prisma.test.ts
@@ -15,7 +15,8 @@ test('keystone prisma exits with the same code as the prisma child process exits
     cwd: tmp,
   });
   expect(result.all!.replace(/[^ -~\n]/g, '?')).toMatchInlineSnapshot(`
-    "
+    "? Generated GraphQL and Prisma schemas
+    
     ! Unknown command "bad-thing"
 
     ?  Prisma is a modern DB toolkit to query, migrate and model your database (https://prisma.io)
@@ -79,8 +80,9 @@ test('keystone prisma uses the db url in the keystone config', async () => {
     all: true,
     cwd: tmp,
   });
-  expect(result.all).toMatchInlineSnapshot(`
-    "Prisma schema loaded from schema.prisma
+  expect(result.all!.replace(/[^ -~\n]/g, '?')).toMatchInlineSnapshot(`
+    "? Generated GraphQL and Prisma schemas
+    Prisma schema loaded from schema.prisma
     Datasource "sqlite": SQLite database "app.db" at "file:./app.db"
     Error: P1003: Database app.db does not exist at ./app.db"
   `);


### PR DESCRIPTION
The `artifacts` test was broken in #8698 - added a new test that tests the same outcome, however requires `build --no-ui --frozen` to be run first so there is a generated Prisma client.