### PR TITLE
Fix `ui.isAccessAllowed` when `undefined` to prevent access

### DIFF
--- a/.changeset/fix-admin-meta-access.md
+++ b/.changeset/fix-admin-meta-access.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes `ui.isAccessAllowed` when `undefined`, to prevent access to the `adminMeta` GraphQL query, akin to the behaviour for the default AdminUI `pageMiddleware`

--- a/packages/core/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/core/src/admin-ui/system/generateAdminUI.ts
@@ -7,7 +7,7 @@ import { Entry, walk as _walk } from '@nodelib/fs.walk';
 import type { KeystoneConfig, AdminFileToWrite } from '../../types';
 import { writeAdminFiles } from '../templates';
 import { serializePathForImport } from '../utils/serializePathForImport';
-import type { AdminMetaRootVal } from './createAdminMeta';
+import type { AdminMetaRootVal } from '../../lib/create-admin-meta';
 
 const walk = promisify(_walk);
 

--- a/packages/core/src/admin-ui/system/index.ts
+++ b/packages/core/src/admin-ui/system/index.ts
@@ -1,2 +1,1 @@
 export { generateAdminUI } from './generateAdminUI';
-export { KeystoneMeta } from './adminMetaSchema';

--- a/packages/core/src/admin-ui/templates/app.ts
+++ b/packages/core/src/admin-ui/templates/app.ts
@@ -12,7 +12,7 @@ import {
   Kind,
 } from 'graphql';
 import { staticAdminMetaQuery, StaticAdminMetaQuery } from '../admin-meta-graphql';
-import type { AdminMetaRootVal } from '../system/createAdminMeta';
+import type { AdminMetaRootVal } from '../../lib/create-admin-meta';
 
 type AppTemplateOptions = { configFileExists: boolean };
 

--- a/packages/core/src/admin-ui/templates/index.ts
+++ b/packages/core/src/admin-ui/templates/index.ts
@@ -1,7 +1,7 @@
 import * as Path from 'path';
 import type { GraphQLSchema } from 'graphql';
 import type { KeystoneConfig, AdminFileToWrite } from '../../types';
-import type { AdminMetaRootVal } from '../system/createAdminMeta';
+import type { AdminMetaRootVal } from '../../lib/create-admin-meta';
 import { appTemplate } from './app';
 import { homeTemplate } from './home';
 import { listTemplate } from './list';

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,6 +1,6 @@
 import { BaseListTypeInfo, FieldTypeFunc, CommonFieldConfig, fieldType } from '../../../types';
 import { graphql } from '../../..';
-import { getAdminMetaForRelationshipField } from '../../../admin-ui/system/createAdminMeta';
+import { getAdminMetaForRelationshipField } from '../../../lib/create-admin-meta';
 
 // This is the default display mode for Relationships
 type SelectDisplayConfig = {

--- a/packages/core/src/lib/create-admin-meta.ts
+++ b/packages/core/src/lib/create-admin-meta.ts
@@ -8,9 +8,10 @@ import type {
   JSONValue,
   MaybeItemFunction,
 } from '../../types';
-import { humanize } from '../../lib/utils';
-import type { InitialisedList } from '../../lib/core/initialise-lists';
-import type { FilterOrderArgs } from '../../types/config/fields';
+import type { FilterOrderArgs } from '../types/config/fields';
+
+import { humanize } from './utils';
+import type { InitialisedList } from './core/initialise-lists';
 
 type ContextFunction<Return> = (context: KeystoneContext) => MaybePromise<Return>;
 

--- a/packages/core/src/lib/createGraphQLSchema.ts
+++ b/packages/core/src/lib/createGraphQLSchema.ts
@@ -1,9 +1,9 @@
 import { GraphQLNamedType, GraphQLSchema } from 'graphql';
 
-import type { KeystoneConfig } from '../types';
-import { KeystoneMeta } from '../admin-ui/system/adminMetaSchema';
 import { graphql } from '../types/schema';
-import type { AdminMetaRootVal } from '../admin-ui/system/createAdminMeta';
+import type { KeystoneConfig } from '../types';
+import { KeystoneMeta } from './admin-meta-resolver';
+import type { AdminMetaRootVal } from './create-admin-meta';
 import type { InitialisedList } from './core/initialise-lists';
 
 import { getMutationsForList } from './core/mutations';

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -2,9 +2,9 @@ import { randomBytes } from 'node:crypto';
 import pLimit from 'p-limit';
 import type { FieldData, KeystoneConfig } from '../types';
 
-import { createAdminMeta } from '../admin-ui/system/createAdminMeta';
 import type { PrismaModule } from '../artifacts';
 import { allowAll } from '../access';
+import { createAdminMeta } from './create-admin-meta';
 import { createGraphQLSchema } from './createGraphQLSchema';
 import { createContext } from './context/createContext';
 import { initialiseLists, InitialisedList } from './core/initialise-lists';

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -25,7 +25,7 @@ import {
 import type { KeystoneConfig } from '../types';
 import { initialiseLists } from '../lib/core/initialise-lists';
 import { printPrismaSchema } from '../lib/core/prisma-schema-printer';
-import type { AdminMetaRootVal } from '../admin-ui/system/createAdminMeta';
+import type { AdminMetaRootVal } from '../lib/create-admin-meta';
 import { pkgDir } from '../pkg-dir';
 import { ExitError } from './utils';
 import type { Flags } from './cli';


### PR DESCRIPTION
This pull request fixes `ui.isAccessAllowed`'s behaviour when `undefined` to be the same as the default AdminUI middleware.

The default AdminUI middleware prevents access to the AdminUI if a `sessionStrategy` has been defined, and a `.session` does not exist.

This is not what happens for the `adminMeta` GraphQL query, which falls back on public access if `isAccessAllowed` is undefined.
This would not impact users of the `auth` package, or any users that have defined `isAccessAllowed`.

This may impact users who are relying on the behaviour of providing **only** a `sessionStrategy`, and expecting `adminMeta` to be inaccessible by the public.
