### PR TITLE
Fix `keystone build` not exiting with versions of NextJS > 13.4.12

### DIFF
--- a/.changeset/next-build-exit.md
+++ b/.changeset/next-build-exit.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': minor
 ---
 
-Fixes `keystone build` hanging with latest versions of NextJS
+Fixes `keystone build` hanging with next version >13.4.12

--- a/.changeset/next-build-exit.md
+++ b/.changeset/next-build-exit.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Fixes `keystone build` hanging with latest versions of NextJS

--- a/.changeset/next-build-exit.md
+++ b/.changeset/next-build-exit.md
@@ -1,5 +1,5 @@
 ---
-'@keystone-6/core': minor
+'@keystone-6/core': patch
 ---
 
 Fixes `keystone build` hanging with next version >13.4.12

--- a/packages/core/src/admin-ui/components/CreateButtonLink.tsx
+++ b/packages/core/src/admin-ui/components/CreateButtonLink.tsx
@@ -5,7 +5,7 @@ import { jsx } from '@keystone-ui/core';
 import type { ListMeta } from '../../types';
 import { Link } from '../router';
 
-export function CreateButtonLink (props: { list: ListMeta }) {
+export function CreateButtonLink(props: { list: ListMeta }) {
   return (
     <Button
       css={{

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -85,7 +85,8 @@ export async function cli(cwd: string, argv: string[]) {
   }
 
   if (command === 'build') {
-    return build(cwd, defaultFlags(flags, { frozen: false, prisma: true, ui: true }));
+    return build(cwd, defaultFlags(flags, { frozen: false, prisma: true, ui: true }))
+      .then(() => process.exit(0))
   }
 
   if (command === 'start') {

--- a/packages/core/src/scripts/cli.ts
+++ b/packages/core/src/scripts/cli.ts
@@ -85,8 +85,9 @@ export async function cli(cwd: string, argv: string[]) {
   }
 
   if (command === 'build') {
-    return build(cwd, defaultFlags(flags, { frozen: false, prisma: true, ui: true }))
-      .then(() => process.exit(0))
+    return build(cwd, defaultFlags(flags, { frozen: false, prisma: true, ui: true })).then(() =>
+      process.exit(0)
+    );
   }
 
   if (command === 'start') {

--- a/packages/core/src/scripts/index.ts
+++ b/packages/core/src/scripts/index.ts
@@ -2,7 +2,6 @@ import { cli } from './cli';
 import { ExitError } from './utils';
 
 cli(process.cwd(), process.argv.slice(2))
-  .then(() => process.exit(0))
   .catch(err => {
     if (err instanceof ExitError) return process.exit(err.code);
 

--- a/packages/core/src/scripts/index.ts
+++ b/packages/core/src/scripts/index.ts
@@ -1,10 +1,9 @@
 import { cli } from './cli';
 import { ExitError } from './utils';
 
-cli(process.cwd(), process.argv.slice(2))
-  .catch(err => {
-    if (err instanceof ExitError) return process.exit(err.code);
+cli(process.cwd(), process.argv.slice(2)).catch(err => {
+  if (err instanceof ExitError) return process.exit(err.code);
 
-    console.error(err);
-    process.exit(1);
-  });
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/core/src/scripts/index.ts
+++ b/packages/core/src/scripts/index.ts
@@ -1,9 +1,11 @@
 import { cli } from './cli';
 import { ExitError } from './utils';
 
-cli(process.cwd(), process.argv.slice(2)).catch(err => {
-  if (err instanceof ExitError) return process.exit(err.code);
+cli(process.cwd(), process.argv.slice(2))
+  .then(() => process.exit(0))
+  .catch(err => {
+    if (err instanceof ExitError) return process.exit(err.code);
 
-  console.error(err);
-  process.exit(1);
-});
+    console.error(err);
+    process.exit(1);
+  });

--- a/tests/cli-tests/artifacts.test.ts
+++ b/tests/cli-tests/artifacts.test.ts
@@ -5,10 +5,8 @@ import {
   recordConsole,
   runCommand,
   schemas,
-  customPrismaKeystoneConfig,
   symlinkKeystoneDeps,
   testdir,
-  customGraphqlPathKeystoneConfig,
 } from './utils';
 
 describe.each(['postinstall', ['build', '--frozen'], ['prisma', 'migrate', 'status']])(

--- a/tests/cli-tests/utils.tsx
+++ b/tests/cli-tests/utils.tsx
@@ -35,16 +35,6 @@ export const schemas = {
   'schema.prisma': fs.readFileSync(`${__dirname}/fixtures/basic-project/schema.prisma`, 'utf8'),
 };
 
-export const customPrismaKeystoneConfig = fs.readFileSync(
-  `${__dirname}/fixtures/custom-prisma-project/keystone.ts`,
-  'utf8'
-);
-
-export const customGraphqlPathKeystoneConfig = fs.readFileSync(
-  `${__dirname}/fixtures/custom-graphql-path/keystone.ts`,
-  'utf8'
-);
-
 export function recordConsole() {
   let oldConsole = { ...console };
   const contents: string[] = [];


### PR DESCRIPTION
The PR adds a `process.exit(0)` after the next build in the `keystone build` cli.
Fixes #8760
Fixes #8581

This is required due to the use of the undocumented `next/dist/build` see - https://github.com/vercel/next.js/issues/54494