### PR TITLE
Use type guards for better type refinement in examples/usecase-blog-moderated

### DIFF
--- a/examples/auth/schema.ts
+++ b/examples/auth/schema.ts
@@ -55,7 +55,7 @@ function isAdmin({ session }: { session?: Session }) {
   return false;
 }
 
-export const lists: Lists = {
+export const lists: Lists<Session> = {
   User: list({
     access: {
       operation: {


### PR DESCRIPTION
This is a better demonstration on how you can ensure your `session` types for access control aren't repeatedly `?:` optional or `null`.
Whenever you can, you should attempt to refine the types down to their narrowest form.