### PR TITLE
Reword `sudo()` documentation to remove ambiguity

### DIFF
--- a/docs/pages/docs/context/overview.md
+++ b/docs/pages/docs/context/overview.md
@@ -105,7 +105,7 @@ The following functions will create a new `Context` object with this behaviour m
 
 `withRequest(req, res)`: A function which returns a new `Context` object with the `.session` determined by your `sessionStrategy.get` function.
 
-`withSession(newSession)`: A function which returns a new `Context` object with the `.session` object replaced with the `newSession` argument.
+`withSession(newSession)`: A function which returns a new `Context` object with the `.session` object replaced by the `newSession` argument.
 
 ### Database access
 

--- a/docs/pages/docs/context/overview.md
+++ b/docs/pages/docs/context/overview.md
@@ -101,7 +101,7 @@ See the [session API](../config/session#session-context) for more details.
 When using the `context.query`, `context.graphql.run`, and `context.graphql.raw` APIs, access control and session information is passed through to these calls from the `context` object.
 The following functions will create a new `Context` object with this behaviour modified.
 
-`sudo()`: A function which returns a new elevated `Context` object with all access control disabled and all filters enabled for subsequent API calls.
+`sudo()`: A function which returns an elevated `Context` object with any access control limitations removed, bypassing your `access` configuration.
 
 `withRequest(req, res)`: A function which returns a new user `Context` object with a session and access control based on the `req` given.
 

--- a/docs/pages/docs/context/overview.md
+++ b/docs/pages/docs/context/overview.md
@@ -101,11 +101,11 @@ See the [session API](../config/session#session-context) for more details.
 When using the `context.query`, `context.graphql.run`, and `context.graphql.raw` APIs, access control and session information is passed through to these calls from the `context` object.
 The following functions will create a new `Context` object with this behaviour modified.
 
-`sudo()`: A function which returns an elevated `Context` object with any access control limitations removed, bypassing your `access` configuration.
+`sudo()`: A function which returns a new `Context` object with access control limitations removed, bypassing your `access` control configuration.
 
-`withRequest(req, res)`: A function which returns a new user `Context` object with a session and access control based on the `req` given.
+`withRequest(req, res)`: A function which returns a new `Context` object with the `.session` determined by your `sessionStrategy.get` function.
 
-`withSession(newSession)`: A function which returns a new `Context` object with the `.session` object replaced with `newSession`.
+`withSession(newSession)`: A function which returns a new `Context` object with the `.session` object replaced with the `newSession` argument.
 
 ### Database access
 


### PR DESCRIPTION
The existing documentation mentions that `sudo()` has a side effect of

> all filters enabled for subsequent API calls

It is my opinion that this is ambiguous as to what `enabled` means, it is referring to an `allowAll` policy, but that is not what a reasonable expectation might be, despite being contradictory to the leading text:

> with all access control disabled

This removes that ambiguity to minimize any confusion around this.