### PR TITLE
Use required types internally for hooks

### DIFF
--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseListTypeInfo, KeystoneContext } from '@keystone-6/core/types';
+import type { BaseListTypeInfo, KeystoneContext } from '@keystone-6/core/types';
 
 export type AuthGqlNames = {
   CreateInitialInput: string;

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -380,7 +380,7 @@ async function resolveInputForCreateOrUpdate(
         // `hookArgs` based on the `operation` which will make `hookArgs.item`
         // be the right type for `originalItem` for the operation
         hookArgs.operation === 'create'
-          ? { ...hookArgs, item: updatedItem, originalItem: hookArgs.item }
+          ? { ...hookArgs, item: updatedItem, originalItem: undefined }
           : { ...hookArgs, item: updatedItem, originalItem: hookArgs.item }
       );
     },

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -299,13 +299,10 @@ async function getResolvedData(
   resolvedData = Object.fromEntries(
     await Promise.all(
       Object.entries(list.fields).map(async ([fieldKey, field]) => {
-        if (field.hooks.resolveInput === undefined) return [fieldKey, resolvedData[fieldKey]];
-
-        const resolver = field.hooks.resolveInput;
         try {
           return [
             fieldKey,
-            await resolver({
+            await field.hooks.resolveInput({
               ...hookArgs,
               resolvedData,
               fieldKey,

--- a/packages/core/src/lib/core/mutations/hooks.ts
+++ b/packages/core/src/lib/core/mutations/hooks.ts
@@ -7,22 +7,22 @@ export async function runSideEffectOnlyHook<
 >(list: InitialisedList, hookName: HookName, args: Args) {
   let shouldRunFieldLevelHook: (fieldKey: string) => boolean;
   if (args.operation === 'delete') {
-    // Always run field hooks for delete operations
+    // always run field hooks for delete operations
     shouldRunFieldLevelHook = () => true;
   } else {
-    // Only run field hooks on if the field was specified in the
-    // original input for create and update operations.
+    // only run field hooks on if the field was specified in the
+    //   original input for create and update operations.
     const inputDataKeys = new Set(Object.keys(args.inputData));
     shouldRunFieldLevelHook = fieldKey => inputDataKeys.has(fieldKey);
   }
 
-  // Field hooks
+  // field hooks
   const fieldsErrors: { error: Error; tag: string }[] = [];
   await Promise.all(
     Object.entries(list.fields).map(async ([fieldKey, field]) => {
       if (shouldRunFieldLevelHook(fieldKey)) {
         try {
-          await field.hooks[hookName]?.({ fieldKey, ...args } as any); // TODO: FIXME any
+          await field.hooks[hookName]({ fieldKey, ...args } as any); // TODO: FIXME any
         } catch (error: any) {
           fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.${hookName}` });
         }
@@ -34,9 +34,9 @@ export async function runSideEffectOnlyHook<
     throw extensionError(hookName, fieldsErrors);
   }
 
-  // List hooks
+  // list hooks
   try {
-    await list.hooks[hookName]?.(args as any); // TODO: FIXME any
+    await list.hooks[hookName](args as any); // TODO: FIXME any
   } catch (error: any) {
     throw extensionError(hookName, [{ error, tag: `${list.listKey}.hooks.${hookName}` }]);
   }

--- a/packages/core/src/lib/core/mutations/validation.ts
+++ b/packages/core/src/lib/core/mutations/validation.ts
@@ -22,7 +22,7 @@ export async function validateUpdateCreate({
       const addValidationError = (msg: string) =>
         messages.push(`${list.listKey}.${fieldKey}: ${msg}`);
       try {
-        await field.hooks.validateInput?.({ ...hookArgs, addValidationError, fieldKey });
+        await field.hooks.validateInput({ ...hookArgs, addValidationError, fieldKey });
       } catch (error: any) {
         fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.validateInput` });
       }
@@ -36,7 +36,7 @@ export async function validateUpdateCreate({
   // List validation hooks
   const addValidationError = (msg: string) => messages.push(`${list.listKey}: ${msg}`);
   try {
-    await list.hooks.validateInput?.({ ...hookArgs, addValidationError });
+    await list.hooks.validateInput({ ...hookArgs, addValidationError });
   } catch (error: any) {
     throw extensionError('validateInput', [{ error, tag: `${list.listKey}.hooks.validateInput` }]);
   }
@@ -62,7 +62,7 @@ export async function validateDelete({
       const addValidationError = (msg: string) =>
         messages.push(`${list.listKey}.${fieldKey}: ${msg}`);
       try {
-        await field.hooks.validateDelete?.({ ...hookArgs, addValidationError, fieldKey });
+        await field.hooks.validateDelete({ ...hookArgs, addValidationError, fieldKey });
       } catch (error: any) {
         fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.validateDelete` });
       }
@@ -74,7 +74,7 @@ export async function validateDelete({
   // List validation
   const addValidationError = (msg: string) => messages.push(`${list.listKey}: ${msg}`);
   try {
-    await list.hooks.validateDelete?.({ ...hookArgs, addValidationError });
+    await list.hooks.validateDelete({ ...hookArgs, addValidationError });
   } catch (error: any) {
     throw extensionError('validateDelete', [
       { error, tag: `${list.listKey}.hooks.validateDelete` },

--- a/packages/core/src/types/config/access-control.ts
+++ b/packages/core/src/types/config/access-control.ts
@@ -5,7 +5,7 @@ import type { BaseListTypeInfo } from '../type-info';
 export type BaseAccessArgs<ListTypeInfo extends BaseListTypeInfo> = {
   context: KeystoneContext<ListTypeInfo['all']>;
   session?: ListTypeInfo['all']['session'];
-  listKey: string;
+  listKey: ListTypeInfo['key'];
 };
 
 export type AccessOperation = 'create' | 'query' | 'update' | 'delete';

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -13,8 +13,8 @@ export type BaseFields<ListTypeInfo extends BaseListTypeInfo> = {
 export type FilterOrderArgs<ListTypeInfo extends BaseListTypeInfo> = {
   context: KeystoneContext<ListTypeInfo['all']>;
   session?: ListTypeInfo['all']['session'];
-  listKey: string;
-  fieldKey: string;
+  listKey: ListTypeInfo['key'];
+  fieldKey: ListTypeInfo['fields'];
 };
 
 export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -71,29 +71,14 @@ export type ListHooks<ListTypeInfo extends BaseListTypeInfo> = {
 };
 
 export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
-  /**
-   * Used to **modify the input** for create and update operations after default values and access control have been applied
-   */
   resolveInput: {
     create: ResolveInputListHook<ListTypeInfo, 'create'>;
     update: ResolveInputListHook<ListTypeInfo, 'update'>;
   };
-  /**
-   * Used to **validate the input** for create and update operations once all resolveInput hooks resolved
-   */
-  validateInput?: ValidateInputHook<ListTypeInfo>;
-  /**
-   * Used to **validate** that a delete operation can happen after access control has occurred
-   */
-  validateDelete?: ValidateDeleteHook<ListTypeInfo>;
-  /**
-   * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
-   */
-  beforeOperation?: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
-  /**
-   * Used to **cause side effects** after a create, update, or delete operation operation has occurred
-   */
-  afterOperation?: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
+  validateInput: ValidateInputHook<ListTypeInfo>;
+  validateDelete: ValidateDeleteHook<ListTypeInfo>;
+  beforeOperation: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
+  afterOperation: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
 };
 
 export type FieldHooks<
@@ -126,11 +111,16 @@ export type FieldHooks<
   afterOperation?: AfterOperationFieldHook<ListTypeInfo, FieldKey>;
 };
 
-// TODO: one day
-export type ResolvedFieldHooks<ListTypeInfo extends BaseListTypeInfo> = FieldHooks<
-  ListTypeInfo,
-  ListTypeInfo['fields']
->;
+export type ResolvedFieldHooks<
+  ListTypeInfo extends BaseListTypeInfo,
+  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields']
+> = {
+  resolveInput: ResolveInputFieldHook<ListTypeInfo, FieldKey>;
+  validateInput: ValidateInputFieldHook<ListTypeInfo, FieldKey>;
+  validateDelete: ValidateDeleteFieldHook<ListTypeInfo, FieldKey>;
+  beforeOperation: BeforeOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>;
+  afterOperation: AfterOperationFieldHook<ListTypeInfo, FieldKey>;
+};
 
 type ArgsForCreateOrUpdateOperation<ListTypeInfo extends BaseListTypeInfo> =
   | {

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -6,7 +6,7 @@ type CommonArgs<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * The key of the list that the operation is occurring on
    */
-  listKey: string;
+  listKey: ListTypeInfo['key'];
 };
 
 type ResolveInputListHook<

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -172,7 +172,7 @@ type ValidateInputHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & {
     addValidationError: (error: string) => void;
   } & CommonArgs<ListTypeInfo>
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type ValidateInputFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
@@ -181,7 +181,7 @@ type ValidateInputFieldHook<
   args: ArgsForCreateOrUpdateOperation<ListTypeInfo> & {
     addValidationError: (error: string) => void;
   } & CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type ValidateDeleteHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: {
@@ -189,7 +189,7 @@ type ValidateDeleteHook<ListTypeInfo extends BaseListTypeInfo> = (
     item: ListTypeInfo['item'];
     addValidationError: (error: string) => void;
   } & CommonArgs<ListTypeInfo>
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type ValidateDeleteFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
@@ -200,7 +200,7 @@ type ValidateDeleteFieldHook<
     item: ListTypeInfo['item'];
     addValidationError: (error: string) => void;
   } & CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type BeforeOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: (
@@ -213,7 +213,7 @@ type BeforeOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
       }
   ) &
     CommonArgs<ListTypeInfo>
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type BeforeOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
@@ -229,7 +229,7 @@ type BeforeOperationFieldHook<
       }
   ) &
     CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type AfterOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
   args: (
@@ -276,7 +276,7 @@ type AfterOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
       }
   ) &
     CommonArgs<ListTypeInfo>
-) => Promise<void> | void;
+) => MaybePromise<void>;
 
 type AfterOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
@@ -326,4 +326,4 @@ type AfterOperationFieldHook<
       }
   ) &
     CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
-) => Promise<void> | void;
+) => MaybePromise<void>;

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -63,11 +63,11 @@ export type ListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
    */
-  beforeOperation?: BeforeOperationHook<ListTypeInfo>;
+  beforeOperation?: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
-  afterOperation?: AfterOperationHook<ListTypeInfo>;
+  afterOperation?: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
 };
 
 export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
@@ -89,11 +89,11 @@ export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
    */
-  beforeOperation?: BeforeOperationHook<ListTypeInfo>;
+  beforeOperation?: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
-  afterOperation?: AfterOperationHook<ListTypeInfo>;
+  afterOperation?: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
 };
 
 export type FieldHooks<
@@ -115,7 +115,11 @@ export type FieldHooks<
   /**
    * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
    */
-  beforeOperation?: BeforeOperationFieldHook<ListTypeInfo, FieldKey>;
+  beforeOperation?: BeforeOperationFieldHook<
+    ListTypeInfo,
+    'create' | 'update' | 'delete',
+    FieldKey
+  >;
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
@@ -202,79 +206,142 @@ type ValidateDeleteFieldHook<
   } & CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
 ) => MaybePromise<void>;
 
-type BeforeOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
-  args: (
-    | ArgsForCreateOrUpdateOperation<ListTypeInfo>
-    | {
-        operation: 'delete';
-        item: ListTypeInfo['item'];
-        inputData: undefined;
-        resolvedData: undefined;
-      }
-  ) &
+type BeforeOperationListHook<
+  ListTypeInfo extends BaseListTypeInfo,
+  Operation extends 'create' | 'update' | 'delete'
+> = (
+  args: {
+    create: {
+      operation: 'create';
+      item: undefined;
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['create'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['create'];
+    };
+    update: {
+      operation: 'update';
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['update'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['update'];
+    };
+    delete: {
+      operation: 'delete';
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: undefined;
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: undefined;
+    };
+  }[Operation] &
     CommonArgs<ListTypeInfo>
 ) => MaybePromise<void>;
 
 type BeforeOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
+  Operation extends 'create' | 'update' | 'delete',
   FieldKey extends ListTypeInfo['fields']
 > = (
-  args: (
-    | ArgsForCreateOrUpdateOperation<ListTypeInfo>
-    | {
-        operation: 'delete';
-        item: ListTypeInfo['item'];
-        inputData: undefined;
-        resolvedData: undefined;
-      }
-  ) &
+  args: {
+    create: {
+      operation: 'create';
+      item: undefined;
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['create'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['create'];
+    };
+    update: {
+      operation: 'update';
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['update'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['update'];
+    };
+    delete: {
+      operation: 'delete';
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: undefined;
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: undefined;
+    };
+  }[Operation] &
     CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
 ) => MaybePromise<void>;
 
-type AfterOperationHook<ListTypeInfo extends BaseListTypeInfo> = (
-  args: (
-    | {
-        operation: 'create';
-        originalItem: undefined;
-        // technically this will never actually exist for a create
-        // but making it optional rather than not here
-        // makes for a better experience
-        // because then people will see the right type even if they haven't refined the type of operation to 'create'
-        item?: ListTypeInfo['item'];
-        /**
-         * The GraphQL input **before** default values are applied
-         */
-        inputData: ListTypeInfo['inputs']['create'];
-        /**
-         * The GraphQL input **after** being resolved by the field type's input resolver
-         */
-        resolvedData: ListTypeInfo['prisma']['create'];
-      }
-    | {
-        operation: 'update';
-        item: ListTypeInfo['item'];
-        originalItem: ListTypeInfo['item'];
-        /**
-         * The GraphQL input **before** default values are applied
-         */
-        inputData: ListTypeInfo['inputs']['update'];
-        /**
-         * The GraphQL input **after** being resolved by the field type's input resolver
-         */
-        resolvedData: ListTypeInfo['prisma']['update'];
-      }
-    | {
-        operation: 'delete';
-        // technically this will never actually exist for a delete
-        // but making it optional rather than not here
-        // makes for a better experience
-        // because then people will see the right type even if they haven't refined the type of operation to 'delete'
-        item: undefined;
-        originalItem: ListTypeInfo['item'];
-        inputData: undefined;
-        resolvedData: undefined;
-      }
-  ) &
+type AfterOperationListHook<
+  ListTypeInfo extends BaseListTypeInfo,
+  Operation extends 'create' | 'update' | 'delete'
+> = (
+  args: {
+    create: {
+      operation: 'create';
+      originalItem: undefined;
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['create'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['create'];
+    };
+    update: {
+      operation: 'update';
+      originalItem: ListTypeInfo['item'];
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['update'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['update'];
+    };
+    delete: {
+      operation: 'delete';
+      originalItem: ListTypeInfo['item'];
+      item: undefined;
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: undefined;
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: undefined;
+    };
+  }[Operation] &
     CommonArgs<ListTypeInfo>
 ) => MaybePromise<void>;
 


### PR DESCRIPTION
As the title suggests, this pull requests changes the types of the resolved hooks to always be `required` and easily and consistently differentiable.  The type verbosity has increased a little, but that has thankfully decreased the complexity of reading the hook types.