### PR TITLE
Use `workspace:^` for internal `devDependencies`

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -31,7 +31,7 @@
     "graphql": "^16.6.0"
   },
   "devDependencies": {
-    "@keystone-6/core": "^5.4.0",
+    "@keystone-6/core": "workspace:^",
     "react": "^18.2.0"
   },
   "peerDependencies": {

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -31,10 +31,8 @@
   "devDependencies": {
     "@keystone-6/core": "^5.4.0",
     "@types/express": "^4.17.14",
-    "@types/mime": "^3.0.0",
     "graphql": "^16.6.0",
-    "graphql-upload": "^15.0.2",
-    "mime": "^3.0.0"
+    "graphql-upload": "^15.0.2"
   },
   "preconstruct": {
     "entrypoints": [

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -29,7 +29,7 @@
     "@keystone-6/core": "^5.0.0"
   },
   "devDependencies": {
-    "@keystone-6/core": "^5.4.0",
+    "@keystone-6/core": "workspace:^",
     "@types/express": "^4.17.14",
     "graphql": "^16.6.0",
     "graphql-upload": "^15.0.2"

--- a/packages/cloudinary/src/test-fixtures.skip.ts
+++ b/packages/cloudinary/src/test-fixtures.skip.ts
@@ -1,11 +1,9 @@
-import fs from 'fs';
-import mime from 'mime';
+import { createReadStream } from 'node:fs';
+import { resolve, basename } from 'node:path';
 // @ts-ignore
 import Upload from 'graphql-upload/Upload.js';
 import cloudinary from 'cloudinary';
 import { cloudinaryImage } from './index';
-
-const path = require('path');
 
 cloudinary.v2.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME || 'cloudinary_cloud_name',
@@ -13,18 +11,17 @@ cloudinary.v2.config({
   api_secret: process.env.CLOUDINARY_SECRET || 'cloudinary_secret',
 });
 
-const prepareFile = (_filePath: string) => {
-  const filePath = path.resolve(`packages/cloudinary/src/test-files/${_filePath}`);
+function prepareFile(path_: string) {
+  const path = resolve(`packages/cloudinary/src/test-files/${path_}`);
   const upload = new Upload();
   upload.resolve({
-    createReadStream: () => fs.createReadStream(filePath),
-    filename: path.basename(filePath),
-    // @ts-ignore
-    mimetype: mime.getType(filePath),
+    createReadStream: () => createReadStream(path),
+    filename: basename(path),
+    mimetype: 'image/jpeg',
     encoding: 'utf-8',
   });
   return upload;
-};
+}
 
 // Configurations
 export const name = 'CloudinaryImage';

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -44,9 +44,7 @@
       "structure-views.tsx"
     ]
   },
-  "peerDependencies": {
-    "@keystone-6/core": "^5.0.0"
-  },
+  "repository": "https://github.com/keystonejs/keystone/tree/main/packages/fields-document",
   "dependencies": {
     "@babel/runtime": "^7.16.3",
     "@braintree/sanitize-url": "^6.0.1",
@@ -81,14 +79,15 @@
     "slate-history": "^0.93.0",
     "slate-react": "^0.97.1"
   },
-  "repository": "https://github.com/keystonejs/keystone/tree/main/packages/fields-document",
   "devDependencies": {
-    "@keystone-6/core": "*",
+    "@keystone-6/core": "workspace:^",
     "@testing-library/react": "^14.0.0",
     "@types/is-hotkey": "^0.1.7",
-    "array.prototype.flat": "^1.2.5",
     "jest-diff": "^29.0.0",
     "pretty-format": "^29.0.0",
     "slate-hyperscript": "^0.81.3"
+  },
+  "peerDependencies": {
+    "@keystone-6/core": "^5.0.0"
   }
 }

--- a/packages/fields-document/src/DocumentEditor/tests/jsx/impl.ts
+++ b/packages/fields-document/src/DocumentEditor/tests/jsx/impl.ts
@@ -1,7 +1,4 @@
-// slate-hyperscript depends on Array.prototype.flat
-import 'array.prototype.flat/auto';
 import { createHyperscript } from 'slate-hyperscript';
-
 import { editorSchema } from '../../index';
 
 const blockTypes: Record<string, { type: string }> = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1835,7 +1835,7 @@ importers:
         version: 16.6.0
     devDependencies:
       '@keystone-6/core':
-        specifier: ^5.4.0
+        specifier: workspace:^
         version: link:../core
       react:
         specifier: ^18.2.0
@@ -1869,23 +1869,17 @@ importers:
         version: 18.2.0
     devDependencies:
       '@keystone-6/core':
-        specifier: ^5.4.0
+        specifier: workspace:^
         version: link:../core
       '@types/express':
         specifier: ^4.17.14
         version: 4.17.14
-      '@types/mime':
-        specifier: ^3.0.0
-        version: 3.0.0
       graphql:
         specifier: ^16.6.0
         version: 16.6.0
       graphql-upload:
         specifier: ^15.0.2
         version: 15.0.2(@types/express@4.17.14)(graphql@16.6.0)
-      mime:
-        specifier: ^3.0.0
-        version: 3.0.0
 
   packages/core:
     dependencies:
@@ -2237,7 +2231,7 @@ importers:
         version: 0.97.1(react-dom@18.2.0)(react@18.2.0)(slate@0.94.1)
     devDependencies:
       '@keystone-6/core':
-        specifier: '*'
+        specifier: workspace:^
         version: link:../core
       '@testing-library/react':
         specifier: ^14.0.0
@@ -2245,9 +2239,6 @@ importers:
       '@types/is-hotkey':
         specifier: ^0.1.7
         version: 0.1.7
-      array.prototype.flat:
-        specifier: ^1.2.5
-        version: 1.2.5
       jest-diff:
         specifier: ^29.0.0
         version: 29.0.0
@@ -10961,10 +10952,6 @@ packages:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==}
     dev: false
 
-  /@types/mime@3.0.0:
-    resolution: {integrity: sha512-fccbsHKqFDXClBZTDLA43zl0+TbxyIwyzIzwwhvoJvhNjOErCdeX2xJbURimv2EbSVUGav001PaCJg4mZxMl4w==}
-    dev: true
-
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
 
@@ -11840,15 +11827,6 @@ packages:
   /array-unique@0.3.2:
     resolution: {integrity: sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /array.prototype.flat@1.2.5:
-    resolution: {integrity: sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
     dev: true
 
   /array.prototype.flat@1.3.1:


### PR DESCRIPTION
This uses `workspace:^` to reduce the number of `devDependencies` - in the monorepo - that need to be updated when bumping our package versions.

Additionally some unused or unnecessary packages have been removed.