### PR TITLE
Fix types for validateInput hook arguments on update operations

### DIFF
--- a/.changeset/odd-lemons-hide.md
+++ b/.changeset/odd-lemons-hide.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixes types for validateInput hook arguments on update operations
+Fixes hooks.validateInput argument types for update operations

--- a/.changeset/odd-lemons-hide.md
+++ b/.changeset/odd-lemons-hide.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fixes types for validateInput hook arguments on update operations

--- a/examples/hooks/schema.graphql
+++ b/examples/hooks/schema.graphql
@@ -107,10 +107,6 @@ input PostUpdateInput {
   title: String!
   content: String!
   preventDelete: Boolean
-  createdBy: String
-  createdAt: DateTime
-  updatedBy: String
-  updatedAt: DateTime
 }
 
 input PostUpdateArgs {
@@ -122,10 +118,6 @@ input PostCreateInput {
   title: String! = ""
   content: String! = ""
   preventDelete: Boolean
-  createdBy: String
-  createdAt: DateTime
-  updatedBy: String
-  updatedAt: DateTime
 }
 
 """

--- a/examples/hooks/schema.graphql
+++ b/examples/hooks/schema.graphql
@@ -5,6 +5,7 @@ type Post {
   id: ID!
   title: String
   content: String
+  feedback: String
   preventDelete: Boolean
   createdBy: String
   createdAt: DateTime
@@ -25,6 +26,7 @@ input PostWhereInput {
   id: IDFilter
   title: StringFilter
   content: StringFilter
+  feedback: StringFilter
   preventDelete: BooleanFilter
   createdBy: StringFilter
   createdAt: DateTimeNullableFilter
@@ -91,6 +93,7 @@ input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
   content: OrderDirection
+  feedback: OrderDirection
   preventDelete: OrderDirection
   createdBy: OrderDirection
   createdAt: OrderDirection
@@ -106,6 +109,7 @@ enum OrderDirection {
 input PostUpdateInput {
   title: String!
   content: String!
+  feedback: String
   preventDelete: Boolean
 }
 

--- a/examples/hooks/schema.prisma
+++ b/examples/hooks/schema.prisma
@@ -16,6 +16,7 @@ model Post {
   id            String    @id @default(cuid())
   title         String    @default("")
   content       String    @default("")
+  feedback      String    @default("")
   preventDelete Boolean   @default(false)
   createdBy     String    @default("")
   createdAt     DateTime?

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -39,11 +39,30 @@ export const lists: Lists = {
       // we use isNonNull for these fields to enforce that they are always provided, and validated against a content filter
       title: text({
         validation: { isRequired: true },
-        graphql: { isNonNull: { create: true, update: true } },
+        graphql: {
+          isNonNull: {
+            create: true,
+            update: true
+          }
+        },
+
       }),
       content: text({
         validation: { isRequired: true },
-        graphql: { isNonNull: { create: true, update: true } },
+        graphql: {
+          isNonNull: {
+            create: true,
+            update: true
+          }
+        },
+      }),
+      feedback: text({
+        validation: { isRequired: true },
+        graphql: {
+          omit: {
+            create: true
+          }
+        },
       }),
       preventDelete: checkbox(),
 
@@ -112,8 +131,13 @@ export const lists: Lists = {
           return resolvedData;
         },
       },
-      validateInput: ({ context, inputData, addValidationError }) => {
+      validateInput: ({ context, operation, inputData, addValidationError }) => {
         const { title, content } = inputData;
+
+        if (operation === 'update') {
+          const { feedback } = inputData;
+          if (/profanity/i.test(feedback)) return addValidationError('Unacceptable feedback');
+        }
 
         // an example of a content filter, the prevents the title or content containing the word "Profanity"
         if (/profanity/i.test(title)) return addValidationError('Unacceptable title');

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -16,8 +16,8 @@ const readOnly = {
   graphql: {
     omit: {
       create: true,
-      update: true
-    }
+      update: true,
+    },
   },
   ui: {
     createView: {
@@ -42,26 +42,25 @@ export const lists: Lists = {
         graphql: {
           isNonNull: {
             create: true,
-            update: true
-          }
+            update: true,
+          },
         },
-
       }),
       content: text({
         validation: { isRequired: true },
         graphql: {
           isNonNull: {
             create: true,
-            update: true
-          }
+            update: true,
+          },
         },
       }),
       feedback: text({
         validation: { isRequired: true },
         graphql: {
           omit: {
-            create: true
-          }
+            create: true,
+          },
         },
       }),
       preventDelete: checkbox(),

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -13,6 +13,12 @@ const readOnly = {
     create: denyAll,
     update: denyAll,
   },
+  graphql: {
+    omit: {
+      create: true,
+      update: true
+    }
+  },
   ui: {
     createView: {
       fieldMode: (args: unknown) => 'hidden' as const,

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -134,9 +134,9 @@ export const lists: Lists = {
       validateInput: ({ context, operation, inputData, addValidationError }) => {
         const { title, content } = inputData;
 
-        if (operation === 'update') {
+        if (operation === 'update' && 'feedback' in inputData) {
           const { feedback } = inputData;
-          if (/profanity/i.test(feedback)) return addValidationError('Unacceptable feedback');
+          if (/profanity/i.test(feedback ?? '')) return addValidationError('Unacceptable feedback');
         }
 
         // an example of a content filter, the prevents the title or content containing the word "Profanity"

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -184,11 +184,11 @@ type ValidateHook<
       /**
        * The GraphQL input **before** default values are applied
        */
-      inputData: ListTypeInfo['inputs']['create'];
+      inputData: ListTypeInfo['inputs']['update'];
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
-      resolvedData: ListTypeInfo['prisma']['create'];
+      resolvedData: ListTypeInfo['prisma']['update'];
       addValidationError: (error: string) => void;
     };
     delete: {
@@ -227,11 +227,11 @@ type ValidateFieldHook<
       /**
        * The GraphQL input **before** default values are applied
        */
-      inputData: ListTypeInfo['inputs']['create'];
+      inputData: ListTypeInfo['inputs']['update'];
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
-      resolvedData: ListTypeInfo['prisma']['create'];
+      resolvedData: ListTypeInfo['prisma']['update'];
       addValidationError: (error: string) => void;
     };
     delete: {


### PR DESCRIPTION
looks like these were updated incorrectly in #8808. Checked the other types and these appeared to be the only incorrect ones.

didn't create an issue/repro case since it seems to be a pretty straightforward bug/typo, though if I need to create an issue/repro let me know and I can do that 😄 I did vet out this change in my project via patch-package.