### PR TITLE
chore(next.config): ScottAgirs: remove deprecated `appDir` flag

### DIFF
--- a/.changeset/strong-swans-destroy.md
+++ b/.changeset/strong-swans-destroy.md
@@ -1,6 +1,5 @@
 ---
-'@keystone-6/example-framework-nextjs-app-directory': patch
 '@keystone-6/core': patch
 ---
 
-Removed deprecated appDir flag from next.config
+Removed deprecated `experimental.appDir` flag from generated next.config

--- a/.changeset/strong-swans-destroy.md
+++ b/.changeset/strong-swans-destroy.md
@@ -1,0 +1,6 @@
+---
+'@keystone-6/example-framework-nextjs-app-directory': patch
+'@keystone-6/core': patch
+---
+
+Removed deprecated appDir flag from next.config

--- a/examples/framework-nextjs-app-directory/next.config.mjs
+++ b/examples/framework-nextjs-app-directory/next.config.mjs
@@ -3,8 +3,6 @@ import withPreconstruct from '@preconstruct/next';
 
 export default withPreconstruct({
   experimental: {
-    appDir: true,
-
     // without this, 'Error: Expected Upload to be a GraphQL nullable type.'
     serverComponentsExternalPackages: ['graphql'],
   },

--- a/packages/core/src/admin-ui/templates/next-config.ts
+++ b/packages/core/src/admin-ui/templates/next-config.ts
@@ -6,9 +6,6 @@ export const nextConfigTemplate = (basePath?: string) =>
     eslint: {
       ignoreDuringBuilds: true,
     },
-    experimental: {
-      appDir: false,
-    },
     // We use transpilePackages for the custom admin-ui pages in the ./admin folder
     // as they import ts files into nextjs
     transpilePackages: ['../../admin'],


### PR DESCRIPTION
It appears to me that the flag can be removed to cleanup the warning as per the below screenshot(?)

<img width="1022" alt="Screenshot 2023-09-22 at 6 39 44 AM" src="https://github.com/keystonejs/keystone/assets/11737572/4ac9bfe5-0537-487d-9d48-d6cf02c31a28">
