### PR TITLE
Add `beforeOperation.[create|update|delete]` and `afterOperation.[create|update|delete]` operation routing for list hooks

### DIFF
--- a/.changeset/odd-lemons-hide.md
+++ b/.changeset/odd-lemons-hide.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fixes hooks.validateInput argument types for update operations
+Fixes `hooks.validateInput` argument types for update operations

--- a/.changeset/refine-hook-types.md
+++ b/.changeset/refine-hook-types.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add `beforeOperation.[create|update|delete]` and `afterOperation.[create|update|delete]` operation routing for list hooks

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -148,11 +148,23 @@ export const lists: Lists = {
         // an example of a content filter, the prevents the title or content containing the word "Profanity"
         if (preventDelete) return addValidationError('Cannot delete Post, preventDelete is true');
       },
-      beforeOperation: ({ resolvedData, operation }) => {
-        console.log(`Post ${operation}`, resolvedData);
+
+      beforeOperation: ({ item, resolvedData, operation }) => {
+        console.log(`Post beforeOperation.${operation}`, resolvedData);
       },
-      afterOperation: ({ resolvedData, operation }) => {
-        console.log(`Post ${operation}`, resolvedData);
+
+      afterOperation: {
+        create: ({ inputData, item }) => {
+          console.log(`Post afterOperation.create`, inputData, '->', item);
+        },
+
+        update: ({ originalItem, item }) => {
+          console.log(`Post afterOperation.update`, originalItem, '->', item);
+        },
+
+        delete: ({ originalItem }) => {
+          console.log(`Post afterOperation.delete`, originalItem, '-> deleted');
+        },
       },
     },
   }),

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -48,9 +48,9 @@ export type InitialisedField = {
     cacheHint: CacheHint | undefined;
   };
   ui: {
-    label: string;
-    description: string;
-    views: string;
+    label: string | null;
+    description: string | null;
+    views: string | null;
     createView: {
       fieldMode: MaybeSessionFunction<'edit' | 'hidden', any>;
     };
@@ -348,9 +348,9 @@ function getListsWithInitialisedFields(
           },
         },
         ui: {
-          label: f.label ?? '',
-          description: f.ui?.description ?? '',
-          views: f.ui?.views ?? '',
+          label: f.label ?? null,
+          description: f.ui?.description ?? null,
+          views: f.ui?.views ?? null,
           createView: {
             fieldMode: _isEnabled.create ? fieldModes.create : 'hidden',
           },

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -247,11 +247,22 @@ function parseFieldHooks(
   hooks: FieldHooks<BaseListTypeInfo>
 ): ResolvedFieldHooks<BaseListTypeInfo> {
   return {
-    resolveInput: hooks.resolveInput ?? defaultFieldHooksResolveInput,
+    resolveInput: {
+      create: hooks.resolveInput ?? defaultFieldHooksResolveInput,
+      update: hooks.resolveInput ?? defaultFieldHooksResolveInput,
+    },
     validateInput: hooks.validateInput ?? defaultOperationHook,
     validateDelete: hooks.validateDelete ?? defaultOperationHook,
-    beforeOperation: hooks.beforeOperation ?? defaultOperationHook,
-    afterOperation: hooks.afterOperation ?? defaultOperationHook,
+    beforeOperation: {
+      create: hooks.beforeOperation ?? defaultOperationHook,
+      update: hooks.beforeOperation ?? defaultOperationHook,
+      delete: hooks.beforeOperation ?? defaultOperationHook,
+    },
+    afterOperation: {
+      create: hooks.afterOperation ?? defaultOperationHook,
+      update: hooks.afterOperation ?? defaultOperationHook,
+      delete: hooks.afterOperation ?? defaultOperationHook,
+    },
   };
 }
 

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -48,7 +48,7 @@ export type InitialisedField = {
     cacheHint: CacheHint | undefined;
   };
   ui: {
-    label: string; // TODO: move to ui
+    label: string;
     description: string;
     views: string;
     createView: {

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -352,7 +352,6 @@ function getListsWithInitialisedFields(
           description: f.ui?.description ?? '',
           views: f.ui?.views ?? '',
           createView: {
-            ...f.ui?.createView, // copy
             fieldMode: _isEnabled.create ? fieldModes.create : 'hidden',
           },
 
@@ -366,7 +365,6 @@ function getListsWithInitialisedFields(
           },
 
           listView: {
-            ...f.ui?.listView, // copy
             fieldMode: _isEnabled.read ? fieldModes.list : 'hidden',
           },
         },

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -176,15 +176,6 @@ function defaultOperationHook() {}
 function defaultListHooksResolveInput({ resolvedData }: { resolvedData: any }) {
   return resolvedData;
 }
-function defaultFieldHooksResolveInput({
-  resolvedData,
-  fieldKey,
-}: {
-  resolvedData: any;
-  fieldKey: string;
-}) {
-  return resolvedData[fieldKey];
-}
 
 function parseListHooksResolveInput(f: ListHooks<BaseListTypeInfo>['resolveInput']) {
   if (typeof f === 'function') {
@@ -198,13 +189,57 @@ function parseListHooksResolveInput(f: ListHooks<BaseListTypeInfo>['resolveInput
   return { create, update };
 }
 
+function parseListHooksBeforeOperation(f: ListHooks<BaseListTypeInfo>['beforeOperation']) {
+  if (typeof f === 'function') {
+    return {
+      create: f,
+      update: f,
+      delete: f,
+    };
+  }
+
+  const {
+    create = defaultOperationHook,
+    update = defaultOperationHook,
+    delete: _delete = defaultOperationHook,
+  } = f ?? {};
+  return { create, update, delete: _delete };
+}
+
+function parseListHooksAfterOperation(f: ListHooks<BaseListTypeInfo>['afterOperation']) {
+  if (typeof f === 'function') {
+    return {
+      create: f,
+      update: f,
+      delete: f,
+    };
+  }
+
+  const {
+    create = defaultOperationHook,
+    update = defaultOperationHook,
+    delete: _delete = defaultOperationHook,
+  } = f ?? {};
+  return { create, update, delete: _delete };
+}
+
+function defaultFieldHooksResolveInput({
+  resolvedData,
+  fieldKey,
+}: {
+  resolvedData: any;
+  fieldKey: string;
+}) {
+  return resolvedData[fieldKey];
+}
+
 function parseListHooks(hooks: ListHooks<BaseListTypeInfo>): ResolvedListHooks<BaseListTypeInfo> {
   return {
     resolveInput: parseListHooksResolveInput(hooks.resolveInput),
     validateInput: hooks.validateInput ?? defaultOperationHook,
     validateDelete: hooks.validateDelete ?? defaultOperationHook,
-    beforeOperation: hooks.beforeOperation ?? defaultOperationHook,
-    afterOperation: hooks.afterOperation ?? defaultOperationHook,
+    beforeOperation: parseListHooksBeforeOperation(hooks.beforeOperation),
+    afterOperation: parseListHooksAfterOperation(hooks.afterOperation),
   };
 }
 

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -302,11 +302,17 @@ async function getResolvedData(
         try {
           return [
             fieldKey,
-            await field.hooks.resolveInput({
-              ...hookArgs,
-              resolvedData,
-              fieldKey,
-            }),
+            operation === 'create'
+              ? await field.hooks.resolveInput.create({
+                  ...hookArgs,
+                  resolvedData,
+                  fieldKey,
+                })
+              : await field.hooks.resolveInput.update({
+                  ...hookArgs,
+                  resolvedData,
+                  fieldKey,
+                }),
           ];
         } catch (error: any) {
           fieldsErrors.push({

--- a/packages/core/src/lib/core/mutations/hooks.ts
+++ b/packages/core/src/lib/core/mutations/hooks.ts
@@ -36,7 +36,7 @@ export async function runSideEffectOnlyHook<
 
   // list hooks
   try {
-    await list.hooks[hookName](args as any); // TODO: FIXME any
+    await list.hooks[hookName][operation](args as any); // TODO: FIXME any
   } catch (error: any) {
     throw extensionError(hookName, [{ error, tag: `${list.listKey}.hooks.${hookName}` }]);
   }

--- a/packages/core/src/lib/core/mutations/hooks.ts
+++ b/packages/core/src/lib/core/mutations/hooks.ts
@@ -22,7 +22,7 @@ export async function runSideEffectOnlyHook<
     Object.entries(list.fields).map(async ([fieldKey, field]) => {
       if (shouldRunFieldLevelHook(fieldKey)) {
         try {
-          await field.hooks[hookName]({ fieldKey, ...args } as any); // TODO: FIXME any
+          await field.hooks[hookName][operation]({ fieldKey, ...args } as any); // TODO: FIXME any
         } catch (error: any) {
           fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.${hookName}` });
         }

--- a/packages/core/src/lib/core/mutations/hooks.ts
+++ b/packages/core/src/lib/core/mutations/hooks.ts
@@ -3,10 +3,14 @@ import type { InitialisedList } from '../initialise-lists';
 
 export async function runSideEffectOnlyHook<
   HookName extends 'beforeOperation' | 'afterOperation',
-  Args extends Parameters<NonNullable<InitialisedList['hooks'][HookName]>>[0]
+  Args extends Parameters<
+    NonNullable<InitialisedList['hooks'][HookName]['create' | 'update' | 'delete']>
+  >[0]
 >(list: InitialisedList, hookName: HookName, args: Args) {
+  const { operation } = args;
+
   let shouldRunFieldLevelHook: (fieldKey: string) => boolean;
-  if (args.operation === 'delete') {
+  if (operation === 'delete') {
     // always run field hooks for delete operations
     shouldRunFieldLevelHook = () => true;
   } else {

--- a/packages/core/src/lib/create-admin-meta.ts
+++ b/packages/core/src/lib/create-admin-meta.ts
@@ -194,8 +194,8 @@ export function createAdminMeta(
 
       const fieldMeta = {
         key: fieldKey,
-        label: field.label ?? humanize(fieldKey),
-        description: field.ui?.description ?? null,
+        label: field.ui.label ?? humanize(fieldKey),
+        description: field.ui.description ?? null,
         viewsIndex: getViewId(field.views),
         customViewsIndex:
           field.ui?.views === undefined

--- a/packages/core/src/lib/create-admin-meta.ts
+++ b/packages/core/src/lib/create-admin-meta.ts
@@ -198,7 +198,7 @@ export function createAdminMeta(
         description: field.ui.description ?? null,
         viewsIndex: getViewId(field.views),
         customViewsIndex:
-          field.ui?.views === undefined
+          field.ui.views === null
             ? null
             : (assertValidView(field.views, `lists.${listKey}.fields.${fieldKey}.ui.views`),
               getViewId(field.ui.views)),
@@ -206,14 +206,14 @@ export function createAdminMeta(
         listKey: listKey,
         search: list.ui.searchableFields.get(fieldKey) ?? null,
         createView: {
-          fieldMode: normalizeMaybeSessionFunction(field.ui?.createView.fieldMode),
+          fieldMode: normalizeMaybeSessionFunction(field.ui.createView.fieldMode),
         },
         itemView: {
-          fieldMode: field.ui?.itemView.fieldMode,
-          fieldPosition: field.ui?.itemView?.fieldPosition || 'form',
+          fieldMode: field.ui.itemView.fieldMode,
+          fieldPosition: field.ui.itemView.fieldPosition,
         },
         listView: {
-          fieldMode: normalizeMaybeSessionFunction(field.ui?.listView?.fieldMode),
+          fieldMode: normalizeMaybeSessionFunction(field.ui.listView.fieldMode),
         },
         isFilterable: normalizeIsOrderFilter(
           field.input?.where ? field.graphql.isEnabled.filter : false,

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -20,7 +20,7 @@ export type FilterOrderArgs<ListTypeInfo extends BaseListTypeInfo> = {
 export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
   access?: FieldAccessControl<ListTypeInfo>;
   hooks?: FieldHooks<ListTypeInfo, ListTypeInfo['fields']>;
-  label?: string;
+  label?: string; // TODO: move to ui?
   ui?: {
     description?: string;
     views?: string;

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -65,11 +65,23 @@ export type ListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
    */
-  beforeOperation?: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
+  beforeOperation?:
+    | BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>
+    | {
+        create?: BeforeOperationListHook<ListTypeInfo, 'create'>;
+        update?: BeforeOperationListHook<ListTypeInfo, 'update'>;
+        delete?: BeforeOperationListHook<ListTypeInfo, 'delete'>;
+      };
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
-  afterOperation?: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
+  afterOperation?:
+    | AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>
+    | {
+        create?: AfterOperationListHook<ListTypeInfo, 'create'>;
+        update?: AfterOperationListHook<ListTypeInfo, 'update'>;
+        delete?: AfterOperationListHook<ListTypeInfo, 'delete'>;
+      };
 };
 
 export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
@@ -79,8 +91,16 @@ export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   };
   validateInput: ValidateHook<ListTypeInfo, 'create' | 'update'>;
   validateDelete: ValidateHook<ListTypeInfo, 'delete'>;
-  beforeOperation: BeforeOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
-  afterOperation: AfterOperationListHook<ListTypeInfo, 'create' | 'update' | 'delete'>;
+  beforeOperation: {
+    create: BeforeOperationListHook<ListTypeInfo, 'create'>;
+    update: BeforeOperationListHook<ListTypeInfo, 'update'>;
+    delete: BeforeOperationListHook<ListTypeInfo, 'delete'>;
+  };
+  afterOperation: {
+    create: AfterOperationListHook<ListTypeInfo, 'create'>;
+    update: AfterOperationListHook<ListTypeInfo, 'update'>;
+    delete: AfterOperationListHook<ListTypeInfo, 'delete'>;
+  };
 };
 
 export type FieldHooks<

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -130,18 +130,29 @@ export type FieldHooks<
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
-  afterOperation?: AfterOperationFieldHook<ListTypeInfo, FieldKey>;
+  afterOperation?: AfterOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>;
 };
 
 export type ResolvedFieldHooks<
   ListTypeInfo extends BaseListTypeInfo,
   FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields']
 > = {
-  resolveInput: ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>;
+  resolveInput: {
+    create: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>;
+    update: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>;
+  };
   validateInput: ValidateFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>;
   validateDelete: ValidateFieldHook<ListTypeInfo, 'delete', FieldKey>;
-  beforeOperation: BeforeOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>;
-  afterOperation: AfterOperationFieldHook<ListTypeInfo, FieldKey>;
+  beforeOperation: {
+    create: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldKey>;
+    update: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldKey>;
+    delete: BeforeOperationFieldHook<ListTypeInfo, 'delete', FieldKey>;
+  };
+  afterOperation: {
+    create: AfterOperationFieldHook<ListTypeInfo, 'create', FieldKey>;
+    update: AfterOperationFieldHook<ListTypeInfo, 'update', FieldKey>;
+    delete: AfterOperationFieldHook<ListTypeInfo, 'delete', FieldKey>;
+  };
 };
 
 type ResolveInputFieldHook<
@@ -406,50 +417,49 @@ type AfterOperationListHook<
 
 type AfterOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
+  Operation extends 'create' | 'update' | 'delete',
   FieldKey extends ListTypeInfo['fields']
 > = (
-  args: (
-    | {
-        operation: 'create';
-        originalItem: undefined;
-        // technically this will never actually exist for a create
-        // but making it optional rather than not here
-        // makes for a better experience
-        // because then people will see the right type even if they haven't refined the type of operation to 'create'
-        item?: ListTypeInfo['item'];
-        /**
-         * The GraphQL input **before** default values are applied
-         */
-        inputData: ListTypeInfo['inputs']['create'];
-        /**
-         * The GraphQL input **after** being resolved by the field type's input resolver
-         */
-        resolvedData: ListTypeInfo['prisma']['create'];
-      }
-    | {
-        operation: 'update';
-        item: ListTypeInfo['item'];
-        originalItem: ListTypeInfo['item'];
-        /**
-         * The GraphQL input **before** default values are applied
-         */
-        inputData: ListTypeInfo['inputs']['update'];
-        /**
-         * The GraphQL input **after** being resolved by the field type's input resolver
-         */
-        resolvedData: ListTypeInfo['prisma']['update'];
-      }
-    | {
-        operation: 'delete';
-        // technically this will never actually exist for a delete
-        // but making it optional rather than not here
-        // makes for a better experience
-        // because then people will see the right type even if they haven't refined the type of operation to 'delete'
-        item: undefined;
-        originalItem: ListTypeInfo['item'];
-        inputData: undefined;
-        resolvedData: undefined;
-      }
-  ) &
+  args: {
+    create: {
+      operation: 'create';
+      originalItem: undefined;
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['create'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['create'];
+    };
+    update: {
+      operation: 'update';
+      originalItem: ListTypeInfo['item'];
+      item: ListTypeInfo['item'];
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: ListTypeInfo['inputs']['update'];
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: ListTypeInfo['prisma']['update'];
+    };
+    delete: {
+      operation: 'delete';
+      originalItem: ListTypeInfo['item'];
+      item: undefined;
+      /**
+       * The GraphQL input **before** default values are applied
+       */
+      inputData: undefined;
+      /**
+       * The GraphQL input **after** being resolved by the field type's input resolver
+       */
+      resolvedData: undefined;
+    };
+  }[Operation] &
     CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
 ) => MaybePromise<void>;


### PR DESCRIPTION
This pull request adds the `.[create|update|delete]` hooks for the `*Operation` list hooks, and adds the same for field hooks internally (but not externally, as that is a breaking change for fields).

This routing is preferred for the refined type guarantees it can offer your application without needing to branch the types yourself.