### PR TITLE
Remove unsafe types from `examples/extend-express-app` example

### DIFF
--- a/examples/extend-express-app/routes/tasks.ts
+++ b/examples/extend-express-app/routes/tasks.ts
@@ -11,10 +11,7 @@ import type { Context } from '.keystone/types';
   We're also demonstrating how you can query related data through the schema.
 */
 
-export async function getTasks(req: Request, res: Response) {
-  // This was added by the context middleware in ../keystone.ts
-  const { context } = req as typeof req & { context: Context };
-
+export async function getTasks(req: Request, res: Response, context: Context) {
   // Let's map the `complete` query param to a where filter
   let isComplete;
   if (req.query.complete === 'true') {


### PR DESCRIPTION
This pull request removes the `(req as any).context` types from the `extend-express-app` example, and instead prefers to pass a refined `Context` directly to the route functions.

This new pattern reduces the number of `req as` casts, while still keeping your root express router definition as minimal as possible. 