### PR TITLE
Reduce verbosity of relationship resolution errors

### DIFF
--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -92,9 +92,7 @@ export const relationship =
     const [foreignListKey, foreignFieldKey] = ref.split('.');
     const foreignList = lists[foreignListKey];
     if (!foreignList) {
-      throw new Error(
-        `${listKey}.${fieldKey} points to ${ref}, but ${ref} doesn't exist`,
-      );
+      throw new Error(`${listKey}.${fieldKey} points to ${ref}, but ${ref} doesn't exist`);
     }
     const foreignListTypes = foreignList.types;
 

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -93,7 +93,7 @@ export const relationship =
     const foreignList = lists[foreignListKey];
     if (!foreignList) {
       throw new Error(
-        `Unable to resolve list '${foreignListKey}' for field ${listKey}.${fieldKey}`
+        `${listKey}.${fieldKey} points to ${ref}, but ${ref} doesn't exist`,
       );
     }
     const foreignListTypes = foreignList.types;

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -138,7 +138,9 @@ export function resolveRelationships(
           );
         }
 
-        const actualRef = foreignField.field ? `${foreignField.list}.${foreignField.field}` : foreignField.list;
+        const actualRef = foreignField.field
+          ? `${foreignField.list}.${foreignField.field}`
+          : foreignField.list;
         if (actualRef !== localRef) {
           throw new Error(
             `${localRef} points to ${foreignRef}, ${foreignRef} points to ${actualRef}, expected ${foreignRef} to point to ${localRef}`

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -138,10 +138,10 @@ export function resolveRelationships(
           );
         }
 
-        const actualRef = `${foreignField.list}.${foreignField.field}`;
+        const actualRef = foreignField.field ? `${foreignField.list}.${foreignField.field}` : foreignField.list;
         if (actualRef !== localRef) {
           throw new Error(
-            `${foreignRef} points to ${actualRef}, but ${localRef} expects a two-way relationship`
+            `${localRef} points to ${foreignRef}, ${foreignRef} points to ${actualRef}, expected ${foreignRef} to point to ${localRef}`
           );
         }
 

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -129,9 +129,7 @@ export function resolveRelationships(
         alreadyResolvedTwoSidedRelationships.add(foreignRef);
         const foreignField = foreignUnresolvedList.fields[field.field]?.dbField;
         if (!foreignField) {
-          throw new Error(
-            `${localRef} points to ${foreignRef}, but ${foreignRef} doesn't exist`
-          );
+          throw new Error(`${localRef} points to ${foreignRef}, but ${foreignRef} doesn't exist`);
         }
 
         if (foreignField.kind !== 'relation') {
@@ -140,7 +138,7 @@ export function resolveRelationships(
           );
         }
 
-        const actualRef = `${foreignField.list}.${foreignField.field}`
+        const actualRef = `${foreignField.list}.${foreignField.field}`;
         if (actualRef !== localRef) {
           throw new Error(
             `${foreignRef} points to ${actualRef}, but ${localRef} expects a two-way relationship`

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -130,31 +130,20 @@ export function resolveRelationships(
         const foreignField = foreignUnresolvedList.fields[field.field]?.dbField;
         if (!foreignField) {
           throw new Error(
-            `The relationship field at ${localRef} points to ${foreignRef} but no field at ${foreignRef} exists`
+            `${localRef} points to ${foreignRef}, but ${foreignRef} doesn't exist`
           );
         }
 
         if (foreignField.kind !== 'relation') {
           throw new Error(
-            `The relationship field at ${localRef} points to ${foreignRef} but ${foreignRef} is not a relationship field`
+            `${localRef} points to ${foreignRef}, but ${foreignRef} is not a relationship field`
           );
         }
 
-        if (foreignField.list !== listKey) {
+        const actualRef = `${foreignField.list}.${foreignField.field}`
+        if (actualRef !== localRef) {
           throw new Error(
-            `The relationship field at ${localRef} points to ${foreignRef} but ${foreignRef} points to the list ${foreignField.list} rather than ${listKey}`
-          );
-        }
-
-        if (foreignField.field === undefined) {
-          throw new Error(
-            `The relationship field at ${localRef} points to ${foreignRef}, ${localRef} points to ${listKey} correctly but does not point to the ${fieldPath} field when it should`
-          );
-        }
-
-        if (foreignField.field !== fieldPath) {
-          throw new Error(
-            `The relationship field at ${localRef} points to ${foreignRef}, ${localRef} points to ${listKey} correctly but points to the ${foreignField.field} field instead of ${fieldPath}`
+            `${foreignRef} points to ${actualRef}, but ${localRef} expects a two-way relationship`
           );
         }
 

--- a/tests/api-tests/fields/types/relationship.test.ts
+++ b/tests/api-tests/fields/types/relationship.test.ts
@@ -7,7 +7,7 @@ import { allowAll } from '@keystone-6/core/access';
 
 const fieldKey = 'foo';
 
-function getSchema (field: { ref: string, many?: boolean }) {
+function getSchema(field: { ref: string; many?: boolean }) {
   return createSystem(
     initConfig(
       config({
@@ -28,31 +28,31 @@ function getSchema (field: { ref: string, many?: boolean }) {
 
 describe('Type Generation', () => {
   test('inputs for relationship fields in create args', () => {
-    const relMany = getSchema(({ many: true, ref: 'Zip' }));
+    const relMany = getSchema({ many: true, ref: 'Zip' });
     expect(
       assertInputObjectType(relMany.getType('TestCreateInput')).getFields().foo.type.toString()
     ).toEqual('ZipRelateToManyForCreateInput');
 
-    const relSingle = getSchema(({ many: false, ref: 'Zip' }));
+    const relSingle = getSchema({ many: false, ref: 'Zip' });
     expect(
       assertInputObjectType(relSingle.getType('TestCreateInput')).getFields().foo.type.toString()
     ).toEqual('ZipRelateToOneForCreateInput');
   });
 
   test('inputs for relationship fields in update args', () => {
-    const relMany = getSchema(({ many: true, ref: 'Zip' }));
+    const relMany = getSchema({ many: true, ref: 'Zip' });
     expect(
       assertInputObjectType(relMany.getType('TestUpdateInput')).getFields().foo.type.toString()
     ).toEqual('ZipRelateToManyForUpdateInput');
 
-    const relSingle = getSchema(({ many: false, ref: 'Zip' }));
+    const relSingle = getSchema({ many: false, ref: 'Zip' });
     expect(
       assertInputObjectType(relSingle.getType('TestUpdateInput')).getFields().foo.type.toString()
     ).toEqual('ZipRelateToOneForUpdateInput');
   });
 
   test('to-one for create relationship nested mutation input', () => {
-    const schema = getSchema(({ many: false, ref: 'Zip' }));
+    const schema = getSchema({ many: false, ref: 'Zip' });
 
     expect(printType(schema.getType('ZipRelateToOneForCreateInput')!)).toMatchInlineSnapshot(`
 "input ZipRelateToOneForCreateInput {
@@ -63,7 +63,7 @@ describe('Type Generation', () => {
   });
 
   test('to-one for update relationship nested mutation input', () => {
-    const schema = getSchema(({ many: false, ref: 'Zip' }));
+    const schema = getSchema({ many: false, ref: 'Zip' });
 
     expect(printType(schema.getType('ZipRelateToOneForUpdateInput')!)).toMatchInlineSnapshot(`
 "input ZipRelateToOneForUpdateInput {
@@ -75,7 +75,7 @@ describe('Type Generation', () => {
   });
 
   test('to-many for create relationship nested mutation input', () => {
-    const schema = getSchema(({ many: true, ref: 'Zip' }));
+    const schema = getSchema({ many: true, ref: 'Zip' });
 
     expect(printType(schema.getType('ZipRelateToManyForCreateInput')!)).toMatchInlineSnapshot(`
 "input ZipRelateToManyForCreateInput {
@@ -86,7 +86,7 @@ describe('Type Generation', () => {
   });
 
   test('to-many for update relationship nested mutation input', () => {
-    const schema = getSchema(({ many: true, ref: 'Zip' }));
+    const schema = getSchema({ many: true, ref: 'Zip' });
 
     expect(printType(schema.getType('ZipRelateToManyForUpdateInput')!)).toMatchInlineSnapshot(`
 "input ZipRelateToManyForUpdateInput {
@@ -99,7 +99,7 @@ describe('Type Generation', () => {
   });
 
   test('to-one relationships cannot be filtered at the field level', () => {
-    const schema = getSchema(({ many: false, ref: 'Zip' }));
+    const schema = getSchema({ many: false, ref: 'Zip' });
 
     expect(
       (
@@ -120,7 +120,7 @@ describe('Type Generation', () => {
   });
 
   test('to-many relationships can be filtered at the field level', () => {
-    const schema = getSchema(({ many: true, ref: 'Zip' }));
+    const schema = getSchema({ many: true, ref: 'Zip' });
 
     expect(printType(schema.getType('Test')!)).toMatchInlineSnapshot(`
 "type Test {
@@ -133,7 +133,7 @@ describe('Type Generation', () => {
 });
 
 describe('Reference errors', () => {
-  function tryf (lists: ListSchemaConfig) {
+  function tryf(lists: ListSchemaConfig) {
     return createSystem(
       initConfig(
         config({
@@ -142,7 +142,7 @@ describe('Reference errors', () => {
         })
       )
     ).graphQLSchema;
-  };
+  }
 
   const fixtures = {
     'list not found': {
@@ -150,8 +150,8 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc.def' })
-          }
+            bar: relationship({ ref: 'Abc.def' }),
+          },
         }),
       },
       error: `Foo.bar points to Abc.def, but Abc.def doesn't exist`,
@@ -161,12 +161,12 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc.def' })
-          }
+            bar: relationship({ ref: 'Abc.def' }),
+          },
         }),
         Abc: list({
           access: allowAll,
-          fields: {}
+          fields: {},
         }),
       },
       error: `Foo.bar points to Abc.def, but Abc.def doesn't exist`,
@@ -176,14 +176,14 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc.def' })
-          }
+            bar: relationship({ ref: 'Abc.def' }),
+          },
         }),
         Abc: list({
           access: allowAll,
           fields: {
-            def: relationship({ ref: 'Foo.bazzz' })
-          }
+            def: relationship({ ref: 'Foo.bazzz' }),
+          },
         }),
       },
       error: `Abc.def points to Foo.bazzz, but Foo.bar expects a two-way relationship`,
@@ -193,14 +193,14 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc.def' })
-          }
+            bar: relationship({ ref: 'Abc.def' }),
+          },
         }),
         Abc: list({
           access: allowAll,
           fields: {
-            def: text()
-          }
+            def: text(),
+          },
         }),
       },
       error: `Foo.bar points to Abc.def, but Abc.def is not a relationship field`,
@@ -210,29 +210,29 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc' })
-          }
+            bar: relationship({ ref: 'Abc' }),
+          },
         }),
         Abc: list({
           access: allowAll,
-          fields: {}
+          fields: {},
         }),
       },
-      error: null
+      error: null,
     },
-  }
+  };
 
   for (const [description, { lists, error }] of Object.entries(fixtures)) {
     if (error) {
       test(`throws for ${description}`, () => {
         expect(() => {
-          tryf(lists)
+          tryf(lists);
         }).toThrow(error);
       });
     } else {
       test(`does not throw for ${description}`, () => {
         expect(() => {
-          tryf(lists)
+          tryf(lists);
         }).not.toThrow();
       });
     }

--- a/tests/api-tests/fields/types/relationship.test.ts
+++ b/tests/api-tests/fields/types/relationship.test.ts
@@ -171,7 +171,24 @@ describe('Reference errors', () => {
       },
       error: `Foo.bar points to Abc.def, but Abc.def doesn't exist`,
     },
-    '2-way not 2-way': {
+    '1-way / 2-way conflict': {
+      lists: {
+        Foo: list({
+          access: allowAll,
+          fields: {
+            bar: relationship({ ref: 'Abc.def' }),
+          },
+        }),
+        Abc: list({
+          access: allowAll,
+          fields: {
+            def: relationship({ ref: 'Foo' }),
+          },
+        }),
+      },
+      error: `Foo.bar points to Abc.def, Abc.def points to Foo, expected Abc.def to point to Foo.bar`,
+    },
+    '3-way / 2-way conflict': {
       lists: {
         Foo: list({
           access: allowAll,
@@ -186,7 +203,7 @@ describe('Reference errors', () => {
           },
         }),
       },
-      error: `Abc.def points to Foo.bazzz, but Foo.bar expects a two-way relationship`,
+      error: `Foo.bar points to Abc.def, Abc.def points to Foo.bazzz, expected Abc.def to point to Foo.bar`,
     },
     'field wrong type': {
       lists: {


### PR DESCRIPTION
This pull request reduces the verbosity of the errors produced by relationship resolution.
Previously, if you had a misconfigured 2 way relationship, you were presented with the following error:

> The relationship field at Foo.bar points to Abc.def, Foo.bar points to Abc correctly but points to the bazz field instead of def

This pull request shortens that to:
> Abc.def points to Foo.bazzz, but Foo.bar expects a two-way relationship

Additionally, I add tests for these different edge cases.