### PR TITLE
Drop unused JEST environment variable from examples/testing

### DIFF
--- a/examples/testing/example-test.ts
+++ b/examples/testing/example-test.ts
@@ -66,15 +66,17 @@ test('Check access control by running updateTask as a specific user via context.
   assert.equal(task.priority, 'high');
   assert.equal(task.isComplete, false);
   assert.equal(task.assignedTo.name, 'Alice');
-  await assert.rejects(async () => {
-    await context
-      .db.Task.updateOne({
+  await assert.rejects(
+    async () => {
+      await context.db.Task.updateOne({
         where: { id: task.id },
-        data: { isComplete: true }
+        data: { isComplete: true },
       });
-  }, {
-    message: `Access denied: You cannot update that Task - it may not exist`
-  });
+    },
+    {
+      message: `Access denied: You cannot update that Task - it may not exist`,
+    }
+  );
 
   // test that we can update the task (with a session)
   {
@@ -82,20 +84,21 @@ test('Check access control by running updateTask as a specific user via context.
       .withSession({ listKey: 'User', itemId: alice.id, data: {} })
       .db.Task.updateOne({
         where: { id: task.id },
-        data: { isComplete: true }
+        data: { isComplete: true },
       });
     assert.equal(result.id, task.id);
   }
 
   // test that we can't update the task (with an invalid session (Bob))
-  await assert.rejects(async () => {
-    await context
-      .withSession({ listKey: 'User', itemId: bob.id, data: {} })
-      .db.Task.updateOne({
+  await assert.rejects(
+    async () => {
+      await context.withSession({ listKey: 'User', itemId: bob.id, data: {} }).db.Task.updateOne({
         where: { id: task.id },
-        data: { isComplete: true }
+        data: { isComplete: true },
       });
-  }, {
-    message: `Access denied: You cannot update that Task - it may not exist`
-  });
+    },
+    {
+      message: `Access denied: You cannot update that Task - it may not exist`,
+    }
+  );
 });

--- a/examples/testing/example-test.ts
+++ b/examples/testing/example-test.ts
@@ -24,19 +24,18 @@ test('Create a User using context.query', async () => {
 });
 
 test('Check that trying to create user with no name (required field) fails', async () => {
-  // the context.graphql.raw API can be useful when you expect errors
-  const { data, errors } = (await context.graphql.raw({
-    query: `mutation {
-          createUser(data: { password: "dont-use-me" }) {
-            id name password { isSet }
-          }
-        }`,
-  })) as any;
-  assert.equal(data!.createUser, null);
-  assert.equal(errors![0].path[0], 'createUser');
-  assert.equal(
-    errors![0].message,
-    'You provided invalid data for this operation.\n  - User.name: Name must not be empty'
+  await assert.rejects(
+    async () => {
+      await context.db.User.createOne({
+        data: {
+          password: 'not-a-password',
+        },
+      });
+    },
+    {
+      message:
+        'You provided invalid data for this operation.\n  - User.name: Name must not be empty',
+    }
   );
 });
 

--- a/examples/testing/example-test.ts
+++ b/examples/testing/example-test.ts
@@ -4,17 +4,14 @@ import assert from 'node:assert/strict';
 
 import { resetDatabase } from '@keystone-6/core/testing';
 import { getContext } from '@keystone-6/core/context';
-import baseConfig from './keystone';
+import config from './keystone';
 import * as PrismaModule from '.myprisma/client';
 
-const dbUrl = `file:./test-${process.env.JEST_WORKER_ID}.db`;
 const prismaSchemaPath = path.join(__dirname, 'schema.prisma');
-const config = { ...baseConfig, db: { ...baseConfig.db, url: dbUrl } };
-
 const context = getContext(config, PrismaModule);
 
 beforeEach(async () => {
-  await resetDatabase(dbUrl, prismaSchemaPath);
+  await resetDatabase(config.db.url, prismaSchemaPath);
 });
 
 test('Create a User using context.query', async () => {

--- a/examples/testing/example-test.ts
+++ b/examples/testing/example-test.ts
@@ -88,18 +88,13 @@ test('Check access control by running updateTask as a specific user via context.
 
   // test that we can update the task (with a session)
   {
-    const { data, errors } = (await context
+    const result = (await context
       .withSession({ listKey: 'User', itemId: alice.id, data: {} })
-      .graphql.raw({
-        query: `mutation update($id: ID!) {
-              updateTask(where: { id: $id }, data: { isComplete: true }) {
-                id
-              }
-            }`,
-        variables: { id: task.id },
-      })) as any;
-    assert.equal(data!.updateTask.id, task.id);
-    assert.equal(errors, undefined);
+      .db.Task.updateOne({
+        where: { id: task.id },
+        data: { isComplete: true }
+      });
+    assert.equal(result.id, task.id);
   }
 
   // test that we can't update the task (with an invalid session (Bob))


### PR DESCRIPTION
This pull request, in addition to the title, prefers `context.db.*` calls rather than `graphql.raw`, which should arguably only be used for custom mutations at this time - and even then, we should introduce `context.query.{customMutation}` at some point.