### PR TITLE
Fix prisma migrate cli regression error 

### DIFF
--- a/.changeset/polite-llamas-sparkle.md
+++ b/.changeset/polite-llamas-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix prisma migrate non-interactive environment error


### PR DESCRIPTION
PR https://github.com/keystonejs/keystone/pull/8790 among many things replaced `execa` with `execFile` as a way to spawn child process for prisma cli commands.

Unfortunately `execFile` does not allow inheriting stdin from parent process like before https://github.com/keystonejs/keystone/blob/f92aa4010995d18ac15df83b70cbe9140bb72a7f/packages/core/src/scripts/prisma.ts#L27

Prisma commands that require user input (eg. `prisma migrate dev` or `prisma migrate reset`) now throw `Error: Prisma Migrate has detected that the environment is non-interactive, which is not supported.` and there is no flag or option to turn it off (https://github.com/prisma/prisma/issues/4669 https://github.com/prisma/prisma/issues/7113)

Related issues: https://github.com/keystonejs/keystone/issues/8888 https://github.com/keystonejs/keystone/issues/8858

There are at least 3 ways to fix this issue:
1) Revert code to old version (`execa`)
2) Switch to `execFileSync`
3) Switch to `spawn`

I chose the last one. In my limited testing everything seems to work fine. Let me know if other way is preferred instead.

