### PR TITLE
Fix initialSort preventing sort by "No field"

### DIFF
--- a/.changeset/no-sort-ok.md
+++ b/.changeset/no-sort-ok.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix ui.listView.initialSort preventing sort by "No field"

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/SortSelection.tsx
@@ -96,7 +96,17 @@ function SortSelectionPopoverContent({
           const fieldPath: string = (newVal as any).value;
           if (fieldPath === noFieldOption.value) {
             const { sortBy, ...restOfQuery } = router.query;
-            router.push({ query: restOfQuery });
+
+            if (list.initialSort) {
+              router.push({
+                query: {
+                  ...router.query,
+                  sortBy: ''
+                }
+              });
+            } else {
+              router.push({ query: restOfQuery });
+            }
           } else {
             router.push({
               query: {

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -295,7 +295,7 @@ const ListPage = ({ listKey }: ListPageProps) => {
               <FilterAdd listKey={listKey} filterableFields={filterableFields} />
             ) : null}
             {filters.filters.length ? <FilterList filters={filters.filters} list={list} /> : null}
-            {Boolean(filters.filters.length || query.sortBy || query.fields || query.search) && (
+            {Boolean(filters.filters.length || query.sortBy !== undefined || query.fields || query.search) && (
               <Button size="small" onClick={resetToDefaults}>
                 Reset to defaults
               </Button>

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
@@ -4,22 +4,26 @@ import { useRouter } from '../../../../admin-ui/router';
 
 export function useSort(list: ListMeta, orderableFields: Set<string>) {
   const { query } = useRouter();
-  let sortByFromUrl = typeof query.sortBy === 'string' ? query.sortBy : '';
+  let sortByFromUrl = typeof query.sortBy === 'string' ? query.sortBy : null;
 
   return useMemo(() => {
-    if (sortByFromUrl === '') {
-      if (!list.initialSort || !orderableFields.has(list.initialSort.field)) {
-        return null;
+    if (sortByFromUrl === '') return null;
+    if (sortByFromUrl === null) return list.initialSort;
+
+    if (sortByFromUrl.startsWith('-')) {
+      const field = sortByFromUrl.slice(1);
+      if (!orderableFields.has(field)) return null;
+
+      return {
+        field,
+        direction: 'DESC'
       }
-      return list.initialSort;
     }
-    let direction: 'ASC' | 'DESC' = 'ASC';
-    let sortByField = sortByFromUrl;
-    if (sortByFromUrl.charAt(0) === '-') {
-      sortByField = sortByFromUrl.slice(1);
-      direction = 'DESC';
+
+    if (!orderableFields.has(sortByFromUrl)) return null;
+    return {
+      field: sortByFromUrl,
+      direction: 'ASC'
     }
-    if (!orderableFields.has(sortByField)) return null;
-    return { field: sortByField, direction };
   }, [sortByFromUrl, list, orderableFields]);
 }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
@@ -17,13 +17,13 @@ export function useSort(list: ListMeta, orderableFields: Set<string>) {
       return {
         field,
         direction: 'DESC'
-      }
+      };
     }
 
     if (!orderableFields.has(sortByFromUrl)) return null;
     return {
       field: sortByFromUrl,
       direction: 'ASC'
-    }
+    };
   }, [sortByFromUrl, list, orderableFields]);
 }


### PR DESCRIPTION
- Fixes https://github.com/keystonejs/keystone/issues/8687

The URL query syntax added with this pull request for "No field" is `?sortBy=`.
This is quite self-explanatory, and still feels intuitive when using the "Reset to defaults" button. 