### PR TITLE
Fix `ui.inlineCreate` for relationships submitting the parent form of nested relationship fields

### DIFF
--- a/.changeset/fix-inline-create.md
+++ b/.changeset/fix-inline-create.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix ui.inlineCreate: { ... } for relationships submitting the parent form of nested relationship fields

--- a/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
+++ b/packages/core/src/fields/types/relationship/views/cards/InlineCreate.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
-import { type FormEvent, useState } from 'react'
+import { useState } from 'react'
 import { jsx, Stack } from '@keystone-ui/core'
 import isDeepEqual from 'fast-deep-equal'
 import { useToasts } from '@keystone-ui/toast'
@@ -53,11 +53,9 @@ export function InlineCreate ({
   })
 
   const invalidFields = useInvalidFields(fields, value)
-
   const [forceValidation, setForceValidation] = useState(false)
 
-  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const onSubmit = () => {
     const newForceValidation = invalidFields.size !== 0
     setForceValidation(newForceValidation)
 
@@ -106,7 +104,7 @@ export function InlineCreate ({
   }
 
   return (
-    <form onSubmit={onSubmit}>
+    <section>
       <Stack gap="xlarge">
         {error && (
           <GraphQLErrorNotice networkError={error?.networkError} errors={error?.graphQLErrors} />
@@ -119,7 +117,7 @@ export function InlineCreate ({
           value={value}
         />
         <Stack gap="small" across>
-          <Button isLoading={loading} size="small" tone="positive" weight="bold" type="submit">
+          <Button onClick={onSubmit} isLoading={loading} size="small" tone="positive" weight="bold">
             Create {list.singular}
           </Button>
           <Button size="small" weight="none" onClick={onCancel}>
@@ -127,6 +125,6 @@ export function InlineCreate ({
           </Button>
         </Stack>
       </Stack>
-    </form>
+    </section>
   )
 }


### PR DESCRIPTION
As described, this pull request stops the parent form submitting when you create an item when using `displayMode: 'cards'` and `inlineCreate`.

Nested `form`s in HTML5 aren't supported - to my knowledge - so I don't know what this was expected to do, but the previous behavior regularly wiped your input fields which can be painful.