### PR TITLE
Added Code Hints to custom-session-jwt example Implementation  

### DIFF
--- a/examples/custom-session-jwt/keystone.ts
+++ b/examples/custom-session-jwt/keystone.ts
@@ -73,8 +73,20 @@ const jwtSessionStrategy = {
   //   context.sessionStrategy.start
   //   context.sessionStrategy.end
   //
-  async start () {},
-  async end () {},
+  async start({
+    context,
+    data,
+  }: {
+    context: Context;
+    data: { listKey: string; itemId: string };
+  }) {
+     // this is required for authentication (authenticateUserWithPassword) mutation to work
+    // const token = await jwtSign({ id: data.itemId });
+    // return token;
+  },
+  async end ({ context }: { context: Context }) {
+    //grab session token and implement any token revokation strategy of choice
+  },
 }
 
 export default config<TypeInfo>({


### PR DESCRIPTION
After Encountering a limitation With Http Only Cookies and Safari, i decided to switch Over to Jwt Session Strategy.
Followed The  Approach provided in the example code here [custom-session-jwt example](https://github.com/keystonejs/keystone/blob/main/examples/custom-session-jwt/keystone.tsl).
The Example Had the token Signed Manually as shown below
https://github.com/keystonejs/keystone/blob/4e1cf3f7101820259a934b6af08d0cccb6e1cf2a/examples/custom-session-jwt/keystone.ts#L88-L99

Spent a whole day trying to figure out where to generate the token for the `authenticateWithPassword` mutation to work right.

Finally cracked it by delving into the `statelessSessions` implementation code. Turns out, the sessionStrategy Start Method should return the signed Token.

Suggest adding a hint in the example to save newcomers like me the trouble of digging deep.