### PR TITLE
Use node 20 in CI and fix testing example

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -8,7 +8,7 @@ runs:
     - uses: actions/setup-node@main
       with:
         # preferably lts/*, but we hit API limits when querying that
-        node-version: 18
+        node-version: 20
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
 

--- a/examples/testing/package.json
+++ b/examples/testing/package.json
@@ -8,7 +8,7 @@
     "start": "keystone start",
     "build": "keystone build",
     "postinstall": "keystone postinstall",
-    "test": "tsx example-test.ts"
+    "test": "node --import tsx --test example-test.ts"
   },
   "dependencies": {
     "@keystone-6/auth": "^7.0.0",

--- a/examples/testing/package.json
+++ b/examples/testing/package.json
@@ -8,7 +8,7 @@
     "start": "keystone start",
     "build": "keystone build",
     "postinstall": "keystone postinstall",
-    "test": "node --loader tsx example-test.ts"
+    "test": "tsx example-test.ts"
   },
   "dependencies": {
     "@keystone-6/auth": "^7.0.0",


### PR DESCRIPTION
We have been `node --loader` originally due to an issue with node 18, however with the upgrade to node `18.19` the `--loader` which was experimental is depreciated so `tsx` is throwing an error for the testing example.
This PR bumps the CI to use node 20 (latest lts) and also fixes the testing example to use  `--import`.