### PR TITLE
docs: Added twitter link in initPage

### DIFF
--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -88,7 +88,11 @@ function Welcome ({ value, onContinue }: { value: any, onContinue: () => void })
       >
         <H1>Welcome</H1>
         <Stack across gap="small">
-          <IconTwitter title="Twitter Logo" />
+          <IconTwitter 
+            href="https://twitter.com/keystonejs"
+            target="_blank"
+            title="Twitter Logo"
+          />
           <IconGithub
             href="https://github.com/keystonejs/keystone"
             target="_blank"


### PR DESCRIPTION
Not a big one but the init page was missing Keystone twitter url, the icon was there but not clickable like the github icon, so added it.