### PR TITLE
feat(core/scripts): expose express and http server from start command

### DIFF
--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -90,4 +90,6 @@ export const start = async (
       }/)`
     )
   })
+
+  return { expressServer, httpServer }
 }


### PR DESCRIPTION
This PR exposes the internal `express.Express` and `http.Server` instances to be handled imperatively.

Sometimes, there is a need to start/stop (production) Keystone manually using `@keystone-6/core/scripts/cli`

The reasons for this would be a Graceful Shutdown or maybe adding a Kubernetes management server.

Even if Graceful Shutdown is possible in [`server.extendHttpServer`](https://keystonejs.com/docs/config/config#extend-http-server), for K8 Management becomes more tricky.

**custom-start.js**

```ts
import { cli } from "@keystone-6/core/scripts/cli";
import express from "express";

// Kubernetes management
const kubernetesManagementExpress = express();
kubernetesManagementExpress.use(configureLivenessReadinessAndStartupProbes);
const kubernetesManagementServer = kubernetesManagementExpress.listen(3001);

kubernetesManagementServer.on("listening", async () => {
  const start = await cli(process.cwd(), ["start"]);

  // This will always run
  if (start && typeof start !== "function") {
    const { expressServer, httpServer } = start;

    // Graceful shutdown
    process.on("SIGTERM", () =>
      httpServer.close(() => {
        kubernetesManagementServer.close();
      })
    );
  }
});

// https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
function configureLivenessReadinessAndStartupProbes() { /* ... */ }
```
