### PR TITLE
Add support for proxying images and files always via keystone express server, no matter local or s3, and add security access control extension hook

### DIFF
--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -482,7 +482,7 @@ export default config({
       region,
       accessKeyId,
       secretAccessKey,
-      proxied: { baseUrl: '/images-proxy' },
+      serverRoute: { path: '/images-proxy' },
       signed: { expiry: 5000 }
       endpoint: 'http://127.0.0.1:9000/',
       forcePathStyle: true,

--- a/docs/pages/docs/guides/images-and-files.md
+++ b/docs/pages/docs/guides/images-and-files.md
@@ -15,7 +15,7 @@ The `storage` object defines how and where the assets are stored and accessed by
 - The `type` of `field` the storage is being used for – `file` or `image`
 - A function to generate the URL (`generateUrl`) Keystone returns in the GraphQL API – pointing to the location or the storage where the assets can be accessed
 - The actual location where Keystone stores the assets – either a local `path` or the details of an `s3` bucket
-- The location Keystone will serve the assets from – either a `serverRoute` for `local` or a `proxied` connection for `s3`. Both of these options add a route to the Keystone backend which the files can be accessed from
+- The location Keystone will serve the assets from – the `serverRoute` for `local` or `s3`. It will add a route to the Keystone backend which the files can be accessed from. Please note that `generateUrl` should be carefully defined when using proxied mode.  
 
 ## Defining `storage` in Keystone config
 

--- a/packages/core/src/lib/assets/createFilesContext.ts
+++ b/packages/core/src/lib/assets/createFilesContext.ts
@@ -28,8 +28,8 @@ export function createFilesContext (config: KeystoneConfig): FilesContext {
       adaptersMap.set(
         storageKey,
         storageConfig.kind === 'local'
-          ? localFileAssetsAPI(storageConfig)
-          : s3FileAssetsAPI(storageConfig)
+          ? localFileAssetsAPI(storageConfig,storageKey)
+          : s3FileAssetsAPI(storageConfig,storageKey)
       )
     }
   }

--- a/packages/core/src/lib/assets/createImagesContext.ts
+++ b/packages/core/src/lib/assets/createImagesContext.ts
@@ -32,8 +32,8 @@ export function createImagesContext (config: KeystoneConfig): ImagesContext {
       imageAssetsAPIs.set(
         storageKey,
         storageConfig.kind === 'local'
-          ? localImageAssetsAPI(storageConfig)
-          : s3ImageAssetsAPI(storageConfig)
+          ? localImageAssetsAPI(storageConfig,storageKey)
+          : s3ImageAssetsAPI(storageConfig,storageKey)
       )
     }
   }

--- a/packages/core/src/lib/assets/local.ts
+++ b/packages/core/src/lib/assets/local.ts
@@ -26,6 +26,9 @@ export function localImageAssetsAPI (
         }
       }
     },
+    async download(filename, stream, headers) {
+      throw new Error("Not implemented yet")
+    }
   }
 }
 
@@ -66,5 +69,8 @@ export function localFileAssetsAPI (storageConfig: StorageConfig & { kind: 'loca
         }
       }
     },
+    async download(filename, stream, headers) {
+      throw new Error("Not implemented yet")
+    }
   }
 }

--- a/packages/core/src/lib/assets/local.ts
+++ b/packages/core/src/lib/assets/local.ts
@@ -10,12 +10,13 @@ export function localImageAssetsAPI (
 ): ImageAdapter {
   return {
     async url (id, extension) {
+      const generateUrl = storageConfig.generateUrl ?? (url=>url);
 
       if(storageConfig.serverRoute) {
-        return storageConfig.generateUrl(`${storageConfig.serverRoute}/${storageKey}/${id}.${extension}`);
+        return generateUrl(`${storageConfig.serverRoute.path}/${storageKey}/${id}.${extension}`);
       }
 
-      return storageConfig.generateUrl(`/${id}.${extension}`)
+      return generateUrl(`/${id}.${extension}`)
     },
     async upload (buffer, id, extension) {
       await fs.writeFile(path.join(storageConfig.storagePath, `${id}.${extension}`), buffer)
@@ -40,12 +41,14 @@ export function localImageAssetsAPI (
 export function localFileAssetsAPI (storageConfig: StorageConfig & { kind: 'local' }, storageKey: string=''): FileAdapter {
   return {
     async url (filename) {
-      
+      const generateUrl = storageConfig.generateUrl ?? (url=>url);
+
+
       if(storageConfig.serverRoute) {
-        return storageConfig.generateUrl(`${storageConfig.serverRoute}/${storageKey}/${filename}`);
+        return generateUrl(`${storageConfig.serverRoute.path}/${storageKey}/${filename}`);
       }
 
-      return storageConfig.generateUrl(`/${filename}`)
+      return generateUrl(`/${filename}`)
     },
     async upload (stream, filename) {
       const writeStream = fs.createWriteStream(path.join(storageConfig.storagePath, filename))

--- a/packages/core/src/lib/assets/local.ts
+++ b/packages/core/src/lib/assets/local.ts
@@ -6,10 +6,15 @@ import { type StorageConfig } from '../../types'
 import { type FileAdapter, type ImageAdapter } from './types'
 
 export function localImageAssetsAPI (
-  storageConfig: StorageConfig & { kind: 'local' }
+  storageConfig: StorageConfig & { kind: 'local' }, storageKey: string=''
 ): ImageAdapter {
   return {
     async url (id, extension) {
+
+      if(storageConfig.serverRoute) {
+        return storageConfig.generateUrl(`${storageConfig.serverRoute}/${storageKey}/${id}.${extension}`);
+      }
+
       return storageConfig.generateUrl(`/${id}.${extension}`)
     },
     async upload (buffer, id, extension) {
@@ -32,9 +37,14 @@ export function localImageAssetsAPI (
   }
 }
 
-export function localFileAssetsAPI (storageConfig: StorageConfig & { kind: 'local' }): FileAdapter {
+export function localFileAssetsAPI (storageConfig: StorageConfig & { kind: 'local' }, storageKey: string=''): FileAdapter {
   return {
     async url (filename) {
+      
+      if(storageConfig.serverRoute) {
+        return storageConfig.generateUrl(`${storageConfig.serverRoute}/${storageKey}/${filename}`);
+      }
+
       return storageConfig.generateUrl(`/${filename}`)
     },
     async upload (stream, filename) {

--- a/packages/core/src/lib/assets/s3.ts
+++ b/packages/core/src/lib/assets/s3.ts
@@ -11,7 +11,7 @@ export function s3ImageAssetsAPI(storageConfig: StorageConfig & { kind: 's3' }, 
   return {
     async url(id, extension) {
       if(storageConfig.serverRoute) {
-        return generateUrl(`${storageConfig.serverRoute}/${storageKey}/${storageConfig.pathPrefix || ''}${id}.${extension}`);
+        return generateUrl(`${storageConfig.serverRoute.path}/${storageKey}/${storageConfig.pathPrefix || ''}${id}.${extension}`);
       }
 
       if (!storageConfig.signed) {
@@ -54,7 +54,7 @@ export function s3FileAssetsAPI(storageConfig: StorageConfig & { kind: 's3' }, s
   return {
     async url(filename) {
       if(storageConfig.serverRoute) {
-        return generateUrl(`${storageConfig.serverRoute}/${storageKey}/${storageConfig.pathPrefix || ''}${filename}`);
+        return generateUrl(`${storageConfig.serverRoute.path}/${storageKey}/${storageConfig.pathPrefix || ''}${filename}`);
       }
       if (!storageConfig.signed) {
         return generateUrl(`${s3Endpoint}${storageConfig.pathPrefix || ''}${filename}`)

--- a/packages/core/src/lib/assets/types.ts
+++ b/packages/core/src/lib/assets/types.ts
@@ -10,7 +10,7 @@ export type ImageAdapter = {
 
 export type FileAdapter = {
   download(filename: string, stream: Writable, headers: (key: string, value: string) => void): void
-  upload(stream: Readable, filename: string): Promise<FileMetadata>
+   upload(stream: Readable, filename: string): Promise<FileMetadata>
   delete(id: string): Promise<void>
   url(filename: string): Promise<string>
 }

--- a/packages/core/src/lib/assets/types.ts
+++ b/packages/core/src/lib/assets/types.ts
@@ -1,13 +1,15 @@
-import type { Readable } from 'stream'
+import type { Readable, Writable } from 'stream'
 import type { ImageExtension, FileMetadata } from '../../types'
 
 export type ImageAdapter = {
+  download(filename: string, stream: Writable, headers: (key: string, value: string) => void): void
   upload(buffer: Buffer, id: string, extension: string): Promise<void>
   delete(id: string, extension: ImageExtension): Promise<void>
   url(id: string, extension: ImageExtension): Promise<string>
 }
 
 export type FileAdapter = {
+  download(filename: string, stream: Writable, headers: (key: string, value: string) => void): void
   upload(stream: Readable, filename: string): Promise<FileMetadata>
   delete(id: string): Promise<void>
   url(filename: string): Promise<string>

--- a/packages/core/src/lib/server/createExpressServer.ts
+++ b/packages/core/src/lib/server/createExpressServer.ts
@@ -11,6 +11,7 @@ import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js'
 import type { KeystoneConfig, KeystoneContext, GraphQLConfig } from '../../types'
 import { addHealthCheck } from './addHealthCheck'
+import { s3AssetsCommon, s3FileAssetsAPI, s3ImageAssetsAPI } from '../assets/s3'
 
 /*
 NOTE: This creates the main Keystone express server, including the
@@ -76,21 +77,99 @@ export const createExpressServer = async (
   }
 
   if (config.storage) {
-    for (const val of Object.values(config.storage)) {
-      if (val.kind !== 'local' || !val.serverRoute) continue
-      expressServer.use(
-        val.serverRoute.path,
-        express.static(val.storagePath, {
-          setHeaders (res) {
-            if (val.type === 'file') {
-              res.setHeader('Content-Type', 'application/octet-stream')
+    for (const key of Object.keys(config.storage)) {
+      const storageConfig = config.storage[key];
+
+      /**we can only verify isAccessAllowed in the following cases: 
+      * 1. local storage: if serverRoute is defined 
+      * 2. s3 storage: if serverRoute is defined. 
+      * 
+      * Otherwise the generateUrl would generate a direct url to s3 supporting solution 
+      * like aws or minio or what not and as such, we wouldn't be able to intercept the 
+      * request properly. 
+      * 
+      * Actually we could by "redirection", sending the browser back to us 
+      * and checking before redirecting, but that would be a bit of a hack.
+      */
+
+      //verifying if isAccessAllowed would be supported in non-proxied mode and warning about it at development time
+      if (storageConfig.isAccessAllowed && (storageConfig.kind === 's3' && !storageConfig.serverRoute)) {
+        process.env.NODE_ENV === 'development' && console.warn("storage api isAccessAllowed is not supported in non-proxied mode for kind: s3. The isAccessAllowed function will not get executed");
+      }
+
+      /**
+       * Also, checking if generateUrl respects the proxied flag. If it doesn't, we warn about it at development time. 
+       */
+      if (storageConfig.generateUrl && storageConfig.serverRoute) {
+        process.env.NODE_ENV === 'development' && console.warn("generateUrl storage api config should respect the serverRoute flag. Some assumptions about the generateUrl function must be in place for serverRoute mode to work.")
+      }
+
+      if (storageConfig.serverRoute) {
+        //now we need 2 implementations 
+        //one for local storage, using express static middleware BUT with isAccessAllowed checked properly beforehand
+        //another for s3, which will issue a GET Object request to s3, and pipe the stream to the response
+        let expressMiddleware: express.RequestHandler;
+        if (storageConfig.kind === 'local') {
+
+          expressMiddleware = (request, response) => {
+
+            const { extraPath } = request.params
+
+            if (typeof storageConfig.isAccessAllowed === 'function' &&
+              !storageConfig.isAccessAllowed(context, extraPath, response.getHeader)) {
+              response.status(403).send('Forbidden')
+              return
             }
-          },
-          index: false,
-          redirect: false,
-          lastModified: false,
-        })
-      )
+
+            express.static(storageConfig.storagePath, {
+              setHeaders(res) {
+                if (storageConfig.type === 'file') {
+                  res.setHeader('Content-Type', 'application/octet-stream')
+                }
+              },
+              index: false,
+              redirect: false,
+              lastModified: false,
+            })
+          }
+        }
+        else if (storageConfig.kind === 's3') {
+
+          const assetApi = storageConfig.type === 'image' ? s3ImageAssetsAPI(storageConfig) : s3FileAssetsAPI(storageConfig);
+
+          expressMiddleware = (request, response) => {
+            const { extraPath } = request.params
+
+            if (!extraPath) {
+              response.status(404).send('Not found')
+              return
+            }
+
+            const { s3, s3Endpoint } = s3AssetsCommon(storageConfig);
+
+            if (typeof storageConfig.isAccessAllowed === 'function' &&
+              !storageConfig.isAccessAllowed(context, s3, s3Endpoint, extraPath, response.getHeader)) {
+              response.status(403).send('Forbidden')
+              return
+            }
+
+            assetApi.download(extraPath, response, response.setHeader);
+          }
+
+        }
+        else {
+          expressMiddleware = (request, response) => {
+            process.env.NODE_ENV === 'development' && console.warn("storage api kind not supported");
+            response.status(404).send('Not found')
+          }
+        }
+
+
+        expressServer.use(
+          `${storageConfig.serverRoute.path}/:extraPath`,
+          expressMiddleware);
+      }
+
     }
   }
 
@@ -105,11 +184,11 @@ export const createExpressServer = async (
       playgroundOption === 'apollo'
         ? apolloConfig?.plugins
         : [
-            playgroundOption
-              ? ApolloServerPluginLandingPageLocalDefault()
-              : ApolloServerPluginLandingPageDisabled(),
-            ...(apolloConfig?.plugins || []),
-          ],
+          playgroundOption
+            ? ApolloServerPluginLandingPageLocalDefault()
+            : ApolloServerPluginLandingPageDisabled(),
+          ...(apolloConfig?.plugins || []),
+        ],
   } as ApolloServerOptions<KeystoneContext>
 
   const apolloServer = new ApolloServer({ ...serverConfig })

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -32,6 +32,17 @@ type FileOrImage =
     transformName?: (filename: string, extension: string) => MaybePromise<string>
   }
 
+export type LocalStorageAccessAllowedOptions = {
+    context: KeystoneContext, 
+    fileKey: string, 
+    headers: (headerKey: string) => string | number | string[] | undefined
+}
+
+export type StorageAccessAllowedOptions = LocalStorageAccessAllowedOptions & {
+  s3?: S3Client, 
+  s3Endpoint?: string, 
+}
+
 export type StorageConfig = (
   | {
     /** The kind of storage being configured */
@@ -52,9 +63,9 @@ export type StorageConfig = (
       path: string
     } | null,
     /** A function that is checked before serving the file or image to check for permissions. 
-     * This function will only be respected if the serverRoute is set
+     * This function will only be respected if the serverRoute is set\
     */
-    isAccessAllowed?: (context: KeystoneContext, fileKey: string, headers: (headerKey: string) => string | number | string[] | undefined) => boolean
+    isAccessAllowed?: (options: StorageAccessAllowedOptions) => boolean,
     /** Sets whether the assets should be preserved locally on removal from keystone's database */
     preserve?: boolean
     transformName?: (filename: string) => string
@@ -88,16 +99,16 @@ export type StorageConfig = (
     /** A function that is checked before serving the file or image to check for permissions. 
      * This function will only be respected if the serverRoute is set
     */
-    isAccessAllowed?: (context: KeystoneContext, s3: S3Client, s3Endpoint: string, fileKey: string, headers: (headerKey: string) => string | number | string[] | undefined) => boolean
+    isAccessAllowed?: (options: StorageAccessAllowedOptions) => boolean,
     /** A string that sets permissions for the uploaded assets. Default is 'private'.
      *
      * Amazon S3 supports a set of predefined grants, known as canned ACLs.
      * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
      * for more details.
      * 
-     * In terms of access control, when using serverRoute with proxied: true, it only matters to protect 
-     * the assets from being accessed directly from the S3 bucket. To protect the assets with serverRoute: { proxied: true } you should instead 
-     * implement the isAccessAllowed function  
+     * In terms of access control, when using serverRoute (proxied through keystone) it only matters to protect 
+     * the assets from being accessed directly from the S3 bucket. To protect the assets with serverRoute: { path: '/some-path' } you should instead 
+     * implement the isAccessAllowed function 
      */
     acl?:
     | 'private'

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -20,76 +20,94 @@ import type {
 import type { BaseFields } from './fields'
 import type { ListAccessControl, FieldAccessControl } from './access-control'
 import type { ListHooks, FieldHooks } from './hooks'
+import { S3Client } from '@aws-sdk/client-s3'
 
 type FileOrImage =
   // is given full file name, returns file name that will be used at
   | { type: 'file', transformName?: (filename: string) => MaybePromise<string> }
   // return does not include extension, extension is handed over in case they want to use it
   | {
-      type: 'image'
-      // is given full file name, returns file name that will be used at
-      transformName?: (filename: string, extension: string) => MaybePromise<string>
-    }
+    type: 'image'
+    // is given full file name, returns file name that will be used at
+    transformName?: (filename: string, extension: string) => MaybePromise<string>
+  }
 
 export type StorageConfig = (
   | {
-      /** The kind of storage being configured */
-      kind: 'local'
-      /** The path to where the asset will be stored on disc, eg 'public/images' */
-      storagePath: string
-      /** A function that receives a partial url, whose return will be used as the URL in graphql
-       *
-       * For example, a local dev usage of this might be:
-       * ```ts
-       * path => `http://localhost:3000/images${path}`
-       * ```
-       */
-      generateUrl: (path: string) => string
-      /** The configuration for keystone's hosting of the assets - if set to null, keystone will not host the assets */
-      serverRoute: {
-        /** The partial path that the assets will be hosted at by keystone, eg `/images` or `/our-cool-files` */
-        path: string
-      } | null
-      /** Sets whether the assets should be preserved locally on removal from keystone's database */
-      preserve?: boolean
-      transformName?: (filename: string) => string
-    }
+    /** The kind of storage being configured */
+    kind: 'local'
+    /** The path to where the asset will be stored on disc, eg 'public/images' */
+    storagePath: string
+    /** A function that receives a partial url, whose return will be used as the URL in graphql
+     *
+     * For example, a local dev usage of this might be:
+     * ```ts
+     * path => `http://localhost:3000/images${path}`
+     * ```
+     */
+    generateUrl: (path: string) => string
+    /** The configuration for keystone's hosting of the assets - if set to null, keystone will not host the assets */
+    serverRoute: {
+      /** The partial path that the assets will be hosted at by keystone, eg `/images` or `/our-cool-files` */
+      path: string
+    } | null,
+    /** A function that is checked before serving the file or image to check for permissions. 
+     * This function will only be respected if the serverRoute is set
+    */
+    isAccessAllowed?: (context: KeystoneContext, fileKey: string, headers: (headerKey: string) => string | number | string[] | undefined) => boolean
+    /** Sets whether the assets should be preserved locally on removal from keystone's database */
+    preserve?: boolean
+    transformName?: (filename: string) => string
+  }
   | {
-      /** The kind of storage being configured */
-      kind: 's3'
-      /** Sets signing of the asset - for use when you want private assets */
-      signed?: { expiry: number }
-      generateUrl?: (path: string) => string
-      /** Sets whether the assets should be preserved locally on removal from keystone's database */
-      preserve?: boolean
-      pathPrefix?: string
-      /** Your s3 instance's bucket name */
-      bucketName: string
-      /** Your s3 instance's region */
-      region: string
-      /** An access Key ID with write access to your S3 instance */
-      accessKeyId?: string
-      /** The secret access key that gives permissions to your access Key Id */
-      secretAccessKey?: string
-      /** An endpoint to use - to be provided if you are not using AWS as your endpoint */
-      endpoint?: string
-      /** If true, will force the 'old' S3 path style of putting bucket name at the start of the pathname of the URL  */
-      forcePathStyle?: boolean
-      /** A string that sets permissions for the uploaded assets. Default is 'private'.
-       *
-       * Amazon S3 supports a set of predefined grants, known as canned ACLs.
-       * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
-       * for more details.
-       */
-      acl?:
-        | 'private'
-        | 'public-read'
-        | 'public-read-write'
-        | 'aws-exec-read'
-        | 'authenticated-read'
-        | 'bucket-owner-read'
-        | 'bucket-owner-full-control'
-    }
+    /** The kind of storage being configured */
+    kind: 's3'
+    /** Sets signing of the asset - for use when you want private assets */
+    signed?: { expiry: number }
+    generateUrl?: (path: string) => string
+    /** Sets whether the assets should be preserved locally on removal from keystone's database */
+    preserve?: boolean
+    pathPrefix?: string
+    /** Your s3 instance's bucket name */
+    bucketName: string
+    /** Your s3 instance's region */
+    region: string
+    /** An access Key ID with write access to your S3 instance */
+    accessKeyId?: string
+    /** The secret access key that gives permissions to your access Key Id */
+    secretAccessKey?: string
+    /** An endpoint to use - to be provided if you are not using AWS as your endpoint */
+    endpoint?: string
+    /** If true, will force the 'old' S3 path style of putting bucket name at the start of the pathname of the URL  */
+    forcePathStyle?: boolean,
+    /** The configuration for keystone's hosting of the assets - if set to null, keystone will not host the assets */
+    serverRoute: {
+      /** The partial path that the assets will be hosted at by keystone, eg `/images` or `/our-cool-files` */
+      path: string,
+    } | null,
+    /** A function that is checked before serving the file or image to check for permissions. 
+     * This function will only be respected if the serverRoute is set
+    */
+    isAccessAllowed?: (context: KeystoneContext, s3: S3Client, s3Endpoint: string, fileKey: string, headers: (headerKey: string) => string | number | string[] | undefined) => boolean
+    /** A string that sets permissions for the uploaded assets. Default is 'private'.
+     *
+     * Amazon S3 supports a set of predefined grants, known as canned ACLs.
+     * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+     * for more details.
+     * 
+     * In terms of access control, when using serverRoute with proxied: true, it only matters to protect 
+     * the assets from being accessed directly from the S3 bucket. To protect the assets with serverRoute: { proxied: true } you should instead 
+     * implement the isAccessAllowed function  
+     */
+    acl?:
+    | 'private'
+    | 'public-read'
+    | 'public-read-write'
+    | 'aws-exec-read'
+    | 'authenticated-read'
+    | 'bucket-owner-read'
+    | 'bucket-owner-full-control'
+  }
 ) &
   FileOrImage
 
@@ -200,11 +218,11 @@ export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
 
   /** @deprecated */
   healthCheck?:
-    | true
-    | {
-        path?: string
-        data?: Record<string, any> | (() => Record<string, any>)
-      }
+  | true
+  | {
+    path?: string
+    data?: Record<string, any> | (() => Record<string, any>)
+  }
 
   /** extend the Express application used by Keystone */
   extendExpressApp?: (
@@ -219,15 +237,15 @@ export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
     graphqlSchema: GraphQLSchema
   ) => void
 } & (
-  | {
+    | {
       /** Port number to start the server on. Defaults to process.env.PORT || 3000 */
       port?: number
     }
-  | {
+    | {
       /** node http.Server options */
       options?: ListenOptions
     }
-)
+  )
 
 // config.graphql
 


### PR DESCRIPTION
Implemented proxied mode (it was referred to in the documentation and examples as creating a server route on express, but it didn't for s3 case) in s3 as well as leaving the same "static express mapping" as before for local storage mode. 
Implemented an access Control hook extension point to validate access to either local or s3 assets with proxied mode 
Fix the documentation to conform to "serverRoute" always (instead of distinguishing between s3 or local kinds). 
Still feel the code could be further improved by: 
1. Not allowing "generateUrl" to be implemented on the case of "proxied" mode (serverRoute.path defined) 
2. Check for "overlaps" between the "serverRoute.path" and other express middlewares at startup and warning the devs about it 
3. Implement the pathPrefix option (correctly on s3) on local storage kind (and mkdir accordingly at startup)
4. Check for "signed" vs "serverRoute.path" vs "acl" options and warn devs appropriately 