### PR TITLE
Drop `chalk`, [most of] `fs-extra` and `node-fetch` as [dev]dependencies

### DIFF
--- a/design-system/packages/icons/build-icons.js
+++ b/design-system/packages/icons/build-icons.js
@@ -1,18 +1,16 @@
-/* eslint-disable import/no-extraneous-dependencies */
-const path = require('path')
+const path = require('node:path')
+const fs = require('node:fs/promises')
 
-const fs = require('fs-extra')
+/* eslint-disable import/no-extraneous-dependencies */
 const svgr = require('@svgr/core').default
 const { icons } = require('feather-icons')
 const toPascalCase = require('to-pascal-case')
 const globby = require('globby')
 
-const chalk = require('chalk')
-
 async function writeIcons () {
   let iconOutDir = path.join(__dirname, 'src', 'icons')
 
-  await fs.ensureDir(iconOutDir)
+  await fs.mkdir(iconOutDir, { recursive: true })
   let names = []
   await Promise.all(
     Object.keys(icons).map(async key => {
@@ -45,11 +43,10 @@ async function writeIcons () {
                     )
               },
               ${t.stringLiteral(name)}
-            );
+            )
             `
           },
           plugins: [
-            // '@svgr/plugin-svgo',
             '@svgr/plugin-jsx',
           ],
         },
@@ -72,11 +69,11 @@ async function writeIndex (icons) {
     encoding: 'utf8',
   })
 
-  console.info(chalk.green('✅ Index file written successfully'))
+  console.info('✅ Index file written successfully')
 }
 
 async function writePkg (pkgPath, content) {
-  await fs.ensureFile(pkgPath)
+  await fs.mkdir(path.dirname(pkgPath), { recursive: true })
   await fs.writeFile(pkgPath, JSON.stringify(content, null, 2) + '\n', {
     encoding: 'utf8',
   })
@@ -94,7 +91,7 @@ async function createEntrypointPkgJsons (icons) {
     })
   )
 
-  console.info(chalk.green('✅ all package.json entrypoint files written successfully'))
+  console.info('✅ all package.json entrypoint files written successfully')
 }
 
 async function clean () {
@@ -110,9 +107,9 @@ async function clean () {
 }
 
 (async () => {
-  console.info(chalk.blue('🧹 Cleaning existing exports'))
+  console.info('🧹 Cleaning existing exports')
   await clean()
-  console.info(chalk.blue('🚧 Building icon exports'))
+  console.info('🚧 Building icon exports')
 
   let icons = await writeIcons()
   await Promise.all([writeIndex(icons), createEntrypointPkgJsons(icons)])

--- a/design-system/packages/icons/package.json
+++ b/design-system/packages/icons/package.json
@@ -1163,9 +1163,7 @@
     "@svgr/plugin-jsx": "^8.0.0",
     "@svgr/plugin-svgo": "^8.0.0",
     "@types/react": "^18.0.9",
-    "chalk": "^4.1.2",
     "feather-icons": "^4.28.0",
-    "fs-extra": "^11.0.0",
     "globby": "^14.0.0",
     "react": "^18.2.0",
     "to-pascal-case": "^1.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -237,7 +237,6 @@
     "intersection-observer": "^0.12.0",
     "meow": "^9.0.0",
     "next": "^13.3.0",
-    "node-fetch": "^2.6.7",
     "p-limit": "^2.3.0",
     "pluralize": "^8.0.0",
     "prisma": "4.16.2",

--- a/packages/core/src/fields/types/image/index.ts
+++ b/packages/core/src/fields/types/image/index.ts
@@ -69,11 +69,12 @@ function isValidImageExtension (extension: string): extension is ImageExtension 
 
 export function image <ListTypeInfo extends BaseListTypeInfo>(config: ImageFieldConfig<ListTypeInfo>): FieldTypeFunc<ListTypeInfo> {
   return meta => {
+    const { fieldKey } = meta
     const storage = meta.getStorage(config.storage)
 
     if (!storage) {
       throw new Error(
-        `${meta.listKey}.${meta.fieldKey} has storage set to ${config.storage}, but no storage configuration was found for that key`
+        `${meta.listKey}.${fieldKey} has storage set to ${config.storage}, but no storage configuration was found for that key`
       )
     }
 
@@ -100,17 +101,17 @@ export function image <ListTypeInfo extends BaseListTypeInfo>(config: ImageField
             async beforeOperation (args) {
               await config.hooks?.beforeOperation?.(args)
               if (args.operation === 'update' || args.operation === 'delete') {
-                const idKey = `${meta.fieldKey}_id`
+                const idKey = `${fieldKey}_id`
                 const id = args.item[idKey]
-                const extensionKey = `${meta.fieldKey}_extension`
+                const extensionKey = `${fieldKey}_extension`
                 const extension = args.item[extensionKey]
 
                 // This will occur on an update where an image already existed but has been
                 // changed, or on a delete, where there is no longer an item
                 if (
                   (args.operation === 'delete' ||
-                    typeof args.resolvedData[meta.fieldKey].id === 'string' ||
-                    args.resolvedData[meta.fieldKey].id === null) &&
+                    typeof args.resolvedData[fieldKey].id === 'string' ||
+                    args.resolvedData[fieldKey].id === null) &&
                   typeof id === 'string' &&
                   typeof extension === 'string' &&
                   isValidImageExtension(extension)

--- a/packages/core/src/lib/assets/local.ts
+++ b/packages/core/src/lib/assets/local.ts
@@ -1,9 +1,10 @@
-import path from 'path'
-import { pipeline } from 'stream'
-import fs from 'fs-extra'
+import fsp from 'node:fs/promises'
+import fs from 'node:fs'
+import path from 'node:path'
+import { pipeline } from 'node:stream'
 
-import { type StorageConfig } from '../../types'
-import { type FileAdapter, type ImageAdapter } from './types'
+import { StorageConfig } from '../../types'
+import { FileAdapter, ImageAdapter } from './types'
 
 export function localImageAssetsAPI (
   storageConfig: StorageConfig & { kind: 'local' }
@@ -13,11 +14,11 @@ export function localImageAssetsAPI (
       return storageConfig.generateUrl(`/${id}.${extension}`)
     },
     async upload (buffer, id, extension) {
-      await fs.writeFile(path.join(storageConfig.storagePath, `${id}.${extension}`), buffer)
+      await fsp.writeFile(path.join(storageConfig.storagePath, `${id}.${extension}`), buffer)
     },
     async delete (id, extension) {
       try {
-        await fs.unlink(path.join(storageConfig.storagePath, `${id}.${extension}`))
+        await fsp.unlink(path.join(storageConfig.storagePath, `${id}.${extension}`))
       } catch (e) {
         const error = e as NodeJS.ErrnoException
         // If the file doesn't exist, we don't care
@@ -48,16 +49,16 @@ export function localFileAssetsAPI (storageConfig: StorageConfig & { kind: 'loca
 
       try {
         await pipeStreams
-        const { size: filesize } = await fs.stat(path.join(storageConfig.storagePath, filename))
+        const { size: filesize } = await fsp.stat(path.join(storageConfig.storagePath, filename))
         return { filesize, filename }
       } catch (e) {
-        await fs.remove(path.join(storageConfig.storagePath, filename))
+        await fsp.rm(path.join(storageConfig.storagePath, filename))
         throw e
       }
     },
     async delete (filename) {
       try {
-        await fs.unlink(path.join(storageConfig.storagePath, filename))
+        await fsp.unlink(path.join(storageConfig.storagePath, filename))
       } catch (e) {
         const error = e as NodeJS.ErrnoException
         // If the file doesn't exist, we don't care

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -1,7 +1,8 @@
 import { platform } from 'node:os'
+import https from 'node:https'
+
 import ci from 'ci-info'
 import Conf from 'conf'
-import fetch from 'node-fetch'
 import chalk from 'chalk'
 import {
   type Configuration,
@@ -11,7 +12,7 @@ import {
   type Telemetry,
 } from '../types/telemetry'
 import { type DatabaseProvider } from '../types'
-import type { InitialisedList } from './core/initialise-lists'
+import { type InitialisedList } from './core/initialise-lists'
 
 const defaultTelemetryEndpoint = 'https://telemetry.keystonejs.com'
 
@@ -223,16 +224,14 @@ function inform () {
 
 async function sendEvent (eventType: 'project' | 'device', eventData: Project | Device) {
   const endpoint = process.env.KEYSTONE_TELEMETRY_ENDPOINT || defaultTelemetryEndpoint
-  const url = `${endpoint}/v1/event/${eventType}`
-
-  await fetch(url, {
+  const req = https.request(`${endpoint}/v1/event/${eventType}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(eventData),
   })
 
+  req.end(JSON.stringify(eventData))
   log(`sent ${eventType} report`)
 }
 

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -1,13 +1,12 @@
+import fsp from 'node:fs/promises'
 import path from 'node:path'
 import type { ListenOptions } from 'node:net'
 import url from 'node:url'
 import { createServer } from 'node:http'
-import fsp from 'node:fs/promises'
 import next from 'next'
 import express from 'express'
-import { type GraphQLSchema, printSchema } from 'graphql'
-import fs from 'fs-extra'
-import esbuild, { type BuildResult } from 'esbuild'
+import { GraphQLSchema, printSchema } from 'graphql'
+import esbuild, { BuildResult } from 'esbuild'
 import { generateAdminUI } from '../admin-ui/system'
 import { devMigrations, pushPrismaSchemaToDatabase } from '../lib/migrations'
 import { createSystem } from '../lib/createSystem'
@@ -75,7 +74,7 @@ export async function dev (
       ...(esbuildConfig.plugins ?? []),
       {
         name: 'esbuildWatchPlugin',
-        setup (build: any) {
+        setup(build: any) {
           // TODO: no any
           build.onEnd(addBuildResult)
         },
@@ -134,7 +133,7 @@ export async function dev (
   }
 
   const initKeystone = async () => {
-    await fs.rm(paths.admin, { recursive: true, force: true })
+    await fsp.rm(paths.admin, { recursive: true, force: true })
     const {
       adminMeta,
       graphQLSchema,
@@ -226,7 +225,7 @@ export async function dev (
         // which means you get a "there's probably a memory leak" warning from node
         const newPrintedGraphQLSchema = printSchema(graphQLSchema)
         if (newPrintedGraphQLSchema !== lastPrintedGraphQLSchema) {
-          await fs.writeFile(
+          await fsp.writeFile(
             paths.schema.graphql,
             getFormattedGraphQLSchema(newPrintedGraphQLSchema)
           )

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -1,6 +1,6 @@
-import type { ListenOptions } from 'net'
+import fs from 'node:fs/promises'
+import type { ListenOptions } from 'node:net'
 import next from 'next'
-import * as fs from 'fs-extra'
 import { createSystem } from '../lib/createSystem'
 import { createExpressServer } from '../lib/server/createExpressServer'
 import { createAdminUIMiddlewareWithNextApp } from '../lib/server/createAdminUIMiddleware'
@@ -13,17 +13,17 @@ import { deployMigrations } from '../lib/migrations'
 import { ExitError } from './utils'
 import type { Flags } from './cli'
 
-export const start = async (
+export async function start (
   cwd: string,
   { ui, withMigrations }: Pick<Flags, 'ui' | 'withMigrations'>
-) => {
+) {
   console.log('✨ Starting Keystone')
 
   // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
   const builtConfigPath = getBuiltKeystoneConfigurationPath(cwd)
 
-  // This is the compiled version of the configuration which was generated during the build step
-  if (!fs.existsSync(builtConfigPath)) {
+  // this is the compiled version of the configuration which was generated during the build step
+  if (!(await fs.stat(builtConfigPath).catch(() => null))) {
     console.error('🚨 keystone build must be run before running keystone start')
     throw new ExitError(1)
   }
@@ -68,12 +68,12 @@ export const start = async (
     Object.assign(httpOptions, config.server.options)
   }
 
-  // preference env.PORT if supplied
+  // prefer env.PORT
   if ('PORT' in process.env) {
     httpOptions.port = parseInt(process.env.PORT || '')
   }
 
-  // preference env.HOST if supplied
+  // prefer env.HOST
   if ('HOST' in process.env) {
     httpOptions.host = process.env.HOST || ''
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,15 +177,9 @@ importers:
       '@types/react':
         specifier: ^18.0.9
         version: 18.2.55
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
       feather-icons:
         specifier: ^4.28.0
         version: 4.29.1
-      fs-extra:
-        specifier: ^11.0.0
-        version: 11.2.0
       globby:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2041,9 +2035,6 @@ importers:
       next:
         specifier: ^13.3.0
         version: 13.5.6(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
-      node-fetch:
-        specifier: ^2.6.7
-        version: 2.7.0
       p-limit:
         specifier: ^2.3.0
         version: 2.3.0
@@ -2244,9 +2235,6 @@ importers:
       '@prisma/internals':
         specifier: ^4.16.2
         version: 4.16.2
-      fs-extra:
-        specifier: ^11.0.0
-        version: 11.2.0
       tsx:
         specifier: ^4.0.0
         version: 4.7.0
@@ -9634,7 +9622,7 @@ packages:
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.9)
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.4
       '@vanilla-extract/css': 1.14.1
-      esbuild: 0.17.6
+      esbuild: 0.19.12
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0

--- a/prisma-utils/main.ts
+++ b/prisma-utils/main.ts
@@ -1,4 +1,4 @@
-import fs from 'fs/promises'
+import fs from 'node:fs/promises'
 import type { DMMF } from '@prisma/generator-helper'
 import { getDMMF } from '@prisma/internals'
 

--- a/prisma-utils/package.json
+++ b/prisma-utils/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@prisma/generator-helper": "^4.16.2",
     "@prisma/internals": "^4.16.2",
-    "fs-extra": "^11.0.0",
     "tsx": "^4.0.0"
   },
   "scripts": {

--- a/tests/api-tests/fields/images.crud.test.disabled.ts
+++ b/tests/api-tests/fields/images.crud.test.disabled.ts
@@ -1,8 +1,10 @@
-import path from 'path'
-import { createHash } from 'crypto'
-import os from 'os'
-import fs from 'fs-extra'
+import fs from 'node:fs'
+import fsp from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { createHash } from 'node:crypto'
 import fetch from 'node-fetch'
+
 // @ts-expect-error
 import Upload from 'graphql-upload/Upload.js'
 import mime from 'mime'
@@ -15,7 +17,7 @@ import { testConfig, expectSingleResolverError } from '../utils'
 
 const fieldPath = path.resolve(__dirname, '../../..', 'packages/core/src/fields/types')
 
-export const prepareFile = (_filePath: string, kind: 'image' | 'file') => {
+export function prepareFile (_filePath: string, kind: 'image' | 'file') {
   const filePath = path.resolve(fieldPath, kind, 'test-files', _filePath)
   const upload = new Upload()
   upload.resolve({
@@ -44,14 +46,14 @@ const s3DefaultStorage = {
   forcePathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
 } as const
 
-const getRunner = ({
+function getRunner ({
   storage,
   fields,
 }: {
   storage: Record<string, StorageConfig>
   fields: KeystoneConfig['lists'][string]['fields']
-}) =>
-  setupTestRunner({
+}) {
+  return setupTestRunner({
     config: testConfig({
       db: {},
       storage,
@@ -66,31 +68,29 @@ const getRunner = ({
       },
     }),
   })
-
-const getFileHash = async (
-  filename: string,
-  config: { matrixValue: 's3' } | { matrixValue: 'local', folder: string }
-) => {
-  let contentFromURL
-
-  if (config.matrixValue === 's3') {
-    contentFromURL = await fetch(filename).then(x => x.buffer())
-  } else {
-    contentFromURL = await fs.readFile(path.join(config.folder, filename))
-  }
-
-  return createHash('sha1').update(contentFromURL).digest('hex')
 }
 
-const checkFile = async (
-  filename: string,
-  config: { matrixValue: 's3' } | { matrixValue: 'local', folder: string }
-) => {
+function sha1 (x: Buffer) {
+  return createHash('sha1').update(x).digest('hex')
+}
+
+async function getFileHash (
+  url: string,
+  config: { matrixValue: 's3' } | { matrixValue: 'local'; folder: string }
+) {
   if (config.matrixValue === 's3') {
-    return await fetch(filename).then(x => x.status === 200)
-  } else {
-    return fs.existsSync(path.join(config.folder, filename))
+    return sha1(await fetch(url).then(x => x.buffer()))
   }
+
+  return sha1(await fsp.readFile(path.join(config.folder, url)))
+}
+
+async function checkFile (
+  filename: string,
+  config: { matrixValue: 's3' } | { matrixValue: 'local'; folder: string }
+) {
+  if (config.matrixValue === 's3') return await fetch(filename).then(x => x.status === 200)
+  return Boolean(await fsp.stat(path.join(config.folder, filename)).catch(() => null))
 }
 
 describe('Image - Crud special tests', () => {

--- a/tests/api-tests/fields/types/utils.ts
+++ b/tests/api-tests/fields/types/utils.ts
@@ -1,6 +1,7 @@
-import fs from 'fs'
-import os from 'os'
-import path from 'path'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { list } from '@keystone-6/core'
 import { integer } from '@keystone-6/core/fields'
 import { setupTestRunner } from '@keystone-6/api-tests/test-runner'

--- a/tests/cli-tests/build.test.ts
+++ b/tests/cli-tests/build.test.ts
@@ -1,5 +1,5 @@
+import fs from 'node:fs/promises'
 import execa from 'execa'
-import * as fs from 'fs-extra'
 import {
   ExitError,
   basicKeystoneConfig,


### PR DESCRIPTION
These dependencies rarely add any value for the implementation and nothing for our downstream users.
The replacement code is often 1:1 with what `node` provides.