### PR TITLE
Add explicit TypeInfo types for examples with getContext

### DIFF
--- a/examples/custom-id/keystone.ts
+++ b/examples/custom-id/keystone.ts
@@ -1,8 +1,9 @@
 import { config } from '@keystone-6/core'
 import { fixPrismaPath } from '../example-utils'
 import { lists } from './schema'
+import type { TypeInfo } from '.keystone/types'
 
-export default config({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',

--- a/examples/limits/keystone.ts
+++ b/examples/limits/keystone.ts
@@ -1,8 +1,9 @@
 import { config } from '@keystone-6/core'
 import { fixPrismaPath } from '../example-utils'
 import { lists } from './schema'
+import type { TypeInfo } from '.keystone/types'
 
-export default config({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',

--- a/examples/singleton/keystone.ts
+++ b/examples/singleton/keystone.ts
@@ -1,8 +1,9 @@
 import { config } from '@keystone-6/core'
 import { fixPrismaPath } from '../example-utils'
 import { lists } from './schema'
+import type { TypeInfo } from '.keystone/types'
 
-export default config({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',

--- a/examples/usecase-blog/keystone.ts
+++ b/examples/usecase-blog/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core'
 import { fixPrismaPath } from '../example-utils'
 import { lists } from './schema'
-import { type TypeInfo } from '.keystone/types'
+import type { TypeInfo } from '.keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/usecase-todo/keystone.ts
+++ b/examples/usecase-todo/keystone.ts
@@ -1,8 +1,9 @@
 import { config } from '@keystone-6/core'
 import { fixPrismaPath } from '../example-utils'
 import { lists } from './schema'
+import type { TypeInfo } from '.keystone/types'
 
-export default config({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',


### PR DESCRIPTION
Resolves the comment from @mmachatschek in https://github.com/keystonejs/keystone/pull/8876#issuecomment-1783321292 that our `usecase-` examples didn't use `TypeInfo`, which left the `seed-data` examples using the unrefined context.