### PR TITLE
Fix `image` field type to use consistent sub-field ordering

### DIFF
--- a/.changeset/same-field-order.md
+++ b/.changeset/same-field-order.md
@@ -1,0 +1,5 @@
+----
+'@keystone-6/core': patch
+----
+
+Fix `image` field type to use consistent sub-field ordering

--- a/examples/assets-local/schema.prisma
+++ b/examples/assets-local/schema.prisma
@@ -16,11 +16,11 @@ model Post {
   id                  String  @id @default(cuid())
   title               String  @default("")
   content             String  @default("")
+  banner_id           String?
   banner_filesize     Int?
-  banner_extension    String?
   banner_width        Int?
   banner_height       Int?
-  banner_id           String?
+  banner_extension    String?
   attachment_filesize Int?
   attachment_filename String?
 }

--- a/examples/assets-s3/schema.prisma
+++ b/examples/assets-s3/schema.prisma
@@ -16,11 +16,11 @@ model Post {
   id                  String  @id @default(cuid())
   title               String  @default("")
   content             String  @default("")
+  banner_id           String?
   banner_filesize     Int?
-  banner_extension    String?
   banner_width        Int?
   banner_height       Int?
-  banner_id           String?
+  banner_extension    String?
   attachment_filesize Int?
   attachment_filename String?
 }

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -1,10 +1,10 @@
 import {
-  fieldType,
   type FieldTypeFunc,
   type CommonFieldConfig,
   type BaseListTypeInfo,
   type KeystoneContext,
   type FileMetadata,
+  fieldType,
 } from '../../../types'
 import { graphql } from '../../..'
 
@@ -44,9 +44,7 @@ async function inputResolver (
   data: graphql.InferValueFromArg<typeof inputArg>,
   context: KeystoneContext
 ) {
-  if (data === null || data === undefined) {
-    return { filename: data, filesize: data }
-  }
+  if (data === null || data === undefined) return { filename: data, filesize: data }
   const upload = await data.upload
   return context.files(storage).getDataFromStream(upload.createReadStream(), upload.filename)
 }
@@ -111,10 +109,13 @@ export function file <ListTypeInfo extends BaseListTypeInfo>(config: FileFieldCo
       output: graphql.field({
         type: FileFieldOutput,
         resolve ({ value: { filesize, filename } }) {
-          if (filesize === null || filename === null) {
-            return null
+          if (filename === null) return null
+          if (filesize === null) return null
+          return {
+            filename,
+            filesize,
+            storage: config.storage
           }
-          return { filename, filesize, storage: config.storage }
         },
       }),
       __ksTelemetryFieldTypeName: '@keystone-6/file',

--- a/tests/sandbox/schema.prisma
+++ b/tests/sandbox/schema.prisma
@@ -39,11 +39,11 @@ model Thing {
   decimal                           Decimal?  @postgresql.Decimal(32, 8)
   bigInt                            BigInt?   @unique
   float                             Float?
+  image_id                          String?
   image_filesize                    Int?
-  image_extension                   String?
   image_width                       Int?
   image_height                      Int?
-  image_id                          String?
+  image_extension                   String?
   file_filesize                     Int?
   file_filename                     String?
   document                          Json      @default("[{\"type\":\"paragraph\",\"children\":[{\"text\":\"\"}]}]")


### PR DESCRIPTION
This pull request updates the `image` field type to be consistent in the ordering of it's sub-fields when comparing the Prisma schema and the GraphQL schema.

This is not a breaking change, but it will result in your GraphQL schema requiring regeneration.