### PR TITLE
Add `await` support to `extendHttpServer`

### DIFF
--- a/.changeset/boolean-not-false-2.md
+++ b/.changeset/boolean-not-false-2.md
@@ -1,0 +1,5 @@
+----
+'@keystone-6/core': patch
+----
+
+Fix `config.server.cors` type blocking `false` values

--- a/.changeset/boolean-not-false.md
+++ b/.changeset/boolean-not-false.md
@@ -1,5 +1,5 @@
 ----
-'@keystone-6/auth': core
+'@keystone-6/core': patch
 ----
 
 Fix `defaultIsFilterable` and `defaultIsOrderable` types blocking `true` values

--- a/.changeset/http-async.md
+++ b/.changeset/http-async.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add `async` to `extendHttpServer`, for `await` on startup

--- a/docs/pages/docs/config/config.md
+++ b/docs/pages/docs/config/config.md
@@ -226,8 +226,8 @@ export default config<TypeInfo>({
     cors: { origin: ['http://localhost:7777'], credentials: true },
     port: 3000,
     maxFileSize: 200 * 1024 * 1024,
-    extendExpressApp: (app, commonContext) => { /* ... */ },
-    extendHttpServer: (httpServer, commonContext, graphQLSchema) => { /* ... */ },
+    extendExpressApp: async (app, commonContext) => { /* ... */ },
+    extendHttpServer: async (httpServer, commonContext, graphQLSchema) => { /* ... */ },
   },
   /* ... */
 });

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -42,10 +42,9 @@ export function initConfig (config: KeystoneConfig) {
     server: {
       cors: false,
       maxFileSize: 200 * 1024 * 1024, // 200 MiB
-
       extendExpressApp: async () => {},
       extendHttpServer: async () => {},
-      ...config?.server,
+      ...config.server,
     },
   }
 }

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -25,10 +25,11 @@ export function initConfig (config: KeystoneConfig) {
   config.db.url ??= 'postgres://'
 
   return {
-    types: {
-      path: 'node_modules/.keystone/types.ts'
-    },
     ...config,
+    types: {
+      path: 'node_modules/.keystone/types.ts',
+      ...config.types,
+    },
     db: {
       prismaSchemaPath: 'schema.prisma',
       ...config.db,
@@ -38,6 +39,14 @@ export function initConfig (config: KeystoneConfig) {
       ...config.graphql,
     },
     lists: applyIdFieldDefaults(config),
+    server: {
+      cors: false,
+      maxFileSize: 200 * 1024 * 1024, // 200 MiB
+
+      extendExpressApp: async () => {},
+      extendHttpServer: async () => {},
+      ...config?.server,
+    },
   }
 }
 

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -210,14 +210,14 @@ export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
   extendExpressApp?: (
     app: express.Express,
     context: KeystoneContext<TypeInfo>
-  ) => void | Promise<void>
+  ) => MaybePromise<void>
 
   /** extend the node:http server used by Keystone */
   extendHttpServer?: (
     server: Server,
     context: KeystoneContext<TypeInfo>,
     graphqlSchema: GraphQLSchema
-  ) => void
+  ) => MaybePromise<void>
 } & (
   | {
       /** Port number to start the server on. Defaults to process.env.PORT || 3000 */

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -193,8 +193,8 @@ export type AdminFileToWrite =
 
 // config.server
 export type ServerConfig<TypeInfo extends BaseKeystoneTypeInfo> = {
-  /** Configuration options for the cors middleware. Set to `true` to use core Keystone defaults */
-  cors?: CorsOptions | true
+  /** Configuration options for the cors middleware. Set to `true` to use Keystone's defaults */
+  cors?: boolean | CorsOptions
   /** Maximum upload file size allowed (in bytes) */
   maxFileSize?: number
 


### PR DESCRIPTION
As described, this pull request allows you to use `await` operations in your `extendHttpServer` hook