### PR TITLE
Always use `context.graphql.schema` for `createExpressServer`

### DIFF
--- a/.changeset/fix-create-express-app.md
+++ b/.changeset/fix-create-express-app.md
@@ -1,0 +1,5 @@
+----
+'@keystone-6/core': patch
+----
+
+Fixes `createExpressApp` to use `context.graphql.schema` rather than the GraphQLSchema argument, removing ambiguity in downstream usage

--- a/.changeset/less-extend-http-server.md
+++ b/.changeset/less-extend-http-server.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ----
 
-Deprecates `extendHttpServer`'s third argument, the graphqlSchema. Use `context.graphql.schema`
+Deprecates `extendHttpServer`'s `graphqlSchema` argument; use `context.graphql.schema` now

--- a/.changeset/less-extend-type.md
+++ b/.changeset/less-extend-type.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': Patch
+---
+
+Deprecates `ExtendGraphQLSchema` type, use type `(schema: GraphQLSchema) => GraphQLSchema` instead

--- a/packages/core/src/admin-ui/templates/app.ts
+++ b/packages/core/src/admin-ui/templates/app.ts
@@ -1,27 +1,27 @@
 import hashString from '@emotion/hash'
 import {
-  executeSync,
+  type ExecutionResult,
+  type FragmentDefinitionNode,
+  type GraphQLSchema,
+  type SelectionNode,
   GraphQLNonNull,
   GraphQLScalarType,
-  type GraphQLSchema,
   GraphQLUnionType,
-  parse,
-  type FragmentDefinitionNode,
-  type SelectionNode,
-  type ExecutionResult,
   Kind,
+  executeSync,
+  parse,
 } from 'graphql'
 import { staticAdminMetaQuery, type StaticAdminMetaQuery } from '../admin-meta-graphql'
 import type { AdminMetaRootVal } from '../../lib/create-admin-meta'
 
 type AppTemplateOptions = { configFileExists: boolean }
 
-export const appTemplate = (
+export function appTemplate (
   adminMetaRootVal: AdminMetaRootVal,
   graphQLSchema: GraphQLSchema,
   { configFileExists }: AppTemplateOptions,
   apiPath: string
-) => {
+) {
   const result = executeSync({
     document: staticAdminMetaQuery,
     schema: graphQLSchema,

--- a/packages/core/src/lib/createExpressServer.ts
+++ b/packages/core/src/lib/createExpressServer.ts
@@ -5,7 +5,6 @@ import { expressMiddleware } from '@apollo/server/express4'
 import express from 'express'
 import {
   type GraphQLFormattedError,
-  type GraphQLSchema
 } from 'graphql'
 import { ApolloServer, type ApolloServerOptions } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
@@ -49,7 +48,7 @@ function formatError (graphqlConfig: GraphQLConfig | undefined) {
 
 export async function createExpressServer (
   config: Pick<KeystoneConfig, 'graphql' | 'server' | 'storage'>,
-  graphQLSchema: GraphQLSchema, // TODO: redundant, prefer context.graphql.schema, remove in breaking change
+  _: any, // TODO: uses context.graphql.schema now, remove in breaking change
   context: KeystoneContext
 ): Promise<{
   expressServer: express.Express
@@ -85,7 +84,7 @@ export async function createExpressServer (
   }
 
   await config.server?.extendExpressApp?.(expressServer, context)
-  await config.server?.extendHttpServer?.(httpServer, context, graphQLSchema)
+  await config.server?.extendHttpServer?.(httpServer, context, context.graphql.schema)
 
   if (config.storage) {
     for (const val of Object.values(config.storage)) {
@@ -117,7 +116,7 @@ export async function createExpressServer (
     includeStacktraceInErrorResponses: config.graphql?.debug,
 
     ...apolloConfig,
-    schema: graphQLSchema,
+    schema: context.graphql.schema,
     plugins:
       playgroundOption === 'apollo'
         ? apolloConfig?.plugins

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import type { ListenOptions } from 'node:net'
 import next from 'next'
-import { createSystem } from '../lib/createSystem'
+import { createSystem } from '../system'
 import { createExpressServer } from '../lib/createExpressServer'
 import { createAdminUIMiddlewareWithNextApp } from '../lib/createAdminUIMiddleware'
 import {
@@ -30,7 +30,7 @@ export async function start (
 
   const config = getBuiltKeystoneConfiguration(cwd)
   const paths = getSystemPaths(cwd, config)
-  const { getKeystone, graphQLSchema } = createSystem(config)
+  const { getKeystone } = createSystem(config)
   const prismaClient = require(paths.prisma)
   const keystone = getKeystone(prismaClient)
 
@@ -43,11 +43,7 @@ export async function start (
   await keystone.connect()
 
   console.log('✨ Creating server')
-  const { expressServer, httpServer } = await createExpressServer(
-    config,
-    graphQLSchema,
-    keystone.context
-  )
+  const { expressServer, httpServer } = await createExpressServer(config, null, keystone.context)
 
   console.log(`✅ GraphQL API ready`)
   if (!config.ui?.isDisabled && ui) {

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -105,7 +105,7 @@ export type KeystoneConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneT
   }
 
   // TODO: why isn't this within .graphql?
-  extendGraphqlSchema?: ExtendGraphqlSchema
+  extendGraphqlSchema?: (schema: GraphQLSchema) => GraphQLSchema
   /** An object containing configuration about keystone's various external storages.
    *
    * Each entry should be of either `kind: 'local'` or `kind: 's3'`, and follow the configuration of each.
@@ -293,8 +293,7 @@ export type GraphQLConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneTy
   schemaPath?: string
 }
 
-// config.extendGraphqlSchema
-
+/** @deprecated */
 export type ExtendGraphqlSchema = (schema: GraphQLSchema) => GraphQLSchema
 
 export type FilesConfig = {

--- a/tests/test-projects/live-reloading/schemas/second.ts
+++ b/tests/test-projects/live-reloading/schemas/second.ts
@@ -2,6 +2,8 @@ import { graphql, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, virtual } from '@keystone-6/core/fields'
 
+import type { Lists } from '.keystone/types'
+
 export const lists = {
   Something: list({
     access: allowAll,
@@ -11,13 +13,13 @@ export const lists = {
         field: graphql.field({
           type: graphql.String,
           resolve (item) {
-            return (item as { text: string }).text
+            return item.text
           },
         }),
       }),
     },
   }),
-}
+} satisfies Lists
 
 export const extendGraphqlSchema = graphql.extend(() => {
   return {


### PR DESCRIPTION
This pull request fixes `createExpressServer` to always use `context.graphql.schema` instead of the `GraphQLSchema` argument passed in.

Users downstream will _nearly_ always be interacting with their GraphQL schema using the `context.query` and `context.db` methods. As part of https://github.com/keystonejs/keystone/pull/9028 we have deprecated the `GraphQLSchema` argument that was provided, but if users are using that instead of `context.graphql.schema`, then I think it is a safe assumption that downstream users would have expected that the the GraphQL schema provided should have been equal to the operating schema of `context`.

This could arguably be considered a breaking change, but I don't think anyone would have reasonably used the argument of `createExpressServer` (deprecated) to differentiate between the two possible schemas, therefore I think this is a patch that will help developers if they made an error in passing a different `GraphQLSchema` through.