### PR TITLE
Add warnings for Field Access Control limitations with `context.db`

### DIFF
--- a/docs/pages/docs/config/access-control.md
+++ b/docs/pages/docs/config/access-control.md
@@ -230,7 +230,7 @@ export default config({
 
 {% hint kind="warn" %}
 Item-level access control is not available for `query` operations.
-Applying access control after fetching items would lead to inconsistent pagination behaviour and incorrect `count` results.
+Keystone has opted to disable `read` access control for `query` operations as applying _after_ queries will reuslt in inconsistent pagination behaviour and mismatched `count` results.
 {% /hint %}
 
 ### Function Arguments {% #list-level-function-arguments %}
@@ -271,6 +271,11 @@ No errors will be returned for `read` access denied.
 
 {% hint kind="tip" %}
 The `read` access control is applied to fields returned from both **queries** and **mutations**.
+{% /hint %}
+
+{% hint kind="tip" %}
+`read` access control is applied as part of GraphQL resolving the output types.
+If a mutation returns an item type that has field access control defined, field access control will apply.
 {% /hint %}
 
 {% hint kind="warn" %}

--- a/docs/pages/docs/config/access-control.md
+++ b/docs/pages/docs/config/access-control.md
@@ -259,6 +259,7 @@ Each operation is defined by a function which returns `true` if access is allowe
 
 Field-level access control rules are applied **after** the list level access rules have been applied.
 Access control rules are only applied to the fields that have an input value provided to the mutation.
+
 If any of the provided fields fail their access control check, the whole operation is aborted.
 The GraphQL API then returns `null` along with an access denied error.
 
@@ -270,6 +271,10 @@ No errors will be returned for `read` access denied.
 
 {% hint kind="tip" %}
 The `read` access control is applied to fields returned from both **queries** and **mutations**.
+{% /hint %}
+
+{% hint kind="warn" %}
+`read` field access control does not apply to `context.db.*` operations, as these operations do not resolve the underlying fields using GraphQL.
 {% /hint %}
 
 ```typescript

--- a/docs/pages/docs/guides/auth-and-access-control.md
+++ b/docs/pages/docs/guides/auth-and-access-control.md
@@ -484,6 +484,10 @@ You can provide field-level rules for:
 If you want to completely block users from setting a field's value, make sure you set both the `create` and `update` rules.
 {% /hint %}
 
+{% hint kind="warn" %}
+`read` field access control does not apply to `context.db.*` operations, as these operations do not resolve the underlying fields using GraphQL.
+{% /hint %}
+
 For more information about the arguments provided to field rules, see the [Access Control API Docs](../config/access-control#field-access-control)
 
 ### People Example


### PR DESCRIPTION
This pull request adds a warning to the field access control documentation to clarify that field access control rules do not apply when using `context.db.*` for database operations.

Keystone has a number of access control capabilities, including field-level access control for `read`, `create`, and `update` field operations. The behavior of `context.db.*` not adhering to `{field}.access.read` is likely not apparent to many developers, especially when many developers often prefer `context.db.*` for the refined Typescript support.

Field access control has been designed to co-operate with GraphQL resolvers, ensuring that any data returned by your GraphQL API respects the field access control rules for a set of particular output types. We refer to this in the documentation as

> field-level rules for... Read - [are] applied when the field is selected through any GraphQL operation

Since `context.db.*` operations don't pass through the GraphQL layer, and interact directly with Prisma, applying `read` field-level access controls isn't straight forward.  You especially need to consider that many fields don't have reasonable behavior without passing through GraphQL output resolvers first, such as `virtual` fields.

---

That said, developers are incentivized to use `context.db` for the superior Typescript integration at this stage of Keystone 6's development, therefore we need to capture these limitations more readily in the documentation; and we should potentially review this behaviour in upcoming major versions.

This pull request adds some warnings that explicitly state that `access.read` field access control rules are not applied to `context.db` operations. This should help prevent confusion until we bridge the gap between `context.query` and Typescript.
