### PR TITLE
Reduce relationship error verbosity

### DIFF
--- a/.changeset/better-relationship-errors.md
+++ b/.changeset/better-relationship-errors.md
@@ -1,0 +1,5 @@
+----
+'@keystone-6/core': patch
+----
+
+Fix static relationship resolution errors to conform to nominal error structure

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -25,7 +25,7 @@ type CardsDisplayConfig = {
     /** Causes the default Card component to render as a link to navigate to the related item */
     linkToItem?: boolean
     /** Determines whether removing a related item in the UI will delete or unlink it */
-    removeMode?: 'disconnect' | 'none' // | 'delete';
+    removeMode?: 'disconnect' | 'none' // | 'delete'
     /** Configures inline create mode for cards (alternative to opening the create modal) */
     inlineCreate?: { fields: readonly string[] }
     /** Configures inline edit mode for cards */
@@ -91,9 +91,8 @@ export const relationship =
     const { many = false } = config
     const [foreignListKey, foreignFieldKey] = ref.split('.')
     const foreignList = lists[foreignListKey]
-    if (!foreignList) {
-      throw new Error(`${listKey}.${fieldKey} points to ${ref}, but ${ref} doesn't exist`)
-    }
+    if (!foreignList) throw new Error(`${listKey}.${fieldKey} points to ${ref}, but ${ref} doesn't exist`)
+
     const foreignListTypes = foreignList.types
 
     const commonConfig = {

--- a/packages/core/src/lib/core/resolve-relationships.ts
+++ b/packages/core/src/lib/core/resolve-relationships.ts
@@ -124,11 +124,10 @@ export function resolveRelationships (
         if (alreadyResolvedTwoSidedRelationships.has(localRef)) {
           continue
         }
+
         alreadyResolvedTwoSidedRelationships.add(foreignRef)
         const foreignField = foreignUnresolvedList.fields[field.field]?.dbField
-        if (!foreignField) {
-          throw new Error(`${localRef} points to ${foreignRef}, but ${foreignRef} doesn't exist`)
-        }
+        if (!foreignField) throw new Error(`${localRef} points to ${foreignRef}, but ${foreignRef} doesn't exist`)
 
         if (foreignField.kind !== 'relation') {
           throw new Error(
@@ -136,16 +135,14 @@ export function resolveRelationships (
           )
         }
 
-        const actualRef = foreignField.field
-          ? `${foreignField.list}.${foreignField.field}`
-          : foreignField.list
+        const actualRef = foreignField.field ? `${foreignField.list}.${foreignField.field}` : foreignField.list
         if (actualRef !== localRef) {
           throw new Error(
-            `${localRef} points to ${foreignRef}, ${foreignRef} points to ${actualRef}, expected ${foreignRef} to point to ${localRef}`
+            `${localRef} expects ${foreignRef} to be a two way relationship, but ${foreignRef} points to ${actualRef}`
           )
         }
 
-        let [leftRel, rightRel] = sortRelationships(
+        const [leftRel, rightRel] = sortRelationships(
           { listKey, fieldPath, field },
           { listKey: field.list, fieldPath: field.field, field: foreignField }
         )

--- a/tests/api-tests/fields/types/relationship.test.ts
+++ b/tests/api-tests/fields/types/relationship.test.ts
@@ -7,7 +7,10 @@ import { allowAll } from '@keystone-6/core/access'
 
 const fieldKey = 'foo'
 
-function getSchema (field: { ref: string, many?: boolean }) {
+function getSchema(field: {
+  ref: string
+  many?: boolean
+}) {
   return createSystem(
     initConfig(
       config({
@@ -150,8 +153,8 @@ describe('Reference errors', () => {
         Foo: list({
           access: allowAll,
           fields: {
-            bar: relationship({ ref: 'Abc.def' }),
-          },
+            bar: relationship({ ref: 'Abc.def' })
+          }
         }),
       },
       error: `Foo.bar points to Abc.def, but Abc.def doesn't exist`,
@@ -186,7 +189,7 @@ describe('Reference errors', () => {
           },
         }),
       },
-      error: `Foo.bar points to Abc.def, Abc.def points to Foo, expected Abc.def to point to Foo.bar`,
+      error: `Foo.bar expects Abc.def to be a two way relationship, but Abc.def points to Foo`,
     },
     '3-way / 2-way conflict': {
       lists: {
@@ -203,7 +206,7 @@ describe('Reference errors', () => {
           },
         }),
       },
-      error: `Foo.bar points to Abc.def, Abc.def points to Foo.bazzz, expected Abc.def to point to Foo.bar`,
+      error: `Foo.bar expects Abc.def to be a two way relationship, but Abc.def points to Foo.bazzz`,
     },
     'field wrong type': {
       lists: {


### PR DESCRIPTION
The scenario where an invalid 3-way relationship is defined, the error presented is quite verbose:
 
>  Foo.bar points to Abc.def, Abc.def points to Foo, expected Abc.def to point to Foo.bar

This pull request changes that error to be equivalent to the following, which is aligned with each of the other relationship errors in structure of `{context}, but {problem}`.

> Foo.bar expects Abc.def to be a two way relationship, but Abc.def points to Foo.bazzz