### PR TITLE
Remove redundant line from SECURITY.txt

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,5 @@ Keystone has not endured publicly-disclosable penetration testing or been profes
 When deploying, we currently recommend not placing Keystone at the hard edge of your infrastructure - instead opting for appropriate defence-in-depth measures such as web application firewalls, reverse proxies and or caching and load balancing infrastructure.
 
 The Keystone team holds security and security-related issues in high regard; and we issue GitHub security advisories (following a CVE process) for security vulnerabilities that are reported to us or discovered by our team.
-Without enduring a publicly-disclosable penetration test, we do not currently recommend using KeystoneJS in hostile environments or for securing highly sensitive data (such as financial or medical information).
 
 Keystone is an open source project, and thereby uses open source security tooling including GitHub security advisories, [dependabot](https://github.com/dependabot) and [renovate](https://github.com/renovatebot/renovate) to monitor and update our dependencies.


### PR DESCRIPTION
The Keystone team isn't making any attestations about Keystone 6's suitability for any particular purpose or industry, and to be honest, that **will always need be evaluated by the developers and teams writing their own software.** 

This line in our **SECURITY.txt** is unhelpful in that respect, as even if we knew everything about a particular project, and even if we had multiple publicly-disclosed penetration tests, it would still be the downstream development teams who need to make any and all assessments, in line with our [MIT license text](https://github.com/keystonejs/keystone/blob/main/LICENSE).