### PR TITLE
Tidy up internal Prisma types

### DIFF
--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -47,10 +47,10 @@ export function getInitFirstItemSchema ({
             throw new Error('No session implementation available on context')
           }
 
-          const dbItemAPI = context.sudo().db[listKey]
+          const sudoContext = context.sudo()
 
           // should approximate hasInitFirstItemConditions
-          const count = await dbItemAPI.count({})
+          const count = await sudoContext.db[listKey].count()
           if (count !== 0) {
             throw new Error('Initial items can only be created when no items exist in that list')
           }
@@ -59,7 +59,7 @@ export function getInitFirstItemSchema ({
           // this is strictly speaking incorrect. the db API will do GraphQL coercion on a value which has already been coerced
           // (this is also mostly fine, the chance that people are using things where
           // the input value can't round-trip like the Upload scalar here is quite low)
-          const item = await dbItemAPI.createOne({ data: { ...data, ...itemData } })
+          const item = await sudoContext.db[listKey].createOne({ data: { ...data, ...itemData } })
           const sessionToken = (await context.sessionStrategy.start({
             data: { listKey, itemId: item.id.toString() },
             context,

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/artifacts.ts
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/artifacts.ts
@@ -4,4 +4,3 @@ export {
   generatePrismaAndGraphQLSchemas,
   getCommittedArtifacts,
 } from '../artifacts'
-export type { PrismaModule } from '../artifacts'

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -217,14 +217,3 @@ async function generatePrismaClient (prismaSchemaPath: string, dataProxy: boolea
     })
   )
 }
-
-export type PrismaModule = {
-  PrismaClient: {
-    new (args: unknown): any
-  }
-  Prisma: {
-    DbNull: unknown
-    JsonNull: unknown
-    [key: string]: unknown
-  }
-}

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -11,6 +11,6 @@ export function getContext<TypeInfo extends BaseKeystoneTypeInfo> (
   PrismaModule: unknown
 ): KeystoneContext<TypeInfo> {
   const system = createSystem(initConfig(config))
-  const { context } = system.getKeystone(PrismaModule as any)
+  const { context } = system.getKeystone(PrismaModule)
   return context
 }

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -1,9 +1,20 @@
-import type { IncomingMessage, ServerResponse } from 'http'
-import { type ExecutionResult, graphql, type GraphQLSchema, print } from 'graphql'
-import type { KeystoneContext, KeystoneGraphQLAPI, KeystoneConfig } from '../../types'
+import {
+  type IncomingMessage,
+  type ServerResponse
+} from 'http'
+import {
+  type ExecutionResult,
+  type GraphQLSchema,
+  graphql,
+  print
+} from 'graphql'
+import {
+  type KeystoneContext,
+  type KeystoneGraphQLAPI,
+  type KeystoneConfig
+} from '../../types'
 
-import type { PrismaClient } from '../core/utils'
-import type { InitialisedList } from '../core/initialise-lists'
+import { type InitialisedList } from '../core/initialise-lists'
 import { createImagesContext } from '../assets/createImagesContext'
 import { createFilesContext } from '../assets/createFilesContext'
 import { getDbFactory, getQueryFactory } from './api'
@@ -14,12 +25,17 @@ export function createContext ({
   graphQLSchema,
   graphQLSchemaSudo,
   prismaClient,
+  prismaTypes
 }: {
   config: KeystoneConfig
   lists: Record<string, InitialisedList>
   graphQLSchema: GraphQLSchema
   graphQLSchemaSudo: GraphQLSchema
-  prismaClient: PrismaClient
+  prismaClient: unknown
+  prismaTypes: {
+    DbNull: unknown,
+    JsonNull: unknown
+  }
 }) {
   const dbFactories: Record<string, ReturnType<typeof getDbFactory>> = {}
   for (const [listKey, list] of Object.entries(lists)) {
@@ -110,12 +126,18 @@ export function createContext ({
       // TODO: deprecated, remove in breaking change
       gqlNames: (listKey: string) => lists[listKey].graphql.names,
 
-      // TODO: rename __internal ?
+      // TODO: deprecated, remove in breaking change
       ...(config.experimental?.contextInitialisedLists
         ? {
             experimental: { initialisedLists: lists },
           }
         : {}),
+
+      __internal: {
+        prisma: {
+          ...prismaTypes
+        }
+      }
     }
 
     const _dbFactories = sudo ? dbFactoriesSudo : dbFactories

--- a/packages/core/src/lib/context/createContext.ts
+++ b/packages/core/src/lib/context/createContext.ts
@@ -9,9 +9,9 @@ import {
   print
 } from 'graphql'
 import {
+  type KeystoneConfig,
   type KeystoneContext,
   type KeystoneGraphQLAPI,
-  type KeystoneConfig
 } from '../../types'
 
 import { type InitialisedList } from '../core/initialise-lists'

--- a/packages/core/src/lib/context/executeGraphQLFieldToRootVal.ts
+++ b/packages/core/src/lib/context/executeGraphQLFieldToRootVal.ts
@@ -145,7 +145,7 @@ function getRootValGivenOutputType (originalType: OutputType, value: any): any {
   return value[rawField]
 }
 
-export function executeGraphQLFieldToRootVal (field: GraphQLField<any, any>) {
+export function executeGraphQLFieldToRootVal (field: GraphQLField<any, unknown>) {
   const { argumentNodes, variableDefinitions } = getVariablesForGraphQLField(field)
   const document: DocumentNode = {
     kind: Kind.DOCUMENT,
@@ -174,7 +174,7 @@ export function executeGraphQLFieldToRootVal (field: GraphQLField<any, any>) {
 
   const type = getTypeForField(field.type)
 
-  const fieldConfig: RequiredButStillAllowUndefined<GraphQLFieldConfig<any, any>> = {
+  const fieldConfig: RequiredButStillAllowUndefined<GraphQLFieldConfig<unknown, unknown>> = {
     args: argsToArgsConfig(field.args),
     astNode: undefined,
     deprecationReason: field.deprecationReason,
@@ -195,7 +195,7 @@ export function executeGraphQLFieldToRootVal (field: GraphQLField<any, any>) {
   })
 
   return async (
-    args: Record<string, any>,
+    args: Record<string, unknown>,
     context: KeystoneContext,
     rootValue: Record<string, string> = {}
   ) => {

--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -22,10 +22,8 @@ import { type InitialisedList } from './initialise-lists'
 import { type InputFilter } from './where-inputs'
 
 export function cannotForItem (operation: string, list: InitialisedList) {
-  return (
-    `You cannot ${operation} that ${list.listKey}` +
-    (operation === 'create' ? '' : ' - it may not exist')
-  )
+  if (operation === 'create') return `You cannot ${operation} that ${list.listKey}`
+  return `You cannot ${operation} that ${list.listKey} - it may not exist`
 }
 
 export function cannotForItemFields (

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -154,8 +154,8 @@ function getIsEnabled (listKey: string, listConfig: KeystoneConfig['lists'][stri
       create: notOmit,
       update: notOmit,
       delete: notOmit,
-      filter: notOmit && defaultIsFilterable,
-      orderBy: notOmit && defaultIsOrderable,
+      filter: notOmit ? defaultIsFilterable : false,
+      orderBy: notOmit ? defaultIsOrderable : false,
     }
   }
 

--- a/packages/core/src/lib/core/mutations/access-control.ts
+++ b/packages/core/src/lib/core/mutations/access-control.ts
@@ -5,11 +5,13 @@ import type { InitialisedList } from '../initialise-lists'
 import { cannotForItem, cannotForItemFields } from '../access-control'
 import {
   type InputFilter,
+  type UniqueInputFilter,
   resolveUniqueWhereInput,
   resolveWhereInput,
-  type UniqueInputFilter,
-  type UniquePrismaFilter,
 } from '../where-inputs'
+import {
+  type UniquePrismaFilter,
+} from '../../../types/prisma'
 
 async function getFilteredItem (
   list: InitialisedList,

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -5,7 +5,6 @@ import {
   promiseAllRejectWithAllErrors,
   getDBFieldKeyForFieldOnMultiField,
   type IdType,
-  getPrismaNamespace,
 } from '../utils'
 import { type InputFilter, resolveUniqueWhereInput, type UniqueInputFilter } from '../where-inputs'
 import {
@@ -390,8 +389,7 @@ function transformInnerDBField (
   value: unknown
 ) {
   if (dbField.kind === 'scalar' && dbField.scalar === 'Json' && value === null) {
-    const Prisma = getPrismaNamespace(context)
-    return Prisma.DbNull
+    return context.__internal.prisma.DbNull
   }
   return value
 }

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -1,12 +1,23 @@
-import type { KeystoneContext, BaseItem } from '../../../types'
-import type { ResolvedDBField } from '../resolve-relationships'
-import type { InitialisedList } from '../initialise-lists'
 import {
+  type BaseItem,
+  type KeystoneContext
+} from '../../../types'
+import {
+  type ResolvedDBField
+} from '../resolve-relationships'
+import {
+  type InitialisedList
+} from '../initialise-lists'
+import {
+  type IdType,
   promiseAllRejectWithAllErrors,
   getDBFieldKeyForFieldOnMultiField,
-  type IdType,
 } from '../utils'
-import { type InputFilter, resolveUniqueWhereInput, type UniqueInputFilter } from '../where-inputs'
+import {
+  type InputFilter,
+  type UniqueInputFilter,
+  resolveUniqueWhereInput,
+} from '../where-inputs'
 import {
   accessDeniedError,
   extensionError,

--- a/packages/core/src/lib/core/mutations/create-update.ts
+++ b/packages/core/src/lib/core/mutations/create-update.ts
@@ -81,8 +81,10 @@ export async function createOne (
   const operationAccess = await getOperationAccess(list, context, 'create')
   if (!operationAccess) throw accessDeniedError(cannotForItem('create', list))
 
+  // operation
   const { item, afterOperation } = await createSingle(createInput, list, context)
 
+  // after operation
   await afterOperation(item)
 
   return item
@@ -99,8 +101,12 @@ export async function createMany (
     // throw for each attempt
     if (!operationAccess) throw accessDeniedError(cannotForItem('create', list))
 
+    // operation
     const { item, afterOperation } = await createSingle({ data }, list, context)
+
+    // after operation
     await afterOperation(item)
+
     return item
   })
 }
@@ -136,6 +142,7 @@ async function updateSingle (
     item
   )
 
+  // operation
   const updatedItem = await context.prisma[list.listKey].update({
     where: { id: item.id },
     data,
@@ -143,6 +150,7 @@ async function updateSingle (
 
   // after operation
   await afterOperation(updatedItem)
+
   return updatedItem
 }
 

--- a/packages/core/src/lib/core/mutations/hooks.ts
+++ b/packages/core/src/lib/core/mutations/hooks.ts
@@ -1,5 +1,5 @@
 import { extensionError } from '../graphql-errors'
-import type { InitialisedList } from '../initialise-lists'
+import { type InitialisedList } from '../initialise-lists'
 
 export async function runSideEffectOnlyHook<
   HookName extends 'beforeOperation' | 'afterOperation',

--- a/packages/core/src/lib/core/queries/resolvers.ts
+++ b/packages/core/src/lib/core/queries/resolvers.ts
@@ -8,13 +8,16 @@ import {
 } from '../../../types'
 import { getOperationAccess, getAccessFilters } from '../access-control'
 import {
-  type PrismaFilter,
-  type UniquePrismaFilter,
   type UniqueInputFilter,
   type InputFilter,
   resolveUniqueWhereInput,
   resolveWhereInput,
 } from '../where-inputs'
+import {
+  type PrismaFilter,
+  type UniquePrismaFilter,
+} from '../../../types/prisma'
+
 import { limitsExceededError, userInputError } from '../graphql-errors'
 import { type InitialisedList } from '../initialise-lists'
 import { getDBFieldKeyForFieldOnMultiField } from '../utils'
@@ -202,7 +205,7 @@ async function resolveOrderBy (
 }
 
 export async function count (
-  { where }: { where: Record<string, any> },
+  { where }: { where: Record<string, unknown> },
   list: InitialisedList,
   context: KeystoneContext,
   info: GraphQLResolveInfo,

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -1,76 +1,7 @@
 import pluralize from 'pluralize'
-import type { BaseItem, KeystoneConfig } from '../../types'
+import { type KeystoneConfig } from '../../types'
 import { getGqlNames } from '../../types/utils'
 import { humanize } from '../utils'
-import type { PrismaFilter, UniquePrismaFilter } from './where-inputs'
-
-declare const prisma: unique symbol
-
-// note prisma "promises" aren't really Promises, they have `then`, `catch` and `finally` but they don't start executation immediately
-// so if you don't call .then/catch/finally/use it in $transaction, the operation will never happen
-export type PrismaPromise<T> = Promise<T> & { [prisma]: true }
-
-type PrismaModel = {
-  count: (arg: {
-    where?: PrismaFilter
-    take?: number
-    skip?: number
-    // this is technically wrong because relation orderBy but we're not doing that yet so it's fine
-    orderBy?: readonly Record<string, 'asc' | 'desc'>[]
-  }) => PrismaPromise<number>
-  findMany: (arg: {
-    where?: PrismaFilter
-    take?: number
-    skip?: number
-    cursor?: UniquePrismaFilter
-    // this is technically wrong because relation orderBy but we're not doing that yet so it's fine
-    orderBy?: readonly Record<string, 'asc' | 'desc'>[]
-    include?: Record<string, boolean>
-    select?: Record<string, any>
-  }) => PrismaPromise<BaseItem[]>
-  delete: (arg: { where: UniquePrismaFilter }) => PrismaPromise<BaseItem>
-  deleteMany: (arg: { where: PrismaFilter }) => PrismaPromise<BaseItem>
-  findUnique: (args: {
-    where: UniquePrismaFilter
-    include?: Record<string, any>
-    select?: Record<string, any>
-  }) => PrismaPromise<BaseItem | null>
-  findFirst: (args: {
-    where: PrismaFilter
-    include?: Record<string, any>
-    select?: Record<string, any>
-  }) => PrismaPromise<BaseItem | null>
-  create: (args: {
-    data: Record<string, any>
-    include?: Record<string, any>
-    select?: Record<string, any>
-  }) => PrismaPromise<BaseItem>
-  update: (args: {
-    where: UniquePrismaFilter
-    data: Record<string, any>
-    include?: Record<string, any>
-    select?: Record<string, any>
-  }) => PrismaPromise<BaseItem>
-}
-
-export type UnwrapPromise<TPromise extends Promise<any>> = TPromise extends Promise<infer T>
-  ? T
-  : never
-
-export type UnwrapPromises<T extends Promise<any>[]> = {
-  // unsure about this conditional
-  [Key in keyof T]: Key extends number ? UnwrapPromise<T[Key]> : never;
-}
-
-// please do not make this type be the value of KeystoneContext['prisma']
-// this type is meant for generic usage, KeystoneContext should be generic over a PrismaClient
-// and we should generate a KeystoneContext type in node_modules/.keystone/types which passes in the user's PrismaClient type
-// so that users get right PrismaClient types specifically for their project
-export type PrismaClient = {
-  $disconnect(): Promise<void>
-  $connect(): Promise<void>
-  $transaction<T extends PrismaPromise<any>[]>(promises: [...T]): UnwrapPromises<T>
-} & Record<string, PrismaModel>
 
 // this is wrong
 // all the things should be generic over the id type

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -1,6 +1,5 @@
 import pluralize from 'pluralize'
-import { type PrismaModule } from '../../artifacts'
-import type { BaseItem, KeystoneConfig, KeystoneContext } from '../../types'
+import type { BaseItem, KeystoneConfig } from '../../types'
 import { getGqlNames } from '../../types/utils'
 import { humanize } from '../utils'
 import type { PrismaFilter, UniquePrismaFilter } from './where-inputs'
@@ -146,22 +145,6 @@ const labelToClass = (str: string) => str.replace(/\s+/g, '')
 
 export function getDBFieldKeyForFieldOnMultiField (fieldKey: string, subField: string) {
   return `${fieldKey}_${subField}`
-}
-
-const prismaNamespaces = new WeakMap<object, PrismaModule['Prisma']>()
-
-export function setPrismaNamespace (prismaClient: object, prismaNamespace: PrismaModule['Prisma']) {
-  prismaNamespaces.set(prismaClient, prismaNamespace)
-}
-
-// this accepts the context instead of the prisma client because the prisma client on context is `any`
-// so by accepting the context, it'll be less likely the wrong thing will be passed.
-export function getPrismaNamespace (context: KeystoneContext) {
-  const limit = prismaNamespaces.get(context.prisma)
-  if (limit === undefined) {
-    throw new Error('unexpected prisma namespace not set for prisma client')
-  }
-  return limit
 }
 
 export function areArraysEqual (a: readonly unknown[], b: readonly unknown[]) {

--- a/packages/core/src/lib/core/utils.ts
+++ b/packages/core/src/lib/core/utils.ts
@@ -87,8 +87,6 @@ export const isFulfilled = <T>(arg: PromiseSettledResult<T>): arg is PromiseFulf
 export const isRejected = (arg: PromiseSettledResult<any>): arg is PromiseRejectedResult =>
   arg.status === 'rejected'
 
-type Awaited<T> = T extends PromiseLike<infer U> ? U : T
-
 export async function promiseAllRejectWithAllErrors<T extends unknown[]> (
   promises: readonly [...T]
 ): Promise<{ [P in keyof T]: Awaited<T[P]> }> {

--- a/packages/core/src/lib/core/where-inputs.ts
+++ b/packages/core/src/lib/core/where-inputs.ts
@@ -1,6 +1,13 @@
-import type { DBField, KeystoneContext } from '../../types'
+import {
+  type DBField,
+  type KeystoneContext,
+} from '../../types'
+import {
+  type PrismaFilter,
+  type UniquePrismaFilter,
+} from '../../types/prisma'
 import { userInputError } from './graphql-errors'
-import type { InitialisedList } from './initialise-lists'
+import { type InitialisedList } from './initialise-lists'
 import { getDBFieldKeyForFieldOnMultiField } from './utils'
 
 export type InputFilter = Record<string, any> & {
@@ -9,23 +16,8 @@ export type InputFilter = Record<string, any> & {
   OR?: InputFilter[]
   NOT?: InputFilter[]
 }
-export type PrismaFilter = Record<string, any> & {
-  _____?: 'prisma filter'
-  AND?: PrismaFilter[] | PrismaFilter
-  OR?: PrismaFilter[] | PrismaFilter
-  NOT?: PrismaFilter[] | PrismaFilter
-  // just so that if you pass an array to something expecting a PrismaFilter, you get an error
-  length?: undefined
-  // so that if you pass a promise, you get an error
-  then?: undefined
-}
 
 export type UniqueInputFilter = Record<string, any> & { _____?: 'unique input filter' }
-export type UniquePrismaFilter = Record<string, any> & {
-  _____?: 'unique prisma filter'
-  // so that if you pass a promise, you get an error
-  then?: undefined
-}
 
 export async function resolveUniqueWhereInput (
   inputFilter: UniqueInputFilter,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -19,16 +19,29 @@ export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystone
   prisma: TypeInfo['prisma']
   files: FilesContext
   images: ImagesContext
+  sessionStrategy?: SessionStrategy<TypeInfo['session'], TypeInfo>
+  session?: TypeInfo['session']
+
   /** @deprecated */
   gqlNames: (listKey: string) => InitialisedList['graphql']['names']
+
+  /** @deprecated */
   experimental?: {
     /** @deprecated This value is only available if you have config.experimental.contextInitialisedLists = true.
      * This is not a stable API and may contain breaking changes in `patch` level releases.
      */
     initialisedLists: Record<string, InitialisedList>
   }
-  sessionStrategy?: SessionStrategy<TypeInfo['session'], TypeInfo>
-  session?: TypeInfo['session']
+
+  /**
+   * WARNING: may change in patch
+   */
+  __internal: {
+    prisma: {
+      DbNull: unknown
+      JsonNull: unknown
+    }
+  }
 }
 
 // List item API

--- a/packages/core/src/types/prisma.ts
+++ b/packages/core/src/types/prisma.ts
@@ -1,0 +1,16 @@
+export type PrismaFilter = Record<string, any> & {
+  _____?: 'prisma filter'
+  AND?: PrismaFilter[] | PrismaFilter
+  OR?: PrismaFilter[] | PrismaFilter
+  NOT?: PrismaFilter[] | PrismaFilter
+  // just so that if you pass an array to something expecting a PrismaFilter, you get an error
+  length?: undefined
+  // so that if you pass a promise, you get an error
+  then?: undefined
+}
+
+export type UniquePrismaFilter = Record<string, any> & {
+  _____?: 'unique prisma filter'
+  // so that if you pass a promise, you get an error
+  then?: undefined
+}

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -1,4 +1,6 @@
-import { type KeystoneContext } from './context'
+import {
+  type KeystoneContext
+} from './context'
 import { type BaseItem } from './next-fields'
 
 type GraphQLInput = Record<string, any>

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -15,8 +15,9 @@ export type BaseListTypeInfo<Session = any> = {
     uniqueWhere: { readonly id?: string | number | null } & GraphQLInput
     orderBy: Record<string, 'asc' | 'desc' | null>
   }
+
   /**
-   * WARNING: may be renamed in patch
+   * WARNING: may change in patch
    */
   prisma: {
     create: Record<string, any>

--- a/tests/api-tests/test-runner.ts
+++ b/tests/api-tests/test-runner.ts
@@ -221,14 +221,16 @@ export function setupTestSuite <TypeInfo extends BaseKeystoneTypeInfo> ({
   identifier?: string
 }) {
   const result = setupTestEnv({ config: config_, serve, identifier })
-  const connectPromise = result.then((x) => x.connect())
+  const connectPromise = result.then((x) => {
+    x.connect()
+    return x
+  })
 
   afterAll(async () => {
     await (await result).disconnect()
   })
 
   return async () => {
-    await connectPromise
-    return await result
+    return await connectPromise
   }
 }

--- a/tests/api-tests/test-runner.ts
+++ b/tests/api-tests/test-runner.ts
@@ -24,7 +24,7 @@ import {
 import {
   type BaseKeystoneTypeInfo,
 } from '@keystone-6/core/types'
-import { generatePrismaAndGraphQLSchemas, type PrismaModule } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/artifacts'
+import { generatePrismaAndGraphQLSchemas } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/artifacts'
 import { pushPrismaSchemaToDatabase } from '../../packages/core/src/lib/migrations'
 import { dbProvider, type FloatingConfig } from './utils'
 
@@ -63,7 +63,7 @@ async function getTestPrismaModuleInner (prismaSchemaPath: string, datamodel: st
   }
 }
 
-const prismaModuleCache = new Map<string, PrismaModule>()
+const prismaModuleCache = new Map<string, unknown>()
 async function getTestPrismaModule (prismaSchemaPath: string, schema: string) {
   if (prismaModuleCache.has(schema)) return prismaModuleCache.get(schema)!
   return prismaModuleCache.set(schema, await getTestPrismaModuleInner(prismaSchemaPath, schema)).get(schema)!


### PR DESCRIPTION
This pull request tidies up a number of internal Prisma types that were duplicated, and often out-of-date.  An explicit `as any` is replacing the two locations where the type was used, and the remaining boilerplate removed.  

An internal `new WeakMap` mapping the Prisma namespaces to Keystone contexts has been removed too.