### PR TITLE
Fix the type of `id` on type `BaseItem`, to be type `unknown`, not `string`

### DIFF
--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -61,7 +61,10 @@ export function getInitFirstItemSchema ({
           // the input value can't round-trip like the Upload scalar here is quite low)
           const item = await sudoContext.db[listKey].createOne({ data: { ...data, ...itemData } })
           const sessionToken = (await context.sessionStrategy.start({
-            data: { listKey, itemId: item.id.toString() },
+            data: {
+              listKey,
+              itemId: item.id.toString()
+            },
             context,
           }))
 

--- a/packages/core/src/types/next-fields.ts
+++ b/packages/core/src/types/next-fields.ts
@@ -12,7 +12,12 @@ import {
 
 export { Decimal }
 
-export type BaseItem = { id: { toString(): string }, [key: string]: unknown }
+export type BaseItem = {
+  id: {
+    toString(): string
+  },
+  [key: string]: unknown
+}
 
 export type ListGraphQLTypes = { types: GraphQLTypesForList }
 

--- a/packages/fields-document/src/structure-graphql-input.ts
+++ b/packages/fields-document/src/structure-graphql-input.ts
@@ -348,14 +348,10 @@ export async function resolveRelateToManyForUpdateInput (
     !Array.isArray(value.disconnect) &&
     !Array.isArray(value.set)
   ) {
-    throw new Error(
-      `You must provide at least one of "set", "connect", "create" or "disconnect" in to-many relationship inputs for "update" operations.`
-    )
+    throw new Error(`You must provide at least one of "set", "connect", "create" or "disconnect" in to-many relationship inputs for "update" operations.`)
   }
   if (value.set && value.disconnect) {
-    throw new Error(
-      `The "set" and "disconnect" fields cannot both be provided to to-many relationship inputs for "update" operations.`
-    )
+    throw new Error(`The "set" and "disconnect" fields cannot both be provided to to-many relationship inputs for "update" operations.`)
   }
 
   // Perform queries for the connections


### PR DESCRIPTION
This pull request updates the type of `id` on type `BaseItem` to be of type `unknown` instead of `string`.  This helps reduce a number of type errors where `string | number | null` is possible, but only `string` was accepted by the `BaseItem`.

This is not strictly related to https://github.com/keystonejs/keystone/issues/8846, but will likely be required as part of fixing that problem in any event.