### PR TITLE
Increase verbosity of `omit` tests 

### DIFF
--- a/tests/api-tests/omit.test.ts
+++ b/tests/api-tests/omit.test.ts
@@ -2,39 +2,36 @@ import { setupTestSuite } from '@keystone-6/api-tests/test-runner'
 import { relationship, text } from '@keystone-6/core/fields'
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
+import { type KeystoneContext } from '@keystone-6/core/types'
 import { dbProvider } from './utils'
-
-function yesNo (x: boolean | undefined) {
-  if (x === true) return 'T'
-  if (x === false) return 'F'
-  return 'U'
-}
-
-const UFT = [false, true] as const
 
 jest.setTimeout(10000000)
 
-function makeFieldEntry ({
+function yn (x: boolean) {
+  return x ? '1' : '0'
+}
+
+function makeField ({
   isFilterable,
   isOrderable,
   omit
 }: {
-  isFilterable?: boolean
-  isOrderable?: boolean
-  omit?:
+  isFilterable: boolean
+  isOrderable: boolean
+  omit:
     | boolean
     | {
-        read?: boolean
-        create?: boolean
-        update?: boolean
+        read: boolean
+        create: boolean
+        update: boolean
       }
 }) {
   const suffix = [
-    `Filterable${yesNo(isFilterable)}`,
-    `Orderable${yesNo(isOrderable)}`,
+    `Filterable${yn(isFilterable)}`,
+    `Orderable${yn(isOrderable)}`,
     `Omit${typeof omit !== 'object'
-      ? yesNo(omit)
-      : [omit.read, omit.create, omit.update].map(yesNo).join('')}`
+      ? yn(omit)
+      : [omit.read, omit.create, omit.update].map(yn).join('')}`
   ].join('')
 
   return [`Field_${suffix}`, text({
@@ -44,30 +41,56 @@ function makeFieldEntry ({
   })] as const
 }
 
+const fieldsMatrix = [...function* () {
+  for (const isFilterable of [false, true]) {
+    for (const isOrderable of [false, true]) {
+      for (const omit of [false, true]) {
+        yield makeField({ isFilterable, isOrderable, omit })
+      }
+
+      for (const read of [false, true]) {
+        for (const create of [false, true]) {
+          for (const update of [false, true]) {
+            yield makeField({
+              isFilterable,
+              isOrderable,
+              omit: {
+                read,
+                create,
+                update,
+              },
+            })
+          }
+        }
+      }
+    }
+  }
+}()]
+
 function makeList ({
   isFilterable,
   isOrderable,
   omit
 }: {
-  isFilterable?: boolean
-  isOrderable?: boolean
-  omit?:
+  isFilterable: boolean
+  isOrderable: boolean
+  omit:
     | boolean
     | {
-        query?: boolean
-        create?: boolean
-        update?: boolean
-        delete?: boolean
+        query: boolean
+        create: boolean
+        update: boolean
+        delete: boolean
       }
-}, fieldsMatrix: ReturnType<typeof makeFieldEntry>[]) {
-  const prefix = `List_Filterable${yesNo(isFilterable)}_Orderable${yesNo(isOrderable)}` as const
-  const name = `${prefix}_Omit${
+}) {
+  const prefix = `List_Filterable${yn(isFilterable)}_Orderable${yn(isOrderable)}` as const
+  const __name = `${prefix}_Omit${
     typeof omit !== 'object'
-      ? yesNo(omit)
-      : [omit.query, omit.create, omit.update, omit.delete].map(yesNo).join('')}`
+      ? yn(omit)
+      : [omit.query, omit.create, omit.update, omit.delete].map(yn).join('')}`
 
   return {
-    name,
+    __name,
     access: allowAll,
     fields: {
       ...Object.fromEntries(fieldsMatrix)
@@ -75,49 +98,23 @@ function makeList ({
     defaultIsFilterable: isFilterable,
     defaultIsOrderable: isOrderable,
     graphql: {
-      plural: name + 's',
+      plural: __name + 's',
       omit,
     },
   } as const
 }
 
 const listsMatrix = [...function* () {
-  const fieldsMatrix = [...function* () {
-    for (const isFilterable of UFT) {
-      for (const isOrderable of UFT) {
-        for (const omit of UFT) {
-          yield makeFieldEntry({ isFilterable, isOrderable, omit })
-        }
-
-        for (const read of UFT) {
-          for (const create of UFT) {
-            for (const update of UFT) {
-              yield makeFieldEntry({
-                isFilterable,
-                isOrderable,
-                omit: {
-                  read,
-                  create,
-                  update,
-                },
-              })
-            }
-          }
-        }
-      }
-    }
-  }()]
-
-  for (const isFilterable of UFT) {
-    for (const isOrderable of UFT) {
-      for (const omit of UFT) {
-        yield makeList({ isFilterable, isOrderable, omit }, fieldsMatrix)
+  for (const isFilterable of [false, true]) {
+    for (const isOrderable of [false, true]) {
+      for (const omit of [false, true]) {
+        yield makeList({ isFilterable, isOrderable, omit })
       }
 
-      for (const query of UFT) {
-        for (const create of UFT) {
-          for (const update of UFT) {
-            for (const delete_ of UFT) {
+      for (const query of [false, true]) {
+        for (const create of [false, true]) {
+          for (const update of [false, true]) {
+            for (const delete_ of [false, true]) {
               yield makeList({
                 isFilterable,
                 isOrderable,
@@ -127,7 +124,7 @@ const listsMatrix = [...function* () {
                   update,
                   delete: delete_,
                 }
-              }, fieldsMatrix)
+              })
             }
           }
         }
@@ -139,181 +136,181 @@ const listsMatrix = [...function* () {
 // TODO: FIXME: skip for now, MySQL has a limit on the number of indexes
 if (dbProvider !== 'mysql') {
   listsMatrix.push({
-    name: 'RelatedToAll',
+    __name: 'RelatedToAll',
     access: allowAll,
     fields: {
       ...Object.fromEntries(function* () {
         for (const l of listsMatrix) {
           // WARNING: if names exceed some length, expect duplicate _AB_unique index errors
-          yield [`R${l.name}_one`, relationship({
-            ref: l.name,
+          yield [`R${l.__name}_one`, relationship({
+            ref: l.__name,
             many: false,
           })] as const
 
-          yield [`R${l.name}_many`, relationship({
-            ref: l.name,
+          yield [`R${l.__name}_many`, relationship({
+            ref: l.__name,
             many: true,
           })] as const
         }
       }()),
     },
-    defaultIsFilterable: undefined,
-    defaultIsOrderable: undefined,
+    defaultIsFilterable: true,
+    defaultIsOrderable: true,
     graphql: {
       plural: 'RelatedToAlls',
-      omit: undefined
+      omit: false
     },
   })
 }
 
-const introspectionQuery = `{
-  __schema {
-    types {
-      name
-      fields {
-        name
+async function introspectSchema (context: KeystoneContext) {
+  const data = await context.graphql.run<{
+    __schema: {
+      types: {
+        name: string
+        fields: {
+          name: string
+        }[]
+      }[]
+      queryType: {
+        fields: {
+          name: string
+        }[]
+      }
+      mutationType: {
+        fields: {
+          name: string
+        }[]
       }
     }
-    queryType {
-      fields {
-        name
+    keystone: {
+      adminMeta: {
+        lists: {
+          key: string
+        }[]
       }
     }
-    mutationType {
-      fields {
-        name
+  }, any>({
+    query: `{
+      __schema {
+        types {
+          name
+          fields {
+            name
+          }
+        }
+        queryType {
+          fields {
+            name
+          }
+        }
+        mutationType {
+          fields {
+            name
+          }
+        }
       }
-    }
-  }
-  keystone {
-    adminMeta {
-      lists {
-        key
+      keystone {
+        adminMeta {
+          lists {
+            key
+          }
+        }
       }
-    }
-  }
-}`
+    }`
+  })
 
-type IntrospectionResult = {
-  __schema: {
-    types: {
-      name: string
-      fields: {
-        name: string
-      }[]
-    }[]
-    queryType: {
-      fields: {
-        name: string
-      }[]
-    }
-    mutationType: {
-      fields: {
-        name: string
-      }[]
-    }
-  }
-  keystone: {
-    adminMeta: {
-      lists: {
-        key: string
-      }[]
-    }
+  return {
+    queries: data.__schema.queryType.fields.map(x => x.name.toLowerCase()),
+    mutations: data.__schema.mutationType.fields.map(x => x.name.toLowerCase()),
+    adminMetaLists: data.keystone.adminMeta.lists.map(x => x.key.toLowerCase()),
+    schemaTypes: data.__schema.types.map(x => x.name.toLowerCase()),
   }
 }
 
 describe(`Omit (${dbProvider})`, () => {
+  function testOmit (listName_: string, d: ReturnType<typeof introspectSchema>, expected: {
+    type: boolean,
+    meta: boolean,
+    query: boolean,
+    create: boolean,
+    update: boolean,
+    delete: boolean
+  }) {
+    const listName = listName_.toLowerCase()
+
+    if (expected.query) test.concurrent('does have find', async () => expect((await d).queries).toContain(listName))
+    if (expected.query) test.concurrent('does have findMany', async () => expect((await d).queries).toContain(listName + 's'))
+    if (expected.create) test.concurrent('does have create', async () => expect((await d).mutations).toContain(`create${listName}`))
+    if (expected.create) test.concurrent('does have createMany', async () => expect((await d).mutations).toContain(`create${listName}s`))
+    if (expected.update) test.concurrent('does have update', async () => expect((await d).mutations).toContain(`update${listName}`))
+    if (expected.update) test.concurrent('does have updateMany', async () => expect((await d).mutations).toContain(`update${listName}s`))
+    if (expected.delete) test.concurrent('does have delete', async () => expect((await d).mutations).toContain(`delete${listName}`))
+    if (expected.delete) test.concurrent('does have deleteMany', async () => expect((await d).mutations).toContain(`delete${listName}s`))
+    if (expected.meta) test.concurrent('does have an Admin meta list entry', async () => expect((await d).adminMetaLists).toContain(listName))
+    if (expected.type) test.concurrent('does have a GraphQL schema type', async () => expect((await d).schemaTypes).toContain(listName))
+
+    if (!expected.query) test.concurrent('does not have find', async () => expect((await d).queries).not.toContain(listName))
+    if (!expected.query) test.concurrent('does not have findMany', async () => expect((await d).queries).not.toContain(listName + 's'))
+    if (!expected.create) test.concurrent('does not have create', async () => expect((await d).mutations).not.toContain(`create${listName}`))
+    if (!expected.create) test.concurrent('does not have createMany', async () => expect((await d).mutations).not.toContain(`create${listName}s`))
+    if (!expected.update) test.concurrent('does not have update', async () => expect((await d).mutations).not.toContain(`update${listName}`))
+    if (!expected.update) test.concurrent('does not have updateMany', async () => expect((await d).mutations).not.toContain(`update${listName}s`))
+    if (!expected.delete) test.concurrent('does not have delete', async () => expect((await d).mutations).not.toContain(`delete${listName}`))
+    if (!expected.delete) test.concurrent('does not have deleteMany', async () => expect((await d).mutations).not.toContain(`delete${listName}s`))
+    if (!expected.meta) test.concurrent('does not have an Admin meta list entry', async () => expect((await d).adminMetaLists).not.toContain(listName))
+    if (!expected.type) test.concurrent('does not have a GraphQL schema type', async () => expect((await d).schemaTypes).not.toContain(listName))
+  }
+
   const suite = setupTestSuite({
     config: {
-      lists: Object.fromEntries(listsMatrix.map(({ name, ...l }) => [name, list(l)]))
+      lists: Object.fromEntries(listsMatrix.map(({ __name, ...l }) => [__name, list(l)]))
     }
   })
 
-  test.concurrent('Common Schema', async () => {
-    const { context } = await suite()
-    const data = await context.graphql.run<IntrospectionResult, any>({ query: introspectionQuery })
+  const data = suite().then(async ({ context }) => await introspectSchema(context))
+  const sudoData = suite().then(async ({ context }) => await introspectSchema(context.sudo()))
 
-    const schemaTypes = data.__schema.types.map(x => x.name.toLowerCase())
-    const adminMetaLists = data.keystone.adminMeta.lists.map(x => x.key.toLowerCase())
-    const queries = data.__schema.queryType.fields.map(x => x.name.toLowerCase())
-    const mutations = data.__schema.mutationType.fields.map(x => x.name.toLowerCase())
+  for (const l of listsMatrix) {
+    const listName = l.__name
+    const omit = l.graphql.omit
 
-    for (const l of listsMatrix) {
-      const name = l.name.toLowerCase()
-      if (typeof l.graphql.omit === 'boolean') {
-        if (l.graphql.omit === true) {
-          expect(schemaTypes).not.toContain(name)
-          expect(adminMetaLists).not.toContain(name)
-          expect(queries).not.toContain(name)
-          expect(queries).not.toContain(name + 's')
-          expect(mutations).not.toContain(`create${name}`)
-          expect(mutations).not.toContain(`update${name}`)
-          expect(mutations).not.toContain(`delete${name}`)
-        } else {
-          expect(schemaTypes).toContain(name)
-          expect(adminMetaLists).toContain(name)
-          expect(queries).toContain(name)
-          expect(queries).toContain(name + 's')
-          expect(mutations).toContain(`create${name}`)
-          expect(mutations).toContain(`update${name}`)
-          expect(mutations).toContain(`delete${name}`)
-        }
+    // common context is configurable
+    describe(`Common context for ${listName}`, () => {
+      if (typeof omit === 'boolean') {
+        testOmit(listName, data, {
+          type: !omit,
+          meta: !omit,
+          query: !omit,
+          create: !omit,
+          update: !omit,
+          delete: !omit,
+        })
 
-        continue
+        return
       }
 
-      expect(schemaTypes).toContain(name)
+      testOmit(listName, data, {
+        type: true,
+        // TODO: see create-admin-meta.ts#L102
+        meta: !omit?.query ?? true,
+        query: !omit?.query ?? true,
+        create: !omit?.create ?? true,
+        update: !omit?.update ?? true,
+        delete: !omit?.delete ?? true,
+      })
+    })
 
-      if (l.graphql.omit?.query) {
-        expect(adminMetaLists).not.toContain(name) // TODO: see create-admin-meta.ts#L102
-        expect(queries).not.toContain(name)
-        expect(queries).not.toContain(name + 's')
-      } else {
-        expect(adminMetaLists).toContain(name)
-        expect(queries).toContain(name)
-        expect(queries).toContain(name + 's')
-      }
-
-      if (l.graphql.omit?.create) {
-        expect(mutations).not.toContain(`create${name}`)
-      } else {
-        expect(mutations).toContain(`create${name}`)
-      }
-
-      if (l.graphql.omit?.update) {
-        expect(mutations).not.toContain(`update${name}`)
-      } else {
-        expect(mutations).toContain(`update${name}`)
-      }
-
-      if (l.graphql.omit?.delete) {
-        expect(mutations).not.toContain(`delete${name}`)
-      } else {
-        expect(mutations).toContain(`delete${name}`)
-      }
-    }
-  })
-
-  test.concurrent('Sudo Schema', async () => {
-    const { context } = await suite()
-    const data = await context.sudo().graphql.run<IntrospectionResult, any>({ query: introspectionQuery })
-
-    const schemaTypes = data.__schema.types.map(x => x.name.toLowerCase())
-    const amLists = data.keystone.adminMeta.lists.map(x => x.key.toLowerCase())
-    const queries = data.__schema.queryType.fields.map(x => x.name.toLowerCase())
-    const mutations = data.__schema.mutationType.fields.map(x => x.name.toLowerCase())
-
-    for (const l of listsMatrix) {
-      const name = l.name.toLowerCase()
-
-      // everything is in the sudo schema, without refrain
-      expect(schemaTypes).toContain(name)
-      expect(amLists).toContain(name)
-      expect(queries).toContain(name)
-      expect(queries).toContain(name + 's')
-      expect(mutations).toContain(`create${name}`)
-      expect(mutations).toContain(`update${name}`)
-      expect(mutations).toContain(`delete${name}`)
-    }
-  })
+    // sudo context has everything, always
+    describe(`Sudo context for ${listName}`, () => {
+      testOmit(listName, sudoData, {
+        type: true,
+        meta: true,
+        query: true,
+        create: true,
+        update: true,
+        delete: true,
+      })
+    })
+  }
 })


### PR DESCRIPTION
When modifying code near to the `omit` functionality, I quickly found myself wanting amount of detail as to when and where the tests were failing.

Unlike `tape` and other testing suites, `jest` only really offers you insight into your tests from the `test(description, () => ...`, which you often might group a number of `expect`s statements within.  This isn't helpful when the tests are verifying a number of expectations at the same time.

This pull request changes that so we many `test`s, with 1 expectation each. This pattern is actually a huge performance win too, and I'll be using in my next pull request for hooks. 