### PR TITLE
fix: move orphaned title to component structure for document-field example

### DIFF
--- a/examples/document-field/src/pages/index.tsx
+++ b/examples/document-field/src/pages/index.tsx
@@ -5,24 +5,26 @@ import { fetchGraphQL, gql } from '../utils'
 type Author = { id: string, name: string, posts: { id: string, slug: string, title: string }[] }
 
 export default function Index ({ authors }: { authors: Author[] }) {
-  <h1>Keystone Blog Project - Home</h1>
   return (
-    <ul>
-      {authors.map(author => (
-        <li key={author.id}>
-          <h2>
-            <Link href={`/author/${author.id}`}>{author.name}</Link>
-          </h2>
-          <ul>
-            {author.posts.map(post => (
-              <li key={post.id}>
-                <Link href={`/post/${post.slug}`}>{post.title}</Link>
-              </li>
-            ))}
-          </ul>
-        </li>
-      ))}
-    </ul>
+    <>
+      <h1>Keystone Blog Project - Home</h1>
+      <ul>
+        {authors.map(author => (
+          <li key={author.id}>
+            <h2>
+              <Link href={`/author/${author.id}`}>{author.name}</Link>
+            </h2>
+            <ul>
+              {author.posts.map(post => (
+                <li key={post.id}>
+                  <Link href={`/post/${post.slug}`}>{post.title}</Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </>
   )
 }
 


### PR DESCRIPTION
It was orphaned H1 header. And it shown just a white page in a default state without data.