### PR TITLE
Version Packages (follow up)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   publish:
-    name: Publish
     runs-on: ubuntu-latest
     environment: Release
     steps:
@@ -15,16 +14,23 @@ jobs:
 
       - uses: ./.github/actions/ci-setup
 
-      - run: pnpm build
+      - name: version packages
+        run: pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.KEYSTONE_RELEASE_BOT_GITHUB_TOKEN }}
 
-      - name: git config
+      - name: git commit
         run: |
           git config --global user.name 'Keystonejs Release Bot'
           git config --global user.email 'automation+keystonejs@thinkmill.com.au'
+          git commit -a -m 'bump packages'
+
+      - run: pnpm build
 
       - name: npm publish, git tag
-        run: pnpm changeset publish --tag latest
+        run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - run: git push origin --follow-tags
+      - name: git push
+        run: git push origin --tags


### PR DESCRIPTION
Follow up to https://github.com/keystonejs/keystone/pull/9071, where the version packages didn't end up releasing the artifacts.