### PR TITLE
Extend `extend-prisma-schema` example to demonstrate adding `previewFeatures`

### DIFF
--- a/examples/extend-prisma-schema/keystone.ts
+++ b/examples/extend-prisma-schema/keystone.ts
@@ -5,13 +5,16 @@ import { lists } from './schema'
 export default config({
   db: {
     provider: 'sqlite',
-    url: process.env.DATABASE_URL || 'file:./keystone-example.db',
+    url: process.env.DATABASE_URL ?? 'file:./keystone-example.db',
 
-    extendPrismaSchema: (schema: any) => {
-      return schema.replace(
-        /(generator [^}]+)}/g,
-        ['$1binaryTargets = ["native", "linux-musl"]', '}'].join('\n')
-      )
+    extendPrismaSchema: (schema) => {
+      return schema
+        .replace(/(generator [^}]+)}/g, [
+          '$1',
+          '  binaryTargets = ["native", "linux-musl"]',
+          '  previewFeatures = ["metrics"]',
+          '}'
+        ].join('\n'))
     },
 
     // WARNING: this is only needed for our monorepo examples, dont do this

--- a/examples/extend-prisma-schema/schema.prisma
+++ b/examples/extend-prisma-schema/schema.prisma
@@ -8,9 +8,11 @@ datasource sqlite {
 }
 
 generator client {
-  provider      = "prisma-client-js"
-  output        = "node_modules/.myprisma/client"
-  binaryTargets = ["native", "linux-musl"]
+  provider = "prisma-client-js"
+  output   = "node_modules/.myprisma/client"
+
+  binaryTargets   = ["native", "linux-musl"]
+  previewFeatures = ["metrics"]
 }
 
 model Author {

--- a/examples/extend-prisma-schema/schema.ts
+++ b/examples/extend-prisma-schema/schema.ts
@@ -29,7 +29,7 @@ export const lists = {
         db: {
           extendPrismaSchema: field => {
             // change relationship to enforce NOT NULL
-            //   WARNING: this won't be easy to use, but this is nice if you know what you're doing
+            //   WARNING: this won't be easy to use, but if you know what you're doing...
             return field
               .replace(/tags Tag\?/g, 'tags Tag')
               .replace(/tagsId String\?/g, 'tagsId String')


### PR DESCRIPTION
With https://github.com/keystonejs/keystone/pull/9083 merged and published (https://github.com/keystonejs/keystone/pull/9094), some developers might be left asking how do I fix my Prisma schema and add `previewFeatures`?

The existing example did cover that abstractly, but to help it be readily transferable, this pull request extends the example to explicitly extend the Prisma schema to contain `previewFeatures`.