### PR TITLE
Custom next.config.js support for admin-ui

### DIFF
--- a/packages/core/src/admin-ui/templates/next-config.ts
+++ b/packages/core/src/admin-ui/templates/next-config.ts
@@ -1,15 +1,32 @@
 export const nextConfigTemplate = (basePath?: string) =>
-  `const nextConfig = {
-    typescript: {
-      ignoreBuildErrors: true,
-    },
-    eslint: {
-      ignoreDuringBuilds: true,
-    },
-    // We use transpilePackages for the custom admin-ui pages in the ./admin folder
-    // as they import ts files into nextjs
-    transpilePackages: ['../../admin'],
-    ${basePath ? `basePath: '${basePath}',` : ''} 
+  `const fs = require('fs');
+const path = require('path');
+const { merge } = require('lodash');
+
+// Base configuration for Next.js
+const nextConfig = {
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  transpilePackages: ['../../admin'], // custom admin-ui pages
+  ${basePath ? `basePath: '${basePath}',` : ""} 
+};
+
+// Path to the potential custom config file
+const customConfigPath = path.join(__dirname, '..', '..', 'next.config.js');
+
+// Check if the custom config file exists and merge it
+try {
+  if (fs.existsSync(customConfigPath)) {
+    const customConfig = require(customConfigPath);
+    merge(nextConfig, customConfig);
   }
-  
-  module.exports = nextConfig`
+} catch (error) {
+  console.error('Failed to load or merge custom config:', error);
+}
+
+module.exports = nextConfig;
+`;


### PR DESCRIPTION
If `/.keystone/admin/../../next.config.js` exists, it will get merged into keystone's admin-ui's NextJS config at runtime.