### PR TITLE
Update image reference on Enterprise page

### DIFF
--- a/docs/pages/enterprise.tsx
+++ b/docs/pages/enterprise.tsx
@@ -155,7 +155,7 @@ export default function ForOrganisations () {
 
         <Quote
           name="Kevin Stafford"
-          img="https://thinkmill.com.au/_astro/kevin-stafford-rugby-au@1280w.24c4530d.webp"
+          img="/assets/kevin-stafford.jpg"
           title="CTO, Rugby Australia"
           grad="grad6"
           css={{


### PR DESCRIPTION
Fixes a broken image reference within Kevin Stafford’s testimonial on the Enterprise page. 

Using the picture of Kevin we already have in the repo. Reproducing from here: https://github.com/keystonejs/keystone/blob/main/docs/pages/for-organisations.tsx#L137