### PR TITLE
feat(core/db): allow to extend PrismaClient

### DIFF
--- a/.changeset/extend-prisma-client.md
+++ b/.changeset/extend-prisma-client.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Add `config.db.extendPrismaClient` to support extending the `PrismaClient`

--- a/packages/core/src/lib/createSystem.ts
+++ b/packages/core/src/lib/createSystem.ts
@@ -224,7 +224,10 @@ export function createSystem (config_: KeystoneConfig) {
         log: config.db.enableLogging
       })
 
-      const prismaClient = injectNewDefaults(prePrismaClient, lists)
+      const prismaClient = config.db.extendPrismaClient(
+        injectNewDefaults(prePrismaClient, lists)
+      )
+
       const context = createContext({
         config,
         lists,

--- a/packages/core/src/lib/defaults.ts
+++ b/packages/core/src/lib/defaults.ts
@@ -74,6 +74,7 @@ function defaultIsAccessAllowed ({ session, sessionStrategy }: KeystoneContext) 
 }
 
 async function noop () {}
+function identity<T> (x: T) { return x }
 
 export function resolveDefaults <TypeInfo extends BaseKeystoneTypeInfo> (config: KeystoneConfig<TypeInfo>): __ResolvedKeystoneConfig<TypeInfo> {
   if (!['postgresql', 'sqlite', 'mysql'].includes(config.db.provider)) {
@@ -108,7 +109,8 @@ export function resolveDefaults <TypeInfo extends BaseKeystoneTypeInfo> (config:
     db: {
       ...config.db,
       shadowDatabaseUrl: config.db?.shadowDatabaseUrl ?? '',
-      extendPrismaSchema: config.db?.extendPrismaSchema ?? ((schema: string) => schema),
+      extendPrismaSchema: config.db?.extendPrismaSchema ?? identity,
+      extendPrismaClient: config.db?.extendPrismaClient ?? identity,
       onConnect: config.db.onConnect ?? noop,
       prismaClientPath: config.db?.prismaClientPath ?? '@prisma/client',
       prismaSchemaPath: config.db?.prismaSchemaPath ?? 'schema.prisma',

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -114,6 +114,7 @@ export type KeystoneConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneT
     prismaSchemaPath?: string
 
     extendPrismaSchema?: (schema: string) => string
+    extendPrismaClient?: (client: any) => any
   }
 
   graphql?: {


### PR DESCRIPTION
Using this feature, one can extend PrismaClient, and add for example hooks at prisma level

```ts
export default withAuth(
  config<TypeInfo>({
    db: {
      extendPrismaClient(client: PrismaClient) {
        return client.$extends({
          query: {
            async $allOperations({ operation, model, args, query }) {
              // Raw Query is executed
              if (model === undefined) {
                const result: unknown = await query(args);
                return result;
              }

              const hooks = getPrismaHooks(model, operation);

              await hooks?.before?.(client, args);
              const result: unknown = await query(args);
              await hooks?.after?.(client, args, result);

              return result;
            },
          },
        });
      },
    },
  }),
);
```