### PR TITLE
feat(core/types): export hooks function types

### DIFF
--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -9,7 +9,7 @@ type CommonArgs<ListTypeInfo extends BaseListTypeInfo> = {
   listKey: ListTypeInfo['key']
 }
 
-type ResolveInputListHook<
+export type ResolveInputListHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update',
 > = (
@@ -126,12 +126,15 @@ export type FieldHooks<
   /**
    * Used to **modify the input** for create and update operations after default values and access control have been applied
    */
+
   resolveInput?: ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>
   // TODO: add in breaking change
-  //      | {
-  //          create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
-  //          update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
-  //        }
+  // resolveInput?:
+  //   | ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>
+  //   | {
+  //       create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
+  //       update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
+  //     }
 
   /**
    * Used to **validate** if a create, update or delete operation is OK
@@ -192,7 +195,7 @@ export type ResolvedFieldHooks<
   }
 }
 
-type ResolveInputFieldHook<
+export type ResolveInputFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update',
   FieldKey extends ListTypeInfo['fields'],
@@ -228,7 +231,7 @@ type ResolveInputFieldHook<
   ListTypeInfo['prisma']['create' | 'update'][FieldKey] | undefined // undefined represents 'don't do anything'
 >
 
-type ValidateHook<
+export type ValidateHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
 > = (
@@ -270,7 +273,7 @@ type ValidateHook<
     CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
-type ValidateFieldHook<
+export type ValidateFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
   FieldKey extends ListTypeInfo['fields'],
@@ -313,7 +316,7 @@ type ValidateFieldHook<
     },
 ) => MaybePromise<void>
 
-type BeforeOperationListHook<
+export type BeforeOperationListHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
 > = (
@@ -358,7 +361,7 @@ type BeforeOperationListHook<
     CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
-type BeforeOperationFieldHook<
+export type BeforeOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
   FieldKey extends ListTypeInfo['fields'],
@@ -404,7 +407,7 @@ type BeforeOperationFieldHook<
     CommonArgs<ListTypeInfo> & { fieldKey: FieldKey },
 ) => MaybePromise<void>
 
-type AfterOperationListHook<
+export type AfterOperationListHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
 > = (
@@ -452,7 +455,7 @@ type AfterOperationListHook<
     CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
-type AfterOperationFieldHook<
+export type AfterOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
   FieldKey extends ListTypeInfo['fields'],

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -1,10 +1,5 @@
-import {
-  type KeystoneContextFromListTypeInfo,
-  type MaybePromise
-} from '..'
-import {
-  type BaseListTypeInfo
-} from '../type-info'
+import { type KeystoneContextFromListTypeInfo, type MaybePromise } from '..'
+import { type BaseListTypeInfo } from '../type-info'
 
 type CommonArgs<ListTypeInfo extends BaseListTypeInfo> = {
   context: KeystoneContextFromListTypeInfo<ListTypeInfo>
@@ -16,7 +11,7 @@ type CommonArgs<ListTypeInfo extends BaseListTypeInfo> = {
 
 type ResolveInputListHook<
   ListTypeInfo extends BaseListTypeInfo,
-  Operation extends 'create' | 'update'
+  Operation extends 'create' | 'update',
 > = (
   args: {
     create: {
@@ -44,7 +39,7 @@ type ResolveInputListHook<
       resolvedData: ListTypeInfo['prisma']['update']
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo>
+    CommonArgs<ListTypeInfo>,
 ) => MaybePromise<ListTypeInfo['prisma'][Operation]>
 
 export type ListHooks<ListTypeInfo extends BaseListTypeInfo> = {
@@ -106,12 +101,12 @@ export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
   resolveInput: {
     create: ResolveInputListHook<ListTypeInfo, 'create'>
     update: ResolveInputListHook<ListTypeInfo, 'update'>
-  },
+  }
   validate: {
     create: ValidateHook<ListTypeInfo, 'create'>
     update: ValidateHook<ListTypeInfo, 'update'>
     delete: ValidateHook<ListTypeInfo, 'delete'>
-  },
+  }
   beforeOperation: {
     create: BeforeOperationListHook<ListTypeInfo, 'create'>
     update: BeforeOperationListHook<ListTypeInfo, 'update'>
@@ -126,18 +121,17 @@ export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
 
 export type FieldHooks<
   ListTypeInfo extends BaseListTypeInfo,
-  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields'],
 > = {
   /**
    * Used to **modify the input** for create and update operations after default values and access control have been applied
    */
-  resolveInput?:
-    | ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>
-// TODO: add in breaking change
-//      | {
-//          create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
-//          update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
-//        }
+  resolveInput?: ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>
+  // TODO: add in breaking change
+  //      | {
+  //          create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
+  //          update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
+  //        }
 
   /**
    * Used to **validate** if a create, update or delete operation is OK
@@ -175,7 +169,7 @@ export type FieldHooks<
 
 export type ResolvedFieldHooks<
   ListTypeInfo extends BaseListTypeInfo,
-  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields'],
 > = {
   resolveInput: {
     create: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
@@ -185,7 +179,7 @@ export type ResolvedFieldHooks<
     create: ValidateFieldHook<ListTypeInfo, 'create', FieldKey>
     update: ValidateFieldHook<ListTypeInfo, 'update', FieldKey>
     delete: ValidateFieldHook<ListTypeInfo, 'delete', FieldKey>
-  },
+  }
   beforeOperation: {
     create: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldKey>
     update: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldKey>
@@ -201,7 +195,7 @@ export type ResolvedFieldHooks<
 type ResolveInputFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update',
-  FieldKey extends ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'],
 > = (
   args: {
     create: {
@@ -229,14 +223,14 @@ type ResolveInputFieldHook<
       resolvedData: ListTypeInfo['prisma']['update']
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey },
 ) => MaybePromise<
   ListTypeInfo['prisma']['create' | 'update'][FieldKey] | undefined // undefined represents 'don't do anything'
 >
 
 type ValidateHook<
   ListTypeInfo extends BaseListTypeInfo,
-  Operation extends 'create' | 'update' | 'delete'
+  Operation extends 'create' | 'update' | 'delete',
 > = (
   args: {
     create: {
@@ -273,13 +267,13 @@ type ValidateHook<
       addValidationError: (error: string) => void
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo>
+    CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
 type ValidateFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'],
 > = (
   args: {
     create: {
@@ -316,12 +310,12 @@ type ValidateFieldHook<
     CommonArgs<ListTypeInfo> & {
       fieldKey: FieldKey
       addValidationError: (error: string) => void
-    }
+    },
 ) => MaybePromise<void>
 
 type BeforeOperationListHook<
   ListTypeInfo extends BaseListTypeInfo,
-  Operation extends 'create' | 'update' | 'delete'
+  Operation extends 'create' | 'update' | 'delete',
 > = (
   args: {
     create: {
@@ -361,13 +355,13 @@ type BeforeOperationListHook<
       resolvedData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo>
+    CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
 type BeforeOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'],
 > = (
   args: {
     create: {
@@ -407,12 +401,12 @@ type BeforeOperationFieldHook<
       resolvedData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey },
 ) => MaybePromise<void>
 
 type AfterOperationListHook<
   ListTypeInfo extends BaseListTypeInfo,
-  Operation extends 'create' | 'update' | 'delete'
+  Operation extends 'create' | 'update' | 'delete',
 > = (
   args: {
     create: {
@@ -455,13 +449,13 @@ type AfterOperationListHook<
       resolvedData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo>
+    CommonArgs<ListTypeInfo>,
 ) => MaybePromise<void>
 
 type AfterOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields']
+  FieldKey extends ListTypeInfo['fields'],
 > = (
   args: {
     create: {
@@ -504,5 +498,5 @@ type AfterOperationFieldHook<
       resolvedData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey },
 ) => MaybePromise<void>

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -16,8 +16,6 @@ import {
   type MaybeSessionFunction,
 } from './lists'
 import type { BaseFields } from './fields'
-import type { ListAccessControl, FieldAccessControl } from './access-control'
-import type { ListHooks, FieldHooks } from './hooks'
 
 type FileOrImage =
   // is given full file name, returns file name that will be used at
@@ -276,8 +274,9 @@ export type AdminFileToWrite =
   | { mode: 'write', src: string, outputPath: string }
   | { mode: 'copy', inputPath: string, outputPath: string }
 
-export type { ListHooks, ListAccessControl, FieldHooks, FieldAccessControl }
 export type {
+  ListAccessControl,
+  FieldAccessControl,
   FieldCreateItemAccessArgs,
   FieldReadItemAccessArgs,
   FieldUpdateItemAccessArgs,
@@ -290,3 +289,16 @@ export type {
 } from './access-control'
 export type { CommonFieldConfig } from './fields'
 export type { CacheHintArgs, IdFieldConfig } from './lists'
+export type {
+  ListHooks,
+  FieldHooks,
+  ResolveInputListHook,
+  ResolveInputFieldHook,
+  ValidateHook,
+  ValidateFieldHook,
+  BeforeOperationListHook,
+  BeforeOperationFieldHook,
+  AfterOperationListHook,
+  AfterOperationFieldHook,
+} from './hooks'
+


### PR DESCRIPTION
It would be better to have the hooks function types exported from KS.

PR is in 2 commits. One formats the changed code, one does the actual changes.

Today, I had to write some code and reuse some KS types that are not exported directly but through the API. It was complicated, but I did it.



<details>
<summary>See the code 🙈</summary>

```ts
import { type BaseListTypeInfo, type ListHooks } from '@keystone-6/core/types';

export type ExtractObject<T> = T extends Record<string, unknown> ? T : never;
export type ApplicableOperation = 'create' | 'update' | 'delete';

// 😱
type ValidateArgs<
	ListTypeInfo extends BaseListTypeInfo,
	Operation extends ApplicableOperation,
> = Omit<
	Parameters<
		NonNullable<ExtractObject<ListHooks<ListTypeInfo>['validate']>[Operation]>
	>[0],
	'addValidationError'
>;

export type ValidateOptions<ListTypeInfo extends BaseListTypeInfo> = (
	| ValidateArgs<ListTypeInfo, 'create'>
	| ValidateArgs<ListTypeInfo, 'update'>
	| ValidateArgs<ListTypeInfo, 'delete'>
) & {
	field: string;
};

export interface Validator<
	ListTypeInfo extends BaseListTypeInfo = BaseListTypeInfo,
> {
	validate: (
		options: ValidateOptions<ListTypeInfo>,
	) => Promise<string | undefined> | string | undefined;
}
```
</details>
