### PR TITLE
Export Pagination components for use in custom pages

### DIFF
--- a/.changeset/light-lamps-eat.md
+++ b/.changeset/light-lamps-eat.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": minor
 ---
 
-Export pagination components `Pagination`, `PaginationLabel` and `usePaginationParams` for use in custom pages
+Add exports for internal AdminUI pagination components `Pagination`, `PaginationLabel` and `usePaginationParams` for use in custom pages

--- a/.changeset/light-lamps-eat.md
+++ b/.changeset/light-lamps-eat.md
@@ -3,3 +3,6 @@
 ---
 
 Export Pagination components for use in custom pages
+- `Pagination`
+- `PaginationLabel`
+- `usePaginationParams` hook

--- a/.changeset/light-lamps-eat.md
+++ b/.changeset/light-lamps-eat.md
@@ -2,7 +2,4 @@
 "@keystone-6/core": minor
 ---
 
-Export Pagination components for use in custom pages
-- `Pagination`
-- `PaginationLabel`
-- `usePaginationParams` hook
+Export pagination components `Pagination`, `PaginationLabel` and `usePaginationParams` for use in custom pages

--- a/.changeset/light-lamps-eat.md
+++ b/.changeset/light-lamps-eat.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Export Pagination components for use in custom pages

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -22,7 +22,7 @@ import {
 import { gql, type TypedDocumentNode, useMutation, useQuery } from '../../../../admin-ui/apollo'
 import { CellLink } from '../../../../admin-ui/components'
 import { PageContainer, HEADER_HEIGHT } from '../../../../admin-ui/components/PageContainer'
-import { Pagination, PaginationLabel } from '../../../../admin-ui/components/Pagination'
+import { Pagination, PaginationLabel, usePaginationParams } from '../../../../admin-ui/components/Pagination'
 import { useList } from '../../../../admin-ui/context'
 import { GraphQLErrorNotice } from '../../../../admin-ui/components/GraphQLErrorNotice'
 import { Link, useRouter } from '../../../../admin-ui/router'
@@ -136,13 +136,7 @@ function ListPage ({ listKey }: ListPageProps) {
   const { query, push } = useRouter()
 
   const { resetToDefaults } = useQueryParamsFromLocalStorage(listKey)
-
-  const currentPage =
-    typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1
-  const pageSize =
-    typeof query.pageSize === 'string' && !Number.isNaN(parseInt(query.pageSize))
-      ? parseInt(query.pageSize)
-      : list.pageSize
+  const { currentPage, pageSize } = usePaginationParams({ defaultPageSize: list.pageSize });
 
   const metaQuery = useQuery(listMetaGraphqlQuery, { variables: { listKey } })
 

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -760,7 +760,7 @@ function ListTable ({
           })}
         </tbody>
       </TableContainer>
-      <Pagination list={list} total={count} currentPage={currentPage} pageSize={pageSize} />
+      <Pagination singular={list.singular} plural={list.plural} total={count} currentPage={currentPage} pageSize={pageSize} />
     </Box>
   )
 }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -134,10 +134,8 @@ function ListPage ({ listKey }: ListPageProps) {
   const list = useList(listKey)
 
   const { query, push } = useRouter()
-
   const { resetToDefaults } = useQueryParamsFromLocalStorage(listKey)
-  const { currentPage, pageSize } = usePaginationParams({ defaultPageSize: list.pageSize });
-
+  const { currentPage, pageSize } = usePaginationParams({ defaultPageSize: list.pageSize })
   const metaQuery = useQuery(listMetaGraphqlQuery, { variables: { listKey } })
 
   const { listViewFieldModesByField, filterableFields, orderableFields } = useMemo(() => {

--- a/packages/core/src/admin-ui/components/Pagination.tsx
+++ b/packages/core/src/admin-ui/components/Pagination.tsx
@@ -14,7 +14,7 @@ type PaginationProps = {
   plural: string
 }
 
-export function usePaginationParams({ defaultPageSize }: { defaultPageSize: number }) {
+export function usePaginationParams ({ defaultPageSize }: { defaultPageSize: number }) {
   const { query } = useRouter()
   const currentPage = Math.max(
     typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1,

--- a/packages/core/src/admin-ui/components/Pagination.tsx
+++ b/packages/core/src/admin-ui/components/Pagination.tsx
@@ -6,7 +6,7 @@ import { Select } from '@keystone-ui/fields'
 import { ChevronRightIcon, ChevronLeftIcon } from '@keystone-ui/icons'
 import { Link, useRouter } from '../router'
 
-interface PaginationProps {
+type PaginationProps = {
   pageSize: number
   total: number
   currentPage: number
@@ -26,7 +26,7 @@ export function usePaginationParams({ defaultPageSize }: { defaultPageSize: numb
   return { currentPage, pageSize }
 }
 
-const getPaginationStats = ({ singular, plural, pageSize, currentPage, total }: PaginationProps) => {
+function getPaginationStats ({ singular, plural, pageSize, currentPage, total }: PaginationProps) {
   let stats = ''
   if (total > pageSize) {
     const start = pageSize * (currentPage - 1) + 1

--- a/packages/core/src/admin-ui/components/Pagination.tsx
+++ b/packages/core/src/admin-ui/components/Pagination.tsx
@@ -15,14 +15,14 @@ interface PaginationProps {
 }
 
 export function usePaginationParams({ defaultPageSize }: { defaultPageSize: number }) {
-  const { query } = useRouter();
+  const { query } = useRouter()
   const currentPage = Math.max(
     typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1,
     1
   )
   const pageSize = typeof query.pageSize === 'string' && !Number.isNaN(parseInt(query.pageSize))
       ? parseInt(query.pageSize)
-      : defaultPageSize;
+      : defaultPageSize
   return { currentPage, pageSize }
 }
 

--- a/packages/core/src/admin-ui/components/Pagination.tsx
+++ b/packages/core/src/admin-ui/components/Pagination.tsx
@@ -14,6 +14,18 @@ interface PaginationProps {
   plural: string
 }
 
+export function usePaginationParams({ defaultPageSize }: { defaultPageSize: number }) {
+  const { query } = useRouter();
+  const currentPage = Math.max(
+    typeof query.page === 'string' && !Number.isNaN(parseInt(query.page)) ? Number(query.page) : 1,
+    1
+  )
+  const pageSize = typeof query.pageSize === 'string' && !Number.isNaN(parseInt(query.pageSize))
+      ? parseInt(query.pageSize)
+      : defaultPageSize;
+  return { currentPage, pageSize }
+}
+
 const getPaginationStats = ({ singular, plural, pageSize, currentPage, total }: PaginationProps) => {
   let stats = ''
   if (total > pageSize) {

--- a/packages/core/src/admin-ui/components/Pagination.tsx
+++ b/packages/core/src/admin-ui/components/Pagination.tsx
@@ -10,28 +10,29 @@ interface PaginationProps {
   pageSize: number
   total: number
   currentPage: number
-  list: Record<string, any>
+  singular: string
+  plural: string
 }
 
-const getPaginationStats = ({ list, pageSize, currentPage, total }: PaginationProps) => {
+const getPaginationStats = ({ singular, plural, pageSize, currentPage, total }: PaginationProps) => {
   let stats = ''
   if (total > pageSize) {
     const start = pageSize * (currentPage - 1) + 1
     const end = Math.min(start + pageSize - 1, total)
-    stats = `${start} - ${end} of ${total} ${list.plural}`
+    stats = `${start} - ${end} of ${total} ${plural}`
   } else {
-    if (total > 1 && list.plural) {
-      stats = `${total} ${list.plural}`
-    } else if (total === 1 && list.singular) {
-      stats = `${total} ${list.singular}`
+    if (total > 1 && plural) {
+      stats = `${total} ${plural}`
+    } else if (total === 1 && singular) {
+      stats = `${total} ${singular}`
     }
   }
   return { stats }
 }
 
-export function Pagination ({ currentPage, total, pageSize, list }: PaginationProps) {
+export function Pagination ({ currentPage, total, pageSize, singular, plural }: PaginationProps) {
   const { query, pathname, push } = useRouter()
-  const { stats } = getPaginationStats({ list, currentPage, total, pageSize })
+  const { stats } = getPaginationStats({ singular, plural, currentPage, total, pageSize })
   const { opacity } = useTheme()
 
   const nextPage = currentPage + 1
@@ -59,7 +60,7 @@ export function Pagination ({ currentPage, total, pageSize, list }: PaginationPr
     }
   }, [total, pageSize, currentPage, pathname, query, push])
 
-  // Don't render the pagiantion component if the pageSize is greater than the total number of items in the list.
+  // Don't render the pagination component if the pageSize is greater than the total number of items in the list.
   if (total <= pageSize) return null
 
   const onChange = (selectedOption: { value: string, label: string }) => {
@@ -96,7 +97,7 @@ export function Pagination ({ currentPage, total, pageSize, list }: PaginationPr
       }}
     >
       <Stack across gap="xxlarge" align="center">
-        <span>{`${list.plural} per page: ${pageSize}`}</span>
+        <span>{`${plural} per page: ${pageSize}`}</span>
         <span>
           <strong>{stats}</strong>
         </span>
@@ -155,15 +156,10 @@ export function PaginationLabel ({
   plural,
   singular,
   total,
-}: {
-  currentPage: number
-  pageSize: number
-  plural: string
-  singular: string
-  total: number
-}) {
+}: PaginationProps) {
   const { stats } = getPaginationStats({
-    list: { plural, singular },
+    plural,
+    singular,
     currentPage,
     total,
     pageSize,

--- a/packages/core/src/admin-ui/components/index.ts
+++ b/packages/core/src/admin-ui/components/index.ts
@@ -16,4 +16,4 @@ export type { NavigationProps } from '../../types'
 export { PageContainer } from './PageContainer'
 export { CreateItemDrawer } from './CreateItemDrawer'
 export { GraphQLErrorNotice } from './GraphQLErrorNotice'
-export { Pagination, PaginationLabel, usePaginationParams } from './Pagination';
+export { Pagination, PaginationLabel, usePaginationParams } from './Pagination'

--- a/packages/core/src/admin-ui/components/index.ts
+++ b/packages/core/src/admin-ui/components/index.ts
@@ -16,4 +16,4 @@ export type { NavigationProps } from '../../types'
 export { PageContainer } from './PageContainer'
 export { CreateItemDrawer } from './CreateItemDrawer'
 export { GraphQLErrorNotice } from './GraphQLErrorNotice'
-export { Pagination, PaginationLabel } from './Pagination';
+export { Pagination, PaginationLabel, usePaginationParams } from './Pagination';

--- a/packages/core/src/admin-ui/components/index.ts
+++ b/packages/core/src/admin-ui/components/index.ts
@@ -16,3 +16,4 @@ export type { NavigationProps } from '../../types'
 export { PageContainer } from './PageContainer'
 export { CreateItemDrawer } from './CreateItemDrawer'
 export { GraphQLErrorNotice } from './GraphQLErrorNotice'
+export { Pagination, PaginationLabel } from './Pagination';


### PR DESCRIPTION
## Changes

- Update `Pagination` component to _not_ require the list as it only needs the `singular` and `plural` string. The apis for `Pagination` and `PaginationLabel` are now identical.
- Export `Pagination` and `PaginationLabel` component so they can be used in custom pages.