### PR TITLE
Fix UUID's breaking relationship filters with POSTGRES

### DIFF
--- a/.changeset/fix-uuid-rel.md
+++ b/.changeset/fix-uuid-rel.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Fix UUID breaking relationship filters
+Fix malformed uuid's from breaking relationship filters when using POSTGRESQL

--- a/.changeset/fix-uuid-rel.md
+++ b/.changeset/fix-uuid-rel.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix UUID breaking relationship filters

--- a/.changeset/light-lamps-eat.md
+++ b/.changeset/light-lamps-eat.md
@@ -1,5 +1,5 @@
 ---
-"@keystone-6/core": minor
+'@keystone-6/core': minor
 ---
 
 Add exports for internal AdminUI pagination components `Pagination`, `PaginationLabel` and `usePaginationParams` for use in custom pages

--- a/examples/custom-id/schema.graphql
+++ b/examples/custom-id/schema.graphql
@@ -178,6 +178,8 @@ type Order {
   assignedTo: Person
   options(where: OptionWhereInput! = {}, orderBy: [OptionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OptionWhereUniqueInput): [Option!]
   optionsCount(where: OptionWhereInput! = {}): Int
+  products(where: ProductWhereInput! = {}, orderBy: [ProductOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ProductWhereUniqueInput): [Product!]
+  productsCount(where: ProductWhereInput! = {}): Int
   orderedAt: DateTime
 }
 
@@ -193,6 +195,7 @@ input OrderWhereInput {
   description: StringFilter
   assignedTo: PersonWhereInput
   options: OptionManyRelationFilter
+  products: ProductManyRelationFilter
   orderedAt: DateTimeNullableFilter
 }
 
@@ -200,6 +203,12 @@ input OptionManyRelationFilter {
   every: OptionWhereInput
   some: OptionWhereInput
   none: OptionWhereInput
+}
+
+input ProductManyRelationFilter {
+  every: ProductWhereInput
+  some: ProductWhereInput
+  none: ProductWhereInput
 }
 
 input OrderOrderByInput {
@@ -212,6 +221,7 @@ input OrderUpdateInput {
   description: String
   assignedTo: PersonRelateToOneForUpdateInput
   options: OptionRelateToManyForUpdateInput
+  products: ProductRelateToManyForUpdateInput
   orderedAt: DateTime
 }
 
@@ -220,6 +230,13 @@ input OptionRelateToManyForUpdateInput {
   set: [OptionWhereUniqueInput!]
   create: [OptionCreateInput!]
   connect: [OptionWhereUniqueInput!]
+}
+
+input ProductRelateToManyForUpdateInput {
+  disconnect: [ProductWhereUniqueInput!]
+  set: [ProductWhereUniqueInput!]
+  create: [ProductCreateInput!]
+  connect: [ProductWhereUniqueInput!]
 }
 
 input OrderUpdateArgs {
@@ -231,12 +248,18 @@ input OrderCreateInput {
   description: String
   assignedTo: PersonRelateToOneForCreateInput
   options: OptionRelateToManyForCreateInput
+  products: ProductRelateToManyForCreateInput
   orderedAt: DateTime
 }
 
 input OptionRelateToManyForCreateInput {
   create: [OptionCreateInput!]
   connect: [OptionWhereUniqueInput!]
+}
+
+input ProductRelateToManyForCreateInput {
+  create: [ProductCreateInput!]
+  connect: [ProductWhereUniqueInput!]
 }
 
 type Option {
@@ -274,6 +297,42 @@ input OptionCreateInput {
   description: String
 }
 
+type Product {
+  id: ID!
+  sku: String
+}
+
+input ProductWhereUniqueInput {
+  id: ID
+  sku: String
+}
+
+input ProductWhereInput {
+  AND: [ProductWhereInput!]
+  OR: [ProductWhereInput!]
+  NOT: [ProductWhereInput!]
+  id: IDFilter
+  sku: StringFilter
+}
+
+input ProductOrderByInput {
+  id: OrderDirection
+  sku: OrderDirection
+}
+
+input ProductUpdateInput {
+  sku: String
+}
+
+input ProductUpdateArgs {
+  where: ProductWhereUniqueInput!
+  data: ProductUpdateInput!
+}
+
+input ProductCreateInput {
+  sku: String
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -304,6 +363,12 @@ type Mutation {
   updateOptions(data: [OptionUpdateArgs!]!): [Option]
   deleteOption(where: OptionWhereUniqueInput!): Option
   deleteOptions(where: [OptionWhereUniqueInput!]!): [Option]
+  createProduct(data: ProductCreateInput!): Product
+  createProducts(data: [ProductCreateInput!]!): [Product]
+  updateProduct(where: ProductWhereUniqueInput!, data: ProductUpdateInput!): Product
+  updateProducts(data: [ProductUpdateArgs!]!): [Product]
+  deleteProduct(where: ProductWhereUniqueInput!): Product
+  deleteProducts(where: [ProductWhereUniqueInput!]!): [Product]
 }
 
 type Query {
@@ -319,6 +384,9 @@ type Query {
   options(where: OptionWhereInput! = {}, orderBy: [OptionOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OptionWhereUniqueInput): [Option!]
   option(where: OptionWhereUniqueInput!): Option
   optionsCount(where: OptionWhereInput! = {}): Int
+  products(where: ProductWhereInput! = {}, orderBy: [ProductOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: ProductWhereUniqueInput): [Product!]
+  product(where: ProductWhereUniqueInput!): Product
+  productsCount(where: ProductWhereInput! = {}): Int
   keystone: KeystoneMeta!
 }
 

--- a/examples/custom-id/schema.prisma
+++ b/examples/custom-id/schema.prisma
@@ -35,6 +35,7 @@ model Order {
   assignedTo   Person?   @relation("Order_assignedTo", fields: [assignedToId], references: [id])
   assignedToId String?   @map("assignedTo")
   options      Option[]  @relation("Order_options")
+  products     Product[] @relation("Order_products")
   orderedAt    DateTime?
 
   @@index([assignedToId])
@@ -44,4 +45,10 @@ model Option {
   id                 Int     @id
   description        String  @default("")
   from_Order_options Order[] @relation("Order_options")
+}
+
+model Product {
+  id                  String  @id @default(uuid())
+  sku                 String  @unique @default("")
+  from_Order_products Order[] @relation("Order_products")
 }

--- a/examples/custom-id/schema.ts
+++ b/examples/custom-id/schema.ts
@@ -39,6 +39,7 @@ export const lists = {
       description: text({ validation: { isRequired: true } }),
       assignedTo: relationship({ ref: 'Person', many: false }),
       options: relationship({ ref: 'Option', many: true }),
+      products: relationship({ ref: 'Product', many: true }),
       orderedAt: timestamp(),
     },
     hooks: {
@@ -63,6 +64,15 @@ export const lists = {
           return { ...resolvedData, id: 3 }
         },
       },
+    },
+  }),
+  Product: list({
+    access: allowAll,
+    db: {
+      idField: { kind: 'uuid' },
+    },
+    fields: {
+      sku: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
     },
   }),
 } satisfies Lists

--- a/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
+++ b/packages/core/src/fields/types/relationship/views/RelationshipSelect.tsx
@@ -2,16 +2,24 @@
 /** @jsx jsx */
 
 import 'intersection-observer'
-import { type RefObject, useEffect, useMemo, useState, createContext, useContext, useRef } from 'react'
+import {
+  type RefObject,
+  useEffect,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+  useRef
+} from 'react'
 
 import { jsx } from '@keystone-ui/core'
 import { MultiSelect, Select, selectComponents } from '@keystone-ui/fields'
-import type { ListMeta } from '../../../../types'
+import { type ListMeta } from '../../../../types'
 import {
+  type TypedDocumentNode,
   ApolloClient,
   gql,
   InMemoryCache,
-  type TypedDocumentNode,
   useApolloClient,
   useQuery,
 } from '../../../../admin-ui/apollo'
@@ -57,24 +65,35 @@ function isBigInt (x: string) {
   }
 }
 
-export function useFilter (search: string, list: ListMeta, searchFields: string[]) {
+// TODO: this is unfortunate, remove in breaking change?
+function isUuid (x: unknown) {
+  if (typeof x !== 'string') return
+  if (x.length !== 36) return
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(x)
+}
+
+export function useFilter (value: string, list: ListMeta, searchFields: string[]) {
   return useMemo(() => {
-    const trimmedSearch = search.trim()
+    const trimmedSearch = value.trim()
     if (!trimmedSearch.length) return { OR: [] }
 
     const conditions: Record<string, any>[] = []
-    const { type: idFieldType } = (list.fields.id.fieldMeta as any) ?? {}
-    if (idFieldType === 'String') {
-      conditions.push({ id: { equals: trimmedSearch } })
-    } else if (idFieldType === 'Int' && isInt(trimmedSearch)) {
-      conditions.push({ id: { equals: Number(trimmedSearch) } })
-    } else if (idFieldType === 'BigInt' && isBigInt(trimmedSearch)) {
-      conditions.push({ id: { equals: trimmedSearch } })
-    } else if (idFieldType === 'UUID') {
-      conditions.push({ id: { equals: trimmedSearch } }) // TODO: remove in breaking change?
-    }
+    const idField = list.fields.id.fieldMeta as { type: string, kind: string }
+    console.error({ idField, value, meta: list.fields.id.fieldMeta })
 
-    if ((list.fields.id.fieldMeta as any)?.type === 'String') {
+    if (idField.type === 'String') {
+      // TODO: remove in breaking change?
+      if (idField.kind === 'uuid') {
+        if (isUuid(value)) {
+          conditions.push({ id: { equals: trimmedSearch } })
+        }
+      } else {
+        conditions.push({ id: { equals: trimmedSearch } })
+      }
+    } else if (idField.type === 'Int' && isInt(trimmedSearch)) {
+      conditions.push({ id: { equals: Number(trimmedSearch) } })
+
+    } else if (idField.type === 'BigInt' && isBigInt(trimmedSearch)) {
       conditions.push({ id: { equals: trimmedSearch } })
     }
 
@@ -89,7 +108,7 @@ export function useFilter (search: string, list: ListMeta, searchFields: string[
     }
 
     return { OR: conditions }
-  }, [search, list, searchFields])
+  }, [value, list, searchFields])
 }
 
 const idFieldAlias = '____id____'

--- a/packages/core/src/lib/id-field.ts
+++ b/packages/core/src/lib/id-field.ts
@@ -32,7 +32,7 @@ function isString (x: IDType) {
   return x
 }
 
-// TODO: this should be on the user, remove in breaking change
+// TODO: this should be on the user, remove in breaking change?
 function isUuid (x: IDType) {
   if (typeof x !== 'string') return
   if (x === '') return

--- a/packages/fields-document/src/DocumentEditor/index.tsx
+++ b/packages/fields-document/src/DocumentEditor/index.tsx
@@ -41,26 +41,27 @@ import {
   createDocumentEditor
 } from './editor-shared'
 
-const orderedListStyles = ['lower-roman', 'decimal', 'lower-alpha']
-const unorderedListStyles = ['square', 'disc', 'circle']
-
-let styles: any = {
+const styles = {
   flex: 1,
-}
-
-let listDepth = 10
-
-while (listDepth--) {
-  let arr = Array.from({ length: listDepth })
-  if (arr.length) {
-    styles[arr.map(() => `ol`).join(' ')] = {
-      listStyle: orderedListStyles[listDepth % 3],
-    }
-    styles[arr.map(() => `ul`).join(' ')] = {
-      listStyle: unorderedListStyles[listDepth % 3],
-    }
-  }
-}
+  'ol ol ol ol ol ol ol ol ol': { listStyle: 'lower-roman' },
+  'ol ol ol ol ol ol ol ol': { listStyle: 'lower-alpha' },
+  'ol ol ol ol ol ol ol': { listStyle: 'decimal' },
+  'ol ol ol ol ol ol': { listStyle: 'lower-roman' },
+  'ol ol ol ol ol': { listStyle: 'lower-alpha' },
+  'ol ol ol ol': { listStyle: 'decimal' },
+  'ol ol ol': { listStyle: 'lower-roman' },
+  'ol ol': { listStyle: 'lower-alpha' },
+  'ol': { listStyle: 'decimal' },
+  'ul ul ul ul ul ul ul ul ul': { listStyle: 'square' },
+  'ul ul ul ul ul ul ul ul': { listStyle: 'circle' },
+  'ul ul ul ul ul ul ul': { listStyle: 'disc' },
+  'ul ul ul ul ul ul': { listStyle: 'square' },
+  'ul ul ul ul ul': { listStyle: 'circle' },
+  'ul ul ul ul': { listStyle: 'disc' },
+  'ul ul ul': { listStyle: 'square' },
+  'ul ul': { listStyle: 'circle' },
+  'ul': { listStyle: 'disc' }
+} as const
 
 const HOTKEYS: Record<string, Mark> = {
   'mod+b': 'bold',


### PR DESCRIPTION
As described in https://github.com/keystonejs/keystone/issues/8884, this pull request prevents malformed UUIDs from being added to the search query, which then results in Prisma throwing an error breaking the search filters.