### PR TITLE
Remove `@deprecated` from storedSessions

### DIFF
--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -124,7 +124,6 @@ export function statelessSessions<Session> ({
   }
 }
 
-/** @deprecated */
 export function storedSessions<Session> ({
   store: storeFn,
   maxAge = 60 * 60 * 8, // 8 hours


### PR DESCRIPTION
Alternative to https://github.com/keystonejs/keystone/pull/9191
Follow up to https://github.com/keystonejs/keystone/discussions/9212