### PR TITLE
Remove `tree-kill` from test devDependencies

### DIFF
--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -25,10 +25,10 @@ export async function build (
   if (prisma) {
     if (frozen) {
       await validateArtifacts(cwd, system)
-      console.log('✨ GraphQL and Prisma schemas are up to date')
+      console.log('✨ GraphQL and Prisma schemas are up to date') // TODO: validating?
     } else {
       await generateArtifacts(cwd, system)
-      console.log('✨ Generated GraphQL and Prisma schemas')
+      console.log('✨ Generated GraphQL and Prisma schemas') // TODO: generating?
     }
 
     await generateTypes(cwd, system)

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -263,22 +263,20 @@ export async function dev (
 
     let nextApp
     if (!system.config.ui?.isDisabled && ui) {
-      const paths = system.getPaths(cwd)
-      await fsp.rm(paths.admin, { recursive: true, force: true })
+      if (!expressServer || !context) throw new TypeError('Error trying to prepare the Admin UI')
 
       console.log('✨ Generating Admin UI code')
+      const paths = system.getPaths(cwd)
+      await fsp.rm(paths.admin, { recursive: true, force: true })
       await generateAdminUI(system.config, system.graphQLSchema, system.adminMeta, paths.admin, false)
 
-      console.log('✨ Preparing Admin UI app')
+      console.log('✨ Preparing Admin UI')
       nextApp = next({ dev: true, dir: paths.admin })
       await nextApp.prepare()
-
+      expressServer.use(createAdminUIMiddlewareWithNextApp(system.config, context, nextApp))
       console.log(`✅ Admin UI ready`)
     }
 
-    if (nextApp && expressServer && context) {
-      expressServer.use(createAdminUIMiddlewareWithNextApp(system.config, context, nextApp))
-    }
     hasAddedAdminUIMiddleware = true
     initKeystonePromiseResolve()
 

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -35,10 +35,9 @@ export async function start (
 
   console.log(`✅ GraphQL API ready`)
   if (!system.config.ui?.isDisabled && ui) {
-    console.log('✨ Preparing Admin UI Next.js app')
+    console.log('✨ Preparing Admin UI')
     const nextApp = next({ dev: false, dir: paths.admin })
     await nextApp.prepare()
-
     expressServer.use(await createAdminUIMiddlewareWithNextApp(system.config, keystone.context, nextApp))
     console.log(`✅ Admin UI ready`)
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5751,83 +5751,83 @@ packages:
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
 
-  '@rollup/rollup-android-arm-eabi@4.18.1':
-    resolution: {integrity: sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==}
+  '@rollup/rollup-android-arm-eabi@4.19.0':
+    resolution: {integrity: sha512-JlPfZ/C7yn5S5p0yKk7uhHTTnFlvTgLetl2VxqE518QgyM7C9bSfFTYvB/Q/ftkq0RIPY4ySxTz+/wKJ/dXC0w==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.18.1':
-    resolution: {integrity: sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==}
+  '@rollup/rollup-android-arm64@4.19.0':
+    resolution: {integrity: sha512-RDxUSY8D1tWYfn00DDi5myxKgOk6RvWPxhmWexcICt/MEC6yEMr4HNCu1sXXYLw8iAsg0D44NuU+qNq7zVWCrw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.18.1':
-    resolution: {integrity: sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==}
+  '@rollup/rollup-darwin-arm64@4.19.0':
+    resolution: {integrity: sha512-emvKHL4B15x6nlNTBMtIaC9tLPRpeA5jMvRLXVbl/W9Ie7HhkrE7KQjvgS9uxgatL1HmHWDXk5TTS4IaNJxbAA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.18.1':
-    resolution: {integrity: sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==}
+  '@rollup/rollup-darwin-x64@4.19.0':
+    resolution: {integrity: sha512-fO28cWA1dC57qCd+D0rfLC4VPbh6EOJXrreBmFLWPGI9dpMlER2YwSPZzSGfq11XgcEpPukPTfEVFtw2q2nYJg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
-    resolution: {integrity: sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.0':
+    resolution: {integrity: sha512-2Rn36Ubxdv32NUcfm0wB1tgKqkQuft00PtM23VqLuCUR4N5jcNWDoV5iBC9jeGdgS38WK66ElncprqgMUOyomw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.18.1':
-    resolution: {integrity: sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.19.0':
+    resolution: {integrity: sha512-gJuzIVdq/X1ZA2bHeCGCISe0VWqCoNT8BvkQ+BfsixXwTOndhtLUpOg0A1Fcx/+eA6ei6rMBzlOz4JzmiDw7JQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.1':
-    resolution: {integrity: sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.19.0':
+    resolution: {integrity: sha512-0EkX2HYPkSADo9cfeGFoQ7R0/wTKb7q6DdwI4Yn/ULFE1wuRRCHybxpl2goQrx4c/yzK3I8OlgtBu4xvted0ug==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.18.1':
-    resolution: {integrity: sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==}
+  '@rollup/rollup-linux-arm64-musl@4.19.0':
+    resolution: {integrity: sha512-GlIQRj9px52ISomIOEUq/IojLZqzkvRpdP3cLgIE1wUWaiU5Takwlzpz002q0Nxxr1y2ZgxC2obWxjr13lvxNQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
-    resolution: {integrity: sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.0':
+    resolution: {integrity: sha512-N6cFJzssruDLUOKfEKeovCKiHcdwVYOT1Hs6dovDQ61+Y9n3Ek4zXvtghPPelt6U0AH4aDGnDLb83uiJMkWYzQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.18.1':
-    resolution: {integrity: sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.19.0':
+    resolution: {integrity: sha512-2DnD3mkS2uuam/alF+I7M84koGwvn3ZVD7uG+LEWpyzo/bq8+kKnus2EVCkcvh6PlNB8QPNFOz6fWd5N8o1CYg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.1':
-    resolution: {integrity: sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==}
+  '@rollup/rollup-linux-s390x-gnu@4.19.0':
+    resolution: {integrity: sha512-D6pkaF7OpE7lzlTOFCB2m3Ngzu2ykw40Nka9WmKGUOTS3xcIieHe82slQlNq69sVB04ch73thKYIWz/Ian8DUA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.18.1':
-    resolution: {integrity: sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==}
+  '@rollup/rollup-linux-x64-gnu@4.19.0':
+    resolution: {integrity: sha512-HBndjQLP8OsdJNSxpNIN0einbDmRFg9+UQeZV1eiYupIRuZsDEoeGU43NQsS34Pp166DtwQOnpcbV/zQxM+rWA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.18.1':
-    resolution: {integrity: sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==}
+  '@rollup/rollup-linux-x64-musl@4.19.0':
+    resolution: {integrity: sha512-HxfbvfCKJe/RMYJJn0a12eiOI9OOtAUF4G6ozrFUK95BNyoJaSiBjIOHjZskTUffUrB84IPKkFG9H9nEvJGW6A==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.18.1':
-    resolution: {integrity: sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==}
+  '@rollup/rollup-win32-arm64-msvc@4.19.0':
+    resolution: {integrity: sha512-HxDMKIhmcguGTiP5TsLNolwBUK3nGGUEoV/BO9ldUBoMLBssvh4J0X8pf11i1fTV7WShWItB1bKAKjX4RQeYmg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.1':
-    resolution: {integrity: sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==}
+  '@rollup/rollup-win32-ia32-msvc@4.19.0':
+    resolution: {integrity: sha512-xItlIAZZaiG/u0wooGzRsx11rokP4qyc/79LkAOdznGRAbOFc+SfEdfUOszG1odsHNgwippUJavag/+W/Etc6Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.18.1':
-    resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
+  '@rollup/rollup-win32-x64-msvc@4.19.0':
+    resolution: {integrity: sha512-xNo5fV5ycvCCKqiZcpB65VMR11NJB+StnxHz20jdqRAktfdfzhgjTiJ2doTDQE/7dqGaV5I7ZGqKpgph6lCIag==}
     cpu: [x64]
     os: [win32]
 
@@ -6270,8 +6270,8 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
-  '@types/dom-view-transitions@1.0.4':
-    resolution: {integrity: sha512-oDuagM6G+xPLrLU4KeCKlr1oalMF5mJqV5pDPMDVIEaa8AkUW00i6u+5P02XCjdEEUQJC9dpnxqSLsZeAciSLQ==}
+  '@types/dom-view-transitions@1.0.5':
+    resolution: {integrity: sha512-N2sILR7fxSMnaFaAPwGj4DtHCXjIyQTHt+xJyf9jATpzUsTkMNM0DWtqZB6W7f501B/Y0tq3uqat/VlbjuTpMA==}
 
   '@types/estree-jsx@0.0.1':
     resolution: {integrity: sha512-gcLAYiMfQklDCPjQegGn0TBAn9it05ISEsEhlKQUddIk7o2XDokOcTN7HBO8tznM0D9dGezvHEfRZBfZf6me0A==}
@@ -7088,9 +7088,6 @@ packages:
 
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -9928,10 +9925,6 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.53.0:
-    resolution: {integrity: sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==}
-    engines: {node: '>= 0.6'}
-
   mime-types@2.1.13:
     resolution: {integrity: sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==}
     engines: {node: '>= 0.6'}
@@ -10633,8 +10626,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.4.39:
-    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
+  postcss@8.4.40:
+    resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact-render-to-string@5.2.6:
@@ -10642,8 +10635,8 @@ packages:
     peerDependencies:
       preact: '>=10'
 
-  preact@10.22.1:
-    resolution: {integrity: sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==}
+  preact@10.23.0:
+    resolution: {integrity: sha512-Pox0jeY4q6PGkFB5AsXni+zHxxx/sAYFIFZzukW4nIpoJLRziRX0xC4WjZENlkSrDQvqVgZcaZzZ/NL8/A+H/w==}
 
   preferred-pm@3.1.4:
     resolution: {integrity: sha512-lEHd+yEm22jXdCphDrkvIJQU66EuLojPPtvZkpKIkiD+l0DMThF/niqZKJSoU8Vl7iuvtmzyMhir9LdVy5WMnA==}
@@ -11176,8 +11169,8 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.18.1:
-    resolution: {integrity: sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==}
+  rollup@4.19.0:
+    resolution: {integrity: sha512-5r7EYSQIowHsK4eTZ0Y81qpZuJz+MUuYeqmmYmRMl1nwhdmbiYqt5jwzf6u7wyOzJgYqtCRMtVRKOtHANBz7rA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -12482,8 +12475,8 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.4.5:
-    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
+  yaml@2.5.0:
+    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
     engines: {node: '>= 14'}
     hasBin: true
 
@@ -15065,14 +15058,14 @@ snapshots:
   '@graphql-tools/optimize@1.4.0(graphql@16.9.0)':
     dependencies:
       graphql: 16.9.0
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.9.0)':
     dependencies:
       '@ardatan/relay-compiler': 12.0.0(graphql@16.9.0)
       '@graphql-tools/utils': 9.2.1(graphql@16.9.0)
       graphql: 16.9.0
-      tslib: 2.4.1
+      tslib: 2.6.3
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -15088,7 +15081,7 @@ snapshots:
   '@graphql-tools/utils@8.13.1(graphql@16.9.0)':
     dependencies:
       graphql: 16.9.0
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   '@graphql-tools/utils@9.2.1(graphql@16.9.0)':
     dependencies:
@@ -16865,10 +16858,10 @@ snapshots:
       picocolors: 1.0.1
       picomatch: 2.3.1
       pidtree: 0.6.0
-      postcss: 8.4.39
-      postcss-discard-duplicates: 5.1.0(postcss@8.4.39)
-      postcss-load-config: 4.0.2(postcss@8.4.39)
-      postcss-modules: 6.0.0(postcss@8.4.39)
+      postcss: 8.4.31
+      postcss-discard-duplicates: 5.1.0(postcss@8.4.31)
+      postcss-load-config: 4.0.2(postcss@8.4.31)
+      postcss-modules: 6.0.0(postcss@8.4.31)
       prettier: 2.8.8
       pretty-ms: 7.0.1
       proxy-agent: 6.4.0
@@ -17029,52 +17022,52 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/rollup-android-arm-eabi@4.18.1':
+  '@rollup/rollup-android-arm-eabi@4.19.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.18.1':
+  '@rollup/rollup-android-arm64@4.19.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.18.1':
+  '@rollup/rollup-darwin-arm64@4.19.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.18.1':
+  '@rollup/rollup-darwin-x64@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.18.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.18.1':
+  '@rollup/rollup-linux-arm64-gnu@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.18.1':
+  '@rollup/rollup-linux-arm64-musl@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.18.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.18.1':
+  '@rollup/rollup-linux-s390x-gnu@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.18.1':
+  '@rollup/rollup-linux-x64-gnu@4.19.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.18.1':
+  '@rollup/rollup-linux-x64-musl@4.19.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.18.1':
+  '@rollup/rollup-win32-arm64-msvc@4.19.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.18.1':
+  '@rollup/rollup-win32-ia32-msvc@4.19.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.18.1':
+  '@rollup/rollup-win32-x64-msvc@4.19.0':
     optional: true
 
   '@shuding/opentype.js@1.4.0-beta.0':
@@ -17702,7 +17695,7 @@ snapshots:
     dependencies:
       '@types/ms': 0.7.34
 
-  '@types/dom-view-transitions@1.0.4': {}
+  '@types/dom-view-transitions@1.0.5': {}
 
   '@types/estree-jsx@0.0.1':
     dependencies:
@@ -18157,7 +18150,7 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.9)
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.6
       '@vanilla-extract/css': 1.15.3(babel-plugin-macros@3.1.0)
-      esbuild: 0.18.20
+      esbuild: 0.17.6
       eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -18423,7 +18416,7 @@ snapshots:
       '@babel/traverse': 7.24.8
       '@babel/types': 7.24.9
       '@types/babel__core': 7.20.5
-      '@types/dom-view-transitions': 1.0.4
+      '@types/dom-view-transitions': 1.0.5
       '@types/yargs-parser': 21.0.3
       acorn: 8.12.1
       boxen: 6.2.1
@@ -18689,7 +18682,7 @@ snapshots:
 
   bl@4.1.0:
     dependencies:
-      buffer: 5.7.1
+      buffer: 5.6.0
       inherits: 2.0.4
       readable-stream: 3.6.2
 
@@ -18785,11 +18778,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -18867,7 +18855,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   camelcase-keys@6.2.2:
     dependencies:
@@ -18886,7 +18874,7 @@ snapshots:
   capital-case@1.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   capture-exit@2.0.0:
@@ -18949,7 +18937,7 @@ snapshots:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   char-regex@1.0.2: {}
 
@@ -19090,7 +19078,7 @@ snapshots:
 
   compressible@2.0.18:
     dependencies:
-      mime-db: 1.53.0
+      mime-db: 1.52.0
 
   compression@1.7.4:
     dependencies:
@@ -19145,7 +19133,7 @@ snapshots:
   constant-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case: 2.0.2
 
   content-disposition@0.5.4:
@@ -20637,7 +20625,7 @@ snapshots:
   header-case@2.0.4:
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   hex-rgb@4.3.0: {}
 
@@ -20729,9 +20717,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.39):
+  icss-utils@5.1.0(postcss@8.4.31):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.31
 
   idb-keyval@6.2.1: {}
 
@@ -20956,7 +20944,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   is-module@1.0.0: {}
 
@@ -21026,7 +21014,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   is-windows@1.0.2: {}
 
@@ -21698,7 +21686,7 @@ snapshots:
 
   lower-case-first@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   lower-case@2.0.2:
     dependencies:
@@ -22744,8 +22732,6 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.53.0: {}
-
   mime-types@2.1.13:
     dependencies:
       mime-db: 1.25.0
@@ -22899,8 +22885,8 @@ snapshots:
       next: 14.2.5(@babel/core@7.24.9)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       oauth: 0.9.15
       openid-client: 5.6.5
-      preact: 10.22.1
-      preact-render-to-string: 5.2.6(preact@10.22.1)
+      preact: 10.23.0
+      preact-render-to-string: 5.2.6(preact@10.23.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
@@ -23214,7 +23200,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   parent-module@1.0.1:
     dependencies:
@@ -23288,7 +23274,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   pascalcase@0.1.1: {}
 
@@ -23315,7 +23301,7 @@ snapshots:
   path-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   path-exists@3.0.0: {}
 
@@ -23401,48 +23387,48 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-discard-duplicates@5.1.0(postcss@8.4.39):
+  postcss-discard-duplicates@5.1.0(postcss@8.4.31):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.31
 
-  postcss-load-config@4.0.2(postcss@8.4.39):
+  postcss-load-config@4.0.2(postcss@8.4.31):
     dependencies:
       lilconfig: 3.1.2
-      yaml: 2.4.5
+      yaml: 2.5.0
     optionalDependencies:
-      postcss: 8.4.39
+      postcss: 8.4.31
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.39):
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.31):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.31
 
-  postcss-modules-local-by-default@4.0.5(postcss@8.4.39):
+  postcss-modules-local-by-default@4.0.5(postcss@8.4.31):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.4.31)
+      postcss: 8.4.31
       postcss-selector-parser: 6.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.0(postcss@8.4.39):
+  postcss-modules-scope@3.2.0(postcss@8.4.31):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.4.31
       postcss-selector-parser: 6.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.4.39):
+  postcss-modules-values@4.0.0(postcss@8.4.31):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.4.31)
+      postcss: 8.4.31
 
-  postcss-modules@6.0.0(postcss@8.4.39):
+  postcss-modules@6.0.0(postcss@8.4.31):
     dependencies:
       generic-names: 4.0.0
-      icss-utils: 5.1.0(postcss@8.4.39)
+      icss-utils: 5.1.0(postcss@8.4.31)
       lodash.camelcase: 4.3.0
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.39)
-      postcss-modules-scope: 3.2.0(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      postcss: 8.4.31
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.31)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.31)
+      postcss-modules-scope: 3.2.0(postcss@8.4.31)
+      postcss-modules-values: 4.0.0(postcss@8.4.31)
       string-hash: 1.1.3
 
   postcss-selector-parser@6.1.1:
@@ -23458,18 +23444,18 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
-  postcss@8.4.39:
+  postcss@8.4.40:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
-  preact-render-to-string@5.2.6(preact@10.22.1):
+  preact-render-to-string@5.2.6(preact@10.23.0):
     dependencies:
-      preact: 10.22.1
+      preact: 10.23.0
       pretty-format: 3.8.0
 
-  preact@10.22.1: {}
+  preact@10.23.0: {}
 
   preferred-pm@3.1.4:
     dependencies:
@@ -24096,26 +24082,26 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  rollup@4.18.1:
+  rollup@4.19.0:
     dependencies:
       '@types/estree': 1.0.5
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.18.1
-      '@rollup/rollup-android-arm64': 4.18.1
-      '@rollup/rollup-darwin-arm64': 4.18.1
-      '@rollup/rollup-darwin-x64': 4.18.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.18.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.18.1
-      '@rollup/rollup-linux-arm64-gnu': 4.18.1
-      '@rollup/rollup-linux-arm64-musl': 4.18.1
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.18.1
-      '@rollup/rollup-linux-s390x-gnu': 4.18.1
-      '@rollup/rollup-linux-x64-gnu': 4.18.1
-      '@rollup/rollup-linux-x64-musl': 4.18.1
-      '@rollup/rollup-win32-arm64-msvc': 4.18.1
-      '@rollup/rollup-win32-ia32-msvc': 4.18.1
-      '@rollup/rollup-win32-x64-msvc': 4.18.1
+      '@rollup/rollup-android-arm-eabi': 4.19.0
+      '@rollup/rollup-android-arm64': 4.19.0
+      '@rollup/rollup-darwin-arm64': 4.19.0
+      '@rollup/rollup-darwin-x64': 4.19.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.19.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.19.0
+      '@rollup/rollup-linux-arm64-gnu': 4.19.0
+      '@rollup/rollup-linux-arm64-musl': 4.19.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.19.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.19.0
+      '@rollup/rollup-linux-s390x-gnu': 4.19.0
+      '@rollup/rollup-linux-x64-gnu': 4.19.0
+      '@rollup/rollup-linux-x64-musl': 4.19.0
+      '@rollup/rollup-win32-arm64-msvc': 4.19.0
+      '@rollup/rollup-win32-ia32-msvc': 4.19.0
+      '@rollup/rollup-win32-x64-msvc': 4.19.0
       fsevents: 2.3.3
 
   rope-sequence@1.3.4: {}
@@ -24232,7 +24218,7 @@ snapshots:
   sentence-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.6.3
       upper-case-first: 2.0.2
 
   serve-static@1.15.0:
@@ -24485,7 +24471,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   sprintf-js@1.0.3: {}
 
@@ -24672,7 +24658,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   symbol-observable@4.0.0: {}
 
@@ -24752,7 +24738,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   tmp@0.0.33:
     dependencies:
@@ -25068,11 +25054,11 @@ snapshots:
 
   upper-case-first@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   upper-case@2.0.2:
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.6.3
 
   uri-js@4.4.1:
     dependencies:
@@ -25204,7 +25190,7 @@ snapshots:
   vite@4.5.3(@types/node@20.14.11)(terser@5.31.3):
     dependencies:
       esbuild: 0.18.20
-      postcss: 8.4.39
+      postcss: 8.4.31
       rollup: 3.29.4
     optionalDependencies:
       '@types/node': 20.14.11
@@ -25214,8 +25200,8 @@ snapshots:
   vite@5.3.4(@types/node@20.14.11)(terser@5.31.3):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.39
-      rollup: 4.18.1
+      postcss: 8.4.40
+      rollup: 4.19.0
     optionalDependencies:
       '@types/node': 20.14.11
       fsevents: 2.3.3
@@ -25466,7 +25452,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.4.5: {}
+  yaml@2.5.0: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2359,7 +2359,13 @@ importers:
         version: 4.16.2
 
   tests/admin-ui-tests:
-    dependencies:
+    devDependencies:
+      '@keystone-6/auth':
+        specifier: workspace:*
+        version: link:../../packages/auth
+      '@keystone-6/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@manypkg/find-root':
         specifier: ^1.1.0
         version: 1.1.0
@@ -2372,19 +2378,6 @@ importers:
       dotenv:
         specifier: ^16.0.0
         version: 16.4.5
-      node-fetch:
-        specifier: ^2.6.7
-        version: 2.7.0
-      tree-kill:
-        specifier: ^1.2.2
-        version: 1.2.2
-    devDependencies:
-      '@keystone-6/auth':
-        specifier: workspace:*
-        version: link:../../packages/auth
-      '@keystone-6/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       execa:
         specifier: ^5.1.1
         version: 5.1.1
@@ -2394,6 +2387,9 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.9.0
+      node-fetch:
+        specifier: ^2.6.7
+        version: 2.7.0
       playwright:
         specifier: ^1.17.1
         version: 1.45.2
@@ -2554,7 +2550,7 @@ importers:
         version: 5.17.0
 
   tests/examples-smoke-tests:
-    dependencies:
+    devDependencies:
       '@types/async-retry':
         specifier: ^1.4.3
         version: 1.4.8

--- a/tests/admin-ui-tests/init.test.ts
+++ b/tests/admin-ui-tests/init.test.ts
@@ -1,5 +1,14 @@
-import { type Browser, type Page } from 'playwright'
-import { adminUITests, deleteAllData, generateDataArray, loadIndex, makeGqlRequest } from './utils'
+import {
+  type Browser,
+  type Page
+} from 'playwright'
+import {
+  adminUITests,
+  deleteAllData,
+  generateDataArray,
+  loadIndex,
+  makeGqlRequest
+} from './utils'
 
 adminUITests('./tests/test-projects/basic', browserType => {
   let browser: Browser = undefined as any

--- a/tests/admin-ui-tests/package.json
+++ b/tests/admin-ui-tests/package.json
@@ -10,9 +10,14 @@
   "devDependencies": {
     "@keystone-6/auth": "workspace:*",
     "@keystone-6/core": "workspace:*",
+    "@manypkg/find-root": "^1.1.0",
+    "@types/async-retry": "^1.4.3",
+    "async-retry": "^1.3.3",
+    "dotenv": "^16.0.0",
     "execa": "^5.1.1",
     "express": "catalog:",
     "graphql": "^16.8.1",
+    "node-fetch": "^2.6.7",
     "playwright": "^1.17.1",
     "treekill": "^1.0.0"
   },
@@ -21,12 +26,5 @@
     "start": "keystone start",
     "build": "keystone build"
   },
-  "dependencies": {
-    "@manypkg/find-root": "^1.1.0",
-    "@types/async-retry": "^1.4.3",
-    "async-retry": "^1.3.3",
-    "dotenv": "^16.0.0",
-    "node-fetch": "^2.6.7",
-    "tree-kill": "^1.2.2"
-  }
+  "dependencies": {}
 }

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -1,9 +1,12 @@
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+} from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
-import { promisify } from 'util'
 import fetch from 'node-fetch'
-import execa, { type ExecaChildProcess } from 'execa'
-import _treeKill from 'tree-kill'
+
+import { type ExecaChildProcess } from 'execa'
 import * as playwright from 'playwright'
 import dotenv from 'dotenv'
 
@@ -20,30 +23,19 @@ export async function loadIndex (page: playwright.Page) {
   }
 }
 
-const treeKill = promisify(_treeKill)
-
 // this'll take a while
 jest.setTimeout(10000000)
 
 const projectRoot = path.resolve(__dirname, '..', '..')
 
-// Light wrapper around node-fetch for making graphql requests to the graphql api of the test instance.
-export const makeGqlRequest = async (query: string, variables?: Record<string, any>) => {
+export async function makeGqlRequest (query: string, variables?: Record<string, any>) {
   const { data, errors } = await fetch('http://localhost:3000/api/graphql', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      query,
-      variables,
-    }),
+    headers: { 'Content-Type': 'application/json', },
+    body: JSON.stringify({ query, variables, }),
   }).then(res => res.json())
 
-  if (errors) {
-    throw new Error(`graphql errors: ${errors.map((x: Error) => x.message).join('\n')}`)
-  }
-
+  if (errors) throw new Error(`graphql errors: ${errors.map((x: Error) => x.message).join('\n')}`)
   return data
 }
 
@@ -77,86 +69,79 @@ export function adminUITests (
   const projectDir = path.join(projectRoot, pathToTest)
 
   dotenv.config()
-  describe.each(['dev', 'prod'] as const)('%s', mode => {
-    let cleanupKeystoneProcess = () => {}
+  describe('development', () => {
+    let exit: (() => Promise<void>) | undefined = undefined
 
-    afterAll(async () => {
-      await cleanupKeystoneProcess()
+    test('start keystone in dev', async () => {
+      exit = await spawnCommand3(projectDir, ['dev'], 'Admin UI ready')
     })
 
-    async function startKeystone (command: 'start' | 'dev') {
-      cleanupKeystoneProcess = (await generalStartKeystone(projectDir, command)).exit
-    }
+    describe('browser tests', () => {
+      tests(playwright.chromium)
+    })
 
-    if (mode === 'dev') {
-      test('start keystone in dev', async () => {
-        await startKeystone('dev')
-      })
-    }
+    afterAll(async () => {
+      await exit?.()
+    })
+  })
 
-    if (mode === 'prod') {
-      test('build keystone', async () => {
-        const ksProcess = execa('pnpm', ['build'], {
-          cwd: projectDir,
-          env: process.env,
-        })
+  describe('production browser tests', () => {
+    let exit: (() => Promise<void>) | undefined = undefined
 
-        if (process.env.VERBOSE) {
-          ksProcess.stdout!.pipe(process.stdout)
-          ksProcess.stderr!.pipe(process.stdout)
-        }
+    test('build keystone', async () => {
+      await spawnCommand3(projectDir, ['build'], 'Admin UI ready')
+    })
 
-        await ksProcess
-      })
-      test('start keystone in prod', async () => {
-        await startKeystone('start')
-      })
-    }
+    test('start keystone in prod', async () => {
+      exit = await spawnCommand3(projectDir, ['start'], 'Admin UI ready')
+    })
 
     describe('browser tests', () => {
-      beforeAll(async () => {
-        await deleteAllData(projectDir)
-      })
       tests(playwright.chromium)
+    })
+
+    afterAll(async () => {
+      await exit?.()
     })
   })
 }
 
-export async function waitForIO (ksProcess: ExecaChildProcess, content: string) {
-  return await new Promise(resolve => {
+export async function waitForIO (p: ExecaChildProcess | ChildProcessWithoutNullStreams, content: string) {
+  return await new Promise<string>((resolve, reject) => {
     let output = ''
     function listener (chunk: Buffer) {
       output += chunk.toString('utf8')
       if (process.env.VERBOSE) console.log(chunk.toString('utf8'))
       if (!output.includes(content)) return
 
-      ksProcess.stdout!.off('data', listener)
-      ksProcess.stderr!.off('data', listener)
-      return resolve(output)
+      p.stdout!.off('data', listener)
+      p.stderr!.off('data', listener)
+      resolve(output)
     }
 
-    ksProcess.stdout!.on('data', listener)
-    ksProcess.stderr!.on('data', listener)
+    p.stdout!.on('data', listener)
+    p.stderr!.on('data', listener)
+    p.on('error', err => reject(err))
   })
 }
 
-export async function generalStartKeystone (projectDir: string, command: 'start' | 'dev') {
-  if (!fs.existsSync(projectDir)) {
-    throw new Error(`No such file or directory ${projectDir}`)
-  }
+const cliBinPath = require.resolve('@keystone-6/core/bin/cli.js')
 
-  const keystoneProcess = execa('pnpm', ['keystone', command], {
-    cwd: projectDir,
-    env: process.env,
+async function spawnCommand3 (cwd: string, commands: string[], waitOn: string) {
+  if (!fs.existsSync(cwd)) throw new Error(`No such file or directory ${cwd}`)
+
+  const p = spawn('node', [cliBinPath, ...commands], { cwd })
+
+  await waitForIO(p, waitOn)
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    p.on('exit', exitCode => {
+      if (typeof exitCode === 'number' && exitCode !== 0) return reject(new Error(`Error ${exitCode}`))
+      resolve()
+    })
   })
 
-  await waitForIO(keystoneProcess, 'Admin UI ready')
-  return {
-    process: keystoneProcess,
-    exit: async () => {
-      // childProcess.kill will only kill the direct child process
-      // so we use tree-kill to kill the process and it's children
-      await treeKill(keystoneProcess.pid!)
-    },
+  return async () => {
+    p.kill('SIGHUP')
+    await exitPromise
   }
 }

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -89,7 +89,7 @@ export function adminUITests (
     let exit: (() => Promise<void>) | undefined = undefined
 
     test('build keystone', async () => {
-      await spawnCommand3(projectDir, ['build'], 'Admin UI ready')
+      await spawnCommand3(projectDir, ['build'])
     })
 
     test('start keystone in prod', async () => {

--- a/tests/admin-ui-tests/utils.ts
+++ b/tests/admin-ui-tests/utils.ts
@@ -67,42 +67,27 @@ export function adminUITests (
   tests: (browser: playwright.BrowserType<playwright.Browser>) => void
 ) {
   const projectDir = path.join(projectRoot, pathToTest)
-
   dotenv.config()
+
   describe('development', () => {
     let exit: (() => Promise<void>) | undefined = undefined
-
-    test('start keystone in dev', async () => {
+    test('prepare keystone', async () => {
       ;({ exit } = await spawnCommand3(projectDir, ['dev'], 'Admin UI ready'))
     })
 
-    describe('browser tests', () => {
-      tests(playwright.chromium)
-    })
-
-    afterAll(async () => {
-      await exit?.()
-    })
+    describe('browser tests', () => tests(playwright.chromium))
+    afterAll(async () => await exit?.())
   })
 
   describe('production browser tests', () => {
     let exit: (() => Promise<void>) | undefined = undefined
-
-    test('build keystone', async () => {
-      await spawnCommand3(projectDir, ['build'])
-    })
-
-    test('start keystone in prod', async () => {
+    test('prepare keystone', async () => {
+      await (await spawnCommand3(projectDir, ['build'])).exited
       ;({ exit } = await spawnCommand3(projectDir, ['start'], 'Admin UI ready'))
     })
 
-    describe('browser tests', () => {
-      tests(playwright.chromium)
-    })
-
-    afterAll(async () => {
-      await exit?.()
-    })
+    describe('browser tests', () => tests(playwright.chromium))
+    afterAll(async () => await exit?.())
   })
 }
 
@@ -147,6 +132,7 @@ export async function spawnCommand3 (cwd: string, commands: string[], waitOn: st
     exit: async () => {
       p.kill('SIGHUP')
       await exitPromise
-    }
+    },
+    exited: exitPromise
   }
 }

--- a/tests/examples-smoke-tests/package.json
+++ b/tests/examples-smoke-tests/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/keystonejs/keystone/tree/main/tests/examples-smoke-tests",
   "homepage": "https://github.com/keystonejs/keystone",
-  "dependencies": {
+  "devDependencies": {
     "@types/async-retry": "^1.4.3",
     "@types/tough-cookie": "^4.0.1",
     "async-retry": "^1.3.3",


### PR DESCRIPTION
We are typically using `spawn` for managing processes now anyway, so this is preferred.