### PR TITLE
Add support for [field].graphql.isNonNull: true

### DIFF
--- a/.changeset/add-isnonnull-true.md
+++ b/.changeset/add-isnonnull-true.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Add support for [field].graphql.isNonNull: true

--- a/packages/core/src/fields/non-null-graphql.ts
+++ b/packages/core/src/fields/non-null-graphql.ts
@@ -25,7 +25,7 @@ export function makeValidateHook <ListTypeInfo extends BaseListTypeInfo> (
       isNullable?: boolean
     }
     graphql?: {
-      isNonNull?: {
+      isNonNull?: boolean | {
         read?: boolean
       }
     }
@@ -75,7 +75,7 @@ export function assertReadIsNonNullAllowed<ListTypeInfo extends BaseListTypeInfo
   meta: FieldData,
   config: {
     graphql?: {
-      isNonNull?: {
+      isNonNull?: boolean | {
         read?: boolean
       }
     }
@@ -83,7 +83,8 @@ export function assertReadIsNonNullAllowed<ListTypeInfo extends BaseListTypeInfo
   dbNullable: boolean
 ) {
   if (!dbNullable) return
-  if (!config.graphql?.isNonNull?.read) return
+  if (!config.graphql?.isNonNull) return
+  if (typeof config.graphql?.isNonNull === 'object' && !config.graphql.isNonNull.read) return
 
   throw new Error(
     `${meta.listKey}.${meta.fieldKey} sets graphql.isNonNull.read: true, but not validation.isRequired: true (or db.isNullable: false)\n` +

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -700,9 +700,9 @@ function getListsWithInitialisedFields (
           cacheHint: f.graphql?.cacheHint,
           isEnabled: isEnabledField,
           isNonNull: {
-            read: f.graphql?.isNonNull?.read ?? false,
-            create: f.graphql?.isNonNull?.create ?? false,
-            update: f.graphql?.isNonNull?.update ?? false,
+            read: typeof f.graphql?.isNonNull === 'boolean' ? f.graphql.isNonNull : f.graphql?.isNonNull?.read ?? false,
+            create: typeof f.graphql?.isNonNull === 'boolean' ? f.graphql.isNonNull : f.graphql?.isNonNull?.create ?? false,
+            update: typeof f.graphql?.isNonNull === 'boolean' ? f.graphql.isNonNull : f.graphql?.isNonNull?.update ?? false,
           },
         },
         ui: {

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -37,25 +37,27 @@ export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
   }
   graphql?: {
     cacheHint?: CacheHint
-    isNonNull?: {
-      // should this field be non-nullable on the {List} GraphQL type?
-      read?: boolean
-      // should this field be non-nullable on the {List}CreateInput GraphQL type?
-      create?: boolean
-      // should this field be non-nullable on the {List}UpdateInput GraphQL type?
-      update?: boolean
-    }
+    isNonNull?:
+      | boolean
+      | {
+        // whether this field is non-nullable on the {List} GraphQL type
+        read?: boolean
+        // whether this field is non-nullable on the {List}CreateInput GraphQL type
+        create?: boolean
+        // whether this field is non-nullable on the {List}UpdateInput GraphQL type
+        update?: boolean
+      }
 
     omit?:
       | boolean
       | {
-          // should this field be omitted from the {List} GraphQL type?
-          read?: boolean
-          // should this field be omitted from the {List}CreateInput GraphQL type?
-          create?: boolean
-          // should this field be omitted from the {List}UpdateInput GraphQL type?
-          update?: boolean
-        }
+        // whether this field is omitted from the {List} GraphQL type
+        read?: boolean
+        // whether this field is omitted from the {List}CreateInput GraphQL type
+        create?: boolean
+        // whether this field is omitted from the {List}UpdateInput GraphQL type
+        update?: boolean
+      }
   }
   isFilterable?: MaybeFieldFunction<ListTypeInfo>
   isOrderable?: MaybeFieldFunction<ListTypeInfo>


### PR DESCRIPTION
This pull request adds support for `[field].graphql.isNonNull: true`, like the rest of our other progressive hierarchies, this could simplify some configurations and results in an more intuitive type expectation when working with our configuration types.

This is a breaking change that will impact and require changes to any custom fields that are not passing this configuration directly onwards.