### PR TITLE
Bump `@braintree/sanitize-url`

### DIFF
--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -47,7 +47,7 @@
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/fields-document",
   "dependencies": {
     "@babel/runtime": "^7.24.7",
-    "@braintree/sanitize-url": "7.0.4",
+    "@braintree/sanitize-url": "^7.0.0",
     "@dnd-kit/core": "^6.0.6",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2243,8 +2243,8 @@ importers:
         specifier: ^7.24.7
         version: 7.25.0
       '@braintree/sanitize-url':
-        specifier: 7.0.4
-        version: 7.0.4
+        specifier: ^7.0.0
+        version: 7.1.0
       '@dnd-kit/core':
         specifier: ^6.0.6
         version: 6.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3663,8 +3663,8 @@ packages:
   '@braintree/sanitize-url@6.0.4':
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
 
-  '@braintree/sanitize-url@7.0.4':
-    resolution: {integrity: sha512-hPYRrKFoI+nuckPgDJfyYAkybFvheo4usS0Vw0HNAe+fmGBQA5Az37b/yStO284atBoqqdOUhKJ3d9Zw3PQkcQ==}
+  '@braintree/sanitize-url@7.1.0':
+    resolution: {integrity: sha512-o+UlMLt49RvtCASlOMW0AkHnabN9wR9rwCCherxO0yG4Npy34GkvrAqdXQvrhNs+jh+gkK8gB8Lf05qL/O7KWg==}
 
   '@changesets/apply-release-plan@7.0.4':
     resolution: {integrity: sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==}
@@ -13900,7 +13900,7 @@ snapshots:
 
   '@braintree/sanitize-url@6.0.4': {}
 
-  '@braintree/sanitize-url@7.0.4': {}
+  '@braintree/sanitize-url@7.1.0': {}
 
   '@changesets/apply-release-plan@7.0.4':
     dependencies:


### PR DESCRIPTION
`jest` is currently failing when bumping `sanitize-url` as a result of https://github.com/braintree/sanitize-url/issues/78 - this pull request [will] fix that issue and moves us back to a caret range.

The problem is `jsdom` doesn't support `URL.canParse` for now