### PR TITLE
Fix missing `fp-ts` for `@keystone-6/field-document`

### DIFF
--- a/examples/custom-esbuild/schema.graphql
+++ b/examples/custom-esbuild/schema.graphql
@@ -100,8 +100,8 @@ type Mutation {
 }
 
 type Query {
-  posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   post(where: PostWhereUniqueInput!): Post
+  posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
   keystone: KeystoneMeta!
 }
@@ -131,6 +131,7 @@ type KeystoneAdminUIListMeta {
   labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
+  graphql: KeystoneAdminUIGraphQL!
   initialSort: KeystoneAdminUISort
   isHidden: Boolean!
   isSingleton: Boolean!
@@ -201,6 +202,33 @@ type KeystoneAdminUIFieldGroupMeta {
   label: String!
   description: String
   fields: [KeystoneAdminUIFieldMeta!]!
+}
+
+type KeystoneAdminUIGraphQL {
+  names: KeystoneAdminUIGraphQLNames!
+}
+
+type KeystoneAdminUIGraphQLNames {
+  outputTypeName: String!
+  whereInputName: String!
+  whereUniqueInputName: String!
+  createInputName: String!
+  createMutationName: String!
+  createManyMutationName: String!
+  relateToOneForCreateInputName: String!
+  relateToManyForCreateInputName: String!
+  itemQueryName: String!
+  listOrderName: String!
+  listQueryCountName: String!
+  listQueryName: String!
+  updateInputName: String!
+  updateMutationName: String!
+  updateManyInputName: String!
+  updateManyMutationName: String!
+  relateToOneForUpdateInputName: String!
+  relateToManyForUpdateInputName: String!
+  deleteMutationName: String!
+  deleteManyMutationName: String!
 }
 
 type KeystoneAdminUISort {

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -88,6 +88,7 @@
     "slate-hyperscript": "^0.100.0"
   },
   "peerDependencies": {
-    "@keystone-6/core": "^6.0.0"
+    "@keystone-6/core": "^6.0.0",
+    "fp-ts": "^2.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,7 +813,7 @@ importers:
         version: 5.17.0
       typescript:
         specifier: 'catalog:'
-        version: 5.5.3
+        version: 5.5.4
 
   examples/custom-field:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2303,6 +2303,9 @@ importers:
       apply-ref:
         specifier: ^1.0.0
         version: 1.0.0
+      fp-ts:
+        specifier: ^2.5.0
+        version: 2.16.9
       graphql:
         specifier: 'catalog:'
         version: 16.9.0


### PR DESCRIPTION
Adding peer dep for `fp-ts` for #9113

The schema for `examples/custom-esbuild` was out of date for some reason, so `pnpm i` was failing.