### PR TITLE
wip - examples management script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^9.2.0",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.0.0",
+    "js-yaml": "^4.1.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^7.8.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       jest-environment-jsdom:
         specifier: ^29.0.0
         version: 29.7.0
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       typescript:
         specifier: ^5.5.0
         version: 5.5.4

--- a/scripts/update-example-dependencies.js
+++ b/scripts/update-example-dependencies.js
@@ -1,0 +1,141 @@
+const fs = require('fs')
+const path = require('path')
+const yaml = require('js-yaml') // You'll need to install this packageCopy
+const { execSync } = require('child_process')
+
+// Function to read package.json and extract version
+function getPublicPackageVersion (packagePath) {
+  const pkgPath = path.join(packagePath, 'package.json')
+  if (fs.existsSync(pkgPath)) {
+    const pkg = require(pkgPath)
+    return pkg.version
+  }
+  return null
+}
+
+function findPackageJsonFiles (dir) {
+  let results = []
+  const list = fs.readdirSync(dir)
+
+  list.forEach(file => {
+    const filePath = path.join(dir, file)
+    const stat = fs.statSync(filePath)
+
+    if (stat && stat.isDirectory()) {
+      // Recursive case: it's a directory
+      if (file === 'node_modules') {
+        return
+      }
+      results = results.concat(findPackageJsonFiles(filePath))
+    } else {
+      // Base case: it's a file
+      if (file === 'package.json') {
+        results.push(filePath)
+      }
+    }
+  })
+
+  return results
+}
+
+function isVersionIncreased (oldVersion, newVersion) {
+  const oldParts = oldVersion.split('.').map(Number)
+  const newParts = newVersion.split('.').map(Number)
+
+  for (let i = 0; i < 3; i++) {
+    if (newParts[i] > oldParts[i]) return true
+    if (newParts[i] < oldParts[i]) return false
+  }
+  return false
+}
+
+/**
+ * Iterate through packages directory and extract versions of public packages
+ */
+const packagesDir = path.join(process.cwd(), 'packages')
+const packageVersions = {}
+fs.readdirSync(packagesDir).forEach(packageName => {
+  const packagePath = path.join(packagesDir, packageName)
+  if (fs.statSync(packagePath).isDirectory()) {
+    const version = getPublicPackageVersion(packagePath)
+    if (version) {
+      packageVersions[packageName] = version
+    }
+  }
+})
+
+/**
+ * Get catalog versions for shared deps like prisma, typescript etc
+ */
+const workspaceYaml = fs.readFileSync('./pnpm-workspace.yaml', 'utf8')
+const workspaceConfig = yaml.load(workspaceYaml)
+const catalogVersions = workspaceConfig.catalog || {}
+
+/**
+ * Update example package.json with new versions, triggering prisma generation
+ * if @prisma/client has been updated.
+ * @param {string} examplePath 
+ */
+function updateExamplePkg (examplePath) {
+  const pkgPath = path.join(examplePath, 'package.json')
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  let prismaClientUpdated = false
+
+  // Update workspace dependencies
+  for (const [name, version] of Object.entries(packageVersions)) {
+    if (pkg.dependencies && pkg.dependencies[`@keystone-6/${name}`]) {
+      pkg.dependencies[`@keystone-6/${name}`] = `^${version}`
+    }
+  }
+
+  // Update catalog dependencies
+  for (const [name, newVersion] of Object.entries(catalogVersions)) {
+    if (pkg.dependencies && pkg.dependencies[name]) {
+      const oldVersion = pkg.dependencies[name].replace('catalog:', '')
+
+      if (name === '@prisma/client') {
+        if (isVersionIncreased(oldVersion, newVersion)) {
+          prismaClientUpdated = true
+        }
+      }
+      pkg.dependencies[name] = `${newVersion}`
+    }
+
+    if (pkg.devDependencies && pkg.devDependencies[name]) {
+      pkg.devDependencies[name] = `${newVersion}`
+    }
+  }
+
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
+
+  if (prismaClientUpdated === true) {
+    console.log(`Updating GraphQL and Prisma schemas ${examplePath}`)
+    try {
+      execSync('pnpm keystone build --no-ui', { cwd: examplePath, stdio: 'inherit' })
+    } catch (error) {
+      console.error(`Error running command in ${examplePath}:`, error)
+    }
+  }
+}
+
+// Traverse the examples directory and update each package.json
+const examplesDir = path.join(process.cwd(), 'examples')
+const exampleDirsToSkip = ['nextjs-keystone-two-servers']
+fs.readdirSync(examplesDir).forEach(example => {
+  if (exampleDirsToSkip.includes(example)) {
+    console.log(`Skipping directory: ${example}`)
+    return // Skip this iteration
+  }
+
+  const examplePath = path.join(examplesDir, example)
+  if (fs.statSync(examplePath).isDirectory()) {
+    const packageJsonFiles = findPackageJsonFiles(examplePath)
+    packageJsonFiles.forEach(packageJsonPath => {
+      updateExamplePkg(path.dirname(packageJsonPath))
+    })
+  }
+})
+
+console.log('Package versions:', packageVersions)
+console.log('Catalog versions:', catalogVersions)
+console.log('Example packages updated successfully.')


### PR DESCRIPTION
Following up on #8462, I did a simple POC for a script that updates all the dependencies in the examples directories.

The intention is this would be triggered alongside `prepare-release.js`. It requires that the package versions are updated to work correctly.

`scripts/update-example-dependencies.js`:

1. iterates through the `packages/*` directories, getting the current package version for each
2. extracts all catalog versions from `pnpm-workspace.yaml`
3. iterates (recursively) through `examples/*` looking for package.json, and updating with the values from 1 / 2
   - if `@prisma/client` is updated, it triggers rebuilding GraphQL and Prisma schemas, which will avoid issues like 53112038c5249d34ec44201e570ce8ca9a78a7b0

To test:

1. checkout this branch
2. delete `examples/assets-local/schema.graphql`
3. run `pnpm i` - this will fail due to missing file above
4. run `node scripts/update-example-dependencies.js`
   - _note, this will trigger generating prisma for all examples, on consequent runs it would only trigger if prisma client is updated_
5. run `pnpm i` - all should be fine

To improve:

- I would solve for `fixPrismaPath` and `example-data` so that CodeSandbox works
- I would probably look at this making its own commit

Any feedback appreciated, I like these kinds of automations, but I know they're not popular with everyone - in my books they fall inside the reducing complexity category.