### PR TITLE
Remove callout link to updates page

### DIFF
--- a/docs/app/(site)/roadmap/page-client.tsx
+++ b/docs/app/(site)/roadmap/page-client.tsx
@@ -233,8 +233,7 @@ export default function Roadmap () {
               margin: '0.5rem 0.8rem 0.5rem 0',
             }}
           >
-            To see what we've recently shipped, checkout our <Link href="/updates">updates</Link>{' '}
-            and <Link href="/releases">release notes</Link> <Emoji symbol="🚀" alt="Rocket" />
+            To see what we've recently shipped, checkout our <Link href="/releases">release notes</Link> <Emoji symbol="🚀" alt="Rocket" />
           </span>
         </Alert>
 


### PR DESCRIPTION
The `/updates` page doesn't exist anymore. It redirects to the blog, but I think this link is unnecessary here — at least while we don't have any recent blog post!