### PR TITLE
Fixed Typo in Docs URL

### DIFF
--- a/docs/content/examples/heroku.yaml
+++ b/docs/content/examples/heroku.yaml
@@ -1,4 +1,4 @@
-url: https://github.com/keystonejs/keystone-6-heroku-example"
+url: https://github.com/keystonejs/keystone-6-heroku-example
 title: Heroku
 kind: deployment
 description: >

--- a/docs/content/examples/next-js.yaml
+++ b/docs/content/examples/next-js.yaml
@@ -1,3 +1,4 @@
+# TODO: The URL Looks broken.
 url: https://keystonejs.com/docs/guides/custom-admin-ui-navigation/framework-nextjs-app-directory
 title: Next.js + Keystone
 kind: end-to-end


### PR DESCRIPTION
This PR fixes a typo in the Heroku deployment doc.

I noticed a few broken links while reading the doc. I fixed one and added a TODO for the other. It might be good for someone to follow up on that one since I’m not sure what the correct link should be.



