### PR TITLE
 Fix Prisma errors not showing when a Prisma migration errors internally

### DIFF
--- a/.changeset/fix-prisma-migrate.md
+++ b/.changeset/fix-prisma-migrate.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': minor
+---
+
+Fix Prisma errors not showing when a Prisma migration errors internally

--- a/packages/core/src/lib/migrations.ts
+++ b/packages/core/src/lib/migrations.ts
@@ -1,4 +1,3 @@
-import { type ChildProcess } from 'node:child_process'
 import { toSchemasContainer } from '@prisma/internals'
 
 // @ts-expect-error
@@ -62,9 +61,9 @@ export async function withMigrate<T> (
       }
     })
   } finally {
+    await migrate.engine.initPromise
     const closePromise = new Promise<void>(resolve => {
-      const { child } = migrate.engine as { child: ChildProcess }
-      child.once('exit', () => resolve())
+      migrate.engine.child.once('exit', resolve)
     })
     migrate.stop()
     await closePromise

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -161,7 +161,7 @@ export async function dev (
         const paths = system.getPaths(cwd)
         if (dbPush) {
           const created = await createDatabase(system.config.db.url, path.dirname(paths.schema.prisma))
-          if (created) console.log(`✨ database created`)
+          if (created) console.log(`✨ Database created`)
 
           const migration = await withMigrate(paths.schema.prisma, system, async (m) => {
             // what does force on migrate.engine.schemaPush mean?

--- a/tests/cli-tests/migrations.test.ts
+++ b/tests/cli-tests/migrations.test.ts
@@ -125,7 +125,7 @@ describe('dev', () => {
       ? Server listening on :3000 (http://localhost:3000/)
       ? GraphQL API available at /api/graphql
       ? Generating GraphQL and Prisma schemas
-      ? database created
+      ? Database created
       ? Database synchronized with Prisma schema
       ? Connecting to the database
       ? Creating server


### PR DESCRIPTION
When testing as part of https://github.com/keystonejs/keystone/pull/9264, an error was found where the Prisma child process hadn't been populated for `new Migrate`.
This appears to be a result of us not waiting for `migrate.engine.initPromise`.

This pull request resolves that by waiting for `initPromise`, and thus show any errors that may have happened internally to Prisma.