### PR TITLE
Version Packages (CKA)

### DIFF
--- a/.changeset/moved-create-app.md
+++ b/.changeset/moved-create-app.md
@@ -1,5 +1,0 @@
----
-"create-keystone-app": major
----
-
-Adds support for `npm_config_user_agent` for determining your package manager

--- a/.changeset/moved-create-app.md
+++ b/.changeset/moved-create-app.md
@@ -1,0 +1,5 @@
+---
+"create-keystone-app": major
+---
+
+Adds support for `npm_config_user_agent` for determining your package manager

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -1,0 +1,7 @@
+# create-keystone-app
+
+## 10.0.0
+
+### Major Changes
+
+- [`7c3db4c`](https://github.com/keystonejs/keystone/commit/7c3db4c8ec8d2838ae902c07131e1f2a51372605) Thanks [@dcousens](https://github.com/dcousens)! - Adds support for `npm_config_user_agent` for determining your package manager

--- a/packages/create/CHANGELOG.md
+++ b/packages/create/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Major Changes
 
-- [`7c3db4c`](https://github.com/keystonejs/keystone/commit/7c3db4c8ec8d2838ae902c07131e1f2a51372605) Thanks [@dcousens](https://github.com/dcousens)! - Adds support for `npm_config_user_agent` for determining your package manager
+- [`7c3db4c`](https://github.com/keystonejs/keystone/commit/7c3db4c8ec8d2838ae902c07131e1f2a51372605) Thanks [@iamandrewluca](https://github.com/iamandrewluca)! - Adds support for `npm_config_user_agent` for determining your package manager

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-keystone-app",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "license": "MIT",
   "type": "module",
   "main": "dist/create-keystone-app.cjs.js",

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -92,12 +92,8 @@ async function normalizeArgs () {
 
   ${c.bold('Next steps:')}
 
-  - Read ${c.bold(
-    `${relativeProjectDir}${path.sep}README.md`
-  )} for additional getting started details.
-  - Edit ${c.bold(
-    `${relativeProjectDir}${path.sep}keystone.ts`
-  )} to customize your app.
+  - Read ${c.bold(`${relativeProjectDir}${path.sep}README.md`)} for additional getting started details.
+  - Edit ${c.bold(`${relativeProjectDir}${path.sep}keystone.ts`)} to customize your app.
   - Star Keystone on GitHub (https://github.com/keystonejs/keystone)
   )}
 `)


### PR DESCRIPTION
#9102 is missing a changeset, this fixes that, and I will add the following copy manually:

- `[create-keystone-app]` Adds support for `npm_config_user_agent` for determining your package manager (#9102) @iamandrewluca