### PR TITLE
Add `keystone telemetry inform` command and update telemetry policy

### DIFF
--- a/.changeset/add-telemetry-inform.md
+++ b/.changeset/add-telemetry-inform.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Adds `keystone telemetry inform` command to show an informed consent notice

--- a/.changeset/fix-telemetry-policy.md
+++ b/.changeset/fix-telemetry-policy.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Update https://keystonejs.com/docs/reference/telemetry to show that `database` type is collected as part of telemetry

--- a/docs/content/docs/reference/telemetry.md
+++ b/docs/content/docs/reference/telemetry.md
@@ -63,7 +63,7 @@ Keystone collects telemetry information in the form of two different types of da
 We refer to these two different reports, as “device telemetry” and “project telemetry” respectively.
 
 These reports are forwarded to [https://telemetry.keystonejs.com/](https://telemetry.keystonejs.com/), and are reported separately to minimize any correlation between them insofar as the timing and grouping of that data, that an otherwise combined report may have. We are collecting these two reports for different reasons, and thus have no need to associate them.
-We differentiate the type and version of reports from the URL used by Keystone.
+We differentiate and record the type and version of reports from the URL used by Keystone.
 
 We additionally record a timestamp of the time that the report is received by the server at [https://telemetry.keystonejs.com](https://telemetry.keystonejs.com/).
 

--- a/docs/content/docs/reference/telemetry.md
+++ b/docs/content/docs/reference/telemetry.md
@@ -63,6 +63,7 @@ Keystone collects telemetry information in the form of two different types of da
 We refer to these two different reports, as “device telemetry” and “project telemetry” respectively.
 
 These reports are forwarded to [https://telemetry.keystonejs.com/](https://telemetry.keystonejs.com/), and are reported separately to minimize any correlation between them insofar as the timing and grouping of that data, that an otherwise combined report may have. We are collecting these two reports for different reasons, and thus have no need to associate them.
+We may record and differentiate reports using the `
 
 We additionally record a timestamp of the time that the report is received by the server at [https://telemetry.keystonejs.com](https://telemetry.keystonejs.com/).
 

--- a/docs/content/docs/reference/telemetry.md
+++ b/docs/content/docs/reference/telemetry.md
@@ -79,9 +79,9 @@ A device telemetry report is formatted as JSON and currently looks like:
 
 ```json
 {
-  "previous": "2022-11-23",
+  "lastSentDate": "2024-11-23",
   "os": "darwin",
-  "node": "18"
+  "node": "20"
 }
 ```
 
@@ -91,6 +91,7 @@ The type of information contained within a project telemetry report is currently
 
 - The last date you used `keystone dev` for this project, and
 - The resolved package versions of any `@keystone-6` packages used by this project, and
+- The database type used by the project,
 - The number of lists for this project, and
 - The name and number of field types that you are using
 
@@ -98,19 +99,20 @@ A project telemetry report is formatted as JSON and currently looks like:
 
 ```json
 {
-  "previous": "2022-11-23",
+  "lastSentDate": "2024-11-23",
   "packages": {
-    "@keystone-6/auth": "5.0.1",
-    "@keystone-6/core": "3.1.2",
+    "@keystone-6/auth": "8.0.1",
+    "@keystone-6/core": "6.1.0",
     "@keystone-6/document-renderer": "1.1.2",
     "@keystone-6/fields-document": "5.0.2"
   },
+  "database": "postgresql",
   "lists": 3,
   "fields": {
     "unknown": 1,
     "@keystone-6/text": 5,
-    "@keystone-6/image": 1,
-    "@keystone-6/file": 1
+    "@keystone-6/timestamp": 2,
+    "@keystone-6/checkbox": 1
   }
 }
 ```

--- a/docs/content/docs/reference/telemetry.md
+++ b/docs/content/docs/reference/telemetry.md
@@ -63,7 +63,7 @@ Keystone collects telemetry information in the form of two different types of da
 We refer to these two different reports, as “device telemetry” and “project telemetry” respectively.
 
 These reports are forwarded to [https://telemetry.keystonejs.com/](https://telemetry.keystonejs.com/), and are reported separately to minimize any correlation between them insofar as the timing and grouping of that data, that an otherwise combined report may have. We are collecting these two reports for different reasons, and thus have no need to associate them.
-We may record and differentiate reports using the `
+We differentiate the type and version of reports from the URL used by Keystone.
 
 We additionally record a timestamp of the time that the report is received by the server at [https://telemetry.keystonejs.com](https://telemetry.keystonejs.com/).
 

--- a/docs/content/docs/reference/telemetry.md
+++ b/docs/content/docs/reference/telemetry.md
@@ -89,7 +89,7 @@ A device telemetry report is formatted as JSON and currently looks like:
 The type of information contained within a project telemetry report is currently:
 
 - The last date you used `keystone dev` for this project, and
-- The resolved versions of any `@keystone-6` packages used by this project, and
+- The resolved package versions of any `@keystone-6` packages used by this project, and
 - The number of lists for this project, and
 - The name and number of field types that you are using
 
@@ -98,7 +98,7 @@ A project telemetry report is formatted as JSON and currently looks like:
 ```json
 {
   "previous": "2022-11-23",
-  "versions": {
+  "packages": {
     "@keystone-6/auth": "5.0.1",
     "@keystone-6/core": "3.1.2",
     "@keystone-6/document-renderer": "1.1.2",
@@ -185,8 +185,8 @@ If you wish to see how telemetry is currently configured for your device or proj
 
 ## What if I have a complaint or question
 
-If you have any questions or concerns about the information that is gathered please contact us by logging a GitHub Issue [https://github.com/keystonejs/keystone](https://github.com/keystonejs/keystone). 
+If you have any questions or concerns about the information that is gathered please contact us by logging a GitHub Issue [https://github.com/keystonejs/keystone](https://github.com/keystonejs/keystone).
 
-Alternatively please contact our Privacy Officer by email to [privacy@keystonejs.com](mailto:privacy@keystonejs.com), or by mail to Level 10, 191 Clarence Street, Sydney NSW 2000. 
+Alternatively please contact our Privacy Officer by email to [privacy@keystonejs.com](mailto:privacy@keystonejs.com), or by mail to Level 10, 191 Clarence Street, Sydney NSW 2000.
 
 For further information about Keystone’s security policy please see [https://github.com/keystonejs/keystone/security/policy](https://github.com/keystonejs/keystone/security/policy)

--- a/examples/custom-output-paths/keystone.ts
+++ b/examples/custom-output-paths/keystone.ts
@@ -8,7 +8,7 @@ export default config({
 
     // when working in a monorepo environment you may want to output the prisma client elsewhere
     //   you can use .db.prismaClientPath to configure where that is
-    prismaClientPath: 'node_modules/.myprisma/client',
+    prismaClientPath: 'node_modules/myprisma',
     prismaSchemaPath: 'my-prisma.prisma',
   },
   lists,

--- a/examples/custom-output-paths/my-prisma.prisma
+++ b/examples/custom-output-paths/my-prisma.prisma
@@ -9,7 +9,7 @@ datasource sqlite {
 
 generator client {
   provider = "prisma-client-js"
-  output   = "node_modules/.myprisma/client"
+  output   = "node_modules/myprisma"
 }
 
 model Post {

--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -123,22 +123,22 @@ export type KeystoneAdminUISortDirection =
   | 'DESC'
 
 type ResolvedPostCreateInput = {
-  id?: import('./node_modules/.myprisma/client').Prisma.PostCreateInput['id']
-  title?: import('./node_modules/.myprisma/client').Prisma.PostCreateInput['title']
-  content?: import('./node_modules/.myprisma/client').Prisma.PostCreateInput['content']
-  publishDate?: import('./node_modules/.myprisma/client').Prisma.PostCreateInput['publishDate']
+  id?: import('./node_modules/myprisma').Prisma.PostCreateInput['id']
+  title?: import('./node_modules/myprisma').Prisma.PostCreateInput['title']
+  content?: import('./node_modules/myprisma').Prisma.PostCreateInput['content']
+  publishDate?: import('./node_modules/myprisma').Prisma.PostCreateInput['publishDate']
 }
 type ResolvedPostUpdateInput = {
   id?: undefined
-  title?: import('./node_modules/.myprisma/client').Prisma.PostUpdateInput['title']
-  content?: import('./node_modules/.myprisma/client').Prisma.PostUpdateInput['content']
-  publishDate?: import('./node_modules/.myprisma/client').Prisma.PostUpdateInput['publishDate']
+  title?: import('./node_modules/myprisma').Prisma.PostUpdateInput['title']
+  content?: import('./node_modules/myprisma').Prisma.PostUpdateInput['content']
+  publishDate?: import('./node_modules/myprisma').Prisma.PostUpdateInput['publishDate']
 }
 
 export declare namespace Lists {
   export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>>
   namespace Post {
-    export type Item = import('./node_modules/.myprisma/client').Post
+    export type Item = import('./node_modules/myprisma').Post
     export type TypeInfo<Session = any> = {
       key: 'Post'
       isSingleton: false
@@ -166,8 +166,8 @@ export type TypeInfo<Session = any> = {
   lists: {
     readonly Post: Lists.Post.TypeInfo<Session>
   }
-  prisma: import('./node_modules/.myprisma/client').PrismaClient
-  prismaTypes: import('./node_modules/.myprisma/client').Prisma
+  prisma: import('./node_modules/myprisma').PrismaClient
+  prismaTypes: import('./node_modules/myprisma').Prisma
   session: Session
 }
 

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -215,14 +215,20 @@ async function sendEvent (eventType: 'project', eventData: Project): Promise<voi
 async function sendEvent (eventType: 'device', eventData: Device): Promise<void>
 async function sendEvent (eventType: 'project' | 'device', eventData: Project | Device) {
   const endpoint = process.env.KEYSTONE_TELEMETRY_ENDPOINT || defaultTelemetryEndpoint
-  const req = https.request(`${endpoint}/2/event/${eventType}`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+  await new Promise<void>((resolve) => {
+    const req = https.request(`${endpoint}/2/event/${eventType}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }, () => {
+      resolve()
+    })
+
+    req.once('error', () => resolve())
+    req.end(JSON.stringify(eventData))
   })
 
-  req.end(JSON.stringify(eventData))
   log(`sent ${eventType} report`)
 }
 

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -146,11 +146,6 @@ async function collectPackageVersions () {
   return packages
 }
 
-function printAbout () {
-  console.log(`${y`Keystone collects anonymous data when you run`} ${g`"keystone dev"`}`)
-  console.log()
-}
-
 function printNext (telemetry: Telemetry) {
   if (!telemetry) {
     console.log(`Telemetry data will ${r`not`} be sent by this system user`)
@@ -192,7 +187,7 @@ function inform (
 ) {
   console.log() // gap to help visiblity
   console.log(`${bold('Keystone Telemetry')}`)
-  printAbout()
+  console.log(`${y`Keystone collects anonymous data when you run`} ${g`"keystone dev"`}`)
   console.log(`You can use ${g`"keystone telemetry --help"`} to update your preferences at any time`)
   if (telemetry.informedAt === null) {
     console.log()

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -215,7 +215,6 @@ async function sendEvent (eventType: 'project' | 'device', eventData: Project | 
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'User-Agent': 'keystonejs'
       },
     }, () => {
       resolve()

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -20,7 +20,7 @@ import {
 import { type DatabaseProvider } from '../types'
 import { type InitialisedList } from './core/initialise-lists'
 
-const defaultTelemetryEndpoint = 'https://telemetry.keystonejs.com'
+const defaultTelemetryEndpoint = 'https://telemetry.keystonejs.com/3/'
 
 function log (message: unknown) {
   if (process.env.KEYSTONE_TELEMETRY_DEBUG === '1') {
@@ -211,7 +211,7 @@ async function sendEvent (eventType: 'device', eventData: Device): Promise<void>
 async function sendEvent (eventType: 'project' | 'device', eventData: Project | Device) {
   const endpoint = process.env.KEYSTONE_TELEMETRY_ENDPOINT || defaultTelemetryEndpoint
   await new Promise<void>((resolve) => {
-    const req = https.request(`${endpoint}/2/${eventType}`, {
+    const req = https.request(`${endpoint}${eventType}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -199,7 +199,7 @@ function inform (
   }
   printNext(telemetry)
   console.log() // gap to help visiblity
-  console.log(`For more information, including how to opt-out see ${grey`https://keystonejs.com/telemetry`} (updated ${b`2024-08-15`})`)
+  console.log(`For more information, including how to opt-out see ${grey`https://keystonejs.com/telemetry`} (updated ${b`2024-08-20`})`)
 
   // update the informedAt
   telemetry.informedAt = new Date().toJSON()

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -195,7 +195,7 @@ function inform () {
   printAbout()
   console.log(`You can use ${g`"keystone telemetry --help"`} to update your preferences at any time`)
   console.log()
-  console.log(`No telemetry data has been sent, but telemetry will be sent the next time you run ${g`"keystone dev"`}, unless you opt-out`)
+  console.log(`No telemetry data has been sent now, but telemetry will be sent the next time you run ${g`"keystone dev"`}, unless you opt-out`)
   console.log() // gap to help visiblity
 
   // update the informedAt

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -137,20 +137,20 @@ function collectFieldCount (lists: Record<string, InitialisedList>) {
 }
 
 function collectPackageVersions () {
-  const versions: Project['versions'] = {
+  const packages: Project['packages'] = {
     '@keystone-6/core': '0.0.0', // effectively unknown
   }
 
   for (const packageName of packageNames) {
     try {
       const packageJson = require(`${packageName}/package.json`)
-      versions[packageName] = packageJson.version
+      packages[packageName] = packageJson.version
     } catch {
       // do nothing, most likely because the package is not installed
     }
   }
 
-  return versions
+  return packages
 }
 
 function printAbout () {
@@ -236,7 +236,7 @@ async function sendProjectTelemetryEvent (
     previous: lastSentDate,
     fields: collectFieldCount(lists),
     lists: Object.keys(lists).length,
-    versions: collectPackageVersions(),
+    packages: collectPackageVersions(),
     database: dbProviderName,
   })
 

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -194,10 +194,11 @@ function inform (
   console.log(`${bold('Keystone Telemetry')}`)
   printAbout()
   console.log(`You can use ${g`"keystone telemetry --help"`} to update your preferences at any time`)
-  console.log()
   if (telemetry.informedAt === null) {
+    console.log()
     console.log(`No telemetry data has been sent as part of this notice`)
   }
+  console.log()
   printNext(telemetry)
   console.log() // gap to help visiblity
   console.log(`For more information, including how to opt-out see ${grey`https://keystonejs.com/telemetry`} (updated ${b`2024-08-20`})`)

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -135,9 +135,10 @@ async function collectPackageVersions () {
     '@opensaas/keystone-nextjs-auth',
   ]) {
     try {
-      const packageJson = await import(`${packageName}/package.json`)
+      const packageJson = require(`${packageName}/package.json`)
+      // const packageJson = await import(`${packageName}/package.json`, { assert: { type: 'json' } }) // TODO: broken in jest
       packages[packageName] = packageJson.version
-    } catch {
+    } catch (err) {
       // do nothing, the package is probably not installed
     }
   }
@@ -216,9 +217,7 @@ async function sendEvent (eventType: 'project' | 'device', eventData: Project | 
       headers: {
         'Content-Type': 'application/json',
       },
-    }, () => {
-      resolve()
-    })
+    }, () => resolve())
 
     req.once('error', (err) => {
       log(err?.message ?? err)

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -154,22 +154,24 @@ function printNext (telemetry: Telemetry) {
   console.log(`Telemetry data will be sent the next time you run ${g`"keystone dev"`}`)
 }
 
-function printTelemetryStatus (telemetry: Telemetry) {
+function printTelemetryStatus (telemetry: Telemetry, updated = false) {
+  const auxverb = updated ? 'has been' : 'is'
+
   if (telemetry === undefined) {
-    console.log(`Keystone telemetry has been reset to ${y`uninitialized`}`)
+    console.log(`Keystone telemetry ${auxverb} ${y`uninitialized`}`)
     console.log()
     printNext(telemetry)
     return
   }
 
   if (telemetry === false) {
-    console.log(`Keystone telemetry is ${r`disabled`}`)
+    console.log(`Keystone telemetry ${auxverb} ${r`disabled`}`)
     console.log()
     printNext(telemetry)
     return
   }
 
-  console.log(`Keystone telemetry is ${g`enabled`}`)
+  console.log(`Keystone telemetry ${auxverb} ${g`enabled`}`)
   console.log()
 
   console.log(`  Device telemetry was last sent on ${telemetry.device.lastSentDate}`)
@@ -304,9 +306,9 @@ export async function runTelemetry (
   }
 }
 
-export function statusTelemetry () {
+export function statusTelemetry (updated = false) {
   const { telemetry } = getTelemetryConfig()
-  printTelemetryStatus(telemetry)
+  printTelemetryStatus(telemetry, updated)
 }
 
 export function informTelemetry () {
@@ -319,17 +321,17 @@ export function enableTelemetry () {
   if (!telemetry) {
     userConfig.set('telemetry', getDefault(telemetry))
   }
-  statusTelemetry()
+  statusTelemetry(true)
 }
 
 export function disableTelemetry () {
   const { userConfig } = getTelemetryConfig()
   userConfig.set('telemetry', false)
-  statusTelemetry()
+  statusTelemetry(true)
 }
 
 export function resetTelemetry () {
   const { userConfig } = getTelemetryConfig()
   userConfig.delete('telemetry')
-  statusTelemetry()
+  statusTelemetry(true)
 }

--- a/packages/core/src/scripts/telemetry.ts
+++ b/packages/core/src/scripts/telemetry.ts
@@ -1,9 +1,10 @@
-import chalk from 'chalk'
+import { bold } from 'chalk'
 import {
-  printTelemetryStatus,
-  enableTelemetry,
   disableTelemetry,
+  enableTelemetry,
   resetTelemetry,
+  statusTelemetry,
+  informTelemetry,
 } from '../lib/telemetry'
 
 export async function telemetry (cwd: string, command?: string) {
@@ -15,6 +16,7 @@ export async function telemetry (cwd: string, command?: string) {
       enable      opt-in to telemetry
       reset       resets your telemetry configuration (if any)
       status      show if telemetry is enabled, disabled or uninitialised
+      inform      show an informed consent notice
 
 For more details visit: https://keystonejs.com/telemetry
     `
@@ -22,9 +24,10 @@ For more details visit: https://keystonejs.com/telemetry
   if (command === 'disable') return disableTelemetry()
   if (command === 'enable') return enableTelemetry()
   if (command === 'reset') return resetTelemetry()
-  if (command === 'status') return printTelemetryStatus()
+  if (command === 'status') return statusTelemetry()
+  if (command === 'inform') return informTelemetry()
   if (command === '--help') {
-    console.log(`${chalk.bold('Keystone Telemetry')}`)
+    console.log(`${bold('Keystone Telemetry')}`)
     console.log(usageText)
     return
   }

--- a/packages/core/src/types/telemetry.ts
+++ b/packages/core/src/types/telemetry.ts
@@ -11,7 +11,7 @@ export type TelemetryVersion1 =
       }
     }
 
-export type TelemetryVersion2and3 =
+export type TelemetryVersion2 =
   | undefined
   | false
   | {
@@ -25,10 +25,6 @@ export type TelemetryVersion2and3 =
       }
     }>
   }
-
-export type Configuration = {
-  telemetry?: undefined | false | TelemetryVersion2and3
-}
 
 export type Device = {
   previous: string | null // new Date().toISOString().slice(0, 10)

--- a/packages/core/src/types/telemetry.ts
+++ b/packages/core/src/types/telemetry.ts
@@ -27,21 +27,13 @@ export type TelemetryVersion2 =
   }
 
 export type Device = {
-  previous: string | null // new Date().toISOString().slice(0, 10)
+  lastSentDate: string | null // new Date().toISOString().slice(0, 10)
   os: string // `linux` | `darwin` | `windows` | ... // os.platform()
   node: string // `14` | ... | `18` // process.version.split('.').shift().slice(1)
 }
 
-export type PackageName =
-  | '@keystone-6/core'
-  | '@keystone-6/auth'
-  | '@keystone-6/fields-document'
-  | '@keystone-6/cloudinary'
-  | '@keystone-6/session-store-redis'
-  | '@opensaas/keystone-nextjs-auth'
-
 export type Project = {
-  previous: string | null // new Date().toISOString().slice(0, 10)
+  lastSentDate: string | null // new Date().toISOString().slice(0, 10)
   // omitted uuid for <BII
   // omitted anything GraphQL related <BII
 
@@ -49,11 +41,11 @@ export type Project = {
   // - `@keystone-6`
   // - `@opensaas`
   // - ...
-  packages: Partial<Record<PackageName, string>>
-  lists: number
+  packages: Partial<Record<string, string>>
   database: DatabaseProvider
-  // uses a new `field.__ksTelemetryFieldTypeName` for the key, defaults to `unknown`
+  lists: number
   fields: {
+    // uses `field.__ksTelemetryFieldTypeName`, default is `unknown`
     [key: string]: number
   }
 }

--- a/packages/core/src/types/telemetry.ts
+++ b/packages/core/src/types/telemetry.ts
@@ -49,7 +49,7 @@ export type Project = {
   // - `@keystone-6`
   // - `@opensaas`
   // - ...
-  versions: Partial<Record<PackageName, string>>
+  packages: Partial<Record<PackageName, string>>
   lists: number
   database: DatabaseProvider
   // uses a new `field.__ksTelemetryFieldTypeName` for the key, defaults to `unknown`

--- a/packages/core/tests/telemetry.test.ts
+++ b/packages/core/tests/telemetry.test.ts
@@ -137,7 +137,7 @@ describe('Telemetry tests', () => {
   }
 
   function expectDidSend (lastSentDate: string | null) {
-    expect(https.request).toHaveBeenCalledWith(`https://telemetry.keystonejs.com/2/event/project`, {
+    expect(https.request).toHaveBeenCalledWith(`https://telemetry.keystonejs.com/3/project`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -156,7 +156,7 @@ describe('Telemetry tests', () => {
       })
     )
 
-    expect(https.request).toHaveBeenCalledWith(`https://telemetry.keystonejs.com/2/event/device`, {
+    expect(https.request).toHaveBeenCalledWith(`https://telemetry.keystonejs.com/3/device`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/core/tests/telemetry.test.ts
+++ b/packages/core/tests/telemetry.test.ts
@@ -8,10 +8,10 @@ import { runTelemetry, disableTelemetry } from '../src/lib/telemetry'
 const mockProjectRoot = path.resolve(__dirname, '..', '..', '..')
 const mockProjectDir = path.join(mockProjectRoot, './tests/test-projects/basic')
 const mockPackageVersions = {
-  '@keystone-6/core': '3.1.0',
-  '@keystone-6/auth': '5.0.1',
-  '@keystone-6/fields-document': '5.0.2',
-  '@keystone-6/cloudinary': '5.0.1',
+  '@keystone-6/core': '14.1.0',
+  '@keystone-6/auth': '9.0.1',
+  '@keystone-6/fields-document': '18.0.2',
+  '@keystone-6/cloudinary': '0.0.1',
 }
 
 jest.mock(
@@ -145,14 +145,14 @@ describe('Telemetry tests', () => {
     })
     expect((https.request as any).end).toHaveBeenCalledWith(
       JSON.stringify({
-        previous: lastSentDate,
+        lastSentDate,
+        packages: mockPackageVersions,
+        database: 'sqlite',
+        lists: 2,
         fields: {
           unknown: 0,
           id: 5,
         },
-        lists: 2,
-        packages: mockPackageVersions,
-        database: 'sqlite',
       })
     )
 
@@ -164,7 +164,7 @@ describe('Telemetry tests', () => {
     })
     expect((https.request as any).end).toHaveBeenCalledWith(
       JSON.stringify({
-        previous: lastSentDate,
+        lastSentDate,
         os: 'keystone-os',
         node: process.versions.node.split('.')[0],
       })

--- a/packages/core/tests/telemetry.test.ts
+++ b/packages/core/tests/telemetry.test.ts
@@ -151,7 +151,7 @@ describe('Telemetry tests', () => {
           id: 5,
         },
         lists: 2,
-        versions: mockPackageVersions,
+        packages: mockPackageVersions,
         database: 'sqlite',
       })
     )

--- a/packages/core/tests/telemetry.test.ts
+++ b/packages/core/tests/telemetry.test.ts
@@ -167,10 +167,11 @@ describe('Telemetry tests', () => {
     await runTelemetry(mockProjectDir, lists, 'sqlite') // inform
 
     expect(https.request).toHaveBeenCalledTimes(0)
-    expect(mockTelemetryConfig).toBeDefined()
-    expect(mockTelemetryConfig?.device.lastSentDate).toBe(null)
-    expect(mockTelemetryConfig?.projects).toBeDefined()
-    expect(Object.keys(mockTelemetryConfig?.projects).length).toBe(0)
+    expect(mockTelemetryConfig).toStrictEqual({
+      informedAt: expect.stringMatching(new RegExp(`^${today}`)),
+      device: { lastSentDate: null },
+      projects: {}
+    })
   })
 
   test('Telemetry is sent after inform', async () => {
@@ -179,11 +180,13 @@ describe('Telemetry tests', () => {
 
     expectDidSend(null)
     expect(https.request).toHaveBeenCalledTimes(2) // would be 4 if sent twice
-    expect(mockTelemetryConfig).toBeDefined()
-    expect(mockTelemetryConfig?.device.lastSentDate).toBe(today)
-    expect(mockTelemetryConfig?.projects).toBeDefined()
-    expect(mockTelemetryConfig?.projects[mockProjectDir]).toBeDefined()
-    expect(mockTelemetryConfig?.projects[mockProjectDir].lastSentDate).toBe(today)
+    expect(mockTelemetryConfig).toStrictEqual({
+      informedAt: expect.stringMatching(new RegExp(`^${today}`)),
+      device: { lastSentDate: today },
+      projects: {
+        [mockProjectDir]: { lastSentDate: today }
+      }
+    })
   })
 
   test('Telemetry is not sent twice in one day', async () => {
@@ -195,18 +198,20 @@ describe('Telemetry tests', () => {
     expect(https.request).toHaveBeenCalledTimes(2) // would be 4 if sent twice
   })
 
-  test('Telemetry sends a lastSentDate on the third run, second day', async () => {
+  test('Telemetry sends a lastSentDate on the next run, a different day', async () => {
     mockTelemetryConfig = mockTelemetryConfigInitialised
 
     await runTelemetry(mockProjectDir, lists, 'sqlite') // send, different day
 
     expectDidSend(mockYesterday)
     expect(https.request).toHaveBeenCalledTimes(2)
-    expect(mockTelemetryConfig).toBeDefined()
-    expect(mockTelemetryConfig?.device.lastSentDate).toBe(today)
-    expect(mockTelemetryConfig?.projects).toBeDefined()
-    expect(mockTelemetryConfig?.projects[mockProjectDir]).toBeDefined()
-    expect(mockTelemetryConfig?.projects[mockProjectDir].lastSentDate).toBe(today)
+    expect(mockTelemetryConfig).toStrictEqual({
+      informedAt: expect.stringMatching(new RegExp(`^${mockYesterday}`)),
+      device: { lastSentDate: today },
+      projects: {
+        [mockProjectDir]: { lastSentDate: today }
+      }
+    })
   })
 
   test(`Telemetry is reset when using "keystone telemetry disable"`, () => {


### PR DESCRIPTION
This pull request adds a `keystone telemetry inform` command to print the consent notice - this is useful for testing:
```bash
> pnpm keystone telemetry inform
Keystone Telemetry
Keystone collects anonymous data when you run "keystone dev"

You can use "keystone telemetry --help" to update your preferences at any time

No telemetry data has been sent as part of this notice
Telemetry data will be sent the next time you run "keystone dev"

For more information, including how to opt-out see https://keystonejs.com/telemetry (updated 2024-08-20)
```

Additionally, as part of https://github.com/keystonejs/keystone/pull/9290 this pull request completes the new migration to a version 3 of the telemetry command.

Lastly, while reviewing https://github.com/keystonejs/keystone/pull/9290 and working on this pull request, I noticed that the `database` project event field was missing from our policy and JSON examples, [but present in the code](https://github.com/keystonejs/keystone/pull/8118/files#diff-0c12687b7ba9bb0fdd4b5a2d9af8eda00ab0ba6248d72b94a17a7ee8629baac7R42).

As in https://github.com/keystonejs/keystone/pull/9290, I will err on the side of missed consent for this and happily drop that information from the telemetry data being analysed as part of https://github.com/keystonejs/keystone/pull/9290.