### PR TITLE
Fix transaction passthrough types, and add linting for examples

### DIFF
--- a/.github/workflows/tests_ci.yml
+++ b/.github/workflows/tests_ci.yml
@@ -31,6 +31,16 @@ jobs:
       - name: Prisma Filters
         run: pnpm test:filters
 
+  linting-examples:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: ./.github/actions/ci-setup-examples
+
+      - name: TypeScript
+        run: pnpm test:types
+
   unit_tests:
     name: Package Unit Tests
     runs-on: ubuntu-latest

--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -167,7 +167,6 @@ export type TypeInfo<Session = any> = {
     readonly Post: Lists.Post.TypeInfo<Session>
   }
   prisma: import('./node_modules/myprisma').PrismaClient
-  prismaTypes: import('./node_modules/myprisma').Prisma
   session: Session
 }
 

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -284,7 +284,6 @@ export type TypeInfo<Session = any> = {
     readonly Author: Lists.Author.TypeInfo<Session>
   }
   prisma: import('./node_modules/myprisma').PrismaClient
-  prismaTypes: import('./node_modules/myprisma').Prisma
   session: Session
 }
 

--- a/packages/core/src/lib/typescript-schema-printer.ts
+++ b/packages/core/src/lib/typescript-schema-printer.ts
@@ -201,7 +201,6 @@ export function printGeneratedTypes (
     })(),
     `  }`,
     `  prisma: import('${prismaClientPath}').PrismaClient`,
-    `  prismaTypes: import('${prismaClientPath}').Prisma`,
     `  session: Session`,
     `}`,
     ``,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -32,7 +32,9 @@ export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystone
     options?: {
       maxWait?: number
       timeout?: number
-      isolationLevel?: TypeInfo['prismaTypes']['TransactionIsolationLevel']
+      isolationLevel?: {
+        Serializable: 'Serializable'
+      }
     }
   ) => Promise<T>
 

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -32,6 +32,5 @@ export type KeystoneContextFromListTypeInfo<ListTypeInfo extends BaseListTypeInf
 export type BaseKeystoneTypeInfo<Session = any> = {
   lists: Record<string, BaseListTypeInfo<Session>>
   prisma: any
-  prismaTypes: any
   session: any
 }

--- a/packages/core/src/types/type-tests.ts
+++ b/packages/core/src/types/type-tests.ts
@@ -8,7 +8,6 @@ const someContext: KeystoneContext<{
     ListOrSingleton: BaseListTypeInfo
   }
   prisma: any
-  prismaTypes: any
   session: any
 }> = undefined!
 

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -148,7 +148,6 @@ export type TypeInfo<Session = any> = {
     readonly Todo: Lists.Todo.TypeInfo<Session>
   }
   prisma: import('@prisma/client').PrismaClient
-  prismaTypes: import('@prisma/client').Prisma
   session: Session
 }
 


### PR DESCRIPTION
https://github.com/keystonejs/keystone/pull/9280 introduced `prismaTypes` to `.keystone/types`, but `Prisma` is a namespace, not a type.

I don't have the capacity to fix this canonically right now, thus I have inlined the `isolationLevel` type, and added a target for CI tests to catch this in future.

```typescript
../auth/node_modules/.keystone/types.ts:172:40 - error TS2694: Namespace '"/home/keystone/workspace/keystone/examples/auth/node_modules/myprisma/index"' has no exported member 'Prisma'.

172   prismaTypes: import('./../myprisma').Prisma
                                           ~~~~~~

Found 53 errors in 53 files.

Errors  Files
     ...
     1  ../auth/node_modules/.keystone/types.ts:137
     ...
```

@acburdine if you wanted to follow this up with a fix, I'm happy to revert this :yellow_heart: 