### PR TITLE
Remove pre-built schemas from `create-keystone-app`

### DIFF
--- a/.changeset/cka-fix.md
+++ b/.changeset/cka-fix.md
@@ -1,0 +1,5 @@
+---
+"create-keystone-app": patch
+---
+
+Fix starter script error when looking for pre-built schemas

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -59,8 +59,6 @@ async function normalizeArgs () {
     'schema.ts',
     'package.json',
     'tsconfig.json',
-    'schema.graphql',
-    'schema.prisma',
     'keystone.ts',
     'auth.ts',
     'README.md',


### PR DESCRIPTION
Followup to https://github.com/keystonejs/keystone/pull/9275, fixes https://github.com/keystonejs/keystone/issues/9313

This really highlights that we need to put this package under test