### PR TITLE
Fix URL validation by preserving percent-encoded characters

### DIFF
--- a/.changeset/old-dolphins-obey.md
+++ b/.changeset/old-dolphins-obey.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/fields-document": patch
+---
+
+Fixes URL validation bug by using `encodeURI` to preserve percent-encoded characters during validation.

--- a/packages/fields-document/src/DocumentEditor/isValidURL.ts
+++ b/packages/fields-document/src/DocumentEditor/isValidURL.ts
@@ -1,5 +1,5 @@
 import { sanitizeUrl } from '@braintree/sanitize-url'
 
 export function isValidURL (url: string) {
-  return url === sanitizeUrl(url)
+  return url === sanitizeUrl(url) ||  url === encodeURI(sanitizeUrl(url))
 }


### PR DESCRIPTION
This issue where the `@braintree/sanitize-url` package automatically decodes certain percent-encoded characters (e.g., %E5%BD%93%E5%89%8D into 当前). This causes the sanitized URL to differ from the original, which can result in false validation failures for URLs containing encoded Unicode characters.

To resolve this:

- Updated the isValidURL function to use encodeURI, ensuring that percent-encoded characters are properly maintained.
- The function now checks both the original and encoded sanitized URLs, improving validation accuracy.

This fix ensures that URLs with percent-encoded Unicode characters are considered valid if they match either the original or the encoded version of the sanitized URL.

Test Cases:
- Verified that both valid and invalid URLs are correctly handled after this update.

Before
<img width="736" alt="Before" src="https://github.com/user-attachments/assets/2049f5ef-db37-4e4c-8107-d6005d447265">
After
<img width="745" alt="After" src="https://github.com/user-attachments/assets/c4df74b1-ac81-48f4-8ae6-15295d586c8e">

Let me know if you need any further changes!