### PR TITLE
Fix `maxFileSize` parameter being ignored

### DIFF
--- a/.changeset/fix-file-size.md
+++ b/.changeset/fix-file-size.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Fixes `serxer.maxFileSize` parameter being ignored

--- a/examples/assets-local/keystone.ts
+++ b/examples/assets-local/keystone.ts
@@ -1,5 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
+import bytes from 'bytes'
 
 export default config({
   db: {
@@ -10,6 +11,9 @@ export default config({
     prismaClientPath: 'node_modules/myprisma',
   },
   lists,
+  server: {
+    maxFileSize: bytes('40Mb')
+  },
   storage: {
     my_images: {
       kind: 'local',

--- a/examples/assets-local/package.json
+++ b/examples/assets-local/package.json
@@ -11,9 +11,11 @@
   },
   "dependencies": {
     "@keystone-6/core": "^6.3.0",
-    "@prisma/client": "5.19.0"
+    "@prisma/client": "5.19.0",
+    "bytes": "^3.1.1"
   },
   "devDependencies": {
+    "@types/bytes": "^3.1.1",
     "prisma": "5.19.0",
     "typescript": "^5.5.0"
   }

--- a/examples/assets-s3/keystone.ts
+++ b/examples/assets-s3/keystone.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config'
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
+import bytes from 'bytes'
 
 const {
   S3_BUCKET_NAME: bucketName = 'keystone-test',
@@ -18,6 +19,9 @@ export default config({
     prismaClientPath: 'node_modules/myprisma',
   },
   lists,
+  server: {
+    maxFileSize: bytes('8Mb')
+  },
   storage: {
     my_images: {
       kind: 's3',

--- a/examples/assets-s3/package.json
+++ b/examples/assets-s3/package.json
@@ -12,9 +12,11 @@
   "dependencies": {
     "@keystone-6/core": "^6.3.0",
     "@prisma/client": "5.19.0",
+    "bytes": "^3.1.1",
     "dotenv": "^16.0.0"
   },
   "devDependencies": {
+    "@types/bytes": "^3.1.1",
     "prisma": "5.19.0",
     "typescript": "^5.5.0"
   }

--- a/packages/core/src/lib/defaults.ts
+++ b/packages/core/src/lib/defaults.ts
@@ -130,6 +130,7 @@ export function resolveDefaults <TypeInfo extends BaseKeystoneTypeInfo> (config:
     },
     lists: injectDefaults(config, defaultIdField),
     server: {
+      ...config.server,
       maxFileSize: config.server?.maxFileSize ?? (200 * 1024 * 1024), // 200 MiB
       extendExpressApp: config.server?.extendExpressApp ?? noop,
       extendHttpServer: config.server?.extendHttpServer ?? noop,

--- a/packages/core/src/lib/defaults.ts
+++ b/packages/core/src/lib/defaults.ts
@@ -130,7 +130,7 @@ export function resolveDefaults <TypeInfo extends BaseKeystoneTypeInfo> (config:
     },
     lists: injectDefaults(config, defaultIdField),
     server: {
-      maxFileSize: 200 * 1024 * 1024, // 200 MiB
+      maxFileSize: config.server?.maxFileSize ?? (200 * 1024 * 1024), // 200 MiB
       extendExpressApp: config.server?.extendExpressApp ?? noop,
       extendHttpServer: config.server?.extendHttpServer ?? noop,
       cors,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,7 +602,13 @@ importers:
       '@prisma/client':
         specifier: 5.19.0
         version: 5.19.0(prisma@5.19.0)
+      bytes:
+        specifier: ^3.1.1
+        version: 3.1.2
     devDependencies:
+      '@types/bytes':
+        specifier: ^3.1.1
+        version: 3.1.4
       prisma:
         specifier: 5.19.0
         version: 5.19.0
@@ -618,10 +624,16 @@ importers:
       '@prisma/client':
         specifier: 5.19.0
         version: 5.19.0(prisma@5.19.0)
+      bytes:
+        specifier: ^3.1.1
+        version: 3.1.2
       dotenv:
         specifier: ^16.0.0
         version: 16.4.5
     devDependencies:
+      '@types/bytes':
+        specifier: ^3.1.1
+        version: 3.1.4
       prisma:
         specifier: 5.19.0
         version: 5.19.0


### PR DESCRIPTION
This pull request fixes https://github.com/keystonejs/keystone/issues/9347, the problem is as simple as the value not being passed through