### PR TITLE
Fix error messages when importing `.keystone/config.js`

### DIFF
--- a/.changeset/slimy-files-appear.md
+++ b/.changeset/slimy-files-appear.md
@@ -2,4 +2,4 @@
 '@keystone-6/core': patch
 ---
 
-Improve error message when importing inaccessible module
+Fix misleading error messages when importing `.keystone/config.js`

--- a/.changeset/slimy-files-appear.md
+++ b/.changeset/slimy-files-appear.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Improve error message when importing inaccessible module

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -11,15 +11,10 @@ export class ExitError extends Error {
 
 // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
 export async function importBuiltKeystoneConfiguration (cwd: string) {
-  try {
-    const builtConfigPath = getBuiltKeystoneConfigurationPath(cwd)
-    if (!(await fs.stat(builtConfigPath).catch(() => null))) {
-      console.error('🚨 keystone build has not been run')
-      throw new ExitError(1)
-    }
-    return require(builtConfigPath).default
-  } catch (err: any) {
-    console.error('🚨 importing built keystone config failed')
-    throw err
+  const builtConfigPath = getBuiltKeystoneConfigurationPath(cwd)
+  if (!(await fs.stat(builtConfigPath).catch(() => null))) {
+    console.error('🚨 keystone build has not been run')
+    throw new ExitError(1)
   }
+  return require(builtConfigPath).default
 }

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs/promises'
 
 export class ExitError extends Error {
   code: number
-  constructor(code: number) {
+  constructor (code: number) {
     super(`The process exited with Error ${code}`)
     this.code = code
   }
 }
 
 // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
-export async function importBuiltKeystoneConfiguration(cwd: string) {
+export async function importBuiltKeystoneConfiguration (cwd: string) {
   try {
     const builtConfigPath = getBuiltKeystoneConfigurationPath(cwd)
     if (!(await fs.stat(builtConfigPath).catch(() => null))) {

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -1,22 +1,25 @@
 import { getBuiltKeystoneConfigurationPath } from '../lib/createSystem'
+import fs from 'node:fs/promises'
 
 export class ExitError extends Error {
   code: number
-  constructor (code: number) {
+  constructor(code: number) {
     super(`The process exited with Error ${code}`)
     this.code = code
   }
 }
 
 // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
-export async function importBuiltKeystoneConfiguration (cwd: string) {
+export async function importBuiltKeystoneConfiguration(cwd: string) {
   try {
-    return require(getBuiltKeystoneConfigurationPath(cwd)).default
-  } catch (err: any) {
-    if (err.code === 'MODULE_NOT_FOUND') {
+    const builtConfigPath = getBuiltKeystoneConfigurationPath(cwd)
+    if (!(await fs.stat(builtConfigPath).catch(() => null))) {
       console.error('🚨 keystone build has not been run')
       throw new ExitError(1)
     }
+    return require(getBuiltKeystoneConfigurationPath(cwd)).default
+  } catch (err: any) {
+    console.error('🚨 importing built keystone config failed')
     throw err
   }
 }

--- a/packages/core/src/scripts/utils.ts
+++ b/packages/core/src/scripts/utils.ts
@@ -17,7 +17,7 @@ export async function importBuiltKeystoneConfiguration(cwd: string) {
       console.error('🚨 keystone build has not been run')
       throw new ExitError(1)
     }
-    return require(getBuiltKeystoneConfigurationPath(cwd)).default
+    return require(builtConfigPath).default
   } catch (err: any) {
     console.error('🚨 importing built keystone config failed')
     throw err


### PR DESCRIPTION
Fixes https://github.com/keystonejs/keystone/issues/9358

I brought back `fs.stat` that was removed in [this commit](https://github.com/keystonejs/keystone/commit/4262e50c35d69847242b541db49afd2fda9cb50c#diff-57052ea56ea99a19fa56523025f085b9cac478339613c94331e17b7fc56ec927).

Now error message is meaningful:
```
(base) exar@exar:~/os/keystone/examples/omit$ pnpm build

> @keystone-6/example-omit@ build /home/exar/os/keystone/examples/omit
> keystone build

🚨 importing built keystone config failed
Error: Cannot find module 'non-existing-module'
Require stack:
- /home/exar/os/keystone/examples/omit/.keystone/config.js
- /home/exar/os/keystone/packages/core/src/scripts/utils.ts
- /home/exar/os/keystone/packages/core/src/scripts/cli.ts
```