### PR TITLE
Fix long identityField values from pushing out SignoutButton component

### DIFF
--- a/packages/core/src/admin-ui/components/Navigation.tsx
+++ b/packages/core/src/admin-ui/components/Navigation.tsx
@@ -72,11 +72,23 @@ const AuthenticatedItemDialog = ({ item }: { item: AuthenticatedItem | undefined
         justifyContent: 'space-between',
         margin: spacing.xlarge,
         marginBottom: 0,
+        gap: spacing.xlarge,
       }}
     >
       {item && item.state === 'authenticated' ? (
-        <div css={{ fontSize: typography.fontSize.small }}>
-          Signed in as <strong css={{ display: 'block' }}>{item.label}</strong>
+        <div 
+          css={{ 
+            fontSize: typography.fontSize.small, 
+            overflow: 'hidden', 
+          }
+        }>
+          Signed in as <strong 
+            css={{ 
+              display: 'block', 
+              textOverflow: 'ellipsis', 
+              overflow: 'hidden',
+            }}
+          >{item.label}</strong>
         </div>
       ) : (
         process.env.NODE_ENV !== 'production' && (


### PR DESCRIPTION
Currently if the `identityField` contains a long value; it will push the SignoutButton out of its wrapping `<div>` element and the user can no longer see it. In order to fix this I've added some styles to the wrapping and containing elements to provide a better user experience.

Old situation:

<img width="320" alt="image" src="https://github.com/user-attachments/assets/c16ccd31-923d-4f0b-943e-bd55f34b1795" />

New situation:

<img width="318" alt="image" src="https://github.com/user-attachments/assets/6551ef67-6c58-4d89-93aa-fc0c6e3de24d" />

This issue was initially reported on Slack by Joakim Trulsson: https://keystonejs.slack.com/archives/C01STDMEW3S/p1737446375987869 

