### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/ci-setup-examples/action.yml
+++ b/.github/actions/ci-setup-examples/action.yml
@@ -2,6 +2,8 @@ name: 'CI setup (w/ examples)'
 runs:
   using: 'composite'
   steps:
+    - run: npm i -g corepack@0.31.0
+      shell: bash
     - run: corepack enable
       shell: bash
 

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -2,6 +2,8 @@ name: 'CI setup'
 runs:
   using: 'composite'
   steps:
+    - run: npm i -g corepack@0.31.0
+      shell: bash
     - run: corepack enable
       shell: bash
 
@@ -19,7 +21,6 @@ runs:
       shell: bash
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
-        COREPACK_DEFAULT_TO_LATEST: 0
 
     - run: pnpm run build
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -11,6 +11,8 @@ runs:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
+      env:
+        COREPACK_DEFAULT_TO_LATEST: 0
 
     - run: rm --recursive --force examples/ tests/test-projects/
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -11,8 +11,6 @@ runs:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
         cache: pnpm
-      env:
-        COREPACK_DEFAULT_TO_LATEST: 0
 
     - run: rm --recursive --force examples/ tests/test-projects/
       shell: bash
@@ -21,6 +19,7 @@ runs:
       shell: bash
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        COREPACK_DEFAULT_TO_LATEST: 0
 
     - run: pnpm run build
       shell: bash

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/keystonejs/keystone",
   "homepage": "https://github.com/keystonejs/keystone",
-  "packageManager": "pnpm@9.15.3",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "coverage": "jest --coverage",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/keystonejs/keystone",
   "homepage": "https://github.com/keystonejs/keystone",
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
+  "packageManager": "pnpm@9.15.3",
   "scripts": {
     "coverage": "jest --coverage",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/keystonejs/keystone",
   "homepage": "https://github.com/keystonejs/keystone",
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
   "scripts": {
     "coverage": "jest --coverage",
     "test": "jest",


### PR DESCRIPTION
Example failure: https://github.com/keystonejs/keystone/actions/runs/13103720106/job/36555202620

Related: https://github.com/nodejs/corepack/issues/612

tldr seems to be it's fixed in corepack but that's not including in a Node release yet. Including the integrity gets around it though (and is kinda better anyway)