### PR TITLE
Replace `bcrypt` and `workFactor` options to `password` field with generic `kdf` option

### DIFF
--- a/.changeset/polite-colts-admire.md
+++ b/.changeset/polite-colts-admire.md
@@ -1,0 +1,6 @@
+---
+"@keystone-6/auth": major
+"@keystone-6/core": major
+---
+
+Replace `bcrypt` and `workFactor` options to `password` field with generic `kdf` option

--- a/.changeset/polite-colts-admire.md
+++ b/.changeset/polite-colts-admire.md
@@ -3,4 +3,4 @@
 "@keystone-6/core": major
 ---
 
-Replace `bcrypt` and `workFactor` options to `password` field with generic `kdf` option
+Replace `bcrypt` and `workFactor` options for `password` field with new generic `kdf` option

--- a/docs/content/docs/fields/password.md
+++ b/docs/content/docs/fields/password.md
@@ -18,8 +18,7 @@ Options:
   - `validation.match.regex`: The regular expression
   - `validation.match.explanation` (default: `${fieldLabel} must match ${validation.match.regex}`): A message shown in the Admin when a value doesn't match the regex and returned as a validation error from the GraphQL API
 - `validation.rejectCommon` (default: `false`): Rejects passwords from a list of commonly used passwords.
-- `bcrypt` (default: `require('bcryptjs')`): A module which implements the same interface as the [`bcryptjs`](https://www.npmjs.com/package/bcryptjs) package, such as the native [`bcrypt`](https://www.npmjs.com/package/bcrypt) package.
-  This module will be used for all encryption routines in the `password` field.
+- `kdf` (default: `{ hash: (secret) => bcryptjs.hash(secret, 10), compare: (secret, hash) => bcryptjs.compare(secret, hash) }`): An object with `hash` and `compare` functions for hashing and comparing passwords.
 
 ```typescript
 import { config, list } from '@keystone-6/core';
@@ -36,7 +35,6 @@ export default config({
             isRequired: true,
             rejectCommon: true,
           },
-          bcrypt: require('bcrypt'),
         }),
         /* ... */
       },

--- a/packages/auth/src/gql/getBaseAuthSchema.ts
+++ b/packages/auth/src/gql/getBaseAuthSchema.ts
@@ -3,9 +3,9 @@ import type {
   KeystoneContext
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
+import { getPasswordFieldKDF } from '@keystone-6/core/fields/types/password'
 import type {
   AuthGqlNames,
-  SecretFieldImpl,
 } from '../types'
 
 const AUTHENTICATION_FAILURE = {
@@ -18,16 +18,21 @@ export function getBaseAuthSchema<I extends string, S extends string> ({
   identityField,
   secretField,
   gqlNames,
-  secretFieldImpl,
   base,
 }: {
   listKey: string
   identityField: I
   secretField: S
   gqlNames: AuthGqlNames
-  secretFieldImpl: SecretFieldImpl
   base: g.BaseSchemaMeta
 }) {
+  const kdf = getPasswordFieldKDF(base.schema, listKey, secretField)
+  if (!kdf) {
+    throw new Error(
+      `${listKey}.${secretField} is not a valid password field.`
+    )
+  }
+
   const ItemAuthenticationWithPasswordSuccess = g.object<{
     sessionToken: string
     item: BaseItem
@@ -94,11 +99,11 @@ export function getBaseAuthSchema<I extends string, S extends string> ({
           })
 
           if ((typeof item?.[secretField] !== 'string')) {
-            await secretFieldImpl.generateHash('simulated-password-to-counter-timing-attack')
+            await kdf.hash('simulated-password-to-counter-timing-attack')
             return AUTHENTICATION_FAILURE
           }
 
-          const equal = await secretFieldImpl.compare(secret, item[secretField])
+          const equal = await kdf.compare(secret, item[secretField])
           if (!equal) return AUTHENTICATION_FAILURE
 
           const sessionToken = await context.sessionStrategy.start({

--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -1,6 +1,4 @@
 import {
-  type GraphQLSchema,
-  assertObjectType,
   assertInputObjectType,
   GraphQLString,
   GraphQLID,
@@ -14,34 +12,9 @@ import type {
   AuthGqlNames,
   AuthTokenTypeConfig,
   InitFirstItemConfig,
-  SecretFieldImpl,
 } from './types'
 import { getBaseAuthSchema } from './gql/getBaseAuthSchema'
 import { getInitFirstItemSchema } from './gql/getInitFirstItemSchema'
-
-function assertSecretFieldImpl (
-  impl: any,
-  listKey: string,
-  secretField: string
-): asserts impl is SecretFieldImpl {
-  if (
-    !impl ||
-    typeof impl.compare !== 'function' ||
-    impl.compare.length < 2 ||
-    typeof impl.generateHash !== 'function'
-  ) {
-    const s = JSON.stringify(secretField)
-    const msg = `A createAuth() invocation for the "${listKey}" list specifies ${s} as its secretField, but the field type doesn't implement the required functionality.`
-    throw new Error(msg)
-  }
-}
-
-export function getSecretFieldImpl (schema: GraphQLSchema, listKey: string, fieldKey: string) {
-  const gqlOutputType = assertObjectType(schema.getType(listKey))
-  const secretFieldImpl = gqlOutputType.getFields()?.[fieldKey].extensions?.keystoneSecretField
-  assertSecretFieldImpl(secretFieldImpl, listKey, fieldKey)
-  return secretFieldImpl
-}
 
 export const getSchemaExtension = ({
   identityField,
@@ -81,7 +54,6 @@ export const getSchemaExtension = ({
       listKey,
       secretField,
       gqlNames,
-      secretFieldImpl: getSecretFieldImpl(base.schema, listKey, secretField),
       base,
     })
 

--- a/packages/core/fields/types/password/package.json
+++ b/packages/core/fields/types/password/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/keystone-6-core-fields-types-password.cjs.js",
+  "module": "dist/keystone-6-core-fields-types-password.esm.js"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,6 +86,11 @@
       "module": "./admin-ui/components/dist/keystone-6-core-admin-ui-components.esm.js",
       "default": "./admin-ui/components/dist/keystone-6-core-admin-ui-components.cjs.js"
     },
+    "./fields/types/password": {
+      "types": "./fields/types/password/dist/keystone-6-core-fields-types-password.cjs.js",
+      "module": "./fields/types/password/dist/keystone-6-core-fields-types-password.esm.js",
+      "default": "./fields/types/password/dist/keystone-6-core-fields-types-password.cjs.js"
+    },
     "./fields/types/file/views": {
       "types": "./fields/types/file/views/dist/keystone-6-core-fields-types-file-views.cjs.js",
       "module": "./fields/types/file/views/dist/keystone-6-core-fields-types-file-views.esm.js",
@@ -305,6 +310,7 @@
       "admin-ui/image.tsx",
       "admin-ui/utils/index.ts",
       "fields/index.ts",
+      "fields/types/password/index.ts",
       "fields/types/*/views/index.tsx",
       "fields/types/{image,file}/utils.ts",
       "types/index.ts"


### PR DESCRIPTION
This pull request replaces the `bcrypt` and `workFactor` options in the `password` field with a more flexible key derivation function (kdf) interface.

Rather than assume `bcrypt`, the new approach supports developers to provide any key derivation function with `hash` and `compare` methods, making it easier to integrate alternative modern password hashing mechanisms like [Argon2](https://en.wikipedia.org/wiki/Argon2).

The default remains for now as `bcryptjs` with a work factor of 10, ensuring compatibility for existing users who do not override the default.

Additionally, this pull request adds a method for retrieving the new interface from your GraphQL schema object using `getPasswordKDF` rather than forcing developers to cast and understand the intricacies of the GraphQL schema object.