### PR TITLE
Fix failing to read dev-loading.html file

### DIFF
--- a/packages/core/src/pkg-dir.ts
+++ b/packages/core/src/pkg-dir.ts
@@ -1,3 +1,4 @@
 import path from 'path'
+import { createRequire } from 'node:module'
 
-export const pkgDir = path.dirname(__dirname)
+export const pkgDir = path.dirname(createRequire(__dirname).resolve('@keystone-6/core/package.json'))


### PR DESCRIPTION
This was broken because the `pkg-dir.ts` module gets bundled into `scripts/dist/whatever-it-is.js` so `__dirname` isn't accurate vs the source location so this uses `createRequire` to resolve the `package.json` and then get the dirname of that which will be more reliable