### PR TITLE
Use `bundlePagesRouterDependencies: true` in Next config

### DIFF
--- a/.changeset/young-cycles-whisper.md
+++ b/.changeset/young-cycles-whisper.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Replace `experimental: { esmExternals: 'loose' }` with `bundlePagesRouterDependencies: true` in Keystone's Next config

--- a/packages/core/src/admin-ui/templates/next-config.ts
+++ b/packages/core/src/admin-ui/templates/next-config.ts
@@ -1,9 +1,6 @@
 export const nextConfigTemplate = (basePath?: string) =>
   `const nextConfig = {
-    // Experimental ESM Externals
-    // https://nextjs.org/docs/messages/import-esm-externals
-    // required to fix build admin ui issues related to "react-day-picker" and "date-fn"
-    experimental: { esmExternals: 'loose' },
+    bundlePagesRouterDependencies: true,
     typescript: {
       ignoreBuildErrors: true,
     },


### PR DESCRIPTION
https://nextjs.org/docs/pages/api-reference/config/next-config-js/bundlePagesRouterDependencies

This is the behaviour in the App Router and just makes the Pages Router work like that too which fixes #9478 along with the sort of things that `esmExternals: 'loose'` tried to fix.

Tested in `0.0.0-rc-20250217014122`