### PR TITLE
Allow `Bytes` Prisma type in TypeScript types when implementing field types

### DIFF
--- a/.changeset/twelve-rings-remain.md
+++ b/.changeset/twelve-rings-remain.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Allow `Bytes` Prisma type in TypeScript types when implementing custom field types

--- a/packages/core/src/lib/core/prisma-schema-printer.ts
+++ b/packages/core/src/lib/core/prisma-schema-printer.ts
@@ -27,6 +27,11 @@ function printNativeType (nativeType: string | undefined, datasourceName: string
 
 function printScalarDefaultValue (defaultValue: ScalarDBFieldDefault): string {
   if (defaultValue.kind === 'literal') {
+    if (defaultValue instanceof Uint8Array) {
+      // can't find documentation for it but it seems the expected format for Bytes defaults in Prisma is base64
+      // https://github.com/prisma/prisma-engines/blob/11f45a26bee8dc9c91606fc5130d1025a6e22197/psl/psl-core/src/validate/validation_pipeline/validations/default_value.rs#L77
+      return ` @default("${Buffer.from(defaultValue).toString('base64')}")`
+    }
     if (typeof defaultValue.value === 'string') {
       return ` @default(${JSON.stringify(defaultValue.value)})`
     }

--- a/packages/core/src/types/next-fields.ts
+++ b/packages/core/src/types/next-fields.ts
@@ -76,6 +76,7 @@ type ScalarPrismaTypes = {
   BigInt: bigint
   Json: JSONValue
   Decimal: Decimal
+  Bytes: Uint8Array
 }
 
 type Literal<T> = {
@@ -104,6 +105,7 @@ export type ScalarDBFieldDefault<
           BigInt: Literal<bigint> | { kind: 'autoincrement' }
           DateTime: Literal<string> | { kind: 'now' }
           Decimal: Literal<string>
+          Bytes: Literal<Uint8Array>
         }[Scalar]
       | { kind: 'dbgenerated', value: string }
 


### PR DESCRIPTION
Note this doesn't implement a field type that uses it, just updates the TypeScript types to allow using `Bytes` when implementing a field type