### PR TITLE
Error on passwords that would be truncated by bcrypt

### DIFF
--- a/.changeset/polite-colts-admire.md
+++ b/.changeset/polite-colts-admire.md
@@ -3,4 +3,4 @@
 "@keystone-6/core": major
 ---
 
-Replace `bcrypt` and `workFactor` options for `password` field with new generic `kdf` option. The default KDF is still `bcryptjs` but it now errors for passwords longer than 72 bytes to avoid bcrypt's truncation behaviour
+Replace `bcrypt` and `workFactor` options for `password` field with new generic `kdf` option.

--- a/.changeset/polite-colts-admire.md
+++ b/.changeset/polite-colts-admire.md
@@ -3,4 +3,4 @@
 "@keystone-6/core": major
 ---
 
-Replace `bcrypt` and `workFactor` options for `password` field with new generic `kdf` option
+Replace `bcrypt` and `workFactor` options for `password` field with new generic `kdf` option. The default KDF is still `bcryptjs` but it now errors for passwords longer than 72 bytes to avoid bcrypt's truncation behaviour

--- a/.changeset/polite-colts-desire.md
+++ b/.changeset/polite-colts-desire.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Fixes the `password` field to throw an error for inputs longer than 72 bytes when using the default `bcrypt` key derivation function (KDF)

--- a/packages/core/src/fields/types/password/index.ts
+++ b/packages/core/src/fields/types/password/index.ts
@@ -55,7 +55,14 @@ const PasswordFilter = g.inputObject({
 export function password <ListTypeInfo extends BaseListTypeInfo> (config: PasswordFieldConfig<ListTypeInfo> = {}): FieldTypeFunc<ListTypeInfo> {
   const {
     kdf = {
-      hash: (secret) => bcryptjs.hash(secret, 10),
+      hash: (secret) => {
+        // note this is slightly different to checking .length > 72 because
+        // bcrypt will truncate to 72 bytes after utf8 encoding
+        // not JS string length which may be different since that's the utf16 length
+        // (though using characters in the error message makes sense since users shouldn't have to think about bytes and it aligns with the validation messages below)
+        if (bcryptjs.truncates(secret)) throw new Error('value must be no longer than 72 characters')
+        return bcryptjs.hash(secret, 10) 
+      },
       compare: (secret, hash) => bcryptjs.compare(secret, hash),
     },
     validation = {},

--- a/tests/api-tests/fields/types/password.test.ts
+++ b/tests/api-tests/fields/types/password.test.ts
@@ -42,7 +42,7 @@ test('password longer than 72 characters is rejected', runner(async ({context}) 
   }
 }))
 
-test('password that is 72 utf-16 code units but 76 utf-8 code units is rejected', runner(async ({context}) => {
+test('password that is 72 utf-16 code units but >72 utf-8 code units is rejected', runner(async ({context}) => {
   const password = 'a'.repeat(70) + '❤️'
   expect(password.length).toBe(72)
   expect(new TextEncoder().encode(password).length).toBe(76)

--- a/tests/api-tests/fields/types/password.test.ts
+++ b/tests/api-tests/fields/types/password.test.ts
@@ -1,5 +1,8 @@
 import { password } from '@keystone-6/core/fields'
 import { filterTests } from './utils'
+import { list } from '@keystone-6/core'
+import { setupTestRunner } from '../../test-runner'
+import { allowAll } from '@keystone-6/core/access'
 
 // note that while password fields can be non-nullable
 // non-nullable password fields cannot be filtered
@@ -9,3 +12,45 @@ filterTests(password(), match => {
   match(values, { isSet: false }, [0])
   match(values, { isSet: true }, [1, 2])
 })
+
+const runner = setupTestRunner({
+  serve: true,
+  config: ({
+    lists: {
+      User: list({
+        access: allowAll,
+        fields: {
+          password: password(),
+        },
+      }),
+    },
+  }),
+})
+
+test('password 72 characters long is allowed', runner(async ({context}) => {
+  await context.db.User.createOne({data: { password: 'a'.repeat(72) }})
+}))
+
+
+test('password longer than 72 characters is rejected', runner(async ({context}) => {
+  try {
+    await context.db.User.createOne({data: { password: 'a'.repeat(73) }})
+    expect(false).toBe(true)
+  } catch (error: any) {
+    expect(error.message).toEqual(`An error occurred while resolving input fields.
+  - User.password: value must be no longer than 72 characters`)
+  }
+}))
+
+test('password that is 72 utf-16 code units but 76 utf-8 code units is rejected', runner(async ({context}) => {
+  const password = 'a'.repeat(70) + '❤️'
+  expect(password.length).toBe(72)
+  expect(new TextEncoder().encode(password).length).toBe(76)
+  try {
+    await context.db.User.createOne({data: { password }})
+    expect(false).toBe(true)
+  } catch (error: any) {
+    expect(error.message).toEqual(`An error occurred while resolving input fields.
+  - User.password: value must be no longer than 72 characters`)
+  }
+}))


### PR DESCRIPTION
This pull request adds length validation to the `password` field in `@keystone-6/core` to ensure passwords do not exceed 72 bytes when using the default `bcrypt` key derivation function. 

This prevents silent truncation by the bcrypt algorithm. 
Tests have been added to verify the behavior.

This update follows concerns raised by a recent Okta incident where improper handling of the input length to bcrypt allowed an authentication bypass in particular situations ([source](https://www.theverge.com/2024/11/1/24285874/okta-52-character-login-password-authentication-bypass)). 

This flaw is additionally present in `bcryptjs`, highlighting similar concerns for downstream users of our `password` field when using the default key derivation function. 

We are not currently opting to publish a CVE, as whether this is a problem strongly depends on how the `password` field is being used downstream. 

If you feel differently, please comment.
