### PR TITLE
Lazily load next build to improve CLI performance

### DIFF
--- a/.changeset/green-lizards-yawn.md
+++ b/.changeset/green-lizards-yawn.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Lazily load next build to improve CLI performance

--- a/packages/core/src/scripts/build.ts
+++ b/packages/core/src/scripts/build.ts
@@ -1,5 +1,4 @@
 import esbuild from 'esbuild'
-import nextBuild from 'next/dist/build'
 import { generateAdminUI } from '../admin-ui/system'
 import {
   createSystem,
@@ -42,6 +41,10 @@ export async function build (
   await generateAdminUI(system.config, system.adminMeta, paths.admin, false)
 
   console.log('✨ Building Admin UI')
+
+  // do _NOT_ change this to a static import, it is intentionally like this
+  // to avoid loading it in the common case where the UI is not being built
+  const nextBuild = require('next/dist/build').default
   await nextBuild(
     paths.admin,
     undefined,


### PR DESCRIPTION
Profiled with `NODE_OPTIONS=--inspect-brk ./node_modules/.bin/keystone postinstall` in `examples/limits`, after running `preconstruct build` so that the Keystone repo-only effects of the `preconstruct dev` require hook don't apply

Before:
<img width="630" alt="flamegraph of keystone postinstall with the next build module taking ~400ms, total time ~1.6 seconds" src="https://github.com/user-attachments/assets/9ecad17d-0c02-4ea3-aa2c-46a23bd20475" />

After:
<img width="603" alt="similar flamegraph without the next build module, total time ~1 second" src="https://github.com/user-attachments/assets/ca00b578-dcdc-42d3-ad3a-35f0b48e3a18" />


Note the require is fine since this code is eventually getting compiled to CJS and only being run as such so `require` is available