### PR TITLE
Rename `executeGraphQLFieldToRootVal` to `executeGraphQLFieldToSource`

### DIFF
--- a/packages/core/src/lib/coerceAndValidateForGraphQLInput.ts
+++ b/packages/core/src/lib/coerceAndValidateForGraphQLInput.ts
@@ -6,7 +6,7 @@ import type {
 } from 'graphql'
 import { Kind } from 'graphql'
 import { getVariableValues } from 'graphql/execution/values'
-import { getTypeNodeForType } from './context/executeGraphQLFieldToRootVal'
+import { getTypeNodeForType } from './context/executeGraphQLFieldToSource'
 
 const argName = 'where'
 

--- a/packages/core/src/lib/context/api.ts
+++ b/packages/core/src/lib/context/api.ts
@@ -1,7 +1,7 @@
 import { type GraphQLSchema } from 'graphql'
 import type { InitialisedList } from '../core/initialise-lists'
 import { type KeystoneContext } from '../../types'
-import { executeGraphQLFieldToRootVal } from './executeGraphQLFieldToRootVal'
+import { executeGraphQLFieldToSource } from './executeGraphQLFieldToSource'
 import { executeGraphQLFieldWithSelection } from './executeGraphQLFieldWithSelection'
 
 export function getQueryFactory (list: InitialisedList, schema: GraphQLSchema) {
@@ -71,7 +71,7 @@ export function getDbFactory (list: InitialisedList, schema: GraphQLSchema) {
       }
     }
 
-    return executeGraphQLFieldToRootVal(field)
+    return executeGraphQLFieldToSource(field)
   }
 
   const fcache = {

--- a/packages/core/src/lib/context/executeGraphQLFieldToSource.ts
+++ b/packages/core/src/lib/context/executeGraphQLFieldToSource.ts
@@ -145,7 +145,7 @@ function getRootValGivenOutputType (originalType: OutputType, value: any): any {
   return value[rawField]
 }
 
-export function executeGraphQLFieldToRootVal (field: GraphQLField<any, unknown>) {
+export function executeGraphQLFieldToSource (field: GraphQLField<any, unknown>) {
   const { argumentNodes, variableDefinitions } = getVariablesForGraphQLField(field)
   const document: DocumentNode = {
     kind: Kind.DOCUMENT,

--- a/packages/core/src/lib/context/executeGraphQLFieldWithSelection.ts
+++ b/packages/core/src/lib/context/executeGraphQLFieldWithSelection.ts
@@ -12,7 +12,7 @@ import {
   validate,
 } from 'graphql'
 import { type KeystoneContext } from '../../types'
-import { getVariablesForGraphQLField } from './executeGraphQLFieldToRootVal'
+import { getVariablesForGraphQLField } from './executeGraphQLFieldToSource'
 
 function getRootTypeName (type: GraphQLOutputType): string {
   if (type instanceof GraphQLNonNull) {


### PR DESCRIPTION
This is purely changing the naming of an internal function (used in `context.db`), `RootVal` is just the wrong term here.