### PR TITLE
Version Packages for @keystone-6/core@6.4.0

### DIFF
--- a/.changeset/add-relationship-search.md
+++ b/.changeset/add-relationship-search.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": minor
----
-
-Add support for searching relationship fields in the list view

--- a/.changeset/fix-search.md
+++ b/.changeset/fix-search.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": patch
----
-
-Fix list view ignoring `.ui.listView.searchFields`

--- a/.changeset/good-pumpkins-juggle.md
+++ b/.changeset/good-pumpkins-juggle.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": patch
----
-
-Fix Admin UI breaking in Safari because of usage of iterator helpers

--- a/.changeset/types-dont-omit.md
+++ b/.changeset/types-dont-omit.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": patch
----
-
-Fixes `context.db` missing types if they are omitted from GraphQL

--- a/examples/assets-local/package.json
+++ b/examples/assets-local/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "bytes": "^3.1.1"
   },

--- a/examples/assets-s3/package.json
+++ b/examples/assets-s3/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "bytes": "^3.1.1",
     "dotenv": "^16.0.0"

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/better-list-search/package.json
+++ b/examples/better-list-search/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@prisma/client": "5.19.0"
   },

--- a/examples/cloudinary/package.json
+++ b/examples/cloudinary/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@keystone-6/cloudinary": "^8.0.0",
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "dotenv": "^16.0.0"
   },

--- a/examples/custom-admin-ui-logo/package.json
+++ b/examples/custom-admin-ui-logo/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-ui/core": "^5.0.2",
     "@prisma/client": "5.19.0",
     "next": "^14.2.0",

--- a/examples/custom-admin-ui-navigation/package.json
+++ b/examples/custom-admin-ui-navigation/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "react": "^18.3.1"
   },

--- a/examples/custom-admin-ui-pages/package.json
+++ b/examples/custom-admin-ui-pages/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-ui/core": "^5.0.2",
     "@prisma/client": "5.19.0",
     "next": "^14.2.0",

--- a/examples/custom-esbuild/package.json
+++ b/examples/custom-esbuild/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/custom-field-view/package.json
+++ b/examples/custom-field-view/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@emotion/css": "^11.7.1",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/core": "^5.0.2",
     "@keystone-ui/fields": "^7.2.0",

--- a/examples/custom-field/package.json
+++ b/examples/custom-field/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-ui/fields": "^7.2.0",
     "@prisma/client": "5.19.0"
   },

--- a/examples/custom-id/package.json
+++ b/examples/custom-id/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.tsx"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@paralleldrive/cuid2": "^2.2.1",
     "@prisma/client": "5.19.0"
   },

--- a/examples/custom-output-paths/package.json
+++ b/examples/custom-output-paths/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "next": "^14.2.0",
     "react": "^18.3.1",

--- a/examples/custom-session-invalidation/keystone.ts
+++ b/examples/custom-session-invalidation/keystone.ts
@@ -32,13 +32,13 @@ const { withAuth } = createAuth({
   sessionData: 'passwordChangedAt',
 })
 
-function withSessionInvalidation (config: Config<Session>) {
+function withSessionInvalidation (config: Config<Session>): Config<Session> {
   const existingSessionStrategy = config.session!
 
   return {
     ...config,
     session: {
-      ...config.session,
+      ...config.session!,
       async get ({ context }: { context: Context }): Promise<Session | undefined> {
         const session = await existingSessionStrategy.get({ context })
         if (!session) return

--- a/examples/custom-session-invalidation/package.json
+++ b/examples/custom-session-invalidation/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/custom-session-jwt/package.json
+++ b/examples/custom-session-jwt/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "jsonwebtoken": "^9.0.0"
   },

--- a/examples/custom-session-next-auth/package.json
+++ b/examples/custom-session-next-auth/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "next-auth": "^4.22.1"
   },

--- a/examples/custom-session-passport/package.json
+++ b/examples/custom-session-passport/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone build --no-ui --frozen"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "dotenv": "^16.0.0",
     "express": "^4.19.2",

--- a/examples/custom-session-redis/package.json
+++ b/examples/custom-session-redis/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "@redis/client": "^1.3.0"
   },

--- a/examples/custom-session/package.json
+++ b/examples/custom-session/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/default-values/package.json
+++ b/examples/default-values/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/document-field-customisation/keystone-server/package.json
+++ b/examples/document-field-customisation/keystone-server/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@keystone-ui/button": "^7.0.1",
     "@keystone-ui/core": "^5.0.1",

--- a/examples/document-field/package.json
+++ b/examples/document-field/package.json
@@ -11,7 +11,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/document-renderer": "^1.1.2",
     "@keystone-6/fields-document": "^9.1.1",
     "@preconstruct/next": "^4.0.0",

--- a/examples/empty-lists/package.json
+++ b/examples/empty-lists/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/extend-express-app/package.json
+++ b/examples/extend-express-app/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "@types/express": "^4.17.14",
     "express": "^4.19.2"

--- a/examples/extend-graphql-schema-graphql-tools/package.json
+++ b/examples/extend-graphql-schema-graphql-tools/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^9.0.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "graphql": "^16.8.1"
   },

--- a/examples/extend-graphql-schema-graphql-ts/package.json
+++ b/examples/extend-graphql-schema-graphql-ts/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/extend-graphql-schema-nexus/package.json
+++ b/examples/extend-graphql-schema-nexus/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^9.0.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "graphql": "^16.8.1",
     "nexus": "^1.3.0"

--- a/examples/extend-graphql-schema-nexus/schema.ts
+++ b/examples/extend-graphql-schema-nexus/schema.ts
@@ -96,7 +96,7 @@ export function extendGraphqlSchema (baseSchema: GraphQLSchema) {
     // Typescript output settings, probably something you might commit in dev
     //   TODO: remove false ??, it is not part of the example, but we are having monorepo issues
     // eslint-disable-next-line no-constant-binary-expression
-    shouldGenerateArtifacts: false ?? process.env.NODE_ENV !== 'production',
+    shouldGenerateArtifacts: false, // ?? process.env.NODE_ENV !== 'production',
     outputs: {
       typegen: path.join(process.cwd(), 'nexus-types.ts'),
     },

--- a/examples/extend-graphql-subscriptions/package.json
+++ b/examples/extend-graphql-subscriptions/package.json
@@ -13,7 +13,7 @@
     "@apollo/client": "^3.7.0",
     "@emotion/css": "^11.7.1",
     "@graphql-tools/schema": "^9.0.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-ui/button": "^7.0.2",
     "@keystone-ui/core": "^5.0.2",
     "@keystone-ui/fields": "^7.2.0",

--- a/examples/extend-prisma-schema/package.json
+++ b/examples/extend-prisma-schema/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@prisma/client": "5.19.0"
   },

--- a/examples/field-groups/package.json
+++ b/examples/field-groups/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/framework-astro/package.json
+++ b/examples/framework-astro/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@astrojs/node": "^8.3.2",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "astro": "^4.12.3"
   },

--- a/examples/framework-nextjs-app-directory/package.json
+++ b/examples/framework-nextjs-app-directory/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/document-renderer": "^1.1.2",
     "@keystone-6/fields-document": "^9.1.1",
     "@preconstruct/next": "^4.0.0",

--- a/examples/framework-nextjs-pages-directory/package.json
+++ b/examples/framework-nextjs-pages-directory/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@preconstruct/next": "^4.0.0",
     "@prisma/client": "5.19.0",

--- a/examples/framework-nextjs-two-servers/keystone-server/package.json
+++ b/examples/framework-nextjs-two-servers/keystone-server/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@prisma/client": "5.19.0"
   },

--- a/examples/framework-remix/package.json
+++ b/examples/framework-remix/package.json
@@ -11,7 +11,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "@remix-run/node": "^1.18.0",
     "@remix-run/react": "^1.18.0",

--- a/examples/graphql-ts-gql/package.json
+++ b/examples/graphql-ts-gql/package.json
@@ -11,7 +11,7 @@
     "postinstall": "keystone postinstall && ts-gql build"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0",
     "graphql": "^16.8.1"
   },

--- a/examples/hooks/package.json
+++ b/examples/hooks/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/limits/package.json
+++ b/examples/limits/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/omit/package.json
+++ b/examples/omit/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/reuse/package.json
+++ b/examples/reuse/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/script/package.json
+++ b/examples/script/package.json
@@ -11,7 +11,7 @@
     "go": "tsx script.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/singleton/package.json
+++ b/examples/singleton/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/testing/package.json
+++ b/examples/testing/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/transactions/package.json
+++ b/examples/transactions/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/usecase-blog-moderated/package.json
+++ b/examples/usecase-blog-moderated/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/usecase-blog/package.json
+++ b/examples/usecase-blog/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@keystone-6/fields-document": "^9.1.1",
     "@prisma/client": "5.19.0"
   },

--- a/examples/usecase-relationship-union/package.json
+++ b/examples/usecase-relationship-union/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/usecase-roles/package.json
+++ b/examples/usecase-roles/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@keystone-6/auth": "^8.1.0",
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/usecase-todo/package.json
+++ b/examples/usecase-todo/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/usecase-versioning/package.json
+++ b/examples/usecase-versioning/package.json
@@ -11,7 +11,7 @@
     "seed-data": "tsx seed-data.ts"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/examples/virtual-field/package.json
+++ b/examples/virtual-field/package.json
@@ -10,7 +10,7 @@
     "postinstall": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "^6.3.1",
+    "@keystone-6/core": "^6.4.0",
     "@prisma/client": "5.19.0"
   },
   "devDependencies": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @keystone-6/core
 
+## 6.4.0
+
+### Minor Changes
+
+- [#9401](https://github.com/keystonejs/keystone/pull/9401) [`48f51be`](https://github.com/keystonejs/keystone/commit/48f51be98216ee4fa64f6d65b24c28b9c08f4b76) Thanks [@dcousens](https://github.com/dcousens)! - Add support for searching relationship fields in the list view
+
+### Patch Changes
+
+- [#9401](https://github.com/keystonejs/keystone/pull/9401) [`48f51be`](https://github.com/keystonejs/keystone/commit/48f51be98216ee4fa64f6d65b24c28b9c08f4b76) Thanks [@dcousens](https://github.com/dcousens)! - Fix list view ignoring `.ui.listView.searchFields`
+
+- [`424b2a2`](https://github.com/keystonejs/keystone/commit/424b2a2297141f55f2450df166d7cdf41765f1da) Thanks [@emmatown](https://github.com/emmatown)! - Fix Admin UI breaking in Safari because of usage of iterator helpers
+
+- [`f3cef4c`](https://github.com/keystonejs/keystone/commit/f3cef4c8ff29f6e3c92399d8e0735fe3bda72950) Thanks [@mikehazell](https://github.com/mikehazell)! - Fixes `context.db` missing types if they are omitted from GraphQL
+
 ## 6.3.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keystone-6/core",
-  "version": "6.3.1",
+  "version": "6.4.0",
   "repository": "https://github.com/keystonejs/keystone/tree/main/packages/core",
   "license": "MIT",
   "main": "dist/keystone-6-core.cjs.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,7 +600,7 @@ importers:
   examples/assets-local:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -622,7 +622,7 @@ importers:
   examples/assets-s3:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -650,7 +650,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -666,7 +666,7 @@ importers:
   examples/better-list-search:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -694,7 +694,7 @@ importers:
         specifier: ^8.0.0
         version: link:../../packages/cloudinary
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -713,7 +713,7 @@ importers:
   examples/custom-admin-ui-logo:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-ui/core':
         specifier: ^5.0.2
@@ -741,7 +741,7 @@ importers:
   examples/custom-admin-ui-navigation:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -760,7 +760,7 @@ importers:
   examples/custom-admin-ui-pages:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-ui/core':
         specifier: ^5.0.2
@@ -788,7 +788,7 @@ importers:
   examples/custom-esbuild:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -804,7 +804,7 @@ importers:
   examples/custom-field:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-ui/fields':
         specifier: ^7.2.0
@@ -826,7 +826,7 @@ importers:
         specifier: ^11.7.1
         version: 11.13.4
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-ui/button':
         specifier: ^7.0.2
@@ -863,7 +863,7 @@ importers:
   examples/custom-id:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@paralleldrive/cuid2':
         specifier: ^2.2.1
@@ -885,7 +885,7 @@ importers:
   examples/custom-output-paths:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -913,7 +913,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -932,7 +932,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -951,7 +951,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -973,7 +973,7 @@ importers:
   examples/custom-session-next-auth:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -992,7 +992,7 @@ importers:
   examples/custom-session-passport:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1035,7 +1035,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1054,7 +1054,7 @@ importers:
   examples/default-values:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1070,7 +1070,7 @@ importers:
   examples/document-field:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/document-renderer':
         specifier: ^1.1.2
@@ -1113,7 +1113,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -1184,7 +1184,7 @@ importers:
   examples/empty-lists:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1200,7 +1200,7 @@ importers:
   examples/extend-express-app:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1228,7 +1228,7 @@ importers:
         specifier: ^9.0.0
         version: 9.0.19(graphql@16.9.0)
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1247,7 +1247,7 @@ importers:
   examples/extend-graphql-schema-graphql-ts:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1266,7 +1266,7 @@ importers:
         specifier: ^9.0.0
         version: 9.0.19(graphql@16.9.0)
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1294,7 +1294,7 @@ importers:
         specifier: ^9.0.0
         version: 9.0.19(graphql@16.9.0)
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-ui/button':
         specifier: ^7.0.2
@@ -1337,7 +1337,7 @@ importers:
   examples/extend-prisma-schema:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -1356,7 +1356,7 @@ importers:
   examples/field-groups:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1375,7 +1375,7 @@ importers:
         specifier: ^8.3.2
         version: 8.3.4(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.2)(terser@5.36.0)(typescript@5.6.3))
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1406,7 +1406,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/document-renderer':
         specifier: ^1.1.2
@@ -1458,7 +1458,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -1513,7 +1513,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -1566,7 +1566,7 @@ importers:
   examples/framework-remix:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1609,7 +1609,7 @@ importers:
   examples/graphql-ts-gql:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1640,7 +1640,7 @@ importers:
   examples/hooks:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1656,7 +1656,7 @@ importers:
   examples/limits:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1675,7 +1675,7 @@ importers:
   examples/omit:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1691,7 +1691,7 @@ importers:
   examples/reuse:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1707,7 +1707,7 @@ importers:
   examples/script:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1726,7 +1726,7 @@ importers:
   examples/singleton:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1748,7 +1748,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1770,7 +1770,7 @@ importers:
   examples/transactions:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1786,7 +1786,7 @@ importers:
   examples/usecase-blog:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@keystone-6/fields-document':
         specifier: ^9.1.1
@@ -1811,7 +1811,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1827,7 +1827,7 @@ importers:
   examples/usecase-relationship-union:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1846,7 +1846,7 @@ importers:
         specifier: ^8.1.0
         version: link:../../packages/auth
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1862,7 +1862,7 @@ importers:
   examples/usecase-todo:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1881,7 +1881,7 @@ importers:
   examples/usecase-versioning:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0
@@ -1900,7 +1900,7 @@ importers:
   examples/virtual-field:
     dependencies:
       '@keystone-6/core':
-        specifier: ^6.3.1
+        specifier: ^6.4.0
         version: link:../../packages/core
       '@prisma/client':
         specifier: 5.19.0


### PR DESCRIPTION
This is releasing `@keystone-6/core@6.4.0` with the following changes:
- https://github.com/keystonejs/keystone/pull/9402
- https://github.com/keystonejs/keystone/pull/9401
- https://github.com/keystonejs/keystone/pull/9453