### PR TITLE
Add eslint-plugin-react-hooks

### DIFF
--- a/docs/components/docs/featured-examples/client.tsx
+++ b/docs/components/docs/featured-examples/client.tsx
@@ -9,8 +9,8 @@ import { type FeaturedExamples } from '.'
 import { Type } from '../../primitives/Type'
 
 export default function ExamplesList({ featuredExamples }: { featuredExamples: FeaturedExamples }) {
-  if (!featuredExamples) return null
   const mq = useMediaQuery()
+  if (!featuredExamples) return null
   return (
     <>
       <Type as="h2" look="heading30" margin="2rem 0 1rem 0">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@
 
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
+import reactHooks from 'eslint-plugin-react-hooks'
 
 export default tseslint.config(
   {
@@ -18,6 +19,7 @@ export default tseslint.config(
   },
   eslint.configs.recommended,
   ...tseslint.configs.strict,
+  reactHooks.configs['recommended-latest'],
   {
     rules: {
       'no-empty': ['error', { allowEmptyCatch: true }],
@@ -40,6 +42,8 @@ export default tseslint.config(
       ],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/prefer-ts-expect-error': 'error',
+      // TODO: enable
+      // 'react-hooks/exhaustive-deps': 'error',
     },
   }
 )

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "esbuild": "^0.25.0",
     "esbuild-jest": "^0.5.0",
     "eslint": "^9.2.0",
+    "eslint-plugin-react-hooks": "5.2.0-canary-662957cc-20250221",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.0.0",
     "prettier": "^3.5.1",

--- a/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
@@ -38,6 +38,13 @@ export function ComboboxSingle({
     state,
   })
 
+  const [lastSeenStateValue, setLastSeenStateValue] = React.useState(state.value)
+
+  if (state.value !== lastSeenStateValue) {
+    setLastSeenStateValue(state.value)
+    setSearch(state.value?.label ?? '')
+  }
+
   // TODO: better error UI
   // TODO: Handle permission errors
   // (ie; user has permission to read this relationship field, but
@@ -48,13 +55,6 @@ export function ComboboxSingle({
 
   if (state.value?.built) {
     items.push(state.value)
-  }
-
-  const [lastSeenStateValue, setLastSeenStateValue] = React.useState(state.value)
-
-  if (state.value !== lastSeenStateValue) {
-    setLastSeenStateValue(state.value)
-    setSearch(state.value?.label ?? '')
   }
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       eslint:
         specifier: ^9.2.0
         version: 9.19.0(jiti@2.4.2)
+      eslint-plugin-react-hooks:
+        specifier: 5.2.0-canary-662957cc-20250221
+        version: 5.2.0-canary-662957cc-20250221(eslint@9.19.0(jiti@2.4.2))
       jest:
         specifier: ^29.0.0
         version: 29.7.0(@types/node@22.13.0)(babel-plugin-macros@3.1.0)
@@ -8064,6 +8067,12 @@ packages:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
+
+  eslint-plugin-react-hooks@5.2.0-canary-662957cc-20250221:
+    resolution: {integrity: sha512-iSo49ZfZg6qPLM9P1aRR2IWrMFtXsTCzRRT/OGRin/8Xd/Tz+pXm/G0bT9cmA/YLV0K9SZZ9H9LEX0rz4baxIQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
@@ -20384,6 +20393,10 @@ snapshots:
       esutils: 2.0.3
     optionalDependencies:
       source-map: 0.6.1
+
+  eslint-plugin-react-hooks@5.2.0-canary-662957cc-20250221(eslint@9.19.0(jiti@2.4.2)):
+    dependencies:
+      eslint: 9.19.0(jiti@2.4.2)
 
   eslint-scope@7.2.2:
     dependencies:


### PR DESCRIPTION
I hit the buggy code in `ComboboxSingle.tsx` which `react-hooks/rules-of-hooks` would have prevented when trying out the rc in a project. The recommended config sets `react-hooks/rules-of-hooks` to error and `react-hooks/exhaustive-deps` to warn. Later `react-hooks/exhaustive-deps` should probably be set to `error` as well but there's a bunch of cases where that rule hits in the codebase right now and some of them should be ignored and some shouldn't and I don't want to deal with that in this PR. Also, the reason the version of `eslint-plugin-react-hooks` is `5.2.0-canary-662957cc-20250221` is because the proper ESLint 9 support isn't in the latest normal version of `eslint-plugin-react-hooks`. There's no changeset for this since it's just a bug fix for not properly released code.