### PR TITLE
Fix all field groups being rendered in sidebar and form even if they're empty in that position

### DIFF
--- a/.github/workflows/tests_ci.yml
+++ b/.github/workflows/tests_ci.yml
@@ -271,6 +271,7 @@ jobs:
             'usecase-roles.test.ts',
             'usecase-todo.test.ts',
             'virtual-field.test.ts',
+            'field-groups.test.ts',
           ]
       fail-fast: false
     steps:

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -96,17 +96,21 @@ export function Fields({
 
             const group = groupByFieldKey[fieldKey]
             if (group) {
+              const fields = [
+                ...(function* () {
+                  for (const { path: fieldKey } of group.fields) {
+                    if (fieldKey in rendered) continue
+                    if (fieldDomByKey[fieldKey]) {
+                      yield fieldDomByKey[fieldKey]
+                    }
+                    rendered[fieldKey] = true
+                  }
+                })(),
+              ]
+              if (fields.length === 0) continue
               yield (
                 <FieldGroup key={group.label} label={group.label} description={group.description}>
-                  {[
-                    ...(function* () {
-                      for (const { path: fieldKey } of group.fields) {
-                        if (fieldKey in rendered) continue
-                        yield fieldDomByKey[fieldKey] ?? null
-                        rendered[fieldKey] = true
-                      }
-                    })(),
-                  ]}
+                  {fields}
                 </FieldGroup>
               )
               continue

--- a/tests/examples-smoke-tests/field-groups.test.ts
+++ b/tests/examples-smoke-tests/field-groups.test.ts
@@ -1,0 +1,36 @@
+import { type Browser, type Page } from 'playwright'
+import { exampleProjectTests, loadIndex } from './utils'
+import { expect } from 'playwright/test'
+
+const gql = ([str]: TemplateStringsArray) => str
+
+exampleProjectTests('field-groups', browserType => {
+  let browser: Browser = undefined as any
+  let page: Page = undefined as any
+  beforeAll(async () => {
+    browser = await browserType.launch()
+    page = await browser.newPage()
+    await loadIndex(page)
+  })
+  test('Field group is rendered exactly once', async () => {
+    const res = await fetch('http://localhost:3000/api/graphql', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: gql`
+          mutation {
+            createPost(data: { title: "Hello World" }) {
+              id
+            }
+          }
+        `,
+      }),
+    }).then(res => res.json())
+    const id = res.data.createPost.id
+    await page.goto(`http://localhost:3000/posts/${id}`)
+    await expect(page.getByText('Some automatically updated meta fields')).toHaveCount(1)
+  })
+  afterAll(async () => {
+    await browser.close()
+  })
+})


### PR DESCRIPTION
This regressed in https://github.com/keystonejs/keystone/pull/9253

This has not been officially released, and thereby no changeset is provided