### PR TITLE
Fix `itemView` `fieldMode` and `fieldPosition` not being called with the item

### DIFF
--- a/.changeset/new-jars-grab.md
+++ b/.changeset/new-jars-grab.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Makes `fieldMode` and `fieldPosition` on `KeystoneAdminUIFieldMetaItemView` non-nullable

--- a/.changeset/new-jars-grab.md
+++ b/.changeset/new-jars-grab.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": patch
 ---
 
-Makes `fieldMode` and `fieldPosition` on `KeystoneAdminUIFieldMetaItemView` non-nullable
+Changes `fieldMode` and `fieldPosition` on `KeystoneAdminUIFieldMetaItemView` to non-nullable

--- a/examples/assets-local/schema.graphql
+++ b/examples/assets-local/schema.graphql
@@ -216,8 +216,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/assets-s3/schema.graphql
+++ b/examples/assets-s3/schema.graphql
@@ -216,8 +216,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/auth-magic-link/schema.graphql
+++ b/examples/auth-magic-link/schema.graphql
@@ -202,8 +202,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/auth/schema.graphql
+++ b/examples/auth/schema.graphql
@@ -179,8 +179,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/better-list-search/schema.graphql
+++ b/examples/better-list-search/schema.graphql
@@ -326,8 +326,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/cloudinary/schema.graphql
+++ b/examples/cloudinary/schema.graphql
@@ -234,8 +234,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-admin-ui-logo/schema.graphql
+++ b/examples/custom-admin-ui-logo/schema.graphql
@@ -300,8 +300,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-admin-ui-navigation/schema.graphql
+++ b/examples/custom-admin-ui-navigation/schema.graphql
@@ -300,8 +300,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-admin-ui-pages/schema.graphql
+++ b/examples/custom-admin-ui-pages/schema.graphql
@@ -300,8 +300,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-esbuild/schema.graphql
+++ b/examples/custom-esbuild/schema.graphql
@@ -177,8 +177,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-field/schema.graphql
+++ b/examples/custom-field/schema.graphql
@@ -195,8 +195,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-id/schema.graphql
+++ b/examples/custom-id/schema.graphql
@@ -593,8 +593,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-output-paths/my-graphql.graphql
+++ b/examples/custom-output-paths/my-graphql.graphql
@@ -195,8 +195,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-invalidation/schema.graphql
+++ b/examples/custom-session-invalidation/schema.graphql
@@ -175,8 +175,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-jwt/schema.graphql
+++ b/examples/custom-session-jwt/schema.graphql
@@ -231,8 +231,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-next-auth/schema.graphql
+++ b/examples/custom-session-next-auth/schema.graphql
@@ -265,8 +265,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-passport/schema.graphql
+++ b/examples/custom-session-passport/schema.graphql
@@ -265,8 +265,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-redis/schema.graphql
+++ b/examples/custom-session-redis/schema.graphql
@@ -169,8 +169,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session/schema.graphql
+++ b/examples/custom-session/schema.graphql
@@ -231,8 +231,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/default-values/schema.graphql
+++ b/examples/default-values/schema.graphql
@@ -319,8 +319,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/document-field-customisation/keystone-server/schema.graphql
+++ b/examples/document-field-customisation/keystone-server/schema.graphql
@@ -291,8 +291,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/document-field/schema.graphql
+++ b/examples/document-field/schema.graphql
@@ -315,8 +315,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/empty-lists/schema.graphql
+++ b/examples/empty-lists/schema.graphql
@@ -440,8 +440,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-express-app/schema.graphql
+++ b/examples/extend-express-app/schema.graphql
@@ -187,8 +187,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-graphql-schema-graphql-tools/schema.graphql
+++ b/examples/extend-graphql-schema-graphql-tools/schema.graphql
@@ -312,8 +312,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-graphql-schema-graphql-ts/schema.graphql
+++ b/examples/extend-graphql-schema-graphql-ts/schema.graphql
@@ -310,8 +310,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-graphql-schema-nexus/schema.graphql
+++ b/examples/extend-graphql-schema-nexus/schema.graphql
@@ -296,8 +296,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-graphql-subscriptions/schema.graphql
+++ b/examples/extend-graphql-subscriptions/schema.graphql
@@ -303,8 +303,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-prisma-schema/schema.graphql
+++ b/examples/extend-prisma-schema/schema.graphql
@@ -323,8 +323,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/field-groups/schema.graphql
+++ b/examples/field-groups/schema.graphql
@@ -196,8 +196,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-astro/schema.graphql
+++ b/examples/framework-astro/schema.graphql
@@ -177,8 +177,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-nextjs-app-directory/schema.graphql
+++ b/examples/framework-nextjs-app-directory/schema.graphql
@@ -197,8 +197,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-nextjs-pages-directory/schema.graphql
+++ b/examples/framework-nextjs-pages-directory/schema.graphql
@@ -195,8 +195,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-nextjs-two-servers/keystone-server/schema.graphql
+++ b/examples/framework-nextjs-two-servers/keystone-server/schema.graphql
@@ -291,8 +291,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-remix/schema.graphql
+++ b/examples/framework-remix/schema.graphql
@@ -177,8 +177,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/graphql-codegen/schema.graphql
+++ b/examples/graphql-codegen/schema.graphql
@@ -273,8 +273,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/graphql-gql.tada/schema.graphql
+++ b/examples/graphql-gql.tada/schema.graphql
@@ -273,8 +273,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/graphql-ts-gql/schema.graphql
+++ b/examples/graphql-ts-gql/schema.graphql
@@ -273,8 +273,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/hooks/schema.graphql
+++ b/examples/hooks/schema.graphql
@@ -216,8 +216,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/limits/schema.graphql
+++ b/examples/limits/schema.graphql
@@ -172,8 +172,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/logging/schema.graphql
+++ b/examples/logging/schema.graphql
@@ -173,8 +173,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/number-fields/schema.graphql
+++ b/examples/number-fields/schema.graphql
@@ -205,8 +205,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/omit/schema.graphql
+++ b/examples/omit/schema.graphql
@@ -262,8 +262,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/relationships/schema.graphql
+++ b/examples/relationships/schema.graphql
@@ -358,8 +358,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/reuse/schema.graphql
+++ b/examples/reuse/schema.graphql
@@ -312,8 +312,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/script/schema.graphql
+++ b/examples/script/schema.graphql
@@ -190,8 +190,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/singleton/schema.graphql
+++ b/examples/singleton/schema.graphql
@@ -267,8 +267,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/testing/schema.graphql
+++ b/examples/testing/schema.graphql
@@ -328,8 +328,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/transactions/schema.graphql
+++ b/examples/transactions/schema.graphql
@@ -354,8 +354,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-blog-moderated/schema.graphql
+++ b/examples/usecase-blog-moderated/schema.graphql
@@ -413,8 +413,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -357,8 +357,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-relationship-union/schema.graphql
+++ b/examples/usecase-relationship-union/schema.graphql
@@ -301,8 +301,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-relationship-union/schema.ts
+++ b/examples/usecase-relationship-union/schema.ts
@@ -3,13 +3,14 @@ import { allowAll } from '@keystone-6/core/access'
 import { text, relationship, virtual } from '@keystone-6/core/fields'
 import type { Lists } from '.keystone/types'
 
-function ifUnsetHideUI(field: string) {
+function ifUnsetHideUI<Key extends string>(field: Key) {
   return {
     itemView: {
-      fieldMode: ({ item }: any) => (item[field] ? 'edit' : 'read'),
+      fieldMode: ({ item }: { item: null | { [_ in Key]: unknown } }) =>
+        item?.[field] ? 'edit' : 'read',
     },
     listView: {
-      fieldMode: () => 'hidden' as const,
+      fieldMode: 'hidden' as const,
     },
   }
 }

--- a/examples/usecase-roles/schema.graphql
+++ b/examples/usecase-roles/schema.graphql
@@ -411,8 +411,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-todo/schema.graphql
+++ b/examples/usecase-todo/schema.graphql
@@ -301,8 +301,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-versioning/schema.graphql
+++ b/examples/usecase-versioning/schema.graphql
@@ -193,8 +193,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/virtual-field/schema.graphql
+++ b/examples/virtual-field/schema.graphql
@@ -202,8 +202,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/packages/core/src/admin-ui/utils/Fields.tsx
+++ b/packages/core/src/admin-ui/utils/Fields.tsx
@@ -21,6 +21,8 @@ export function Fields({
   invalidFields,
   onChange,
   value: itemValue,
+  fieldModes = {},
+  fieldPositions = {},
 }: {
   view: 'createView' | 'itemView'
   position: 'form' | 'sidebar'
@@ -30,14 +32,17 @@ export function Fields({
   invalidFields: ReadonlySet<string>
   onChange(value: Record<string, unknown>): void
   value: Record<string, unknown>
+  fieldPositions?: Record<string, 'form' | 'sidebar'>
+  fieldModes?: Record<string, 'edit' | 'read' | 'hidden'>
 }) {
   const fieldDomByKey: Record<string, ReactNode> = {}
   let focused = false
   for (const fieldKey in fields) {
     const field = fields[fieldKey]
-    if (view === 'itemView' && field.itemView.fieldPosition !== position) continue
+    const fieldPosition = fieldPositions[fieldKey] ?? field.itemView.fieldPosition
+    if (view === 'itemView' && fieldPosition !== position) continue
 
-    const { fieldMode } = field[view]
+    const fieldMode = fieldModes[fieldKey] ?? field[view].fieldMode
     if (fieldMode === 'hidden') continue
 
     const fieldValue = itemValue[fieldKey]

--- a/tests/cli-tests/fixtures/basic-project/schema.graphql
+++ b/tests/cli-tests/fixtures/basic-project/schema.graphql
@@ -172,8 +172,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/tests/cli-tests/fixtures/custom-prisma-project/schema.graphql
+++ b/tests/cli-tests/fixtures/custom-prisma-project/schema.graphql
@@ -164,8 +164,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/tests/sandbox/schema.graphql
+++ b/tests/sandbox/schema.graphql
@@ -731,8 +731,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/tests/test-projects/basic/schema.graphql
+++ b/tests/test-projects/basic/schema.graphql
@@ -349,8 +349,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/tests/test-projects/crud-notifications/schema.graphql
+++ b/tests/test-projects/crud-notifications/schema.graphql
@@ -300,8 +300,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/tests/test-projects/live-reloading/schema.graphql
+++ b/tests/test-projects/live-reloading/schema.graphql
@@ -173,8 +173,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {


### PR DESCRIPTION
This regressed in https://github.com/keystonejs/keystone/pull/9253

The actual fix here doesn't need a changeset since the broken behaviour was never released but I did a slightly unrelated change here of making `fieldMode` and `fieldPosition` on `KeystoneAdminUIFieldMetaItemView` non-nullable since I think that makes sense and aligns with other parts of the schema and there's a changeset for that.