### PR TITLE
Fix docs scripts

### DIFF
--- a/docs/markdoc/load-all.ts
+++ b/docs/markdoc/load-all.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
-import { globby } from 'globby'
 
 export async function loadAllMarkdoc() {
+  const { globby } = await import('globby')
   const paths = await globby(['pages/docs/**/*.md', 'pages/blog/**/*.md'])
   return await Promise.all(
     paths.map(async file => {

--- a/docs/scripts/rss.ts
+++ b/docs/scripts/rss.ts
@@ -1,11 +1,11 @@
 import path from 'path'
 import fs from 'fs/promises'
 import RSS from 'rss'
-import { globby } from 'globby'
 import { extractBlogFrontmatter } from '../markdoc'
 import { siteBaseUrl } from '../lib/og-util'
 
 async function getPosts() {
+  const { globby } = await import('globby')
   const files = await globby('*.md', {
     cwd: path.join(process.cwd(), 'pages/blog'),
   })


### PR DESCRIPTION
_something_ changed with `tsx`, making `globby` dynamically imported is just the easiest way to fix it.

Example failure: https://github.com/keystonejs/keystone/actions/runs/13533434251/job/37820505910

```
> tsx scripts/validate-links.ts

node:internal/modules/esm/resolve:314
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /home/runner/work/keystone/keystone/node_modules/.pnpm/globby@14.1.0/node_modules/unicorn-magic/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:605:13)
    at resolveExports (node:internal/modules/cjs/loader:638:[36](https://github.com/keystonejs/keystone/actions/runs/13533434251/job/37820505910#step:7:37))
    at Function._findPath (node:internal/modules/cjs/loader:743:31)
    at node:internal/modules/cjs/loader:1230:27
    at nextResolveSimple (/home/runner/work/keystone/keystone/node_modules/.pnpm/tsx@4.19.3/node_modules/tsx/dist/register-DCnOAxY2.cjs:3:942)
    at /home/runner/work/keystone/keystone/node_modules/.pnpm/tsx@4.19.3/node_modules/tsx/dist/register-DCnOAxY2.cjs:2:2550
    at /home/runner/work/keystone/keystone/node_modules/.pnpm/tsx@4.19.3/node_modules/tsx/dist/register-DCnOAxY2.cjs:2:1624
    at resolveTsPaths (/home/runner/work/keystone/keystone/node_modules/.pnpm/tsx@4.19.3/node_modules/tsx/dist/register-DCnOAxY2.cjs:3:760)
    at /home/runner/work/keystone/keystone/node_modules/.pnpm/tsx@4.19.3/node_modules/tsx/dist/register-DCnOAxY2.cjs:3:10[38](https://github.com/keystonejs/keystone/actions/runs/13533434251/job/37820505910#step:7:39) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```