### PR TITLE
Update most `rootVal` names to `source`

### DIFF
--- a/docs/content/docs/guides/virtual-fields.md
+++ b/docs/content/docs/guides/virtual-fields.md
@@ -226,7 +226,7 @@ export default config({
 });
 ```
 
-This example is written in TypeScript, so we need to specify the type of the root value expected by the `PostCounts` type.
+This example is written in TypeScript, so we need to specify the type expected by the `PostCounts` type.
 This type must correspond to the return type of the `resolve` function.
 
 Because our `virtual` field has an object type, we also need to provide a value for the option `ui.query`.

--- a/examples/extend-graphql-schema-graphql-tools/README.md
+++ b/examples/extend-graphql-schema-graphql-tools/README.md
@@ -104,7 +104,7 @@ Note that we're not doing any actual fetching inside `Query.stats`, we're doing 
       },
       Statistics: {
         // The stats resolver returns an object which is passed to this resolver as
-        // the root value. We use that object to further resolve ths specific fields.
+        // the first argument. We use that object to further resolve ths specific fields.
         // In this case we want to take root.authorId and get the latest post for that author
         //
         // As above we use the context.db.Post API to achieve this.

--- a/examples/extend-graphql-schema-graphql-tools/schema.ts
+++ b/examples/extend-graphql-schema-graphql-tools/schema.ts
@@ -105,7 +105,7 @@ export function extendGraphqlSchema(baseSchema: GraphQLSchema) {
       },
       Statistics: {
         // The stats resolver returns an object which is passed to this resolver as
-        // the root value. We use that object to further resolve ths specific fields.
+        // the first argument. We use that object to further resolve ths specific fields.
         // In this case we want to take root.authorId and get the latest post for that author
         //
         // As above we use the context.db.Post API to achieve this.

--- a/packages/core/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/core/src/admin-ui/system/generateAdminUI.ts
@@ -5,7 +5,7 @@ import fse from 'fs-extra'
 import { type Entry, walk as _walk } from '@nodelib/fs.walk'
 import type { AdminFileToWrite, KeystoneConfig } from '../../types'
 import { writeAdminFiles } from '../templates'
-import type { AdminMetaRootVal } from '../../lib/create-admin-meta'
+import type { AdminMetaSource } from '../../lib/create-admin-meta'
 
 const walk = promisify(_walk)
 
@@ -47,7 +47,7 @@ const pageExtensions = new Set(['.js', '.jsx', '.ts', '.tsx'])
 
 export async function generateAdminUI(
   config: KeystoneConfig,
-  adminMeta: AdminMetaRootVal,
+  adminMeta: AdminMetaSource,
   projectAdminPath: string,
   isLiveReload: boolean
 ) {

--- a/packages/core/src/admin-ui/templates/app.ts
+++ b/packages/core/src/admin-ui/templates/app.ts
@@ -1,7 +1,7 @@
 import Path from 'path'
 import resolve from 'resolve'
 
-import type { AdminMetaRootVal } from '../../lib/create-admin-meta'
+import type { AdminMetaSource } from '../../lib/create-admin-meta'
 import type { KeystoneConfig } from '../../types'
 
 function doesConfigExist(path: string[]) {
@@ -18,8 +18,8 @@ function doesConfigExist(path: string[]) {
   }
 }
 
-export function appTemplate(config: KeystoneConfig, adminMetaRootVal: AdminMetaRootVal) {
-  const allViews = adminMetaRootVal.views.map(viewRelativeToProject => {
+export function appTemplate(config: KeystoneConfig, adminMeta: AdminMetaSource) {
+  const allViews = adminMeta.views.map(viewRelativeToProject => {
     const isRelativeToFile =
       viewRelativeToProject.startsWith('./') || viewRelativeToProject.startsWith('../')
     const viewRelativeToAppFile = isRelativeToFile

--- a/packages/core/src/admin-ui/templates/index.ts
+++ b/packages/core/src/admin-ui/templates/index.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import type { KeystoneConfig } from '../../types'
-import type { AdminMetaRootVal } from '../../lib/create-admin-meta'
+import type { AdminMetaSource } from '../../lib/create-admin-meta'
 import { appTemplate } from './app'
 import { homeTemplate } from './home'
 import { listTemplate } from './list'
@@ -11,7 +11,7 @@ import { nextConfigTemplate } from './next-config'
 
 const pkgDir = path.dirname(require.resolve('@keystone-6/core/package.json'))
 
-export function writeAdminFiles(config: KeystoneConfig, adminMeta: AdminMetaRootVal) {
+export function writeAdminFiles(config: KeystoneConfig, adminMeta: AdminMetaSource) {
   return [
     {
       mode: 'write' as const,

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../types'
 import { g } from '../../..'
 import {
-  type ListMetaRootVal,
+  type ListMetaSource,
   getAdminMetaForRelationshipField,
 } from '../../../lib/create-admin-meta'
 import { type controller } from './views'
@@ -54,8 +54,8 @@ type ManyDbConfig = {
 }
 
 function throwIfMissingFields(
-  localListMeta: ListMetaRootVal,
-  foreignListMeta: ListMetaRootVal,
+  localListMeta: ListMetaSource,
+  foreignListMeta: ListMetaSource,
   refLabelField: string,
   refSearchFields: string[],
   fieldKey: string

--- a/packages/core/src/lib/context/executeGraphQLFieldToSource.ts
+++ b/packages/core/src/lib/context/executeGraphQLFieldToSource.ts
@@ -82,8 +82,8 @@ const ReturnRawValueObjectType = new GraphQLObjectType({
   fields: {
     [rawField]: {
       type: RawScalar,
-      resolve(rootVal) {
-        return rootVal
+      resolve(source) {
+        return source
       },
     },
   },
@@ -134,13 +134,13 @@ function getTypeForField(originalType: GraphQLOutputType): OutputType {
   return ReturnRawValueObjectType
 }
 
-function getRootValGivenOutputType(originalType: OutputType, value: any): any {
+function getSourceGivenOutputType(originalType: OutputType, value: any): any {
   if (originalType instanceof GraphQLNonNull) {
-    return getRootValGivenOutputType(originalType.ofType, value)
+    return getSourceGivenOutputType(originalType.ofType, value)
   }
   if (value === null) return null
   if (originalType instanceof GraphQLList) {
-    return value.map((x: any) => getRootValGivenOutputType(originalType.ofType, x))
+    return value.map((x: any) => getSourceGivenOutputType(originalType.ofType, x))
   }
   return value[rawField]
 }
@@ -209,6 +209,6 @@ export function executeGraphQLFieldToSource(field: GraphQLField<any, unknown>) {
     if (result.errors?.length) {
       throw result.errors[0]
     }
-    return getRootValGivenOutputType(type, result.data![field.name])
+    return getSourceGivenOutputType(type, result.data![field.name])
   }
 }

--- a/packages/core/src/lib/core/queries/output-field.ts
+++ b/packages/core/src/lib/core/queries/output-field.ts
@@ -123,7 +123,7 @@ async function fetchRelatedItems(
 }
 
 function getValueForDBField(
-  rootVal: BaseItem,
+  item: BaseItem,
   dbField: ResolvedDBField,
   id: IdType,
   fieldPath: string,
@@ -135,7 +135,7 @@ function getValueForDBField(
     return Object.fromEntries(
       Object.keys(dbField.fields).map(innerDBFieldKey => {
         const keyOnDbValue = getDBFieldKeyForFieldOnMultiField(fieldPath, innerDBFieldKey)
-        return [innerDBFieldKey, rootVal[keyOnDbValue] as any]
+        return [innerDBFieldKey, item[keyOnDbValue] as any]
       })
     )
   }
@@ -143,11 +143,11 @@ function getValueForDBField(
     // If we're holding a foreign key value, let's take advantage of that.
     let fk: IdType | undefined
     if (dbField.mode === 'one' && dbField.foreignIdField.kind !== 'none') {
-      fk = rootVal[`${fieldPath}Id`] as IdType
+      fk = item[`${fieldPath}Id`] as IdType
     }
     return getRelationVal(dbField, id, lists[dbField.list], context, info, fk)
   } else {
-    return rootVal[fieldPath] as any
+    return item[fieldPath] as any
   }
 }
 
@@ -168,9 +168,9 @@ export function outputTypeField(
     description: output.description,
     args: output.args,
     extensions: output.extensions,
-    async resolve(rootVal: BaseItem, args, context, info) {
-      const id = rootVal.id as IdType
-      const fieldAccess = await getOperationFieldAccess(rootVal, list, fieldKey, context, 'read')
+    async resolve(item: BaseItem, args, context, info) {
+      const id = item.id as IdType
+      const fieldAccess = await getOperationFieldAccess(item, list, fieldKey, context, 'read')
       if (!fieldAccess) return null
 
       // only static cache hints are supported at the field level until a use-case makes it clear what parameters a dynamic hint would take
@@ -178,9 +178,9 @@ export function outputTypeField(
         maybeCacheControlFromInfo(info)?.setCacheHint(cacheHint)
       }
 
-      const value = getValueForDBField(rootVal, dbField, id, fieldKey, context, lists, info)
+      const value = getValueForDBField(item, dbField, id, fieldKey, context, lists, info)
       if (output.resolve) {
-        return output.resolve({ value, item: rootVal }, args, context, info)
+        return output.resolve({ value, item: item }, args, context, info)
       } else {
         return value
       }

--- a/packages/core/src/lib/createGraphQLSchema.ts
+++ b/packages/core/src/lib/createGraphQLSchema.ts
@@ -3,7 +3,7 @@ import { type GraphQLNamedType, GraphQLSchema } from 'graphql'
 import { g } from '../types/schema'
 import type { KeystoneConfig } from '../types'
 import { KeystoneMeta } from './resolve-admin-meta'
-import type { AdminMetaRootVal } from './create-admin-meta'
+import type { AdminMetaSource } from './create-admin-meta'
 import type { InitialisedList } from './core/initialise-lists'
 
 import { getQueriesForList } from './core/queries'
@@ -100,7 +100,7 @@ function collectTypes(
 export function createGraphQLSchema(
   config: KeystoneConfig,
   lists: Record<string, InitialisedList>,
-  adminMeta: AdminMetaRootVal | null,
+  adminMeta: AdminMetaSource | null,
   sudo: boolean
 ) {
   const graphQLSchema = getGraphQLSchema(

--- a/packages/core/src/lib/resolve-admin-meta.ts
+++ b/packages/core/src/lib/resolve-admin-meta.ts
@@ -3,10 +3,10 @@ import type { GraphQLNames } from '../types/utils'
 import { QueryMode } from '../types'
 import { g as graphqlBoundToKeystoneContext } from '../types/schema'
 import type {
-  AdminMetaRootVal,
-  FieldGroupMetaRootVal,
-  FieldMetaRootVal,
-  ListMetaRootVal,
+  AdminMetaSource,
+  FieldGroupMetaSource,
+  FieldMetaSource,
+  ListMetaSource,
 } from './create-admin-meta'
 
 const g = {
@@ -14,7 +14,7 @@ const g = {
   ...graphqlBoundToKeystoneContext.bindGraphQLSchemaAPIToContext<Context>(),
 }
 
-const KeystoneAdminUIFieldMeta = g.object<FieldMetaRootVal>()({
+const KeystoneAdminUIFieldMeta = g.object<FieldMetaSource>()({
   name: 'KeystoneAdminUIFieldMeta',
   fields: {
     path: g.field({ type: g.nonNull(g.String) }),
@@ -37,7 +37,7 @@ const KeystoneAdminUIFieldMeta = g.object<FieldMetaRootVal>()({
     customViewsIndex: g.field({ type: g.Int }),
     createView: g.field({
       type: g.nonNull(
-        g.object<FieldMetaRootVal['createView']>()({
+        g.object<FieldMetaSource['createView']>()({
           name: 'KeystoneAdminUIFieldMetaCreateView',
           fields: {
             fieldMode: g.field({
@@ -54,7 +54,7 @@ const KeystoneAdminUIFieldMeta = g.object<FieldMetaRootVal>()({
     }),
     listView: g.field({
       type: g.nonNull(
-        g.object<FieldMetaRootVal['listView']>()({
+        g.object<FieldMetaSource['listView']>()({
           name: 'KeystoneAdminUIFieldMetaListView',
           fields: {
             fieldMode: g.field({
@@ -91,8 +91,8 @@ const KeystoneAdminUIFieldMeta = g.object<FieldMetaRootVal>()({
       },
       type: g.object<{
         listKey: string
-        fieldMode: FieldMetaRootVal['itemView']['fieldMode']
-        fieldPosition: FieldMetaRootVal['itemView']['fieldPosition']
+        fieldMode: FieldMetaSource['itemView']['fieldMode']
+        fieldPosition: FieldMetaSource['itemView']['fieldPosition']
         item: BaseItem | null
       }>()({
         name: 'KeystoneAdminUIFieldMetaItemView',
@@ -138,7 +138,7 @@ const KeystoneAdminUIFieldMeta = g.object<FieldMetaRootVal>()({
   },
 })
 
-const KeystoneAdminUIFieldGroupMeta = g.object<FieldGroupMetaRootVal>()({
+const KeystoneAdminUIFieldGroupMeta = g.object<FieldGroupMetaSource>()({
   name: 'KeystoneAdminUIFieldGroupMeta',
   fields: {
     label: g.field({ type: g.nonNull(g.String) }),
@@ -149,7 +149,7 @@ const KeystoneAdminUIFieldGroupMeta = g.object<FieldGroupMetaRootVal>()({
   },
 })
 
-const KeystoneAdminUISort = g.object<NonNullable<ListMetaRootVal['initialSort']>>()({
+const KeystoneAdminUISort = g.object<NonNullable<ListMetaSource['initialSort']>>()({
   name: 'KeystoneAdminUISort',
   fields: {
     field: g.field({ type: g.nonNull(g.String) }),
@@ -205,7 +205,7 @@ const KeystoneAdminUIGraphQL = g.object<any>()({
   },
 })
 
-const KeystoneAdminUIListMeta = g.object<ListMetaRootVal>()({
+const KeystoneAdminUIListMeta = g.object<ListMetaSource>()({
   name: 'KeystoneAdminUIListMeta',
   fields: {
     key: g.field({ type: g.nonNull(g.String) }),
@@ -232,7 +232,7 @@ const KeystoneAdminUIListMeta = g.object<ListMetaRootVal>()({
   },
 })
 
-const adminMeta = g.object<AdminMetaRootVal>()({
+const adminMeta = g.object<AdminMetaSource>()({
   name: 'KeystoneAdminMeta',
   fields: {
     lists: g.field({
@@ -241,14 +241,14 @@ const adminMeta = g.object<AdminMetaRootVal>()({
     list: g.field({
       type: KeystoneAdminUIListMeta,
       args: { key: g.arg({ type: g.nonNull(g.String) }) },
-      resolve(rootVal, { key }) {
-        return rootVal.listsByKey[key]
+      resolve(source, { key }) {
+        return source.listsByKey[key]
       },
     }),
   },
 })
 
-export const KeystoneMeta = g.object<{ adminMeta: AdminMetaRootVal }>()({
+export const KeystoneMeta = g.object<{ adminMeta: AdminMetaSource }>()({
   name: 'KeystoneMeta',
   fields: {
     adminMeta: g.field({

--- a/packages/core/src/types/json-field-type-polyfill-for-sqlite.ts
+++ b/packages/core/src/types/json-field-type-polyfill-for-sqlite.ts
@@ -26,15 +26,15 @@ function mapOutputFieldToSQLite(
       deprecationReason: field.deprecationReason,
       description: field.description,
       extensions: field.extensions as any,
-      resolve(rootVal, ...extra) {
-        if (rootVal.value === null) {
-          return innerResolver(rootVal, ...extra)
+      resolve(source, ...extra) {
+        if (source.value === null) {
+          return innerResolver(source, ...extra)
         }
         let value: JSONValue = null
         try {
-          value = JSON.parse(rootVal.value)
+          value = JSON.parse(source.value)
         } catch (err) {}
-        return innerResolver({ item: rootVal.item, value }, ...extra)
+        return innerResolver({ item: source.item, value }, ...extra)
       },
     }),
   }).value

--- a/tests/api-tests/fields/types/Virtual.test.ts
+++ b/tests/api-tests/fields/types/Virtual.test.ts
@@ -96,16 +96,16 @@ describe('Virtual field type', () => {
                       name: 'Author',
                       types: [lists.Person.types.output, lists.Organisation.types.output],
                     }),
-                    async resolve(rootVal, args, context) {
+                    async resolve(item, args, context) {
                       const [personAuthors, organisationAuthors] = await Promise.all([
                         context.db.Person.findMany({
                           where: {
-                            authoredPosts: { some: { id: { equals: rootVal.id.toString() } } },
+                            authoredPosts: { some: { id: { equals: item.id.toString() } } },
                           },
                         }),
                         context.db.Organisation.findMany({
                           where: {
-                            authoredPosts: { some: { id: { equals: rootVal.id.toString() } } },
+                            authoredPosts: { some: { id: { equals: item.id.toString() } } },
                           },
                         }),
                       ])


### PR DESCRIPTION
These types are never publicly exported, this is purely internal refactoring.

And context on the naming, the "root value" is really just the source for the query/mutation/subscription types (often just an empty object or something like that), not the source that every resolver receives.