### PR TITLE
Add support for `displayMode: 'table'` on relationship fields

### DIFF
--- a/.changeset/crazy-poems-cross.md
+++ b/.changeset/crazy-poems-cross.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add support for `displayMode: 'table'` on relationship fields

--- a/examples/usecase-todo/schema.ts
+++ b/examples/usecase-todo/schema.ts
@@ -26,7 +26,11 @@ export const lists = {
     access: allowAll,
     fields: {
       name: text({ validation: { isRequired: true }, isIndexed: 'unique' }),
-      tasks: relationship({ ref: 'Task.assignedTo', many: true }),
+      tasks: relationship({
+        ref: 'Task.assignedTo',
+        many: true,
+        ui: { displayMode: 'table', itemView: { fieldMode: 'read' } },
+      }),
     },
   }),
 } satisfies Lists

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/PaginationControls.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/PaginationControls.tsx
@@ -1,0 +1,171 @@
+import { ActionButton } from '@keystar/ui/button'
+import { Icon } from '@keystar/ui/icon'
+import { chevronLeftIcon } from '@keystar/ui/icon/icons/chevronLeftIcon'
+import { chevronRightIcon } from '@keystar/ui/icon/icons/chevronRightIcon'
+import { HStack } from '@keystar/ui/layout'
+import { Picker } from '@keystar/ui/picker'
+import { Item } from '@keystar/ui/tag'
+import { Text } from '@keystar/ui/typography'
+import type { ReactNode } from 'react'
+import React, { useMemo } from 'react'
+
+type PageItem = {
+  label: string
+  id: number
+}
+
+export function PaginationControls(props: {
+  pageSize: number
+  total: number
+  currentPage: number
+  singular: string
+  plural: string
+  onChangePage: (page: number) => void
+  onChangePageSize: (pageSize: number) => void
+  extraActions?: ReactNode
+}) {
+  const { currentPage, total, pageSize } = props
+
+  const { stats } = getPaginationStats(props)
+
+  const nextPage = currentPage + 1
+  const prevPage = currentPage - 1
+  const minPage = 1
+
+  const limit = Math.ceil(total / pageSize)
+  const pageItems = useMemo(() => {
+    const result: PageItem[] = []
+    for (let page = minPage; page <= limit; page++) {
+      result.push({
+        id: page,
+        label: String(page),
+      })
+    }
+    return result
+  }, [limit])
+
+  // Don't render the pagination component if the pageSize is greater than the
+  // total number of items in the list.
+  // if (total <= pageSize) {
+  //   return null
+  // }
+
+  return (
+    <HStack
+      as="nav"
+      role="navigation"
+      aria-label="Pagination"
+      // alignItems="center"
+      justifyContent="space-between"
+    >
+      {/*
+        left-side
+        mobile: counts
+        desktop^: items per page (picker), counts
+      */}
+      <HStack gap="large" alignItems="center">
+        <HStack isHidden={{ below: 'desktop' }} gap="regular" alignItems="center">
+          <Text id="items-per-page">{props.plural} per page:</Text>
+          <Picker
+            aria-labelledby="items-per-page"
+            items={PAGE_SIZES.map(n => ({ label: String(n), id: n }))}
+            onSelectionChange={key => {
+              props.onChangePageSize(Number(key))
+            }}
+            selectedKey={pageSize}
+            // disable sizes greater than the total, allowing the next page to be the last
+            disabledKeys={PAGE_SIZES.filter(n => {
+              return n > snapValueToNextAvailable(total)
+            })}
+            width="scale.1000"
+          >
+            {item => <Item>{item.label}</Item>}
+          </Picker>
+        </HStack>
+        <Text color="neutralSecondary">{stats}</Text>
+      </HStack>
+
+      {/*
+        right-side
+        mobile: next/prev
+        desktop^: current page (picker), next/prev
+      */}
+      <HStack gap="large" alignItems="center">
+        <HStack isHidden={{ below: 'desktop' }} gap="regular" alignItems="center">
+          <Picker
+            // prominence="low"
+            aria-label={`Page number, of 11 pages`}
+            items={pageItems}
+            onSelectionChange={page => {
+              props.onChangePage(Number(page))
+            }}
+            selectedKey={currentPage}
+            width="scale.1000"
+          >
+            {item => <Item>{item.label}</Item>}
+          </Picker>
+          <Text>of {limit} pages</Text>
+        </HStack>
+        <HStack gap="regular">
+          <ActionButton
+            aria-label="Previous page"
+            isDisabled={prevPage < minPage}
+            onPress={() => props.onChangePage(prevPage)}
+            // prominence="low"
+          >
+            <Icon src={chevronLeftIcon} />
+          </ActionButton>
+          <ActionButton
+            aria-label="Next page"
+            isDisabled={nextPage > limit}
+            onPress={() => props.onChangePage(nextPage)}
+            // prominence="low"
+          >
+            <Icon src={chevronRightIcon} />
+          </ActionButton>
+          {props.extraActions}
+        </HStack>
+      </HStack>
+    </HStack>
+  )
+}
+
+function getPaginationStats({
+  singular,
+  plural,
+  pageSize,
+  currentPage,
+  total,
+}: {
+  singular: string
+  plural: string
+  pageSize: number
+  currentPage: number
+  total: number
+}) {
+  let stats = ''
+  if (total > pageSize) {
+    const start = pageSize * (currentPage - 1) + 1
+    const end = Math.min(start + pageSize - 1, total)
+    stats = `${start} - ${end} of ${total} ${plural}`
+  } else {
+    if (total > 1 && plural) {
+      stats = `${total} ${plural}`
+    } else if (total === 1 && singular) {
+      stats = `${total} ${singular}`
+    }
+  }
+  return { stats }
+}
+
+const PAGE_SIZES = [10, 25, 50, 100]
+
+function snapValueToNextAvailable(input: number, range = PAGE_SIZES) {
+  return range.find(value => input <= value) ?? range[range.length - 1]
+}
+
+export function snapValueToClosest(input: number, range = PAGE_SIZES) {
+  return range.reduce((prev, curr) =>
+    Math.abs(curr - input) < Math.abs(prev - input) ? curr : prev
+  )
+}

--- a/packages/core/src/fields/types/relationship/views/ContextualActions.tsx
+++ b/packages/core/src/fields/types/relationship/views/ContextualActions.tsx
@@ -97,7 +97,7 @@ function ContextualActionsMenu(props: RelationshipProps) {
   )
 }
 
-function useRelatedItemLabel(field: RelationshipController) {
+export function useRelatedItemLabel(field: RelationshipController) {
   const foreignList = useList(field.refListKey)
   if (field.many) {
     return `View related ${foreignList.plural.toLocaleLowerCase()}`
@@ -105,7 +105,10 @@ function useRelatedItemLabel(field: RelationshipController) {
   return `View ${foreignList.singular.toLocaleLowerCase()}`
 }
 
-function useRelatedItemHref({ field, value }: FieldProps<() => RelationshipController>) {
+export function useRelatedItemHref({
+  field,
+  value,
+}: Pick<FieldProps<() => RelationshipController>, 'field' | 'value'>) {
   const foreignList = useList(field.refListKey)
   if (value.kind === 'one') {
     if (!value.value) return null

--- a/packages/core/src/fields/types/relationship/views/RelationshipTable.tsx
+++ b/packages/core/src/fields/types/relationship/views/RelationshipTable.tsx
@@ -1,0 +1,180 @@
+import React, { useMemo } from 'react'
+import type { SortDescriptor } from '@keystar/ui/table'
+import { Cell, Column, Row, TableBody, TableHeader, TableView } from '@keystar/ui/table'
+import { Field as KeystarField } from '@keystar/ui/field'
+import { useList } from '../../../../admin-ui/context'
+import type { controller } from '.'
+import { textSelectIcon } from '@keystar/ui/icon/icons/textSelectIcon'
+import { EmptyState } from '../../../../admin-ui/components/EmptyState'
+import { gql, useQuery } from '../../../../admin-ui/apollo'
+import { Text } from '@keystar/ui/typography'
+import { GraphQLErrorNotice } from '../../../../admin-ui/components'
+import { PaginationControls } from '../../../../___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/PaginationControls'
+import type { CountRelationshipValue } from './types'
+import { useRelatedItemHref, useRelatedItemLabel } from './ContextualActions'
+import { ActionButton } from '@keystar/ui/button'
+import { Icon } from '@keystar/ui/icon'
+import { arrowUpRightIcon } from '@keystar/ui/icon/icons/arrowUpRightIcon'
+import { TooltipTrigger, Tooltip } from '@keystar/ui/tooltip'
+import { ProgressCircle } from '@keystar/ui/progress'
+
+export function RelationshipTable({
+  field,
+  value,
+}: {
+  field: ReturnType<typeof controller>
+  value: CountRelationshipValue
+}) {
+  if (!field.refFieldKey) {
+    throw new Error('refFieldKey is required for displayMode: table')
+  }
+  const [currentPage, setCurrentPage] = React.useState(1)
+  const [pageSize, setPageSize] = React.useState(50)
+  const list = useList(field.refListKey)
+  const hasManyOnRefList: boolean = (list.fields[field.refFieldKey].controller as any).many
+
+  const selectedFields = field.columns ?? list.initialColumns
+  const columns = useMemo(() => {
+    return selectedFields.map(path => {
+      const field = list.fields[path]
+      return {
+        id: path,
+        label: field.label,
+        allowsSorting: field.isOrderable,
+      }
+    })
+  }, [selectedFields, list])
+
+  const [sort, setSort] = React.useState<SortDescriptor>(() => {
+    if (field.initialSort) {
+      return {
+        column: field.initialSort.field,
+        direction: field.initialSort.direction === 'ASC' ? 'ascending' : 'descending',
+      }
+    }
+    return { column: 'id', direction: 'ascending' }
+  })
+
+  const { data, error, loading } = useQuery(
+    useMemo(() => {
+      const selectedGqlFields = [...selectedFields]
+        .map(fieldPath => list.fields[fieldPath].controller.graphqlSelection)
+        .join('\n')
+
+      // TODO: FIXME: this is bad
+      return gql`
+          query (
+            $where: ${list.graphql.names.whereInputName},
+            $take: Int!,
+            $skip: Int!,
+            $orderBy: [${list.graphql.names.listOrderName}!]
+          ) {
+            items: ${list.graphql.names.listQueryName}(
+              where: $where,
+              take: $take,
+              skip: $skip,
+              orderBy: $orderBy
+            ) {
+              ${selectedFields.includes('id') ? '' : 'id'}
+              ${selectedGqlFields}
+            }
+          }
+        `
+    }, [list, selectedFields]),
+    {
+      fetchPolicy: 'cache-and-network',
+      errorPolicy: 'all',
+      variables: {
+        where: {
+          [field.refFieldKey]: hasManyOnRefList
+            ? { some: { id: { equals: value.id } } }
+            : { id: { equals: value.id } },
+        },
+        take: pageSize,
+        skip: (currentPage - 1) * pageSize,
+        orderBy: [{ [sort.column]: sort.direction === 'ascending' ? 'asc' : 'desc' }],
+      },
+    }
+  )
+  const relatedItemLabel = useRelatedItemLabel(field)
+  const relatedItemHref = useRelatedItemHref({ field, value })
+  const items: Record<string, unknown>[] = data?.items ?? []
+  return (
+    <KeystarField label={field.label} description={field.description}>
+      {inputProps => (
+        <>
+          <TableView
+            {...inputProps}
+            selectionMode="none"
+            onSortChange={sort => setSort(sort)}
+            sortDescriptor={sort}
+            density="compact"
+            UNSAFE_style={{ minHeight: 29 * 10, maxHeight: 29 * 10 }}
+            overflowMode="truncate"
+            renderEmptyState={() =>
+              loading ? (
+                <ProgressCircle isIndeterminate />
+              ) : error ? (
+                <GraphQLErrorNotice errors={[error.networkError, ...(error.graphQLErrors ?? [])]} />
+              ) : (
+                <EmptyState
+                  icon={textSelectIcon}
+                  title="Empty related items"
+                  message="There are no related items."
+                />
+              )
+            }
+            flex
+          >
+            <TableHeader columns={columns}>
+              {({ label, id, ...options }) => (
+                <Column key={id} isRowHeader {...options}>
+                  {label}
+                </Column>
+              )}
+            </TableHeader>
+            <TableBody items={items}>
+              {row => {
+                return (
+                  <Row href={`/${list.path}/${row?.id}`}>
+                    {key => {
+                      const field = list.fields[key]
+                      const value = row[key]
+                      const CellContent = field.views.Cell
+                      return (
+                        <Cell>
+                          {CellContent ? (
+                            <CellContent value={value} field={field.controller} item={row} />
+                          ) : (
+                            <Text>{value?.toString()}</Text>
+                          )}
+                        </Cell>
+                      )
+                    }}
+                  </Row>
+                )
+              }}
+            </TableBody>
+          </TableView>
+          <PaginationControls
+            currentPage={currentPage}
+            pageSize={pageSize}
+            plural={list.plural}
+            singular={list.singular}
+            total={value.count}
+            onChangePage={page => setCurrentPage(page)}
+            onChangePageSize={size => setPageSize(size)}
+            extraActions={
+              <TooltipTrigger>
+                <ActionButton href={relatedItemHref!}>
+                  <Icon src={arrowUpRightIcon} />
+                </ActionButton>
+                <Tooltip>{relatedItemLabel}</Tooltip>
+              </TooltipTrigger>
+            }
+          />
+        </>
+      )}
+    </KeystarField>
+  )
+}

--- a/packages/core/src/fields/types/relationship/views/types.ts
+++ b/packages/core/src/fields/types/relationship/views/types.ts
@@ -23,7 +23,7 @@ export type ManyRelationshipValue = {
 
 export type CountRelationshipValue = {
   kind: 'count'
-  id: null | string
+  id: string
   count: number
 }
 
@@ -31,7 +31,7 @@ export type RelationshipController = FieldController<
   ManyRelationshipValue | SingleRelationshipValue | CountRelationshipValue,
   string[] | (string | null) // | number // TODO: count
 > & {
-  display: 'select' | 'count'
+  display: 'select' | 'count' | 'table'
   listKey: string
   refListKey: string
   refFieldKey?: string
@@ -39,4 +39,6 @@ export type RelationshipController = FieldController<
   refSearchFields: string[]
   hideCreate: boolean
   many: boolean
+  columns: string[] | null
+  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null
 }


### PR DESCRIPTION
This is intentionally narrowly scoped for now to make it straightforward to design and implement, it might do more in the future:
- The relationship must be two-sided (i.e. `ref: 'List.fieldKey'`)
- Editing is not supported, `itemView.fieldMode: 'read'` must be set
- The only customisation is `columns` and `initialSort` (defaulted from the related list's `initialColumns` and `initialSort` respectively), the height of the table is fixed

https://github.com/user-attachments/assets/e6fbe803-e8a9-40af-a0b7-91522f1f1ea1

