### PR TITLE
Fix cache hint application for findOne queries

### DIFF
--- a/.changeset/seven-windows-itch.md
+++ b/.changeset/seven-windows-itch.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Add more specific types to `cacheHint` and respect `cacheHint` on `findOne` queries.

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -127,7 +127,7 @@ export type InitialisedList = {
   }
 
   isSingleton: boolean
-  cacheHint: ((args: CacheHintArgs) => CacheHint) | undefined
+  cacheHint: ((args: CacheHintArgs<BaseListTypeInfo>) => CacheHint) | undefined
 }
 
 function throwIfNotAFilter(x: unknown, listKey: string, fieldKey: string) {

--- a/packages/core/src/lib/core/queries/index.ts
+++ b/packages/core/src/lib/core/queries/index.ts
@@ -13,8 +13,8 @@ export function getQueriesForList(list: InitialisedList) {
         defaultValue: list.isSingleton ? { id: '1' } : undefined,
       }),
     },
-    async resolve(_rootVal, args, context) {
-      return queries.findOne(args, list, context)
+    async resolve(_rootVal, args, context, info) {
+      return queries.findOne(args, list, context, info)
     },
   })
 

--- a/packages/core/src/lib/core/queries/resolvers.ts
+++ b/packages/core/src/lib/core/queries/resolvers.ts
@@ -105,7 +105,7 @@ export async function findOne(
   if (list.cacheHint) {
     maybeCacheControlFromInfo(info)?.setCacheHint(
       list.cacheHint({
-        results: result,
+        results: result ? [result] : [],
         operationName: info.operation.name?.value,
         meta: false,
       })
@@ -249,7 +249,7 @@ export async function count(
         results: count,
         operationName: info.operation.name?.value,
         meta: true,
-      }) as any
+      })
     )
   }
   return count

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -25,7 +25,7 @@ export type ListConfig<ListTypeInfo extends BaseListTypeInfo> = {
    */
   hooks?: ListHooks<ListTypeInfo>
 
-  graphql?: ListGraphQLConfig
+  graphql?: ListGraphQLConfig<ListTypeInfo>
 
   db?: ListDBConfig
 
@@ -189,7 +189,7 @@ export type MaybeItemFunction<T, ListTypeInfo extends BaseListTypeInfo> =
       item: ListTypeInfo['item'] | null
     }) => MaybePromise<T>)
 
-export type ListGraphQLConfig = {
+export type ListGraphQLConfig<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * The description added to the GraphQL schema
    * @default listConfig.description
@@ -204,7 +204,7 @@ export type ListGraphQLConfig = {
    * The maximum value for the take parameter when querying this list
    */
   maxTake?: number
-  cacheHint?: ((args: CacheHintArgs) => CacheHint) | CacheHint
+  cacheHint?: ((args: CacheHintArgs<ListTypeInfo>) => CacheHint) | CacheHint
   // Setting any of these values will remove the corresponding operations from the GraphQL schema.
   // Queries:
   //   'query':  Does item()/items() exist?
@@ -226,7 +226,17 @@ export type ListGraphQLConfig = {
       }
 }
 
-export type CacheHintArgs = { results: any; operationName?: string; meta: boolean }
+export type CacheHintArgs<ListTypeInfo extends BaseListTypeInfo> =
+  | {
+      results: ListTypeInfo['item'][]
+      operationName?: string
+      meta: false
+    }
+  | {
+      results: number
+      operationName?: string
+      meta: true
+    }
 
 // TODO: duplicate, merge with next-fields?
 export type IdFieldConfig =


### PR DESCRIPTION
## Problem
When using list-level cacheHint with findOne queries that contain nested findMany queries, the cache hint does not apply correctly. This happens because the findOne resolver doesn't receive or apply the GraphQLResolveInfo parameter needed for cache hint application.

## Solution
This PR adds cache hint application to the findOne resolver, similar to how it's already implemented in the findMany and count resolvers:

1. Updated the findOne resolver in resolvers.ts to accept the GraphQLResolveInfo parameter
2. Added cache hint application logic to the findOne resolver
3. Updated the findOne field definition in index.ts to pass the info parameter to the resolver

## Testing
Verified that with these changes, a query like:
```graphql
query {
  user(where: { id: "22fc8814-3845-4287-bbbe-34cb65ecebb6" }) {
    name
    posts(where: { category: { equals: "Category_1" } }) {
      title
      body
    }
  }
}
```
Now correctly applies the cache hint from the User list configuration instead of defaulting to "no-cache".

## Related Issues
Fixes #9434 