### PR TITLE
Require itemView.fieldMode: 'read' when displayMode: 'count' is set on relationship fields

### DIFF
--- a/.changeset/ready-laws-refuse.md
+++ b/.changeset/ready-laws-refuse.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": major
+---
+
+`displayMode: 'count'` on relationship fields now requires `itemView.fieldMode: 'read'` to be set.

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -30,6 +30,9 @@ type CountDisplayConfig = {
   ui?: {
     // Sets the relationship to display as a count
     displayMode: 'count'
+    itemView: {
+      fieldMode: 'read'
+    }
   }
 }
 
@@ -144,6 +147,11 @@ export function relationship<ListTypeInfo extends BaseListTypeInfo>({
         }
 
         if (config.ui?.displayMode === 'count') {
+          if (config.ui.itemView?.fieldMode !== 'read') {
+            throw new Error(
+              `displayMode: 'count' on relationship fields requires itemView.fieldMode to be 'read' but ${listKey}.${fieldKey} does not have this set`
+            )
+          }
           return {
             displayMode: 'count',
             refListKey: foreignListKey,

--- a/packages/core/src/fields/types/relationship/views/ContextualActions.tsx
+++ b/packages/core/src/fields/types/relationship/views/ContextualActions.tsx
@@ -8,7 +8,7 @@ import { ActionMenu, Item } from '@keystar/ui/menu'
 import { Text } from '@keystar/ui/typography'
 
 import { useList } from '../../../../admin-ui/context'
-import type { FieldProps } from '../../../../types'
+import type { FieldProps, ListMeta } from '../../../../types'
 import type { RelationshipController } from './types'
 import { ActionButton } from '@keystar/ui/button'
 import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip'
@@ -118,13 +118,22 @@ export function useRelatedItemHref({
     return `/${foreignList.path}/${value.value.id}`
   }
   let query: string | undefined
-  if (field.refFieldKey) {
-    const foreignField = foreignList.fields[field.refFieldKey]
-    query = `!${field.refFieldKey}_${(foreignField.fieldMeta as any).many ? 'some' : 'is'}=${JSON.stringify(value.id)}`
+  if (field.refFieldKey && value.id !== null) {
+    query = buildQueryForRelationshipFieldWithForeignField(foreignList, field.refFieldKey, value.id)
   } else if (value.kind === 'many' && value.value.length > 0) {
     query = `!id_in=${JSON.stringify(value.value.map(x => x.id))}`
   }
   if (query === undefined) return null
 
   return `/${foreignList.path}?${query}`
+}
+
+export function buildQueryForRelationshipFieldWithForeignField(
+  foreignList: ListMeta,
+  refFieldKey: string,
+  localId: string
+) {
+  const foreignField = foreignList.fields[refFieldKey]
+  const foreignMany: boolean = (foreignField.fieldMeta as any).many
+  return `!${refFieldKey}_${foreignMany ? 'some' : 'is'}=${JSON.stringify(foreignMany ? [localId] : localId)}`
 }

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -2,7 +2,7 @@ import React, { Fragment, useState } from 'react'
 import { useListFormatter } from '@react-aria/i18n'
 
 import { DialogContainer } from '@keystar/ui/dialog'
-import { VStack } from '@keystar/ui/layout'
+import { HStack, VStack } from '@keystar/ui/layout'
 import { TextLink } from '@keystar/ui/link'
 import { TagGroup, Item } from '@keystar/ui/tag'
 import { TextField } from '@keystar/ui/text-field'
@@ -12,13 +12,19 @@ import type { CellComponent, FieldControllerConfig, FieldProps } from '../../../
 import { useList } from '../../../../admin-ui/context'
 import { BuildItemDialog } from '../../../../admin-ui/components'
 
-import { ContextualActions } from './ContextualActions'
+import {
+  buildQueryForRelationshipFieldWithForeignField,
+  ContextualActions,
+} from './ContextualActions'
 import { ComboboxMany } from './ComboboxMany'
 import { ComboboxSingle } from './ComboboxSingle'
 
 export { ComboboxSingle, ComboboxMany }
 import type { RelationshipController, RelationshipValue } from './types'
 import { RelationshipTable } from './RelationshipTable'
+import { Icon } from '@keystar/ui/icon'
+import { arrowUpRightIcon } from '@keystar/ui/icon/icons/arrowUpRightIcon'
+import { ActionButton } from '@keystar/ui/button'
 
 export function Field(props: FieldProps<typeof controller>) {
   const { autoFocus, field, onChange, value } = props
@@ -32,7 +38,7 @@ export function Field(props: FieldProps<typeof controller>) {
     if (field.display === 'table') {
       return <RelationshipTable field={field} value={value} />
     }
-    return (
+    const textField = (
       <TextField
         autoFocus={autoFocus}
         label={field.label}
@@ -41,6 +47,17 @@ export function Field(props: FieldProps<typeof controller>) {
         value={value.count.toString()}
         width="alias.singleLineWidth"
       />
+    )
+    if (!field.refFieldKey) return textField
+    return (
+      <HStack gap="small" alignItems="end">
+        {textField}
+        <ActionButton
+          href={`/${foreignList.path}?${buildQueryForRelationshipFieldWithForeignField(foreignList, field.refFieldKey, value.id)}`}
+        >
+          <Icon src={arrowUpRightIcon} />
+        </ActionButton>
+      </HStack>
     )
   }
 
@@ -167,7 +184,7 @@ function renderItem(item: { id: string; href: string; label: string }) {
 export const Cell: CellComponent<typeof controller> = ({ field, item }) => {
   const list = useList(field.refListKey)
 
-  if (field.display === 'count') {
+  if (field.display === 'count' || field.display === 'table') {
     const count = item[`${field.path}Count`] as number
     return count != null ? <Numeral value={count} abbreviate /> : null
   }


### PR DESCRIPTION
This aligns with `displayMode: 'table'` in #9523.

There's also some related fixes/improvements:
- `displayMode: 'count'` now shows the button to go to the related list filtered by items that relate to the item you're looking at (this is only shown for two-sided relationships since if the relationship is one-sided, we can't link to the list since we can't filter on the relationship from the other side and since we only have the count, we can't link to a filter by specific ids like we do in some other cases)
- The link to the list view filtered by the relationship was wrong when the other side had `many: true`, this fixes that (this is not specific to `displayMode: 'count'`