### PR TITLE
Bundle all modules not in node_modules in the `.keystone/config.js` build

### DIFF
--- a/.changeset/cruel-horses-train.md
+++ b/.changeset/cruel-horses-train.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add support for using TypeScript/etc. in modules imported via the `package.json` `imports` field along with packages in a monorepo without a seperate build step

--- a/examples/custom-session-next-auth/admin/pages/api/auth/[...nextauth].ts
+++ b/examples/custom-session-next-auth/admin/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,48 @@
-import NextAuth from 'next-auth'
+import NextAuth, { DefaultUser } from 'next-auth'
 import { nextAuthOptions } from '../../../../session'
+// WARNING: this is only needed for our monorepo examples, dont do this
+import * as Prisma from 'myprisma'
+// import * as Prisma from '@prisma/client' // <-- do this
+import { getContext } from '@keystone-6/core/context'
+import keystoneConfig from '../../../../keystone'
+import type { Context } from '.keystone/types'
 
-export default NextAuth(nextAuthOptions)
+let _keystoneContext: Context = (globalThis as any)._keystoneContext
+
+async function getKeystoneContext() {
+  if (_keystoneContext) return _keystoneContext
+
+  _keystoneContext = getContext(keystoneConfig, Prisma)
+  if (process.env.NODE_ENV !== 'production') {
+    ;(globalThis as any)._keystoneContext = _keystoneContext
+  }
+  return _keystoneContext
+}
+
+export default NextAuth({
+  ...nextAuthOptions,
+  callbacks: {
+    ...nextAuthOptions.callbacks,
+    async signIn({ user }: { user: DefaultUser }) {
+      // console.error('next-auth signIn', { user, account, profile });
+      const sudoContext = (await getKeystoneContext()).sudo()
+
+      // check if the user exists in keystone
+      const author = await sudoContext.query.Author.findOne({
+        where: { authId: user.id },
+      })
+
+      // if not, sign up
+      if (!author) {
+        await sudoContext.query.Author.createOne({
+          data: {
+            authId: user.id,
+            name: user.name,
+          },
+        })
+      }
+
+      return true // accept the signin
+    },
+  },
+})


### PR DESCRIPTION
This adds support for importing packages that use TypeScript/etc. in a monorepo without a seperate build step. Also, it notably also allows using the `package.json` `imports` field while allowing TypeScript/etc. so you can e.g. add this to your `package.json` and import `something.ts` everywhere via `#something` rather than relative paths.

```json
{
  "imports": {
    "#something": "./something.ts"
   }
}
```