### PR TITLE
Remove usage of bindGraphQLSchemaAPIToContext in admin meta

### DIFF
--- a/packages/core/src/lib/resolve-admin-meta.ts
+++ b/packages/core/src/lib/resolve-admin-meta.ts
@@ -1,18 +1,13 @@
-import type { BaseItem, KeystoneContext as Context } from '../types'
+import type { BaseItem } from '../types'
 import type { GraphQLNames } from '../types/utils'
 import { QueryMode } from '../types'
-import { g as graphqlBoundToKeystoneContext } from '../types/schema'
+import { g } from '../types/schema'
 import type {
   AdminMetaSource,
   FieldGroupMetaSource,
   FieldMetaSource,
   ListMetaSource,
 } from './create-admin-meta'
-
-const g = {
-  ...graphqlBoundToKeystoneContext,
-  ...graphqlBoundToKeystoneContext.bindGraphQLSchemaAPIToContext<Context>(),
-}
 
 const KeystoneAdminUIFieldMeta = g.object<FieldMetaSource>()({
   name: 'KeystoneAdminUIFieldMeta',


### PR DESCRIPTION
This was only here because there used to be a different context value that could be passed to the admin meta types but that was removed in #9253

(This is another thing to make the diff in #9535 smaller)