### PR TITLE
Remove imports that should be using `g.`

### DIFF
--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -17,7 +17,6 @@ import { QueryMode } from '../../types'
 import { type GraphQLNames, __getNames } from '../../types/utils'
 import { g } from '../..'
 import type { FieldHooks, ResolvedListHooks, ResolvedFieldHooks } from '../../types/config/hooks'
-import { Empty } from '../../types/schema/graphql-ts-schema'
 import type { MaybeItemFunction, MaybeSessionFunction } from '../../types/config/lists'
 import {
   type ResolvedFieldAccessControl,
@@ -865,12 +864,12 @@ export function initialiseLists(config: KeystoneConfig): Record<string, Initiali
     }
 
     if (!hasAnEnabledCreateField) {
-      list.graphql.types.create = Empty
+      list.graphql.types.create = g.Empty
       list.graphql.names.createInputName = 'Empty'
     }
 
     if (!hasAnEnabledUpdateField) {
-      list.graphql.types.update = Empty
+      list.graphql.types.update = g.Empty
       list.graphql.names.updateInputName = 'Empty'
     }
   }

--- a/packages/core/src/lib/core/mutations/index.ts
+++ b/packages/core/src/lib/core/mutations/index.ts
@@ -1,5 +1,4 @@
 import { type BaseItem, type KeystoneContext } from '../../../types'
-import { Empty } from '../../../types/schema/graphql-ts-schema'
 import { type UniquePrismaFilter } from '../../../types/prisma'
 import { g } from '../../../types/schema'
 import { type ResolvedDBField } from '../resolve-relationships'
@@ -558,7 +557,7 @@ function promisesButSettledWhenAllSettledAndInOrder<T extends Promise<unknown>[]
 }
 
 function nonNull<T extends g.NullableInputType>(t: T) {
-  if (t === Empty) return t
+  if (t === g.Empty) return t
   return g.nonNull(t)
 }
 


### PR DESCRIPTION
Another thing to make https://github.com/keystonejs/keystone/pull/9535 smaller