### PR TITLE
Remove @types/bcryptjs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -292,7 +292,6 @@
   "devDependencies": {
     "@keystone-6/core": "workspace:^",
     "@types/apollo-upload-client": "17.0.5",
-    "@types/bcryptjs": "^3.0.0",
     "@types/body-parser": "^1.19.2",
     "@types/bytes": "^3.1.1",
     "@types/cookie": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1865,9 +1865,6 @@ importers:
       '@types/apollo-upload-client':
         specifier: 17.0.5
         version: 17.0.5(@types/react@19.0.10)(graphql-ws@6.0.4(graphql@16.10.0)(ws@8.18.1))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@types/bcryptjs':
-        specifier: ^3.0.0
-        version: 3.0.0
       '@types/body-parser':
         specifier: ^1.19.2
         version: 1.19.5
@@ -6024,10 +6021,6 @@ packages:
 
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
-
-  '@types/bcryptjs@3.0.0':
-    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
-    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -17825,10 +17818,6 @@ snapshots:
   '@types/babel__traverse@7.20.6':
     dependencies:
       '@babel/types': 7.26.10
-
-  '@types/bcryptjs@3.0.0':
-    dependencies:
-      bcryptjs: 3.0.2
 
   '@types/body-parser@1.19.5':
     dependencies:


### PR DESCRIPTION
`bcryptjs` has built-in types now and the version of @types/bcryptjs updated to in #9549 is just an empty stub: https://unpkg.com/browse/@types/bcryptjs@3.0.0/README.md