### PR TITLE
Fix `initFirstItem` fields not applying on InitPage

### DIFF
--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -20,12 +20,10 @@ function InitPage({
   authGqlNames,
   listKey,
   fieldPaths,
-  enableWelcome,
 }: {
   authGqlNames: AuthGqlNames
   listKey: string
   fieldPaths: string[]
-  enableWelcome: boolean
 }) {
   const router = useRouter()
   const redirect = useRedirect()

--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -29,7 +29,7 @@ function InitPage({
   const redirect = useRedirect()
   const list = useList(listKey)
 
-  const builder = useBuildItem(list)
+  const builder = useBuildItem(list, fieldPaths)
   const {
     createInitialItem,
     CreateInitialInput,

--- a/packages/core/src/admin-ui/utils/useCreateItem.ts
+++ b/packages/core/src/admin-ui/utils/useCreateItem.ts
@@ -121,7 +121,9 @@ type BuildItemHookResult = {
 export function useBuildItem(list: ListMeta, fieldKeys?: string[] = []): BuildItemHookResult {
   const [forceValidation, setForceValidation] = useState(false)
   const [value, setValue] = useState(() => makeDefaultValueState(list.fields))
-  const fields = fieldKeys.length ? Object.fromEntries(Object.entries(list.fields).filter(([key]) => fieldKeys.includes(key))) : list.fields
+  const fields = fieldKeys.length
+    ? Object.fromEntries(Object.entries(list.fields).filter(([key]) => fieldKeys.includes(key)))
+    : list.fields
   const invalidFields = useInvalidFields(list.fields, value)
 
   return {

--- a/packages/core/src/admin-ui/utils/useCreateItem.ts
+++ b/packages/core/src/admin-ui/utils/useCreateItem.ts
@@ -118,7 +118,7 @@ type BuildItemHookResult = {
   build: () => Promise<Record<string, unknown> | undefined>
 }
 
-export function useBuildItem(list: ListMeta, fieldKeys?: string[] = []): BuildItemHookResult {
+export function useBuildItem(list: ListMeta, fieldKeys: string[] = []): BuildItemHookResult {
   const [forceValidation, setForceValidation] = useState(false)
   const [value, setValue] = useState(() => makeDefaultValueState(list.fields))
   const fields = fieldKeys.length

--- a/packages/core/src/admin-ui/utils/useCreateItem.ts
+++ b/packages/core/src/admin-ui/utils/useCreateItem.ts
@@ -118,9 +118,10 @@ type BuildItemHookResult = {
   build: () => Promise<Record<string, unknown> | undefined>
 }
 
-export function useBuildItem(list: ListMeta): BuildItemHookResult {
+export function useBuildItem(list: ListMeta, fieldKeys: string[] = []): BuildItemHookResult {
   const [forceValidation, setForceValidation] = useState(false)
   const [value, setValue] = useState(() => makeDefaultValueState(list.fields))
+  const fields = fieldKeys.length ? Object.fromEntries(Object.entries(list.fields).filter(([key]) => fieldKeys.includes(key))) : list.fields
   const invalidFields = useInvalidFields(list.fields, value)
 
   return {
@@ -128,7 +129,7 @@ export function useBuildItem(list: ListMeta): BuildItemHookResult {
     props: {
       view: 'createView',
       position: 'form',
-      fields: list.fields,
+      fields,
       groups: list.groups,
       forceValidation,
       invalidFields,

--- a/packages/core/src/admin-ui/utils/useCreateItem.ts
+++ b/packages/core/src/admin-ui/utils/useCreateItem.ts
@@ -118,7 +118,7 @@ type BuildItemHookResult = {
   build: () => Promise<Record<string, unknown> | undefined>
 }
 
-export function useBuildItem(list: ListMeta, fieldKeys: string[] = []): BuildItemHookResult {
+export function useBuildItem(list: ListMeta, fieldKeys?: string[] = []): BuildItemHookResult {
   const [forceValidation, setForceValidation] = useState(false)
   const [value, setValue] = useState(() => makeDefaultValueState(list.fields))
   const fields = fieldKeys.length ? Object.fromEntries(Object.entries(list.fields).filter(([key]) => fieldKeys.includes(key))) : list.fields


### PR DESCRIPTION
No changeset required, as this hasn't been publicly released