### PR TITLE
Set `Session` type via module augmentation

### DIFF
--- a/.changeset/old-buttons-wave.md
+++ b/.changeset/old-buttons-wave.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Adds support for setting the `Session` type with `declare module "./generated/keystone/types" { interface Session {} }`. The existing session type parameter still exists though will be removed in a future major version.

--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -131,11 +131,14 @@ type ResolvedPostUpdateInput = {
   publishDate?: import('./generated/custom-prisma/client.js').Prisma.PostUpdateInput['publishDate']
 }
 
+export interface Session {}
+type __Session = keyof Session extends never ? any : Session
+
 export declare namespace Lists {
-  export type Post<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Post.TypeInfo<Session>>
+  export type Post<Session = __Session> = import('@keystone-6/core/types').ListConfig<Lists.Post.TypeInfo<Session>>
   namespace Post {
     export type Item = import('./generated/custom-prisma/client.js').Post
-    export type TypeInfo<Session = any> = {
+    export type TypeInfo<Session = __Session> = {
       key: 'Post'
       isSingleton: false
       fields: 'id' | 'title' | 'content' | 'publishDate'
@@ -156,10 +159,10 @@ export declare namespace Lists {
     }
   }
 }
-export type Context<Session = any> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
-export type Config<Session = any> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
+export type Context<Session = __Session> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
+export type Config<Session = __Session> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
 
-export type TypeInfo<Session = any> = {
+export type TypeInfo<Session = __Session> = {
   lists: {
     readonly Post: Lists.Post.TypeInfo<Session>
   }
@@ -169,9 +172,9 @@ export type TypeInfo<Session = any> = {
   dbProvider: 'sqlite'
 }
 
-type __TypeInfo<Session = any> = TypeInfo<Session>
+type __TypeInfo<Session = __Session> = TypeInfo<Session>
 
-export type Lists<Session = any> = {
+export type Lists<Session = __Session> = {
   [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core/types').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core/types').ListConfig<any>>
 

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -226,11 +226,14 @@ type ResolvedAuthorUpdateInput = {
   posts?: import('./generated/prisma/client.js').Prisma.AuthorUpdateInput['posts']
 }
 
+export interface Session {}
+type __Session = keyof Session extends never ? any : Session
+
 export declare namespace Lists {
-  export type Post<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Post.TypeInfo<Session>>
+  export type Post<Session = __Session> = import('@keystone-6/core/types').ListConfig<Lists.Post.TypeInfo<Session>>
   namespace Post {
     export type Item = import('./generated/prisma/client.js').Post
-    export type TypeInfo<Session = any> = {
+    export type TypeInfo<Session = __Session> = {
       key: 'Post'
       isSingleton: false
       fields: 'id' | 'title' | 'status' | 'content' | 'publishDate' | 'author'
@@ -250,10 +253,10 @@ export declare namespace Lists {
       all: __TypeInfo<Session>
     }
   }
-  export type Author<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Author.TypeInfo<Session>>
+  export type Author<Session = __Session> = import('@keystone-6/core/types').ListConfig<Lists.Author.TypeInfo<Session>>
   namespace Author {
     export type Item = import('./generated/prisma/client.js').Author
-    export type TypeInfo<Session = any> = {
+    export type TypeInfo<Session = __Session> = {
       key: 'Author'
       isSingleton: false
       fields: 'id' | 'name' | 'posts'
@@ -274,10 +277,10 @@ export declare namespace Lists {
     }
   }
 }
-export type Context<Session = any> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
-export type Config<Session = any> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
+export type Context<Session = __Session> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
+export type Config<Session = __Session> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
 
-export type TypeInfo<Session = any> = {
+export type TypeInfo<Session = __Session> = {
   lists: {
     readonly Post: Lists.Post.TypeInfo<Session>
     readonly Author: Lists.Author.TypeInfo<Session>
@@ -288,9 +291,9 @@ export type TypeInfo<Session = any> = {
   dbProvider: 'sqlite'
 }
 
-type __TypeInfo<Session = any> = TypeInfo<Session>
+type __TypeInfo<Session = __Session> = TypeInfo<Session>
 
-export type Lists<Session = any> = {
+export type Lists<Session = __Session> = {
   [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core/types').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core/types').ListConfig<any>>
 

--- a/packages/core/src/lib/typescript-schema-printer.ts
+++ b/packages/core/src/lib/typescript-schema-printer.ts
@@ -159,6 +159,9 @@ export function printGeneratedTypes(
       }
     })(),
     '',
+    'export interface Session {}',
+    'type __Session = keyof Session extends never ? any : Session',
+    '',
     'export declare namespace Lists {',
     ...(function* () {
       for (const [listKey, list] of Object.entries(lists)) {
@@ -166,10 +169,10 @@ export function printGeneratedTypes(
         const listTypeInfoName = `Lists.${listKey}.TypeInfo`
 
         yield [
-          `export type ${listKey}<Session = any> = import('@keystone-6/core/types').ListConfig<${listTypeInfoName}<Session>>`,
+          `export type ${listKey}<Session = __Session> = import('@keystone-6/core/types').ListConfig<${listTypeInfoName}<Session>>`,
           `namespace ${listKey} {`,
           `  export type Item = import('${prismaClientPath}').${listKey}`,
-          `  export type TypeInfo<Session = any> = {`,
+          `  export type TypeInfo<Session = __Session> = {`,
           `    key: '${listKey}'`,
           `    isSingleton: ${list.isSingleton}`,
           `    fields: ${Object.keys(list.fields)
@@ -201,10 +204,10 @@ export function printGeneratedTypes(
       }
     })(),
     '}',
-    `export type Context<Session = any> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>`,
-    `export type Config<Session = any> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>`,
+    `export type Context<Session = __Session> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>`,
+    `export type Config<Session = __Session> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>`,
     '',
-    'export type TypeInfo<Session = any> = {',
+    'export type TypeInfo<Session = __Session> = {',
     `  lists: {`,
     ...(function* () {
       for (const listKey in lists) {
@@ -219,9 +222,9 @@ export function printGeneratedTypes(
     `}`,
     ``,
     // we need to reference the `TypeInfo` above in another type that is also called `TypeInfo`
-    `type __TypeInfo<Session = any> = TypeInfo<Session>`,
+    `type __TypeInfo<Session = __Session> = TypeInfo<Session>`,
     ``,
-    `export type Lists<Session = any> = {`,
+    `export type Lists<Session = __Session> = {`,
     `  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core/types').ListConfig<TypeInfo<Session>['lists'][Key]>`,
     `} & Record<string, import('@keystone-6/core/types').ListConfig<any>>`,
     ``,

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -112,11 +112,14 @@ type ResolvedTodoUpdateInput = {
   title?: import('../prisma/client.js').Prisma.TodoUpdateInput['title']
 }
 
+export interface Session {}
+type __Session = keyof Session extends never ? any : Session
+
 export declare namespace Lists {
-  export type Todo<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Todo.TypeInfo<Session>>
+  export type Todo<Session = __Session> = import('@keystone-6/core/types').ListConfig<Lists.Todo.TypeInfo<Session>>
   namespace Todo {
     export type Item = import('../prisma/client.js').Todo
-    export type TypeInfo<Session = any> = {
+    export type TypeInfo<Session = __Session> = {
       key: 'Todo'
       isSingleton: false
       fields: 'id' | 'title'
@@ -137,10 +140,10 @@ export declare namespace Lists {
     }
   }
 }
-export type Context<Session = any> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
-export type Config<Session = any> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
+export type Context<Session = __Session> = import('@keystone-6/core/types').KeystoneContext<TypeInfo<Session>>
+export type Config<Session = __Session> = import('@keystone-6/core/types').KeystoneConfig<TypeInfo<Session>>
 
-export type TypeInfo<Session = any> = {
+export type TypeInfo<Session = __Session> = {
   lists: {
     readonly Todo: Lists.Todo.TypeInfo<Session>
   }
@@ -150,9 +153,9 @@ export type TypeInfo<Session = any> = {
   dbProvider: 'sqlite'
 }
 
-type __TypeInfo<Session = any> = TypeInfo<Session>
+type __TypeInfo<Session = __Session> = TypeInfo<Session>
 
-export type Lists<Session = any> = {
+export type Lists<Session = __Session> = {
   [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core/types').ListConfig<TypeInfo<Session>['lists'][Key]>
 } & Record<string, import('@keystone-6/core/types').ListConfig<any>>
 


### PR DESCRIPTION
The `Session` type parameter currently needs to be provided in a number places in `.keystone/types` currently which is confusing and easy to mess up since you have to remember to include the `Session` type in every place and if you forget you won't get an error, the `Session` type will just be `any`. This PR should be more straightforward since it only needs to be set once with module augmentation like this: 

```ts
declare module "./generated/keystone/types" {
  interface Session {
    something: string
  }
}
```

Note this is using module augmentation on the generated types rather than augmenting types in Keystone itself, this means that if you have multiple Keystone projects in the same TypeScript compilation, they won't interfere since the module augmentation only effects the specific generated types for each Keystone project.

To avoid a breaking change, instead of removing the current type parameter to TypeInfo and etc. this just makes the default:

```ts
type __Session = keyof Session extends never ? any : Session
```

So if you define properties on `Session` that's what you get, otherwise you get the current behaviour.

See the next PR in this stack for usages of this in examples.