### PR TITLE
Fix multiple filter values for the same property and pass them as an AND query to GraphQL

### DIFF
--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
@@ -30,16 +30,13 @@ export function useFilters(list: ListMeta) {
     const filters: Filter[] = []
     for (const key in query) {
       const filter = possibleFilters[key]
+      if (!filter) continue
       const val = query[key]
-      if (filter && typeof val === 'string') {
-        let value
-        try {
-          value = JSON.parse(val)
-        } catch (err) {}
-        if (val !== undefined) {
-          filters.push({ ...filter, value })
-        }
-      }
+      if (typeof val !== 'string') continue
+      try {
+        const value = JSON.parse(val)
+        filters.push({ ...filter, value })
+      } catch (err) {}
     }
 
     const where = filters.reduce<{ AND: Array<Record<string, string>> }>(

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
@@ -42,15 +42,18 @@ export function useFilters(list: ListMeta) {
       }
     }
 
-    const where = filters.reduce<{AND: Array<Record<string, string>>}>((acc, filter) => {
-      acc.AND.push(
-        list.fields[filter.field].controller.filter!.graphql({
-          type: filter.type,
-          value: filter.value,
-        })
-      )
-      return acc;
-    }, {AND: []})
+    const where = filters.reduce<{ AND: Array<Record<string, string>> }>(
+      (acc, filter) => {
+        acc.AND.push(
+          list.fields[filter.field].controller.filter!.graphql({
+            type: filter.type,
+            value: filter.value,
+          })
+        )
+        return acc
+      },
+      { AND: [] }
+    )
 
     if (list.isSingleton) return { filters, where: { id: { equals: 1 }, AND: [where] } }
     return { filters, where }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
@@ -55,7 +55,6 @@ export function useFilters(list: ListMeta) {
       { AND: [] }
     )
 
-    if (list.isSingleton) return { filters, where: { id: { equals: 1 }, AND: [where] } }
     return { filters, where }
   }, [query, possibleFilters, list])
   return filters

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useFilters.tsx
@@ -42,15 +42,16 @@ export function useFilters(list: ListMeta) {
       }
     }
 
-    const where = filters.reduce((_where, filter) => {
-      return Object.assign(
-        _where,
+    const where = filters.reduce<{AND: Array<Record<string, string>>}>((acc, filter) => {
+      acc.AND.push(
         list.fields[filter.field].controller.filter!.graphql({
           type: filter.type,
           value: filter.value,
         })
       )
-    }, {})
+      return acc;
+    }, {AND: []})
+
     if (list.isSingleton) return { filters, where: { id: { equals: 1 }, AND: [where] } }
     return { filters, where }
   }, [query, possibleFilters, list])


### PR DESCRIPTION
The current implementation doesn't work with multiple filters for the same property. 
It's possible to add ">" and  "<"filters for the value on UI, but only the last filter is sent to the backend (see screenshots).
This PR is rough code that fixes the issue.

![image](https://github.com/user-attachments/assets/56f668a5-7f6f-4553-b8e3-4aa5a634b146)
*Notice that viewCount in DevTools has only one filter value*

![Screenshot From 2025-04-02 21-41-23](https://github.com/user-attachments/assets/aff9759e-d8f3-4ec1-aedb-672bea81b80d)
*After applying this PR changes*



