### PR TITLE
Refine field value types in field hooks

### DIFF
--- a/.changeset/add-itemfield-to-fieldmeta-functions.md
+++ b/.changeset/add-itemfield-to-fieldmeta-functions.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": minor
 ---
 
-Add `.itemField` and `.fieldKey` parameters to `{field}.ui.fieldMode` and `{field).ui.fieldPosition` functions
+Add `itemField` and `fieldKey` parameters to field `ui.fieldMode` and `ui.fieldPosition` functions

--- a/.changeset/add-itemfield-to-fieldmeta-functions.md
+++ b/.changeset/add-itemfield-to-fieldmeta-functions.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add `.itemField` and `.fieldKey` parameters to `{field}.ui.fieldMode` and `{field).ui.fieldPosition` functions

--- a/.changeset/add-itemfield-to-hooks.md
+++ b/.changeset/add-itemfield-to-hooks.md
@@ -1,5 +1,5 @@
 ---
-"@keystone-6/core": minor
+"@keystone-6/core": major
 ---
 
 Add `itemField`, `originalItemField`, `inputFieldData` and `resolvedFieldData` parameters to field hooks

--- a/.changeset/add-itemfield-to-hooks.md
+++ b/.changeset/add-itemfield-to-hooks.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add `itemField`, `inputFieldData` and `resolvedFieldData` parameters to field hooks

--- a/.changeset/add-itemfield-to-hooks.md
+++ b/.changeset/add-itemfield-to-hooks.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": minor
 ---
 
-Add `itemField`, `inputFieldData` and `resolvedFieldData` parameters to field hooks
+Add `itemField`, `originalItemField`, `inputFieldData` and `resolvedFieldData` parameters to field hooks

--- a/examples/custom-field/1-text-field/index.ts
+++ b/examples/custom-field/1-text-field/index.ts
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -7,7 +8,10 @@ import {
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 
-type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo> & {
+type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo // TODO
+> & {
   isIndexed?: boolean | 'unique'
 }
 

--- a/examples/custom-field/2-stars-field/index.ts
+++ b/examples/custom-field/2-stars-field/index.ts
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -12,7 +13,10 @@ import { g } from '@keystone-6/core'
 // and a different input in the Admin UI
 // https://github.com/keystonejs/keystone/tree/main/packages/core/src/fields/types/integer
 
-type StarsFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo> & {
+type StarsFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo // TODO
+> & {
   isIndexed?: boolean | 'unique'
   maxStars?: number
 }

--- a/examples/custom-field/3-pair-field-json/index.ts
+++ b/examples/custom-field/3-pair-field-json/index.ts
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -6,7 +7,10 @@ import {
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 
-type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo>
+type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo // TODO
+>
 
 type PairInput = {
   left: string | null | undefined

--- a/examples/custom-field/3-pair-field-nested/index.ts
+++ b/examples/custom-field/3-pair-field-nested/index.ts
@@ -1,5 +1,5 @@
 import {
-  BaseFieldTypeInfo,
+  type BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,

--- a/examples/custom-field/3-pair-field-nested/index.ts
+++ b/examples/custom-field/3-pair-field-nested/index.ts
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -6,7 +7,10 @@ import {
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 
-type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo>
+type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo // TODO
+>
 
 type PairInput = {
   left: string | null | undefined

--- a/examples/custom-field/3-pair-field/index.ts
+++ b/examples/custom-field/3-pair-field/index.ts
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -6,7 +7,10 @@ import {
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 
-type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo>
+type PairFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo // TODO
+>
 
 type PairInput = string
 type PairOutput = string

--- a/examples/custom-field/4-conditional-field/index.tsx
+++ b/examples/custom-field/4-conditional-field/index.tsx
@@ -1,4 +1,5 @@
 import {
+  BaseFieldTypeInfo,
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
@@ -7,7 +8,10 @@ import {
 } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 
-type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<ListTypeInfo> & {
+type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo
+> & {
   isIndexed?: boolean | 'unique'
   dependency: {
     field: string

--- a/examples/reuse/schema.graphql
+++ b/examples/reuse/schema.graphql
@@ -172,41 +172,6 @@ input OrderCreateInput {
   name: String
 }
 
-type Foo {
-  id: ID!
-  completed: Boolean
-}
-
-input FooWhereUniqueInput {
-  id: ID
-}
-
-input FooWhereInput {
-  AND: [FooWhereInput!]
-  OR: [FooWhereInput!]
-  NOT: [FooWhereInput!]
-  id: IDFilter
-  completed: BooleanFilter
-}
-
-input FooOrderByInput {
-  id: OrderDirection
-  completed: OrderDirection
-}
-
-input FooUpdateInput {
-  completed: Boolean
-}
-
-input FooUpdateArgs {
-  where: FooWhereUniqueInput!
-  data: FooUpdateInput!
-}
-
-input FooCreateInput {
-  completed: Boolean
-}
-
 type User {
   id: ID!
   name: String
@@ -242,6 +207,41 @@ input UserCreateInput {
   name: String
 }
 
+type Unused {
+  id: ID!
+  completed: Boolean
+}
+
+input UnusedWhereUniqueInput {
+  id: ID
+}
+
+input UnusedWhereInput {
+  AND: [UnusedWhereInput!]
+  OR: [UnusedWhereInput!]
+  NOT: [UnusedWhereInput!]
+  id: IDFilter
+  completed: BooleanFilter
+}
+
+input UnusedOrderByInput {
+  id: OrderDirection
+  completed: OrderDirection
+}
+
+input UnusedUpdateInput {
+  completed: Boolean
+}
+
+input UnusedUpdateArgs {
+  where: UnusedWhereUniqueInput!
+  data: UnusedUpdateInput!
+}
+
+input UnusedCreateInput {
+  completed: Boolean
+}
+
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
@@ -260,18 +260,18 @@ type Mutation {
   updateOrders(data: [OrderUpdateArgs!]!): [Order]
   deleteOrder(where: OrderWhereUniqueInput!): Order
   deleteOrders(where: [OrderWhereUniqueInput!]!): [Order]
-  createFoo(data: FooCreateInput!): Foo
-  createFoos(data: [FooCreateInput!]!): [Foo]
-  updateFoo(where: FooWhereUniqueInput!, data: FooUpdateInput!): Foo
-  updateFoos(data: [FooUpdateArgs!]!): [Foo]
-  deleteFoo(where: FooWhereUniqueInput!): Foo
-  deleteFoos(where: [FooWhereUniqueInput!]!): [Foo]
   createUser(data: UserCreateInput!): User
   createUsers(data: [UserCreateInput!]!): [User]
   updateUser(where: UserWhereUniqueInput!, data: UserUpdateInput!): User
   updateUsers(data: [UserUpdateArgs!]!): [User]
   deleteUser(where: UserWhereUniqueInput!): User
   deleteUsers(where: [UserWhereUniqueInput!]!): [User]
+  createUnused(data: UnusedCreateInput!): Unused
+  createUnuseds(data: [UnusedCreateInput!]!): [Unused]
+  updateUnused(where: UnusedWhereUniqueInput!, data: UnusedUpdateInput!): Unused
+  updateUnuseds(data: [UnusedUpdateArgs!]!): [Unused]
+  deleteUnused(where: UnusedWhereUniqueInput!): Unused
+  deleteUnuseds(where: [UnusedWhereUniqueInput!]!): [Unused]
 }
 
 type Query {
@@ -281,12 +281,12 @@ type Query {
   order(where: OrderWhereUniqueInput!): Order
   orders(where: OrderWhereInput! = {}, orderBy: [OrderOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrderWhereUniqueInput): [Order!]
   ordersCount(where: OrderWhereInput! = {}): Int
-  foo(where: FooWhereUniqueInput!): Foo
-  foos(where: FooWhereInput! = {}, orderBy: [FooOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FooWhereUniqueInput): [Foo!]
-  foosCount(where: FooWhereInput! = {}): Int
   user(where: UserWhereUniqueInput!): User
   users(where: UserWhereInput! = {}, orderBy: [UserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserWhereUniqueInput): [User!]
   usersCount(where: UserWhereInput! = {}): Int
+  unused(where: UnusedWhereUniqueInput!): Unused
+  unuseds(where: UnusedWhereInput! = {}, orderBy: [UnusedOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UnusedWhereUniqueInput): [Unused!]
+  unusedsCount(where: UnusedWhereInput! = {}): Int
   keystone: KeystoneMeta!
 }
 

--- a/examples/reuse/schema.graphql
+++ b/examples/reuse/schema.graphql
@@ -119,6 +119,7 @@ type Order {
   id: ID!
   title: String
   completed: Boolean
+  name: String
   createdBy: String
   createdAt: DateTime
   updatedBy: String
@@ -136,6 +137,7 @@ input OrderWhereInput {
   id: IDFilter
   title: StringFilter
   completed: BooleanFilter
+  name: StringFilter
   createdBy: StringFilter
   createdAt: DateTimeNullableFilter
   updatedBy: StringFilter
@@ -146,6 +148,7 @@ input OrderOrderByInput {
   id: OrderDirection
   title: OrderDirection
   completed: OrderDirection
+  name: OrderDirection
   createdBy: OrderDirection
   createdAt: OrderDirection
   updatedBy: OrderDirection
@@ -155,6 +158,7 @@ input OrderOrderByInput {
 input OrderUpdateInput {
   title: String
   completed: Boolean
+  name: String
 }
 
 input OrderUpdateArgs {
@@ -164,6 +168,42 @@ input OrderUpdateArgs {
 
 input OrderCreateInput {
   title: String
+  completed: Boolean
+  name: String
+}
+
+type Foo {
+  id: ID!
+  completed: Boolean
+}
+
+input FooWhereUniqueInput {
+  id: ID
+}
+
+input FooWhereInput {
+  AND: [FooWhereInput!]
+  OR: [FooWhereInput!]
+  NOT: [FooWhereInput!]
+  id: IDFilter
+  completed: BooleanFilter
+}
+
+input FooOrderByInput {
+  id: OrderDirection
+  completed: OrderDirection
+}
+
+input FooUpdateInput {
+  completed: Boolean
+}
+
+input FooUpdateArgs {
+  where: FooWhereUniqueInput!
+  data: FooUpdateInput!
+}
+
+input FooCreateInput {
   completed: Boolean
 }
 
@@ -220,6 +260,12 @@ type Mutation {
   updateOrders(data: [OrderUpdateArgs!]!): [Order]
   deleteOrder(where: OrderWhereUniqueInput!): Order
   deleteOrders(where: [OrderWhereUniqueInput!]!): [Order]
+  createFoo(data: FooCreateInput!): Foo
+  createFoos(data: [FooCreateInput!]!): [Foo]
+  updateFoo(where: FooWhereUniqueInput!, data: FooUpdateInput!): Foo
+  updateFoos(data: [FooUpdateArgs!]!): [Foo]
+  deleteFoo(where: FooWhereUniqueInput!): Foo
+  deleteFoos(where: [FooWhereUniqueInput!]!): [Foo]
   createUser(data: UserCreateInput!): User
   createUsers(data: [UserCreateInput!]!): [User]
   updateUser(where: UserWhereUniqueInput!, data: UserUpdateInput!): User
@@ -235,6 +281,9 @@ type Query {
   order(where: OrderWhereUniqueInput!): Order
   orders(where: OrderWhereInput! = {}, orderBy: [OrderOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: OrderWhereUniqueInput): [Order!]
   ordersCount(where: OrderWhereInput! = {}): Int
+  foo(where: FooWhereUniqueInput!): Foo
+  foos(where: FooWhereInput! = {}, orderBy: [FooOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: FooWhereUniqueInput): [Foo!]
+  foosCount(where: FooWhereInput! = {}): Int
   user(where: UserWhereUniqueInput!): User
   users(where: UserWhereInput! = {}, orderBy: [UserOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: UserWhereUniqueInput): [User!]
   usersCount(where: UserWhereInput! = {}): Int

--- a/examples/reuse/schema.prisma
+++ b/examples/reuse/schema.prisma
@@ -26,10 +26,16 @@ model Order {
   id        String    @id @default(cuid())
   title     String    @default("")
   completed Boolean   @default(false)
+  name      String    @default("")
   createdBy String    @default("")
   createdAt DateTime?
   updatedBy String    @default("")
   updatedAt DateTime?
+}
+
+model Foo {
+  id        String  @id @default(cuid())
+  completed Boolean @default(false)
 }
 
 model User {

--- a/examples/reuse/schema.prisma
+++ b/examples/reuse/schema.prisma
@@ -33,12 +33,12 @@ model Order {
   updatedAt DateTime?
 }
 
-model Foo {
-  id        String  @id @default(cuid())
-  completed Boolean @default(false)
-}
-
 model User {
   id   String @id @default(cuid())
   name String @default("")
+}
+
+model Unused {
+  id        String  @id @default(cuid())
+  completed Boolean @default(false)
 }

--- a/examples/reuse/schema.ts
+++ b/examples/reuse/schema.ts
@@ -106,17 +106,17 @@ export const lists = {
     },
   }),
 
-  Foo: list({
-    access: allowAll,
-    fields: {
-      completed: checkbox(),
-    },
-  }),
-
   User: list({
     access: allowAll,
     fields: {
       name: text(),
+    },
+  }),
+
+  Unused: list({
+    access: allowAll,
+    fields: {
+      completed: checkbox(),
     },
   }),
 } satisfies Lists

--- a/examples/reuse/schema.ts
+++ b/examples/reuse/schema.ts
@@ -1,10 +1,9 @@
 import { list } from '@keystone-6/core'
-//  import type { BaseListTypeInfo } from '@keystone-6/core/types';
-import type { FieldHooks } from '@keystone-6/core/types'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists, TypeInfo } from '.keystone/types'
+import type { Lists } from '.keystone/types'
+import { BaseListTypeInfo } from '@keystone-6/core/types'
 
 const readOnlyField = {
   access: {
@@ -39,92 +38,49 @@ function isTrue(b: boolean) {
   return b === true
 }
 
-type ListsT = TypeInfo['lists']
-type FindListsWithField<K> = {
-  [key in keyof ListsT]: K extends ListsT[key]['fields'] ? ListsT[key] : never
-}[keyof ListsT]
-
-// alternatively, if you don't like type functions
-//  type CompatibleLists = Lists.Invoice.TypeInfo | Lists.Order.TypeInfo
-type CompatibleLists = FindListsWithField<'completed'>
-//  type CompatibleLists = TypeInfo['lists'][keyof TypeInfo['lists']] // item is resolved, but not completed
-//  type CompatibleLists = BaseListTypeInfo // nothing is refined, item is Record<string, unknown>
-
-function trackingByHooks<
-  ListTypeInfo extends CompatibleLists,
-  //    FieldKey extends 'createdBy' | 'updatedBy' // TODO: refined types for the return types
->(immutable: boolean = false): FieldHooks<ListTypeInfo> {
-  return {
-    resolveInput: {
-      async create({ context, operation, resolvedData, item, fieldKey }) {
-        // TODO: refined types for the return types
-        //   FIXME: CommonFieldConfig need not always be generalised
-        return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})` as any
-      },
-      async update({ context, operation, resolvedData, item, fieldKey }) {
-        if (immutable) return undefined
-
-        // show we have refined types for compatible item.* fields
-        if (isTrue(item.completed) && resolvedData.completed !== false) return undefined
-
-        // TODO: refined types for the return types
-        //   FIXME: CommonFieldConfig need not always be generalised
-        return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})` as any
-      },
-    },
-  }
-}
-
-function trackingAtHooks<
-  ListTypeInfo extends CompatibleLists,
-  //    FieldKey extends 'createdAt' | 'updatedAt' // TODO: refined types for the return types
->(immutable: boolean = false): FieldHooks<ListTypeInfo> {
-  return {
-    // TODO: switch to operation routing when supported for fields
-    resolveInput: {
-      async create({ context, operation, resolvedData, item, fieldKey }) {
-        // TODO: refined types for the return types
-        //   FIXME: CommonFieldConfig need not always be generalised
-        return new Date() as any
-      },
-      async update({ context, operation, resolvedData, item, fieldKey }) {
-        if (immutable) return undefined
-
-        // show we have refined types for compatible item.* fields
-        if (isTrue(item.completed) && resolvedData.completed !== false) return undefined
-
-        // TODO: refined types for the return types
-        //   FIXME: CommonFieldConfig need not always be generalised
-        return new Date() as any
-      },
-    },
-  }
-}
+type CompatibleLists = BaseListTypeInfo & { item: { completed: boolean } }
 
 function trackingFields<ListTypeInfo extends CompatibleLists>() {
   return {
     createdBy: text<ListTypeInfo>({
       ...readOnlyField,
       hooks: {
-        ...trackingByHooks<ListTypeInfo>(true),
+        resolveInput: {
+          async create({ context }) {
+            return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+          },
+        },
       },
     }),
     createdAt: timestamp<ListTypeInfo>({
       ...readOnlyField,
       hooks: {
-        ...trackingAtHooks<ListTypeInfo>(true),
+        resolveInput: {
+          async create() {
+            return new Date()
+          },
+        },
       },
     }),
     updatedBy: text<ListTypeInfo>({
       ...readOnlyField,
       hooks: {
-        ...trackingByHooks<ListTypeInfo>(),
+        async resolveInput({ context, operation, resolvedData, item, fieldKey }) {
+          // show we have refined types for compatible item.* fields
+          if (isTrue(item?.completed ?? false) && resolvedData.completed !== false) return undefined
+
+          // TODO: refined types for the return types
+          //   FIXME: CommonFieldConfig need not always be generalised
+          return `${context.req?.socket.remoteAddress} (${context.req?.headers['user-agent']})`
+        },
       },
     }),
     updatedAt: timestamp<ListTypeInfo>({
       ...readOnlyField,
       hooks: {
-        ...trackingAtHooks<ListTypeInfo>(),
+        async resolveInput() {
+          return new Date()
+        },
       },
     }),
   }
@@ -136,7 +92,7 @@ export const lists = {
     fields: {
       title: text(),
       completed: checkbox(),
-      ...trackingFields(),
+      ...trackingFields<Lists.Invoice.TypeInfo>(),
     },
   }),
 
@@ -145,7 +101,15 @@ export const lists = {
     fields: {
       title: text(),
       completed: checkbox(),
-      ...trackingFields(),
+      name: text(),
+      ...trackingFields<Lists.Order.TypeInfo>(),
+    },
+  }),
+
+  Foo: list({
+    access: allowAll,
+    fields: {
+      completed: checkbox(),
     },
   }),
 

--- a/examples/usecase-relationship-union/schema.ts
+++ b/examples/usecase-relationship-union/schema.ts
@@ -5,8 +5,7 @@ import type { Lists, Context } from '.keystone/types'
 
 const ifUnsetHideUI = {
   itemView: {
-    fieldMode: ({ itemField }: { itemField: unknown | null }) =>
-      itemField ? 'edit' : 'read',
+    fieldMode: ({ itemField }: { itemField: unknown | null }) => (itemField ? 'edit' : 'read'),
   },
   listView: {
     fieldMode: 'hidden',

--- a/packages/cloudinary/src/index.ts
+++ b/packages/cloudinary/src/index.ts
@@ -1,5 +1,10 @@
 import { randomBytes } from 'node:crypto'
-import type { CommonFieldConfig, BaseListTypeInfo, FieldTypeFunc } from '@keystone-6/core/types'
+import type {
+  CommonFieldConfig,
+  BaseListTypeInfo,
+  FieldTypeFunc,
+  BaseFieldTypeInfo,
+} from '@keystone-6/core/types'
 import { jsonFieldTypePolyfilledForSQLite } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
 import type Cloudinary from 'cloudinary'
@@ -15,16 +20,18 @@ type StoredFile = {
   _meta: Cloudinary.UploadApiResponse
 }
 
-type CloudinaryImageFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    cloudinary: {
-      cloudName: string
-      apiKey: string
-      apiSecret: string
-      folder?: string
-    }
-    db?: { map?: string }
+type CloudinaryImageFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo
+> & {
+  cloudinary: {
+    cloudName: string
+    apiKey: string
+    apiSecret: string
+    folder?: string
   }
+  db?: { map?: string }
+}
 
 const CloudinaryImageFormat = g.inputObject({
   name: 'CloudinaryImageFormat',

--- a/packages/core/src/fields/non-null-graphql.ts
+++ b/packages/core/src/fields/non-null-graphql.ts
@@ -1,3 +1,4 @@
+import type { BaseFieldTypeInfo } from '../types'
 import { type BaseListTypeInfo, type FieldData } from '../types'
 import type { FieldHooks } from '../types/config/hooks'
 import { type ValidateFieldHook } from '../types/config/hooks'
@@ -33,10 +34,10 @@ export function makeValidateHook<ListTypeInfo extends BaseListTypeInfo>(
       [key: string]: unknown
     }
     hooks?: {
-      validate?: FieldHooks<ListTypeInfo>['validate']
+      validate?: FieldHooks<ListTypeInfo, any>['validate']
     }
   },
-  f?: ValidateFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', ListTypeInfo['fields']>
+  f?: ValidateFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', BaseFieldTypeInfo>
 ) {
   const dbNullable = resolveDbNullable(config.validation, config.db)
   const mode = dbNullable ? ('optional' as const) : ('required' as const)
@@ -59,11 +60,7 @@ export function makeValidateHook<ListTypeInfo extends BaseListTypeInfo>(
       }
 
       await f?.(args)
-    } satisfies ValidateFieldHook<
-      ListTypeInfo,
-      'create' | 'update' | 'delete',
-      ListTypeInfo['fields']
-    >
+    } satisfies ValidateFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', BaseFieldTypeInfo>
 
     return {
       mode,

--- a/packages/core/src/fields/types/bigInt/index.ts
+++ b/packages/core/src/fields/types/bigInt/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -9,21 +10,23 @@ import { g } from '../../..'
 import { filters } from '../../filters'
 import { resolveDbNullable, makeValidateHook } from '../../non-null-graphql'
 
-export type BigIntFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    defaultValue?: bigint | null | { kind: 'autoincrement' }
-    validation?: {
-      isRequired?: boolean
-      min?: bigint
-      max?: bigint
-    }
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type BigIntFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'BigInt'>
+> & {
+  isIndexed?: boolean | 'unique'
+  defaultValue?: bigint | null | { kind: 'autoincrement' }
+  validation?: {
+    isRequired?: boolean
+    min?: bigint
+    max?: bigint
   }
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 // for a signed 64-bit integer
 const MAX_INT = 9223372036854775807n

--- a/packages/core/src/fields/types/bytes/index.ts
+++ b/packages/core/src/fields/types/bytes/index.ts
@@ -9,40 +9,64 @@ import { g } from '../../..'
 import { makeValidateHook } from '../../non-null-graphql'
 import { weakMemoize } from '../../../lib/core/utils'
 import { GraphQLError } from 'graphql'
-import type { GArg, GInputObjectType, GList, GNonNull, GScalarType } from '@graphql-ts/schema'
+import type {
+  GArg,
+  GInputObjectType,
+  GList,
+  GNonNull,
+  GScalarType,
+  InferValueFromInputType,
+} from '@graphql-ts/schema'
 
-export type BytesFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    graphql?: {
-      scalar?: GScalarType<Uint8Array, string>
-    }
-    validation?: {
-      /**
-       * Makes the field disallow null values. It does not constrain the length of the value.
-       */
-      isRequired?: boolean
-      /**
-       * Specifies the minimum and maximum length of the value in _bytes_. It does _not_ represent the length in the encoded form.
-       */
-      length?: { min?: number; max?: number }
-    }
-    defaultValue?: Uint8Array | null
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-      /**
-       * The underlying database type.
-       * Only some of the types are supported on PostgreSQL and MySQL.
-       * The native type is not customisable on SQLite.
-       * See Prisma's documentation for more information about the supported types.
-       *
-       * https://www.prisma.io/docs/orm/reference/prisma-schema-reference#bytes
-       */
-      nativeType?: string
-    }
+export type FieldTypeInfo = {
+  item: Uint8Array | null
+  inputs: {
+    create: Uint8Array | null | undefined
+    update: Uint8Array | null | undefined
+    where: InferValueFromInputType<BytesFilterType> | undefined
+    uniqueWhere: Uint8Array | null | undefined
+    orderBy: undefined
   }
+  prisma: {
+    create: Uint8Array | null | undefined
+    update: Uint8Array | null | undefined
+  }
+}
+
+export type BytesFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  isIndexed?: boolean | 'unique'
+  graphql?: {
+    scalar?: GScalarType<Uint8Array, string>
+  }
+  validation?: {
+    /**
+     * Makes the field disallow null values. It does not constrain the length of the value.
+     */
+    isRequired?: boolean
+    /**
+     * Specifies the minimum and maximum length of the value in _bytes_. It does _not_ represent the length in the encoded form.
+     */
+    length?: { min?: number; max?: number }
+  }
+  defaultValue?: Uint8Array | null
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+    /**
+     * The underlying database type.
+     * Only some of the types are supported on PostgreSQL and MySQL.
+     * The native type is not customisable on SQLite.
+     * See Prisma's documentation for more information about the supported types.
+     *
+     * https://www.prisma.io/docs/orm/reference/prisma-schema-reference#bytes
+     */
+    nativeType?: string
+  }
+}
 
 export type TextFieldMeta = {
   isNullable: boolean

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -17,19 +18,21 @@ import type {
   InferValueFromInputType,
 } from '@graphql-ts/schema'
 
-export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    validation?: {
-      isRequired?: boolean
-    }
-    defaultValue?: string
-    db?: {
-      isNullable?: boolean
-      extendPrismaSchema?: (field: string) => string
-      map?: string
-    }
+export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'String' | 'DateTime'>
+> & {
+  isIndexed?: boolean | 'unique'
+  validation?: {
+    isRequired?: boolean
   }
+  defaultValue?: string
+  db?: {
+    isNullable?: boolean
+    extendPrismaSchema?: (field: string) => string
+    map?: string
+  }
+}
 
 export function calendarDay<ListTypeInfo extends BaseListTypeInfo>(
   config: CalendarDayFieldConfig<ListTypeInfo> = {}

--- a/packages/core/src/fields/types/checkbox/index.ts
+++ b/packages/core/src/fields/types/checkbox/index.ts
@@ -1,4 +1,5 @@
 import { userInputError } from '../../../lib/core/graphql-errors'
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -10,14 +11,16 @@ import { g } from '../../..'
 import { assertReadIsNonNullAllowed } from '../../non-null-graphql'
 import { filters } from '../../filters'
 
-export type CheckboxFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    defaultValue?: boolean
-    db?: {
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type CheckboxFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'Boolean'>
+> & {
+  defaultValue?: boolean
+  db?: {
+    map?: string
+    extendPrismaSchema?: (field: string) => string
   }
+}
 
 export function checkbox<ListTypeInfo extends BaseListTypeInfo>(
   config: CheckboxFieldConfig<ListTypeInfo> = {}

--- a/packages/core/src/fields/types/decimal/index.ts
+++ b/packages/core/src/fields/types/decimal/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -10,23 +11,25 @@ import { g } from '../../..'
 import { filters } from '../../filters'
 import { makeValidateHook } from '../../non-null-graphql'
 
-export type DecimalFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    defaultValue?: string | null
-    validation?: {
-      isRequired?: boolean
-      min?: string
-      max?: string
-    }
-    precision?: number
-    scale?: number
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type DecimalFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'Decimal'>
+> & {
+  isIndexed?: boolean | 'unique'
+  defaultValue?: string | null
+  validation?: {
+    isRequired?: boolean
+    min?: string
+    max?: string
   }
+  precision?: number
+  scale?: number
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 function safeParseDecimal(value: string | null | undefined) {
   if (value === null || value === undefined) return value

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -11,17 +11,34 @@ import type {
 import { fieldType } from '../../../types'
 import { g } from '../../..'
 import { merge } from '../../resolve-hooks'
-import type { InferValueFromArg } from '@graphql-ts/schema'
+import type { InferValueFromArg, InferValueFromInputType } from '@graphql-ts/schema'
 import { randomBytes } from 'node:crypto'
 
-export type FileFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    storage: StorageStrategy<ListTypeInfo['all']>
-    transformName?: (originalFilename: string) => MaybePromise<string>
-    db?: {
-      extendPrismaSchema?: (field: string) => string
-    }
+export type FieldTypeInfo = {
+  item: undefined
+  inputs: {
+    create: InferValueFromInputType<typeof FileFieldInput> | null | undefined
+    update: InferValueFromInputType<typeof FileFieldInput> | null | undefined
+    where: undefined
+    uniqueWhere: undefined
+    orderBy: undefined
   }
+  prisma: {
+    create: undefined
+    update: undefined
+  }
+}
+
+export type FileFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  storage: StorageStrategy<ListTypeInfo['all']>
+  transformName?: (originalFilename: string) => MaybePromise<string>
+  db?: {
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 const FileFieldInput = g.inputObject({
   name: 'FileFieldInput',
@@ -76,7 +93,7 @@ export function file<ListTypeInfo extends BaseListTypeInfo>(
     }
 
     const afterOperationResolver: Extract<
-      FieldHooks<BaseListTypeInfo, string>['afterOperation'],
+      FieldHooks<BaseListTypeInfo, FieldTypeInfo>['afterOperation'],
       (args: any) => any
     > = async function afterOperationResolver(args) {
       if (args.operation === 'update' || args.operation === 'delete') {

--- a/packages/core/src/fields/types/float/index.ts
+++ b/packages/core/src/fields/types/float/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type FieldTypeFunc,
@@ -9,21 +10,23 @@ import { g } from '../../..'
 import { filters } from '../../filters'
 import { makeValidateHook } from '../../non-null-graphql'
 
-export type FloatFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    defaultValue?: number | null
-    validation?: {
-      isRequired?: boolean
-      min?: number
-      max?: number
-    }
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type FloatFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'Float'>
+> & {
+  isIndexed?: boolean | 'unique'
+  defaultValue?: number | null
+  validation?: {
+    isRequired?: boolean
+    min?: number
+    max?: number
   }
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 export function float<ListTypeInfo extends BaseListTypeInfo>(
   config: FloatFieldConfig<ListTypeInfo> = {}

--- a/packages/core/src/fields/types/integer/index.ts
+++ b/packages/core/src/fields/types/integer/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -9,21 +10,23 @@ import { g } from '../../..'
 import { filters } from '../../filters'
 import { resolveDbNullable, makeValidateHook } from '../../non-null-graphql'
 
-export type IntegerFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    defaultValue?: number | null | { kind: 'autoincrement' }
-    validation?: {
-      isRequired?: boolean
-      min?: number
-      max?: number
-    }
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type IntegerFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'Int'>
+> & {
+  isIndexed?: boolean | 'unique'
+  defaultValue?: number | null | { kind: 'autoincrement' }
+  validation?: {
+    isRequired?: boolean
+    min?: number
+    max?: number
   }
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 // for a signed 32-bit integer
 const MAX_INT = 0x7fffffff

--- a/packages/core/src/fields/types/json/index.ts
+++ b/packages/core/src/fields/types/json/index.ts
@@ -7,11 +7,28 @@ import {
 } from '../../../types'
 import { g } from '../../..'
 
-export type JsonFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    defaultValue?: JSONValue
-    db?: { map?: string; extendPrismaSchema?: (field: string) => string }
+type FieldTypeInfo = {
+  item: JSONValue | null
+  inputs: {
+    where: never
+    create: JSONValue | undefined
+    update: JSONValue | undefined
+    uniqueWhere: never
+    orderBy: never
   }
+  prisma: {
+    create: JSONValue | undefined
+    update: JSONValue | undefined
+  }
+}
+
+export type JsonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  defaultValue?: JSONValue
+  db?: { map?: string; extendPrismaSchema?: (field: string) => string }
+}
 
 export const json =
   <ListTypeInfo extends BaseListTypeInfo>({

--- a/packages/core/src/fields/types/multiselect/index.ts
+++ b/packages/core/src/fields/types/multiselect/index.ts
@@ -1,5 +1,6 @@
 import { classify } from 'inflection'
 import { humanize } from '../../../lib/utils'
+import type { JSONValue } from '../../../types'
 import {
   type BaseListTypeInfo,
   type FieldTypeFunc,
@@ -10,36 +11,53 @@ import {
 import { g } from '../../..'
 import { makeValidateHook } from '../../non-null-graphql'
 
-export type MultiselectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> &
-    (
-      | {
-          /**
-           * When a value is provided as just a string, it will be formatted in the same way
-           * as field labels are to create the label.
-           */
-          options: readonly ({ label: string; value: string } | string)[]
-          /**
-           * If `enum` is provided on SQLite, it will use an enum in GraphQL but a string in the database.
-           */
-          type?: 'string' | 'enum'
-          defaultValue?: readonly string[] | null
-        }
-      | {
-          options: readonly { label: string; value: number }[]
-          type: 'integer'
-          defaultValue?: readonly number[] | null
-        }
-    ) & {
-      ui?: {
-        displayMode?: 'checkboxes' | 'select'
+type FieldTypeInfo = {
+  item: JSONValue | null
+  inputs: {
+    where: never
+    create: JSONValue | undefined
+    update: JSONValue | undefined
+    uniqueWhere: never
+    orderBy: never
+  }
+  prisma: {
+    create: JSONValue | undefined
+    update: JSONValue | undefined
+  }
+}
+
+export type MultiselectFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> &
+  (
+    | {
+        /**
+         * When a value is provided as just a string, it will be formatted in the same way
+         * as field labels are to create the label.
+         */
+        options: readonly ({ label: string; value: string } | string)[]
+        /**
+         * If `enum` is provided on SQLite, it will use an enum in GraphQL but a string in the database.
+         */
+        type?: 'string' | 'enum'
+        defaultValue?: readonly string[] | null
       }
-      db?: {
-        isNullable?: boolean
-        map?: string
-        extendPrismaSchema?: (field: string) => string
+    | {
+        options: readonly { label: string; value: number }[]
+        type: 'integer'
+        defaultValue?: readonly number[] | null
       }
+  ) & {
+    ui?: {
+      displayMode?: 'checkboxes' | 'select'
     }
+    db?: {
+      isNullable?: boolean
+      map?: string
+      extendPrismaSchema?: (field: string) => string
+    }
+  }
 
 // these are the lowest and highest values for a signed 32-bit integer
 const MAX_INT = 2147483647

--- a/packages/core/src/fields/types/password/index.ts
+++ b/packages/core/src/fields/types/password/index.ts
@@ -12,26 +12,44 @@ import { g } from '../../..'
 import { type PasswordFieldMeta } from './views'
 import { makeValidateHook } from '../../non-null-graphql'
 import { isObjectType, type GraphQLSchema } from 'graphql'
+import type { InferValueFromInputType } from '@graphql-ts/schema'
 
-export type PasswordFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    validation?: {
-      isRequired?: boolean
-      rejectCommon?: boolean
-      match?: { regex: RegExp; explanation?: string }
-      length?: {
-        /** @default 8 */
-        min?: number
-        max?: number
-      }
-    }
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
-    kdf?: KDF
+type FieldTypeInfo = {
+  item: string | null
+  inputs: {
+    where: InferValueFromInputType<typeof PasswordFilter> | undefined
+    create: string | null | undefined
+    update: string | null | undefined
+    uniqueWhere: never
+    orderBy: never
   }
+  prisma: {
+    create: string | null | undefined
+    update: string | null | undefined
+  }
+}
+
+export type PasswordFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  validation?: {
+    isRequired?: boolean
+    rejectCommon?: boolean
+    match?: { regex: RegExp; explanation?: string }
+    length?: {
+      /** @default 8 */
+      min?: number
+      max?: number
+    }
+  }
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+  kdf?: KDF
+}
 
 type KDF = {
   compare(preImage: string, hash: string): Promise<boolean>

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from '../../../types'
 import {
   type BaseListTypeInfo,
   type FieldTypeFunc,
@@ -96,15 +97,50 @@ function throwIfMissingFields(
   }
 }
 
-export type RelationshipFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    many?: boolean
-    ref: string
-    ui?: {
-      hideCreate?: boolean
-    }
-  } & (OneDbConfig | ManyDbConfig) &
-    (SelectDisplayConfig | CountDisplayConfig | TableDisplayConfig)
+type ArrayOr<T> = T | T[]
+
+// TODO: add types based on list types
+type FieldTypeInfo = {
+  item: undefined
+  inputs: {
+    where: JSONValue | undefined
+    create: JSONValue | undefined
+    update: JSONValue | undefined
+    uniqueWhere: undefined
+    orderBy: undefined
+  }
+  prisma: {
+    create:
+      | {
+          connect?: ArrayOr<{ id?: string; [key: string]: unknown }>
+          create?: any
+          set?: ArrayOr<{ id?: string; [key: string]: unknown }>
+        }
+      | undefined
+      | null
+    update:
+      | {
+          connect?: ArrayOr<{ id?: string; [key: string]: unknown }>
+          create?: any
+          set?: ArrayOr<{ id?: string; [key: string]: unknown }>
+          disconnect?: boolean | ArrayOr<{ id?: string; [key: string]: unknown }> | undefined
+        }
+      | undefined
+      | null
+  }
+}
+
+export type RelationshipFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  many?: boolean
+  ref: string
+  ui?: {
+    hideCreate?: boolean
+  }
+} & (OneDbConfig | ManyDbConfig) &
+  (SelectDisplayConfig | CountDisplayConfig | TableDisplayConfig)
 
 export function relationship<ListTypeInfo extends BaseListTypeInfo>({
   ref,

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,16 +1,16 @@
-import type { JSONValue } from '../../../types'
-import {
-  type BaseListTypeInfo,
-  type FieldTypeFunc,
-  type CommonFieldConfig,
-  fieldType,
-} from '../../../types'
 import { g } from '../../..'
 import {
   type ListMetaSource,
   getAdminMetaForRelationshipField,
 } from '../../../lib/create-admin-meta'
-import { type controller } from './views'
+import type { JSONValue } from '../../../types'
+import {
+  type BaseListTypeInfo,
+  type CommonFieldConfig,
+  type FieldTypeFunc,
+  fieldType,
+} from '../../../types'
+import type { controller } from './views'
 
 // This is the default display mode for Relationships
 type SelectDisplayConfig = {
@@ -276,19 +276,19 @@ export function relationship<ListTypeInfo extends BaseListTypeInfo>({
         input: {
           where: {
             arg: g.arg({ type: foreignListTypes.relateTo.many.where }),
-            resolve(value, context, resolve) {
+            resolve(value, _context, resolve) {
               return resolve(value)
             },
           },
           create: {
             arg: g.arg({ type: foreignListTypes.relateTo.many.create }),
-            async resolve(value, context, resolve) {
+            async resolve(value, _context, resolve) {
               return resolve(value)
             },
           },
           update: {
             arg: g.arg({ type: foreignListTypes.relateTo.many.update }),
-            async resolve(value, context, resolve) {
+            async resolve(value, _context, resolve) {
               return resolve(value)
             },
           },
@@ -331,7 +331,7 @@ export function relationship<ListTypeInfo extends BaseListTypeInfo>({
       input: {
         where: {
           arg: g.arg({ type: foreignListTypes.where }),
-          resolve(value, context, resolve) {
+          resolve(value, _context, resolve) {
             return resolve(value)
           },
         },
@@ -341,14 +341,14 @@ export function relationship<ListTypeInfo extends BaseListTypeInfo>({
 
         create: foreignListTypes.relateTo.one.create && {
           arg: g.arg({ type: foreignListTypes.relateTo.one.create }),
-          async resolve(value, context, resolve) {
+          async resolve(value, _context, resolve) {
             return resolve(value)
           },
         },
 
         update: foreignListTypes.relateTo.one.update && {
           arg: g.arg({ type: foreignListTypes.relateTo.one.update }),
-          async resolve(value, context, resolve) {
+          async resolve(value, _context, resolve) {
             return resolve(value)
           },
         },

--- a/packages/core/src/fields/types/select/index.ts
+++ b/packages/core/src/fields/types/select/index.ts
@@ -1,5 +1,6 @@
 import { classify } from 'inflection'
 import { humanize } from '../../../lib/utils'
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -11,44 +12,46 @@ import { g } from '../../..'
 import { filters } from '../../filters'
 import { makeValidateHook } from '../../non-null-graphql'
 
-export type SelectFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> &
-    (
-      | {
-          /**
-           * When a value is provided as just a string, it will be formatted in the same way
-           * as field labels are to create the label.
-           */
-          options: readonly ({ label: string; value: string } | string)[]
-          /**
-           * If `enum` is provided on SQLite, it will use an enum in GraphQL but a string in the database.
-           */
-          type?: 'string' | 'enum'
-          defaultValue?: string
-        }
-      | {
-          options: readonly { label: string; value: number }[]
-          type: 'integer'
-          defaultValue?: number
-        }
-    ) & {
-      ui?: {
-        displayMode?: 'select' | 'segmented-control' | 'radio'
-      }
-
-      validation?: {
+export type SelectFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'String' | 'Int'>
+> &
+  (
+    | {
         /**
-         * @default false
+         * When a value is provided as just a string, it will be formatted in the same way
+         * as field labels are to create the label.
          */
-        isRequired?: boolean
+        options: readonly ({ label: string; value: string } | string)[]
+        /**
+         * If `enum` is provided on SQLite, it will use an enum in GraphQL but a string in the database.
+         */
+        type?: 'string' | 'enum'
+        defaultValue?: string
       }
-      isIndexed?: boolean | 'unique'
-      db?: {
-        isNullable?: boolean
-        map?: string
-        extendPrismaSchema?: (field: string) => string
+    | {
+        options: readonly { label: string; value: number }[]
+        type: 'integer'
+        defaultValue?: number
       }
+  ) & {
+    ui?: {
+      displayMode?: 'select' | 'segmented-control' | 'radio'
     }
+
+    validation?: {
+      /**
+       * @default false
+       */
+      isRequired?: boolean
+    }
+    isIndexed?: boolean | 'unique'
+    db?: {
+      isNullable?: boolean
+      map?: string
+      extendPrismaSchema?: (field: string) => string
+    }
+  }
 
 // these are the lowest and highest values for a signed 32-bit integer
 const MAX_INT = 2147483647

--- a/packages/core/src/fields/types/text/index.ts
+++ b/packages/core/src/fields/types/text/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -9,48 +10,50 @@ import { g } from '../../..'
 import { makeValidateHook } from '../../non-null-graphql'
 import { filters } from '../../filters'
 
-export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    ui?: {
-      displayMode?: 'input' | 'textarea'
-    }
-    validation?: {
-      /**
-       * Makes the field disallow null values and require a string at least 1 character long
-       */
-      isRequired?: boolean
-      match?: { regex: RegExp; explanation?: string }
-      length?: { min?: number; max?: number }
-    }
-    defaultValue?: string | null
-    db?: {
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-      /**
-       * The underlying database type.
-       * Only some of the types are supported on PostgreSQL and MySQL.
-       * The native type is not customisable on SQLite.
-       * See Prisma's documentation for more information about the supported types.
-       *
-       * https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
-       */
-      nativeType?:
-        | 'Text' // PostgreSQL and MySQL
-        | `VarChar(${number})`
-        | `Char(${number})`
-        | `Bit(${number})` // PostgreSQL
-        | 'VarBit'
-        | 'Uuid'
-        | 'Xml'
-        | 'Inet'
-        | 'Citext'
-        | 'TinyText' // MySQL
-        | 'MediumText'
-        | 'LargeText'
-    }
+export type TextFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'String'>
+> & {
+  isIndexed?: boolean | 'unique'
+  ui?: {
+    displayMode?: 'input' | 'textarea'
   }
+  validation?: {
+    /**
+     * Makes the field disallow null values and require a string at least 1 character long
+     */
+    isRequired?: boolean
+    match?: { regex: RegExp; explanation?: string }
+    length?: { min?: number; max?: number }
+  }
+  defaultValue?: string | null
+  db?: {
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+    /**
+     * The underlying database type.
+     * Only some of the types are supported on PostgreSQL and MySQL.
+     * The native type is not customisable on SQLite.
+     * See Prisma's documentation for more information about the supported types.
+     *
+     * https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
+     */
+    nativeType?:
+      | 'Text' // PostgreSQL and MySQL
+      | `VarChar(${number})`
+      | `Char(${number})`
+      | `Bit(${number})` // PostgreSQL
+      | 'VarBit'
+      | 'Uuid'
+      | 'Xml'
+      | 'Inet'
+      | 'Citext'
+      | 'TinyText' // MySQL
+      | 'MediumText'
+      | 'LargeText'
+  }
+}
 
 export type TextFieldMeta = {
   displayMode: 'input' | 'textarea'

--- a/packages/core/src/fields/types/timestamp/index.ts
+++ b/packages/core/src/fields/types/timestamp/index.ts
@@ -1,3 +1,4 @@
+import type { SimpleFieldTypeInfo } from '../../../types'
 import {
   type BaseListTypeInfo,
   type FieldTypeFunc,
@@ -10,21 +11,23 @@ import { filters } from '../../filters'
 import { makeValidateHook } from '../../non-null-graphql'
 import { type TimestampFieldMeta } from './views'
 
-export type TimestampFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    isIndexed?: boolean | 'unique'
-    validation?: {
-      isRequired?: boolean
-    }
-    defaultValue?: string | { kind: 'now' }
-    db?: {
-      // this is @updatedAt in Prisma
-      updatedAt?: boolean
-      isNullable?: boolean
-      map?: string
-      extendPrismaSchema?: (field: string) => string
-    }
+export type TimestampFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  SimpleFieldTypeInfo<'DateTime' | 'String'> // TODO: make more exact
+> & {
+  isIndexed?: boolean | 'unique'
+  validation?: {
+    isRequired?: boolean
   }
+  defaultValue?: string | { kind: 'now' }
+  db?: {
+    // this is @updatedAt in Prisma
+    updatedAt?: boolean
+    isNullable?: boolean
+    map?: string
+    extendPrismaSchema?: (field: string) => string
+  }
+}
 
 export function timestamp<ListTypeInfo extends BaseListTypeInfo>(
   config: TimestampFieldConfig<ListTypeInfo> = {}

--- a/packages/core/src/fields/types/virtual/index.ts
+++ b/packages/core/src/fields/types/virtual/index.ts
@@ -20,34 +20,51 @@ type VirtualFieldGraphQLField<Item extends BaseItem, Context extends KeystoneCon
   Context
 >
 
-export type VirtualFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    field:
-      | VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>
-      | ((lists: {
-          [Key in keyof ListTypeInfo['all']['lists']]: ListGraphQLTypes<
-            ListTypeInfo['all']['lists'][Key]
-          >
-        }) => VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>)
-    unreferencedConcreteInterfaceImplementations?: readonly GObjectType<
-      any,
-      KeystoneContext<ListTypeInfo['all']>
-    >[]
-    ui?: {
-      /**
-       * This can be used by the AdminUI to fetch the relevant sub-fields
-       *   or arguments on a non-scalar field GraphQL type
-       * ```graphql
-       * query {
-       *   ${list}(where: { id: "..." }) {
-       *     ${field}${ui.query}
-       *   }
-       * }
-       * ```
-       */
-      query?: string
-    }
+type FieldTypeInfo = {
+  item: undefined
+  inputs: {
+    where: undefined
+    create: undefined
+    update: undefined
+    uniqueWhere: undefined
+    orderBy: undefined
   }
+  prisma: {
+    create: undefined
+    update: undefined
+  }
+}
+
+export type VirtualFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  FieldTypeInfo
+> & {
+  field:
+    | VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>
+    | ((lists: {
+        [Key in keyof ListTypeInfo['all']['lists']]: ListGraphQLTypes<
+          ListTypeInfo['all']['lists'][Key]
+        >
+      }) => VirtualFieldGraphQLField<ListTypeInfo['item'], KeystoneContext<ListTypeInfo['all']>>)
+  unreferencedConcreteInterfaceImplementations?: readonly GObjectType<
+    any,
+    KeystoneContext<ListTypeInfo['all']>
+  >[]
+  ui?: {
+    /**
+     * This can be used by the AdminUI to fetch the relevant sub-fields
+     *   or arguments on a non-scalar field GraphQL type
+     * ```graphql
+     * query {
+     *   ${list}(where: { id: "..." }) {
+     *     ${field}${ui.query}
+     *   }
+     * }
+     * ```
+     */
+    query?: string
+  }
+}
 
 export function virtual<ListTypeInfo extends BaseListTypeInfo>({
   field,

--- a/packages/core/src/lib/core/hooks.ts
+++ b/packages/core/src/lib/core/hooks.ts
@@ -23,7 +23,14 @@ export async function validate({
       const hook = field.hooks.validate[operation]
 
       try {
-        await hook({ ...hookArgs, addValidationError, fieldKey } as never) // TODO: FIXME
+        await hook({
+          ...hookArgs,
+          addValidationError,
+          fieldKey,
+          itemField: hookArgs.item?.[fieldKey],
+          inputFieldData: hookArgs.inputData?.[fieldKey],
+          resolvedFieldData: hookArgs.resolvedData?.[fieldKey],
+        } as never) // TODO: FIXME
       } catch (error: any) {
         fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.validateInput` })
       }
@@ -76,7 +83,14 @@ export async function runSideEffectOnlyHook<
     Object.entries(list.fields).map(async ([fieldKey, field]) => {
       if (shouldRunFieldLevelHook(fieldKey)) {
         try {
-          await field.hooks[hookName][operation]({ fieldKey, ...args } as any) // TODO: FIXME any
+          await field.hooks[hookName][operation]({
+            ...args,
+            fieldKey,
+            itemField: args.item?.[fieldKey],
+            inputFieldData: args.inputData?.[fieldKey],
+            resolvedFieldData: args.resolvedData?.[fieldKey],
+            originalItemField: (args as any).originalItem?.[fieldKey],
+          } as any) // TODO: FIXME any
         } catch (error: any) {
           fieldsErrors.push({ error, tag: `${list.listKey}.${fieldKey}.hooks.${hookName}` })
         }

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -1,37 +1,37 @@
 import type { CacheHint } from '@apollo/cache-control-types'
+import type { GArg, GInputType } from '@graphql-ts/schema'
+import { GNonNull } from '@graphql-ts/schema'
 import { GraphQLString, isInputObjectType } from 'graphql'
+import { g } from '../..'
+import { expandVoidHooks } from '../../fields/resolve-hooks'
 import type {
+  BaseFieldTypeInfo,
   BaseItem,
   BaseListTypeInfo,
   CacheHintArgs,
+  FieldTypeFunc,
   FindManyArgs,
   GraphQLTypesForList,
+  KeystoneConfig,
   ListGraphQLTypes,
   ListHooks,
-  KeystoneConfig,
   MaybeFieldFunction,
   NextFieldType,
-  FieldTypeFunc,
-  BaseFieldTypeInfo,
 } from '../../types'
 import { QueryMode } from '../../types'
+import type { FieldHooks, ResolvedFieldHooks, ResolvedListHooks } from '../../types/config/hooks'
+import type { MaybeItemFieldFunction, MaybeSessionFunction } from '../../types/config/lists'
 import { type GraphQLNames, __getNames } from '../../types/utils'
-import { g } from '../..'
-import type { FieldHooks, ResolvedListHooks, ResolvedFieldHooks } from '../../types/config/hooks'
-import type { MaybeItemFunction, MaybeSessionFunction } from '../../types/config/lists'
 import {
   type ResolvedFieldAccessControl,
   type ResolvedListAccessControl,
-  parseListAccessControl,
   parseFieldAccessControl,
+  parseListAccessControl,
 } from './access-control'
-import { areArraysEqual } from './utils'
-import { type ResolvedDBField, resolveRelationships } from './resolve-relationships'
-import { outputTypeField } from './queries/output-field'
 import { assertFieldsValid } from './field-assertions'
-import { expandVoidHooks } from '../../fields/resolve-hooks'
-import type { GArg, GInputType } from '@graphql-ts/schema'
-import { GNonNull } from '@graphql-ts/schema'
+import { outputTypeField } from './queries/output-field'
+import { type ResolvedDBField, resolveRelationships } from './resolve-relationships'
+import { areArraysEqual } from './utils'
 
 export type InitialisedField = {
   fieldKey: string
@@ -62,8 +62,8 @@ export type InitialisedField = {
       fieldMode: MaybeSessionFunction<'edit' | 'hidden', any>
     }
     itemView: {
-      fieldMode: MaybeItemFunction<'read' | 'edit' | 'hidden', any>
-      fieldPosition: MaybeItemFunction<'form' | 'sidebar', any>
+      fieldMode: MaybeItemFieldFunction<'read' | 'edit' | 'hidden', any, any>
+      fieldPosition: MaybeItemFieldFunction<'form' | 'sidebar', any, any>
     }
     listView: {
       fieldMode: MaybeSessionFunction<'read' | 'hidden', any>

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -12,6 +12,7 @@ import type {
   MaybeFieldFunction,
   NextFieldType,
   FieldTypeFunc,
+  BaseFieldTypeInfo,
 } from '../../types'
 import { QueryMode } from '../../types'
 import { type GraphQLNames, __getNames } from '../../types/utils'
@@ -37,7 +38,7 @@ export type InitialisedField = {
 
   access: ResolvedFieldAccessControl
   dbField: ResolvedDBField
-  hooks: ResolvedFieldHooks<BaseListTypeInfo>
+  hooks: ResolvedFieldHooks<BaseListTypeInfo, BaseFieldTypeInfo>
   graphql: {
     isEnabled: {
       read: boolean
@@ -259,8 +260,8 @@ function defaultFieldHooksResolveInput({
 }
 
 function parseFieldHooks(
-  hooks: FieldHooks<BaseListTypeInfo>
-): ResolvedFieldHooks<BaseListTypeInfo> {
+  hooks: FieldHooks<BaseListTypeInfo, BaseFieldTypeInfo>
+): ResolvedFieldHooks<BaseListTypeInfo, BaseFieldTypeInfo> {
   return {
     resolveInput: {
       create:

--- a/packages/core/src/lib/core/mutations/index.ts
+++ b/packages/core/src/lib/core/mutations/index.ts
@@ -416,12 +416,18 @@ async function getResolvedData(
             operation === 'create'
               ? await field.hooks.resolveInput.create({
                   ...hookArgs,
+                  itemField: undefined,
+                  inputFieldData: hookArgs.inputData[fieldKey],
                   resolvedData,
+                  resolvedFieldData: resolvedData[fieldKey],
                   fieldKey,
                 })
               : await field.hooks.resolveInput.update({
                   ...hookArgs,
+                  itemField: hookArgs.item[fieldKey],
+                  inputFieldData: hookArgs.inputData[fieldKey],
                   resolvedData,
+                  resolvedFieldData: resolvedData[fieldKey],
                   fieldKey,
                 }),
           ]

--- a/packages/core/src/lib/create-admin-meta.ts
+++ b/packages/core/src/lib/create-admin-meta.ts
@@ -7,7 +7,7 @@ import type {
   MaybeFieldFunction,
   MaybeItemFieldFunction,
   MaybePromise,
-  MaybeSessionFunction
+  MaybeSessionFunction,
 } from '../types'
 import type { FieldGroupMeta, FieldMeta, ListMeta } from '../types/admin-meta'
 import type { GraphQLNames } from '../types/utils'
@@ -28,7 +28,11 @@ type FieldMetaSource_ = {
     fieldMode: EmptyResolver<'edit' | 'hidden'>
   }
   itemView: {
-    fieldMode: MaybeItemFieldFunction<'edit' | 'read' | 'hidden', BaseListTypeInfo, BaseFieldTypeInfo>
+    fieldMode: MaybeItemFieldFunction<
+      'edit' | 'read' | 'hidden',
+      BaseListTypeInfo,
+      BaseFieldTypeInfo
+    >
     fieldPosition: MaybeItemFieldFunction<'form' | 'sidebar', BaseListTypeInfo, BaseFieldTypeInfo>
   }
   listView: {

--- a/packages/core/src/lib/create-admin-meta.ts
+++ b/packages/core/src/lib/create-admin-meta.ts
@@ -3,10 +3,10 @@ import type {
   BaseListTypeInfo,
   KeystoneContext,
   MaybeFieldFunction,
-  MaybeItemFunction,
   MaybePromise,
   MaybeSessionFunction,
   KeystoneConfig,
+  MaybeItemFunction,
 } from '../types'
 import type { GraphQLNames } from '../types/utils'
 import type { FieldMeta, FieldGroupMeta, ListMeta } from '../types/admin-meta'

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -1,10 +1,10 @@
 import type { CacheHint } from '@apollo/cache-control-types'
+import type { KeystoneContext } from '..'
 import type { FieldTypeFunc } from '../next-fields'
 import type { BaseListTypeInfo } from '../type-info'
-import type { KeystoneContext } from '..'
-import type { MaybeFieldFunction, MaybeItemFunction, MaybeSessionFunction } from './lists'
-import type { FieldHooks } from './hooks'
 import type { FieldAccessControl } from './access-control'
+import type { FieldHooks } from './hooks'
+import type { MaybeFieldFunction, MaybeItemFieldFunction, MaybeSessionFunction } from './lists'
 
 export type BaseFields<ListTypeInfo extends BaseListTypeInfo> = {
   [key: string]: FieldTypeFunc<ListTypeInfo>
@@ -44,8 +44,8 @@ export type CommonFieldConfig<
     views?: string
     createView?: { fieldMode?: MaybeSessionFunction<'edit' | 'hidden', ListTypeInfo> }
     itemView?: {
-      fieldMode?: MaybeItemFunction<'edit' | 'read' | 'hidden', ListTypeInfo>
-      fieldPosition?: MaybeItemFunction<'form' | 'sidebar', ListTypeInfo>
+      fieldMode?: MaybeItemFieldFunction<'edit' | 'read' | 'hidden', ListTypeInfo, FieldTypeInfo>
+      fieldPosition?: MaybeItemFieldFunction<'form' | 'sidebar', ListTypeInfo, FieldTypeInfo>
     }
     listView?: { fieldMode?: MaybeSessionFunction<'read' | 'hidden', ListTypeInfo> }
   }

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -17,9 +17,27 @@ export type FilterOrderArgs<ListTypeInfo extends BaseListTypeInfo> = {
   fieldKey: ListTypeInfo['fields']
 }
 
-export type CommonFieldConfig<ListTypeInfo extends BaseListTypeInfo> = {
+export type BaseFieldTypeInfo = {
+  item: any
+  inputs: {
+    create: any
+    update: any
+    where: any
+    uniqueWhere: any
+    orderBy: any
+  }
+  prisma: {
+    create: any
+    update: any
+  }
+}
+
+export type CommonFieldConfig<
+  ListTypeInfo extends BaseListTypeInfo,
+  FieldTypeInfo extends BaseFieldTypeInfo,
+> = {
   access?: FieldAccessControl<ListTypeInfo>
-  hooks?: FieldHooks<ListTypeInfo, ListTypeInfo['fields']>
+  hooks?: FieldHooks<ListTypeInfo, FieldTypeInfo>
   label?: string // TODO: move to .ui in breaking change
   ui?: {
     description?: string

--- a/packages/core/src/types/config/hooks.ts
+++ b/packages/core/src/types/config/hooks.ts
@@ -1,5 +1,5 @@
-import { type KeystoneContextFromListTypeInfo, type MaybePromise } from '..'
-import { type BaseListTypeInfo } from '../type-info'
+import type { BaseFieldTypeInfo, KeystoneContextFromListTypeInfo, MaybePromise } from '..'
+import type { BaseListTypeInfo } from '../type-info'
 
 type CommonArgs<ListTypeInfo extends BaseListTypeInfo> = {
   context: KeystoneContextFromListTypeInfo<ListTypeInfo>
@@ -111,111 +111,117 @@ export type ResolvedListHooks<ListTypeInfo extends BaseListTypeInfo> = {
 
 export type FieldHooks<
   ListTypeInfo extends BaseListTypeInfo,
-  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = {
   /**
    * Used to **modify the input** for create and update operations after default values and access control have been applied
    */
   resolveInput?:
-    | ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldKey>
+    | ResolveInputFieldHook<ListTypeInfo, 'create' | 'update', FieldTypeInfo>
     | {
-        create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
-        update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
+        create?: ResolveInputFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+        update?: ResolveInputFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
       }
 
   /**
    * Used to **validate** if a create, update or delete operation is OK
    */
   validate?:
-    | ValidateFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>
+    | ValidateFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldTypeInfo>
     | {
-        create?: ValidateFieldHook<ListTypeInfo, 'create', FieldKey>
-        update?: ValidateFieldHook<ListTypeInfo, 'update', FieldKey>
-        delete?: ValidateFieldHook<ListTypeInfo, 'delete', FieldKey>
+        create?: ValidateFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+        update?: ValidateFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+        delete?: ValidateFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
       }
 
   /**
    * Used to **cause side effects** before a create, update, or delete operation once all validateInput hooks have resolved
    */
   beforeOperation?:
-    | BeforeOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>
+    | BeforeOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldTypeInfo>
     | {
-        create?: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldKey>
-        update?: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldKey>
-        delete?: BeforeOperationFieldHook<ListTypeInfo, 'delete', FieldKey>
+        create?: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+        update?: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+        delete?: BeforeOperationFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
       }
 
   /**
    * Used to **cause side effects** after a create, update, or delete operation operation has occurred
    */
   afterOperation?:
-    | AfterOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldKey>
+    | AfterOperationFieldHook<ListTypeInfo, 'create' | 'update' | 'delete', FieldTypeInfo>
     | {
-        create?: AfterOperationFieldHook<ListTypeInfo, 'create', FieldKey>
-        update?: AfterOperationFieldHook<ListTypeInfo, 'update', FieldKey>
-        delete?: AfterOperationFieldHook<ListTypeInfo, 'delete', FieldKey>
+        create?: AfterOperationFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+        update?: AfterOperationFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+        delete?: AfterOperationFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
       }
 }
 
 export type ResolvedFieldHooks<
   ListTypeInfo extends BaseListTypeInfo,
-  FieldKey extends ListTypeInfo['fields'] = ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = {
   resolveInput: {
-    create: ResolveInputFieldHook<ListTypeInfo, 'create', FieldKey>
-    update: ResolveInputFieldHook<ListTypeInfo, 'update', FieldKey>
+    create: ResolveInputFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+    update: ResolveInputFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
   }
   validate: {
-    create: ValidateFieldHook<ListTypeInfo, 'create', FieldKey>
-    update: ValidateFieldHook<ListTypeInfo, 'update', FieldKey>
-    delete: ValidateFieldHook<ListTypeInfo, 'delete', FieldKey>
+    create: ValidateFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+    update: ValidateFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+    delete: ValidateFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
   }
   beforeOperation: {
-    create: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldKey>
-    update: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldKey>
-    delete: BeforeOperationFieldHook<ListTypeInfo, 'delete', FieldKey>
+    create: BeforeOperationFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+    update: BeforeOperationFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+    delete: BeforeOperationFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
   }
   afterOperation: {
-    create: AfterOperationFieldHook<ListTypeInfo, 'create', FieldKey>
-    update: AfterOperationFieldHook<ListTypeInfo, 'update', FieldKey>
-    delete: AfterOperationFieldHook<ListTypeInfo, 'delete', FieldKey>
+    create: AfterOperationFieldHook<ListTypeInfo, 'create', FieldTypeInfo>
+    update: AfterOperationFieldHook<ListTypeInfo, 'update', FieldTypeInfo>
+    delete: AfterOperationFieldHook<ListTypeInfo, 'delete', FieldTypeInfo>
   }
 }
 
 type ResolveInputFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update',
-  FieldKey extends ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = (
   args: {
     create: {
       operation: 'create'
+      itemField: undefined
       item: undefined
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['create']
+      inputFieldData: FieldTypeInfo['inputs']['create']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['create']
+      resolvedFieldData: FieldTypeInfo['prisma']['create']
     }
     update: {
       operation: 'update'
+      itemField: FieldTypeInfo['item']
       item: ListTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['update']
+      inputFieldData: FieldTypeInfo['inputs']['update']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['update']
+      resolvedFieldData: FieldTypeInfo['prisma']['update']
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: ListTypeInfo['fields'] }
 ) => MaybePromise<
-  ListTypeInfo['prisma']['create' | 'update'][FieldKey] | undefined // undefined represents 'don't do anything'
+  FieldTypeInfo['prisma']['update'] | undefined // undefined represents 'don't do anything'
 >
 
 export type ValidateHook<
@@ -263,16 +269,18 @@ export type ValidateHook<
 export type ValidateFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = (
   args: {
     create: {
       operation: 'create'
       item: undefined
+      itemField: undefined
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['create']
+      inputFieldData: FieldTypeInfo['inputs']['create']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
@@ -281,24 +289,30 @@ export type ValidateFieldHook<
     update: {
       operation: 'update'
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['update']
+      inputFieldData: FieldTypeInfo['inputs']['update']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['update']
+      resolvedFieldData: FieldTypeInfo['prisma']['update']
     }
     delete: {
       operation: 'delete'
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       inputData: undefined
+      inputFieldData: undefined
       resolvedData: undefined
+      resolvedFieldData: undefined
     }
   }[Operation] &
     CommonArgs<ListTypeInfo> & {
-      fieldKey: FieldKey
+      fieldKey: ListTypeInfo['fields']
       addValidationError: (error: string) => void
     }
 ) => MaybePromise<void>
@@ -315,6 +329,7 @@ type BeforeOperationListHook<
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['create']
+
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
@@ -351,47 +366,56 @@ type BeforeOperationListHook<
 type BeforeOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = (
   args: {
     create: {
       operation: 'create'
       item: undefined
+      itemField: undefined
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['create']
+      inputFieldData: FieldTypeInfo['inputs']['create']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['create']
+      resolvedFieldData: FieldTypeInfo['prisma']['create']
     }
     update: {
       operation: 'update'
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['update']
+      inputFieldData: FieldTypeInfo['inputs']['update']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['update']
+      resolvedFieldData: FieldTypeInfo['prisma']['update']
     }
     delete: {
       operation: 'delete'
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: undefined
+      inputFieldData: undefined
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: undefined
+      resolvedFieldData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: ListTypeInfo['fields'] }
 ) => MaybePromise<void>
 
 type AfterOperationListHook<
@@ -445,48 +469,60 @@ type AfterOperationListHook<
 type AfterOperationFieldHook<
   ListTypeInfo extends BaseListTypeInfo,
   Operation extends 'create' | 'update' | 'delete',
-  FieldKey extends ListTypeInfo['fields'],
+  FieldTypeInfo extends BaseFieldTypeInfo,
 > = (
   args: {
     create: {
       operation: 'create'
       originalItem: undefined
+      originalItemField: undefined
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['create']
+      inputFieldData: FieldTypeInfo['inputs']['create']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['create']
+      resolvedFieldData: FieldTypeInfo['prisma']['create']
     }
     update: {
       operation: 'update'
       originalItem: ListTypeInfo['item']
+      originalItemField: FieldTypeInfo['item']
       item: ListTypeInfo['item']
+      itemField: FieldTypeInfo['item']
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: ListTypeInfo['inputs']['update']
+      inputFieldData: FieldTypeInfo['inputs']['update']
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: ListTypeInfo['prisma']['update']
+      resolvedFieldData: FieldTypeInfo['prisma']['update']
     }
     delete: {
       operation: 'delete'
       originalItem: ListTypeInfo['item']
+      originalItemField: FieldTypeInfo['item']
       item: undefined
+      itemField: undefined
       /**
        * The GraphQL input **before** default values are applied
        */
       inputData: undefined
+      inputFieldData: undefined
       /**
        * The GraphQL input **after** being resolved by the field type's input resolver
        */
       resolvedData: undefined
+      resolvedFieldData: undefined
     }
   }[Operation] &
-    CommonArgs<ListTypeInfo> & { fieldKey: FieldKey }
+    CommonArgs<ListTypeInfo> & { fieldKey: ListTypeInfo['fields'] }
 ) => MaybePromise<void>

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -4,7 +4,7 @@ import type { BaseListTypeInfo } from '../type-info'
 import type { KeystoneContext } from '../context'
 import type { ListHooks } from './hooks'
 import type { ListAccessControl } from './access-control'
-import type { BaseFields } from './fields'
+import type { BaseFields, BaseFieldTypeInfo } from './fields'
 
 export type ListConfig<ListTypeInfo extends BaseListTypeInfo> = {
   isSingleton?: boolean
@@ -181,11 +181,27 @@ export type MaybeSessionFunction<
       session?: ListTypeInfo['all']['session']
     }) => MaybePromise<T>)
 
+export type MaybeItemFieldFunction<
+  T,
+  ListTypeInfo extends BaseListTypeInfo,
+  FieldTypeInfo extends BaseFieldTypeInfo,
+> =
+  | T
+  | ((args: {
+      context: KeystoneContext<ListTypeInfo['all']>
+      session?: ListTypeInfo['all']['session']
+      listKey: ListTypeInfo['key']
+      fieldKey: ListTypeInfo['fields']
+      item: ListTypeInfo['item'] | null
+      itemField: FieldTypeInfo['item'] | null
+    }) => MaybePromise<T>)
+
 export type MaybeItemFunction<T, ListTypeInfo extends BaseListTypeInfo> =
   | T
   | ((args: {
       context: KeystoneContext<ListTypeInfo['all']>
       session?: ListTypeInfo['all']['session']
+      listKey: ListTypeInfo['key']
       item: ListTypeInfo['item'] | null
     }) => MaybePromise<T>)
 

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -1,5 +1,5 @@
-import { type BaseItem } from './next-fields'
-import { type KeystoneContext } from '../types'
+import type { BaseItem } from './next-fields'
+import type { KeystoneContext } from '../types'
 
 type GraphQLInput = Record<string, any>
 
@@ -32,5 +32,5 @@ export type KeystoneContextFromListTypeInfo<ListTypeInfo extends BaseListTypeInf
 export type BaseKeystoneTypeInfo<Session = any> = {
   lists: Record<string, BaseListTypeInfo<Session>>
   prisma: any
-  session: any
+  session: Session
 }

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql'
+import type { BaseFieldTypeInfo } from '@keystone-6/core/types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -60,16 +61,18 @@ type FormattingConfig = {
   softBreaks?: boolean
 }
 
-export type DocumentFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    relationships?: RelationshipsConfig
-    componentBlocks?: Record<string, ComponentBlock>
-    formatting?: boolean | FormattingConfig
-    links?: boolean
-    dividers?: boolean
-    layouts?: readonly (readonly [number, ...number[]])[]
-    db?: { map?: string; extendPrismaSchema?: (field: string) => string }
-  }
+export type DocumentFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo
+> & {
+  relationships?: RelationshipsConfig
+  componentBlocks?: Record<string, ComponentBlock>
+  formatting?: boolean | FormattingConfig
+  links?: boolean
+  dividers?: boolean
+  layouts?: readonly (readonly [number, ...number[]])[]
+  db?: { map?: string; extendPrismaSchema?: (field: string) => string }
+}
 
 export function document<ListTypeInfo extends BaseListTypeInfo>({
   componentBlocks = {},

--- a/packages/fields-document/src/structure.ts
+++ b/packages/fields-document/src/structure.ts
@@ -1,3 +1,4 @@
+import type { BaseFieldTypeInfo } from '@keystone-6/core/types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
@@ -17,11 +18,13 @@ import {
 import { assertValidComponentSchema } from './DocumentEditor/component-blocks/field-assertions'
 import { addRelationshipDataToComponentProps, fetchRelationshipData } from './relationship-data'
 
-export type StructureFieldConfig<ListTypeInfo extends BaseListTypeInfo> =
-  CommonFieldConfig<ListTypeInfo> & {
-    db?: { map?: string }
-    schema: ComponentSchema
-  }
+export type StructureFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
+  ListTypeInfo,
+  BaseFieldTypeInfo
+> & {
+  db?: { map?: string }
+  schema: ComponentSchema
+}
 
 export function structure<ListTypeInfo extends BaseListTypeInfo>({
   schema,


### PR DESCRIPTION
This pull request updates field hook types throughout Keystone to appropriately refine the field-level type information without requiring the `ListTypeInfo` for that particular list.

Hook arguments now include:

- `itemField`: the value of `item[fieldKey]`
- `inputFieldData`: the raw input value for the field
- `resolvedFieldData`: the post-resolution value passed to Prisma

Additionally `ui.fieldMode` and `ui.fieldPosition` functions are now passed `itemField` and `fieldKey`. 

Using these parameters should now be preferred compared to patterns like `resolvedData[fieldKey]`, which could not readily infer the type of the value as the exact `fieldKey` type is a sum type.

The only caveat for `itemField` is that it may not always be defined for complex field types like relationships and fields with no direct mapping between the prisma type and the field key. 