### PR TITLE
Fix error when accessing Apollo Sandbox

### DIFF
--- a/.changeset/curvy-breads-itch.md
+++ b/.changeset/curvy-breads-itch.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Fix error when accessing Apollo Sandbox

--- a/.changeset/curvy-breads-itch.md
+++ b/.changeset/curvy-breads-itch.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": patch
----
-
-Fix error when accessing Apollo Sandbox

--- a/packages/core/src/lib/createExpressServer.ts
+++ b/packages/core/src/lib/createExpressServer.ts
@@ -93,6 +93,11 @@ export async function createExpressServer(
   expressServer.use(
     config.graphql.path,
     json(config.graphql.bodyParser),
+    (req, res, next) => {
+      // to bring back old behavior of body-parser always setting req.body that apollo server expects
+      req.body ??= {}
+      next()
+    },
     expressMiddleware(apolloServer, {
       context: async ({ req, res }) => {
         return await context.withRequest(req, res)

--- a/packages/core/src/lib/createExpressServer.ts
+++ b/packages/core/src/lib/createExpressServer.ts
@@ -94,7 +94,7 @@ export async function createExpressServer(
     config.graphql.path,
     json(config.graphql.bodyParser),
     (req, res, next) => {
-      // to bring back old behavior of body-parser always setting req.body that apollo server expects
+      // WARNING: body-parser@^2 only sets .body if a .body is parsed, Apollo always wants .body to be set
       req.body ??= {}
       next()
     },


### PR DESCRIPTION
`body-parser@^2` only sets `req.body` [if a `req.body` is parsed](https://github.com/expressjs/body-parser/blob/master/HISTORY.md#200-beta1--2021-12-17), Apollo always wants `req.body` to be set.