### PR TITLE
Sync Examples GraphQL Schemas

### DIFF
--- a/examples/custom-admin-ui-pages/schema.graphql
+++ b/examples/custom-admin-ui-pages/schema.graphql
@@ -241,22 +241,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -300,8 +302,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/custom-session-passport/schema.graphql
+++ b/examples/custom-session-passport/schema.graphql
@@ -182,6 +182,7 @@ type Mutation {
   updateAuthors(data: [AuthorUpdateArgs!]!): [Author]
   deleteAuthor(where: AuthorWhereUniqueInput!): Author
   deleteAuthors(where: [AuthorWhereUniqueInput!]!): [Author]
+  endSession: Boolean!
 }
 
 type Query {
@@ -206,22 +207,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -265,8 +268,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/empty-lists/schema.graphql
+++ b/examples/empty-lists/schema.graphql
@@ -381,22 +381,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -440,8 +442,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -230,7 +230,7 @@ type ResolvedAuthorUpdateInput = {
 }
 
 export declare namespace Lists {
-  export type Post<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Post.TypeInfo<Session>>
+  export type Post<Session = any> = import('@keystone-6/core').ListConfig<Lists.Post.TypeInfo<Session>>
   namespace Post {
     export type Item = import('./node_modules/myprisma').Post
     export type TypeInfo<Session = any> = {
@@ -252,7 +252,7 @@ export declare namespace Lists {
       all: __TypeInfo<Session>
     }
   }
-  export type Author<Session = any> = import('@keystone-6/core/types').ListConfig<Lists.Author.TypeInfo<Session>>
+  export type Author<Session = any> = import('@keystone-6/core').ListConfig<Lists.Author.TypeInfo<Session>>
   namespace Author {
     export type Item = import('./node_modules/myprisma').Author
     export type TypeInfo<Session = any> = {
@@ -290,7 +290,7 @@ export type TypeInfo<Session = any> = {
 type __TypeInfo<Session = any> = TypeInfo<Session>
 
 export type Lists<Session = any> = {
-  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core/types').ListConfig<TypeInfo<Session>['lists'][Key]>
-} & Record<string, import('@keystone-6/core/types').ListConfig<any>>
+  [Key in keyof TypeInfo['lists']]?: import('@keystone-6/core').ListConfig<TypeInfo<Session>['lists'][Key]>
+} & Record<string, import('@keystone-6/core').ListConfig<any>>
 
 export {}

--- a/examples/extend-graphql-schema-nexus/schema.graphql
+++ b/examples/extend-graphql-schema-nexus/schema.graphql
@@ -237,22 +237,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -296,8 +298,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-nextjs-app-directory/schema.graphql
+++ b/examples/framework-nextjs-app-directory/schema.graphql
@@ -138,22 +138,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -197,8 +199,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/framework-nextjs-two-servers/keystone-server/schema.graphql
+++ b/examples/framework-nextjs-two-servers/keystone-server/schema.graphql
@@ -232,22 +232,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -291,8 +293,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/reuse/schema.graphql
+++ b/examples/reuse/schema.graphql
@@ -302,22 +302,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -361,8 +363,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {

--- a/examples/usecase-versioning/schema.graphql
+++ b/examples/usecase-versioning/schema.graphql
@@ -134,22 +134,24 @@ type KeystoneAdminMeta {
 type KeystoneAdminUIListMeta {
   key: String!
   path: String!
-  description: String
   label: String!
-  labelField: String!
   singular: String!
   plural: String!
+  description: String
+  pageSize: Int!
+  labelField: String!
   fields: [KeystoneAdminUIFieldMeta!]!
   groups: [KeystoneAdminUIFieldGroupMeta!]!
   graphql: KeystoneAdminUIGraphQL!
-  pageSize: Int!
   initialColumns: [String!]!
   initialSearchFields: [String!]!
   initialSort: KeystoneAdminUISort
   isSingleton: Boolean!
-  hideNavigation: Boolean!
   hideCreate: Boolean!
   hideDelete: Boolean!
+  isHidden: Boolean!
+  itemQueryName: String!
+  listQueryName: String!
 }
 
 type KeystoneAdminUIFieldMeta {
@@ -193,8 +195,8 @@ enum KeystoneAdminUIFieldMetaListViewFieldMode {
 }
 
 type KeystoneAdminUIFieldMetaItemView {
-  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode!
-  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition!
+  fieldMode: KeystoneAdminUIFieldMetaItemViewFieldMode
+  fieldPosition: KeystoneAdminUIFieldMetaItemViewFieldPosition
 }
 
 enum KeystoneAdminUIFieldMetaItemViewFieldMode {


### PR DESCRIPTION
I've run this using npm, but it might be wrong because npm installed deps not from lock file because does not exist, and installed instead based on package.json

I could use pnpm, but it won't do any schema updates, probably because `@keystone-6/*` are not updated.

We need first to update the `@keystone-6/*` dependencies in all examples folders, then generate again the schemas. (will try to create a different PR for that)

```bash
for dir in $(find examples/ -name "package.json" -not -path "*/node_modules/*" -exec dirname {} \;); do
  echo "\nChecking $dir..."
  cd "$dir"
  if grep -q '"build":' package.json 2>/dev/null; then
    npm i --cache ~/.npm_keystone --prefer-offline --legacy-peer-deps --ignore-scripts
    npm run build
  else
    echo "No build script found in $dir"
  fi
  cd - > /dev/null
done
```