### PR TITLE
Use `new URL` rather than `encodeURI` for document field validation

### DIFF
--- a/.changeset/fix-document-uris.mx
+++ b/.changeset/fix-document-uris.mx
@@ -1,0 +1,5 @@
+---
+"@keystone-6/fields-document": patch
+---
+
+Use `new URL` rather than `encodeURI` for encoding URLs safely

--- a/packages/fields-document/src/DocumentEditor/isValidURL.ts
+++ b/packages/fields-document/src/DocumentEditor/isValidURL.ts
@@ -1,5 +1,5 @@
 import { sanitizeUrl } from '@braintree/sanitize-url'
 
 export function isValidURL(url: string) {
-  return url === sanitizeUrl(url) || url === encodeURI(sanitizeUrl(url))
+  return url === sanitizeUrl(url) || url === new URL(sanitizeUrl(url)).toString()
 }

--- a/packages/fields-document/src/DocumentEditor/isValidURL.ts
+++ b/packages/fields-document/src/DocumentEditor/isValidURL.ts
@@ -1,5 +1,8 @@
 import { sanitizeUrl } from '@braintree/sanitize-url'
 
 export function isValidURL(url: string) {
-  return url === sanitizeUrl(url) || new URL(url, 'https://example') === new URL(sanitizeUrl(url), 'https://example').toString()
+  return (
+    url === sanitizeUrl(url) ||
+    new URL(url, 'https://a').toString() === new URL(sanitizeUrl(url), 'https://a').toString()
+  )
 }

--- a/packages/fields-document/src/DocumentEditor/isValidURL.ts
+++ b/packages/fields-document/src/DocumentEditor/isValidURL.ts
@@ -1,5 +1,5 @@
 import { sanitizeUrl } from '@braintree/sanitize-url'
 
 export function isValidURL(url: string) {
-  return url === sanitizeUrl(url) || url === new URL(sanitizeUrl(url)).toString()
+  return url === sanitizeUrl(url) || new URL(url, 'https://example') === new URL(sanitizeUrl(url), 'https://example').toString()
 }


### PR DESCRIPTION
Followup to https://github.com/keystonejs/keystone/pull/9326