### PR TITLE
Fix UI of many relationship removing selected items

### DIFF
--- a/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
@@ -47,7 +47,15 @@ export function ComboboxMany({
   // not the related list, or some items on the list)
   if (error) return <span>Error</span>
 
-  const items = data?.items?.map(x => ({ ...x, built: false })) ?? []
+  const items: RelationshipValue[] = data?.items?.map(x => ({ ...x, built: false })) ?? []
+  const fetchedIds = new Set(items.map(item => item.id))
+
+  for (const item of state.value) {
+    if (!fetchedIds.has(item.id)) {
+      items.push(item)
+    }
+  }
+
   return (
     <ComboboxMulti
       {...props}

--- a/packages/core/src/fields/types/relationship/views/types.ts
+++ b/packages/core/src/fields/types/relationship/views/types.ts
@@ -1,7 +1,7 @@
 import type { FieldController } from '../../../../types'
 
 export type RelationshipValue = {
-  id: string | number
+  id: string
   label: string | null
   data?: Record<string, unknown>
   built: undefined | boolean

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
@@ -277,13 +277,13 @@ type DiscriminantStringToDiscriminantValue<
   : DiscriminantString
 
 export type HydratedRelationshipData = {
-  id: string | number
+  id: string
   label: string | null
   data?: Record<string, unknown>
 }
 
 export type RelationshipData = {
-  id: string | number
+  id: string
   label: string | null | undefined
   data?: Record<string, unknown>
 }


### PR DESCRIPTION
This mirrors the behaviour of the to-one combobox where it adds the selected item to the items in the combobox so when the selection changes it still includes selected items.

No changeset since it's a regression with the new UI