### PR TITLE
Fix missing scrollable area in array field modals

### DIFF
--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -40,6 +40,7 @@ import { getKeysForArrayValue, setKeysForArrayValue } from './preview-props'
 
 import { assertNever, clientSideValidateProp } from './utils'
 import { createGetPreviewProps } from './preview-props'
+import { Content } from '@keystar/ui/slots'
 
 type DefaultFieldProps<Key> = GenericPreviewProps<
   Extract<ComponentSchema, { kind: Key }>,
@@ -228,11 +229,13 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
               return (
                 <Dialog>
                   <Heading>Edit item</Heading>
-                  <ArrayFieldItemModalContent
-                    onChange={onModalChange}
-                    schema={element.schema as any /* TODO FIXME */}
-                    value={modalState.value}
-                  />
+                  <Content>
+                    <ArrayFieldItemModalContent
+                      onChange={onModalChange}
+                      schema={element.schema as any /* TODO FIXME */}
+                      value={modalState.value}
+                    />
+                  </Content>
                   <ButtonGroup>
                     <Button
                       prominence="low"


### PR DESCRIPTION
No changeset is required as this is a regression with the unreleased admin interface.