### PR TITLE
Add support for `ui.*.defaultFieldMode` in groups

### DIFF
--- a/.changeset/bright-drinks-end.md
+++ b/.changeset/bright-drinks-end.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add support for `ui.*.defaultFieldMode` in groups

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -20,17 +20,6 @@ const readOnly = {
       update: true,
     },
   },
-  ui: {
-    createView: {
-      fieldMode: () => 'hidden' as const,
-    },
-    itemView: {
-      fieldMode: () => 'read' as const,
-    },
-    listView: {
-      fieldMode: () => 'read' as const,
-    },
-  },
 }
 
 export const lists = {
@@ -69,6 +58,14 @@ export const lists = {
       ...group({
         label: 'Authorship',
         description: 'Fields that show who created and updated this Post',
+        ui: {
+          createView: {
+            defaultFieldMode: 'hidden',
+          },
+          itemView: {
+            defaultFieldMode: 'read',
+          },
+        },
         fields: {
           createdBy: text({ ...readOnly }),
           createdAt: timestamp({


### PR DESCRIPTION
This allows setting `ui.*.defaultFieldMode` on a group to default all the `ui.*.fieldMode` options on the fields inside.

```tsx
...group({
  label: 'Authorship',
  ui: {
    createView: {
      defaultFieldMode: 'hidden',
    },
    itemView: {
      defaultFieldMode: 'read',
    },
  },
  fields: {
    ...fields
  }
})
```