### PR TITLE
Move `{field}.label` to `{field}.ui.label`

### DIFF
--- a/.changeset/move-field-label.md
+++ b/.changeset/move-field-label.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": major
+---
+
+Move `{field}.label` to `{field}.ui.label`

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -674,7 +674,7 @@ function getListsWithInitialisedFields(
           },
         },
         ui: {
-          label: f.label ?? null,
+          label: f.ui?.label ?? null,
           description: f.ui?.description ?? null,
           views: f.ui?.views ?? null,
           createView: {

--- a/packages/core/src/types/config/fields.ts
+++ b/packages/core/src/types/config/fields.ts
@@ -45,8 +45,8 @@ export type CommonFieldConfig<
 > = {
   access?: FieldAccessControl<ListTypeInfo>
   hooks?: FieldHooks<ListTypeInfo, FieldTypeInfo>
-  label?: string // TODO: move to .ui in breaking change
   ui?: {
+    label?: string
     description?: string
     views?: string
     createView?: {

--- a/tests/test-projects/live-reloading/schema.ts
+++ b/tests/test-projects/live-reloading/schema.ts
@@ -6,7 +6,7 @@ export const lists = {
   Something: list({
     access: allowAll,
     fields: {
-      text: text({ label: 'Initial Label For Text' }),
+      text: text({ ui: { label: 'Initial Label For Text' } }),
     },
   }),
 }

--- a/tests/test-projects/live-reloading/schemas/changed-prisma-schema.ts
+++ b/tests/test-projects/live-reloading/schemas/changed-prisma-schema.ts
@@ -6,7 +6,7 @@ export const lists = {
   Something: list({
     access: allowAll,
     fields: {
-      text: text({ label: 'Initial Label For Text' }),
+      text: text({ ui: { label: 'Initial Label For Text' } }),
       anotherField: text(),
     },
   }),

--- a/tests/test-projects/live-reloading/schemas/initial.ts
+++ b/tests/test-projects/live-reloading/schemas/initial.ts
@@ -6,7 +6,7 @@ export const lists = {
   Something: list({
     access: allowAll,
     fields: {
-      text: text({ label: 'Initial Label For Text' }),
+      text: text({ ui: { label: 'Initial Label For Text' } }),
     },
   }),
 }

--- a/tests/test-projects/live-reloading/schemas/second.ts
+++ b/tests/test-projects/live-reloading/schemas/second.ts
@@ -11,7 +11,7 @@ export const lists = {
   Something: list({
     access: allowAll,
     fields: {
-      text: text({ label: 'Very Important Text' }),
+      text: text({ ui: { label: 'Very Important Text' } }),
       virtual: virtual({
         field: g.field({
           type: g.String,


### PR DESCRIPTION
This pull request moves `{field}.label` to `{field}.ui.label`, as one of the few remaining fields that are not scoped to where they are actually used.

This is a breaking change, and while it may be annoying for users who _only_ use a `label` field, but deeply frustrating for users who use `ui` already and find this field is sitting outside that object.

The fields previous location can sometimes lend developers to think that `{field}.label` is used somewhere other than the `ui`, when it isn't.
