### PR TITLE
Add `ui.{sort,filter}` options to relationship fields with the select displayMode

### DIFF
--- a/.changeset/twenty-ghosts-bathe.md
+++ b/.changeset/twenty-ghosts-bathe.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add `ui.{sort,filter}` options to relationship fields with the select displayMode

--- a/.changeset/twenty-ghosts-bathe.md
+++ b/.changeset/twenty-ghosts-bathe.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": minor
 ---
 
-Add `ui.{sort,filter}` options to relationship fields with the select displayMode
+Add `ui.{sort,filter}` options to relationship fields with `ui.displayMode: 'select'`

--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -8,7 +8,7 @@ type Author {
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
   createdAt: DateTime
-  active: Boolean
+  verified: Boolean
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -27,7 +27,7 @@ input AuthorWhereInput {
   email: StringFilter
   posts: PostManyRelationFilter
   createdAt: DateTimeNullableFilter
-  active: BooleanFilter
+  verified: BooleanFilter
 }
 
 input IDFilter {
@@ -96,7 +96,7 @@ input AuthorOrderByInput {
   name: OrderDirection
   email: OrderDirection
   createdAt: OrderDirection
-  active: OrderDirection
+  verified: OrderDirection
 }
 
 enum OrderDirection {
@@ -109,7 +109,7 @@ input AuthorUpdateInput {
   email: String
   posts: PostRelateToManyForUpdateInput
   createdAt: DateTime
-  active: Boolean
+  verified: Boolean
 }
 
 input PostRelateToManyForUpdateInput {
@@ -129,7 +129,7 @@ input AuthorCreateInput {
   email: String
   posts: PostRelateToManyForCreateInput
   createdAt: DateTime
-  active: Boolean
+  verified: Boolean
 }
 
 input PostRelateToManyForCreateInput {

--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -8,6 +8,7 @@ type Author {
   posts(where: PostWhereInput! = {}, orderBy: [PostOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: PostWhereUniqueInput): [Post!]
   postsCount(where: PostWhereInput! = {}): Int
   createdAt: DateTime
+  active: Boolean
 }
 
 scalar DateTime @specifiedBy(url: "https://datatracker.ietf.org/doc/html/rfc3339#section-5.6")
@@ -26,6 +27,7 @@ input AuthorWhereInput {
   email: StringFilter
   posts: PostManyRelationFilter
   createdAt: DateTimeNullableFilter
+  active: BooleanFilter
 }
 
 input IDFilter {
@@ -84,11 +86,17 @@ input DateTimeNullableFilter {
   not: DateTimeNullableFilter
 }
 
+input BooleanFilter {
+  equals: Boolean
+  not: BooleanFilter
+}
+
 input AuthorOrderByInput {
   id: OrderDirection
   name: OrderDirection
   email: OrderDirection
   createdAt: OrderDirection
+  active: OrderDirection
 }
 
 enum OrderDirection {
@@ -101,6 +109,7 @@ input AuthorUpdateInput {
   email: String
   posts: PostRelateToManyForUpdateInput
   createdAt: DateTime
+  active: Boolean
 }
 
 input PostRelateToManyForUpdateInput {
@@ -120,6 +129,7 @@ input AuthorCreateInput {
   email: String
   posts: PostRelateToManyForCreateInput
   createdAt: DateTime
+  active: Boolean
 }
 
 input PostRelateToManyForCreateInput {

--- a/examples/usecase-blog/schema.prisma
+++ b/examples/usecase-blog/schema.prisma
@@ -18,7 +18,7 @@ model Author {
   email     String    @unique @default("")
   posts     Post[]    @relation("Post_author")
   createdAt DateTime? @default(now())
-  active    Boolean   @default(true)
+  verified  Boolean   @default(true)
 }
 
 model Post {

--- a/examples/usecase-blog/schema.prisma
+++ b/examples/usecase-blog/schema.prisma
@@ -18,6 +18,7 @@ model Author {
   email     String    @unique @default("")
   posts     Post[]    @relation("Post_author")
   createdAt DateTime? @default(now())
+  active    Boolean   @default(true)
 }
 
 model Post {

--- a/examples/usecase-blog/schema.ts
+++ b/examples/usecase-blog/schema.ts
@@ -44,7 +44,7 @@ export const lists = {
         defaultValue: { kind: 'now' },
       }),
 
-      active: checkbox({
+      verified: checkbox({
         defaultValue: true,
       }),
     },
@@ -77,8 +77,9 @@ export const lists = {
         // we could have used 'Author', but then the relationship would only be 1-way
         ref: 'Author.posts',
         ui: {
+          // prevent the user from selecting an unverified Author
           filter: {
-            active: { equals: true },
+            verified: { equals: true },
           },
           sort: { direction: 'ASC', field: 'name' },
         },

--- a/examples/usecase-blog/schema.ts
+++ b/examples/usecase-blog/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 
 // see https://keystonejs.com/docs/fields/overview for the full list of fields
 //   this is a few common fields for an example
-import { text, relationship, timestamp } from '@keystone-6/core/fields'
+import { text, relationship, timestamp, checkbox } from '@keystone-6/core/fields'
 
 // the document field is a more complicated field, so it has it's own package
 import { document } from '@keystone-6/fields-document'
@@ -43,6 +43,10 @@ export const lists = {
         // default this timestamp to Date.now() when first created
         defaultValue: { kind: 'now' },
       }),
+
+      active: checkbox({
+        defaultValue: true,
+      }),
     },
   }),
 
@@ -72,6 +76,12 @@ export const lists = {
       author: relationship({
         // we could have used 'Author', but then the relationship would only be 1-way
         ref: 'Author.posts',
+        ui: {
+          filter: {
+            active: { equals: true },
+          },
+          sort: { direction: 'ASC', field: 'name' },
+        },
         many: false, // only 1 author for each Post (the default)
       }),
 

--- a/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
@@ -17,6 +17,8 @@ export function ComboboxMany({
   list,
   searchFields,
   state,
+  filter,
+  sort,
   ...props
 }: {
   autoFocus?: boolean
@@ -32,6 +34,8 @@ export function ComboboxMany({
   searchFields: string[]
   list: ListMeta
   placeholder?: string
+  filter?: Record<string, any> | null
+  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
   state: {
     kind: 'many'
     value: RelationshipValue[]
@@ -44,6 +48,8 @@ export function ComboboxMany({
     list,
     searchFields,
     state,
+    filter,
+    sort,
   })
   const [shouldShowErrors, setShouldShowErrors] = useState(false)
   const validationMessages =

--- a/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
@@ -15,6 +15,8 @@ export function ComboboxSingle({
   list,
   searchFields,
   state,
+  filter,
+  sort,
   ...props
 }: {
   autoFocus?: boolean
@@ -29,6 +31,8 @@ export function ComboboxSingle({
   searchFields: string[]
   list: ListMeta
   placeholder?: string
+  filter?: Record<string, any> | null
+  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
   state: {
     kind: 'one'
     value: RelationshipValue | null
@@ -40,6 +44,8 @@ export function ComboboxSingle({
     list,
     searchFields,
     state,
+    filter,
+    sort,
   })
 
   const [shouldShowErrors, setShouldShowErrors] = useState(false)

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -83,6 +83,8 @@ export function Field(props: FieldProps<typeof controller>) {
                   onChange?.({ ...value, value: newItems })
                 },
               }}
+              filter={field.selectFilter}
+              sort={field.sort}
             />
           ) : (
             <ComboboxSingle
@@ -102,6 +104,8 @@ export function Field(props: FieldProps<typeof controller>) {
                   onChange?.({ ...value, value: newItem })
                 },
               }}
+              filter={field.selectFilter}
+              sort={field.sort}
             />
           )}
         </ContextualActions>
@@ -222,7 +226,11 @@ export function controller(
       refLabelField: string
       refSearchFields: string[]
     } & (
-      | { displayMode: 'select' }
+      | {
+          displayMode: 'select'
+          sort: { field: string; direction: 'ASC' | 'DESC' } | null
+          filter: Record<string, any> | null
+        }
       | { displayMode: 'count' }
       | {
           displayMode: 'table'
@@ -251,13 +259,15 @@ export function controller(
     graphqlSelection:
       displayMode === 'count' || displayMode === 'table'
         ? `${fieldKey}Count`
-        : `${fieldKey} {
+        : `${fieldKey}${many && config.fieldMeta.sort ? `(orderBy: { ${config.fieldMeta.sort.field}: ${config.fieldMeta.sort.direction.toLowerCase()} })` : ''} {
               id
               label: ${refLabelField}
             }`,
     hideCreate: hideCreate || displayMode === 'table',
     columns: displayMode === 'table' ? config.fieldMeta.columns : null,
     initialSort: displayMode === 'table' ? config.fieldMeta.initialSort : null,
+    selectFilter: displayMode === 'select' ? config.fieldMeta.filter : null,
+    sort: displayMode === 'select' ? config.fieldMeta.sort : null,
     // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
     // that ui.displayMode: 'count' is really just a way to have reasonable performance
     // because our other UIs don't handle relationships with a large number of items well
@@ -384,6 +394,8 @@ export function controller(
                   props.onChange(newItem === null ? null : newItem.id.toString())
                 },
               }}
+              filter={config.fieldMeta.displayMode === 'select' ? config.fieldMeta.filter : null}
+              sort={config.fieldMeta.displayMode === 'select' ? config.fieldMeta.sort : null}
             />
           )
         }
@@ -405,6 +417,8 @@ export function controller(
                   props.onChange(newItem.map(x => x.id.toString()))
                 },
               }}
+              filter={config.fieldMeta.displayMode === 'select' ? config.fieldMeta.filter : null}
+              sort={config.fieldMeta.displayMode === 'select' ? config.fieldMeta.sort : null}
             />
             <TagGroup
               aria-label={`related ${foreignList.plural}`}

--- a/packages/core/src/fields/types/relationship/views/types.ts
+++ b/packages/core/src/fields/types/relationship/views/types.ts
@@ -41,4 +41,6 @@ export type RelationshipController = FieldController<
   many: boolean
   columns: string[] | null
   initialSort: { field: string; direction: 'ASC' | 'DESC' } | null
+  selectFilter: Record<string, any> | null
+  sort: { field: string; direction: 'ASC' | 'DESC' } | null
 }

--- a/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
+++ b/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
@@ -139,7 +139,7 @@ export function useApolloQuery(args: {
         }
       > = gql`
         query RelationshipSelectMore($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.graphql.names.listOrderName}!]) {
-          items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip,orderBy: $orderBy) {
+          items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
             label: ${labelField}
             id: id
           }

--- a/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
+++ b/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
@@ -29,6 +29,8 @@ export function useApolloQuery(args: {
   labelField: string
   list: ListMeta
   searchFields: string[]
+  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
+  filter?: Record<string, any> | null
   state:
     | { kind: 'many'; value: RelationshipValue[] }
     | { kind: 'one'; value: RelationshipValue | null }
@@ -41,10 +43,15 @@ export function useApolloQuery(args: {
 
   const QUERY: TypedDocumentNode<
     { items: { id: string; label: string | null }[]; count: number },
-    { where: Record<string, any>; take: number; skip: number }
+    {
+      where: Record<string, any>
+      take: number
+      skip: number
+      orderBy: Record<string, any> | undefined
+    }
   > = gql`
-    query RelationshipSelect($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!) {
-      items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip) {
+    query RelationshipSelect($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.graphql.names.listOrderName}!]) {
+      items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
         id: id
         label: ${labelField}
       }
@@ -55,7 +62,15 @@ export function useApolloQuery(args: {
   const debouncedSearch = useDebouncedValue(search, 200)
   const manipulatedSearch =
     state.kind === 'one' && state.value?.label === debouncedSearch ? '' : debouncedSearch
-  const where = useSearchFilter(manipulatedSearch, list, searchFields)
+  const _where = useSearchFilter(manipulatedSearch, list, searchFields)
+
+  const where = useMemo(() => {
+    return args.filter ? { AND: [_where, args.filter] } : _where
+  }, [args.filter, _where])
+
+  const orderBy = useMemo(() => {
+    return args.sort ? { [args.sort.field]: args.sort.direction.toLowerCase() } : undefined
+  }, [args.sort])
 
   const link = useApolloClient().link
   // we're using a local apollo client here because writing a global implementation of the typePolicies
@@ -91,7 +106,7 @@ export function useApolloQuery(args: {
   const subsequentItemsToLoad = Math.min(list.pageSize, 50)
   const { data, previousData, error, loading, fetchMore } = useQuery(QUERY, {
     fetchPolicy: 'network-only',
-    variables: { where, take: initialItemsToLoad, skip: 0 },
+    variables: { where, take: initialItemsToLoad, skip: 0, orderBy },
     client: apolloClient,
   })
 
@@ -116,10 +131,15 @@ export function useApolloQuery(args: {
     ) {
       const QUERY: TypedDocumentNode<
         { items: { id: string; label: string | null }[] },
-        { where: Record<string, any>; take: number; skip: number }
+        {
+          where: Record<string, any>
+          take: number
+          skip: number
+          orderBy: Record<string, any> | undefined
+        }
       > = gql`
-        query RelationshipSelectMore($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!) {
-          items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip) {
+        query RelationshipSelectMore($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.graphql.names.listOrderName}!]) {
+          items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip,orderBy: $orderBy) {
             label: ${labelField}
             id: id
           }
@@ -132,6 +152,7 @@ export function useApolloQuery(args: {
           where,
           take: subsequentItemsToLoad,
           skip,
+          orderBy,
         },
       })
         .then(() => setLastFetchMore(null))


### PR DESCRIPTION
These options allow sorting and filtering the options shown in a relationship field when the displayMode is `select` (the default). Note the filtering only applies to the options available to select, it does not filter the already selected items shown but the sort does apply to both the selected items and the items available to select.