### PR TITLE
Fix document field fields.select not allowing selected an option with an empty string value

### DIFF
--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
@@ -73,7 +73,7 @@ export function makeSelectFieldInput({
         items={options}
         onSelectionChange={key => {
           const newVal = options.find(option => option.value === key)?.value
-          if (newVal) {
+          if (newVal !== undefined) {
             onChange?.(newVal)
           }
         }}


### PR DESCRIPTION
No changeset since it's new with the unreleased UI updates.