### PR TITLE
Add `ui.labelField` support for `field-document` relationship fields

### DIFF
--- a/.changeset/add-ui-label.md
+++ b/.changeset/add-ui-label.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/fields-document": minor
+---
+
+Add `ui.labelField` support for relationship fields

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
@@ -123,8 +123,9 @@ export type RelationshipField<Many extends boolean> = {
   kind: 'relationship'
   listKey: string
   label: string
+  labelField: string | null
+  selection: string | null
   many: Many
-  selection?: string
 }
 
 export type ConditionalField<

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -322,12 +322,14 @@ export const fields = {
   },
   relationship<Many extends boolean | undefined = false>({
     listKey,
-    selection,
     label,
+    labelField,
+    selection,
     many,
   }: {
     listKey: string
     label: string
+    labelField?: string
     selection?: string
   } & (Many extends undefined | false ? { many?: Many } : { many: Many })): RelationshipField<
     Many extends true ? true : false
@@ -335,8 +337,9 @@ export const fields = {
     return {
       kind: 'relationship' as const,
       listKey,
-      selection,
       label,
+      labelField: labelField ?? null,
+      selection: selection ?? null,
       many: (many ? true : false) as any,
     }
   },

--- a/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/document-features-normalization.test.tsx
@@ -308,8 +308,9 @@ function makeEditorWithChildField(
       },
       relationships: {
         mention: {
-          label: 'Mention',
           listKey: 'User',
+          label: 'Mention',
+          labelField: null,
           selection: null,
         },
       },

--- a/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/normalization.test.tsx
@@ -2,9 +2,9 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { Transforms } from 'slate'
-import { component, fields } from '../../component-blocks'
-import { jsx, makeEditor } from '../tests/utils'
 import { insertComponentBlock } from '.'
+import { component, fields } from '../../component-blocks'
+import { makeEditor, jsx } from '../tests/utils'
 
 const componentBlocks = {
   basic: component({

--- a/packages/fields-document/src/DocumentEditor/document-features-normalization.ts
+++ b/packages/fields-document/src/DocumentEditor/document-features-normalization.ts
@@ -1,6 +1,6 @@
-import { Text, Transforms, Element, type NodeEntry, Editor, Node } from 'slate'
-import { type DocumentFeatures } from '../views-shared'
-import { type Relationships } from './relationship-shared'
+import { Editor, Element, Node, Text, Transforms, type NodeEntry } from 'slate'
+import type { DocumentFeatures } from '../views-shared'
+import type { Relationships } from './relationship-shared'
 
 export function areArraysEqual(a: readonly unknown[], b: readonly unknown[]) {
   return a.length === b.length && a.every((x, i) => x === b[i])

--- a/packages/fields-document/src/DocumentEditor/relationship-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/relationship-shared.ts
@@ -1,4 +1,4 @@
-import { type Editor } from 'slate'
+import type { Editor } from 'slate'
 
 export type Relationships = Record<
   string,

--- a/packages/fields-document/src/DocumentEditor/relationship-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/relationship-shared.ts
@@ -4,9 +4,10 @@ export type Relationships = Record<
   string,
   {
     listKey: string
+    label: string
+    labelField: string | null
     /** GraphQL fields to select when querying the field */
     selection: string | null
-    label: string
   }
 >
 

--- a/packages/fields-document/src/relationship-data.ts
+++ b/packages/fields-document/src/relationship-data.ts
@@ -28,8 +28,10 @@ export function addRelationshipData(
           ...node,
           data: await fetchDataForOne(
             context,
-            relationship.listKey,
-            relationship.selection || '',
+            {
+              ...relationship,
+              many: false,
+            },
             node.data
           ),
         }
@@ -41,14 +43,7 @@ export function addRelationshipData(
             addRelationshipDataToComponentProps(
               { kind: 'object', fields: componentBlock.schema },
               node.props,
-              (relationship, data) =>
-                fetchRelationshipData(
-                  context,
-                  relationship.listKey,
-                  relationship.many,
-                  relationship.selection || '',
-                  data
-                )
+              (relationship, data) => fetchRelationshipData(context, relationship, data)
             ),
             addRelationshipData(node.children, context, relationships, componentBlocks),
           ])
@@ -75,27 +70,25 @@ export function addRelationshipData(
   )
 }
 
+type Relationship_ = Omit<RelationshipField<boolean>, 'kind'>
+
 export async function fetchRelationshipData(
   context: KeystoneContext,
-  listKey: string,
-  many: boolean,
-  selection: string,
+  relationship: Relationship_,
   data: any
 ) {
-  if (!many) return fetchDataForOne(context, listKey, selection, data)
+  if (!relationship.many) return fetchDataForOne(context, relationship, data)
 
   const ids = Array.isArray(data) ? data.filter(item => item.id != null).map(x => x.id) : []
   if (!ids.length) return []
 
-  const {
-    graphql: {
-      names: { listQueryName },
-    },
-    ui: { labelField },
-  } = context.__internal.lists[listKey]
+  const list = context.__internal.lists[relationship.listKey]
+  const { listQueryName } = list.graphql.names
+  const labelField = relationship.labelField ?? list.ui.labelField
+
   const value = (await context.graphql.run({
     query: `query($ids: [ID!]!) {items:${listQueryName}(where: { id: { in: $ids } }) {${idFieldAlias}:id ${labelFieldAlias}:${labelField}\n${
-      selection || ''
+      relationship.selection || ''
     }}}`,
     variables: { ids },
   })) as { items: { [idFieldAlias]: string | number; [labelFieldAlias]: string }[] }
@@ -107,12 +100,7 @@ export async function fetchRelationshipData(
     : []
 }
 
-async function fetchDataForOne(
-  context: KeystoneContext,
-  listKey: string,
-  selection: string,
-  data: any
-) {
+async function fetchDataForOne(context: KeystoneContext, relationship: Relationship_, data: any) {
   // Single related item
   const id = data?.id
   if (id == null) return null
@@ -120,14 +108,11 @@ async function fetchDataForOne(
   // An exception here indicates something wrong with either the system or the
   // configuration (e.g. a bad selection field). These will surface as system
   // errors from the GraphQL field resolver.
-  const {
-    graphql: {
-      names: { itemQueryName },
-    },
-    ui: { labelField },
-  } = context.__internal.lists[listKey]
+  const list = context.__internal.lists[relationship.listKey]
+  const { itemQueryName } = list.graphql.names
+  const labelField = relationship.labelField ?? list.ui.labelField
   const value = (await context.graphql.run({
-    query: `query($id: ID!) {item:${itemQueryName}(where: {id:$id}) {${labelFieldAlias}:${labelField}\n${selection}}}`,
+    query: `query($id: ID!) {item:${itemQueryName}(where: { id: $id }) {${labelFieldAlias}:${labelField}\n${relationship.selection || ''}}}`,
     variables: { id },
   })) as { item: Record<string, any> | null }
 

--- a/packages/fields-document/src/relationship-data.ts
+++ b/packages/fields-document/src/relationship-data.ts
@@ -1,14 +1,13 @@
-import { type KeystoneContext } from '@keystone-6/core/types'
-import { type Descendant } from 'slate'
+import type { KeystoneContext } from '@keystone-6/core/types'
+import type { Descendant } from 'slate'
 
-import {
-  type ComponentBlock,
-  type ComponentSchema,
-  type RelationshipField,
+import type {
+  ComponentBlock,
+  ComponentSchema,
+  RelationshipField,
 } from './DocumentEditor/component-blocks/api-shared'
-
 import { assertNever } from './DocumentEditor/component-blocks/utils'
-import { type Relationships } from './DocumentEditor/relationship-shared'
+import type { Relationships } from './DocumentEditor/relationship-shared'
 
 const labelFieldAlias = '____document_field_relationship_item_label'
 const idFieldAlias = '____document_field_relationship_item_id'

--- a/packages/fields-document/src/structure-graphql-input.ts
+++ b/packages/fields-document/src/structure-graphql-input.ts
@@ -1,11 +1,11 @@
 import { g } from '@keystone-6/core'
+import type { GArg, GInputType, GNonNull, InferValueFromArg } from '@keystone-6/core/graphql-ts'
 import type {
   BaseItem,
   FieldData,
   GraphQLTypesForList,
   KeystoneContext,
 } from '@keystone-6/core/types'
-import type { GArg, GInputType, GNonNull, InferValueFromArg } from '@keystone-6/core/graphql-ts'
 import type { GraphQLResolveInfo } from 'graphql'
 
 import type { ComponentSchema } from './DocumentEditor/component-blocks/api'

--- a/packages/fields-document/src/structure.ts
+++ b/packages/fields-document/src/structure.ts
@@ -120,13 +120,7 @@ export function structure<ListTypeInfo extends BaseListTypeInfo>({
                 resolve({ value }, args, context) {
                   if (!args.hydrateRelationships) return value
                   return addRelationshipDataToComponentProps(schema, value, (schema, value) => {
-                    return fetchRelationshipData(
-                      context,
-                      schema.listKey,
-                      schema.many,
-                      schema.selection || '',
-                      value
-                    )
+                    return fetchRelationshipData(context, schema, value)
                   })
                 },
               }),

--- a/packages/fields-document/src/structure.ts
+++ b/packages/fields-document/src/structure.ts
@@ -1,3 +1,4 @@
+import { g } from '@keystone-6/core'
 import type { BaseFieldTypeInfo } from '@keystone-6/core/types'
 import {
   type BaseListTypeInfo,
@@ -6,17 +7,16 @@ import {
   type JSONValue,
   jsonFieldTypePolyfilledForSQLite,
 } from '@keystone-6/core/types'
-import { g } from '@keystone-6/core'
-import { getInitialPropsValue } from './DocumentEditor/component-blocks/initial-values'
-import { getOutputGraphQLField } from './structure-graphql-output'
 import type { ComponentSchema } from './DocumentEditor/component-blocks/api'
+import { assertValidComponentSchema } from './DocumentEditor/component-blocks/field-assertions'
+import { getInitialPropsValue } from './DocumentEditor/component-blocks/initial-values'
+import { addRelationshipDataToComponentProps, fetchRelationshipData } from './relationship-data'
 import {
   getGraphQLInputType,
   getValueForCreate,
   getValueForUpdate,
 } from './structure-graphql-input'
-import { assertValidComponentSchema } from './DocumentEditor/component-blocks/field-assertions'
-import { addRelationshipDataToComponentProps, fetchRelationshipData } from './relationship-data'
+import { getOutputGraphQLField } from './structure-graphql-output'
 
 export type StructureFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
   ListTypeInfo,
@@ -93,7 +93,7 @@ export function structure<ListTypeInfo extends BaseListTypeInfo>({
             arg: g.arg({
               type: getGraphQLInputType(name, schema, 'update', new Map(), meta),
             }),
-            resolve(val, context) {
+            resolve(val) {
               return val as any
             },
           },

--- a/packages/fields-document/src/validation.test.tsx
+++ b/packages/fields-document/src/validation.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { component, type ComponentBlock, fields } from './DocumentEditor/component-blocks/api'
-import { type Relationships } from './DocumentEditor/relationship'
+import type { Relationships } from './DocumentEditor/relationship'
 import { defaultDocumentFeatures, makeEditor, jsx } from './DocumentEditor/tests/utils'
 import { PropValidationError, validateAndNormalizeDocument } from './validation'
 
@@ -11,8 +11,9 @@ import { PropValidationError, validateAndNormalizeDocument } from './validation'
 
 const relationships: Relationships = {
   inline: {
-    label: 'Inline',
     listKey: 'Post',
+    label: 'Inline',
+    labelField: null,
     selection: `something`,
   },
 }
@@ -27,8 +28,8 @@ const componentBlocks: Record<string, ComponentBlock> = {
     preview: () => null,
     label: '',
     schema: {
-      one: fields.relationship({ label: '', listKey: 'Post', selection: 'something' }),
-      many: fields.relationship({ label: '', listKey: 'Post', many: true, selection: 'something' }),
+      one: fields.relationship({ listKey: 'Post', label: '', selection: 'something' }),
+      many: fields.relationship({ listKey: 'Post', label: '', many: true, selection: 'something' }),
     },
   }),
   object: component({

--- a/tests/api-tests/fields/types/document.test.ts
+++ b/tests/api-tests/fields/types/document.test.ts
@@ -46,7 +46,7 @@ const runner = setupTestRunner({
               mention: {
                 listKey: 'Author',
                 label: 'Mention',
-                selection: 'bad selection',
+                selection: 'id notafield',
               },
             },
           }),
@@ -270,8 +270,8 @@ describe('Document field type', () => {
                 { text: '' },
                 {
                   type: 'relationship',
-                  data: { id: alice.id },
                   relationship: 'mention',
+                  data: { id: alice.id },
                   children: [{ text: '' }],
                 },
                 { text: '' },
@@ -286,12 +286,12 @@ describe('Document field type', () => {
           'query ($id: ID!){ author(where: { id: $id }) { badBio { document(hydrateRelationships: true) } } }',
         variables: { id: badBob.id },
       })
-      // FIXME: The path doesn't match the null field here!
+
       expect(body.data).toEqual({ author: { badBio: null } })
       expectInternalServerError(body.errors, [
         {
           path: ['author', 'badBio', 'document'],
-          message: 'Cannot query field "bad" on type "Author". Did you mean "bio" or "id"?',
+          message: 'Cannot query field "notafield" on type "Author".',
         },
       ])
     })


### PR DESCRIPTION
This pull request adds the equivalent `ui.labelField` support from relationship fields to document field relationships.