### PR TITLE
Revert https://github.com/keystonejs/keystone/pull/9663, keeping fixes only

### DIFF
--- a/.changeset/respect-the-choice.md
+++ b/.changeset/respect-the-choice.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": major
----
-
-Changes `{field}.ui.*.fieldMode` to always use the value provided, if any, before falling back to defaults

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -663,37 +663,34 @@ function getListsWithInitialisedFields(
           views: f.ui?.views ?? null,
           createView: {
             isRequired: f.ui?.createView?.isRequired ?? false,
-            fieldMode:
-              f.ui?.createView?.fieldMode ??
-              (isEnabledField.create
-                ? (group?.ui?.createView?.defaultFieldMode ??
-                  listConfig.ui?.createView?.defaultFieldMode ??
-                  'edit')
-                : 'hidden'),
+            fieldMode: isEnabledField.create
+              ? (f.ui?.createView?.fieldMode ??
+                group?.ui?.createView?.defaultFieldMode ??
+                listConfig.ui?.createView?.defaultFieldMode ??
+                'edit')
+              : 'hidden',
           },
 
           itemView: {
             isRequired: f.ui?.itemView?.isRequired ?? false,
             fieldPosition: f.ui?.itemView?.fieldPosition ?? 'form',
-            fieldMode:
-              f.ui?.itemView?.fieldMode ??
-              (isEnabledField.update
-                ? (group?.ui?.itemView?.defaultFieldMode ??
-                  listConfig.ui?.itemView?.defaultFieldMode ??
-                  'edit')
-                : isEnabledField.read
-                  ? 'read'
-                  : 'hidden'),
+            fieldMode: isEnabledField.update
+              ? (f.ui?.itemView?.fieldMode ??
+                group?.ui?.itemView?.defaultFieldMode ??
+                listConfig.ui?.itemView?.defaultFieldMode ??
+                'edit')
+              : isEnabledField.read
+                ? (f.ui?.itemView?.fieldMode ?? 'read')
+                : 'hidden',
           },
 
           listView: {
-            fieldMode:
-              f.ui?.listView?.fieldMode ??
-              (isEnabledField.read
-                ? (group?.ui?.listView?.defaultFieldMode ??
-                  listConfig.ui?.listView?.defaultFieldMode ??
-                  'read')
-                : 'hidden'),
+            fieldMode: isEnabledField.read
+              ? (f.ui?.listView?.fieldMode ??
+                group?.ui?.listView?.defaultFieldMode ??
+                listConfig.ui?.listView?.defaultFieldMode ??
+                'read')
+              : 'hidden',
           },
         },
 


### PR DESCRIPTION
https://github.com/keystonejs/keystone/pull/9663 opted to always use the provided values, but in retrospect, this will only break things downstream.

This pull request reverts that breaking change, but maintains the fixes to ensure the provided value is used when that value won't break downstream.