### PR TITLE
Add `.description` for component block relationships and fix filter/sort

### DIFF
--- a/.changeset/add-block-description.md
+++ b/.changeset/add-block-description.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/fields-document": minor
+---
+
+Add `.description` support for component block relationship fields

--- a/.changeset/add-ui-label.md
+++ b/.changeset/add-ui-label.md
@@ -2,4 +2,4 @@
 "@keystone-6/fields-document": minor
 ---
 
-Add `ui.labelField` support for relationship fields
+Add `.labelField` support for inline and component block relationship fields

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -11,6 +11,14 @@ import { schema as bundlesStructureSchema } from './structure-relationships-2'
 export const lists = {
   Post: list({
     access: allowAll, // WARNING: public
+    ui: {
+      listView:{
+        initialSort: {
+          field: 'title',
+          direction: 'DESC',
+        },
+      }
+    },
     fields: {
       title: text({
         validation: { isRequired: true },

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -12,12 +12,12 @@ export const lists = {
   Post: list({
     access: allowAll, // WARNING: public
     ui: {
-      listView:{
+      listView: {
         initialSort: {
           field: 'title',
           direction: 'DESC',
         },
-      }
+      },
     },
     fields: {
       title: text({

--- a/examples/relationships/structure-relationships-2.tsx
+++ b/examples/relationships/structure-relationships-2.tsx
@@ -2,8 +2,9 @@ import { fields } from '@keystone-6/fields-document/component-blocks'
 
 export const schema = fields.array(
   fields.relationship({
-    label: 'Bundle',
     listKey: 'Post',
+    label: 'Bundle',
+    description: 'What posts should be bundled with this post',
     many: true,
   }),
   {

--- a/examples/relationships/structure-relationships.tsx
+++ b/examples/relationships/structure-relationships.tsx
@@ -2,8 +2,9 @@ import { fields } from '@keystone-6/fields-document/component-blocks'
 
 export const schema = fields.array(
   fields.relationship({
-    label: 'Recommended Post',
     listKey: 'Post',
+    label: 'Recommended Post',
+    description: 'What posts do you recommend?',
   }),
   {
     itemLabel: props => {

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/useSort.tsx
@@ -5,14 +5,13 @@ import type { ListMeta } from '../../../../types'
 export function useSort(list: ListMeta) {
   const { query } = useRouter()
   const sortByFromUrl = typeof query.sortBy === 'string' ? query.sortBy : null
-  if (!sortByFromUrl) return null
+  if (sortByFromUrl === '') return null
+  if (!sortByFromUrl) return list.initialSort
   const fieldKey = sortByFromUrl.startsWith('-') ? sortByFromUrl.slice(1) : sortByFromUrl
   const direction = sortByFromUrl.startsWith('-') ? ('DESC' as const) : ('ASC' as const)
   const field = list.fields[fieldKey]
   if (!field) return null
   if (!field.isOrderable) return null
-  if (sortByFromUrl === '') return null
-  if (sortByFromUrl === null) return list.initialSort
   return {
     field: fieldKey,
     direction,

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -232,8 +232,8 @@ export function controller(
     } & (
       | {
           displayMode: 'select'
-          sort: { field: string; direction: 'ASC' | 'DESC' } | null
           filter: Record<string, any> | null
+          sort: { field: string; direction: 'ASC' | 'DESC' } | null
         }
       | { displayMode: 'count' }
       | {

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -56,7 +56,7 @@ export type ListAdminUIConfig<ListTypeInfo extends BaseListTypeInfo> = {
    * It is always possible to search by id and `id` should not be specified in this option.
    * @default The `labelField` if it has a string `contains` filter, otherwise none.
    */
-  searchFields?: ListTypeInfo['fields'][];
+  searchFields?: ListTypeInfo['fields'][]
 
   /** The path that the list should be at in the Admin UI */
   // Not currently used. Should be passed into `keystone.createList()`.

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -50,13 +50,13 @@ export type ListAdminUIConfig<ListTypeInfo extends BaseListTypeInfo> = {
    * The field to use as a label in the Admin UI. If you want to base the label off more than a single field, use a virtual field and reference that field here.
    * @default 'label', if it exists, falling back to 'name', then 'title', and finally 'id', which is guaranteed to exist.
    */
-  labelField?: 'id' | Exclude<keyof BaseFields<ListTypeInfo>, number>
+  labelField?: 'id' | Exclude<ListTypeInfo['fields'], number>
   /**
    * The fields used by the Admin UI when searching this list.
    * It is always possible to search by id and `id` should not be specified in this option.
    * @default The `labelField` if it has a string `contains` filter, otherwise none.
    */
-  searchFields?: readonly Extract<keyof BaseFields<ListTypeInfo>, string>[]
+  searchFields?: ListTypeInfo['fields'][];
 
   /** The path that the list should be at in the Admin UI */
   // Not currently used. Should be passed into `keystone.createList()`.
@@ -124,9 +124,9 @@ export type ListAdminUIConfig<ListTypeInfo extends BaseListTypeInfo> = {
      * Users of the Admin UI can select different columns to show in the UI.
      * @default the first three fields in the list
      */
-    initialColumns?: readonly ('id' | keyof BaseFields<ListTypeInfo>)[]
+    initialColumns?: readonly ('id' | ListTypeInfo['fields'])[]
     // was previously top-level defaultSort
-    initialSort?: { field: 'id' | keyof BaseFields<ListTypeInfo>; direction: 'ASC' | 'DESC' }
+    initialSort?: { field: 'id' | ListTypeInfo['fields']; direction: 'ASC' | 'DESC' }
     // was previously defaultPageSize
     pageSize?: number // default number of items to display per page on the list screen
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
@@ -123,6 +123,7 @@ export type RelationshipField<Many extends boolean> = {
   kind: 'relationship'
   listKey: string
   label: string
+  description: string | null
   labelField: string | null
   selection: string | null
   many: Many

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -323,12 +323,15 @@ export const fields = {
   relationship<Many extends boolean | undefined = false>({
     listKey,
     label,
+    description,
     labelField,
     selection,
     many,
   }: {
     listKey: string
     label: string
+    /** The description to show adjacent to the label */
+    description?: string
     /** The label field to use for this relationship when showing the select */
     labelField?: string
     /** The GraphQL selection to use for this relationship when hydrating .data */
@@ -340,6 +343,7 @@ export const fields = {
       kind: 'relationship' as const,
       listKey,
       label,
+      description: description ?? null,
       labelField: labelField ?? null,
       selection: selection ?? null,
       many: (many ? true : false) as any,

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -273,12 +273,7 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
 
 function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
   const { autoFocus, onChange, schema, value } = props
-  const {
-    listKey,
-    label,
-    description,
-    many
-  } = schema
+  const { listKey, label, description, many } = schema
   const list = useList(listKey)
   const formValue = (function () {
     if (many) {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -331,10 +331,12 @@ function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
 
           // see relationship controller for these fields
           refListKey: list.key,
+          many,
+          hideCreate: true,
           refLabelField: list.labelField,
           refSearchFields: list.initialSearchFields,
-          hideCreate: true,
-          many,
+          filter: list.initialFilter as any,
+          sort: list.initialSort,
         } as any
       }
       onChange={val => {

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -1,18 +1,17 @@
 import { useList } from '@keystone-6/core/admin-ui/context'
-import { Field as RelationshipFieldView } from '@keystone-6/core/fields/types/relationship/views'
 import { GroupIndicatorLine } from '@keystone-6/core/admin-ui/utils'
+import { Field as RelationshipFieldView } from '@keystone-6/core/fields/types/relationship/views'
 
 import { ActionButton, Button, ButtonGroup } from '@keystar/ui/button'
 import { Dialog, DialogContainer } from '@keystar/ui/dialog'
+import { type ItemDropTarget, move, useDragAndDrop } from '@keystar/ui/drag-and-drop'
 import { Field } from '@keystar/ui/field'
-import { Heading, Text } from '@keystar/ui/typography'
 import { Icon } from '@keystar/ui/icon'
-import { Item, ListView } from '@keystar/ui/list-view'
-import { type ItemDropTarget, useDragAndDrop } from '@keystar/ui/drag-and-drop'
-import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip'
-import { HStack, VStack } from '@keystar/ui/layout'
-import { move } from '@keystar/ui/drag-and-drop'
 import { trash2Icon } from '@keystar/ui/icon/icons/trash2Icon'
+import { HStack, VStack } from '@keystar/ui/layout'
+import { Item, ListView } from '@keystar/ui/list-view'
+import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip'
+import { Heading, Text } from '@keystar/ui/typography'
 
 import {
   type Key,
@@ -20,10 +19,10 @@ import {
   type ReactElement,
   memo,
   useCallback,
-  useMemo,
-  useState,
-  useRef,
   useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from 'react'
 import type {
   ArrayField,
@@ -38,9 +37,9 @@ import type {
 } from './api'
 import { getKeysForArrayValue, setKeysForArrayValue } from './preview-props'
 
-import { assertNever, clientSideValidateProp } from './utils'
-import { createGetPreviewProps } from './preview-props'
 import { Content } from '@keystar/ui/slots'
+import { createGetPreviewProps } from './preview-props'
+import { assertNever, clientSideValidateProp } from './utils'
 
 type DefaultFieldProps<Key> = GenericPreviewProps<
   Extract<ComponentSchema, { kind: Key }>,
@@ -274,7 +273,12 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
 
 function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
   const { autoFocus, onChange, schema, value } = props
-  const { label, listKey, many } = schema
+  const {
+    listKey,
+    label,
+    description,
+    many
+  } = schema
   const list = useList(listKey)
   const formValue = (function () {
     if (many) {
@@ -321,9 +325,11 @@ function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
         {
           path: '', // unused
           label,
-          description: '', // TODO
+          description,
           display: 'select',
           listKey: '', // unused
+
+          // see relationship controller for these fields
           refListKey: list.key,
           refLabelField: list.labelField,
           refSearchFields: list.initialSearchFields,

--- a/packages/fields-document/src/DocumentEditor/relationship-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/relationship-shared.ts
@@ -1,12 +1,14 @@
 import type { Editor } from 'slate'
 
+// inline relationship type
 export type Relationships = Record<
   string,
   {
     listKey: string
     label: string
+    /** The label field to use for this relationship when showing the select */
     labelField: string | null
-    /** GraphQL fields to select when querying the field */
+    /** The GraphQL selection to use for this relationship when hydrating .data */
     selection: string | null
   }
 >

--- a/packages/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages/fields-document/src/DocumentEditor/relationship.tsx
@@ -19,6 +19,7 @@ export function useDocumentFieldRelationships() {
 
 export const DocumentFieldRelationshipsProvider = DocumentFieldRelationshipsContext.Provider
 
+// this is the inline relationship, see form-from-preview for the component field
 export function RelationshipElement({
   attributes,
   children,

--- a/packages/fields-document/src/relationship-data.ts
+++ b/packages/fields-document/src/relationship-data.ts
@@ -70,7 +70,7 @@ export function addRelationshipData(
   )
 }
 
-type Relationship_ = Omit<RelationshipField<boolean>, 'kind'>
+type Relationship_ = Omit<RelationshipField<boolean>, 'kind' | 'description'>
 
 export async function fetchRelationshipData(
   context: KeystoneContext,


### PR DESCRIPTION
This pull request adds a `.description` field, and fixes the relationship field filtering and sorting as added in https://github.com/keystonejs/keystone/pull/9666 and https://github.com/keystonejs/keystone/pull/9629

The sorting bug has not been released, thereby a changeset is not required for that.