### PR TITLE
Fix `graphql.isNonNull` preventing Item page from submitting

### DIFF
--- a/examples/field-groups/schema.graphql
+++ b/examples/field-groups/schema.graphql
@@ -89,7 +89,6 @@ enum OrderDirection {
 
 input PostUpdateInput {
   title: String!
-  slug: String
   content: String
 }
 
@@ -100,7 +99,6 @@ input PostUpdateArgs {
 
 input PostCreateInput {
   title: String! = ""
-  slug: String
   content: String
 }
 

--- a/examples/field-groups/schema.ts
+++ b/examples/field-groups/schema.ts
@@ -23,14 +23,16 @@ export const lists = {
               create: denyAll,
               update: denyAll,
             },
-            // for this example, we are going to use a hook for fun
-            //  defaultValue: { kind: 'now' }
+            graphql: {
+              omit: {
+                create: true,
+                update: true,
+              },
+            },
             hooks: {
-              resolveInput: {
-                create: ({ context, operation, resolvedData }) => {
-                  // TODO: text should allow you to prevent a defaultValue, then Prisma create could be non-null
-                  return resolvedData.title?.replace(/ /g, '-').toLowerCase()
-                },
+              resolveInput: ({ context, operation, resolvedData }) => {
+                if (typeof resolvedData.title !== 'string') return undefined // TODO: remove this
+                return resolvedData.title?.replace(/ /g, '-').toLowerCase()
               },
             },
           }),

--- a/packages/core/src/admin-ui/utils/useCreateItem.ts
+++ b/packages/core/src/admin-ui/utils/useCreateItem.ts
@@ -3,16 +3,16 @@ import { type ComponentProps, useEffect, useMemo, useRef, useState } from 'react
 
 import { toastQueue } from '@keystar/ui/toast'
 
-import type { ListMeta } from '../../types'
-import { type ApolloError, gql, useMutation } from '../apollo'
-import { usePreventNavigation } from './usePreventNavigation'
 import type { Fields } from '.'
 import {
-  serializeValueToOperationItem,
   makeDefaultValueState,
+  serializeValueToOperationItem,
   useHasChanges,
   useInvalidFields,
 } from '../../admin-ui/utils'
+import type { ListMeta } from '../../types'
+import { type ApolloError, gql, useMutation } from '../apollo'
+import { usePreventNavigation } from './usePreventNavigation'
 
 type CreateItemHookResult = {
   state: 'editing' | 'loading' | 'created'

--- a/packages/core/src/admin-ui/utils/utils.tsx
+++ b/packages/core/src/admin-ui/utils/utils.tsx
@@ -86,10 +86,8 @@ export function serializeValueToOperationItem(
 
   for (const fieldKey in fields) {
     const field = fields[fieldKey]
-
     const fieldValue = value[fieldKey]
     const fieldValueSerialized = field.controller.serialize(fieldValue)
-
     const fieldValueReference = valueReference[fieldKey]
 
     const isAlwaysRequired = field.graphql.isNonNull.includes(operation)
@@ -111,13 +109,18 @@ export function useHasChanges(
   valueReference?: Record<string, unknown>
 ) {
   return useMemo(() => {
-    const alwaysRequiredCount = Object.values(fields).filter(f =>
-      f.graphql.isNonNull.includes(operation)
-    ).length
+    valueReference ??= makeDefaultValueState(fields)
 
-    const itemForUpdate = serializeValueToOperationItem(operation, fields, value, valueReference)
+    for (const fieldKey in fields) {
+      const field = fields[fieldKey]
+      const fieldValue = value[fieldKey]
+      const fieldValueSerialized = field.controller.serialize(fieldValue)
+      const fieldValueReference = valueReference[fieldKey]
 
-    // add any fields that are always required
-    return Object.keys(itemForUpdate).length - alwaysRequiredCount > 0
+      if (!isDeepEqual(fieldValueSerialized, field.controller.serialize(fieldValueReference)))
+        return true
+    }
+
+    return false
   }, [fields, operation, value, valueReference])
 }


### PR DESCRIPTION
`useHasChanges` erroneously showed that the input had no changes from the initial item.
This bug has not been released, thereby a changeset is not required.