### PR TITLE
Sanitise URLs in document field content on input

### DIFF
--- a/.changeset/fix-document-uris.mx
+++ b/.changeset/fix-document-uris.mx
@@ -2,4 +2,4 @@
 "@keystone-6/fields-document": patch
 ---
 
-Use `new URL` rather than `encodeURI` for encoding URLs safely
+Use `new URL` rather than `encodeURI` when validating, and sanitize user input


### PR DESCRIPTION
https://github.com/user-attachments/assets/4ff2376e-745b-4b35-8460-2b4b69078b3a

This pull request builds on https://github.com/keystonejs/keystone/pull/9613, but rather than continuing on the path of accepting a wider range of inputs, this hooks into the `onSubmit` of the inbuilt link to ensure links are sanitised early.