### PR TITLE
Change the type for `ui.getAdditionalFiles` to be flattened

### DIFF
--- a/.changeset/less-arrays-ui.md
+++ b/.changeset/less-arrays-ui.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": major
+---
+
+Changes the type for `ui.getAdditionalFiles` to be flattened, prefer function composition when wrapping

--- a/examples/document-field/keystone.ts
+++ b/examples/document-field/keystone.ts
@@ -6,7 +6,7 @@ export default config({
     provider: 'sqlite',
     url: process.env.DATABASE_URL || 'file:./keystone-example.db',
 
-    // WARNING: this is only needed for our monorepo examples, dont do this
+    // WARNING: this is needed for our monorepo, you may not want this
     prismaClientPath: 'node_modules/myprisma',
   },
   lists,

--- a/examples/document-field/next.config.js
+++ b/examples/document-field/next.config.js
@@ -1,5 +1,4 @@
-// you don't need this if you're building something outside of the Keystone repo
-
+// WARNING: this is needed for our monorepo, you may not want this
 const withPreconstruct = require('@preconstruct/next')
 
 module.exports = withPreconstruct()

--- a/examples/logging/keystone.ts
+++ b/examples/logging/keystone.ts
@@ -68,5 +68,21 @@ export default config<TypeInfo>({
       ],
     },
   },
+  ui: {
+    getAdditionalFiles: async () => [{
+      mode: 'write',
+      src: `export default ${JSON.stringify({
+        // stop the default Next logging
+        logging: false, // we use pino
+
+        // defaults from packages/core/src/templates/next-config.ts
+        bundlePagesRouterDependencies: true,
+        eslint: { ignoreDuringBuilds: true },
+        typescript: { ignoreBuildErrors: true },
+        transpilePackages: ['../../admin'],
+      })}`,
+      outputPath: 'next.config.js',
+    }]
+  },
   lists,
 })

--- a/examples/logging/keystone.ts
+++ b/examples/logging/keystone.ts
@@ -69,20 +69,22 @@ export default config<TypeInfo>({
     },
   },
   ui: {
-    getAdditionalFiles: async () => [{
-      mode: 'write',
-      src: `export default ${JSON.stringify({
-        // stop the default Next logging
-        logging: false, // we use pino
+    getAdditionalFiles: async () => [
+      {
+        mode: 'write',
+        src: `export default ${JSON.stringify({
+          // stop the default Next logging
+          logging: false, // we use pino
 
-        // defaults from packages/core/src/templates/next-config.ts
-        bundlePagesRouterDependencies: true,
-        eslint: { ignoreDuringBuilds: true },
-        typescript: { ignoreBuildErrors: true },
-        transpilePackages: ['../../admin'],
-      })}`,
-      outputPath: 'next.config.js',
-    }]
+          // defaults from packages/core/src/templates/next-config.ts
+          bundlePagesRouterDependencies: true,
+          eslint: { ignoreDuringBuilds: true },
+          typescript: { ignoreBuildErrors: true },
+          transpilePackages: ['../../admin'],
+        })}`,
+        outputPath: 'next.config.js',
+      },
+    ],
   },
   lists,
 })

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -225,8 +225,8 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
         ...ui,
         publicPages: [...publicPages, ...authPublicPages],
         getAdditionalFiles: async () => [
-          ...await getAdditionalFiles(),
-          ...authGetAdditionalFiles(config)
+          ...(await getAdditionalFiles()),
+          ...authGetAdditionalFiles(config),
         ],
 
         isAccessAllowed: async (context: KeystoneContext) => {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -215,7 +215,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
     let { ui } = config
     if (!ui?.isDisabled) {
       const {
-        getAdditionalFiles = [],
+        getAdditionalFiles = () => [],
         isAccessAllowed = defaultIsAccessAllowed,
         pageMiddleware,
         publicPages = [],
@@ -224,7 +224,10 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
       ui = {
         ...ui,
         publicPages: [...publicPages, ...authPublicPages],
-        getAdditionalFiles: [...getAdditionalFiles, () => authGetAdditionalFiles(config)],
+        getAdditionalFiles: async () => [
+          ...await getAdditionalFiles(),
+          ...authGetAdditionalFiles(config)
+        ],
 
         isAccessAllowed: async (context: KeystoneContext) => {
           if (await hasInitFirstItemConditions(context)) return true

--- a/packages/core/src/admin-ui/system/generateAdminUI.ts
+++ b/packages/core/src/admin-ui/system/generateAdminUI.ts
@@ -68,8 +68,7 @@ export async function generateAdminUI(
   }
 
   // Write out the files configured by the user
-  const userFiles = config.ui?.getAdditionalFiles?.map(x => x()) ?? []
-  const userFilesToWrite = (await Promise.all(userFiles)).flat()
+  const userFilesToWrite = await config.ui.getAdditionalFiles()
   const savedFiles = await Promise.all(
     userFilesToWrite.map(file => writeAdminFile(file, projectAdminPath))
   )

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -139,7 +139,7 @@ export function config<TypeInfo extends BaseKeystoneTypeInfo>(
       basePath: config.ui?.basePath ?? '',
       isAccessAllowed: config.ui?.isAccessAllowed ?? defaultIsAccessAllowed,
       isDisabled: config.ui?.isDisabled ?? false,
-      getAdditionalFiles: config.ui?.getAdditionalFiles ?? [],
+      getAdditionalFiles: config.ui?.getAdditionalFiles ?? (() => []),
       pageMiddleware: config.ui?.pageMiddleware ?? noop,
       publicPages: config.ui?.publicPages ?? [],
     },

--- a/packages/core/src/scripts/start.ts
+++ b/packages/core/src/scripts/start.ts
@@ -1,11 +1,11 @@
 import next from 'next'
 
-import { createSystem } from '../lib/createSystem'
-import { createExpressServer } from '../lib/createExpressServer'
 import { createAdminUIMiddlewareWithNextApp } from '../lib/createAdminUIMiddleware'
+import { createExpressServer } from '../lib/createExpressServer'
+import { createSystem } from '../lib/createSystem'
 import { withMigrate } from '../lib/migrations'
+import type { Flags } from './cli'
 import { importBuiltKeystoneConfiguration } from './utils'
-import { type Flags } from './cli'
 
 export async function start(
   cwd: string,

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -162,7 +162,7 @@ export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeysto
     /** The Base Path for Keystones Admin UI */
     basePath?: string
 
-    getAdditionalFiles?: readonly (() => MaybePromise<readonly AdminFileToWrite[]>)[]
+    getAdditionalFiles?: () => MaybePromise<readonly AdminFileToWrite[]>
 
     /** An async middleware function that can optionally return a redirect */
     pageMiddleware?: (args: {

--- a/tests/test-projects/live-reloading/keystone.ts
+++ b/tests/test-projects/live-reloading/keystone.ts
@@ -15,14 +15,12 @@ export default config({
     extendGraphqlSchema,
   },
   ui: {
-    getAdditionalFiles: [
-      () => [
-        {
-          mode: 'write',
-          src: "export default function(req,res) {res.send('something')}",
-          outputPath: 'pages/api/blah/[...rest].js',
-        },
-      ],
+    getAdditionalFiles: () => [
+      {
+        mode: 'write',
+        src: "export default function(req,res) {res.send('something')}",
+        outputPath: 'pages/api/blah/[...rest].js',
+      },
     ],
   },
 })


### PR DESCRIPTION
Rather than downstream developers using the following pattern when merging these arrays:
```typescript
getAdditionalFiles: [...getAdditionalFiles, () => authGetAdditionalFiles(config)],
```

They should now use:
```typescript
getAdditionalFiles: async () => [
   ...await getAdditionalFiles(),
   ...authGetAdditionalFiles(config)
],
```

This aligns with the name of the function as `get*`, and keeps the composition story as the same as our other functions.