### PR TITLE
Sanitise URLs in document field `fields.url` on input

### DIFF
--- a/.changeset/fix-document-uris.mx
+++ b/.changeset/fix-document-uris.mx
@@ -1,5 +1,5 @@
 ---
-"@keystone-6/fields-document": patch
+"@keystone-6/fields-document": major
 ---
 
-Use `new URL` rather than `encodeURI` when validating, and sanitize user input
+Changes `fields.url` and document links to sanitise and `encodeURI` on blur

--- a/docs/components/docs/Heading.tsx
+++ b/docs/components/docs/Heading.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import slugify from '@sindresorhus/slugify'
-import { type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 import { HeadingIdLink } from './CopyToClipboard'
 

--- a/packages/core/src/admin-ui/components/Logo.tsx
+++ b/packages/core/src/admin-ui/components/Logo.tsx
@@ -1,5 +1,6 @@
-import { type SVGAttributes } from 'react'
+import type { SVGAttributes } from 'react'
 import Link from 'next/link'
+
 import { css, tokenSchema } from '@keystar/ui/style'
 import { Heading } from '@keystar/ui/typography'
 

--- a/packages/core/src/fields/types/calendarDay/index.ts
+++ b/packages/core/src/fields/types/calendarDay/index.ts
@@ -1,22 +1,23 @@
-import type { SimpleFieldTypeInfo } from '../../../types'
-import {
-  type BaseListTypeInfo,
-  type CommonFieldConfig,
-  type FieldTypeFunc,
-  fieldType,
-  orderDirectionEnum,
-} from '../../../types'
-import { type CalendarDayFieldMeta } from './views'
-import { g } from '../../..'
-import { filters } from '../../filters'
-import { makeValidateHook, defaultIsRequired } from '../../non-null-graphql'
 import type {
-  GInputObjectType,
   GArg,
+  GInputObjectType,
   GList,
   GNonNull,
   InferValueFromInputType,
 } from '@graphql-ts/schema'
+
+import { g } from '../../..'
+import {
+  type BaseListTypeInfo,
+  type CommonFieldConfig,
+  type FieldTypeFunc,
+  type SimpleFieldTypeInfo,
+  fieldType,
+  orderDirectionEnum,
+} from '../../../types'
+import { filters } from '../../filters'
+import { defaultIsRequired, makeValidateHook } from '../../non-null-graphql'
+import type { CalendarDayFieldMeta } from './views'
 
 export type CalendarDayFieldConfig<ListTypeInfo extends BaseListTypeInfo> = CommonFieldConfig<
   ListTypeInfo,

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -1,10 +1,10 @@
 import { g } from '../../..'
 import { type ListMetaSource, getAdminMetaForRelationshipField } from '../../../lib/admin-meta'
-import type { JSONValue } from '../../../types'
 import {
   type BaseListTypeInfo,
   type CommonFieldConfig,
   type FieldTypeFunc,
+  type JSONValue,
   fieldType,
 } from '../../../types'
 import type { controller } from './views'

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -110,6 +110,7 @@ export const fields = {
     label: string
     defaultValue?: string
   }): FormField<string, undefined> {
+    // TODO: use zod?
     const validate = (value: unknown) => {
       return typeof value === 'string' && (value === '' || isValidURL(value))
     }

--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
@@ -58,7 +58,11 @@ export function makeUrlFieldInput(opts: {
       <TextField
         autoFocus={autoFocus}
         label={opts.label}
-        errorMessage={(forceValidation || isDirty) && !opts.validate(value) ? 'This type of URL is not accepted' : null}
+        errorMessage={
+          (forceValidation || isDirty) && !opts.validate(value)
+            ? 'This type of URL is not accepted'
+            : null
+        }
         onBlur={onBlur}
         onChange={x => onChange?.(x)}
         value={value}

--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
@@ -11,6 +11,7 @@ import { TextField } from '@keystar/ui/text-field'
 import { VStack } from '@keystar/ui/layout'
 import { TagGroup } from '@keystar/ui/tag'
 import { Text } from '@keystar/ui/typography'
+import { sanitizeUrl } from '@braintree/sanitize-url'
 
 export { TextField, TextArea } from '@keystar/ui/text-field'
 export { Text } from '@keystar/ui/typography'
@@ -44,12 +45,21 @@ export function makeUrlFieldInput(opts: {
 }): FormField<string, unknown>['Input'] {
   return function UrlFieldInput({ autoFocus, forceValidation, onChange, value }) {
     const [isDirty, setDirty] = useState(false)
+
+    function onBlur() {
+      const sanitisedHref = encodeURI(sanitizeUrl(value))
+      if (value !== sanitisedHref && sanitisedHref !== 'about:blank') {
+        onChange(sanitisedHref)
+      }
+      setDirty(true)
+    }
+
     return (
       <TextField
         autoFocus={autoFocus}
         label={opts.label}
-        errorMessage={(forceValidation || isDirty) && !opts.validate(value) ? 'Invalid URL' : null}
-        onBlur={() => setDirty(true)}
+        errorMessage={(forceValidation || isDirty) && !opts.validate(value) ? 'This type of URL is not accepted' : null}
+        onBlur={onBlur}
         onChange={x => onChange?.(x)}
         value={value}
       />

--- a/packages/fields-document/src/DocumentEditor/heading.tsx
+++ b/packages/fields-document/src/DocumentEditor/heading.tsx
@@ -1,4 +1,4 @@
-import { type RenderElementProps } from 'slate-react'
+import type { RenderElementProps } from 'slate-react'
 
 export function HeadingElement({
   attributes,

--- a/packages/fields-document/src/DocumentEditor/lists.tsx
+++ b/packages/fields-document/src/DocumentEditor/lists.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { type Element, type Node } from 'slate'
+import type { Element, Node } from 'slate'
 
 import { useToolbarState } from './toolbar-state'
 import { toggleList } from './lists-shared'

--- a/packages/fields-document/src/DocumentEditor/pasting/utils.ts
+++ b/packages/fields-document/src/DocumentEditor/pasting/utils.ts
@@ -1,5 +1,5 @@
-import { type Text } from 'slate'
-import { type Mark } from '../utils'
+import type { Text } from 'slate'
+import type { Mark } from '../utils'
 
 // a v important note
 // marks in the markdown ast/html are represented quite differently to how they are in slate

--- a/packages/fields-document/src/structure-validation.ts
+++ b/packages/fields-document/src/structure-validation.ts
@@ -22,14 +22,15 @@ const zText = z
   .strict()
 
 const zTextAlign = z.union([z.undefined(), z.literal('center'), z.literal('end')])
+const zUrl = z.string().refine(val => isValidURL(val), {
+  error: `This type of URL is not accepted`,
+})
 
 // recursive types
 const zLink = z
   .object({
     type: z.literal('link'),
-    href: z.string().refine(val => isValidURL(val), {
-      error: `This type of URL is not accepted`,
-    }),
+    href: zUrl,
   })
   .strict()
 


### PR DESCRIPTION
Follow up to https://github.com/keystonejs/keystone/pull/9674

This behaviour is now the same for `fields.url` too, not only the editor.