### PR TITLE
Replace `url.parse` with `new URL`

### DIFF
--- a/packages/core/src/lib/middleware.ts
+++ b/packages/core/src/lib/middleware.ts
@@ -1,9 +1,9 @@
-import url from 'url'
-import path from 'path'
+import path from 'node:path'
+
 import type express from 'express'
 import type next from 'next'
-import type { KeystoneContext, KeystoneConfig } from '../types'
 import { pkgDir } from '../pkg-dir'
+import type { KeystoneConfig, KeystoneContext } from '../types'
 
 const adminErrorHTMLFilepath = path.join(pkgDir, 'static', 'admin-error.html')
 
@@ -21,7 +21,7 @@ export function createAdminUIMiddlewareWithNextApp(
   if (basePath.endsWith('/')) throw new TypeError('basePath must not end with a trailing slash')
 
   return async (req: express.Request, res: express.Response) => {
-    const { pathname } = url.parse(req.url)
+    const { pathname } = new URL(req.url, 'http://ks')
 
     if (pathname?.startsWith(`${basePath}/_next`) || pathname?.startsWith(`${basePath}/__next`)) {
       return handle(req, res)

--- a/packages/core/src/scripts/dev.ts
+++ b/packages/core/src/scripts/dev.ts
@@ -2,7 +2,6 @@ import fsp from 'node:fs/promises'
 import { createServer } from 'node:http'
 import type { ListenOptions } from 'node:net'
 import path from 'node:path'
-import url from 'node:url'
 
 import { createDatabase } from '@prisma/internals'
 import chalk from 'chalk'
@@ -393,7 +392,7 @@ export async function dev(
         return expressServer(req, res, next)
       }
 
-      const { pathname } = url.parse(req.url)
+      const { pathname } = new URL(req.url, 'http://ks')
       if (expressServer && pathname === (config.graphql?.path ?? '/api/graphql')) {
         return expressServer(req, res, next)
       }


### PR DESCRIPTION
Remediates the warning shown from https://github.com/nodejs/node/pull/55017