### PR TITLE
Add `.filter` and `.sort` to `fields-document` relationship fields, revert `initialFilter` defaults

### DIFF
--- a/.changeset/filter-relationships-too.md
+++ b/.changeset/filter-relationships-too.md
@@ -1,5 +1,5 @@
 ---
-"@keystone-6/fields-document": patch
+"@keystone-6/fields-document": minor
 ---
 
-Fix the relationship fields to default to `initialFilter` and `initialSort` from the foreign list (if provided)
+Add `filter` and `sort` options to inline and component relationship fields

--- a/.changeset/list-sort-filter.md
+++ b/.changeset/list-sort-filter.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Add `ui.{sort,filter}` options to relationship fields with `ui.displayMode: 'select'`, with sort defaulting to the foreign list's `ui.{initialSort}` options

--- a/.changeset/twenty-ghosts-bathe.md
+++ b/.changeset/twenty-ghosts-bathe.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": minor
----
-
-Add `ui.{sort,filter}` options to relationship fields with `ui.displayMode: 'select'`, defaulting to the foreign list's `ui.{initialSort,initialFilter}` options

--- a/examples/relationships/schema.graphql
+++ b/examples/relationships/schema.graphql
@@ -11,6 +11,7 @@ type Post {
   relatedCount(where: PostWhereInput! = {}): Int
   recommendations: PostRecommendationsOutput
   bundles: PostBundlesOutput
+  hidden: Boolean
 }
 
 type PostRecommendationsOutput {
@@ -36,6 +37,7 @@ input PostWhereInput {
   category: CategoryWhereInput
   tags: TagManyRelationFilter
   related: PostManyRelationFilter
+  hidden: BooleanFilter
 }
 
 input IDFilter {
@@ -89,9 +91,15 @@ input PostManyRelationFilter {
   none: PostWhereInput
 }
 
+input BooleanFilter {
+  equals: Boolean
+  not: BooleanFilter
+}
+
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
+  hidden: OrderDirection
 }
 
 enum OrderDirection {
@@ -106,6 +114,7 @@ input PostUpdateInput {
   related: PostRelateToManyForUpdateInput
   recommendations: [PostRelateToOneForUpdateInput]
   bundles: [PostRelateToManyForUpdateInput]
+  hidden: Boolean
 }
 
 input CategoryRelateToOneForUpdateInput {
@@ -146,6 +155,7 @@ input PostCreateInput {
   related: PostRelateToManyForCreateInput
   recommendations: [PostRelateToOneForCreateInput]
   bundles: [PostRelateToManyForCreateInput]
+  hidden: Boolean
 }
 
 input CategoryRelateToOneForCreateInput {

--- a/examples/relationships/schema.graphql
+++ b/examples/relationships/schema.graphql
@@ -11,6 +11,7 @@ type Post {
   relatedCount(where: PostWhereInput! = {}): Int
   recommendations: PostRecommendationsOutput
   bundles: PostBundlesOutput
+  relatable: Boolean
   hidden: Boolean
 }
 
@@ -37,6 +38,7 @@ input PostWhereInput {
   category: CategoryWhereInput
   tags: TagManyRelationFilter
   related: PostManyRelationFilter
+  relatable: BooleanFilter
   hidden: BooleanFilter
 }
 
@@ -99,6 +101,7 @@ input BooleanFilter {
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
+  relatable: OrderDirection
   hidden: OrderDirection
 }
 
@@ -114,6 +117,7 @@ input PostUpdateInput {
   related: PostRelateToManyForUpdateInput
   recommendations: [PostRelateToOneForUpdateInput]
   bundles: [PostRelateToManyForUpdateInput]
+  relatable: Boolean
   hidden: Boolean
 }
 
@@ -155,6 +159,7 @@ input PostCreateInput {
   related: PostRelateToManyForCreateInput
   recommendations: [PostRelateToOneForCreateInput]
   bundles: [PostRelateToManyForCreateInput]
+  relatable: Boolean
   hidden: Boolean
 }
 

--- a/examples/relationships/schema.prisma
+++ b/examples/relationships/schema.prisma
@@ -21,6 +21,7 @@ model Post {
   related           Post[]    @relation("Post_related")
   recommendations   Json
   bundles           Json
+  relatable         Boolean   @default(true)
   hidden            Boolean   @default(false)
   from_Post_related Post[]    @relation("Post_related")
 

--- a/examples/relationships/schema.prisma
+++ b/examples/relationships/schema.prisma
@@ -21,6 +21,7 @@ model Post {
   related           Post[]    @relation("Post_related")
   recommendations   Json
   bundles           Json
+  hidden            Boolean   @default(false)
   from_Post_related Post[]    @relation("Post_related")
 
   @@index([categoryId])

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -1,6 +1,6 @@
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
-import { text, relationship } from '@keystone-6/core/fields'
+import { checkbox, text, relationship } from '@keystone-6/core/fields'
 import { structure } from '@keystone-6/fields-document'
 import type { Lists } from '.keystone/types'
 
@@ -13,6 +13,11 @@ export const lists = {
     access: allowAll, // WARNING: public
     ui: {
       listView: {
+        initialFilter: {
+          hidden: {
+            equals: false
+          }
+        },
         initialSort: {
           field: 'title',
           direction: 'DESC',
@@ -57,6 +62,12 @@ export const lists = {
         schema: bundlesStructureSchema,
         ui: {
           views: './structure-relationships-2',
+        },
+      }),
+
+      hidden: checkbox({
+        ui: {
+          itemView: { fieldPosition: 'sidebar' },
         },
       }),
     },

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -15,8 +15,8 @@ export const lists = {
       listView: {
         initialFilter: {
           hidden: {
-            equals: false
-          }
+            equals: false,
+          },
         },
         initialSort: {
           field: 'title',
@@ -34,7 +34,7 @@ export const lists = {
         // many: false, // a Post can have one Category
         ui: {
           sort: { field: 'name', direction: 'ASC' },
-        }
+        },
       }),
 
       // with this field, you can add some Tags to Posts
@@ -52,8 +52,8 @@ export const lists = {
         ui: {
           filter: {
             relatable: {
-              equals: true
-            }
+              equals: true,
+            },
           },
           sort: { field: 'title', direction: 'ASC' },
           hideCreate: true,

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -32,6 +32,9 @@ export const lists = {
       category: relationship({
         ref: 'Category.posts',
         // many: false, // a Post can have one Category
+        ui: {
+          sort: { field: 'name', direction: 'ASC' },
+        }
       }),
 
       // with this field, you can add some Tags to Posts
@@ -47,6 +50,12 @@ export const lists = {
         ref: 'Post',
         many: true,
         ui: {
+          filter: {
+            relatable: {
+              equals: true
+            }
+          },
+          sort: { field: 'title', direction: 'ASC' },
           hideCreate: true,
         },
       }),
@@ -65,6 +74,12 @@ export const lists = {
         },
       }),
 
+      relatable: checkbox({
+        defaultValue: true,
+        ui: {
+          itemView: { fieldPosition: 'sidebar' },
+        },
+      }),
       hidden: checkbox({
         ui: {
           itemView: { fieldPosition: 'sidebar' },

--- a/examples/relationships/structure-relationships-2.tsx
+++ b/examples/relationships/structure-relationships-2.tsx
@@ -8,7 +8,7 @@ export const schema = fields.array(
     many: true,
     sort: { field: 'title', direction: 'ASC' },
     filter: {
-      hidden: { equals: false }
+      hidden: { equals: false },
     },
   }),
   {

--- a/examples/relationships/structure-relationships-2.tsx
+++ b/examples/relationships/structure-relationships-2.tsx
@@ -6,6 +6,10 @@ export const schema = fields.array(
     label: 'Bundle',
     description: 'What posts do you want to bundle with this post?',
     many: true,
+    sort: { field: 'title', direction: 'ASC' },
+    filter: {
+      hidden: { equals: false }
+    },
   }),
   {
     itemLabel: props => {

--- a/examples/relationships/structure-relationships.tsx
+++ b/examples/relationships/structure-relationships.tsx
@@ -7,7 +7,7 @@ export const schema = fields.array(
     description: 'What posts do you recommend?',
     filter: {
       relatable: { equals: true },
-      hidden: { equals: false }
+      hidden: { equals: false },
     },
   }),
   {

--- a/examples/relationships/structure-relationships.tsx
+++ b/examples/relationships/structure-relationships.tsx
@@ -5,6 +5,10 @@ export const schema = fields.array(
     listKey: 'Post',
     label: 'Recommended Post',
     description: 'What posts do you recommend?',
+    filter: {
+      relatable: { equals: true },
+      hidden: { equals: false }
+    },
   }),
   {
     itemLabel: props => {

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -155,7 +155,7 @@ function getFilters(list: ListMeta, query: ParsedUrlQueryInput): Filter[] {
       for (const f of controller.filter?.parseGraphQL(filter as any as never) ?? []) {
         filters.push({
           field: fieldKey,
-          ...f
+          ...f,
         })
       }
     }

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -142,12 +142,28 @@ function FilterDialog({
   )
 }
 
-function getFilters(list: ListMeta, query: ParsedUrlQueryInput) {
+function getFilters(list: ListMeta, query: ParsedUrlQueryInput): Filter[] {
   const param_ = query.filter
   const params = Array.isArray(param_) ? param_ : typeof param_ === 'string' ? [param_] : []
-  if (!params.length) return []
-  const filters: Filter[] = []
 
+  if (!params.length) {
+    if (!list.initialFilter) return []
+
+    const filters: Filter[] = []
+    for (const [fieldKey, filter] of Object.entries(list.initialFilter)) {
+      const { controller } = list.fields[fieldKey]
+      for (const f of controller.filter?.parseGraphQL(filter as any as never) ?? []) {
+        filters.push({
+          field: fieldKey,
+          ...f
+        })
+      }
+    }
+
+    return filters
+  }
+
+  const filters: Filter[] = []
   for (const [fieldPath, field] of Object.entries(list.fields)) {
     if (!field.isFilterable) continue
     if (!field.controller.filter) continue

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -5,6 +5,7 @@ import {
   type CommonFieldConfig,
   type FieldTypeFunc,
   type JSONValue,
+  type ListSortDescriptor,
   fieldType,
 } from '../../../types'
 import type { controller } from './views'
@@ -35,7 +36,7 @@ type SelectDisplayConfig<ListTypeInfo extends BaseListTypeInfo, Ref extends stri
      * The sort to apply when shown in the select.
      * Defaults to the initialSort (if set) on the related list.
      */
-    sort?: { field: string; direction: 'ASC' | 'DESC' }
+    sort?: ListSortDescriptor<string>
   }
 }
 
@@ -55,7 +56,7 @@ type TableDisplayConfig = {
   many: true
   ui?: {
     displayMode: 'table'
-    initialSort?: { field: string; direction: 'ASC' | 'DESC' }
+    initialSort?: ListSortDescriptor<string>
     columns?: string[]
 
     itemView: {
@@ -273,7 +274,7 @@ export function relationship<
           hideCreate,
           refLabelField: specificRefLabelField,
           refSearchFields: specificRefSearchFields,
-          filter: config.ui?.filter ?? foreignListMeta.initialFilter ?? null,
+          filter: config.ui?.filter ?? null,
           sort: config.ui?.sort ?? foreignListMeta.initialSort ?? null,
         }
       },

--- a/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxMany.tsx
@@ -1,7 +1,7 @@
 import { ComboboxMulti, Item } from '@keystar/ui/combobox'
 import { css } from '@keystar/ui/style'
 
-import type { ListMeta } from '../../../../types'
+import type { ListMeta, ListSortDescriptor } from '../../../../types'
 import type { RelationshipValue } from './types'
 import { useApolloQuery } from './useApolloQuery'
 import { useState } from 'react'
@@ -35,7 +35,7 @@ export function ComboboxMany({
   list: ListMeta
   placeholder?: string
   filter?: Record<string, any> | null
-  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
+  sort?: ListSortDescriptor<string> | null
   state: {
     kind: 'many'
     value: RelationshipValue[]

--- a/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
+++ b/packages/core/src/fields/types/relationship/views/ComboboxSingle.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { Combobox, Item } from '@keystar/ui/combobox'
 import { css } from '@keystar/ui/style'
 
-import type { ListMeta } from '../../../../types'
+import type { ListMeta, ListSortDescriptor } from '../../../../types'
 import type { RelationshipValue } from './types'
 import { useApolloQuery } from './useApolloQuery'
 
@@ -32,7 +32,7 @@ export function ComboboxSingle({
   list: ListMeta
   placeholder?: string
   filter?: Record<string, any> | null
-  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
+  sort?: ListSortDescriptor<string> | null
   state: {
     kind: 'one'
     value: RelationshipValue | null

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -10,7 +10,12 @@ import { Numeral, Text } from '@keystar/ui/typography'
 
 import { BuildItemDialog } from '../../../../admin-ui/components'
 import { useList } from '../../../../admin-ui/context'
-import type { CellComponent, FieldControllerConfig, FieldProps, ListSortDescriptor } from '../../../../types'
+import type {
+  CellComponent,
+  FieldControllerConfig,
+  FieldProps,
+  ListSortDescriptor,
+} from '../../../../types'
 
 import { ActionButton } from '@keystar/ui/button'
 import { Icon } from '@keystar/ui/icon'

--- a/packages/core/src/fields/types/relationship/views/index.tsx
+++ b/packages/core/src/fields/types/relationship/views/index.tsx
@@ -10,7 +10,7 @@ import { Numeral, Text } from '@keystar/ui/typography'
 
 import { BuildItemDialog } from '../../../../admin-ui/components'
 import { useList } from '../../../../admin-ui/context'
-import type { CellComponent, FieldControllerConfig, FieldProps } from '../../../../types'
+import type { CellComponent, FieldControllerConfig, FieldProps, ListSortDescriptor } from '../../../../types'
 
 import { ActionButton } from '@keystar/ui/button'
 import { Icon } from '@keystar/ui/icon'
@@ -77,7 +77,7 @@ export function Field(props: FieldProps<typeof controller>) {
               labelField={field.refLabelField}
               searchFields={field.refSearchFields}
               filter={field.selectFilter}
-              sort={field.sort}
+              sort={field.selectSort}
               state={{
                 kind: 'many',
                 value: value.value,
@@ -98,7 +98,7 @@ export function Field(props: FieldProps<typeof controller>) {
               labelField={field.refLabelField}
               searchFields={field.refSearchFields}
               filter={field.selectFilter}
-              sort={field.sort}
+              sort={field.selectSort}
               state={{
                 kind: 'one',
                 value: value.value,
@@ -233,13 +233,13 @@ export function controller(
       | {
           displayMode: 'select'
           filter: Record<string, any> | null
-          sort: { field: string; direction: 'ASC' | 'DESC' } | null
+          sort: ListSortDescriptor<string> | null
         }
       | { displayMode: 'count' }
       | {
           displayMode: 'table'
           refFieldKey: string
-          initialSort: { field: string; direction: 'ASC' | 'DESC' } | null
+          initialSort: ListSortDescriptor<string> | null
           columns: string[] | null
         }
     )
@@ -271,7 +271,7 @@ export function controller(
     columns: displayMode === 'table' ? config.fieldMeta.columns : null,
     initialSort: displayMode === 'table' ? config.fieldMeta.initialSort : null,
     selectFilter: displayMode === 'select' ? config.fieldMeta.filter : null,
-    sort: displayMode === 'select' ? config.fieldMeta.sort : null,
+    selectSort: displayMode === 'select' ? config.fieldMeta.sort : null,
     // note we're not making the state kind: 'count' when ui.displayMode is set to 'count'.
     // that ui.displayMode: 'count' is really just a way to have reasonable performance
     // because our other UIs don't handle relationships with a large number of items well

--- a/packages/core/src/fields/types/relationship/views/types.ts
+++ b/packages/core/src/fields/types/relationship/views/types.ts
@@ -1,4 +1,4 @@
-import type { FieldController } from '../../../../types'
+import type { FieldController, ListSortDescriptor } from '../../../../types'
 
 export type RelationshipValue = {
   id: string
@@ -40,7 +40,7 @@ export type RelationshipController = FieldController<
   hideCreate: boolean
   many: boolean
   columns: string[] | null
-  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null
+  initialSort: ListSortDescriptor<string> | null
   selectFilter: Record<string, any> | null
-  sort: { field: string; direction: 'ASC' | 'DESC' } | null
+  selectSort: ListSortDescriptor<string> | null
 }

--- a/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
+++ b/packages/core/src/fields/types/relationship/views/useApolloQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 
-import type { ListMeta } from '../../../../types'
+import type { ListMeta, ListSortDescriptor } from '../../../../types'
 import {
   type TypedDocumentNode,
   ApolloClient,
@@ -10,7 +10,7 @@ import {
   useQuery,
 } from '../../../../admin-ui/apollo'
 import { useSearchFilter } from './useFilter'
-import { type RelationshipValue } from './types'
+import type { RelationshipValue } from './types'
 
 function useDebouncedValue<T>(value: T, limitMs: number) {
   const [debouncedValue, setDebouncedValue] = useState(() => value)
@@ -29,7 +29,7 @@ export function useApolloQuery(args: {
   labelField: string
   list: ListMeta
   searchFields: string[]
-  sort?: { field: string; direction: 'ASC' | 'DESC' } | null
+  sort?: ListSortDescriptor<string> | null
   filter?: Record<string, any> | null
   state:
     | { kind: 'many'; value: RelationshipValue[] }
@@ -144,8 +144,8 @@ export function useApolloQuery(args: {
       > = gql`
         query RelationshipSelectMore($where: ${list.graphql.names.whereInputName}!, $take: Int!, $skip: Int!, $orderBy: [${list.graphql.names.listOrderName}!]) {
           items: ${list.graphql.names.listQueryName}(where: $where, take: $take, skip: $skip, orderBy: $orderBy) {
+            id
             label: ${labelField}
-            id: id
           }
         }
       `

--- a/packages/core/src/lib/admin-meta.ts
+++ b/packages/core/src/lib/admin-meta.ts
@@ -152,9 +152,7 @@ export function createAdminMeta(
       initialColumns,
       initialSearchFields,
       initialSort:
-        (listConfig.ui?.listView?.initialSort as
-          | ListSortDescriptor<string>
-          | undefined) ?? null,
+        (listConfig.ui?.listView?.initialSort as ListSortDescriptor<string> | undefined) ?? null,
       initialFilter: normalizeMaybeSessionFunction(listConfig.ui?.listView?.initialFilter ?? {}),
       isSingleton: list.isSingleton,
 

--- a/packages/core/src/lib/admin-meta.ts
+++ b/packages/core/src/lib/admin-meta.ts
@@ -8,6 +8,7 @@ import type {
   ConditionalFilterCase,
   KeystoneConfig,
   KeystoneContext,
+  ListSortDescriptor,
   MaybeBooleanItemFunctionWithFilter,
   MaybeFieldFunction,
   MaybeItemFieldFunction,
@@ -62,9 +63,9 @@ type ListMetaSource_ = {
   graphql: { names: GraphQLNames }
   pageSize: number
   initialColumns: string[]
-  initialSearchFields: string[]
-  initialSort: { field: string; direction: 'ASC' | 'DESC' } | null
   initialFilter: EmptyResolver<JSONValue>
+  initialSearchFields: string[]
+  initialSort: ListSortDescriptor<string> | null
   isSingleton: boolean
 
   hideNavigation: EmptyResolver<boolean>
@@ -72,9 +73,7 @@ type ListMetaSource_ = {
   hideDelete: EmptyResolver<boolean>
 }
 export type ListMetaSource = ListMetaSource_ &
-  Omit<ListMeta, keyof ListMetaSource_> & {
-    item: any
-  }
+  Omit<ListMeta, keyof ListMetaSource_> & { item: BaseItem | null }
 
 export type AdminMetaSource = {
   lists: ListMetaSource[]
@@ -154,7 +153,7 @@ export function createAdminMeta(
       initialSearchFields,
       initialSort:
         (listConfig.ui?.listView?.initialSort as
-          | { field: string; direction: 'ASC' | 'DESC' }
+          | ListSortDescriptor<string>
           | undefined) ?? null,
       initialFilter: normalizeMaybeSessionFunction(listConfig.ui?.listView?.initialFilter ?? {}),
       isSingleton: list.isSingleton,

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import type { GraphQLNames, JSONValue } from './utils'
-import type { ConditionalFilter, ConditionalFilterCase } from './config'
+import type { ConditionalFilter, ConditionalFilterCase, ListSortDescriptor } from './config'
 import type { BaseListTypeInfo } from './type-info'
 
 export type NavigationProps = {
@@ -124,7 +124,7 @@ export type ListMeta = {
   pageSize: number
   initialColumns: string[]
   initialSearchFields: string[]
-  initialSort: null | { direction: 'ASC' | 'DESC'; field: string }
+  initialSort: ListSortDescriptor<string>
   initialFilter: JSONValue
   isSingleton: boolean
 

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -40,6 +40,11 @@ export type ListConfig<ListTypeInfo extends BaseListTypeInfo> = {
   defaultIsOrderable?: MaybeFieldFunction<ListTypeInfo>
 }
 
+export type ListSortDescriptor<Fields extends string> = {
+  field: 'id' | Fields
+  direction: 'ASC' | 'DESC'
+}
+
 export type ListAdminUIConfig<ListTypeInfo extends BaseListTypeInfo> = {
   /**
    * The label used to identify the list in navigation and etc.
@@ -142,15 +147,14 @@ export type ListAdminUIConfig<ListTypeInfo extends BaseListTypeInfo> = {
      * @default the first three fields in the list
      */
     initialColumns?: readonly ('id' | ListTypeInfo['fields'])[]
-    // was previously top-level defaultSort
-    initialSort?: { field: 'id' | ListTypeInfo['fields']; direction: 'ASC' | 'DESC' }
-    // was previously defaultPageSize
-    pageSize?: number // default number of items to display per page on the list screen
-
     initialFilter?: MaybeSessionFunction<
       Omit<ListTypeInfo['inputs']['where'], 'AND' | 'OR' | 'NOT'>,
       ListTypeInfo
     >
+    initialSort?: ListSortDescriptor<ListTypeInfo['fields']>
+
+    // TODO: rename to initialItemsPerPage or initialPageSize?
+    pageSize?: number // default number of items to display per page on the list screen
   }
 }
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api-shared.ts
@@ -5,7 +5,7 @@ import type {
   GOutputType,
   GNullableInputType,
 } from '@keystone-6/core/graphql-ts'
-import type { KeystoneContext } from '@keystone-6/core/types'
+import type { KeystoneContext, ListSortDescriptor } from '@keystone-6/core/types'
 import type { ReactElement, ReactNode } from 'react'
 
 export type FormFieldValue =
@@ -125,7 +125,9 @@ export type RelationshipField<Many extends boolean> = {
   label: string
   description: string | null
   labelField: string | null
+  filter: Record<string, any> | null
   selection: string | null
+  sort: ListSortDescriptor<string> | null
   many: Many
 }
 

--- a/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/api.tsx
@@ -1,30 +1,32 @@
 import { g } from '@keystone-6/core'
-
 import type { HTMLAttributes, ReactElement, ReactNode } from 'react'
-import { isValidURL } from '../isValidURL'
-import type {
-  BlockFormattingConfig,
-  ChildField,
-  ConditionalField,
-  ComponentBlock,
-  ComponentSchema,
-  GenericPreviewProps,
-  InlineMarksConfig,
-  ObjectField,
-  RelationshipField,
-  FormField,
-  ArrayField,
-} from './api-shared'
+
 import {
+  Checkbox,
   makeIntegerFieldInput,
   makeMultiselectFieldInput,
   makeSelectFieldInput,
   makeUrlFieldInput,
-  Checkbox,
   Text,
-  TextField,
   TextArea,
+  TextField,
 } from '#fields-ui'
+
+import { isValidURL } from '../isValidURL'
+import type {
+  ArrayField,
+  BlockFormattingConfig,
+  ChildField,
+  ComponentBlock,
+  ComponentSchema,
+  ConditionalField,
+  FormField,
+  GenericPreviewProps,
+  InlineMarksConfig,
+  ObjectField,
+  RelationshipField,
+} from './api-shared'
+import type { ListSortDescriptor } from '@keystone-6/core/types'
 
 export * from './api-shared'
 
@@ -326,7 +328,9 @@ export const fields = {
     label,
     description,
     labelField,
+    filter,
     selection,
+    sort,
     many,
   }: {
     listKey: string
@@ -337,6 +341,10 @@ export const fields = {
     labelField?: string
     /** The GraphQL selection to use for this relationship when hydrating .data */
     selection?: string
+    /** The default sort to apply to the relationship when showing the select */
+    sort?: ListSortDescriptor<string>
+    /** A filter to apply to the relationship when showing the select */
+    filter?: Record<string, unknown>
   } & (Many extends undefined | false ? { many?: Many } : { many: Many })): RelationshipField<
     Many extends true ? true : false
   > {
@@ -346,7 +354,9 @@ export const fields = {
       label,
       description: description ?? null,
       labelField: labelField ?? null,
+      filter: filter ?? null,
       selection: selection ?? null,
+      sort: sort ?? null,
       many: (many ? true : false) as any,
     }
   },

--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui.tsx
@@ -1,21 +1,21 @@
-import { useState } from 'react'
 import { useFilter } from '@react-aria/i18n'
+import { useState } from 'react'
 
-import { type FormField } from './api-shared'
-import { NumberField } from '@keystar/ui/number-field'
-import { tokenSchema } from '@keystar/ui/style'
-import { Item as PickerItem, Picker } from '@keystar/ui/picker'
-import { Combobox, Item as ComboboxItem } from '@keystar/ui/combobox'
-import { TextField } from '@keystar/ui/text-field'
-
-import { VStack } from '@keystar/ui/layout'
-import { TagGroup } from '@keystar/ui/tag'
-import { Text } from '@keystar/ui/typography'
 import { sanitizeUrl } from '@braintree/sanitize-url'
+import { Combobox, Item as ComboboxItem } from '@keystar/ui/combobox'
+import { VStack } from '@keystar/ui/layout'
+import { NumberField } from '@keystar/ui/number-field'
+import { Picker, Item as PickerItem } from '@keystar/ui/picker'
+import { tokenSchema } from '@keystar/ui/style'
+import { TagGroup } from '@keystar/ui/tag'
+import { TextField } from '@keystar/ui/text-field'
+import { Text } from '@keystar/ui/typography'
 
-export { TextField, TextArea } from '@keystar/ui/text-field'
-export { Text } from '@keystar/ui/typography'
+import type { FormField } from './api-shared'
+
 export { Checkbox } from '@keystar/ui/checkbox'
+export { TextArea, TextField } from '@keystar/ui/text-field'
+export { Text } from '@keystar/ui/typography'
 
 export function makeIntegerFieldInput(opts: {
   label: string

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -273,14 +273,7 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
 
 function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
   const { autoFocus, onChange, schema, value } = props
-  const {
-    listKey,
-    label,
-    description,
-    filter,
-    sort,
-    many,
-  } = schema
+  const { listKey, label, description, filter, sort, many } = schema
   const list = useList(listKey)
   const formValue = (function () {
     if (many) {
@@ -323,30 +316,28 @@ function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
     <RelationshipFieldView
       autoFocus={autoFocus}
       isRequired={false}
-      field={
-        {
-          label,
-          description: description ?? '',
-          display: 'select',
-          listKey: '?', // unused
-          fieldKey: '?', // unused
-          defaultValue: null as any, // unused
-          deserialize: null as any, // unused
-          serialize: null as any, // unused
-          graphqlSelection: null as any, // unused
+      field={{
+        label,
+        description: description ?? '',
+        display: 'select',
+        listKey: '?', // unused
+        fieldKey: '?', // unused
+        defaultValue: null as any, // unused
+        deserialize: null as any, // unused
+        serialize: null as any, // unused
+        graphqlSelection: null as any, // unused
 
-          // see relationship controller for these fields
-          refListKey: list.key,
-          many,
-          hideCreate: true,
-          refLabelField: list.labelField,
-          refSearchFields: list.initialSearchFields,
-          columns: list.initialColumns,
-          initialSort: null,
-          selectFilter: filter || null,
-          selectSort: sort ?? list.initialSort,
-        }
-      }
+        // see relationship controller for these fields
+        refListKey: list.key,
+        many,
+        hideCreate: true,
+        refLabelField: list.labelField,
+        refSearchFields: list.initialSearchFields,
+        columns: list.initialColumns,
+        initialSort: null,
+        selectFilter: filter || null,
+        selectSort: sort ?? list.initialSort,
+      }}
       onChange={val => {
         if (val.kind === 'count') return // shouldnt happen
         const { value } = val

--- a/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/form-from-preview.tsx
@@ -273,7 +273,14 @@ function ArrayFieldPreview(props: DefaultFieldProps<'array'>) {
 
 function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
   const { autoFocus, onChange, schema, value } = props
-  const { listKey, label, description, many } = schema
+  const {
+    listKey,
+    label,
+    description,
+    filter,
+    sort,
+    many,
+  } = schema
   const list = useList(listKey)
   const formValue = (function () {
     if (many) {
@@ -318,11 +325,15 @@ function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
       isRequired={false}
       field={
         {
-          path: '', // unused
           label,
-          description,
+          description: description ?? '',
           display: 'select',
-          listKey: '', // unused
+          listKey: '?', // unused
+          fieldKey: '?', // unused
+          defaultValue: null as any, // unused
+          deserialize: null as any, // unused
+          serialize: null as any, // unused
+          graphqlSelection: null as any, // unused
 
           // see relationship controller for these fields
           refListKey: list.key,
@@ -330,9 +341,11 @@ function RelationshipFieldPreview(props: DefaultFieldProps<'relationship'>) {
           hideCreate: true,
           refLabelField: list.labelField,
           refSearchFields: list.initialSearchFields,
-          filter: list.initialFilter as any,
-          sort: list.initialSort,
-        } as any
+          columns: list.initialColumns,
+          initialSort: null,
+          selectFilter: filter || null,
+          selectSort: sort ?? list.initialSort,
+        }
       }
       onChange={val => {
         if (val.kind === 'count') return // shouldnt happen

--- a/packages/fields-document/src/DocumentEditor/relationship-shared.ts
+++ b/packages/fields-document/src/DocumentEditor/relationship-shared.ts
@@ -1,15 +1,16 @@
+import type { ListSortDescriptor } from '@keystone-6/core/types'
 import type { Editor } from 'slate'
 
-// inline relationship type
+// inline relationship type (used by and duplicated in fields-document/src/index)
 export type Relationships = Record<
   string,
   {
     listKey: string
     label: string
-    /** The label field to use for this relationship when showing the select */
     labelField: string | null
-    /** The GraphQL selection to use for this relationship when hydrating .data */
     selection: string | null
+    filter: Record<string, any> | null
+    sort: ListSortDescriptor<string> | null
   }
 >
 

--- a/packages/fields-document/src/DocumentEditor/relationship.tsx
+++ b/packages/fields-document/src/DocumentEditor/relationship.tsx
@@ -1,14 +1,16 @@
 import { createContext, useContext } from 'react'
-import { ReactEditor, type RenderElementProps } from 'slate-react'
 import { Transforms } from 'slate'
-import { useSlateStatic as useStaticEditor } from 'slate-react'
+import {
+  type RenderElementProps,
+  ReactEditor,
+  useSlateStatic as useStaticEditor,
+} from 'slate-react'
 
+import { css } from '@keystar/ui/style'
 import { useList } from '@keystone-6/core/admin-ui/context'
-
 import { ComboboxSingle } from '@keystone-6/core/fields/types/relationship/views'
 
 import type { Relationships } from './relationship-shared'
-import { css } from '@keystar/ui/style'
 export type { Relationships } from './relationship-shared'
 
 export const DocumentFieldRelationshipsContext = createContext<Relationships>({})
@@ -19,7 +21,7 @@ export function useDocumentFieldRelationships() {
 
 export const DocumentFieldRelationshipsProvider = DocumentFieldRelationshipsContext.Provider
 
-// this is the inline relationship, see form-from-preview for the component field
+// WARNING: this is the inline relationship, see form-from-preview for the component field
 export function RelationshipElement({
   attributes,
   children,
@@ -53,9 +55,9 @@ export function RelationshipElement({
           <ComboboxSingle
             list={list}
             labelField={list.labelField}
+            filter={relationship.filter}
             searchFields={list.initialSearchFields}
-            filter={list.initialFilter as any}
-            sort={list.initialSort}
+            sort={relationship.sort}
             state={{
               kind: 'one',
               value:

--- a/packages/fields-document/src/index.ts
+++ b/packages/fields-document/src/index.ts
@@ -6,6 +6,7 @@ import {
   type FieldData,
   type FieldTypeFunc,
   type JSONValue,
+  type ListSortDescriptor,
   fieldType,
 } from '@keystone-6/core/types'
 import { GraphQLError } from 'graphql'
@@ -21,9 +22,14 @@ type RelationshipsConfig = Record<
   {
     listKey: string
     label: string
+    /** The label field to use when showing the select */
     labelField?: string
-    /** GraphQL fields to select when querying the field */
+    /** The GraphQL selection to use when hydrating .data */
     selection?: string
+    /** The filter to use when showing the select */
+    filter?: Record<string, any>
+    /** The sort to use when showing the select */
+    sort?: ListSortDescriptor<string>
   }
 >
 
@@ -199,6 +205,8 @@ function normaliseRelationships(
       ...relationship,
       labelField: relationship.labelField ?? null,
       selection: relationship.selection ?? null,
+      filter: relationship.filter ?? null,
+      sort: relationship.sort ?? null,
     }
   }
   return relationships
@@ -269,5 +277,5 @@ function normaliseDocumentFeatures(
   return documentFeatures
 }
 
-export type { Node } from './structure-validation'
 export { structure } from './structure'
+export type { Node } from './structure-validation'

--- a/packages/fields-document/src/relationship-data.ts
+++ b/packages/fields-document/src/relationship-data.ts
@@ -29,8 +29,9 @@ export function addRelationshipData(
           data: await fetchDataForOne(
             context,
             {
-              ...relationship,
-              many: false,
+              listKey: relationship.listKey,
+              labelField: relationship.labelField,
+              selection: relationship.selection,
             },
             node.data
           ),
@@ -70,25 +71,35 @@ export function addRelationshipData(
   )
 }
 
-type Relationship_ = Omit<RelationshipField<boolean>, 'kind' | 'description'>
-
 export async function fetchRelationshipData(
   context: KeystoneContext,
-  relationship: Relationship_,
-  data: any
-) {
-  if (!relationship.many) return fetchDataForOne(context, relationship, data)
+  {
+    listKey,
+    labelField: preferredLabelField,
+    selection,
+    many,
+  }: {
+    listKey: string
+    labelField: string | null
+    selection: string | null
+    many: boolean,
+  }, data: any) {
+  if (!many) return fetchDataForOne(context, {
+    listKey,
+    labelField: preferredLabelField,
+    selection,
+  }, data)
 
   const ids = Array.isArray(data) ? data.filter(item => item.id != null).map(x => x.id) : []
   if (!ids.length) return []
 
-  const list = context.__internal.lists[relationship.listKey]
+  const list = context.__internal.lists[listKey]
   const { listQueryName } = list.graphql.names
-  const labelField = relationship.labelField ?? list.ui.labelField
+  const labelField = preferredLabelField ?? list.ui.labelField
 
   const value = (await context.graphql.run({
     query: `query($ids: [ID!]!) {items:${listQueryName}(where: { id: { in: $ids } }) {${idFieldAlias}:id ${labelFieldAlias}:${labelField}\n${
-      relationship.selection || ''
+      selection || ''
     }}}`,
     variables: { ids },
   })) as { items: { [idFieldAlias]: string | number; [labelFieldAlias]: string }[] }
@@ -100,7 +111,15 @@ export async function fetchRelationshipData(
     : []
 }
 
-async function fetchDataForOne(context: KeystoneContext, relationship: Relationship_, data: any) {
+async function fetchDataForOne(context: KeystoneContext, {
+  listKey,
+  labelField: preferredLabelField,
+  selection,
+}: {
+  listKey: string
+  labelField: string | null
+  selection: string | null
+}, data: any) {
   // Single related item
   const id = data?.id
   if (id == null) return null
@@ -108,11 +127,11 @@ async function fetchDataForOne(context: KeystoneContext, relationship: Relations
   // An exception here indicates something wrong with either the system or the
   // configuration (e.g. a bad selection field). These will surface as system
   // errors from the GraphQL field resolver.
-  const list = context.__internal.lists[relationship.listKey]
+  const list = context.__internal.lists[listKey]
   const { itemQueryName } = list.graphql.names
-  const labelField = relationship.labelField ?? list.ui.labelField
+  const labelField = preferredLabelField ?? list.ui.labelField
   const value = (await context.graphql.run({
-    query: `query($id: ID!) {item:${itemQueryName}(where: { id: $id }) {${labelFieldAlias}:${labelField}\n${relationship.selection || ''}}}`,
+    query: `query($id: ID!) {item:${itemQueryName}(where: { id: $id }) {${labelFieldAlias}:${labelField}\n${selection || ''}}}`,
     variables: { id },
   })) as { item: Record<string, any> | null }
 

--- a/packages/fields-document/src/relationship-data.ts
+++ b/packages/fields-document/src/relationship-data.ts
@@ -82,13 +82,20 @@ export async function fetchRelationshipData(
     listKey: string
     labelField: string | null
     selection: string | null
-    many: boolean,
-  }, data: any) {
-  if (!many) return fetchDataForOne(context, {
-    listKey,
-    labelField: preferredLabelField,
-    selection,
-  }, data)
+    many: boolean
+  },
+  data: any
+) {
+  if (!many)
+    return fetchDataForOne(
+      context,
+      {
+        listKey,
+        labelField: preferredLabelField,
+        selection,
+      },
+      data
+    )
 
   const ids = Array.isArray(data) ? data.filter(item => item.id != null).map(x => x.id) : []
   if (!ids.length) return []
@@ -111,15 +118,19 @@ export async function fetchRelationshipData(
     : []
 }
 
-async function fetchDataForOne(context: KeystoneContext, {
-  listKey,
-  labelField: preferredLabelField,
-  selection,
-}: {
-  listKey: string
-  labelField: string | null
-  selection: string | null
-}, data: any) {
+async function fetchDataForOne(
+  context: KeystoneContext,
+  {
+    listKey,
+    labelField: preferredLabelField,
+    selection,
+  }: {
+    listKey: string
+    labelField: string | null
+    selection: string | null
+  },
+  data: any
+) {
   // Single related item
   const id = data?.id
   if (id == null) return null

--- a/packages/fields-document/src/validation.test.tsx
+++ b/packages/fields-document/src/validation.test.tsx
@@ -15,6 +15,8 @@ const relationships: Relationships = {
     label: 'Inline',
     labelField: null,
     selection: `something`,
+    filter: null,
+    sort: null,
   },
 }
 


### PR DESCRIPTION
Partially reverts https://github.com/keystonejs/keystone/pull/9666

Using `initialFilter` as the default for something that can't necessarily be edited can be confusing.  Unlike `initialSort`, which is a behaviour with low consequence and is generally beneficial, filtering without the developers explicit consent can result in difficult to detect anomalies.

This stops the relationship fields (including their document field counterparts) from using `{list}.ui.listView.initialFilter` as the default for their own `filter` functionality.

`{list}.ui.listView.initialSort` is still used as the default for relationships, as any default used there is often better than nothing. However, that may be reverted depending on developer feedback.

Importantly, this pull request adds `.filter` and `.sort` to the document field relationship fields, which were missing this option.