### PR TITLE
Fix list view filters replacing or displacing other filters

### DIFF
--- a/examples/actions/schema.graphql
+++ b/examples/actions/schema.graphql
@@ -5,6 +5,7 @@ type Post {
   id: ID!
   title: String
   content: String
+  hidden: Boolean
   votes: Int
   reportedAt: DateTime
 }
@@ -22,6 +23,7 @@ input PostWhereInput {
   id: IDFilter
   title: StringFilter
   content: StringFilter
+  hidden: BooleanFilter
   votes: IntNullableFilter
   reportedAt: DateTimeNullableFilter
 }
@@ -65,6 +67,11 @@ input NestedStringFilter {
   not: NestedStringFilter
 }
 
+input BooleanFilter {
+  equals: Boolean
+  not: BooleanFilter
+}
+
 input IntNullableFilter {
   equals: Int
   in: [Int!]
@@ -91,6 +98,7 @@ input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
   content: OrderDirection
+  hidden: OrderDirection
   votes: OrderDirection
   reportedAt: OrderDirection
 }
@@ -103,6 +111,7 @@ enum OrderDirection {
 input PostUpdateInput {
   title: String
   content: String
+  hidden: Boolean
   votes: Int
   reportedAt: DateTime
 }
@@ -115,6 +124,7 @@ input PostUpdateArgs {
 input PostCreateInput {
   title: String
   content: String
+  hidden: Boolean
   votes: Int
   reportedAt: DateTime
 }

--- a/examples/actions/schema.prisma
+++ b/examples/actions/schema.prisma
@@ -16,6 +16,7 @@ model Post {
   id         String    @id @default(cuid())
   title      String    @default("")
   content    String    @default("")
+  hidden     Boolean   @default(false)
   votes      Int?      @default(0)
   reportedAt DateTime?
 }

--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -1,6 +1,6 @@
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
-import { integer, text, timestamp } from '@keystone-6/core/fields'
+import { checkbox, integer, text, timestamp } from '@keystone-6/core/fields'
 
 import type { Lists } from '.keystone/types'
 
@@ -14,6 +14,7 @@ export const lists = {
     fields: {
       title: text(),
       content: text(),
+      hidden: checkbox(),
       votes: integer({ defaultValue: 0 }),
       reportedAt: timestamp({
         ui: {
@@ -101,6 +102,14 @@ export const lists = {
             actionMode: 'enabled',
           },
         },
+      },
+    },
+    ui: {
+      listView: {
+        initialFilter: {
+          hidden: { equals: false },
+        },
+        initialSort: { field: 'votes', direction: 'DESC' },
       },
     },
   }),

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -54,12 +54,12 @@ export type Filter = {
 function FilterTag({
   filter,
   field,
-  onAdd,
+  onChange,
   onRemove,
 }: {
   filter: Filter
   field: FieldMeta
-  onAdd: (filter: Filter) => void
+  onChange: (filter: Filter) => void
   onRemove: () => void
 }) {
   const Label = field.controller.filter!.Label
@@ -86,21 +86,21 @@ function FilterTag({
     <DialogTrigger type="popover" mobileType="tray">
       {tagElement}
       {onDismiss => (
-        <FilterDialog onAdd={onAdd} onDismiss={onDismiss} field={field} filter={filter} />
+        <FilterEdit onChange={onChange} onDismiss={onDismiss} field={field} filter={filter} />
       )}
     </DialogTrigger>
   )
 }
 
-function FilterDialog({
+function FilterEdit({
   filter,
   field,
-  onAdd,
+  onChange: onAdd,
   onDismiss,
 }: {
   filter: Filter
   field: FieldMeta
-  onAdd: (filter: Filter) => void
+  onChange: (filter: Filter) => void
   onDismiss: () => void
 }) {
   const formId = useId()
@@ -109,7 +109,10 @@ function FilterDialog({
     if (event.target !== event.currentTarget) return
     event.preventDefault()
 
-    onAdd(filter)
+    onAdd({
+      ...filter,
+      value,
+    })
     onDismiss()
   }
 
@@ -505,16 +508,24 @@ function ListPage({ listKey }: ListPageProps) {
 
         {filters.length ? (
           <Flex gap="small" wrap>
-            {filters.map(filter => {
+            {filters.map((filter, i) => {
               const field = list.fields[filter.field]
-              const onRemove = () =>
+              function onRemove() {
                 setFilters(prevFilters => prevFilters.filter(f => f !== filter))
+              }
+              function onChange(updatedFilter: Filter) {
+                setFilters(prevFilters => [
+                  ...prevFilters.filter(f => f !== filter),
+                  updatedFilter
+                ])
+              }
+
               return (
                 <FilterTag
-                  key={`${filter.field}_${filter.type}`}
+                  key={i}
                   field={field}
                   filter={filter}
-                  onAdd={onAddFilter}
+                  onChange={onChange}
                   onRemove={onRemove}
                 />
               )

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -173,6 +173,8 @@ function getFilters(list: ListMeta, query: ParsedUrlQueryInput): Filter[] {
     for (const filterType in field.controller.filter.types) {
       const prefix = `${fieldPath}_${filterType}`
       for (const queryFilter of params) {
+        if (!queryFilter.startsWith(prefix)) continue
+
         if (queryFilter === prefix) {
           filters.push({
             type: filterType,
@@ -182,7 +184,6 @@ function getFilters(list: ListMeta, query: ParsedUrlQueryInput): Filter[] {
           continue
         }
 
-        if (!queryFilter.startsWith(prefix)) continue
         const queryValue = queryFilter.slice(prefix.length + 1)
         try {
           const value = JSON.parse(queryValue)
@@ -191,7 +192,9 @@ function getFilters(list: ListMeta, query: ParsedUrlQueryInput): Filter[] {
             field: fieldPath,
             value,
           })
-        } catch {}
+        } catch (e) {
+          console.error('Error parsing filter', queryFilter)
+        }
       }
     }
   }
@@ -514,10 +517,7 @@ function ListPage({ listKey }: ListPageProps) {
                 setFilters(prevFilters => prevFilters.filter(f => f !== filter))
               }
               function onChange(updatedFilter: Filter) {
-                setFilters(prevFilters => [
-                  ...prevFilters.filter(f => f !== filter),
-                  updatedFilter
-                ])
+                setFilters(prevFilters => [...prevFilters.filter(f => f !== filter), updatedFilter])
               }
 
               return (


### PR DESCRIPTION
This pull request fixes a bug where the list view used the same React `key` for the same filter, and additionally mutated the `filter` object passed around resulting in undefined behaviour when rendering and using these filters.

Additionally, this pull request surfaces any errors that occur when parsing filters from the window query. 

This bug has not been released, thereby a changeset is not required.