### PR TITLE
Add error details for actions on the List page and fix action modes

### DIFF
--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -67,6 +67,7 @@ export const lists = {
         access: allowAll,
         async resolve({ actionKey, where }, context) {
           console.log(`${actionKey}`, JSON.stringify({ where }))
+          // throw new Error('Random failure, try again')
           return await context.db.Post.updateOne({
             where,
             data: {
@@ -88,7 +89,7 @@ export const lists = {
             promptMany: 'Are you sure you want to report {count} {singular|plural}?',
             promptConfirmLabel: 'Yes, report',
             promptConfirmLabelMany: 'Yes, report {count} {singular|plural}',
-            fail: 'Could not report {singular}',
+            fail: 'Could not report {singular} “{itemLabel}”',
             failMany: 'Could not report {countFail} {singular|plural}',
             success: '{Singular} reported',
             successMany: 'Successfully reported {countSuccess} {singular|plural}',

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/CreateItemPage/index.tsx
@@ -25,6 +25,7 @@ function CreateItemPage({ listKey }: { listKey: string }) {
       header={
         <ItemPageHeader
           list={list}
+          actions={[]}
           label="Create"
           title={`Create ${list.singular}`}
           item={null}

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -736,13 +736,17 @@ function ActionItemsDialog({
 
   async function onTryAction() {
     try {
-      const { data, errors } = await actionOnItems()
-      const failed = itemIds.filter(id => !data?.results?.some(x => x?.id === id))
-      const countSuccess = itemIds.length - failed.length
-      const countFail = failed.length
+      const { errors } = await actionOnItems()
+      const countFail = errors?.length ?? 0
+      const countSuccess = itemIds.length - countFail
+      const failed = []
+      for (const error of errors ?? []) {
+        const i = error.path?.[1]
+        if (typeof i !== 'number') continue
+        failed.push(itemIds[i])
+      }
 
-      // if there are errors
-      if (failed.length || errors?.length) {
+      if (countFail) {
         toastQueue.critical(
           replace(
             m.failMany,

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -1,4 +1,5 @@
 import isDeepEqual from 'fast-deep-equal'
+import type { GraphQLFormattedError } from 'graphql'
 import { useRouter } from 'next/router'
 import type { ParsedUrlQuery, ParsedUrlQueryInput } from 'querystring'
 import { type FormEvent, type Key, Fragment, useEffect, useId, useMemo, useState } from 'react'
@@ -12,7 +13,7 @@ import { chevronDownIcon } from '@keystar/ui/icon/icons/chevronDownIcon'
 import { searchXIcon } from '@keystar/ui/icon/icons/searchXIcon'
 import { textSelectIcon } from '@keystar/ui/icon/icons/textSelectIcon'
 import { undo2Icon } from '@keystar/ui/icon/icons/undo2Icon'
-import { Flex, HStack, VStack } from '@keystar/ui/layout'
+import { Box, Flex, HStack, VStack } from '@keystar/ui/layout'
 import { Menu, MenuTrigger } from '@keystar/ui/menu'
 import { ProgressCircle } from '@keystar/ui/progress'
 import { SearchField } from '@keystar/ui/search-field'
@@ -31,6 +32,8 @@ import { toastQueue } from '@keystar/ui/toast'
 import { Tooltip, TooltipTrigger } from '@keystar/ui/tooltip'
 import { Heading, Text } from '@keystar/ui/typography'
 
+import { TextLink } from '@keystar/ui/link'
+import { Notice } from '@keystar/ui/notice'
 import type { TypedDocumentNode } from '../../../../admin-ui/apollo'
 import { gql, useMutation, useQuery } from '../../../../admin-ui/apollo'
 import { CreateButtonLink } from '../../../../admin-ui/components/CreateButtonLink'
@@ -251,7 +254,7 @@ function ListPage({ listKey }: ListPageProps) {
   const localStorageListKey = `keystone.list.${listKey}.list.page.info`
 
   const list = useList(listKey)
-  const { query, replace, isReady } = useRouter()
+  const { query, replace: routerReplace, isReady } = useRouter()
   const [sort, setSort] = useState<SortDescriptor | null>(() => getSort(list, {}))
   const [columns, setColumns] = useState<string[]>(list.initialColumns)
   const [filters, setFilters] = useState<Filter[]>(() => getFilters(list, {}))
@@ -260,6 +263,7 @@ function ListPage({ listKey }: ListPageProps) {
   const [searchString, setSearchString] = useState('')
   const [selectedItems, setSelectedItems] = useState<Selection>(() => new Set([]))
   const [activeAction, setActiveAction] = useState<Key | null>(null)
+  const [actionResult, setActionResult] = useState<ActionErrorResult | null>(null)
   const dirty = useMemo(() => {
     const defaultFilters = getFilters(list, {})
     const defaultSort = getSort(list, {})
@@ -313,7 +317,7 @@ function ListPage({ listKey }: ListPageProps) {
     }
 
     localStorage.setItem(localStorageListKey, JSON.stringify(updatedQuery))
-    replace({ query: updatedQuery })
+    routerReplace({ query: updatedQuery })
   }, [columns, sort, filters, currentPage, pageSize, searchString, list])
 
   const allowCreate = !(list.hideCreate ?? true)
@@ -655,14 +659,74 @@ function ListPage({ listKey }: ListPageProps) {
                   itemIds={selectedItemIds}
                   {...action}
                   list={list}
-                  onSuccess={() => {
+                  onSuccess={remaining => {
                     refetch()
-                    setSelectedItems(new Set())
+                    setSelectedItems(remaining)
                   }}
+                  onErrors={setActionResult}
                 />
               )
             })
             .pop()}
+        </DialogContainer>
+        <DialogContainer onDismiss={() => setActionResult(null)} isDismissable>
+          {actionResult ? (
+            <Dialog>
+              <Heading>Error details for {actionResult.action.label} action</Heading>
+              <Content>
+                <VStack gap="large">
+                  {[
+                    ...(function* () {
+                      const { action, errors: actionErrors } = actionResult
+                      for (const [itemId, itemActionErrors] of Object.entries(actionErrors)) {
+                        const item = data?.items?.find(i => i.id === itemId) ?? null
+                        const itemLabel = (item?.[list.labelField] as string | null) ?? itemId
+                        const href = `/${list.path}/${itemId}`
+
+                        for (const error of itemActionErrors) {
+                          yield (
+                            <VStack key={itemId} gap="regular">
+                              <Notice tone="critical">
+                                <Content>
+                                  <Text>
+                                    You might try running the action again from{' '}
+                                    <TextLink href={href}>
+                                      the {list.singular.toLowerCase()}.
+                                    </TextLink>
+                                  </Text>
+                                  <Box
+                                    elementType="pre"
+                                    backgroundColor="critical"
+                                    borderRadius="regular"
+                                    maxHeight="100%"
+                                    overflow="auto"
+                                  >
+                                    <Text
+                                      color="critical"
+                                      UNSAFE_className={css({
+                                        fontFamily: tokenSchema.typography.fontFamily.code,
+                                      })}
+                                    >
+                                      {error.message}
+                                    </Text>
+                                  </Box>
+                                </Content>
+                                <div>
+                                  <Heading>
+                                    {replace(action.messages.fail, list, { itemLabel }, false)}
+                                  </Heading>
+                                </div>
+                              </Notice>
+                            </VStack>
+                          )
+                        }
+                      }
+                    })(),
+                  ]}
+                </VStack>
+              </Content>
+            </Dialog>
+          ) : null}
         </DialogContainer>
       </VStack>
     </PageContainer>
@@ -711,15 +775,23 @@ function replace(
   return s
 }
 
+type ActionErrors = Record<string, GraphQLFormattedError[]>
+type ActionErrorResult = {
+  action: ActionMeta
+  errors: ActionErrors
+}
+
 function ActionItemsDialog({
   list,
   itemIds,
   onSuccess,
+  onErrors,
   ...action
 }: {
   list: ListMeta
   itemIds: string[]
-  onSuccess: (remaining: string[]) => void
+  onSuccess: (remaining: Set<string>) => void
+  onErrors: (result: ActionErrorResult) => void
 } & ActionMeta) {
   const [actionOnItems] = useMutation<{ results?: ({ id: string } | null)[] }>(
     gql`mutation($where: [${list.graphql.names.whereUniqueInputName}!]!) {
@@ -739,11 +811,16 @@ function ActionItemsDialog({
       const { errors } = await actionOnItems()
       const countFail = errors?.length ?? 0
       const countSuccess = itemIds.length - countFail
-      const failed = []
+      const failed = new Set<string>()
+      const actionErrors: ActionErrors = {}
       for (const error of errors ?? []) {
         const i = error.path?.[1]
         if (typeof i !== 'number') continue
-        failed.push(itemIds[i])
+        const itemId = itemIds[i]
+
+        failed.add(itemId)
+        actionErrors[itemId] ??= []
+        actionErrors[itemId].push(error)
       }
 
       if (countFail) {
@@ -758,7 +835,11 @@ function ActionItemsDialog({
             },
             countFail > 1
           ),
-          { timeout: 5000 }
+          {
+            actionLabel: 'Details',
+            onAction: () => onErrors({ action, errors: actionErrors }),
+            shouldCloseOnAction: true,
+          }
         )
       }
 

--- a/packages/core/src/admin-ui/components/Errors.tsx
+++ b/packages/core/src/admin-ui/components/Errors.tsx
@@ -5,6 +5,7 @@ import { Dialog } from '@keystar/ui/dialog'
 import { Icon } from '@keystar/ui/icon'
 import { alertTriangleIcon } from '@keystar/ui/icon/icons/alertTriangleIcon'
 import { Box, Grid, VStack } from '@keystar/ui/layout'
+import { Notice } from '@keystar/ui/notice'
 import { Content, SlotProvider } from '@keystar/ui/slots'
 import { css, tokenSchema } from '@keystar/ui/style'
 import { Heading, Text } from '@keystar/ui/typography'
@@ -83,26 +84,34 @@ export function ErrorContainer({ children }: ErrorContainerProps) {
   )
 }
 
-export function ErrorDetailsDialog({ error }: { error: Error }) {
+export function ErrorDetailsDialog({ title, error }: { title: string; error: Error }) {
   const { message, stack } = error
   return (
     <Dialog>
       <Heading>Error details</Heading>
       <Content>
-        <VStack gap="large">
-          <Text weight="medium">{message}</Text>
-          {stack && (
+        <Notice tone="critical">
+          <Content>
+            <Text weight="medium">{message}</Text>
             <Box
               elementType="pre"
               backgroundColor="critical"
               borderRadius="regular"
               maxHeight="100%"
-              padding="medium"
               overflow="auto"
             >
               <Text
                 color="critical"
-                trim={false}
+                UNSAFE_className={css({
+                  fontFamily: tokenSchema.typography.fontFamily.code,
+                })}
+              >
+                {message}
+              </Text>
+              <Text
+                color="critical"
+                marginTop="small"
+                size="small"
                 UNSAFE_className={css({
                   fontFamily: tokenSchema.typography.fontFamily.code,
                 })}
@@ -110,8 +119,11 @@ export function ErrorDetailsDialog({ error }: { error: Error }) {
                 {stack}
               </Text>
             </Box>
-          )}
-        </VStack>
+          </Content>
+          <div>
+            <Heading>{title}</Heading>
+          </div>
+        </Notice>
       </Content>
     </Dialog>
   )

--- a/packages/core/src/admin-ui/context.tsx
+++ b/packages/core/src/admin-ui/context.tsx
@@ -237,6 +237,12 @@ export function useListItem(
               isRequired: ConditionalFilterCase<BaseListTypeInfo>
             } | null
           }[]
+          actions: {
+            key: string
+            itemView: {
+              actionMode: ConditionalFilter<'enabled' | 'disabled' | 'hidden', BaseListTypeInfo>
+            } | null
+          }[]
         } | null
       }
     }

--- a/tests/admin-ui-tests/list-view-crud.test.ts
+++ b/tests/admin-ui-tests/list-view-crud.test.ts
@@ -88,7 +88,7 @@ adminUITests('./tests/test-projects/crud-notifications', browserType => {
     await page.getByRole('button', { name: 'Yes, delete' }).click()
     const alertDialog = page.locator('[role=alertdialog][aria-modal=false]')
     await alertDialog.waitFor()
-    expect(await alertDialog.innerText()).toBe('Unable to delete 25 tasks.')
+    expect(await alertDialog.innerText()).toBe('Unable to delete 25 tasks.\nDetails')
     await alertDialog.getByRole('button', { name: 'Close' }).click()
     await page
       .locator('[role=alertdialog][aria-modal=false]:has-text("Deleted 25 tasks.")')


### PR DESCRIPTION
This pull request expands on the list view to show any errors that may have occurred when executing a particular action, as added in https://github.com/keystonejs/keystone/pull/9689.

Additionally, this pull request fixes the `{action}.ui.itemView.actionMode` not propagating to the item view context when it is different than the static variant (`item === null`).

As neither of these have been released, no additional changesets are required.