### PR TITLE
Fix emitting imports to modules resolved from "module" condition intended for bundlers in build Keystone configs

### DIFF
--- a/packages/core/src/scripts/esbuild.ts
+++ b/packages/core/src/scripts/esbuild.ts
@@ -52,6 +52,7 @@ export async function getEsbuildConfig(cwd: string): Promise<BuildOptions> {
     outfile: '.keystone/config.js',
     format: 'cjs',
     platform: 'node',
+    conditions: [],
     plugins: [
       {
         name: 'external-node_modules',


### PR DESCRIPTION
This fixes it because by including a conditions array, esbuild doesn't resolve from the `module` condition: https://esbuild.github.io/api/#how-conditions-work:~:text=be%20automatically%20included%3A-,module,-This%20condition%20can

No changeset since it's a fix to the unreleased "Add support for importing TypeScript (and similar) packages in a monorepo without a separate build step."