### PR TITLE
Add `query` and `mutation` prefixes when reporting Open Telemetry spans

### DIFF
--- a/packages/core/src/lib/core/mutations/index.ts
+++ b/packages/core/src/lib/core/mutations/index.ts
@@ -691,7 +691,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { data }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return createOne(data, list, context)
         },
@@ -709,7 +709,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { data }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return promisesButSettledWhenAllSettledAndInOrder(await createMany(data, list, context))
         },
@@ -729,7 +729,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { where, data }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return updateOne({ where, data }, list, context)
         },
@@ -757,7 +757,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { data }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return promisesButSettledWhenAllSettledAndInOrder(await updateMany(data, list, context))
         },
@@ -776,7 +776,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { where }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return deleteOne(where, list, context)
         },
@@ -794,7 +794,7 @@ export function getMutationsForList(list: InitialisedList) {
     },
     async resolve(_, { where }, context, info) {
       return await withSpan(
-        info.fieldName,
+        `mutation ${info.fieldName}`,
         async () => {
           return promisesButSettledWhenAllSettledAndInOrder(await deleteMany(where, list, context))
         },
@@ -867,7 +867,7 @@ export function getMutationsForList(list: InitialisedList) {
                 },
                 async resolve(_, { where }, context, info) {
                   return await withSpan(
-                    info.fieldName,
+                    `mutation ${info.fieldName}`,
                     async () => {
                       return actionOne(where, list, context, action)
                     },
@@ -887,7 +887,7 @@ export function getMutationsForList(list: InitialisedList) {
                 },
                 async resolve(_, { where }, context, info) {
                   return await withSpan(
-                    info.fieldName,
+                    `mutation ${info.fieldName}`,
                     async () => {
                       return promisesButSettledWhenAllSettledAndInOrder(
                         await actionMany(where, list, context, action)

--- a/packages/core/src/lib/core/queries/index.ts
+++ b/packages/core/src/lib/core/queries/index.ts
@@ -16,7 +16,7 @@ export function getQueriesForList(list: InitialisedList) {
     },
     async resolve(_, args, context, info) {
       return await withSpan(
-        info.fieldName,
+        `query ${info.fieldName}`,
         async () => {
           return queries.findOne(args, list, context, info)
         },
@@ -30,7 +30,7 @@ export function getQueriesForList(list: InitialisedList) {
     args: list.graphql.types.findManyArgs,
     async resolve(_, args, context, info) {
       return await withSpan(
-        info.fieldName,
+        `query ${info.fieldName}`,
         async () => {
           return queries.findMany(args, list, context, info)
         },
@@ -49,7 +49,7 @@ export function getQueriesForList(list: InitialisedList) {
     },
     async resolve(_, args, context, info) {
       return await withSpan(
-        info.fieldName,
+        `query ${info.fieldName}`,
         async () => {
           return queries.count(args, list, context, info)
         },


### PR DESCRIPTION
Followup to https://github.com/keystonejs/keystone/pull/9696 and https://github.com/keystonejs/keystone/pull/9700

When testing this, it became clear that the event messages of `posts` is ambiguous when surrounded by other spans.

This pull request adds the context of `query` and `mutation` to help observers understand what they are reading.