### PR TITLE
Fix `item` and `itemField` is `null` for `ui.*.fieldPosition` and `ui.*.fieldMode`

### DIFF
--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -14,7 +14,18 @@ export const lists = {
     fields: {
       title: text(),
       content: text(),
-      hidden: checkbox(),
+      hidden: checkbox({
+        ui: {
+          itemView: {
+            fieldMode: ({ item, itemField }) => {
+              // WARNING: none of this is access control
+              if (!item || item.votes === null) return 'edit'
+              if (itemField) return 'edit'
+              return item.votes > 0 ? 'read' : 'edit'
+            },
+          },
+        },
+      }),
       votes: integer({ defaultValue: 0 }),
       reportedAt: timestamp({
         ui: {

--- a/packages/core/src/fields/types/checkbox/views/index.tsx
+++ b/packages/core/src/fields/types/checkbox/views/index.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@keystar/ui/icon'
 import { checkIcon } from '@keystar/ui/icon/icons/checkIcon'
 import { Text, VisuallyHidden } from '@keystar/ui/typography'
 
+import { entriesTyped } from '../../../../lib/core/utils'
 import type {
   CellComponent,
   FieldController,
@@ -10,7 +11,6 @@ import type {
   FieldProps,
   SimpleFieldTypeInfo,
 } from '../../../../types'
-import { entriesTyped } from '../../../../lib/core/utils'
 
 export function Field({ field, value, onChange, autoFocus }: FieldProps<typeof controller>) {
   return (

--- a/tests2/omit.test.ts
+++ b/tests2/omit.test.ts
@@ -89,7 +89,8 @@ function makeList({
         delete: boolean
       }
 }) {
-  const prefix = `List${fields.length}_Filt${yn(defaultIsFilterable)}_Ord${yn(defaultIsOrderable)}` as const
+  const prefix =
+    `List${fields.length}_Filt${yn(defaultIsFilterable)}_Ord${yn(defaultIsOrderable)}` as const
   const name__ = `${prefix}_Omit${
     typeof omit !== 'object'
       ? yn(omit)
@@ -118,7 +119,7 @@ const listsMatrix = [
             fields: fieldsMatrix,
             defaultIsFilterable,
             defaultIsOrderable,
-            omit
+            omit,
           })
         }
 


### PR DESCRIPTION
https://github.com/keystonejs/keystone/pull/9689 moved the GraphQL resolving of these fields up to the `list` rather than resolving the `item` at the field.

This pull request fixes an unreleased regression that prevented `item` from flowing down to the `field` resolver unintentionally.