### PR TITLE
Fix `statelessSessions` to only accept `Authorization: Bearer` prefixed tokens

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto'
 import * as cookie from 'cookie'
 import Iron from '@hapi/iron'
-import type { SessionStrategy, SessionStoreFunction } from '../types'
+import type { KeystoneContext, SessionStrategy, SessionStoreFunction } from '../types'
 
 // TODO: should we also accept httpOnly?
 type StatelessSessionsOptions = {
@@ -59,11 +59,11 @@ type StatelessSessionsOptions = {
   sameSite?: true | false | 'lax' | 'strict' | 'none'
 }
 
-function getToken (req: Request, cookieName: string) {
+function getToken(req: NonNullable<KeystoneContext['req']>, cookieName: string) {
   const authorization = req.headers.authorization ?? ''
 
   if (authorization.startsWith('Bearer')) {
-    return req.headers.authorization.slice('Bearer '.length)
+    return authorization.slice('Bearer '.length)
   }
 
   const cookies = cookie.parse(req.headers.cookie || '')


### PR DESCRIPTION
This may help https://github.com/keystonejs/keystone/issues/9785, by restricting the types of `Authorization` headers that we accept.

`Authorization: Basic` is not supported by `statelessSessions`, but `Iron.unseal` would have been attempted for any `Authorization:` header.

This may break downstreams who inadvertently used `Authorization: {token}`, but that has not been intentionally supported.