### PR TITLE
Fix typos in comments

### DIFF
--- a/packages/core/src/fields/types/bytes/index.ts
+++ b/packages/core/src/fields/types/bytes/index.ts
@@ -257,7 +257,7 @@ export function bytesScalar(opts: {
       // so that when you're doing a mutation in a resolver, you can just pass in a Uint8Array directly
       if (value instanceof Uint8Array) {
         // duplicate it though to avoid any weirdness with the array being mutated
-        // + ensuring that if you pass in a Buffer, resolvers recieve a normal Uint8Array
+        // + ensuring that if you pass in a Buffer, resolvers receive a normal Uint8Array
         return Uint8Array.from(value)
       }
       if (typeof value !== 'string') {

--- a/packages/core/src/fields/types/calendarDay/views/index.tsx
+++ b/packages/core/src/fields/types/calendarDay/views/index.tsx
@@ -99,7 +99,7 @@ export function Field(props: FieldProps<typeof controller>) {
 }
 
 function validate(value: Value, isRequired: boolean, label: string): string | undefined {
-  // if we recieve null initially on the item view and the current value is null,
+  // if we receive null initially on the item view and the current value is null,
   // we should always allow saving it because:
   // - the value might be null in the database and we don't want to prevent saving the whole item because of that
   // - we might have null because of an access control error

--- a/packages/core/src/fields/types/timestamp/views/index.tsx
+++ b/packages/core/src/fields/types/timestamp/views/index.tsx
@@ -103,7 +103,7 @@ function validate(
 ): string | undefined {
   const isEmpty = !value.value
 
-  // if we recieve null initially on the item view and the current value is null,
+  // if we receive null initially on the item view and the current value is null,
   // we should always allow saving it because:
   // - the value might be null in the database and we don't want to prevent saving the whole item because of that
   // - we might have null because of an access control error

--- a/packages/core/src/types/schema/scalars.ts
+++ b/packages/core/src/types/schema/scalars.ts
@@ -53,7 +53,7 @@ export const Hex = new GraphQLScalarType({
     // so that when you're doing a mutation in a resolver, you can just pass in a Uint8Array directly
     if (value instanceof Uint8Array) {
       // duplicate it though to avoid any weirdness with the array being mutated
-      // + ensuring that if you pass in a Buffer, resolvers recieve a normal Uint8Array
+      // + ensuring that if you pass in a Buffer, resolvers receive a normal Uint8Array
       return Uint8Array.from(value)
     }
     if (typeof value !== 'string') {


### PR DESCRIPTION

**Repo:** keystonejs/keystone (⭐ 9000)
**Type:** docs
**Files changed:** 4
**Lines:** +4/-4

## What
Corrects the misspelling "recieve" → "receive" in four code comments across `packages/core` (bytes/scalars field types and the timestamp/calendarDay view comments).

## Why
Comment typos are minor but reduce code professionalism and make grep/search inconsistent. This is a low-risk drive-by cleanup limited to comments — no behavior change.

## Testing
No runtime change; comments only. `git diff` confirms only comment lines were touched. No need to run tests.

## Risk
Low — comments only, zero functional impact.
