### PR TITLE
feat: add startup telemetry status logs

### DIFF
--- a/.changeset/plenty-things-work.md
+++ b/.changeset/plenty-things-work.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Add startup log messages to inform users of telemetry status

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -273,23 +273,33 @@ export async function runTelemetry(
   dbProviderName: DatabaseProvider
 ) {
   try {
-    if (
-      ci.isCI || // don't run in CI
-      process.env.NODE_ENV === 'production' || // don't run in production
-      process.env.KEYSTONE_TELEMETRY_DISABLED === '1' // don't run if the user has disabled it
-    ) {
+    if (ci.isCI) {
+      console.log(`Keystone Telemetry is ${r`disabled`} (running in CI)`)
+      return
+    }
+
+    if (process.env.NODE_ENV === 'production') {
+      console.log(`Keystone Telemetry is ${r`disabled`} (NODE_ENV is production)`)
+      return
+    }
+
+    if (process.env.KEYSTONE_TELEMETRY_DISABLED === '1') {
+      console.log(`Keystone Telemetry is ${r`disabled`} (via KEYSTONE_TELEMETRY_DISABLED env)`)
       return
     }
 
     const { telemetry, userConfig } = getTelemetryConfig()
 
-    // don't run if the user has opted out
-    //   or if somehow our defaults are problematic, do nothing
-    if (telemetry === false) return
+    if (telemetry === false) {
+      console.log(`Keystone Telemetry is ${r`disabled`} (via opt-out)`)
+      return
+    }
 
     // don't send telemetry before we inform the user, allowing opt-out
     const telemetryDefaulted = getDefault(telemetry)
     if (!telemetryDefaulted.informedAt) return inform(telemetryDefaulted, userConfig)
+
+    console.log(`Keystone Telemetry is ${g`enabled`}`)
 
     await sendProjectTelemetryEvent(cwd, lists, dbProviderName, telemetryDefaulted, userConfig)
     await sendDeviceTelemetryEvent(telemetryDefaulted, userConfig)

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -273,6 +273,13 @@ export async function runTelemetry(
   dbProviderName: DatabaseProvider
 ) {
   try {
+    const { telemetry, userConfig } = getTelemetryConfig()
+
+    if (telemetry === false) {
+      console.log(`Keystone Telemetry is ${r`disabled`} (via opt-out)`)
+      return
+    }
+
     if (ci.isCI) {
       console.log(`Keystone Telemetry is ${r`disabled`} (running in CI)`)
       return
@@ -288,10 +295,8 @@ export async function runTelemetry(
       return
     }
 
-    const { telemetry, userConfig } = getTelemetryConfig()
-
-    if (telemetry === false) {
-      console.log(`Keystone Telemetry is ${r`disabled`} (via opt-out)`)
+    if (process.env.DO_NOT_TRACK === '1') {
+      console.log(`Keystone Telemetry is ${r`disabled`} (DO_NOT_TRACK is set)`)
       return
     }
 
@@ -307,7 +312,6 @@ export async function runTelemetry(
     log(err?.message ?? err)
   }
 }
-
 export function statusTelemetry(updated = false) {
   const { telemetry } = getTelemetryConfig()
   printTelemetryStatus(telemetry, updated)

--- a/packages/core/src/lib/telemetry.ts
+++ b/packages/core/src/lib/telemetry.ts
@@ -280,6 +280,16 @@ export async function runTelemetry(
       return
     }
 
+    if (process.env.KEYSTONE_TELEMETRY_DISABLED === '1') {
+      console.log(`Keystone Telemetry is ${r`disabled`} (KEYSTONE_TELEMETRY_DISABLED is set)`)
+      return
+    }
+
+    if (process.env.DO_NOT_TRACK === '1') {
+      console.log(`Keystone Telemetry is ${r`disabled`} (DO_NOT_TRACK is set)`)
+      return
+    }
+
     if (ci.isCI) {
       console.log(`Keystone Telemetry is ${r`disabled`} (running in CI)`)
       return
@@ -287,16 +297,6 @@ export async function runTelemetry(
 
     if (process.env.NODE_ENV === 'production') {
       console.log(`Keystone Telemetry is ${r`disabled`} (NODE_ENV is production)`)
-      return
-    }
-
-    if (process.env.KEYSTONE_TELEMETRY_DISABLED === '1') {
-      console.log(`Keystone Telemetry is ${r`disabled`} (via KEYSTONE_TELEMETRY_DISABLED env)`)
-      return
-    }
-
-    if (process.env.DO_NOT_TRACK === '1') {
-      console.log(`Keystone Telemetry is ${r`disabled`} (DO_NOT_TRACK is set)`)
       return
     }
 

--- a/packages/core/tests/telemetry.test.ts
+++ b/packages/core/tests/telemetry.test.ts
@@ -287,7 +287,7 @@ describe('Telemetry tests', () => {
 
         await runTelemetry(mockProjectDir, lists, 'sqlite') // try send again
 
-        expect(new Conf().get).toHaveBeenCalledTimes(0)
+        expect(new Conf().get).toHaveBeenCalledTimes(1)
         expect(https.request).toHaveBeenCalledTimes(0)
         expect(mockTelemetryConfig).toBe(mockTelemetryConfigInitialised) // unchanged
       })
@@ -298,7 +298,7 @@ describe('Telemetry tests', () => {
         await runTelemetry(mockProjectDir, lists, 'sqlite') // try inform
         await runTelemetry(mockProjectDir, lists, 'sqlite') // try send
 
-        expect(new Conf().get).toHaveBeenCalledTimes(0)
+        expect(new Conf().get).toHaveBeenCalledTimes(2)
         expect(https.request).toHaveBeenCalledTimes(0)
         expect(mockTelemetryConfig).toBe(undefined) // unchanged
       })


### PR DESCRIPTION
Closes #9299

Added log messages to runTelemetry() to inform users of telemetry status at startup:

- Keystone Telemetry is disabled (running in CI)
- Keystone Telemetry is disabled (NODE_ENV is production)
- Keystone Telemetry is disabled (via KEYSTONE_TELEMETRY_DISABLED env)
- Keystone Telemetry is disabled (via opt-out)
- Keystone Telemetry is enabled