### PR TITLE
fix: add error logging to access control catch block

### DIFF
--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -428,7 +428,12 @@ export async function checkUniqueItemExists(
   try {
     const item = await context.db[foreignList.listKey].findOne({ where: uniqueInput })
     if (item !== null) return uniqueWhere
-  } catch (err) {}
+  } catch (err) {
+    // Log access control errors for debugging — access will still be denied below
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(`[keystone] access-control: findOne failed for ${foreignList.listKey}:`, err)
+    }
+  }
 
   throw accessDeniedError(cannotForItem(operation, foreignList))
 }


### PR DESCRIPTION
## Problem

`checkUniqueItemExists` in `access-control.ts` has an empty catch block (line 431) that silently swallows all errors from `findOne`:

```typescript
try {
    const item = await context.db[foreignList.listKey].findOne({ where: uniqueInput })
    if (item !== null) return uniqueWhere
} catch (err) {} // <- all errors silently swallowed
```

If `findOne` fails for any reason (DB connection error, misconfiguration, schema mismatch), the error is invisible — making access control issues extremely hard to debug in development.

## Fix

Add `console.warn` in non-production environments:

```typescript
} catch (err) {
    if (process.env.NODE_ENV !== 'production') {
        console.warn(\`[keystone] access-control: findOne failed for ${foreignList.listKey}:\`, err)
    }
}
```

- **Behavior unchanged** — access is still denied on error
- **Development visibility** — errors are now logged for debugging
- **Production safe** — no logging in production (opt-in only)

Found during a [static analysis sweep of 97 popular open source projects](https://dev.to/_1353e04f14b156240b/i-scanned-50-popular-open-source-projects-for-security-patterns-heres-what-i-found-8l5).