### PR TITLE
Fix seeding errors in `exampless/usecase-blog`

### DIFF
--- a/examples/usecase-blog/schema.ts
+++ b/examples/usecase-blog/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 
 // see https://keystonejs.com/docs/fields/overview for the full list of fields
 //   this is a few common fields for an example
-import { text, relationship, timestamp, checkbox } from '@keystone-6/core/fields'
+import { text, relationship, timestamp, checkbox, select } from '@keystone-6/core/fields'
 
 // the document field is a more complicated field, so it has it's own package
 import { document } from '@keystone-6/fields-document'
@@ -56,6 +56,15 @@ export const lists = {
 
     fields: {
       title: text({ validation: { isRequired: true } }),
+      status: select({
+        options: [
+          { label: 'Published', value: 'published' },
+          { label: 'Draft', value: 'draft' },
+        ],
+        defaultValue: 'draft',
+        ui: { displayMode: 'segmented-control' },
+      }),
+      publishDate: timestamp(),
 
       // the document field can be used for making rich editable content
       //   learn more at https://keystonejs.com/docs/guides/document-fields

--- a/examples/usecase-blog/seed-data.ts
+++ b/examples/usecase-blog/seed-data.ts
@@ -27,8 +27,19 @@ async function main() {
       where: { name: { equals: post.author } },
     })
 
+    if (authors.length === 0) {
+      console.warn(`⚠️ No author found for post: ${post.title}`)
+      continue
+    }
+
+    const { author, content, ...postData } = post
+
     await context.db.Post.createOne({
-      data: { ...post, author: { connect: { id: authors[0].id } } },
+      data: {
+        ...postData,
+        content: [{ type: 'paragraph', children: [{ text: content }] }],
+        author: { connect: { id: authors[0].id } },
+      },
     })
   }
 

--- a/examples/usecase-blog/seed-data.ts
+++ b/examples/usecase-blog/seed-data.ts
@@ -23,22 +23,23 @@ async function main() {
   for (const post of posts) {
     console.log(`📝 Adding post: ${post.title}`)
 
-    const authors = await context.db.Author.findMany({
+    const authorsList = await context.db.Author.findMany({
       where: { name: { equals: post.author } },
     })
 
-    if (authors.length === 0) {
+    const authorItem = authorsList[0]
+    if (!authorItem) {
       console.warn(`⚠️ No author found for post: ${post.title}`)
       continue
     }
 
-    const { author, content, ...postData } = post
+    const { author: _author, content, ...postData } = post
 
     await context.db.Post.createOne({
       data: {
         ...postData,
         content: [{ type: 'paragraph', children: [{ text: content }] }],
-        author: { connect: { id: authors[0].id } },
+        author: { connect: { id: authorItem.id } },
       },
     })
   }


### PR DESCRIPTION
## Description
This PR fixes the seeding errors in the `usecase-blog` example reported in #9782.

The issues were:
1. The `Post` schema was missing `status` and `publishDate` fields which are present in the example data.
2. The `content` field (Document type) was receiving a raw string from the example data, causing a GraphQL error.
3. Lack of safety checks when connecting authors during seeding.

## Changes
- Updated `examples/usecase-blog/schema.ts` to include `status` and `publishDate` fields.
- Added `select` to the imported fields in `schema.ts`.
- Updated `examples/usecase-blog/seed-data.ts` to transform the raw `content` string into a valid Document structure `[{ type: 'paragraph', children: [{ text: content }] }]`.
- Added a check in `seed-data.ts` to skip posts if the author is not found, preventing crashes.

## Verification
I have manually verified the schema and seed logic changes. Since this is a fix for an example's seed script, it ensures a better onboarding experience for new users.

Resolves #9782