### PR TITLE
feat: implement default GraphQL query depth limiting #9789

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -273,6 +273,7 @@
     "fast-deep-equal": "^3.1.3",
     "fs-extra": "^11.0.0",
     "graphql": "^16.8.1",
+    "graphql-depth-limit": "^1.1.0",
     "graphql-upload": "^15.0.2",
     "image-size": "^2.0.0",
     "intersection-observer": "^0.12.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -300,7 +300,8 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/resolve": "^1.20.2",
-    "@types/uuid": "^11.0.0"
+    "@types/uuid": "^11.0.0",
+    "@types/graphql-depth-limit": "^1.1.6"
   },
   "preconstruct": {
     "entrypoints": [

--- a/packages/core/src/lib/express.ts
+++ b/packages/core/src/lib/express.ts
@@ -7,7 +7,7 @@ import { GraphQLError, type GraphQLFormattedError } from 'graphql'
 import { type ApolloServerOptions, ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
-// @ts-expect-error
+
 import depthLimit from 'graphql-depth-limit'
 // @ts-expect-error
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js'

--- a/packages/core/src/lib/express.ts
+++ b/packages/core/src/lib/express.ts
@@ -8,6 +8,8 @@ import { type ApolloServerOptions, ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 // @ts-expect-error
+import depthLimit from 'graphql-depth-limit'
+// @ts-expect-error
 import graphqlUploadExpress from 'graphql-upload/graphqlUploadExpress.js'
 import type { KeystoneContext, KeystoneConfig } from '../types'
 
@@ -74,6 +76,10 @@ export async function createExpressServer(
     ...apolloConfig,
     formatError: formatError(config.graphql),
     schema: context.graphql.schema,
+    validationRules: [
+      depthLimit(config.graphql.maxDepth ?? 20),
+      ...(apolloConfig?.validationRules ?? []),
+    ],
     plugins:
       config.graphql.playground === 'apollo'
         ? apolloConfig?.plugins

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -116,9 +116,16 @@ export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeysto
      * @default 'schema.graphql'
      */
     extendGraphqlSchema?: (schema: GraphQLSchema) => GraphQLSchema
+
+    /**
+     * The maximum depth allowed for queries.
+     * @default 20
+     */
+    maxDepth?: number
   }
 
   lists: Record<string, ListConfig<any>>
+
   server?: {
     /** Configuration options for the cors middleware. Set to `true` to use Keystone's defaults */
     cors?: boolean | CorsOptions


### PR DESCRIPTION
## Description
This PR addresses the security concern raised in #9789 by implementing a default GraphQL query depth limit. 

### 🛡️ Why is this needed?
Without a depth limit, malicious users can send deeply nested circular queries (e.g., `author -> posts -> author -> posts...`) that consume exponential server resources, leading to a Denial of Service (DoS).

### 🛠️ Changes
- **Configuration**: Added `maxDepth` to the `graphql` section of `KeystoneConfig`. It defaults to `20` levels, which is a sensible balance between security and flexibility.
- **Validation**: Integrated the industry-standard `graphql-depth-limit` package as a validation rule in the Apollo Server setup.
- **Dependencies**: Added `graphql-depth-limit` to `@keystone-6/core`.

## Verification
- Added the `maxDepth` type to the config so it's discoverable via IntelliSense.
- Updated the server creation logic to inject the `depthLimit` rule before any user-defined rules.

Resolves #9789