### PR TITLE
fix: regenerate schema artifacts for usecase-blog after #9830

### DIFF
--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -141,6 +141,8 @@ input PostRelateToManyForCreateInput {
 type Post {
   id: ID!
   title: String
+  status: String
+  publishDate: DateTime
   content: Post_content_Document
   author: Author
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
@@ -161,6 +163,8 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   id: IDFilter
   title: StringFilter
+  status: StringFilter
+  publishDate: DateTimeNullableFilter
   author: AuthorWhereInput
   tags: TagManyRelationFilter
 }
@@ -174,10 +178,14 @@ input TagManyRelationFilter {
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
 }
 
 input PostUpdateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForUpdateInput
   tags: TagRelateToManyForUpdateInput
@@ -203,6 +211,8 @@ input PostUpdateArgs {
 
 input PostCreateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForCreateInput
   tags: TagRelateToManyForCreateInput

--- a/examples/usecase-blog/schema.prisma
+++ b/examples/usecase-blog/schema.prisma
@@ -22,12 +22,14 @@ model Author {
 }
 
 model Post {
-  id       String  @id @default(cuid())
-  title    String  @default("")
-  content  Json
-  author   Author? @relation("Post_author", fields: [authorId], references: [id])
-  authorId String? @map("author")
-  tags     Tag[]   @relation("Post_tags")
+  id          String    @id @default(cuid())
+  title       String    @default("")
+  status      String    @default("draft")
+  publishDate DateTime?
+  content     Json
+  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId    String?   @map("author")
+  tags        Tag[]     @relation("Post_tags")
 
   @@index([authorId])
 }


### PR DESCRIPTION
## Description

This is a follow-up fix for #9830.

PR #9830 added `status` (select) and `publishDate` (timestamp) fields to `examples/usecase-blog/schema.ts`, but the auto-generated `schema.prisma` and `schema.graphql` artifacts were not regenerated and committed. This caused the CI `keystone postinstall` check to fail with:

```
Error: Your Prisma and GraphQL schemas are not up to date
```

## Changes

- Updated `examples/usecase-blog/schema.prisma` — added `status String @default(\"draft\")` and `publishDate DateTime?` to the `Post` model
- Updated `examples/usecase-blog/schema.graphql` — added `status` and `publishDate` fields to the `Post` type, `PostWhereInput`, `PostOrderByInput`, `PostUpdateInput`, and `PostCreateInput`

## Root Cause

The generated schema files (`schema.prisma`, `schema.graphql`) are committed to the repo and must always stay in sync with `schema.ts`. When `schema.ts` is modified, `keystone postinstall` must be run locally and the regenerated files committed alongside the change.

Fixes the broken `postinstall` CI check introduced by #9830."