### PR TITLE
fix(core): prevent silent error swallowing in unique item checks

### DIFF
--- a/.changeset/fix-access-control-silent-error.md
+++ b/.changeset/fix-access-control-silent-error.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Fixed an issue where database errors (connection issues, timeouts, etc.) occurring during unique item existence checks (e.g. in relationship resolvers) were silently swallowed and replaced with a generic "Access denied" error. Unexpected errors are now correctly rethrown to aid debugging.

--- a/packages/core/src/lib/core/access-control.ts
+++ b/packages/core/src/lib/core/access-control.ts
@@ -17,6 +17,7 @@ import type {
   ListFilterAccessControl,
   ListOperationAccessControl,
   UpdateListItemAccessControl,
+  DeleteListItemAccessControl,
 } from '../../types'
 import { coerceAndValidateForGraphQLInput } from '../coerceAndValidateForGraphQLInput'
 import { accessDeniedError, accessReturnError, extensionError, formatKeys } from './graphql-errors'
@@ -428,7 +429,15 @@ export async function checkUniqueItemExists(
   try {
     const item = await context.db[foreignList.listKey].findOne({ where: uniqueInput })
     if (item !== null) return uniqueWhere
-  } catch (err) {}
+  } catch (err: any) {
+    // If it's an access denied error from context.db, we swallow it and throw our own
+    // to keep the error message consistent with "item may not exist".
+    // But if it's a real database error (e.g. connection, timeout, malformed query),
+    // we MUST rethrow it so the developer knows what happened.
+    if (err?.extensions?.code !== 'KS_ACCESS_DENIED') {
+      throw err
+    }
+  }
 
   throw accessDeniedError(cannotForItem(operation, foreignList))
 }


### PR DESCRIPTION
### Description

This PR fixes a bug in the access control logic where actual database errors (like timeouts, connection drops, or Prisma internal errors) were being silently swallowed during relationship resolution.

Previously, `checkUniqueItemExists` used an empty `catch (err) {}` block. This caused any error from `context.db[...].findOne()` to be masked as a generic "Access denied: it may not exist" error. This made infrastructure-level failures extremely difficult to debug, as developers would waste time checking their access control rules instead of their database connection.

### Changes

- Updated `checkUniqueItemExists` in `packages/core/src/lib/core/access-control.ts` to only swallow `KS_ACCESS_DENIED` errors.
- Any other error (unexpected exceptions) is now correctly rethrown.
- Added a changeset to document the fix.

### Impact

- **Better Debugging:** Developers will now see real database/connection errors in their logs instead of misleading "Access denied" messages.
- **Predictability:** System-level failures are no longer conflated with security-level denials.