### PR TITLE
updated schema for usecase-blog

### DIFF
--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -141,6 +141,8 @@ input PostRelateToManyForCreateInput {
 type Post {
   id: ID!
   title: String
+  status: String
+  publishDate: DateTime
   content: Post_content_Document
   author: Author
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
@@ -161,8 +163,24 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   id: IDFilter
   title: StringFilter
+  status: StringNullableFilter
+  publishDate: DateTimeNullableFilter
   author: AuthorWhereInput
   tags: TagManyRelationFilter
+}
+
+input StringNullableFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: StringNullableFilter
 }
 
 input TagManyRelationFilter {
@@ -174,10 +192,14 @@ input TagManyRelationFilter {
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
 }
 
 input PostUpdateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForUpdateInput
   tags: TagRelateToManyForUpdateInput
@@ -203,6 +225,8 @@ input PostUpdateArgs {
 
 input PostCreateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForCreateInput
   tags: TagRelateToManyForCreateInput

--- a/examples/usecase-blog/schema.prisma
+++ b/examples/usecase-blog/schema.prisma
@@ -22,12 +22,14 @@ model Author {
 }
 
 model Post {
-  id       String  @id @default(cuid())
-  title    String  @default("")
-  content  Json
-  author   Author? @relation("Post_author", fields: [authorId], references: [id])
-  authorId String? @map("author")
-  tags     Tag[]   @relation("Post_tags")
+  id          String    @id @default(cuid())
+  title       String    @default("")
+  status      String?   @default("draft")
+  publishDate DateTime?
+  content     Json
+  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId    String?   @map("author")
+  tags        Tag[]     @relation("Post_tags")
 
   @@index([authorId])
 }


### PR DESCRIPTION
This PR updates the GraphQL schema to align with the latest Prisma model changes for the Post entity.

Changes Included:

- Added status field to the Post type
- Added publishDate field to the Post type
- Updated PostWhereInput with:
- status: StringNullableFilter
- publishDate: DateTimeNullableFilter
- Introduced StringNullableFilter input type for nullable string filtering support
- Synced GraphQL schema changes with Prisma schema updates
- 

### Impact

Resolves schema mismatch issues between Prisma and GraphQL layers and ensures newly added fields are available for queries, filtering, and validation.