### PR TITLE
Fix  zod `optional` versus `undefined` usage

### DIFF
--- a/examples/usecase-blog/schema.graphql
+++ b/examples/usecase-blog/schema.graphql
@@ -141,6 +141,8 @@ input PostRelateToManyForCreateInput {
 type Post {
   id: ID!
   title: String
+  status: String
+  publishDate: DateTime
   content: Post_content_Document
   author: Author
   tags(where: TagWhereInput! = {}, orderBy: [TagOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: TagWhereUniqueInput): [Tag!]
@@ -161,8 +163,24 @@ input PostWhereInput {
   NOT: [PostWhereInput!]
   id: IDFilter
   title: StringFilter
+  status: StringNullableFilter
+  publishDate: DateTimeNullableFilter
   author: AuthorWhereInput
   tags: TagManyRelationFilter
+}
+
+input StringNullableFilter {
+  equals: String
+  in: [String!]
+  notIn: [String!]
+  lt: String
+  lte: String
+  gt: String
+  gte: String
+  contains: String
+  startsWith: String
+  endsWith: String
+  not: StringNullableFilter
 }
 
 input TagManyRelationFilter {
@@ -174,10 +192,14 @@ input TagManyRelationFilter {
 input PostOrderByInput {
   id: OrderDirection
   title: OrderDirection
+  status: OrderDirection
+  publishDate: OrderDirection
 }
 
 input PostUpdateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForUpdateInput
   tags: TagRelateToManyForUpdateInput
@@ -203,6 +225,8 @@ input PostUpdateArgs {
 
 input PostCreateInput {
   title: String
+  status: String
+  publishDate: DateTime
   content: JSON
   author: AuthorRelateToOneForCreateInput
   tags: TagRelateToManyForCreateInput

--- a/examples/usecase-blog/schema.prisma
+++ b/examples/usecase-blog/schema.prisma
@@ -22,12 +22,14 @@ model Author {
 }
 
 model Post {
-  id       String  @id @default(cuid())
-  title    String  @default("")
-  content  Json
-  author   Author? @relation("Post_author", fields: [authorId], references: [id])
-  authorId String? @map("author")
-  tags     Tag[]   @relation("Post_tags")
+  id          String    @id @default(cuid())
+  title       String    @default("")
+  status      String?   @default("draft")
+  publishDate DateTime?
+  content     Json
+  author      Author?   @relation("Post_author", fields: [authorId], references: [id])
+  authorId    String?   @map("author")
+  tags        Tag[]     @relation("Post_tags")
 
   @@index([authorId])
 }

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -102,7 +102,7 @@
     "slate": "^0.120.0",
     "slate-history": "^0.113.1",
     "slate-react": "^0.120.0",
-    "zod": "^4.0.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@keystone-6/core": "workspace:^",

--- a/packages/fields-document/src/structure-validation.ts
+++ b/packages/fields-document/src/structure-validation.ts
@@ -3,7 +3,7 @@ import type { RelationshipData } from './DocumentEditor/component-blocks/api-sha
 import { isValidURL } from './DocumentEditor/isValidURL'
 
 // leaf types
-const zMarkValue = z.union([z.literal(true), z.undefined()])
+const zMarkValue = z.literal(true).optional()
 
 const zText = z
   .object({
@@ -21,7 +21,7 @@ const zText = z
   })
   .strict()
 
-const zTextAlign = z.union([z.undefined(), z.literal('center'), z.literal('end')])
+const zTextAlign = z.literal('center').or(z.literal('end')).or(z.literal('right')).optional()
 const zUrl = z.string().refine(val => isValidURL(val), {
   error: `This type of URL is not accepted`,
 })

--- a/packages/fields-document/src/validation.test.tsx
+++ b/packages/fields-document/src/validation.test.tsx
@@ -135,41 +135,57 @@ test('excess properties', () => {
       },
     ])
   ).toMatchInlineSnapshot(`
-[Error: Invalid document structure: [
-  {
-    "code": "invalid_union",
-    "errors": [
-      [
-        {
-          "code": "invalid_union",
-          "errors": [],
-          "note": "No matching discriminator",
-          "discriminator": "type",
-          "path": [
-            "type"
+    [Error: Invalid document structure: [
+      {
+        "code": "invalid_union",
+        "errors": [
+          [
+            {
+              "code": "invalid_union",
+              "errors": [],
+              "note": "No matching discriminator",
+              "discriminator": "type",
+              "options": [
+                "component-block",
+                "component-block-prop",
+                "component-inline-prop",
+                "blockquote",
+                "layout-area",
+                "code",
+                "divider",
+                "list-item",
+                "list-item-content",
+                "ordered-list",
+                "unordered-list",
+                "heading",
+                "layout",
+                "paragraph"
+              ],
+              "path": [
+                "type"
+              ],
+              "message": "Invalid discriminator value. Expected 'component-block' | 'component-block-prop' | 'component-inline-prop' | 'blockquote' | 'layout-area' | 'code' | 'divider' | 'list-item' | 'list-item-content' | 'ordered-list' | 'unordered-list' | 'heading' | 'layout' | 'paragraph'"
+            }
           ],
-          "message": "Invalid input"
-        }
-      ],
-      [
-        {
-          "code": "unrecognized_keys",
-          "keys": [
-            "somethingElse"
-          ],
-          "path": [],
-          "message": "Unrecognized key: \\"somethingElse\\""
-        }
-      ]
-    ],
-    "path": [
-      0,
-      "children",
-      0
-    ],
-    "message": "Invalid input"
-  }
-]]
+          [
+            {
+              "code": "unrecognized_keys",
+              "keys": [
+                "somethingElse"
+              ],
+              "path": [],
+              "message": "Unrecognized key: \\"somethingElse\\""
+            }
+          ]
+        ],
+        "path": [
+          0,
+          "children",
+          0
+        ],
+        "message": "Invalid input"
+      }
+    ]]
   `)
 })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2170,8 +2170,8 @@ importers:
         specifier: ^0.120.0
         version: 0.120.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.120.0))(slate@0.120.0)
       zod:
-        specifier: ^4.0.0
-        version: 4.3.6
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@keystone-6/core':
         specifier: workspace:^
@@ -13574,8 +13574,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
@@ -21436,8 +21436,8 @@ snapshots:
       '@babel/parser': 7.29.2
       eslint: 10.2.1(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.6
-      zod-validation-error: 4.0.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -27456,13 +27456,13 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.3.6):
+  zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}
 
   zwitch@1.0.5: {}
 


### PR DESCRIPTION
It seems `zod` changed the behaviour of `undefined`/optionality in a minor/patch, this uses `.optional()` properly.

No changeset since only the new unreleased version uses zod v4.