### PR TITLE
Fix attempting to serialize fields on list page that aren't used by client side filters

### DIFF
--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -29,6 +29,7 @@ import { useList, useListItem } from '../../../../admin-ui/context'
 import {
   deserializeItemToValue,
   Fields,
+  getConditionalFilterFieldKeys,
   isActionAvailable,
   resolveActionMode,
   serializeItemForConditionalFilters,
@@ -36,6 +37,7 @@ import {
   useHasChanges,
   useInvalidFields,
 } from '../../../../admin-ui/utils'
+import { pick } from '../../../../admin-ui/utils/pick'
 import type {
   ActionMeta,
   BaseListTypeInfo,
@@ -386,17 +388,21 @@ function ItemPage({ listKey }: ItemPageProps) {
 
   const actionsInContext = useMemo(() => {
     if (!value) return []
-    const serializedValue = serializeItemForConditionalFilters(list.fields, value)
     return list.actions
-      .map(action => ({
-        ...action,
-        itemView: {
-          ...action.itemView,
-          actionMode: resolveActionMode(actionModes[action.key], serializedValue),
-        },
-      }))
+      .map(action => {
+        const fieldKeys = getConditionalFilterFieldKeys(actionModes[action.key])
+        const fields = pick(list.fields, fieldKeys)
+        const serializedValue = serializeItemForConditionalFilters(fields, value)
+        return {
+          ...action,
+          itemView: {
+            ...action.itemView,
+            actionMode: resolveActionMode(actionModes[action.key], serializedValue),
+          },
+        }
+      })
       .filter(action => isActionAvailable(action, action.itemView))
-  }, [actionModes, list.actions, value])
+  }, [actionModes, list.actions, list.fields, value])
 
   function onAction(action: ActionMeta, resultId: string | null) {
     const { navigation } = action.itemView

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -49,6 +49,7 @@ import {
   serializeItemForConditionalFilters,
 } from '../../../../admin-ui/utils'
 import { getActionArguments } from '../../../../admin-ui/utils/actionData'
+import { pick } from '../../../../admin-ui/utils/pick'
 import { useSearchFilter } from '../../../../fields/types/relationship/views/useFilter'
 import type { ActionMeta, FieldMeta, JSONValue, ListMeta } from '../../../../types'
 import { FilterAdd } from './FilterAdd'
@@ -355,6 +356,15 @@ function ListPage({ listKey }: ListPageProps) {
     () => list.actions.filter(x => isActionAvailable(x, x.listView)),
     [list.actions]
   )
+  const actionConditionalFilterFieldKeys = useMemo(() => {
+    const fieldKeys = new Set<string>()
+    for (const action of actionsAvailable) {
+      for (const fieldKey of getConditionalFilterFieldKeys(action.listView.actionMode)) {
+        fieldKeys.add(fieldKey)
+      }
+    }
+    return fieldKeys
+  }, [actionsAvailable])
   const search = useSearchFilter(searchString, list, list.initialSearchFields)
   const { data, error, refetch, loading } = useQuery(
     useMemo((): TypedDocumentNode<{
@@ -364,10 +374,10 @@ function ListPage({ listKey }: ListPageProps) {
       const fieldKeys = new Set(columns) // only the shown columns
 
       // and any fields needed by the action filters
+      for (const fieldKey of actionConditionalFilterFieldKeys) {
+        fieldKeys.add(fieldKey)
+      }
       for (const action of actionsAvailable) {
-        for (const fieldKey of getConditionalFilterFieldKeys(action.listView.actionMode)) {
-          fieldKeys.add(fieldKey)
-        }
         for (const arg of action.graphql.arguments) {
           if (!arg.source) continue
           fieldKeys.add(arg.source.itemField)
@@ -400,7 +410,7 @@ function ListPage({ listKey }: ListPageProps) {
           count: ${list.graphql.names.listQueryCountName}(where: $where)
         }
       `
-    }, [list, list.fields, columns, actionsAvailable]),
+    }, [list, list.fields, columns, actionsAvailable, actionConditionalFilterFieldKeys]),
     {
       fetchPolicy: 'cache-and-network',
       errorPolicy: 'all',
@@ -499,12 +509,17 @@ function ListPage({ listKey }: ListPageProps) {
     () => data?.items?.filter(item => selectedItemIds.includes(String(item.id))) ?? [],
     [data?.items, selectedItemIds]
   )
+  const actionConditionalFilterFields = useMemo(
+    () => pick(list.fields, actionConditionalFilterFieldKeys),
+    [actionConditionalFilterFieldKeys, list.fields]
+  )
   const serializedSelectedRows = useMemo(
     () =>
-      selectedRows.map(row =>
-        serializeItemForConditionalFilters(list.fields, deserializeItemToValue(list.fields, row))
-      ),
-    [list.fields, selectedRows]
+      selectedRows.map(row => {
+        const value = deserializeItemToValue(actionConditionalFilterFields, row)
+        return serializeItemForConditionalFilters(actionConditionalFilterFields, value)
+      }),
+    [actionConditionalFilterFields, selectedRows]
   )
   const { actions, disabledKeys: disabledActionKeys } = useMemo(() => {
     const disabledKeys: string[] = []

--- a/packages/core/src/admin-ui/utils/pick.ts
+++ b/packages/core/src/admin-ui/utils/pick.ts
@@ -1,6 +1,6 @@
 export function pick<T extends Record<string, unknown>, K extends keyof T>(
   value: T,
-  keys: readonly K[]
+  keys: Iterable<K>
 ): Pick<T, K> {
   const result: Partial<Pick<T, K>> = {}
   for (const key of keys) {

--- a/packages/core/src/admin-ui/utils/utils.tsx
+++ b/packages/core/src/admin-ui/utils/utils.tsx
@@ -66,8 +66,7 @@ export function deserializeItemToValue(
   item: Record<string, unknown | null>
 ) {
   const result: Record<string, unknown | null> = {}
-  for (const fieldKey in fields) {
-    const field = fields[fieldKey]
+  for (const [fieldKey, field] of Object.entries(fields)) {
     const itemForField: Record<string, unknown> = {}
     for (const graphqlField of getRootGraphQLFieldsFromFieldController(field.controller)) {
       itemForField[graphqlField] = item?.[graphqlField] ?? null


### PR DESCRIPTION
So the problem is that we were trying to serialize fields for use by the conditional client side filters that we never fetched (since they aren't used by the filters) which meant we deserialized from `undefined` for those fields and then attempted to serialize them, for the structure field, deserialising from `undefined` and then serialising errors.