### PR TITLE
Add slate-dom explicitly to enforce a specific version

### DIFF
--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -101,6 +101,7 @@
     "slate": "^0.120.0",
     "slate-history": "^0.113.1",
     "slate-react": "^0.120.0",
+    "slate-dom": "^0.119.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2220,12 +2220,15 @@ importers:
       slate:
         specifier: ^0.120.0
         version: 0.120.0
+      slate-dom:
+        specifier: ^0.119.0
+        version: 0.119.0(slate@0.120.0)
       slate-history:
         specifier: ^0.113.1
         version: 0.113.1(slate@0.120.0)
       slate-react:
         specifier: ^0.120.0
-        version: 0.120.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.120.0))(slate@0.120.0)
+        version: 0.120.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.119.0(slate@0.120.0))(slate@0.120.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -12413,10 +12416,10 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  slate-dom@0.124.1:
-    resolution: {integrity: sha512-D3yVibjLZM4Oj4MmXxOEXbjrlf4wJez3OvGABBNYrAP7gXb0d96tKNtWZ0hGm/5y84idw/LHjZ7W1uTYqFR9rQ==}
+  slate-dom@0.119.0:
+    resolution: {integrity: sha512-foc8a2NkE+1SldDIYaoqjhVKupt8RSuvHI868rfYOcypD4we5TT7qunjRKJ852EIRh/Ql8sSTepXgXKOUJnt1w==}
     peerDependencies:
-      slate: '>=0.121.0'
+      slate: '>=0.99.0'
 
   slate-history@0.113.1:
     resolution: {integrity: sha512-J9NSJ+UG2GxoW0lw5mloaKcN0JI0x2IA5M5FxyGiInpn+QEutxT1WK7S/JneZCMFJBoHs1uu7S7e6pxQjubHmQ==}
@@ -26242,7 +26245,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  slate-dom@0.124.1(slate@0.120.0):
+  slate-dom@0.119.0(slate@0.120.0):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       direction: 1.0.4
@@ -26268,7 +26271,7 @@ snapshots:
       is-plain-object: 5.0.0
       slate: 0.120.0
 
-  slate-react@0.120.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.120.0))(slate@0.120.0):
+  slate-react@0.120.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.119.0(slate@0.120.0))(slate@0.120.0):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       direction: 1.0.4
@@ -26278,7 +26281,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       scroll-into-view-if-needed: 3.1.0
       slate: 0.120.0
-      slate-dom: 0.124.1(slate@0.120.0)
+      slate-dom: 0.119.0(slate@0.120.0)
       tiny-invariant: 1.3.1
 
   slate-react@0.91.11(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate@0.91.4):


### PR DESCRIPTION
The problem this solves: `slate-react` has a peer dep on `slate-dom@>=0.119.1`, slate-dom is implicitly installed and based on the `>=0.119.1`, it gets the latest version of `slate-dom` (at the time `0.124.1`) and this new version of `slate-dom` has a peer dep on `slate@>=0.121.0` which is higher than the version of `slate` we have and `slate-dom@0.124.1` depends on things only in this newer version of `slate` so `slate-dom` 💥.