### PR TITLE
Using fields as ui.source for action args

### DIFF
--- a/examples/actions/schema.graphql
+++ b/examples/actions/schema.graphql
@@ -141,6 +141,8 @@ type Mutation {
   votePosts(data: [VotePostArgs!]!): [Post]
   reportAPost(where: PostWhereUniqueInput!): Post
   reportSomePosts(data: [ReportAPostArgs!]!): [Post]
+  hideWithReasonPost(where: PostWhereUniqueInput!, reason: String!): Post
+  hideWithReasonPosts(data: [HideWithReasonPostArgs!]!): [Post]
 }
 
 input VotePostArgs {
@@ -149,6 +151,11 @@ input VotePostArgs {
 
 input ReportAPostArgs {
   where: PostWhereUniqueInput!
+}
+
+input HideWithReasonPostArgs {
+  where: PostWhereUniqueInput!
+  reason: String!
 }
 
 type Query {

--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -1,4 +1,4 @@
-import { list, action } from '@keystone-6/core'
+import { list, action, g } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, integer, text, timestamp } from '@keystone-6/core/fields'
 
@@ -136,6 +136,57 @@ export const lists = {
           },
           listView: {
             actionMode: { disabled: isReportDisabled },
+          },
+        },
+      }),
+      hideWithReason: action({
+        access: allowAll,
+        args: {
+          reason: {
+            graphql: g.arg({ type: g.nonNull(g.String) }),
+            ui: {
+              source: {
+                field: text({
+                  validation: { isRequired: true },
+                  ui: {
+                    label: 'Reason',
+                    description: 'This is collected for the action only, not stored on the post.',
+                    displayMode: 'textarea',
+                  },
+                }),
+              },
+            },
+          },
+        },
+        async resolve({ actionKey, where, args }, context) {
+          console.log(`${actionKey}`, JSON.stringify({ where, reason: args.reason }))
+
+          return await context.sudo().db.Post.updateOne({
+            where,
+            data: {
+              hidden: true,
+            },
+          })
+        },
+        ui: {
+          label: 'Hide with reason',
+          icon: 'eyeOffIcon',
+          messages: {
+            promptTitle: 'Hide {singular}',
+            promptTitleMany: 'Hide {count} {singular|plural}',
+            prompt: 'Provide a reason before hiding “{itemLabel}”.',
+            promptMany: 'Provide a reason before hiding {count} {singular|plural}.',
+            promptConfirmLabel: 'Hide',
+            promptConfirmLabelMany: 'Hide {count} {singular|plural}',
+            success: '{Singular} hidden',
+            successMany: 'Successfully hid {countSuccess} {singular|plural}',
+          },
+          itemView: {
+            actionMode: { disabled: { hidden: { equals: true } } },
+            navigation: 'refetch',
+          },
+          listView: {
+            actionMode: { disabled: { hidden: { equals: true } } },
           },
         },
       }),

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/common.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/common.tsx
@@ -15,6 +15,7 @@ import { Heading, Text } from '@keystar/ui/typography'
 import { gql, type TypedDocumentNode, useApolloClient } from '../../../../admin-ui/apollo'
 import { Container, CONTAINER_MAX } from '../../../../admin-ui/components/Container'
 import { ErrorDetailsDialog } from '../../../../admin-ui/components/Errors'
+import { ActionDialog } from '../../../../admin-ui/components/ActionDialog'
 import {
   getActionArguments,
   getActionGraphQLArgs,
@@ -153,22 +154,12 @@ function ItemActions({
     [actions]
   )
 
-  async function onTryAction(action: ActionMeta, confirmed: boolean) {
-    setActiveAction(null)
-
-    if (hasUnsavedChanges) {
-      setBlockedAction(action)
-      return
-    }
-
-    if (!confirmed && !action.itemView.hidePrompt) {
-      setActiveAction(action)
-      return
-    }
-
+  async function runAction(action: ActionMeta, actionArgValue: Record<string, unknown>) {
     const { messages: m } = action
     try {
-      const argsForAction = initialValue ? getActionArguments(list, action, initialValue) : {}
+      const argsForAction = initialValue
+        ? getActionArguments(list, action, initialValue, actionArgValue)
+        : {}
       const graphqlArgs = getActionGraphQLArgs(action)
       const graphqlVariables = getActionGraphQLVariables(action)
       const mutation = (
@@ -217,7 +208,20 @@ function ItemActions({
         onAction={key => {
           const action = list.actions.find(action => action.key === key)
           if (!action) return
-          onTryAction(action, false)
+
+          setActiveAction(null)
+
+          if (hasUnsavedChanges) {
+            setBlockedAction(action)
+            return
+          }
+
+          if (!action.itemView.hidePrompt) {
+            setActiveAction(action)
+            return
+          }
+
+          runAction(action, {})
         }}
       >
         {item => (
@@ -229,19 +233,19 @@ function ItemActions({
       </ActionGroup>
       <DialogContainer onDismiss={() => setActiveAction(null)}>
         {activeAction && (
-          <AlertDialog
+          <ActionDialog
+            action={activeAction}
             title={replace(activeAction.messages.promptTitle, list, { ...activeAction, itemLabel })}
-            cancelLabel="Cancel"
-            primaryActionLabel={replace(activeAction.messages.promptConfirmLabel, list, {
+            prompt={replace(activeAction.messages.prompt, list, { ...activeAction, itemLabel })}
+            confirmLabel={replace(activeAction.messages.promptConfirmLabel, list, {
               ...activeAction,
               itemLabel,
             })}
-            onPrimaryAction={async () => {
-              await onTryAction(activeAction, true)
+            onConfirm={async actionArgValue => {
+              setActiveAction(null)
+              await runAction(activeAction, actionArgValue)
             }}
-          >
-            {replace(activeAction.messages.prompt, list, { ...activeAction, itemLabel })}
-          </AlertDialog>
+          />
         )}
       </DialogContainer>
 

--- a/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
+++ b/packages/core/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ListPage/index.tsx
@@ -6,7 +6,7 @@ import { type FormEvent, type Key, Fragment, useEffect, useId, useMemo, useState
 
 import { ActionBar, ActionBarContainer, Item } from '@keystar/ui/action-bar'
 import { ActionButton, Button, ButtonGroup } from '@keystar/ui/button'
-import { AlertDialog, Dialog, DialogContainer, DialogTrigger } from '@keystar/ui/dialog'
+import { Dialog, DialogContainer, DialogTrigger } from '@keystar/ui/dialog'
 import { Icon } from '@keystar/ui/icon'
 import { allIcons as KeystarIcons } from '@keystar/ui/icon/all'
 import { chevronDownIcon } from '@keystar/ui/icon/icons/chevronDownIcon'
@@ -36,6 +36,7 @@ import { TextLink } from '@keystar/ui/link'
 import { Notice } from '@keystar/ui/notice'
 import type { TypedDocumentNode } from '../../../../admin-ui/apollo'
 import { CombinedGraphQLErrors, gql, useMutation, useQuery } from '../../../../admin-ui/apollo'
+import { ActionDialog } from '../../../../admin-ui/components/ActionDialog'
 import { CreateButtonLink } from '../../../../admin-ui/components/CreateButtonLink'
 import { EmptyState } from '../../../../admin-ui/components/EmptyState'
 import { GraphQLErrorNotice } from '../../../../admin-ui/components/GraphQLErrorNotice'
@@ -379,8 +380,10 @@ function ListPage({ listKey }: ListPageProps) {
       }
       for (const action of actionsAvailable) {
         for (const arg of action.graphql.arguments) {
-          if (!arg.source) continue
-          fieldKeys.add(arg.source.itemField)
+          const itemField =
+            arg.source && 'itemField' in arg.source ? arg.source.itemField : undefined
+          if (!itemField) continue
+          fieldKeys.add(itemField)
         }
       }
 
@@ -898,27 +901,28 @@ function ActionItemsDialog({
       }
     }`
   const [actionOnItems] = useMutation<{ results?: ({ id: string } | null)[] }>(actionMutation, {
-    variables:
-      action.key === 'delete'
-        ? { where: itemIds.map(id => ({ id })) }
-        : {
-            data: itemIds.flatMap(id => {
-              const row = items.find(item => String(item.id) === id)
-              if (!row) {
-                return []
-              }
-              const deserialized = deserializeItemToValue(list.fields, row)
-              const args = getActionArguments(list, action, deserialized)
-              return { where: { id }, ...args }
-            }),
-          },
     errorPolicy: 'all',
   })
   const { messages: m } = action
 
-  async function onTryAction() {
+  async function onTryAction(actionArgValue: Record<string, unknown>) {
     try {
-      const { error } = await actionOnItems()
+      const { error } = await actionOnItems({
+        variables:
+          action.key === 'delete'
+            ? { where: itemIds.map(id => ({ id })) }
+            : {
+                data: itemIds.flatMap(id => {
+                  const row = items.find(item => String(item.id) === id)
+                  if (!row) {
+                    return []
+                  }
+                  const deserialized = deserializeItemToValue(list.fields, row)
+                  const args = getActionArguments(list, action, deserialized, actionArgValue)
+                  return { where: { id }, ...args }
+                }),
+              },
+      })
       const failed = new Set<string>()
       const actionErrors: ActionErrors = {}
       let countFail = 0
@@ -981,7 +985,8 @@ function ActionItemsDialog({
   }
 
   return (
-    <AlertDialog
+    <ActionDialog
+      action={action}
       tone={action.key === 'delete' ? 'critical' : 'neutral'}
       title={replace(
         m.promptTitleMany,
@@ -989,18 +994,14 @@ function ActionItemsDialog({
         { ...action, count: itemIds.length },
         itemIds.length > 1
       )}
-      cancelLabel="Cancel"
-      primaryActionLabel={replace(
+      prompt={replace(m.promptMany, list, { ...action, count: itemIds.length }, itemIds.length > 1)}
+      confirmLabel={replace(
         m.promptConfirmLabelMany,
         list,
         { ...action, count: itemIds.length },
         itemIds.length > 1
       )}
-      onPrimaryAction={onTryAction}
-    >
-      <Text>
-        {replace(m.promptMany, list, { ...action, count: itemIds.length }, itemIds.length > 1)}
-      </Text>
-    </AlertDialog>
+      onConfirm={onTryAction}
+    />
   )
 }

--- a/packages/core/src/admin-ui/components/ActionDialog.tsx
+++ b/packages/core/src/admin-ui/components/ActionDialog.tsx
@@ -1,0 +1,127 @@
+import { useId, useMemo, useState } from 'react'
+
+import { Button, ButtonGroup } from '@keystar/ui/button'
+import { AlertDialog, Dialog, useDialogContainer } from '@keystar/ui/dialog'
+import { Box, VStack } from '@keystar/ui/layout'
+import { Content } from '@keystar/ui/slots'
+import { Heading, Text } from '@keystar/ui/typography'
+
+import type { ActionMeta, FieldMeta } from '../../types'
+import { Fields } from '../utils/Fields'
+import { getActionFieldArgFields } from '../utils/actionData'
+import { makeDefaultValueState, useInvalidFields } from '../utils/utils'
+
+export function ActionDialog({
+  action,
+  title,
+  prompt,
+  confirmLabel,
+  tone = 'neutral',
+  onConfirm,
+}: {
+  action: ActionMeta
+  title: string
+  prompt: string
+  confirmLabel: string
+  tone?: 'critical' | 'neutral'
+  onConfirm: (actionArgValue: Record<string, unknown>) => Promise<void>
+}) {
+  const fields = useMemo(() => getActionFieldArgFields(action), [action])
+  const fieldEntries = Object.entries(fields)
+  const hasFields = fieldEntries.length > 0
+
+  if (!hasFields) {
+    return (
+      <AlertDialog
+        tone={tone}
+        title={title}
+        cancelLabel="Cancel"
+        primaryActionLabel={confirmLabel}
+        onPrimaryAction={() => onConfirm({})}
+      >
+        <Text>{prompt}</Text>
+      </AlertDialog>
+    )
+  }
+
+  return (
+    <ActionFieldDialog
+      fields={fields}
+      title={title}
+      prompt={prompt}
+      confirmLabel={confirmLabel}
+      onConfirm={onConfirm}
+    />
+  )
+}
+
+function ActionFieldDialog({
+  fields,
+  title,
+  prompt,
+  confirmLabel,
+  onConfirm,
+}: {
+  fields: Record<string, FieldMeta>
+  title: string
+  prompt: string
+  confirmLabel: string
+  onConfirm: (actionArgValue: Record<string, unknown>) => Promise<void>
+}) {
+  const dialog = useDialogContainer()
+  const formId = useId()
+  const [forceValidation, setForceValidation] = useState(false)
+  const [value, setValue] = useState(() => makeDefaultValueState(fields))
+  const isRequireds = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(fields).map(([key, field]) => [key, field.createView.isRequired])
+      ),
+    [fields]
+  )
+  const invalidFields = useInvalidFields(fields, value, isRequireds)
+
+  return (
+    <Dialog>
+      <Heading>{title}</Heading>
+      <Content>
+        <form
+          id={formId}
+          onSubmit={async event => {
+            if (event.target !== event.currentTarget) return
+            event.preventDefault()
+
+            const newForceValidation = invalidFields.size !== 0
+            setForceValidation(newForceValidation)
+            if (newForceValidation) return
+
+            await onConfirm(value)
+            dialog.dismiss()
+          }}
+        >
+          <VStack gap="xlarge">
+            <Text>{prompt}</Text>
+            <Box paddingTop="regular">
+              <Fields
+                view="createView"
+                position="form"
+                fields={fields}
+                forceValidation={forceValidation}
+                invalidFields={invalidFields}
+                value={value}
+                isRequireds={isRequireds}
+                onChange={setValue}
+              />
+            </Box>
+          </VStack>
+        </form>
+      </Content>
+      <ButtonGroup>
+        <Button onPress={dialog.dismiss}>Cancel</Button>
+        <Button form={formId} prominence="high" type="submit">
+          {confirmLabel}
+        </Button>
+      </ButtonGroup>
+    </Dialog>
+  )
+}

--- a/packages/core/src/admin-ui/context.tsx
+++ b/packages/core/src/admin-ui/context.tsx
@@ -81,7 +81,7 @@ function InternalKeystoneProvider({
         groups: [],
       }
 
-      for (const field of listData.fields) {
+      function hydrateField(field: (typeof listData.fields)[number]) {
         for (const exportName of expectedExports) {
           if ((fieldViews[field.viewsIndex] as any)[exportName] === undefined) {
             throw new Error(
@@ -105,10 +105,10 @@ function InternalKeystoneProvider({
           }
         }
 
-        lists[listData.key].fields[field.key] = {
+        return {
           ...field,
           createView: {
-            fieldMode: field.createView?.fieldMode ?? null,
+            fieldMode: field.createView?.fieldMode ?? 'edit',
             isRequired: field.createView?.isRequired ?? false,
           },
           itemView: {
@@ -131,6 +131,10 @@ function InternalKeystoneProvider({
         }
       }
 
+      for (const field of listData.fields) {
+        lists[listData.key].fields[field.key] = hydrateField(field)
+      }
+
       for (const group of listData.groups) {
         lists[listData.key].groups.push({
           label: group.label,
@@ -138,6 +142,23 @@ function InternalKeystoneProvider({
           fields: group.fields.map(field => lists[listData.key].fields[field.key]),
         })
       }
+
+      lists[listData.key].actions = listData.actions.map(action => ({
+        ...action,
+        graphql: {
+          ...action.graphql,
+          arguments: action.graphql.arguments.map(arg =>
+            arg.source && 'field' in arg.source
+              ? {
+                  ...arg,
+                  source: {
+                    field: hydrateField(arg.source.field as (typeof listData.fields)[number]),
+                  },
+                }
+              : arg
+          ),
+        },
+      }))
     }
 
     return lists
@@ -291,8 +312,9 @@ export function useListItem(
       }
 
       for (const arg of action.graphql.arguments) {
-        if (!arg.source) continue
-        selectedFieldKeys.add(arg.source.itemField)
+        const itemField = arg.source && 'itemField' in arg.source ? arg.source.itemField : undefined
+        if (!itemField) continue
+        selectedFieldKeys.add(itemField)
       }
     }
 

--- a/packages/core/src/admin-ui/utils/actionData.ts
+++ b/packages/core/src/admin-ui/utils/actionData.ts
@@ -1,27 +1,46 @@
-import type { ActionMeta, ListMeta } from '../../types'
-import { serializeValueToOperationItem } from './utils'
+import type { ActionMeta, FieldMeta, ListMeta } from '../../types'
+import { makeDefaultValueState, serializeValueToOperationItem } from './utils'
+
+export function getActionFieldArgFields(action: ActionMeta) {
+  return Object.fromEntries(
+    action.graphql.arguments.flatMap(arg => {
+      const field = arg.source && 'field' in arg.source ? arg.source.field : undefined
+      return field ? [[arg.name, field as FieldMeta]] : []
+    })
+  )
+}
 
 export function getActionArguments(
   list: ListMeta,
   action: ActionMeta,
-  value: Record<string, unknown>
+  value: Record<string, unknown>,
+  actionArgValue: Record<string, unknown> = {}
 ): Record<string, unknown> {
   const args: Record<string, unknown> = {}
   for (const arg of action.graphql.arguments) {
-    const { source } = arg
-    if (!source) continue
+    const fieldSource = arg.source && 'field' in arg.source ? arg.source.field : undefined
+    if (fieldSource) {
+      const fields = { [arg.name]: fieldSource }
+      const serialized = serializeValueToOperationItem(
+        'create',
+        fields,
+        actionArgValue,
+        makeDefaultValueState(fields)
+      )
+      if (Object.prototype.hasOwnProperty.call(serialized, arg.name)) {
+        args[arg.name] = serialized[arg.name]
+      }
+      continue
+    }
+    const itemField = arg.source && 'itemField' in arg.source ? arg.source.itemField : undefined
+    if (!itemField) continue
 
-    const field = list.fields[source.itemField]
+    const field = list.fields[itemField]
     if (!field) continue
 
-    const serialized = serializeValueToOperationItem(
-      'update',
-      { [source.itemField]: field },
-      value,
-      {}
-    )
-    if (Object.prototype.hasOwnProperty.call(serialized, source.itemField)) {
-      args[arg.name] = serialized[source.itemField]
+    const serialized = serializeValueToOperationItem('update', { [itemField]: field }, value, {})
+    if (Object.prototype.hasOwnProperty.call(serialized, itemField)) {
+      args[arg.name] = serialized[itemField]
     }
   }
   return args

--- a/packages/core/src/lib/admin-meta.ts
+++ b/packages/core/src/lib/admin-meta.ts
@@ -207,11 +207,7 @@ export function createAdminMeta(
 
     const listMeta = adminMetaRoot.listsByKey[listKey]
 
-    // populate .fields
-    for (const [fieldKey, field] of Object.entries(list.fields)) {
-      // if the field is a relationship field and is related to an omitted list, skip.
-      if (field.dbField.kind === 'relation' && omittedLists.includes(field.dbField.list)) continue
-      if (Object.values(field.graphql.isEnabled).every(x => x === false)) continue
+    function getFieldMeta(fieldKey: string, field: InitialisedList['fields'][string]) {
       assertValidView(
         field.views,
         `The \`views\` on the implementation of the field type at lists.${listKey}.fields.${fieldKey}`
@@ -221,7 +217,7 @@ export function createAdminMeta(
       const isNonNull = (['read', 'create', 'update'] as const).filter(
         operation => field.graphql.isNonNull[operation]
       )
-      const fieldMeta = {
+      return {
         // FieldMeta
         key: fieldKey,
         label: field.ui.label,
@@ -264,6 +260,14 @@ export function createAdminMeta(
         item: null, // part of resolver
         itemField: null, // part of resolver
       } satisfies FieldMetaSource
+    }
+
+    // populate .fields
+    for (const [fieldKey, field] of Object.entries(list.fields)) {
+      // if the field is a relationship field and is related to an omitted list, skip.
+      if (field.dbField.kind === 'relation' && omittedLists.includes(field.dbField.list)) continue
+      if (Object.values(field.graphql.isEnabled).every(x => x === false)) continue
+      const fieldMeta = getFieldMeta(fieldKey, field)
 
       listMeta.fields.push(fieldMeta)
       listMeta.fieldsByKey[fieldKey] = fieldMeta
@@ -280,7 +284,26 @@ export function createAdminMeta(
           ...action.ui.messages,
         },
         graphql: {
-          arguments: action.graphql.arguments,
+          arguments: action.graphql.arguments.map(arg => ({
+            name: arg.name,
+            type: arg.type,
+            source: (() => {
+              const field = arg.source && 'field' in arg.source ? arg.source.field : undefined
+              if (!field) return arg.source
+              return {
+                field: {
+                  ...getFieldMeta(arg.name, field),
+                  createView: {
+                    fieldMode: 'edit' as const,
+                    isRequired:
+                      typeof field.ui.createView.isRequired === 'boolean'
+                        ? field.ui.createView.isRequired
+                        : false,
+                  },
+                },
+              }
+            })(),
+          })),
           names: action.graphql.names,
         },
 
@@ -322,6 +345,31 @@ export function createAdminMeta(
         fieldMetaSource.fieldMeta = list.fields[fieldMetaSource.fieldKey].getAdminMeta?.() ?? null
       } finally {
         currentAdminMeta = undefined
+      }
+    }
+    for (const actionMetaSource of adminMetaRoot.listsByKey[key].actions) {
+      for (const arg of actionMetaSource.graphql.arguments) {
+        if (!arg.source || !('field' in arg.source)) continue
+
+        const action = list.actions.find(action => action.actionKey === actionMetaSource.key)
+        const initialisedArg = action?.graphql.arguments.find(
+          initialisedArg =>
+            initialisedArg.name === arg.name &&
+            initialisedArg.source &&
+            'field' in initialisedArg.source
+        )
+        const field =
+          initialisedArg?.source && 'field' in initialisedArg.source
+            ? initialisedArg.source.field
+            : undefined
+        if (!field) continue
+
+        currentAdminMeta = adminMetaRoot
+        try {
+          arg.source.field.fieldMeta = field.getAdminMeta?.() ?? null
+        } finally {
+          currentAdminMeta = undefined
+        }
       }
     }
   }

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -3,6 +3,7 @@ import { GInputObjectType, type GArg, type GInputType } from '@graphql-ts/schema
 import { GNonNull } from '@graphql-ts/schema'
 import {
   GraphQLList,
+  type GraphQLNamedType,
   GraphQLNonNull,
   GraphQLString,
   isInputObjectType,
@@ -14,6 +15,7 @@ import { expandVoidHooks } from '../../fields/resolve-hooks'
 import { humanize } from '../../lib/utils'
 import type { GroupInfo } from '../../schema'
 import type {
+  ActionArgumentSourceMeta,
   ActionMeta,
   BaseFieldTypeInfo,
   BaseItem,
@@ -59,7 +61,11 @@ export type InitialisedAction = {
   access: ResolvedActionAccessControl
   resolve: BaseActions<BaseListTypeInfo>[keyof BaseActions<BaseListTypeInfo>]['resolve']
   graphql: {
-    arguments: { name: string; type: string; source: { itemField: string } | null }[]
+    arguments: {
+      name: string
+      type: string
+      source: ActionArgumentSourceMeta<InitialisedField>
+    }[]
     names: {
       one: string
       many: string
@@ -109,6 +115,37 @@ function getArgSources(
       return [[arg, { itemField: field }]]
     })
   )
+}
+
+function getArgFieldSources(
+  action: NonNullable<KeystoneConfig['lists'][string]['actions']>[string]
+): Record<string, FieldTypeFunc<BaseListTypeInfo>> {
+  return Object.fromEntries(
+    Object.entries(action.args ?? {}).flatMap(([arg, value]) => {
+      const field = value.ui?.source?.field
+      if (!field) return []
+      return [[arg, field as FieldTypeFunc<BaseListTypeInfo>]]
+    })
+  )
+}
+
+function unwrapNonNullGraphQLType(type: GraphQLType): GraphQLType {
+  return type instanceof GraphQLNonNull ? unwrapNonNullGraphQLType(type.ofType) : type
+}
+
+function isGraphQLInputTypeAssignable(source: GraphQLType, target: GraphQLType): boolean {
+  source = unwrapNonNullGraphQLType(source)
+  target = unwrapNonNullGraphQLType(target)
+
+  if (source instanceof GraphQLList || target instanceof GraphQLList) {
+    return (
+      source instanceof GraphQLList &&
+      target instanceof GraphQLList &&
+      isGraphQLInputTypeAssignable(source.ofType, target.ofType)
+    )
+  }
+
+  return (source as GraphQLNamedType).name === (target as GraphQLNamedType).name
 }
 
 export type InitialisedField = {
@@ -918,6 +955,102 @@ function graphqlArgForInputField(
   })
 }
 
+function initialiseActionArgField(
+  listKey: string,
+  actionKey: string,
+  argKey: string,
+  fieldFunc: FieldTypeFunc<BaseListTypeInfo>,
+  provider: KeystoneConfig['db']['provider'],
+  listsRef: Record<string, InitialisedList>
+): InitialisedField {
+  const f = fieldFunc({
+    provider,
+    lists: Object.fromEntries(
+      Object.entries(listsRef).map(([listKey, list]) => [listKey, { types: list.graphql.types }])
+    ),
+    listKey,
+    fieldKey: argKey,
+  })
+  const path = `${listKey}.${actionKey}.${argKey}`
+
+  if (f.access !== undefined) {
+    throw new Error(`${path} cannot define field access control`)
+  }
+  if (f.hooks?.resolveInput || f.hooks?.beforeOperation || f.hooks?.afterOperation) {
+    throw new Error(`${path} cannot define field hooks`)
+  }
+  if (f.ui?.createView?.fieldMode !== undefined) {
+    throw new Error(`${path} cannot define createView.fieldMode`)
+  }
+  if (f.ui?.itemView?.fieldPosition !== undefined) {
+    throw new Error(`${path} cannot define itemView.fieldPosition`)
+  }
+  if (f.ui?.itemView?.fieldMode !== undefined || f.ui?.listView?.fieldMode !== undefined) {
+    throw new Error(`${path} cannot define itemView or listView field modes`)
+  }
+  const typeName = f.__ksTelemetryFieldTypeName ?? 'unknown'
+
+  const createIsNonNull =
+    typeof f.graphql?.isNonNull === 'boolean'
+      ? f.graphql.isNonNull
+      : (f.graphql?.isNonNull?.create ?? false)
+  const createIsOmitted =
+    typeof f.graphql?.omit === 'boolean' ? f.graphql.omit : (f.graphql?.omit?.create ?? false)
+
+  const field: InitialisedField = {
+    fieldKey: argKey,
+    dbField: f.dbField as ResolvedDBField,
+    access: parseFieldAccessControl(undefined),
+    hooks: parseFieldHooks(f.hooks ?? {}),
+    graphql: {
+      cacheHint: undefined,
+      isEnabled: {
+        read: false,
+        create: !createIsOmitted,
+        update: false,
+        filter: false,
+        orderBy: false,
+      },
+      isNonNull: {
+        read: false,
+        create: createIsNonNull,
+        update: false,
+      },
+    },
+    ui: {
+      label: f.ui?.label || humanize(argKey),
+      description: f.ui?.description ?? '',
+      views: f.ui?.views ?? null,
+      createView: {
+        isRequired: f.ui?.createView?.isRequired ?? false,
+        fieldMode: 'edit',
+      },
+      itemView: {
+        isRequired: false,
+        fieldPosition: 'form',
+        fieldMode: 'hidden',
+      },
+      listView: {
+        fieldMode: 'hidden',
+      },
+    },
+    __ksTelemetryFieldTypeName: typeName,
+    extraOutputFields: undefined,
+    getAdminMeta: f.getAdminMeta,
+    input: { ...f.input },
+    output: undefined as any,
+    unreferencedConcreteInterfaceImplementations: undefined,
+    views: f.views ?? '',
+  }
+
+  const arg = graphqlArgForInputField(field, 'create', listsRef)
+  if (!arg) {
+    throw new Error(`${path} does not provide a create GraphQL input`)
+  }
+
+  return field
+}
+
 function graphqlForOutputField(field: InitialisedField) {
   const output = field.output
   if (!output || !field.graphql.isEnabled.read) return output
@@ -931,25 +1064,68 @@ function graphqlForOutputField(field: InitialisedField) {
 }
 
 function getInitialisedActionGraphql(
-  list: Pick<InitialisedList, 'graphql'>,
+  list: Pick<InitialisedList, 'graphql' | 'listKey'>,
   listGraphqlNames: { singular: string; plural: string },
   actionKey: string,
-  action: NonNullable<KeystoneConfig['lists'][string]['actions']>[string]
+  action: NonNullable<KeystoneConfig['lists'][string]['actions']>[string],
+  provider: KeystoneConfig['db']['provider'],
+  listsRef: Record<string, InitialisedList>
 ): InitialisedAction['graphql'] {
+  const actionArgFields = new Map<string, InitialisedField>()
   const graphqlNames = {
     one: action.graphql?.singular ?? `${actionKey}${listGraphqlNames.singular}`,
     many: action.graphql?.plural ?? `${actionKey}${listGraphqlNames.plural}`,
   }
   const argsName = `${graphqlNames.one[0].toUpperCase()}${graphqlNames.one.slice(1)}Args`
+  const argSources = getArgSources(action)
+  const argFieldSources = getArgFieldSources(action)
   const argumentFields = Object.fromEntries(
-    Object.entries(action.args ?? {}).map(([arg, value]) => [arg, value.graphql])
+    Object.entries(action.args ?? {}).map(([arg, value]) => {
+      if (value.ui?.source?.itemField && value.ui.source.field) {
+        throw new Error(
+          `${list.listKey}.${actionKey}.${arg} cannot define both ui.source.itemField and ui.source.field`
+        )
+      }
+      const fieldSource = argFieldSources[arg]
+      if (fieldSource) {
+        const field = initialiseActionArgField(
+          list.listKey,
+          actionKey,
+          arg,
+          fieldSource,
+          provider,
+          listsRef
+        )
+        const fieldArg = graphqlArgForInputField(field, 'create', listsRef)!
+        if (
+          !isGraphQLInputTypeAssignable(
+            fieldArg.type as unknown as GraphQLType,
+            value.graphql.type as unknown as GraphQLType
+          )
+        ) {
+          throw new Error(
+            `${list.listKey}.${actionKey}.${arg} field-rendered UI source type ${printGraphQLType(
+              fieldArg.type as unknown as GraphQLType
+            )} is not assignable to GraphQL arg type ${printGraphQLType(
+              value.graphql.type as unknown as GraphQLType
+            )}`
+          )
+        }
+        actionArgFields.set(arg, field)
+      }
+      return [arg, value.graphql]
+    })
   )
 
   return {
     arguments: Object.entries(argumentFields).map(([name, arg]) => ({
       name,
       type: printGraphQLType(arg.type as unknown as GraphQLType),
-      source: getArgSources(action)[name] ?? null,
+      source: actionArgFields.has(name)
+        ? { field: actionArgFields.get(name)! }
+        : argSources[name]
+          ? { itemField: argSources[name].itemField }
+          : null,
     })),
     names: {
       ...graphqlNames,
@@ -1041,11 +1217,19 @@ export function initialiseLists(config: KeystoneConfig): Record<string, Initiali
     list.actions = Object.entries(listConfig.actions ?? {}).map(
       ([actionKey, action]): InitialisedAction => {
         const { label } = action.ui
+        const hasFieldArgs = Object.values(action.args ?? {}).some(value => value.ui?.source?.field)
+        if (hasFieldArgs && action.ui.itemView?.hidePrompt === true) {
+          throw new Error(
+            `${list.listKey}.${actionKey} cannot set ui.itemView.hidePrompt when using field-rendered action arguments`
+          )
+        }
         const graphql = getInitialisedActionGraphql(
           list,
           __getNames(list.listKey, listConfig).graphql,
           actionKey,
-          action
+          action,
+          config.db.provider,
+          listsRef
         )
 
         return {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -217,6 +217,13 @@ export function list<ListTypeInfo extends BaseListTypeInfo>(listConfig: ListConf
 
 export function action<
   ListTypeInfo extends BaseListTypeInfo,
+  Args extends ActionArgsConfig<ListTypeInfo>,
+>(action: Action<ListTypeInfo, Args> & { args: Args }): DeclaredAction<ListTypeInfo>
+export function action<ListTypeInfo extends BaseListTypeInfo>(
+  action: Action<ListTypeInfo, undefined>
+): DeclaredAction<ListTypeInfo>
+export function action<
+  ListTypeInfo extends BaseListTypeInfo,
   Args extends ActionArgsConfig<ListTypeInfo> | undefined = undefined,
 >(action: Action<ListTypeInfo, Args>): DeclaredAction<ListTypeInfo> {
   return {

--- a/packages/core/src/types/admin-meta.ts
+++ b/packages/core/src/types/admin-meta.ts
@@ -106,10 +106,25 @@ export type FieldGroupMeta = {
   fields: FieldMeta[]
 }
 
+export type ActionArgumentSourceMeta<Field = FieldMeta> =
+  | null
+  | {
+      itemField: string
+      field?: never
+    }
+  | {
+      field: Field
+      itemField?: never
+    }
+
 export type ActionMeta = {
   key: string
   graphql: {
-    arguments: readonly { name: string; type: string; source: { itemField: string } | null }[]
+    arguments: readonly {
+      name: string
+      type: string
+      source: ActionArgumentSourceMeta<any>
+    }[]
     names: {
       one: string
       many: string

--- a/packages/core/src/types/config/lists.ts
+++ b/packages/core/src/types/config/lists.ts
@@ -8,19 +8,28 @@ import type { MaybePromise } from '../utils'
 import type { ListAccessControl, ActionAccessControlFunction } from './access-control'
 import type { BaseFields, BaseFieldTypeInfo } from './fields'
 import type { ListHooks } from './hooks'
+import type { FieldTypeFunc } from '../next-fields'
 
 export type ActionArgumentsConfig = Record<string, GArg<any, any>>
 
+export type ActionArgConfig<ListTypeInfo extends BaseListTypeInfo> = {
+  graphql: GArg<any, any>
+  ui?: {
+    source?:
+      | {
+          itemField: ListTypeInfo['fields']
+          field?: never
+        }
+      | {
+          field: FieldTypeFunc<ListTypeInfo>
+          itemField?: never
+        }
+  }
+}
+
 export type ActionArgsConfig<ListTypeInfo extends BaseListTypeInfo> = Record<
   string,
-  {
-    graphql: GArg<any, any>
-    ui?: {
-      source?: {
-        itemField: ListTypeInfo['fields']
-      }
-    }
-  }
+  ActionArgConfig<ListTypeInfo>
 >
 
 type ActionArgs<Args extends ActionArgsConfig<any> | undefined> =

--- a/tests/api-tests/actions.test.ts
+++ b/tests/api-tests/actions.test.ts
@@ -1,0 +1,302 @@
+import { action, g, list } from '@keystone-6/core'
+import { allowAll } from '@keystone-6/core/access'
+import { text } from '@keystone-6/core/fields'
+
+import { adminMetaQuery } from '../../packages/core/src/admin-ui/admin-meta-graphql'
+import { setupTestRunner } from './test-runner'
+
+const runner = setupTestRunner({
+  config: {
+    lists: {
+      Task: list({
+        access: allowAll,
+        fields: {
+          title: text(),
+        },
+        actions: {
+          rename: action({
+            access: allowAll,
+            args: {
+              title: {
+                graphql: g.arg({ type: g.String }),
+                ui: { source: { field: text({ validation: { isRequired: true } }) } },
+              },
+              previousTitle: {
+                graphql: g.arg({ type: g.String }),
+                ui: { source: { itemField: 'title' } },
+              },
+              apiOnly: { graphql: g.arg({ type: g.String }) },
+            },
+            resolve: async ({ where, args }, context) => {
+              return context.db.Task.updateOne({
+                where,
+                data: { title: `${args.previousTitle}:${args.title}:${args.apiOnly}` },
+              })
+            },
+            ui: {
+              label: 'Rename',
+              itemView: { hidePrompt: false },
+            },
+          }),
+        },
+      }),
+    },
+  },
+})
+
+describe('actions', () => {
+  it(
+    'uses explicit GraphQL input for field-rendered GraphQL arguments',
+    runner(async ({ context, artifacts }) => {
+      expect(artifacts.graphql).toContain(`input RenameTaskArgs {
+  where: TaskWhereUniqueInput!
+  title: String
+  previousTitle: String
+  apiOnly: String
+}`)
+
+      const task = await context.db.Task.createOne({ data: { title: 'Old' } })
+      const data = await context.graphql.run({
+        query: `
+          mutation($id: ID!) {
+            renameTask(where: { id: $id }, title: "New", previousTitle: "Old", apiOnly: "API") {
+              title
+            }
+          }
+        `,
+        variables: { id: task.id },
+      })
+
+      expect(data).toEqual({
+        renameTask: {
+          title: 'Old:New:API',
+        },
+      })
+    })
+  )
+
+  it(
+    'exposes explicit action argument UI metadata',
+    runner(async ({ context }) => {
+      const data = (await context.sudo().graphql.run({ query: adminMetaQuery })) as any
+      const task = data.keystone.adminMeta.lists.find((list: any) => list.key === 'Task')
+      expect(task.actions[0].graphql.arguments).toMatchObject([
+        {
+          name: 'title',
+          type: 'String',
+          source: {
+            field: {
+              key: 'title',
+              label: 'Title',
+            },
+          },
+        },
+        {
+          name: 'previousTitle',
+          type: 'String',
+          source: {
+            itemField: 'title',
+          },
+        },
+        {
+          name: 'apiOnly',
+          type: 'String',
+          source: null,
+        },
+      ])
+    })
+  )
+})
+
+describe('action field argument config validation', () => {
+  it('rejects field access control', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.String }),
+                    ui: { source: { field: text({ access: { read: () => true } }) } },
+                  },
+                },
+                resolve: async () => null,
+                ui: { label: 'Rename' },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename.title cannot define field access control'
+    )
+  })
+
+  it('rejects hidden prompts for field-rendered arguments', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.String }),
+                    ui: { source: { field: text() } },
+                  },
+                },
+                resolve: async () => null,
+                ui: {
+                  label: 'Rename',
+                  itemView: { hidePrompt: true },
+                },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename cannot set ui.itemView.hidePrompt when using field-rendered action arguments'
+    )
+  })
+
+  it('rejects action argument field create-view modes', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.String }),
+                    ui: {
+                      source: {
+                        field: text({ ui: { createView: { fieldMode: 'hidden' } } }),
+                      },
+                    },
+                  },
+                },
+                resolve: async () => null,
+                ui: { label: 'Rename' },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename.title cannot define createView.fieldMode'
+    )
+  })
+
+  it('rejects field-rendered sources without GraphQL create inputs', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.String }),
+                    ui: {
+                      source: {
+                        field: text({ graphql: { omit: { create: true } } }),
+                      },
+                    },
+                  },
+                },
+                resolve: async () => null,
+                ui: { label: 'Rename' },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename.title does not provide a create GraphQL input'
+    )
+  })
+
+  it('rejects field-rendered sources that are incompatible with the explicit GraphQL arg', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.Int }),
+                    ui: { source: { field: text() } },
+                  },
+                },
+                resolve: async () => null,
+                ui: { label: 'Rename' },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename.title field-rendered UI source type String is not assignable to GraphQL arg type Int'
+    )
+  })
+
+  it('rejects action argument UI sources with both itemField and field', async () => {
+    const invalidRunner = setupTestRunner({
+      config: {
+        lists: {
+          Task: list({
+            access: allowAll,
+            fields: { title: text() },
+            actions: {
+              rename: action({
+                access: allowAll,
+                args: {
+                  title: {
+                    graphql: g.arg({ type: g.String }),
+                    ui: { source: { itemField: 'title', field: text() } } as any,
+                  },
+                },
+                resolve: async () => null,
+                ui: { label: 'Rename' },
+              }),
+            },
+          }),
+        },
+      },
+    })
+
+    await expect(invalidRunner(async () => {})()).rejects.toThrow(
+      'Task.rename.title cannot define both ui.source.itemField and ui.source.field'
+    )
+  })
+})


### PR DESCRIPTION
This add a `ui.source.field` option to args on actions which accepts a standard Keystone field which is used to show UI in the action's modal.

The obvious question about this design is probably "why is a GraphQL type explicitly defined rather than using the GraphQL type from the Keystone field?" basically this is just because the GraphQL type isn't exposed in the TypeScript of the return type of Keystone fields so the field is used purely for the UI, we use the create UI and we assert that the GraphQL field you specify is compatible with the Keystone field's GraphQL create type. Fields like e.g. relationship and etc. naturally won't work here.

```ts
action({
  args: {
    reason: {
      graphql: g.arg({ type: g.nonNull(g.String) }),
      ui: {
        reason: {
          field: text({
            validation: { isRequired: true },
          }),
        },
      },
    },
  },
  // ...
})
```