### PR TITLE
Allow dynamic itemView.fieldMode on relationship fields with displayMode: 'count' or 'table'

### DIFF
--- a/.changeset/ready-laws-refuse.md
+++ b/.changeset/ready-laws-refuse.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": major
 ---
 
-`displayMode: 'count'` on relationship fields now requires `itemView.fieldMode: 'read'` to be set.
+`displayMode: 'count'` on relationship fields now requires `itemView.fieldMode: 'read'` or a dynamic `fieldMode` that only resolves to `'read'` or `'hidden'`.

--- a/packages/core/src/fields/types/relationship/index.ts
+++ b/packages/core/src/fields/types/relationship/index.ts
@@ -6,6 +6,7 @@ import {
   type FieldTypeFunc,
   type JSONValue,
   type ListSortDescriptor,
+  type MaybeItemFieldFunctionWithFilter,
   fieldType,
 } from '../../../types'
 import type { controller } from './views'
@@ -40,18 +41,18 @@ type SelectDisplayConfig<ListTypeInfo extends BaseListTypeInfo, Ref extends stri
   }
 }
 
-type CountDisplayConfig = {
+type CountDisplayConfig<ListTypeInfo extends BaseListTypeInfo> = {
   many: true
   ui?: {
     // Sets the relationship to display as a count
     displayMode: 'count'
     itemView: {
-      fieldMode: 'read'
+      fieldMode: ReadOnlyItemViewFieldMode<ListTypeInfo>
     }
   }
 }
 
-type TableDisplayConfig = {
+type TableDisplayConfig<ListTypeInfo extends BaseListTypeInfo> = {
   ref: `${string}.${string}`
   many: true
   ui?: {
@@ -60,7 +61,7 @@ type TableDisplayConfig = {
     columns?: string[]
 
     itemView: {
-      fieldMode: 'read'
+      fieldMode: ReadOnlyItemViewFieldMode<ListTypeInfo>
     }
   }
 }
@@ -145,6 +146,27 @@ type FieldTypeInfo = {
   }
 }
 
+type ReadOnlyItemViewFieldMode<ListTypeInfo extends BaseListTypeInfo> =
+  MaybeItemFieldFunctionWithFilter<
+    'read' | 'hidden',
+    'read' | 'hidden',
+    ListTypeInfo,
+    FieldTypeInfo
+  >
+
+function assertReadOnlyFieldMode(
+  fieldMode: unknown,
+  displayMode: 'count' | 'table',
+  listKey: string,
+  fieldKey: string
+) {
+  if (fieldMode === undefined || fieldMode === 'edit') {
+    throw new Error(
+      `displayMode: '${displayMode}' on relationship fields requires itemView.fieldMode to be 'read', 'hidden', or a dynamic field mode but ${listKey}.${fieldKey} does not have this set`
+    )
+  }
+}
+
 export type RelationshipFieldConfig<
   ListTypeInfo extends BaseListTypeInfo,
   Ref extends `${keyof ListTypeInfo['all']['lists'] & string}${'' | `.${string}`}`,
@@ -155,7 +177,11 @@ export type RelationshipFieldConfig<
     hideCreate?: boolean
   }
 } & (OneDbConfig | ManyDbConfig) &
-  (SelectDisplayConfig<ListTypeInfo, Ref> | CountDisplayConfig | TableDisplayConfig)
+  (
+    | SelectDisplayConfig<ListTypeInfo, Ref>
+    | CountDisplayConfig<ListTypeInfo>
+    | TableDisplayConfig<ListTypeInfo>
+  )
 
 export function relationship<
   ListTypeInfo extends BaseListTypeInfo,
@@ -196,11 +222,7 @@ export function relationship<
         }
 
         if (config.ui?.displayMode === 'count') {
-          if (config.ui.itemView?.fieldMode !== 'read') {
-            throw new Error(
-              `displayMode: 'count' on relationship fields requires itemView.fieldMode to be 'read' but ${listKey}.${fieldKey} does not have this set`
-            )
-          }
+          assertReadOnlyFieldMode(config.ui.itemView?.fieldMode, 'count', listKey, fieldKey)
           return {
             displayMode: 'count',
             refListKey: foreignListKey,
@@ -218,11 +240,7 @@ export function relationship<
               `Using a two-sided relationship (\`ref\` must specify "List.fieldKey", not just "List") is required when using displayMode: 'table' for relationship fields but ${listKey}.${fieldKey} has \`ref: ${JSON.stringify(ref)}\``
             )
           }
-          if (config.ui.itemView?.fieldMode !== 'read') {
-            throw new Error(
-              `displayMode: 'table' on relationship fields currently requires itemView.fieldMode to be 'read' but ${listKey}.${fieldKey} does not have this set`
-            )
-          }
+          assertReadOnlyFieldMode(config.ui.itemView?.fieldMode, 'table', listKey, fieldKey)
           for (const key of config.ui.columns ?? []) {
             if (!(key in foreignListMeta.fieldsByKey)) {
               throw new Error(

--- a/tests/api-tests/fields/types/relationship.test.ts
+++ b/tests/api-tests/fields/types/relationship.test.ts
@@ -132,6 +132,85 @@ describe('Type Generation', () => {
   })
 })
 
+describe('Admin UI display modes', () => {
+  function getAdminMetaForField(field: Parameters<typeof relationship>[0]) {
+    return createSystem(
+      config({
+        db: { url: 'file:./thing.db', provider: 'sqlite' },
+        lists: {
+          Foo: list({
+            access: allowAll,
+            fields: {
+              bar: relationship(field),
+            },
+          }),
+          Bar: list({
+            access: allowAll,
+            fields: {
+              foo: relationship({ ref: 'Foo.bar' }),
+            },
+          }),
+        },
+      })
+    ).adminMeta.listsByKey.Foo.fieldsByKey.bar.fieldMeta
+  }
+
+  test('table display mode allows dynamic itemView.fieldMode', () => {
+    expect(() => {
+      getAdminMetaForField({
+        ref: 'Bar.foo',
+        many: true,
+        ui: {
+          displayMode: 'table',
+          itemView: { fieldMode: () => 'read' },
+        },
+      })
+    }).not.toThrow()
+  })
+
+  test('count display mode allows dynamic itemView.fieldMode', () => {
+    expect(() => {
+      getAdminMetaForField({
+        ref: 'Bar.foo',
+        many: true,
+        ui: {
+          displayMode: 'count',
+          itemView: { fieldMode: () => 'read' },
+        },
+      })
+    }).not.toThrow()
+  })
+
+  test('table display mode rejects missing itemView.fieldMode', () => {
+    expect(() => {
+      getAdminMetaForField({
+        ref: 'Bar.foo',
+        many: true,
+        ui: {
+          displayMode: 'table',
+        },
+      } as any)
+    }).toThrow(
+      "displayMode: 'table' on relationship fields requires itemView.fieldMode to be 'read', 'hidden', or a dynamic field mode but Foo.bar does not have this set"
+    )
+  })
+
+  test('table display mode rejects static editable itemView.fieldMode', () => {
+    expect(() => {
+      getAdminMetaForField({
+        ref: 'Bar.foo',
+        many: true,
+        ui: {
+          displayMode: 'table',
+          itemView: { fieldMode: 'edit' },
+        },
+      } as any)
+    }).toThrow(
+      "displayMode: 'table' on relationship fields requires itemView.fieldMode to be 'read', 'hidden', or a dynamic field mode but Foo.bar does not have this set"
+    )
+  })
+})
+
 describe('Reference errors', () => {
   function tryf(lists: KeystoneConfigPre['lists']) {
     return createSystem(


### PR DESCRIPTION
This allows dynamic values on `itemView.fieldMode` in `relationship` fields with `displayMode: 'count'` or `'table'` so that's possible to make a table or count relationship field e.g. only visible to certain people.