### PR TITLE
Remove next/head usages

### DIFF
--- a/examples/framework-nextjs-pages-directory/src/pages/index.tsx
+++ b/examples/framework-nextjs-pages-directory/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import type { NextPage, GetServerSideProps, InferGetServerSidePropsType } from 'next'
-import Head from 'next/head'
 import { gql } from 'graphql-request'
 import { client } from '../util/request'
 import { keystoneContext } from '../keystone/context'
@@ -12,14 +11,12 @@ const Home: NextPage = ({ users }: InferGetServerSidePropsType<typeof getServerS
         padding: '0 2rem',
       }}
     >
-      <Head>
-        <title>Keystone + Next.js</title>
-        <meta
-          name="description"
-          content="Example to use Keystone APIs in a Next.js server environment."
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+      <title>Keystone + Next.js</title>
+      <meta
+        name="description"
+        content="Example to use Keystone APIs in a Next.js server environment."
+      />
+      <link rel="icon" href="/favicon.ico" />
 
       <main style={{ display: 'flex', justifyContent: 'center' }}>
         <section>

--- a/packages/auth/src/pages/InitPage.tsx
+++ b/packages/auth/src/pages/InitPage.tsx
@@ -1,5 +1,3 @@
-import NextHead from 'next/head'
-
 import { Button } from '@keystar/ui/button'
 import { Grid, HStack, VStack } from '@keystar/ui/layout'
 import { Heading } from '@keystar/ui/typography'
@@ -74,9 +72,7 @@ function InitPage({
 
   return (
     <>
-      <NextHead>
-        <title key="title">Welcome to KeystoneJS</title>
-      </NextHead>
+      <title>Welcome to KeystoneJS</title>
       <Grid
         alignItems="center"
         marginX="auto"

--- a/packages/auth/src/pages/SigninPage.tsx
+++ b/packages/auth/src/pages/SigninPage.tsx
@@ -1,4 +1,3 @@
-import NextHead from 'next/head'
 import { useState } from 'react'
 
 import { Button } from '@keystar/ui/button'
@@ -79,9 +78,7 @@ function SigninPage({
 
   return (
     <>
-      <NextHead>
-        <title key="title">Keystone - Sign in</title>
-      </NextHead>
+      <title>Keystone - Sign in</title>
       <Grid
         alignItems="center"
         marginX="auto"

--- a/packages/core/src/admin-ui/components/PageContainer.tsx
+++ b/packages/core/src/admin-ui/components/PageContainer.tsx
@@ -1,4 +1,3 @@
-import NextHead from 'next/head'
 import { type HTMLAttributes, type ReactNode, useState } from 'react'
 
 import { ActionButton } from '@keystar/ui/button'
@@ -98,9 +97,7 @@ export function PageContainer({ children, header, title }: PageContainerProps) {
   const [isSidebarOpen, setSidebarOpen] = useState(false)
   return (
     <PageWrapper>
-      <NextHead>
-        <title key="title">{title ? `Keystone - ${title}` : 'Keystone'}</title>
-      </NextHead>
+      <title>{title ? `Keystone - ${title}` : 'Keystone'}</title>
       <HStack
         alignItems="center"
         borderBottom="neutral"

--- a/packages/core/src/admin-ui/context.tsx
+++ b/packages/core/src/admin-ui/context.tsx
@@ -1,5 +1,4 @@
 import UploadLink from 'apollo-upload-client/UploadHttpLink.mjs'
-import NextHead from 'next/head'
 import { type ReactNode, createContext, useContext, useEffect, useMemo } from 'react'
 
 import { ClientSideOnlyDocumentElement, KeystarProvider } from '@keystar/ui/core'
@@ -188,13 +187,11 @@ function InternalKeystoneProvider({
   return (
     <KeystarProvider router={keystarRouter}>
       <ClientSideOnlyDocumentElement bodyBackground="surface" />
-      <NextHead>
-        <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-          rel="stylesheet"
-        />
-      </NextHead>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+      />
 
       <KeystoneContext.Provider
         value={{


### PR DESCRIPTION
These have been unnecessary since React 19 because React will hoist these elements to the head