### PR TITLE
Remove date-fns

### DIFF
--- a/docs/app/(site)/blog/[post]/page-client.tsx
+++ b/docs/app/(site)/blog/[post]/page-client.tsx
@@ -4,7 +4,6 @@
 
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
-import { parse, format } from 'date-fns'
 
 import { Markdoc } from '../../../../components/Markdoc'
 import { BlogPage } from '../../../../components/Page'
@@ -13,13 +12,9 @@ import { Type } from '../../../../components/primitives/Type'
 import { type BlogPost } from './page'
 import { extractHeadings } from '../../../../markdoc/headings'
 
-export default function Page({ post }: { post: BlogPost }) {
+export default function Page({ post, formattedDate }: { post: BlogPost; formattedDate: string }) {
   const params = useParams()
   const headings = [{ id: 'title', depth: 1, label: post.title }, ...extractHeadings(post.content)]
-
-  const publishedDate = post.publishDate
-  const parsedDate = parse(publishedDate, 'yyyy-M-d', new Date())
-  const formattedDateStr = format(parsedDate, 'MMMM do, yyyy')
 
   return (
     <BlogPage headings={headings} editPath={`blog/${params?.post}.md`}>
@@ -37,7 +32,7 @@ export default function Page({ post }: { post: BlogPost }) {
         }}
       >
         <em>
-          <span>Published on {formattedDateStr}</span>
+          <span>Published on {formattedDate}</span>
           {post.authorHandle ? (
             <span>
               {' '}

--- a/docs/app/(site)/blog/[post]/page.tsx
+++ b/docs/app/(site)/blog/[post]/page.tsx
@@ -8,6 +8,7 @@ import { type EntryWithResolvedLinkedFiles } from '@keystatic/core/reader'
 import type keystaticConfig from '../../../../keystatic.config'
 import PageClient from './page-client'
 import { type Metadata } from 'next'
+import { blogDateFormatter } from '../../../../lib/date'
 
 export type BlogPost = NonNullable<
   Omit<
@@ -25,6 +26,8 @@ export default async function Page({ params }) {
   })
 
   if (!post) return notFound()
+  const publishedDate = post.publishDate
+  const formattedDateStr = blogDateFormatter.format(Temporal.PlainDate.from(publishedDate))
 
   return (
     <PageClient
@@ -35,6 +38,7 @@ export default async function Page({ params }) {
           content: transform(post.content.node, baseMarkdocConfig),
         })
       )}
+      formattedDate={formattedDateStr}
     />
   )
 }

--- a/docs/app/(site)/blog/page.tsx
+++ b/docs/app/(site)/blog/page.tsx
@@ -1,10 +1,7 @@
-import { parse, format } from 'date-fns'
-
 import { reader } from '../../../keystatic/reader'
+import { blogDateFormatter } from '../../../lib/date'
 import ClientPage from './page-client'
 import { type Metadata } from 'next'
-
-const today = new Date()
 
 export const metadata: Metadata = {
   title: 'Keystone Blog',
@@ -26,12 +23,10 @@ export default async function Docs() {
   const sortedPosts = transformedPosts
     .map(p => {
       const publishedDate = p.frontmatter.publishDate
-      const parsedDate = parse(publishedDate, 'yyyy-M-d', today)
-      const formattedDateStr = format(parsedDate, 'MMMM do, yyyy')
+      const formattedDateStr = blogDateFormatter.format(Temporal.PlainDate.from(publishedDate))
       return {
         ...p,
         frontmatter: { ...p.frontmatter },
-        parsedDate: parsedDate,
         formattedDateStr: formattedDateStr,
       }
     })

--- a/docs/lib/date.ts
+++ b/docs/lib/date.ts
@@ -1,0 +1,1 @@
+export const blogDateFormatter = new Intl.DateTimeFormat('en-US', { dateStyle: 'long' })

--- a/docs/markdoc/index.ts
+++ b/docs/markdoc/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises'
-import { isMatch } from 'date-fns'
 import Markdoc, { type Config, type Tag, type ValidateError } from '@markdoc/markdoc'
 import { load } from 'js-yaml'
 import { baseMarkdocConfig } from './config'
@@ -148,16 +147,10 @@ export function extractBlogFrontmatter(content: string): BlogFrontmatter {
   if (typeof obj.publishDate !== 'string') {
     throw new Error(`Expected frontmatter to contain publishDate`)
   } else {
-    const publishDate = obj.publishDate
-    // making sure months are always MM and not M, same with dd and d
-    // Eg. 2022-04-01 is correct
-    // 2022-4-1 is incorrect
-    // why do we do this manually? because date-fns isMatch doesn't validate this
-    if (publishDate.split('-').some(s => s.length < 2)) {
-      throw new Error(`Frontmatter publishDate format should be yyyy-MM-dd`)
-    }
-    const isValidDateFormat = isMatch(publishDate, 'yyyy-MM-dd')
-    if (!isValidDateFormat) {
+    try {
+      const publishDate = Temporal.PlainDate.from(obj.publishDate)
+      if (publishDate.toString() !== obj.publishDate) throw new RangeError()
+    } catch {
       throw new Error(`Frontmatter publishDate format should be yyyy-MM-dd`)
     }
   }

--- a/docs/package.json
+++ b/docs/package.json
@@ -30,7 +30,6 @@
     "@vercel/og": "^0.11.0",
     "classnames": "^2.3.1",
     "clipboard-copy": "^4.0.1",
-    "date-fns": "^4.0.0",
     "dedent": "^1.0.0",
     "facepaint": "^1.2.1",
     "globby": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@eslint/js": "^10.0.0",
     "@preconstruct/cli": "^2.8.9",
     "@types/node": "catalog:",
-    "@types/node-fetch": "^2.5.12",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "esbuild": "^0.28.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -265,7 +265,6 @@
     "cookie": "^1.0.0",
     "cors": "^2.8.5",
     "dataloader": "^2.1.0",
-    "date-fns": "^4.0.0",
     "decimal.js": "^10.4.1",
     "dumb-passwords": "^0.2.1",
     "esbuild": "^0.28.0",

--- a/packages/core/src/fields/types/timestamp/views/__tests__/utils.tsx
+++ b/packages/core/src/fields/types/timestamp/views/__tests__/utils.tsx
@@ -1,4 +1,3 @@
-import { parseISO } from 'date-fns'
 import { constructTimestamp } from '../utils'
 
 const STUBVALIDDATE = '2020-10-31'
@@ -11,6 +10,6 @@ describe('constructTimestamp()', () => {
   })
   it('should take two valid timestamp values and construct them into a valid ISO string', () => {
     const result = constructTimestamp({ dateValue: STUBVALIDDATE, timeValue: STUBVALIDTIME })
-    expect(Boolean(parseISO(result).toISOString())).toBe(true)
+    expect(Boolean(Temporal.Instant.from(result).toString())).toBe(true)
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
-      '@types/node-fetch':
-        specifier: ^2.5.12
-        version: 2.6.13
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -185,9 +182,6 @@ importers:
       clipboard-copy:
         specifier: ^4.0.1
         version: 4.0.1
-      date-fns:
-        specifier: ^4.0.0
-        version: 4.1.0
       dedent:
         specifier: ^1.0.0
         version: 1.7.2(babel-plugin-macros@3.1.0)
@@ -2157,9 +2151,6 @@ importers:
       dataloader:
         specifier: ^2.1.0
         version: 2.2.3
-      date-fns:
-        specifier: ^4.0.0
-        version: 4.1.0
       decimal.js:
         specifier: ^10.4.1
         version: 10.6.0
@@ -8217,9 +8208,6 @@ packages:
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
-
-  date-fns@4.1.0:
-    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   deasync@0.1.31:
     resolution: {integrity: sha512-/6/cXqkw4LPqBVK6H0Y3L4zT7yI3pxykxPXErQ2tDCw0LJyThWL5VpBCpUOWX0vPq2OnF1pzcXvlNnvCiOQJuA==}
@@ -19752,8 +19740,6 @@ snapshots:
   dataloader@1.4.0: {}
 
   dataloader@2.2.3: {}
-
-  date-fns@4.1.0: {}
 
   deasync@0.1.31:
     dependencies:


### PR DESCRIPTION
Note the usages of Temporal here are purely in a test and the server-side of the docs site, so this doesn't make a version of Node with Temporal required for Keystone