### PR TITLE
Resolve catalog: in starter when publishing create-keystone-app

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
 
       - run: pnpm build
 
+      - name: Resolve starter catalog dependencies
+        run: pnpm resolve:create-starter-catalog
+
       - name: npm publish, git tag
         run: pnpm changeset publish --tag ${{ inputs.tag }}
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint --fix",
     "build": "preconstruct build",
     "postinstall": "preconstruct dev && pnpm -r check",
+    "resolve:create-starter-catalog": "node scripts/resolve-create-starter-catalog.mts",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -46,7 +47,8 @@
     "typescript": "catalog:",
     "typescript-eslint": "^8.0.0",
     "vite": "^6.0.0",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "yaml": "^2.8.3"
   },
   "preconstruct": {
     "packages": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       vitest:
         specifier: ^4.0.0
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@20.0.3)(vite@6.4.2(@types/node@24.12.2)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   docs:
     dependencies:

--- a/scripts/resolve-create-starter-catalog.mts
+++ b/scripts/resolve-create-starter-catalog.mts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+
+const workspacePath = new URL('../pnpm-workspace.yaml', import.meta.url)
+const starterPackagePath = new URL('../packages/create/starter/package.json', import.meta.url)
+
+const workspace = parse(readFileSync(workspacePath, 'utf8')) as {
+  catalog?: Record<string, string>
+}
+const { catalog } = workspace
+if (!catalog || typeof catalog !== 'object') {
+  throw new Error(`No default catalog found in ${fileURLToPath(workspacePath)}`)
+}
+
+const dependencyFields = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const
+type DependencyField = (typeof dependencyFields)[number]
+type PackageJson = Partial<Record<DependencyField, Record<string, string>>>
+
+const starterPackage = JSON.parse(readFileSync(starterPackagePath, 'utf8')) as PackageJson
+
+let replacements = 0
+for (const field of dependencyFields) {
+  for (const [name, version] of Object.entries(starterPackage[field] ?? {})) {
+    if (version !== 'catalog:') continue
+
+    const catalogVersion = catalog[name]
+    if (typeof catalogVersion !== 'string') {
+      throw new Error(`${field}.${name} uses catalog: but is missing from the default catalog`)
+    }
+
+    starterPackage[field]![name] = catalogVersion
+    replacements++
+  }
+}
+
+writeFileSync(starterPackagePath, `${JSON.stringify(starterPackage, null, 2)}\n`)
+console.log(`Resolved ${replacements} catalog dependencies in ${fileURLToPath(starterPackagePath)}`)


### PR DESCRIPTION
While working on #9872, I noticed that the `starter` package in `create-keystone-app` had `catalog:` deps and I suspected that since it's not the `starter` package that's being published but actually `create-keystone-app` that's being published then the `catalog:` deps wouldn't be replaced, I was correct so this adds a script to resolve them before publishing.