### PR TITLE
Make react and react-dom peer deps

### DIFF
--- a/.changeset/bump-react.md
+++ b/.changeset/bump-react.md
@@ -1,5 +1,8 @@
 ---
-"@keystone-6/core": major
+'@keystone-6/core': major
+'@keystone-6/fields-document': major
+'@keystone-6/cloudinary': major
+'@keystone-6/auth': major
 ---
 
-Upgrades React major version to 19
+Upgrades React major version to 19. `react` and `react-dom` are also now peer dependencies.

--- a/examples/actions/package.json
+++ b/examples/actions/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/assets-local/package.json
+++ b/examples/assets-local/package.json
@@ -14,7 +14,9 @@
     "@prisma/client": "catalog:",
     "bytes": "^3.1.1",
     "express": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/bytes": "^3.1.1",

--- a/examples/assets-s3/package.json
+++ b/examples/assets-s3/package.json
@@ -17,7 +17,9 @@
     "@prisma/client": "catalog:",
     "bytes": "^3.1.1",
     "dotenv": "^16.0.0",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/bytes": "^3.1.1",

--- a/examples/auth/package.json
+++ b/examples/auth/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/better-list-search/package.json
+++ b/examples/better-list-search/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/byte-encoding/package.json
+++ b/examples/byte-encoding/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/cloudinary/package.json
+++ b/examples/cloudinary/package.json
@@ -16,7 +16,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "dotenv": "^16.0.0",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-esbuild/package.json
+++ b/examples/custom-esbuild/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-field/package.json
+++ b/examples/custom-field/package.json
@@ -14,7 +14,8 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "next": "catalog:",
-    "react": "catalog:"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-id/package.json
+++ b/examples/custom-id/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@paralleldrive/cuid2": "^2.2.1",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-session-invalidation/package.json
+++ b/examples/custom-session-invalidation/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-session-jwt/package.json
+++ b/examples/custom-session-jwt/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "jsonwebtoken": "^9.0.0",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^9.0.2",

--- a/examples/custom-session-next-auth/package.json
+++ b/examples/custom-session-next-auth/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "next": "catalog:",
-    "next-auth": "^4.24.11"
+    "next-auth": "^4.24.11",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-session-passport/package.json
+++ b/examples/custom-session-passport/package.json
@@ -16,7 +16,9 @@
     "express": "catalog:",
     "next": "catalog:",
     "passport": "^0.7.0",
-    "passport-github2": "^0.1.12"
+    "passport-github2": "^0.1.12",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/express": "catalog:",

--- a/examples/custom-session-redis/package.json
+++ b/examples/custom-session-redis/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "@redis/client": "^1.3.0",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/custom-session/package.json
+++ b/examples/custom-session/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/default-values/package.json
+++ b/examples/default-values/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/document-field-customisation/keystone-server/package.json
+++ b/examples/document-field-customisation/keystone-server/package.json
@@ -17,6 +17,7 @@
     "@prisma/client": "catalog:",
     "next": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:"
   },
   "devDependencies": {

--- a/examples/document-field-hooks/package.json
+++ b/examples/document-field-hooks/package.json
@@ -15,7 +15,9 @@
     "@keystone-6/document-renderer": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/dynamic-is-required/package.json
+++ b/examples/dynamic-is-required/package.json
@@ -10,10 +10,12 @@
     "check": "keystone postinstall"
   },
   "dependencies": {
-    "@keystone-6/core": "workspace:^",
     "@keystar/ui": "^0.7.21",
+    "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/empty-lists/package.json
+++ b/examples/empty-lists/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/extend-express-app/package.json
+++ b/examples/extend-express-app/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "express": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/extend-full-text-search/package.json
+++ b/examples/extend-full-text-search/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/extend-graphql-schema-graphql-tools/package.json
+++ b/examples/extend-graphql-schema-graphql-tools/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "graphql": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/extend-graphql-schema-graphql-ts/package.json
+++ b/examples/extend-graphql-schema-graphql-ts/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/extend-graphql-schema-nexus/package.json
+++ b/examples/extend-graphql-schema-nexus/package.json
@@ -15,7 +15,9 @@
     "@prisma/client": "catalog:",
     "graphql": "catalog:",
     "next": "catalog:",
-    "nexus": "^1.3.0"
+    "nexus": "^1.3.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:"

--- a/examples/extend-graphql-subscriptions/package.json
+++ b/examples/extend-graphql-subscriptions/package.json
@@ -21,6 +21,7 @@
     "graphql-ws": "^5.9.1",
     "next": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "ws": "^8.8.0"
   },
   "devDependencies": {

--- a/examples/extend-prisma-schema/package.json
+++ b/examples/extend-prisma-schema/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/field-groups/package.json
+++ b/examples/field-groups/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/framework-astro/package.json
+++ b/examples/framework-astro/package.json
@@ -18,7 +18,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "astro": "^4.12.3",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/framework-nextjs-two-servers/keystone-server/package.json
+++ b/examples/framework-nextjs-two-servers/keystone-server/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/graphql-codegen/package.json
+++ b/examples/graphql-codegen/package.json
@@ -17,7 +17,9 @@
     "@parcel/watcher": "^2.5.1",
     "@prisma/client": "catalog:",
     "graphql": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.4",

--- a/examples/graphql-gql.tada/package.json
+++ b/examples/graphql-gql.tada/package.json
@@ -17,7 +17,9 @@
     "@prisma/client": "catalog:",
     "gql.tada": "^1.8.10",
     "graphql": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/graphql-ts-gql/package.json
+++ b/examples/graphql-ts-gql/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "graphql": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@ts-gql/compiler": "^0.16.7",

--- a/examples/hooks/package.json
+++ b/examples/hooks/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/limits/package.json
+++ b/examples/limits/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/logging-opentelemetry/package.json
+++ b/examples/logging-opentelemetry/package.json
@@ -14,7 +14,9 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-node": "^2.0.1",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "^2.0.1",

--- a/examples/logging/package.json
+++ b/examples/logging/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
     "next": "catalog:",
-    "pino-http": "^10.5.0"
+    "pino-http": "^10.5.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/number-fields/package.json
+++ b/examples/number-fields/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/omit/package.json
+++ b/examples/omit/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/relationships/package.json
+++ b/examples/relationships/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/core": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/reuse/package.json
+++ b/examples/reuse/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/script/package.json
+++ b/examples/script/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/singleton/package.json
+++ b/examples/singleton/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/testing/package.json
+++ b/examples/testing/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/transactions/package.json
+++ b/examples/transactions/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-blog-moderated/package.json
+++ b/examples/usecase-blog-moderated/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-blog/package.json
+++ b/examples/usecase-blog/package.json
@@ -14,7 +14,9 @@
     "@keystone-6/core": "workspace:^",
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-relationship-union/package.json
+++ b/examples/usecase-relationship-union/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-roles/package.json
+++ b/examples/usecase-roles/package.json
@@ -13,7 +13,9 @@
     "@keystone-6/auth": "workspace:^",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-todo/package.json
+++ b/examples/usecase-todo/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/usecase-versioning/package.json
+++ b/examples/usecase-versioning/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/virtual-field-banner/package.json
+++ b/examples/virtual-field-banner/package.json
@@ -13,7 +13,9 @@
     "@keystar/ui": "^0.7.22",
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/examples/virtual-field/package.json
+++ b/examples/virtual-field/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -36,11 +36,13 @@
   },
   "devDependencies": {
     "@keystone-6/core": "workspace:^",
-    "react": "catalog:"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "peerDependencies": {
     "@keystone-6/core": "^6.0.0",
-    "react": "catalog:"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "preconstruct": {
     "entrypoints": [

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -20,11 +20,12 @@
   "dependencies": {
     "@babel/runtime": "^7.24.7",
     "@keystar/ui": "^0.7.22",
-    "cloudinary": "^2.0.0",
-    "react": "catalog:"
+    "cloudinary": "^2.0.0"
   },
   "peerDependencies": {
-    "@keystone-6/core": "^6.0.0"
+    "@keystone-6/core": "^6.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@keystone-6/core": "workspace:^",
@@ -32,7 +33,9 @@
     "@types/react": "catalog:",
     "graphql": "catalog:",
     "graphql-upload": "^15.0.2",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "preconstruct": {
     "entrypoints": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -277,13 +277,13 @@
     "pluralize": "^8.0.0",
     "prisma": "catalog:",
     "prompts": "^2.4.2",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "resolve": "^1.20.0",
     "uuid": "^14.0.0"
   },
   "peerDependencies": {
-    "next": "^16.0.0"
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@keystone-6/core": "workspace:^",
@@ -298,7 +298,9 @@
     "@types/react-dom": "catalog:",
     "@types/resolve": "^1.20.2",
     "@types/uuid": "^11.0.0",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "preconstruct": {
     "entrypoints": [

--- a/packages/create/starter/package.json
+++ b/packages/create/starter/package.json
@@ -12,6 +12,8 @@
     "@keystone-6/core": "^6.0.0",
     "@keystone-6/fields-document": "^9.0.0",
     "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "typescript": "catalog:"
   }
 }

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -95,8 +95,6 @@
     "mdast-util-gfm-strikethrough": "^2.0.0",
     "micromark-extension-gfm-autolink-literal": "^2.1.0",
     "micromark-extension-gfm-strikethrough": "^2.1.0",
-    "react": "catalog:",
-    "react-dom": "catalog:",
     "scroll-into-view-if-needed": "^3.0.0",
     "slate": "^0.120.0",
     "slate-history": "^0.113.1",
@@ -111,11 +109,15 @@
     "jest-diff": "^29.0.0",
     "next": "catalog:",
     "pretty-format": "^29.0.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "slate-hyperscript": "^0.100.0",
     "@types/react": "catalog:"
   },
   "peerDependencies": {
-    "@keystone-6/core": "^6.0.0"
+    "@keystone-6/core": "^6.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "imports": {
     "#fields-ui": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -292,6 +298,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/bytes':
         specifier: ^3.1.1
@@ -332,6 +344,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/bytes':
         specifier: ^3.1.1
@@ -357,6 +375,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -407,6 +431,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -429,6 +459,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -463,6 +499,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -566,6 +608,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -591,6 +639,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -613,6 +664,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -663,6 +720,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -685,6 +748,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -710,6 +779,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/jsonwebtoken':
         specifier: ^9.0.2
@@ -735,6 +810,12 @@ importers:
       next-auth:
         specifier: ^4.24.11
         version: 4.24.14(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -766,6 +847,12 @@ importers:
       passport-github2:
         specifier: ^0.1.12
         version: 0.1.12
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/express':
         specifier: 'catalog:'
@@ -803,6 +890,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -822,6 +915,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -886,6 +985,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -942,6 +1044,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -964,6 +1072,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -983,6 +1097,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1005,6 +1125,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/express':
         specifier: 'catalog:'
@@ -1030,6 +1156,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1055,6 +1187,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1074,6 +1212,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1102,6 +1246,12 @@ importers:
       nexus:
         specifier: ^1.3.0
         version: 1.3.0(graphql@16.13.2)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1142,6 +1292,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       ws:
         specifier: ^8.8.0
         version: 8.20.0
@@ -1170,6 +1323,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1189,6 +1348,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1214,6 +1379,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -1224,9 +1395,6 @@ importers:
       prisma:
         specifier: 'catalog:'
         version: 6.19.3(magicast@0.3.5)(typescript@6.0.3)
-      react:
-        specifier: 'catalog:'
-        version: 19.2.5
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1345,6 +1513,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1450,6 +1624,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@graphql-codegen/cli':
         specifier: ^5.0.4
@@ -1484,6 +1664,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1506,6 +1692,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@ts-gql/compiler':
         specifier: ^0.16.7
@@ -1537,6 +1729,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1556,6 +1754,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1581,6 +1785,12 @@ importers:
       pino-http:
         specifier: ^10.5.0
         version: 10.5.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1609,6 +1819,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@opentelemetry/sdk-trace-base':
         specifier: ^2.0.1
@@ -1634,6 +1850,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1653,6 +1875,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1675,6 +1903,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1694,6 +1928,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1713,6 +1953,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1735,6 +1981,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1788,6 +2040,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@prisma/engines':
         specifier: 'catalog:'
@@ -1816,6 +2074,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1838,6 +2102,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1863,6 +2133,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1882,6 +2158,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1904,6 +2186,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1923,6 +2211,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1945,6 +2239,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1967,6 +2267,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -1989,6 +2295,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -2021,6 +2333,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
 
   packages/cloudinary:
     dependencies:
@@ -2033,9 +2348,6 @@ importers:
       cloudinary:
         specifier: ^2.0.0
         version: 2.10.0
-      react:
-        specifier: 'catalog:'
-        version: 19.2.5
     devDependencies:
       '@keystone-6/core':
         specifier: workspace:^
@@ -2055,6 +2367,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
 
   packages/core:
     dependencies:
@@ -2190,12 +2508,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      react:
-        specifier: 'catalog:'
-        version: 19.2.5
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.2.5(react@19.2.5)
       resolve:
         specifier: ^1.20.0
         version: 1.22.12
@@ -2242,6 +2554,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
 
   packages/create:
     dependencies:
@@ -2326,12 +2644,6 @@ importers:
       micromark-extension-gfm-strikethrough:
         specifier: ^2.1.0
         version: 2.1.0
-      react:
-        specifier: 'catalog:'
-        version: 19.2.5
-      react-dom:
-        specifier: 'catalog:'
-        version: 19.2.5(react@19.2.5)
       scroll-into-view-if-needed:
         specifier: ^3.0.0
         version: 3.1.0
@@ -2372,6 +2684,12 @@ importers:
       pretty-format:
         specifier: ^29.0.0
         version: 29.7.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       slate-hyperscript:
         specifier: ^0.100.0
         version: 0.100.0(slate@0.120.0)
@@ -2417,6 +2735,12 @@ importers:
       playwright:
         specifier: ^1.60.0
         version: 1.60.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       treekill:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2493,6 +2817,12 @@ importers:
       prisma:
         specifier: 'catalog:'
         version: 6.19.3(magicast@0.3.5)(typescript@6.0.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       supertest:
         specifier: ^6.1.6
         version: 6.3.4
@@ -2514,6 +2844,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
       testcheck:
         specifier: ^1.0.0-rc.2
         version: 1.0.0-rc.2
@@ -2626,6 +2962,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -2645,6 +2984,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -2664,6 +3009,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -2683,6 +3034,12 @@ importers:
       next:
         specifier: 'catalog:'
         version: 16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       prisma:
         specifier: 'catalog:'
@@ -2711,6 +3068,12 @@ importers:
       prisma:
         specifier: 'catalog:'
         version: 6.19.3(magicast@0.3.5)(typescript@6.0.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
 
 packages:
 

--- a/tests/admin-ui-tests/package.json
+++ b/tests/admin-ui-tests/package.json
@@ -17,6 +17,8 @@
     "graphql": "catalog:",
     "next": "catalog:",
     "playwright": "^1.60.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "treekill": "^1.0.0"
   },
   "scripts": {

--- a/tests/api-tests/package.json
+++ b/tests/api-tests/package.json
@@ -17,7 +17,12 @@
     "@prisma/client": "catalog:",
     "@prisma/engines": "catalog:",
     "@prisma/internals": "catalog:",
+    "@types/body-parser": "^1.19.2",
     "@types/express": "catalog:",
+    "@types/mime": "^2.0.3",
+    "@types/superagent": "^4.1.15",
+    "@types/supertest": "^2.0.11",
+    "@types/uuid": "^9.0.0",
     "cookie-signature": "^1.1.0",
     "globby": "^11.0.4",
     "graphql": "catalog:",
@@ -25,14 +30,11 @@
     "mime": "^3.0.0",
     "next": "catalog:",
     "prisma": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "supertest": "^6.1.6",
     "testcheck": "^1.0.0-rc.2",
-    "uuid": "^9.0.0",
-    "@types/body-parser": "^1.19.2",
-    "@types/mime": "^2.0.3",
-    "@types/superagent": "^4.1.15",
-    "@types/supertest": "^2.0.11",
-    "@types/uuid": "^9.0.0"
+    "uuid": "^9.0.0"
   },
   "dependencies": {
     "express": "catalog:"

--- a/tests/benchmarks/package.json
+++ b/tests/benchmarks/package.json
@@ -14,6 +14,8 @@
     "@keystone-6/core": "workspace:^",
     "cookie-signature": "^1.1.0",
     "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "testcheck": "^1.0.0-rc.2"
   }
 }

--- a/tests/sandbox/package.json
+++ b/tests/sandbox/package.json
@@ -15,7 +15,8 @@
     "@keystone-6/fields-document": "workspace:^",
     "@prisma/client": "catalog:",
     "next": "catalog:",
-    "react": "catalog:"
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "repository": "https://github.com/keystonejs/keystone/tree/main/tests/sandbox",
   "devDependencies": {

--- a/tests/test-projects/basic/package.json
+++ b/tests/test-projects/basic/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/tests/test-projects/crud-notifications/package.json
+++ b/tests/test-projects/crud-notifications/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/tests/test-projects/live-reloading/package.json
+++ b/tests/test-projects/live-reloading/package.json
@@ -12,7 +12,9 @@
   "dependencies": {
     "@keystone-6/core": "workspace:^",
     "@prisma/client": "catalog:",
-    "next": "catalog:"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "prisma": "catalog:",

--- a/tests2/package.json
+++ b/tests2/package.json
@@ -8,6 +8,8 @@
     "@prisma/engines": "catalog:",
     "@prisma/internals": "catalog:",
     "next": "catalog:",
-    "prisma": "catalog:"
+    "prisma": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
   }
 }


### PR DESCRIPTION
This is essentially just like #9827 but it also makes react and react-dom peer dependencies. Since next already has peer deps on react and react-dom this doesn't really add more requirements beyond what next implies, this basically just removes the risk of duplicate copies of react.