### PR TITLE
Simplify legacy `graphql` export

### DIFF
--- a/packages/core/src/types/schema/legacy-alias.js
+++ b/packages/core/src/types/schema/legacy-alias.js
@@ -1,1 +1,0 @@
-export { g as graphql } from './g'

--- a/packages/core/src/types/schema/legacy-alias.ts
+++ b/packages/core/src/types/schema/legacy-alias.ts
@@ -7,7 +7,7 @@ import { g as _graphql } from './g'
  *
  * 1. Navigate to
  *    `node_modules/@keystone-6/core/dist/declarations/src/types/schema/legacy-alias.d.ts`
- *    in your editor ("Go to Definition" will not take you to the correct file)
+ *    in your editor
  * 2. Use "Rename Symbol" to rename `graphql` to `g`, this will update usages of
  *    `graphql` to `g`
  * 3. Change this deprecated alias back from `g` to `graphql` using normal text
@@ -20,9 +20,9 @@ import { g as _graphql } from './g'
  * @deprecated
  */
 // this is what you should run "Rename Symbol" on
-// when that is done, you should change it back to `export import graphql = _graphql;`
+// when that is done, you should change it back to be named graphql
 // avoid using "Rename Symbol" to revert it because you want to
 // preserve the updates you made to the usages of `graphql`
-//            |||||||
-//            vvvvvvv
-export import graphql = _graphql
+//           |||||||
+//           vvvvvvv
+export const graphql = _graphql


### PR DESCRIPTION
Using `export import` here just made things unnecessarily complicated since we don't care about preserving types on the `graphql` namespace since the old types (e.g. `graphql.ObjectType<>`, etc.) already don't exist on this. The only thing this was adding was the `g<typeof g.blah>` and that wouldn't be used by anyone who hasn't migrated. If we really wanted to we could define `export type graphql<T> = gWithContext.infer<T>` but that would just be encouraging using the old name with the new API.