### PR TITLE
Remove changeset for `AND`, `OR` and `NOT` in conditional client-state filters

### DIFF
--- a/.changeset/and-or-not-conditional-filters.md
+++ b/.changeset/and-or-not-conditional-filters.md
@@ -1,5 +1,0 @@
----
-"@keystone-6/core": minor
----
-
-Add `AND`, `OR` and `NOT` support for conditional client-state filters


### PR DESCRIPTION
The changeset is unhelpful since conditional client-state filters didn't exist in the previous major so it's describing adding support for a thing in a new feature that people would reasonably already expect in the new feature