### PR TITLE
Fix `isolationLevel` type in `context.transaction`

### DIFF
--- a/.changeset/slow-points-listen.md
+++ b/.changeset/slow-points-listen.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Fix `isolationLevel` type in `context.transaction`

--- a/examples/custom-output-paths/my-types.ts
+++ b/examples/custom-output-paths/my-types.ts
@@ -165,6 +165,7 @@ export type TypeInfo<Session = any> = {
   }
   prisma: import('./node_modules/myprisma').PrismaClient
   session: Session
+  dbProvider: 'sqlite'
 }
 
 type __TypeInfo<Session = any> = TypeInfo<Session>

--- a/examples/extend-graphql-schema-nexus/keystone-types.ts
+++ b/examples/extend-graphql-schema-nexus/keystone-types.ts
@@ -284,6 +284,7 @@ export type TypeInfo<Session = any> = {
   }
   prisma: import('./node_modules/myprisma').PrismaClient
   session: Session
+  dbProvider: 'sqlite'
 }
 
 type __TypeInfo<Session = any> = TypeInfo<Session>

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -82,7 +82,8 @@ export async function generateTypes(cwd: string, system: System) {
     const schema = printGeneratedTypes(
       paths.types.relativePrismaPath,
       system.graphql.schemas.internal,
-      system.lists
+      system.lists,
+      system.config.db.provider
     )
     await fs.mkdir(path.dirname(paths.schema.types), { recursive: true })
     await fs.writeFile(paths.schema.types, schema)

--- a/packages/core/src/lib/typescript-schema-printer.ts
+++ b/packages/core/src/lib/typescript-schema-printer.ts
@@ -10,6 +10,7 @@ import {
   introspectionTypes,
 } from 'graphql'
 import type { InitialisedList } from './core/initialise-lists'
+import type { DatabaseProvider } from '../types'
 
 const introspectionTypesSet = new Set(introspectionTypes)
 
@@ -103,7 +104,8 @@ function printInterimType<L extends InitialisedList>(
 export function printGeneratedTypes(
   prismaClientPath: string,
   graphQLSchema: GraphQLSchema,
-  lists: Record<string, InitialisedList>
+  lists: Record<string, InitialisedList>,
+  dbProvider: DatabaseProvider
 ) {
   prismaClientPath = stringify(prismaClientPath).replace(/'/g, `\\'`)
 
@@ -212,6 +214,7 @@ export function printGeneratedTypes(
     `  }`,
     `  prisma: import('${prismaClientPath}').PrismaClient`,
     `  session: Session`,
+    `  dbProvider: '${dbProvider}'`,
     `}`,
     ``,
     // we need to reference the `TypeInfo` above in another type that is also called `TypeInfo`

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -11,16 +11,21 @@ export type KeystoneContext<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystone
   query: KeystoneListsAPI<TypeInfo['lists']>
   graphql: KeystoneGraphQLAPI
   prisma: TypeInfo['prisma']
-  transaction: <T>(
+  // note this using the method syntax is important because we want TypeInfo['dbProvider'] to be bivariant, not contravariant
+  // essentially so you don't get errors when assigning between contexts, this is technically unsound in the same way arrays in TS are unsound,
+  // but not doing this would make things much harder to use
+  transaction<T>(
     f: (context: KeystoneContext<TypeInfo>) => MaybePromise<T>,
     options?: {
       maxWait?: number
       timeout?: number
       isolationLevel?: {
-        Serializable: 'Serializable'
-      }
+        sqlite: 'Serializable'
+        mysql: 'ReadUncommitted' | 'ReadCommitted' | 'RepeatableRead' | 'Serializable'
+        postgresql: 'ReadUncommitted' | 'ReadCommitted' | 'RepeatableRead' | 'Serializable'
+      }[TypeInfo['dbProvider']]
     }
-  ) => Promise<T>
+  ): Promise<T>
 
   req?: IncomingMessage
   res?: ServerResponse

--- a/packages/core/src/types/type-info.ts
+++ b/packages/core/src/types/type-info.ts
@@ -1,5 +1,6 @@
 import type { BaseItem } from './next-fields'
 import type { KeystoneContext } from '../types'
+import type { DatabaseProvider } from './core'
 
 type GraphQLInput = Record<string, any>
 
@@ -35,4 +36,5 @@ export type BaseKeystoneTypeInfo<Session = any> = {
   lists: Record<string, BaseListTypeInfo<Session>>
   prisma: any
   session: Session
+  dbProvider: DatabaseProvider
 }

--- a/packages/core/src/types/type-tests.ts
+++ b/packages/core/src/types/type-tests.ts
@@ -1,5 +1,6 @@
 import type { KeystoneContext } from './context'
 import type { BaseListTypeInfo } from './type-info'
+import type { DatabaseProvider } from './core'
 
 const someContext: KeystoneContext<{
   lists: {
@@ -9,6 +10,7 @@ const someContext: KeystoneContext<{
   }
   prisma: any
   session: any
+  dbProvider: 'sqlite'
 }> = undefined!
 
 someContext.query.Singleton.findOne({})
@@ -19,3 +21,21 @@ someContext.query.List.findOne({ where: { id: '1' } })
 // @ts-expect-error
 someContext.query.ListOrSingleton.findOne({})
 someContext.query.ListOrSingleton.findOne({ where: { id: '1' } })
+
+type TypeInfoForProvider<Provider extends DatabaseProvider> = {
+  lists: Record<string, BaseListTypeInfo>
+  prisma: any
+  session: any
+  dbProvider: Provider
+}
+
+const postgresContext: KeystoneContext<TypeInfoForProvider<'postgresql'>> = undefined!
+postgresContext.transaction(async () => {}, { isolationLevel: 'ReadCommitted' })
+
+const mysqlContext: KeystoneContext<TypeInfoForProvider<'mysql'>> = undefined!
+mysqlContext.transaction(async () => {}, { isolationLevel: 'RepeatableRead' })
+
+const sqliteContext: KeystoneContext<TypeInfoForProvider<'sqlite'>> = undefined!
+sqliteContext.transaction(async () => {}, { isolationLevel: 'Serializable' })
+// @ts-expect-error SQLite only supports Serializable transactions
+sqliteContext.transaction(async () => {}, { isolationLevel: 'ReadCommitted' })

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -146,6 +146,7 @@ export type TypeInfo<Session = any> = {
   }
   prisma: import('@prisma/client').PrismaClient
   session: Session
+  dbProvider: 'sqlite'
 }
 
 type __TypeInfo<Session = any> = TypeInfo<Session>


### PR DESCRIPTION
It seems the type for `isolationLevel` was wrong from when `context.transaction` was added, this fixes that + allows the extra isolation levels beyond serialized in mysql and postgres.