### PR TITLE
Only allow single item from concurrent initFirstItem API calls

### DIFF
--- a/.changeset/ready-crews-unite.md
+++ b/.changeset/ready-crews-unite.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Only allow single item from concurrent initFirstItem API calls

--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -1,10 +1,20 @@
 import type { BaseItem, KeystoneContext } from '@keystone-6/core/types'
 import { g } from '@keystone-6/core'
-import { assertInputObjectType, GraphQLInputObjectType, type GraphQLSchema } from 'graphql'
+import {
+  assertInputObjectType,
+  GraphQLError,
+  GraphQLInputObjectType,
+  type GraphQLSchema,
+} from 'graphql'
 import { type AuthGqlNames, type InitFirstItemConfig } from '../types'
 import type { Extension } from '@keystone-6/core/graphql-ts'
 
 const AUTHENTICATION_FAILURE = 'Authentication failed.' as const
+
+function isTransactionConflict(error: unknown): boolean {
+  if (error instanceof GraphQLError) return isTransactionConflict(error.originalError)
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'P2034'
+}
 
 export function getInitFirstItemSchema({
   authGqlNames,
@@ -47,22 +57,33 @@ export function getInitFirstItemSchema({
         async resolve(rootVal, { data }, context: KeystoneContext) {
           if (!context.sessionStrategy) throw new Error('No session strategy on context')
 
-          const sudoContext = context.sudo()
+          let item: BaseItem
+          try {
+            item = await context.transaction(
+              async transactionContext => {
+                const sudoContext = transactionContext.sudo()
 
-          // should approximate hasInitFirstItemConditions
-          const count = await sudoContext.db[listKey].count()
-          if (count !== 0) throw AUTHENTICATION_FAILURE
+                // should approximate hasInitFirstItemConditions
+                const count = await sudoContext.db[listKey].count()
+                if (count !== 0) throw AUTHENTICATION_FAILURE
 
-          // Update system state
-          // this is strictly speaking incorrect. the db API will do GraphQL coercion on a value which has already been coerced
-          // (this is also mostly fine, the chance that people are using things where
-          // the input value can't round-trip like the Upload scalar here is quite low)
-          const item = await sudoContext.db[listKey].createOne({
-            data: {
-              ...defaultItemData,
-              ...data,
-            },
-          })
+                // Update system state
+                // this is strictly speaking incorrect. the db API will do GraphQL coercion on a value which has already been coerced
+                // (this is also mostly fine, the chance that people are using things where
+                // the input value can't round-trip like the Upload scalar here is quite low)
+                return await sudoContext.db[listKey].createOne({
+                  data: {
+                    ...defaultItemData,
+                    ...data,
+                  },
+                })
+              },
+              { isolationLevel: 'Serializable' }
+            )
+          } catch (error) {
+            if (isTransactionConflict(error)) throw AUTHENTICATION_FAILURE
+            throw error
+          }
 
           const sessionToken = await context.sessionStrategy.start({
             data: {

--- a/tests/api-tests/auth.test.ts
+++ b/tests/api-tests/auth.test.ts
@@ -188,6 +188,40 @@ describe('Auth testing', () => {
     )
 
     test(
+      'Failure - concurrent requests only create one initial item',
+      runner(async ({ context, gqlSuper }) => {
+        const createInitialUser = (email: string) =>
+          gqlSuper({
+            query: `
+              mutation($email: String!, $password: String!) {
+                createInitialUser(data: { email: $email, password: $password }) {
+                  sessionToken
+                  item { id email }
+                }
+              }
+            `,
+            variables: { email, password: 'new_password' },
+          }) as Promise<any>
+
+        const results = await Promise.all([
+          createInitialUser('first@example.com'),
+          createInitialUser('second@example.com'),
+        ])
+        const failures = results.filter(({ body }) => body.errors)
+
+        expect(results.filter(({ body }) => body.data?.createInitialUser).length).toBe(1)
+        expect(failures).toHaveLength(1)
+        expectInternalServerError(failures[0].body.errors, [
+          {
+            path: ['createInitialUser'],
+            message: 'Unexpected error value: "Authentication failed."',
+          },
+        ])
+        expect(await context.db.User.count()).toBe(1)
+      })
+    )
+
+    test(
       'Failure - no required field value',
       runner(async ({ gqlSuper }) => {
         const { body, res } = (await gqlSuper({


### PR DESCRIPTION
This runs initFirstItem in a serializable transaction so that two concurrent initFirstItem calls only creates a single item. We have received a large number of reports about this (presumably largely driven by LLMs), this race condition is not useful since if you can do a request to init the first item, you can just do that, you don't need a race condition but I'm adding this anyway to stop the reports.