### PR TITLE
Throw actual error in initFirstItem instead of directly throwing string

### DIFF
--- a/packages/auth/src/gql/getInitFirstItemSchema.ts
+++ b/packages/auth/src/gql/getInitFirstItemSchema.ts
@@ -65,7 +65,7 @@ export function getInitFirstItemSchema({
 
                 // should approximate hasInitFirstItemConditions
                 const count = await sudoContext.db[listKey].count()
-                if (count !== 0) throw AUTHENTICATION_FAILURE
+                if (count !== 0) throw new GraphQLError(AUTHENTICATION_FAILURE)
 
                 // Update system state
                 // this is strictly speaking incorrect. the db API will do GraphQL coercion on a value which has already been coerced
@@ -81,7 +81,7 @@ export function getInitFirstItemSchema({
               { isolationLevel: 'Serializable' }
             )
           } catch (error) {
-            if (isTransactionConflict(error)) throw AUTHENTICATION_FAILURE
+            if (isTransactionConflict(error)) throw new GraphQLError(AUTHENTICATION_FAILURE)
             throw error
           }
 
@@ -94,7 +94,7 @@ export function getInitFirstItemSchema({
           })
 
           if (typeof sessionToken !== 'string' || sessionToken.length === 0) {
-            throw AUTHENTICATION_FAILURE
+            throw new GraphQLError(AUTHENTICATION_FAILURE)
           }
 
           return {

--- a/tests/api-tests/auth.test.ts
+++ b/tests/api-tests/auth.test.ts
@@ -180,7 +180,7 @@ describe('Auth testing', () => {
         expectInternalServerError(body.errors, [
           {
             path: ['createInitialUser'],
-            message: 'Unexpected error value: "Authentication failed."',
+            message: 'Authentication failed.',
           },
         ])
         expect(body.data).toEqual(null)
@@ -214,7 +214,7 @@ describe('Auth testing', () => {
         expectInternalServerError(failures[0].body.errors, [
           {
             path: ['createInitialUser'],
-            message: 'Unexpected error value: "Authentication failed."',
+            message: 'Authentication failed.',
           },
         ])
         expect(await context.db.User.count()).toBe(1)


### PR DESCRIPTION
Throwing a string wasn't present in the currently published version so no changeset