### PR TITLE
Clarify `endSession` changesets

### DIFF
--- a/.changeset/add-end-session.md
+++ b/.changeset/add-end-session.md
@@ -2,4 +2,4 @@
 "@keystone-6/auth": minor
 ---
 
-Adds the `EndSession` GraphQL mutation addition when `context.session.end` is defined
+Adds the `endSession` GraphQL mutation addition when `context.session.end` is defined

--- a/.changeset/remove-end-session.md
+++ b/.changeset/remove-end-session.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": major
 ---
 
-Removes the `EndSession` GraphQL mutation addition when `context.session.end` is defined, extend this yourself if required
+Removes the `endSession` GraphQL mutation addition when `context.session.end` is defined, extend this yourself or use `@keystone-6/auth` which adds `endSession` if required


### PR DESCRIPTION
The mutation is called `endSession`, not `EndSession` and the core changeset could mislead people into thinking that `endSession` is gone completely when it's just that `@keystone-6/auth` is adding it now instead of `@keystone-6/core`