### PR TITLE
Fix document-renderer changeset

### DIFF
--- a/.changeset/eleven-queens-fix.md
+++ b/.changeset/eleven-queens-fix.md
@@ -2,4 +2,4 @@
 "@keystone-6/document-renderer": minor
 ---
 
-Support React 19 Types and export `Element`, `Text` and `Node` types.
+Export `Element`, `Text` and `Node` types


### PR DESCRIPTION
Since in the backport release we added supported the React 19 types that part is no longer relevant for the next release