### PR TITLE
Fix changeset removing `{list}.description` and `{list}.ui.description`

### DIFF
--- a/.changeset/less-high-description.md
+++ b/.changeset/less-high-description.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": major
 ---
 
-Removes unused `{list}.description` and `{list}.ui.description`, retains `{list}.graphql.description` functionality
+Removes `{list}.description` and `{list}.ui.description`, retains `{list}.graphql.description` functionality


### PR DESCRIPTION
`{list}.description`/`{list}.ui.description` wasn't unused in previous major versions of Keystone so this is misleading. I assume this changeset was added while implementing the new design system where it probably existed unused for a while.