### PR TITLE
Replace `schema.extensions.sudo` with `schema.extensions.scope: 'public' | 'internal'`

### DIFF
--- a/.changeset/bright-ducks-scope.md
+++ b/.changeset/bright-ducks-scope.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Replace the `sudo` boolean on GraphQL schema extensions with `scope`, which is either `'public'` or `'internal'`. Code that previously checked `schema.extensions.sudo` should now check `schema.extensions.scope === 'internal'`.

--- a/examples/extend-graphql-schema-graphql-ts/schema.ts
+++ b/examples/extend-graphql-schema-graphql-ts/schema.ts
@@ -87,8 +87,8 @@ export const extendGraphqlSchema = g.extend(base => {
         },
       }),
 
-      // only add this mutation for a sudo Context (this is not usable from the API)
-      ...(base.schema.extensions.sudo
+      // only add this mutation to the internal schema (this is not usable from the API)
+      ...(base.schema.extensions.scope === 'internal'
         ? {
             banPost: g.field({
               type: base.object('Post'),

--- a/packages/auth/src/schema.ts
+++ b/packages/auth/src/schema.ts
@@ -28,7 +28,7 @@ export const getSchemaExtension = ({
     )
     const identityFieldOnUniqueWhere = uniqueWhereInputType.getFields()[identityField]
     if (
-      base.schema.extensions.sudo &&
+      base.schema.extensions.scope === 'internal' &&
       identityFieldOnUniqueWhere?.type !== GraphQLString &&
       identityFieldOnUniqueWhere?.type !== GraphQLID
     ) {
@@ -48,25 +48,27 @@ export const getSchemaExtension = ({
       base,
     })
 
-    // technically this will incorrectly error if someone has a schema extension that adds a field to the list output type
-    // and then wants to fetch that field with `sessionData` but it's extremely unlikely someone will do that since if
-    // they want to add a GraphQL field, they'll probably use a virtual field
-    const query = `query($id: ID!) { ${authGqlNames.itemQueryName}(where: { id: $id }) { ${sessionData} } }`
+    if (base.schema.extensions.scope === 'internal') {
+      // technically this will incorrectly error if someone has a schema extension that adds a field to the list output type
+      // and then wants to fetch that field with `sessionData` but it's extremely unlikely someone will do that since if
+      // they want to add a GraphQL field, they'll probably use a virtual field
+      const query = `query($id: ID!) { ${authGqlNames.itemQueryName}(where: { id: $id }) { ${sessionData} } }`
 
-    let ast
-    try {
-      ast = parse(query)
-    } catch (err) {
-      throw new Error(
-        `The query to get session data has a syntax error, the sessionData option in your createAuth usage is likely incorrect\n${err}`
-      )
-    }
+      let ast
+      try {
+        ast = parse(query)
+      } catch (err) {
+        throw new Error(
+          `The query to get session data has a syntax error, the sessionData option in your createAuth usage is likely incorrect\n${err}`
+        )
+      }
 
-    const errors = validate(base.schema, ast)
-    if (errors.length) {
-      throw new Error(
-        `The query to get session data has validation errors, the sessionData option in your createAuth usage is likely incorrect\n${errors.join('\n')}`
-      )
+      const errors = validate(base.schema, ast)
+      if (errors.length) {
+        throw new Error(
+          `The query to get session data has validation errors, the sessionData option in your createAuth usage is likely incorrect\n${errors.join('\n')}`
+        )
+      }
     }
 
     return [

--- a/packages/core/src/lib/graphql.ts
+++ b/packages/core/src/lib/graphql.ts
@@ -21,7 +21,7 @@ function getGraphQLSchema(
       GField<unknown, any, GOutputType<KeystoneContext>, unknown, KeystoneContext>
     >
   },
-  sudo: boolean
+  scope: 'public' | 'internal'
 ) {
   const query = g.object()({
     name: 'Query',
@@ -51,7 +51,7 @@ function getGraphQLSchema(
     mutation,
     types: [...collectedTypes, g.JSON, mutation],
     extensions: {
-      sudo,
+      scope,
     },
   })
 }
@@ -60,7 +60,7 @@ export function createGraphQLSchema(
   config: KeystoneConfig,
   lists: Record<string, InitialisedList>,
   adminMeta: AdminMetaSource | null,
-  sudo: boolean
+  scope: 'public' | 'internal'
 ) {
   const graphQLSchema = getGraphQLSchema(
     lists,
@@ -75,7 +75,7 @@ export function createGraphQLSchema(
           }
         : {},
     },
-    sudo
+    scope
   )
 
   // merge in the user defined graphQL API

--- a/packages/core/src/lib/system.ts
+++ b/packages/core/src/lib/system.ts
@@ -93,7 +93,7 @@ function getInternalGraphQLSchema(config: KeystoneConfig) {
 
   const lists = initialiseLists(withoutOmit)
   const adminMeta = createAdminMeta(withoutOmit, lists)
-  return createGraphQLSchema(withoutOmit, lists, adminMeta, true)
+  return createGraphQLSchema(withoutOmit, lists, adminMeta, 'internal')
 }
 
 function injectNewDefaults(prismaClient: unknown, lists: Record<string, InitialisedList>) {
@@ -148,7 +148,7 @@ export function createSystem(config: KeystoneConfig) {
   const lists = initialiseLists(config)
   const adminMeta = createAdminMeta(config, lists)
   const graphQLSchemas = {
-    public: createGraphQLSchema(config, lists, adminMeta, false),
+    public: createGraphQLSchema(config, lists, adminMeta, 'public'),
     internal: getInternalGraphQLSchema(config),
   }
 

--- a/tests/api-tests/extend-graphql-schema.test.ts
+++ b/tests/api-tests/extend-graphql-schema.test.ts
@@ -6,6 +6,7 @@ import { setupTestRunner } from './test-runner'
 import { expectInternalServerError } from './utils'
 
 const falseFn: (...args: any) => boolean = () => false
+const observedSchemaExtensions: unknown[] = []
 
 function withAccessCheck<T, Args extends unknown[]>(
   access: boolean | ((...args: Args) => boolean),
@@ -33,7 +34,8 @@ const runner = setupTestRunner({
       }),
     },
     graphql: {
-      extendGraphqlSchema: g.extend(() => {
+      extendGraphqlSchema: g.extend(base => {
+        observedSchemaExtensions.push(base.schema.extensions)
         return {
           mutation: {
             triple: g.field({
@@ -61,6 +63,16 @@ const runner = setupTestRunner({
 })
 
 describe('extendGraphqlSchema', () => {
+  it(
+    'Identifies whether the schema is public or internal',
+    runner(async () => {
+      expect(observedSchemaExtensions.slice(-2)).toEqual([
+        { scope: 'public' },
+        { scope: 'internal' },
+      ])
+    })
+  )
+
   it(
     'Executes custom queries correctly',
     runner(async ({ context }) => {


### PR DESCRIPTION
This aligns with the new "internal" schema which both `context.internal()` and `context.sudo()` use.