### PR TITLE
Generate fewer Prisma clients in tests

### DIFF
--- a/tests/api-tests/auth-header.test.ts
+++ b/tests/api-tests/auth-header.test.ts
@@ -13,7 +13,7 @@ const initialData = {
   ],
 }
 
-function setup(options?: any) {
+function testOptions(options?: any) {
   const { withAuth } = createAuth({
     listKey: 'User',
     identityField: 'email',
@@ -22,7 +22,7 @@ function setup(options?: any) {
     ...options,
   })
 
-  return setupTestRunner({
+  return {
     config: withAuth({
       lists: {
         Post: list({
@@ -44,7 +44,13 @@ function setup(options?: any) {
       session: statelessSessions(),
     } as any) as any,
     serve: true,
-  })
+  }
+}
+
+const runner = setupTestRunner(testOptions())
+
+function setup(options?: any) {
+  return setupTestRunner(testOptions(options))
 }
 
 async function login(
@@ -71,7 +77,7 @@ async function login(
 describe('Auth testing', () => {
   test(
     'Gives access denied when not logged in',
-    setup()(async ({ context }) => {
+    runner(async ({ context }) => {
       await seed(context, initialData)
       const { data, errors } = await context.graphql.raw({ query: '{ users { id } }' })
       expect(data).toEqual({ users: [] })
@@ -122,7 +128,7 @@ describe('Auth testing', () => {
   describe('logged in', () => {
     test(
       'Allows access with bearer token',
-      setup()(async ({ context, gqlSuper }) => {
+      runner(async ({ context, gqlSuper }) => {
         await seed(context, initialData)
         const { sessionToken } = await login(
           gqlSuper,
@@ -144,7 +150,7 @@ describe('Auth testing', () => {
 
     test(
       'Allows access with cookie',
-      setup()(async ({ context, gqlSuper }) => {
+      runner(async ({ context, gqlSuper }) => {
         await seed(context, initialData)
         const { sessionToken } = await login(
           gqlSuper,
@@ -167,7 +173,7 @@ describe('Auth testing', () => {
 
     test(
       'Invalid session receives nothing',
-      setup()(async ({ context, gqlSuper }) => {
+      runner(async ({ context, gqlSuper }) => {
         await seed(context, initialData)
         const { body } = await gqlSuper({ query: '{ users { id } }' }).set(
           'Cookie',
@@ -183,7 +189,7 @@ describe('Auth testing', () => {
 
     test(
       'Session is dropped if user is removed',
-      setup()(async ({ context, gqlSuper }) => {
+      runner(async ({ context, gqlSuper }) => {
         const { User: users } = await seed(context, initialData)
         const { sessionToken } = await login(
           gqlSuper,

--- a/tests/api-tests/fields/files.test.ts
+++ b/tests/api-tests/fields/files.test.ts
@@ -17,20 +17,46 @@ import type { BaseKeystoneTypeInfo, StorageStrategy } from '@keystone-6/core/typ
 
 vi.setConfig({ testTimeout: 10000 })
 
-function getRunner(opts: Parameters<typeof file>[0]) {
-  return setupTestRunner({
-    config: {
-      lists: {
-        Test: list({
-          access: allowAll,
-          fields: {
-            name: text(),
-            secretFile: file(opts),
-          },
-        }),
-      },
+let activeStorage: StorageStrategy<BaseKeystoneTypeInfo>
+let activeTransformName: Parameters<typeof file>[0]['transformName']
+
+const storage: StorageStrategy<BaseKeystoneTypeInfo> = {
+  put: (...args) => activeStorage.put(...args),
+  delete: (...args) => activeStorage.delete(...args),
+  url: (...args) => activeStorage.url(...args),
+}
+
+const runner = setupTestRunner({
+  config: {
+    lists: {
+      Test: list({
+        access: allowAll,
+        fields: {
+          name: text(),
+          secretFile: file({
+            storage,
+            transformName: originalFilename => {
+              if (activeTransformName) return activeTransformName(originalFilename)
+              const [, name, extension] = originalFilename.match(
+                /^([^:\n].*?)(\.[A-Za-z0-9]{0,10})?$/
+              ) as RegExpMatchArray
+              const id = randomBytes(16).toString('base64url')
+              return `${name.replace(/[^A-Za-z0-9]/g, '-')}-${id}${extension ?? ''}`
+            },
+          }),
+        },
+      }),
     },
-  })
+  },
+})
+
+function getRunner(opts: Parameters<typeof file>[0]) {
+  return (testFn: Parameters<typeof runner>[0]) =>
+    runner(async result => {
+      activeStorage = opts.storage
+      activeTransformName = opts.transformName
+      await testFn(result)
+    })
 }
 
 const createItem = (context: any) =>

--- a/tests/api-tests/fields/images.test.ts
+++ b/tests/api-tests/fields/images.test.ts
@@ -18,20 +18,41 @@ import type { BaseKeystoneTypeInfo, StorageStrategy } from '@keystone-6/core/typ
 
 vi.setConfig({ testTimeout: 10000 })
 
-function getRunner(args: Parameters<typeof image>[0]) {
-  return setupTestRunner({
-    config: {
-      lists: {
-        Test: list({
-          access: allowAll,
-          fields: {
-            name: text(),
-            avatar: image(args),
-          },
-        }),
-      },
+let activeStorage: StorageStrategy<BaseKeystoneTypeInfo>
+let activeTransformName: Parameters<typeof image>[0]['transformName']
+
+const storage: StorageStrategy<BaseKeystoneTypeInfo> = {
+  put: (...args) => activeStorage.put(...args),
+  delete: (...args) => activeStorage.delete(...args),
+  url: (...args) => activeStorage.url(...args),
+}
+
+const runner = setupTestRunner({
+  config: {
+    lists: {
+      Test: list({
+        access: allowAll,
+        fields: {
+          name: text(),
+          avatar: image({
+            storage,
+            transformName: (originalFilename, extension) =>
+              activeTransformName?.(originalFilename, extension) ??
+              randomBytes(16).toString('base64url'),
+          }),
+        },
+      }),
     },
-  })
+  },
+})
+
+function getRunner(args: Parameters<typeof image>[0]) {
+  return (testFn: Parameters<typeof runner>[0]) =>
+    runner(async result => {
+      activeStorage = args.storage
+      activeTransformName = args.transformName
+      await testFn(result)
+    })
 }
 
 const createItem = async (context: any, filename: string) =>

--- a/tests/api-tests/prisma-errors.test.ts
+++ b/tests/api-tests/prisma-errors.test.ts
@@ -36,7 +36,7 @@ const extendGraphqlSchema = g.extend(base => ({
 for (const name of ['with custom formatError', 'without custom formatError'] as const) {
   describe(name, () => {
     const extraExtensions = name === 'with custom formatError' ? { someCustomThing: true } : {}
-    const runner = (debug: boolean) =>
+    const createRunner = (debug: boolean) =>
       setupTestRunner({
         serve: true,
         config: {
@@ -65,6 +65,11 @@ for (const name of ['with custom formatError', 'without custom formatError'] as 
           },
         },
       })
+    const runners = {
+      enabled: createRunner(true),
+      disabled: createRunner(false),
+    }
+    const runner = (debug: boolean) => (debug ? runners.enabled : runners.disabled)
 
     for (const query of [
       'createUser',


### PR DESCRIPTION
Split out of #9872 to reduce the size of that diff. This is neccessary for the Prisma 7 PR because generating Prisma Clients in the tests is slower so this change generates fewer Prisma Clients