### PR TITLE
Update default `types.path` to `generated/keystone/types.ts`

### DIFF
--- a/.changeset/green-teeth-wear.md
+++ b/.changeset/green-teeth-wear.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': major
+---
+
+Updates default `types.path` to `generated/keystone/types.ts`

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 .next/
 dist/
 node_modules/
-**/generated/prisma/
-**/generated/custom-prisma/
+**/generated/
 *.db
 *.log
 .env

--- a/docs/content/blog/embedded-mode-with-sqlite-nextjs.md
+++ b/docs/content/blog/embedded-mode-with-sqlite-nextjs.md
@@ -91,11 +91,12 @@ npm install @keystone-6/core
 
 ### Update .gitignore
 
-Add the `.keystone` directory to your `.gitignore` file. The contents of `.keystone` are generated at build time. You'll never have to change them.
+Add the `.keystone` and `generated` directories to your `.gitignore` file. Their contents are generated at build time. You'll never have to change them.
 
 ```bash
 # In your .gitignore
 .keystone
+generated
 ```
 
 ### Create your Keystone config
@@ -108,7 +109,7 @@ To create and edit blog records in Keystone's Admin UI, add a `keystone.ts` [con
 import { config, list } from '@keystone-6/core';
 import { text } from '@keystone-6/core/fields';
 import { allowAll } from '@keystone-6/core/access';
-import type { Lists } from '.keystone/types';
+import type { Lists } from './generated/keystone/types';
 
 const Post: Lists.Post = list({
   fields: {
@@ -191,7 +192,7 @@ import { InferGetStaticPropsType } from 'next';
 import Link from 'next/link';
 
 // Import the generated Lists API and types from Keystone
-import type { Lists } from '.keystone/types';
+import type { Lists } from '../generated/keystone/types';
 
 type Post = {
   id: string;
@@ -239,7 +240,7 @@ import { GetStaticPathsResult, GetStaticPropsContext, InferGetStaticPropsType } 
 import Link from 'next/link';
 
 import { query } from '.keystone/api';
-import type { Lists } from '.keystone/types';
+import type { Lists } from '../../generated/keystone/types';
 
 type Post = {
   id: string;

--- a/docs/content/blog/nextjs-keystone.md
+++ b/docs/content/blog/nextjs-keystone.md
@@ -39,7 +39,7 @@ Importing Keystone's `getContext`
 
 import { getContext } from '@keystone-6/core/context';
 import config from '../../keystone';
-import { Context } from '.keystone/types';
+import { Context } from '../../generated/keystone/types';
 import * as PrismaModule from '.prisma/client';
 
 // Making sure multiple prisma clients are not created during dev hot reloading

--- a/docs/content/docs/config/config.md
+++ b/docs/content/docs/config/config.md
@@ -30,10 +30,10 @@ We will cover each of these options below.
 The configuration object has a TypeScript type of `KeystoneConfig`, which can be imported from `@keystone-6/core/types`.
 This type definition should be considered the source of truth for the available configuration options.
 
-Note: It is important to pass a `TypeInfo` type argument to the config function as it ensures proper typing for the [Keystone Context](../context/overview). This type is automatically created in `.keystone/types`. You can customize the output path of the generated type by specifying it in the config object.
+Note: It is important to pass a `TypeInfo` type argument to the config function as it ensures proper typing for the [Keystone Context](../context/overview). This type is automatically created in `generated/keystone/types`. You can customize the output path of the generated type by specifying it in the config object.
 
 ```typescript
-import { TypeInfo } from ".keystone/types";
+import { TypeInfo } from "./generated/keystone/types";
 
 export default config<TypeInfo>({ /* ... */ });
 ```
@@ -46,7 +46,7 @@ See the [Lists API](./lists) docs for details on how to use this function.
 
 ```typescript
 import { config } from '@keystone-6/core';
-import { TypeInfo } from ".keystone/types";
+import { TypeInfo } from "./generated/keystone/types";
 
 export default config<TypeInfo>({
   lists: { /* ... */ },

--- a/docs/content/docs/context/overview.md
+++ b/docs/content/docs/context/overview.md
@@ -11,7 +11,7 @@ The APIs provided by the `Context` object can be used to write the business logi
 The `Context` object has the following properties, which are documented below.
 
 ```typescript
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 const context = {
   // Query API

--- a/docs/content/docs/guides/schema-extension.md
+++ b/docs/content/docs/guides/schema-extension.md
@@ -10,7 +10,7 @@ The `extendGraphqlSchema` option expects a function that takes the GraphQL Schem
 
 ## Using Keystone's g.extend
 
-Keystone exports `g` from `@keystone-6/core`, this uses [@graphql-ts/schema](https://docsmill.dev/npm/@graphql-ts/schema) which can be used in combination with `Context` from `.keystone/types` to extend your GraphQL schema in a type-safe way. The `g` export is pre-bound to Keystone's `Context` type. If you need to bind `g` to a custom context type, you can use `gWithContext` from `@keystone-6/core` instead.
+Keystone exports `g` from `@keystone-6/core`, this uses [@graphql-ts/schema](https://docsmill.dev/npm/@graphql-ts/schema) which can be used in combination with `Context` from `generated/keystone/types` to extend your GraphQL schema in a type-safe way. The `g` export is pre-bound to Keystone's `Context` type. If you need to bind `g` to a custom context type, you can use `gWithContext` from `@keystone-6/core` instead.
 
 You can then import this into your Keystone configuration file
 
@@ -25,7 +25,7 @@ It then returns the Post that is updated which has a GraphQL type of `Post` that
 
 ```ts
 import { g, config } from '@keystone-6/core';
-import { Context } from '.keystone/types';
+import { Context } from './generated/keystone/types';
 
 export default config({
   {/* ... */},

--- a/examples/actions/keystone.ts
+++ b/examples/actions/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/actions/schema.ts
+++ b/examples/actions/schema.ts
@@ -2,7 +2,7 @@ import { list, action, g } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, integer, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/assets-local/schema.ts
+++ b/examples/assets-local/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { text, image, file } from '@keystone-6/core/fields'
 import fs from 'node:fs/promises'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/assets-s3/schema.ts
+++ b/examples/assets-s3/schema.ts
@@ -5,7 +5,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { S3, GetObjectCommand } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 const {
   S3_BUCKET_NAME: bucketName = 'keystone-test',

--- a/examples/auth-magic-link/keystone.ts
+++ b/examples/auth-magic-link/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { type Session, lists, extendGraphqlSchema } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/auth-magic-link/schema.ts
+++ b/examples/auth-magic-link/schema.ts
@@ -1,7 +1,7 @@
 import { gWithContext, list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { password, text, timestamp } from '@keystone-6/core/fields'
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 import { randomBytes } from 'node:crypto'
 

--- a/examples/auth/keystone.ts
+++ b/examples/auth/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { type Session, lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/auth/schema.ts
+++ b/examples/auth/schema.ts
@@ -1,4 +1,4 @@
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, password, text } from '@keystone-6/core/fields'

--- a/examples/better-list-search/keystone.ts
+++ b/examples/better-list-search/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/better-list-search/schema.ts
+++ b/examples/better-list-search/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 
 import { text, relationship } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/byte-encoding/keystone.ts
+++ b/examples/byte-encoding/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/byte-encoding/schema.ts
+++ b/examples/byte-encoding/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import { bytes } from '@keystone-6/core/fields'
 import { bytesScalar } from '@keystone-6/core/fields/types/bytes'
 

--- a/examples/cloudinary/schema.ts
+++ b/examples/cloudinary/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
 import { cloudinaryImage } from '@keystone-6/cloudinary'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/custom-admin-ui-logo/schema.ts
+++ b/examples/custom-admin-ui-logo/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Task: list({

--- a/examples/custom-admin-ui-navigation/schema.ts
+++ b/examples/custom-admin-ui-navigation/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Task: list({

--- a/examples/custom-admin-ui-pages/schema.ts
+++ b/examples/custom-admin-ui-pages/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Task: list({

--- a/examples/custom-esbuild/keystone.ts
+++ b/examples/custom-esbuild/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/custom-esbuild/schema.ts
+++ b/examples/custom-esbuild/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/custom-field/keystone.ts
+++ b/examples/custom-field/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/custom-field/schema.ts
+++ b/examples/custom-field/schema.ts
@@ -8,7 +8,7 @@ import { pair as pairNested } from './3-pair-field-nested'
 import { pair as pairJson } from './3-pair-field-json'
 import { feedback } from './4-conditional-field'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/custom-id/keystone.ts
+++ b/examples/custom-id/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/custom-id/schema.ts
+++ b/examples/custom-id/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
 import { createId } from '@paralleldrive/cuid2'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 function makeCustomIdentifier(listKey: string) {
   return `${listKey.toUpperCase()}_${createId()}`

--- a/examples/custom-session-invalidation/keystone.ts
+++ b/examples/custom-session-invalidation/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { type Session, lists } from './schema'
-import type { Config, Context, TypeInfo } from '.keystone/types'
+import type { Config, Context, TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-invalidation/schema.ts
+++ b/examples/custom-session-invalidation/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { text, password, timestamp } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-jwt/keystone.ts
+++ b/examples/custom-session-jwt/keystone.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken'
 import { config } from '@keystone-6/core'
 import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from '.keystone/types'
+import type { Context, TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-jwt/schema.ts
+++ b/examples/custom-session-jwt/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll, unfiltered, allOperations } from '@keystone-6/core/access'
 import { checkbox, text } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export type Session = {
   id: string

--- a/examples/custom-session-next-auth/admin/pages/api/auth/[...nextauth].ts
+++ b/examples/custom-session-next-auth/admin/pages/api/auth/[...nextauth].ts
@@ -5,7 +5,7 @@ import * as Prisma from 'myprisma'
 // import * as Prisma from '@prisma/client' // <-- do this
 import { getContext } from '@keystone-6/core/context'
 import keystoneConfig from '../../../../keystone'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../../../generated/keystone/types'
 
 let _keystoneContext: Context = (globalThis as any)._keystoneContext
 

--- a/examples/custom-session-next-auth/keystone.ts
+++ b/examples/custom-session-next-auth/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import { lists } from './schema'
 
 import { type Session, nextAuthSessionStrategy } from './session'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-next-auth/schema.ts
+++ b/examples/custom-session-next-auth/schema.ts
@@ -2,7 +2,7 @@ import { denyAll, allOperations } from '@keystone-6/core/access'
 import { list } from '@keystone-6/core'
 import { text, relationship } from '@keystone-6/core/fields'
 import type { Session } from './session'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-next-auth/session.ts
+++ b/examples/custom-session-next-auth/session.ts
@@ -2,7 +2,7 @@ import { getServerSession } from 'next-auth/next'
 import type { DefaultJWT } from 'next-auth/jwt'
 import type { DefaultSession } from 'next-auth'
 import GithubProvider from 'next-auth/providers/github'
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-passport/auth.ts
+++ b/examples/custom-session-passport/auth.ts
@@ -7,7 +7,7 @@ import type { VerifyCallback } from 'passport-oauth2'
 import { Strategy, type StrategyOptions, type Profile } from 'passport-github2'
 
 import type { Author } from 'myprisma'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export type Session = Author
 

--- a/examples/custom-session-passport/keystone.ts
+++ b/examples/custom-session-passport/keystone.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config'
 
 import { config } from '@keystone-6/core'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 import { lists } from './schema'
 import { type Session, session, passportMiddleware } from './auth'
 

--- a/examples/custom-session-passport/schema.ts
+++ b/examples/custom-session-passport/schema.ts
@@ -1,7 +1,7 @@
 import { denyAll, allOperations } from '@keystone-6/core/access'
 import { list } from '@keystone-6/core'
 import { text, relationship } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 import type { Session } from './auth'
 

--- a/examples/custom-session-redis/keystone.ts
+++ b/examples/custom-session-redis/keystone.ts
@@ -3,7 +3,7 @@ import { storedSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { createClient } from '@redis/client'
 import { lists, type Session } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-redis/schema.ts
+++ b/examples/custom-session-redis/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { text, password } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session/keystone.ts
+++ b/examples/custom-session/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from '.keystone/types'
+import type { Context, TypeInfo } from './generated/keystone/types'
 
 const sillySessionStrategy = {
   async get({ context }: { context: Context }): Promise<Session | undefined> {

--- a/examples/custom-session/schema.ts
+++ b/examples/custom-session/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll, unfiltered } from '@keystone-6/core/access'
 import { checkbox, text } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export type Session = {
   id: string

--- a/examples/default-values/schema.ts
+++ b/examples/default-values/schema.ts
@@ -1,4 +1,4 @@
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import {

--- a/examples/document-field-customisation/keystone-server/keystone.ts
+++ b/examples/document-field-customisation/keystone-server/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import type { KeystoneConfigPre } from '@keystone-6/core/types'
 import { seedDatabase } from './src/seed'
 import { lists } from './src/schema'
-import type { Context, TypeInfo } from '.keystone/types'
+import type { Context, TypeInfo } from './generated/keystone/types'
 
 const db: KeystoneConfigPre<TypeInfo>['db'] = {
   provider: 'sqlite',

--- a/examples/document-field-customisation/keystone-server/src/schema.ts
+++ b/examples/document-field-customisation/keystone-server/src/schema.ts
@@ -4,7 +4,7 @@ import { relationship, text, timestamp } from '@keystone-6/core/fields'
 import { document } from '@keystone-6/fields-document'
 import { componentBlocks } from './component-blocks'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from '../generated/keystone/types'
 
 export const lists = {
   User: list({

--- a/examples/document-field-customisation/keystone-server/src/seed/index.ts
+++ b/examples/document-field-customisation/keystone-server/src/seed/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 const seedUsers = async (context: Context) => {
   const { db } = context.sudo()

--- a/examples/document-field-hooks/schema.ts
+++ b/examples/document-field-hooks/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { relationship, text } from '@keystone-6/core/fields'
 import { document, type Node } from '@keystone-6/fields-document'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 function mapNodes(
   nodes: Node[],

--- a/examples/document-field/schema.ts
+++ b/examples/document-field/schema.ts
@@ -3,7 +3,7 @@ import { select, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { document } from '@keystone-6/fields-document'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/dynamic-is-required/keystone.ts
+++ b/examples/dynamic-is-required/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/dynamic-is-required/schema.ts
+++ b/examples/dynamic-is-required/schema.ts
@@ -1,4 +1,4 @@
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import { action, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { checkbox, relationship, select, text } from '@keystone-6/core/fields'

--- a/examples/empty-lists/keystone.ts
+++ b/examples/empty-lists/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/empty-lists/schema.ts
+++ b/examples/empty-lists/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/extend-express-app/keystone.ts
+++ b/examples/extend-express-app/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core'
 
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/extend-express-app/schema.ts
+++ b/examples/extend-express-app/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { checkbox, text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/extend-full-text-search/schema.ts
+++ b/examples/extend-full-text-search/schema.ts
@@ -1,7 +1,7 @@
 import { gWithContext, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { relationship, text } from '@keystone-6/core/fields'
-import type { Context, Lists } from '.keystone/types'
+import type { Context, Lists } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/extend-graphql-schema-graphql-tools/schema.ts
+++ b/examples/extend-graphql-schema-graphql-tools/schema.ts
@@ -4,7 +4,7 @@ import { mergeSchemas } from '@graphql-tools/schema'
 import { allowAll } from '@keystone-6/core/access'
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/extend-graphql-schema-graphql-ts/schema.ts
+++ b/examples/extend-graphql-schema-graphql-ts/schema.ts
@@ -1,7 +1,7 @@
 import { gWithContext, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { select, relationship, text, timestamp } from '@keystone-6/core/fields'
-import type { Context, Lists } from '.keystone/types'
+import type { Context, Lists } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/extend-graphql-subscriptions/schema.ts
+++ b/examples/extend-graphql-subscriptions/schema.ts
@@ -5,7 +5,7 @@ import { select, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 import { pubSub } from './websocket'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/extend-graphql-subscriptions/websocket.ts
+++ b/examples/extend-graphql-subscriptions/websocket.ts
@@ -4,7 +4,7 @@ import { WebSocketServer } from 'ws'
 import { PubSub } from 'graphql-subscriptions'
 import { parse } from 'graphql'
 
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 // Setup pubsub as a Global variable in dev so it survives Hot Reloads.
 declare global {

--- a/examples/extend-prisma-schema/schema.ts
+++ b/examples/extend-prisma-schema/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { text, relationship } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Author: list({

--- a/examples/field-groups/keystone.ts
+++ b/examples/field-groups/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/field-groups/schema.ts
+++ b/examples/field-groups/schema.ts
@@ -2,7 +2,7 @@ import { list, group } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/framework-astro/keystone.ts
+++ b/examples/framework-astro/keystone.ts
@@ -7,7 +7,7 @@
 
 import { config } from '@keystone-6/core'
 import { lists } from './src/keystone/schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/framework-astro/src/keystone/context.ts
+++ b/examples/framework-astro/src/keystone/context.ts
@@ -1,7 +1,7 @@
 import { getContext } from '@keystone-6/core/context'
 import * as PrismaModule from 'myprisma'
 import config from '../../keystone'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 // Making sure multiple prisma clients are not created during hot reloading
 export const keystoneContext: Context =

--- a/examples/framework-astro/src/keystone/schema.ts
+++ b/examples/framework-astro/src/keystone/schema.ts
@@ -15,8 +15,8 @@ import { text, select } from '@keystone-6/core/fields'
 // if you want to make your own fields, see https://keystonejs.com/docs/guides/custom-fields
 
 // when using Typescript, you can refine your types to a stricter subset by importing
-// the generated types from '.keystone/types'
-import type { Lists } from '.keystone/types'
+// the generated types from '../../generated/keystone/types'
+import type { Lists } from '../../generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/framework-nextjs-app-directory/keystone.ts
+++ b/examples/framework-nextjs-app-directory/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core'
 import { lists } from './src/keystone/schema'
 import { seedDemoData } from './src/keystone/seed'
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 export default config({
   db: {

--- a/examples/framework-nextjs-app-directory/src/keystone/context.ts
+++ b/examples/framework-nextjs-app-directory/src/keystone/context.ts
@@ -1,6 +1,6 @@
 import { getContext } from '@keystone-6/core/context'
 import config from '../../keystone'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 import * as PrismaModule from 'myprisma'
 
 // Making sure multiple prisma clients are not created during hot reloading

--- a/examples/framework-nextjs-app-directory/src/keystone/schema.ts
+++ b/examples/framework-nextjs-app-directory/src/keystone/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { text, timestamp } from '@keystone-6/core/fields'
 import { document } from '@keystone-6/fields-document'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from '../../generated/keystone/types'
 
 export const lists = {
   User: list({

--- a/examples/framework-nextjs-app-directory/src/keystone/seed.ts
+++ b/examples/framework-nextjs-app-directory/src/keystone/seed.ts
@@ -1,4 +1,4 @@
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 export async function seedDemoData(context: Context) {
   if ((await context.db.User.count()) > 0) return

--- a/examples/framework-nextjs-pages-directory/keystone.ts
+++ b/examples/framework-nextjs-pages-directory/keystone.ts
@@ -1,7 +1,7 @@
 import { config } from '@keystone-6/core'
 import { lists } from './src/keystone/schema'
 import { seedDemoData } from './src/keystone/seed'
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 export default config({
   db: {

--- a/examples/framework-nextjs-pages-directory/src/keystone/context.ts
+++ b/examples/framework-nextjs-pages-directory/src/keystone/context.ts
@@ -1,6 +1,6 @@
 import { getContext } from '@keystone-6/core/context'
 import config from '../../keystone'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 import * as PrismaModule from 'myprisma'
 
 // Making sure multiple prisma clients are not created during hot reloading

--- a/examples/framework-nextjs-pages-directory/src/keystone/schema.ts
+++ b/examples/framework-nextjs-pages-directory/src/keystone/schema.ts
@@ -1,7 +1,7 @@
 import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, timestamp } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from '../../generated/keystone/types'
 
 export const lists = {
   User: list({

--- a/examples/framework-nextjs-pages-directory/src/keystone/seed.ts
+++ b/examples/framework-nextjs-pages-directory/src/keystone/seed.ts
@@ -1,4 +1,4 @@
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 export async function seedDemoData(context: Context) {
   if ((await context.db.User.count()) > 0) return

--- a/examples/framework-nextjs-two-servers/keystone-server/keystone.ts
+++ b/examples/framework-nextjs-two-servers/keystone-server/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import type { KeystoneConfigPre } from '@keystone-6/core/types'
 import { seedDatabase } from './src/seed'
 import { lists } from './src/schema'
-import type { Context, TypeInfo } from '.keystone/types'
+import type { Context, TypeInfo } from './generated/keystone/types'
 
 const db: KeystoneConfigPre<TypeInfo>['db'] = {
   provider: 'sqlite',

--- a/examples/framework-nextjs-two-servers/keystone-server/src/schema.ts
+++ b/examples/framework-nextjs-two-servers/keystone-server/src/schema.ts
@@ -3,7 +3,7 @@ import { allowAll } from '@keystone-6/core/access'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
 import { document } from '@keystone-6/fields-document'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from '../generated/keystone/types'
 
 export const lists = {
   User: list({

--- a/examples/framework-nextjs-two-servers/keystone-server/src/seed/index.ts
+++ b/examples/framework-nextjs-two-servers/keystone-server/src/seed/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 const seedUsers = async (context: Context) => {
   const { db } = context.sudo()

--- a/examples/framework-remix/app/utils/keystone.server.ts
+++ b/examples/framework-remix/app/utils/keystone.server.ts
@@ -1,7 +1,7 @@
 import { getContext } from '@keystone-6/core/context'
 import config from '../../keystone'
 import * as PrismaModule from 'myprisma'
-import type { Context } from '.keystone/types'
+import type { Context } from '../../generated/keystone/types'
 
 // Making sure multiple prisma clients are not created during hot reloading
 export const keystoneContext: Context =

--- a/examples/framework-remix/keystone.ts
+++ b/examples/framework-remix/keystone.ts
@@ -1,7 +1,7 @@
 import { list, config } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/graphql-codegen/schema.ts
+++ b/examples/graphql-codegen/schema.ts
@@ -4,7 +4,7 @@ import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 import { graphql } from './gql'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/graphql-gql.tada/schema.ts
+++ b/examples/graphql-gql.tada/schema.ts
@@ -2,7 +2,7 @@ import { list, gWithContext } from '@keystone-6/core'
 import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 import { graphql } from './tada'
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const LatestPostQuery = graphql(`
   query LastestPostQuery($id: ID!) {

--- a/examples/graphql-ts-gql/schema.ts
+++ b/examples/graphql-ts-gql/schema.ts
@@ -4,7 +4,7 @@ import { relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 import { gql } from '@ts-gql/tag/no-transform'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const LatestPostQuery = gql`
   query LastestPostQuery($id: ID!) {

--- a/examples/hooks/keystone.ts
+++ b/examples/hooks/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/hooks/schema.ts
+++ b/examples/hooks/schema.ts
@@ -2,7 +2,7 @@ import { list, group } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/limits/keystone.ts
+++ b/examples/limits/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/limits/schema.ts
+++ b/examples/limits/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/logging-opentelemetry/keystone.ts
+++ b/examples/logging-opentelemetry/keystone.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { config } from '@keystone-6/core'
 
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 import { lists } from './schema'
 import { init as initOtel, tracer } from './otel'
 

--- a/examples/logging-opentelemetry/schema.ts
+++ b/examples/logging-opentelemetry/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/logging/keystone.ts
+++ b/examples/logging/keystone.ts
@@ -2,7 +2,7 @@ import { config } from '@keystone-6/core'
 import { createHash } from 'node:crypto'
 import pino_ from 'pino-http'
 
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 import { lists } from './schema'
 
 function sha256(q: string) {

--- a/examples/logging/schema.ts
+++ b/examples/logging/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/number-fields/schema.ts
+++ b/examples/number-fields/schema.ts
@@ -1,7 +1,7 @@
 import { list, gWithContext } from '@keystone-6/core'
 import { bigInt, float, integer, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/omit/keystone.ts
+++ b/examples/omit/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { Context } from '.keystone/types'
+import type { Context } from './generated/keystone/types'
 
 export default config({
   db: {

--- a/examples/omit/schema.ts
+++ b/examples/omit/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, relationship } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Person: list({

--- a/examples/relationships/keystone.ts
+++ b/examples/relationships/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/relationships/schema.ts
+++ b/examples/relationships/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { checkbox, text, relationship } from '@keystone-6/core/fields'
 import { structure } from '@keystone-6/fields-document'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 import { schema as recommendationsStructureSchema } from './structure-relationships'
 import { schema as bundlesStructureSchema } from './structure-relationships-2'

--- a/examples/reuse/schema.ts
+++ b/examples/reuse/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import type { BaseListTypeInfo } from '@keystone-6/core/types'
 
 const systemField = {

--- a/examples/script/keystone.ts
+++ b/examples/script/keystone.ts
@@ -1,7 +1,7 @@
 import { config, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, timestamp } from '@keystone-6/core/fields'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/singleton/keystone.ts
+++ b/examples/singleton/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/singleton/schema.ts
+++ b/examples/singleton/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { relationship, text, timestamp } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Settings: list({

--- a/examples/structure-field/schema.ts
+++ b/examples/structure-field/schema.ts
@@ -3,7 +3,7 @@ import { text } from '@keystone-6/core/fields'
 import { structure } from '@keystone-6/fields-document'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import { schema } from './featured-posts'
 
 export const lists = {

--- a/examples/testing/keystone.ts
+++ b/examples/testing/keystone.ts
@@ -3,7 +3,7 @@ import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { lists } from './schema'
 import type { Session } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for TESTING purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/testing/schema.ts
+++ b/examples/testing/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { checkbox, password, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 // needs to be compatible with withAuth
 export type Session = {

--- a/examples/transactions/schema.ts
+++ b/examples/transactions/schema.ts
@@ -1,7 +1,7 @@
 import { gWithContext, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, integer, relationship, timestamp, virtual } from '@keystone-6/core/fields'
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/usecase-blog-moderated/keystone.ts
+++ b/examples/usecase-blog-moderated/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from '.keystone/types'
+import type { Context, TypeInfo } from './generated/keystone/types'
 
 const sillySessionStrategy = {
   async get({ context }: { context: Context }): Promise<Session | undefined> {

--- a/examples/usecase-blog-moderated/schema.ts
+++ b/examples/usecase-blog-moderated/schema.ts
@@ -1,4 +1,4 @@
-import type { Context, Lists } from '.keystone/types'
+import type { Context, Lists } from './generated/keystone/types'
 import { action, gWithContext, list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp, virtual } from '@keystone-6/core/fields'

--- a/examples/usecase-blog/keystone.ts
+++ b/examples/usecase-blog/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/usecase-blog/schema.ts
+++ b/examples/usecase-blog/schema.ts
@@ -10,8 +10,8 @@ import { document } from '@keystone-6/fields-document'
 // if you want to make your own fields, see https://keystonejs.com/docs/guides/custom-fields
 
 // when using Typescript, you can refine your types to a stricter subset by importing
-// the generated types from '.keystone/types'
-import type { Lists } from '.keystone/types'
+// the generated types from './generated/keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Author: list({

--- a/examples/usecase-relationship-union/keystone.ts
+++ b/examples/usecase-relationship-union/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/usecase-relationship-union/schema.ts
+++ b/examples/usecase-relationship-union/schema.ts
@@ -1,7 +1,7 @@
 import { list, group, gWithContext } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, relationship, virtual, select } from '@keystone-6/core/fields'
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const hiddenIfWrongKind = (kind: 'post' | 'link') =>
   ({

--- a/examples/usecase-roles/schema.ts
+++ b/examples/usecase-roles/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allOperations, denyAll } from '@keystone-6/core/access'
 import { checkbox, password, relationship, text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 import type { Session } from './access'
 import { isSignedIn as hasSession, permissions, rules } from './access'
 

--- a/examples/usecase-todo/keystone.ts
+++ b/examples/usecase-todo/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/usecase-todo/schema.ts
+++ b/examples/usecase-todo/schema.ts
@@ -2,7 +2,7 @@ import { list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Task: list({

--- a/examples/usecase-versioning/keystone.ts
+++ b/examples/usecase-versioning/keystone.ts
@@ -1,6 +1,6 @@
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
-import type { TypeInfo } from '.keystone/types'
+import type { TypeInfo } from './generated/keystone/types'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/usecase-versioning/schema.ts
+++ b/examples/usecase-versioning/schema.ts
@@ -2,7 +2,7 @@ import { action, g, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { integer, text } from '@keystone-6/core/fields'
 
-import type { Lists } from '.keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   Post: list({

--- a/examples/virtual-field-banner/schema.ts
+++ b/examples/virtual-field-banner/schema.ts
@@ -2,7 +2,7 @@ import { list, gWithContext } from '@keystone-6/core'
 import { text, checkbox, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/examples/virtual-field/schema.ts
+++ b/examples/virtual-field/schema.ts
@@ -2,7 +2,7 @@ import { list, gWithContext } from '@keystone-6/core'
 import { text, checkbox, virtual } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from './generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>

--- a/packages/core/src/lib/system.ts
+++ b/packages/core/src/lib/system.ts
@@ -26,7 +26,7 @@ function getSystemPaths(cwd: string, config: KeystoneConfig) {
 
   const builtTypesPath = config.types?.path
     ? path.join(cwd, config.types.path) // TODO: enforce initConfig before getSystemPaths
-    : path.join(cwd, 'node_modules/.keystone/types.ts')
+    : path.join(cwd, 'generated/keystone/types.ts')
 
   const builtPrismaPath = config.db?.prismaSchemaPath
     ? path.join(cwd, config.db.prismaSchemaPath) // TODO: enforce initConfig before getSystemPaths

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -117,7 +117,7 @@ export function config<TypeInfo extends BaseKeystoneTypeInfo>(
   return {
     types: {
       ...config.types,
-      path: config.types?.path ?? 'node_modules/.keystone/types.ts',
+      path: config.types?.path ?? 'generated/keystone/types.ts',
     },
     db: {
       ...config.db,

--- a/packages/create/starter/_gitignore
+++ b/packages/create/starter/_gitignore
@@ -1,4 +1,5 @@
 node_modules
 .keystone/
+generated/
 keystone.db
 *.log

--- a/packages/create/starter/schema.ts
+++ b/packages/create/starter/schema.ts
@@ -17,8 +17,8 @@ import { document } from '@keystone-6/fields-document'
 // if you want to make your own fields, see https://keystonejs.com/docs/guides/custom-fields
 
 // when using Typescript, you can refine your types to a stricter subset by importing
-// the generated types from '.keystone/types'
-import type { Lists } from '.keystone/types'
+// the generated types from './generated/keystone/types'
+import type { Lists } from './generated/keystone/types'
 
 export const lists = {
   User: list({

--- a/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
+++ b/tests/cli-tests/__snapshots__/artifacts.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`postinstall > writes the correct node_modules files 1`] = `
-⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ node_modules/.keystone/types.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
+exports[`postinstall > writes the correct generated files 1`] = `
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ generated/keystone/types.ts ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
 /* eslint-disable */
 
 export type TodoWhereUniqueInput = {

--- a/tests/cli-tests/artifacts.test.ts
+++ b/tests/cli-tests/artifacts.test.ts
@@ -57,7 +57,7 @@ describe('postinstall', () => {
     expect(recording()).toMatchInlineSnapshot(`"? GraphQL and Prisma schemas are up to date"`)
   })
 
-  test('writes the correct node_modules files', async () => {
+  test('writes the correct generated files', async () => {
     const cwd = await testdir({
       ...symlinkKeystoneDeps,
       ...schemas,
@@ -67,7 +67,7 @@ describe('postinstall', () => {
     const recording = recordConsole()
     await cliMock(cwd, 'postinstall')
 
-    expect(await getFiles(cwd, ['node_modules/.keystone/**/*'])).toMatchSnapshot()
+    expect(await getFiles(cwd, ['generated/keystone/**/*'])).toMatchSnapshot()
     expect(recording()).toMatchInlineSnapshot(`"? GraphQL and Prisma schemas are up to date"`)
   })
 })

--- a/tests/sandbox/configs/all-the-things.ts
+++ b/tests/sandbox/configs/all-the-things.ts
@@ -23,7 +23,7 @@ import { schema as structureSchema } from '../structure'
 import { schema as structureNestedSchema } from '../structure-nested'
 import { schema as structureRelationshipsSchema } from '../structure-relationships'
 import { trackingFields } from '../utils'
-//  import { type Lists } from '.keystone/types' // TODO
+//  import { type Lists } from '../generated/keystone/types' // TODO
 
 const description =
   'Some thing to describe to test the length of the text for width, blah blah blah blah blah blah blah blah blah'

--- a/tests/test-projects/live-reloading/schemas/second.ts
+++ b/tests/test-projects/live-reloading/schemas/second.ts
@@ -2,7 +2,7 @@ import { gWithContext, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, virtual } from '@keystone-6/core/fields'
 
-import type { Lists, Context } from '.keystone/types'
+import type { Lists, Context } from '../generated/keystone/types'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>


### PR DESCRIPTION
This aligns with the new location of the Prisma client at `generated/prisma`. It can still be customised to go into `node_modules/.keystone/types.ts` or wherever else if you'd like to.

Note this doesn't change the location of the `.keystone` directory outside of `node_modules` where the esbuild outputs and Next app are.