### PR TITLE
Add `listDefaults`

### DIFF
--- a/.changeset/add-list-defaults.md
+++ b/.changeset/add-list-defaults.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": minor
+---
+
+Adds `listDefaults` configuration for `graphql.omit` and `graphql.maxTake`

--- a/docs/content/docs/config/config.md
+++ b/docs/content/docs/config/config.md
@@ -16,6 +16,7 @@ The `config` function accepts an object representing all the configurable parts 
 ```typescript
 export default config({
   lists: { /* ... */ },
+  listDefaults: { /* ... */ },
   db: { /* ... */ },
   ui: { /* ... */ },
   server: { /* ... */ },
@@ -53,6 +54,39 @@ export default config<TypeInfo>({
   /* ... */
 });
 ```
+
+## listDefaults
+
+The `listDefaults` config option provides defaults for every list. It supports
+`graphql.omit` and `graphql.maxTake`:
+
+```typescript
+export default config<TypeInfo>({
+  listDefaults: {
+    graphql: {
+      omit: { delete: true },
+      maxTake: 100,
+    },
+  },
+  lists: {
+    Post: list({
+      fields: { /* ... */ },
+    }),
+    AuditLog: list({
+      fields: { /* ... */ },
+      graphql: {
+        omit: false,
+        maxTake: Infinity,
+      },
+    }),
+  },
+  /* ... */
+});
+```
+
+Per-list configuration takes precedence. Boolean `omit` values replace the default
+entirely, while object values inherit operations that are not specified. An undefined
+`maxTake` inherits the default; set it to `Infinity` to make a list unlimited.
 
 ## db
 

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -601,7 +601,7 @@ function getListsWithInitialisedFields(
     })
 
     let take: any = g.arg({ type: g.Int })
-    if (listConfig.graphql?.maxTake !== undefined) {
+    if (listConfig.graphql?.maxTake !== undefined && listConfig.graphql.maxTake !== Infinity) {
       take = g.arg({
         type: g.nonNull(g.Int),
         // WARNING: used by queries/resolvers.ts to enforce the limit

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -13,10 +13,39 @@ import type {
   KeystoneConfigPre,
   KeystoneContext,
   ListConfig,
+  ListGraphQLConfig,
   MaybeItemFunctionWithFilter,
   MaybeSessionFunction,
   MaybeSessionFunctionWithFilter,
 } from './types'
+
+type ListGraphQLOmit = NonNullable<ListGraphQLConfig<BaseListTypeInfo>['omit']>
+
+function normalizeListOmit(omit: ListGraphQLOmit): Exclude<ListGraphQLOmit, boolean> {
+  if (typeof omit !== 'boolean') return omit
+  return {
+    query: omit,
+    create: omit,
+    update: omit,
+    delete: omit,
+  }
+}
+
+function resolveListOmit(
+  listOmit: ListGraphQLOmit | undefined,
+  defaultOmit: ListGraphQLOmit | undefined
+): ListGraphQLOmit | undefined {
+  if (listOmit === undefined) return defaultOmit
+  if (typeof listOmit === 'boolean' || defaultOmit === undefined) return listOmit
+
+  const normalizedDefault = normalizeListOmit(defaultOmit)
+  return {
+    query: listOmit.query ?? normalizedDefault.query,
+    create: listOmit.create ?? normalizedDefault.create,
+    update: listOmit.update ?? normalizedDefault.update,
+    delete: listOmit.delete ?? normalizedDefault.delete,
+  }
+}
 
 function listsWithDefaults(config: KeystoneConfigPre, defaultIdField: IdFieldConfig) {
   // some error checking
@@ -66,6 +95,8 @@ function listsWithDefaults(config: KeystoneConfigPre, defaultIdField: IdFieldCon
             },
             graphql: {
               ...list.graphql,
+              omit: resolveListOmit(list.graphql?.omit, config.listDefaults?.graphql?.omit),
+              maxTake: list.graphql?.maxTake ?? config.listDefaults?.graphql?.maxTake,
             },
             ui: {
               ...list.ui,
@@ -143,6 +174,11 @@ export function config<TypeInfo extends BaseKeystoneTypeInfo>(
       extendGraphqlSchema: config.graphql?.extendGraphqlSchema ?? (s => s),
     },
     lists: listsWithDefaults(config, defaultIdField),
+    listDefaults: {
+      graphql: {
+        ...config.listDefaults?.graphql,
+      },
+    },
     server: {
       ...config.server,
       maxFileSize: config.server?.maxFileSize ?? 200 * 1024 * 1024, // 200 MiB

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -16,6 +16,7 @@ import type { FieldHooks, ListHooks } from './hooks'
 import type {
   IdFieldConfig,
   ListConfig,
+  ListGraphQLConfig,
   MaybeItemFunctionWithFilter,
   MaybeSessionFunction,
 } from './lists'
@@ -29,6 +30,10 @@ type PrismaLogLevel = 'info' | 'query' | 'warn' | 'error'
 type PrismaLogDefinition = {
   level: PrismaLogLevel
   emit: 'stdout' | 'event'
+}
+
+export type ListDefaults = {
+  graphql?: Pick<ListGraphQLConfig<any>, 'omit' | 'maxTake'>
 }
 
 export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneTypeInfo> = {
@@ -119,6 +124,7 @@ export type KeystoneConfigPre<TypeInfo extends BaseKeystoneTypeInfo = BaseKeysto
   }
 
   lists: Record<string, ListConfig<any>>
+  listDefaults?: ListDefaults
   server?: {
     /** Configuration options for the cors middleware. Set to `true` to use Keystone's defaults */
     cors?: boolean | CorsOptions
@@ -186,6 +192,9 @@ export type KeystoneConfig<TypeInfo extends BaseKeystoneTypeInfo = BaseKeystoneT
     [listKey: string]: {
       listKey: string
     } & Required<KeystoneConfigPre<TypeInfo>['lists'][string]>
+  }
+  listDefaults: {
+    graphql: NonNullable<ListDefaults['graphql']>
   }
   server: Omit<Required<NonNullable<KeystoneConfigPre<TypeInfo>['server']>>, 'cors' | 'port'> & {
     cors: CorsOptions | null

--- a/tests/api-tests/queries/limits.test.ts
+++ b/tests/api-tests/queries/limits.test.ts
@@ -9,15 +9,17 @@ import { depthLimit, definitionLimit, fieldLimit } from './validation'
 const runner = setupTestRunner({
   serve: true,
   config: {
+    listDefaults: {
+      graphql: {
+        maxTake: 3,
+      },
+    },
     lists: {
       Post: list({
         access: allowAll,
         fields: {
           title: text(),
           author: relationship({ ref: 'User.posts', many: true }),
-        },
-        graphql: {
-          maxTake: 3,
         },
       }),
       User: list({
@@ -26,6 +28,9 @@ const runner = setupTestRunner({
           name: text(),
           favNumber: integer(),
           posts: relationship({ ref: 'Post.author', many: true }),
+        },
+        graphql: {
+          maxTake: Infinity,
         },
       }),
     },
@@ -80,6 +85,23 @@ describe('graphql.maxTake', () => {
       })
 
       expect(errors).toMatchSnapshot()
+    })
+  )
+
+  test(
+    'Infinity disables an inherited default',
+    runner(async ({ gql }) => {
+      const body = await gql({
+        query: `
+        query {
+          users(take: 5) {
+            id
+          }
+        }
+      `,
+      })
+
+      expect(body.errors).toBeUndefined()
     })
   )
 

--- a/tests2/list-defaults.test.ts
+++ b/tests2/list-defaults.test.ts
@@ -1,0 +1,131 @@
+import { config, list } from '@keystone-6/core'
+import { createSystem } from '@keystone-6/core/___internal-do-not-use-will-break-in-patch/artifacts'
+import { allowAll } from '@keystone-6/core/access'
+import { text } from '@keystone-6/core/fields'
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+function makeList(graphql?: Parameters<typeof list>[0]['graphql']) {
+  return list({
+    access: allowAll,
+    fields: {
+      name: text(),
+    },
+    graphql,
+  })
+}
+
+test('listDefaults are normalized and inherited by lists', () => {
+  const resolved = config({
+    db: {
+      provider: 'sqlite',
+      url: 'file:./test.db',
+    },
+    listDefaults: {
+      graphql: {
+        omit: {
+          query: true,
+          create: true,
+        },
+        maxTake: 10,
+      },
+    },
+    lists: {
+      Inherited: makeList(),
+      PartialOverride: makeList({
+        omit: {
+          query: false,
+          create: undefined,
+        },
+        maxTake: undefined,
+      }),
+      Replaced: makeList({
+        omit: false,
+        maxTake: Infinity,
+      }),
+    },
+  })
+
+  assert.deepEqual(resolved.listDefaults, {
+    graphql: {
+      omit: {
+        query: true,
+        create: true,
+      },
+      maxTake: 10,
+    },
+  })
+  assert.deepEqual(resolved.lists.Inherited.graphql, {
+    omit: {
+      query: true,
+      create: true,
+    },
+    maxTake: 10,
+  })
+  assert.deepEqual(resolved.lists.PartialOverride.graphql, {
+    omit: {
+      query: false,
+      create: true,
+      update: undefined,
+      delete: undefined,
+    },
+    maxTake: 10,
+  })
+  assert.deepEqual(resolved.lists.Replaced.graphql, {
+    omit: false,
+    maxTake: Infinity,
+  })
+
+  const booleanDefaults = config({
+    db: {
+      provider: 'sqlite',
+      url: 'file:./test.db',
+    },
+    listDefaults: {
+      graphql: {
+        omit: true,
+      },
+    },
+    lists: {
+      Override: makeList({
+        omit: {
+          query: false,
+        },
+      }),
+    },
+  })
+  assert.deepEqual(booleanDefaults.lists.Override.graphql.omit, {
+    query: false,
+    create: true,
+    update: true,
+    delete: true,
+  })
+
+  const system = createSystem(resolved)
+  const queryFields = system.graphql.schemas.public.getQueryType()!.getFields()
+  const inheritedQueryName = system.lists.Inherited.graphql.names.listQueryName
+  const partialQueryName = system.lists.PartialOverride.graphql.names.listQueryName
+  const replacedQueryName = system.lists.Replaced.graphql.names.listQueryName
+
+  assert.equal(queryFields[inheritedQueryName], undefined)
+  assert.equal(
+    queryFields[partialQueryName].args.find(arg => arg.name === 'take')!.defaultValue,
+    10
+  )
+  assert.equal(
+    queryFields[replacedQueryName].args.find(arg => arg.name === 'take')!.defaultValue,
+    undefined
+  )
+})
+
+test('listDefaults are present when omitted', () => {
+  const resolved = config({
+    db: {
+      provider: 'sqlite',
+      url: 'file:./test.db',
+    },
+    lists: {},
+  })
+
+  assert.deepEqual(resolved.listDefaults, { graphql: {} })
+})


### PR DESCRIPTION
This allows defaulting `graphql.omit` and `graphql.maxTake` in `listDefaults` inside `config`. Explicit values on lists will take precedence over the defaults