### PR TITLE
Swap around omit on example

### DIFF
--- a/docs/content/docs/config/config.md
+++ b/docs/content/docs/config/config.md
@@ -71,11 +71,13 @@ export default config<TypeInfo>({
   lists: {
     Post: list({
       fields: { /* ... */ },
+      graphql: {
+        omit: false,
+      },
     }),
     AuditLog: list({
       fields: { /* ... */ },
       graphql: {
-        omit: false,
         maxTake: Infinity,
       },
     }),


### PR DESCRIPTION
Making `AuditLog` the only list that can be deleted was weird