### PR TITLE
Accept filename in sqlite resetDatabase instead of url

### DIFF
--- a/docs/content/docs/guides/testing.md
+++ b/docs/content/docs/guides/testing.md
@@ -32,7 +32,8 @@ import { afterAll, beforeEach, expect, test } from 'vitest'
 import * as PrismaModule from './generated/prisma/client'
 import baseConfig from './keystone'
 
-const dbUrl = `file:./test-${process.env.VITEST_WORKER_ID}.db`
+const dbPath = `./test-${process.env.VITEST_WORKER_ID}.db`
+const dbUrl = `file:${dbPath}`
 const config = {
   ...baseConfig,
   db: {
@@ -43,7 +44,7 @@ const config = {
 
 beforeEach(async () => {
   const migrationsDirectory = path.join(__dirname, 'migrations')
-  await resetDatabase({ url: dbUrl }, migrationsDirectory)
+  await resetDatabase({ filename: dbPath }, migrationsDirectory)
 })
 
 const context = getContext(config, PrismaModule)

--- a/examples/testing/example-test.ts
+++ b/examples/testing/example-test.ts
@@ -12,7 +12,7 @@ const databaseUrl = process.env.DATABASE_URL || 'file:./keystone-example.db'
 const context = getContext(config, PrismaModule)
 
 beforeEach(async () => {
-  await resetDatabase({ url: databaseUrl }, migrationsDirectory)
+  await resetDatabase({ filename: databaseUrl.replace('file:./', '') }, migrationsDirectory)
 })
 afterEach(async () => context.prisma.$disconnect())
 

--- a/packages/core/src/testing/sqlite.ts
+++ b/packages/core/src/testing/sqlite.ts
@@ -5,15 +5,10 @@ import Database, { type Options } from 'better-sqlite3'
 
 import { applyMigrations } from './migrations'
 
-export type SqliteDatabaseConfig = Options & {
-  url: ':memory:' | (string & {})
-}
-
 export async function resetDatabase(
-  { url, ...options }: SqliteDatabaseConfig,
+  { filename, ...options }: Options & { filename: string },
   migrationsDirectory: string
 ) {
-  const filename = url.replace(/^file:/, '')
   if (filename !== ':memory:') {
     await fs.mkdir(path.dirname(path.resolve(filename)), { recursive: true })
     await Promise.all(

--- a/tests2/prisma-migrations.test.ts
+++ b/tests2/prisma-migrations.test.ts
@@ -35,9 +35,8 @@ async function createTestDatabase(cwd: string): Promise<TestDatabase> {
 
   if (dbProvider === 'sqlite') {
     const filename = path.join(cwd, `${identifier}.db`)
-    const config = { url: `file:${filename}` }
     return {
-      reset: migrationsDirectory => resetSqliteDatabase(config, migrationsDirectory),
+      reset: migrationsDirectory => resetSqliteDatabase({ filename }, migrationsDirectory),
       async execute(sql) {
         new Database(filename).exec(sql).close()
       },


### PR DESCRIPTION
Stripping out `file:` ourselves here is just confusing since `better-sqlite3` just accepts a path