### PR TITLE
Type exports from fields-ui-empty

### DIFF
--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui-empty.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui-empty.tsx
@@ -1,14 +1,16 @@
-function throwAlways(): never {
+import type * as ui from './fields-ui'
+
+function throwAlways(..._args: any[]): never {
   throw new Error(
     'React components from @keystone-6/fields-document/component-blocks cannot be rendered on the server'
   )
 }
 
-export const TextField = throwAlways,
-  TextArea = throwAlways,
-  Checkbox = throwAlways,
-  Text = throwAlways,
-  makeIntegerFieldInput = () => throwAlways,
-  makeSelectFieldInput = () => throwAlways,
-  makeUrlFieldInput = () => throwAlways,
-  makeMultiselectFieldInput = () => throwAlways
+export const TextField = throwAlways as unknown as typeof ui.TextField,
+  TextArea = throwAlways as unknown as typeof ui.TextArea,
+  Checkbox = throwAlways as unknown as typeof ui.Checkbox,
+  Text = throwAlways as unknown as typeof ui.Text,
+  makeIntegerFieldInput = () => throwAlways as unknown as typeof ui.makeIntegerFieldInput,
+  makeSelectFieldInput = () => throwAlways as unknown as typeof ui.makeSelectFieldInput,
+  makeUrlFieldInput = () => throwAlways as unknown as typeof ui.makeUrlFieldInput,
+  makeMultiselectFieldInput = () => throwAlways as unknown as typeof ui.makeMultiselectFieldInput


### PR DESCRIPTION
This is for #9929, since in that PR we're using `"moduleResolution": "nodenext"`, TypeScript uses the `node` condition when evaluating `exports`/`imports` fields so TypeScript treats imports to `#fields-ui` as importing `fields-ui-empty.tsx` instead of `fields-ui.tsx` so this PR types `fields-ui-empty.tsx` properly based on `fields-ui.tsx`.