### PR TITLE
Fix fields-ui-empty

### DIFF
--- a/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui-empty.tsx
+++ b/packages/fields-document/src/DocumentEditor/component-blocks/fields-ui-empty.tsx
@@ -10,7 +10,7 @@ export const TextField = throwAlways as unknown as typeof ui.TextField,
   TextArea = throwAlways as unknown as typeof ui.TextArea,
   Checkbox = throwAlways as unknown as typeof ui.Checkbox,
   Text = throwAlways as unknown as typeof ui.Text,
-  makeIntegerFieldInput = () => throwAlways as unknown as typeof ui.makeIntegerFieldInput,
-  makeSelectFieldInput = () => throwAlways as unknown as typeof ui.makeSelectFieldInput,
-  makeUrlFieldInput = () => throwAlways as unknown as typeof ui.makeUrlFieldInput,
-  makeMultiselectFieldInput = () => throwAlways as unknown as typeof ui.makeMultiselectFieldInput
+  makeIntegerFieldInput = (() => throwAlways) as unknown as typeof ui.makeIntegerFieldInput,
+  makeSelectFieldInput = (() => throwAlways) as unknown as typeof ui.makeSelectFieldInput,
+  makeUrlFieldInput = (() => throwAlways) as unknown as typeof ui.makeUrlFieldInput,
+  makeMultiselectFieldInput = (() => throwAlways) as unknown as typeof ui.makeMultiselectFieldInput


### PR DESCRIPTION
Fix for #9938 which casted the wrong thing in a few cases. Again this is for https://github.com/keystonejs/keystone/pull/9929