### PR TITLE
Remove auto dependency installing in create-keystone-app

### DIFF
--- a/.changeset/lazy-tools-rest.md
+++ b/.changeset/lazy-tools-rest.md
@@ -1,0 +1,5 @@
+---
+"create-keystone-app": major
+---
+
+Removes auto-install, use your preferred package manager to install dependencies instead

--- a/docs/content/docs/getting-started.md
+++ b/docs/content/docs/getting-started.md
@@ -6,13 +6,14 @@ description: 'Learn how to get your first Keystone project up and running using 
 ![A terminal with the output of create-keystone-app](/assets/getting-started/cover.svg)
 
 [`create-keystone-app`](https://github.com/keystonejs/create-keystone-app) is a CLI app that makes it easier for you to initiate a Keystone project.
-It generates some files for you and installs all the dependencies you need to run the Admin UI and start using the [GraphQL API](/docs/graphql/overview).
+It generates the files you need to run the Admin UI and start using the [GraphQL API](/docs/graphql/overview).
 
 ## Quick Start
 
 ```sh
 npm create keystone-app@latest
 cd my-app
+npm install
 npm run dev
 ```
 
@@ -45,10 +46,11 @@ You can switch to another database such as PostgreSQL once your project is creat
 
 ## Opening your shiny new Admin UI
 
-You can now `cd` into the folder that was created for you and start Keystone:
+You can now `cd` into the folder that was created for you, install dependencies, and start Keystone:
 
 ```sh
 cd my-app
+npm install
 npm run dev
 ```
 

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -22,9 +22,7 @@
   },
   "dependencies": {
     "enquirer": "^2.4.1",
-    "execa": "^5.1.1",
     "meow": "^9.0.0",
-    "ora": "^9.0.0",
     "package-json": "^10.0.0"
   },
   "files": [

--- a/packages/create/src/index.ts
+++ b/packages/create/src/index.ts
@@ -4,10 +4,8 @@ import { fileURLToPath } from 'node:url'
 import { styleText } from 'node:util'
 
 import enquirer from 'enquirer'
-import execa from 'execa'
 import getPackageJson from 'package-json'
 import meow from 'meow'
-import ora from 'ora'
 
 import thisPackage from '../package.json'
 
@@ -77,24 +75,14 @@ async function normalizeArgs() {
   )
 
   const [packageManager] = process.env.npm_config_user_agent?.split('/', 1) ?? ['npm']
-  const spinner = ora(
-    `Installing dependencies with ${packageManager}. This may take a few minutes.`
-  ).start()
-  try {
-    await execa(packageManager, ['install'], { cwd: nextCwd })
-    spinner.succeed(`Installed dependencies with ${packageManager}.`)
-  } catch (err) {
-    spinner.fail(`Failed to install with ${packageManager}.`)
-    throw err
-  }
-
   const relativeProjectDir = path.relative(process.cwd(), normalizedArgs.directory)
   process.stdout.write('\n')
   console.log(`🎉  Keystone created a starter project in: ${styleText('bold', relativeProjectDir)}
 
-  ${styleText('bold', 'To launch your app, run:')}
+  ${styleText('bold', 'To install dependencies and launch your app, run:')}
 
   - cd ${relativeProjectDir}
+  - ${packageManager} install
   - ${packageManager} run dev
 
   ${styleText('bold', 'Next steps:')}

--- a/packages/create/starter/README.md
+++ b/packages/create/starter/README.md
@@ -2,9 +2,10 @@
 
 Welcome to Keystone!
 
-Run
+Install dependencies and start Keystone:
 
 ```
+npm install
 npm run dev
 ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2926,15 +2926,9 @@ importers:
       enquirer:
         specifier: ^2.4.1
         version: 2.4.1
-      execa:
-        specifier: ^5.1.1
-        version: 5.1.1
       meow:
         specifier: ^9.0.0
         version: 9.0.0
-      ora:
-        specifier: ^9.0.0
-        version: 9.4.0
       package-json:
         specifier: ^10.0.0
         version: 10.0.1


### PR DESCRIPTION
This removes the auto dependency installing in create-keystone-app because the UX is quite frustrating to just see a spinner, we could pass through stdio but I think people just installing dependencies with whatever package manager they want themselves is a better approach