### PR TITLE
Add graphql as a peer dependency

### DIFF
--- a/.changeset/free-deserts-remain.md
+++ b/.changeset/free-deserts-remain.md
@@ -1,0 +1,7 @@
+---
+'@keystone-6/fields-document': major
+'@keystone-6/auth': major
+'@keystone-6/core': major
+---
+
+Updates to `graphql@^16.14.2`, `graphql` is now also a peer dependency in addition to a normal dependency so if you have a dependency on `graphql` yourself, you must have a compatible version installed

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,6 +22,7 @@
   },
   "peerDependencies": {
     "@keystone-6/core": "^7.0.0",
+    "graphql": "catalog:",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@keystar/ui": "catalog:"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,6 +97,7 @@
   "peerDependencies": {
     "@prisma/client": "^7.9.0",
     "better-sqlite3": "^12.6.0",
+    "graphql": "catalog:",
     "mariadb": "^3.4.5",
     "pg": "^8.16.3",
     "prisma": "^7.9.0",

--- a/packages/fields-document/package.json
+++ b/packages/fields-document/package.json
@@ -84,6 +84,7 @@
   },
   "peerDependencies": {
     "@keystone-6/core": "^7.0.0",
+    "graphql": "catalog:",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@keystar/ui": "catalog:",


### PR DESCRIPTION
Similar to #9888/#9943 but for `graphql` since it's another package where if you have a different version of `graphql` installed, you'll get errors