### PR TITLE
Use Node ESM + Node type stripping in examples/script

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -23,6 +23,12 @@
       "rules": {
         "esm-imports/node-esm-imports": "off"
       }
+    },
+    {
+      "files": ["examples/script/**/*"],
+      "rules": {
+        "esm-imports/node-esm-imports": "error"
+      }
     }
   ],
   "ignorePatterns": ["tests/test-projects/live-reloading/schemas/syntax-error.js"]

--- a/docs/content/docs/context/get-context.md
+++ b/docs/content/docs/context/get-context.md
@@ -14,8 +14,8 @@ Using the `getContext` function does not use the typical Keystone entry point - 
 
 ```typescript
 import { getContext } from '@keystone-6/core/context'
-import config from './keystone'
-import * as PrismaModule from './generated/prisma/client'
+import config from './keystone.ts'
+import * as PrismaModule from './generated/prisma/client.ts'
 
 const context = getContext(config, PrismaModule)
 
@@ -23,7 +23,7 @@ const context = getContext(config, PrismaModule)
 ```
 
 {% hint kind="tip" %}
-For inspiration, see [the script example project](https://github.com/keystonejs/keystone/tree/main/examples/script), and how we use [`tsx`](https://github.com/esbuild-kit/tsx) to seed the database with some data.
+For inspiration, see [the script example project](https://github.com/keystonejs/keystone/tree/main/examples/script), which uses Node.js's built-in TypeScript support to seed the database with some data. Running the example requires Node.js 22.18 or newer and `"allowImportingTsExtensions": true` in your `tsconfig.json. You can also use tools like [tsx](https://github.com/esbuild-kit/tsx) if you don't want to use imports with extensions that Node's built-in TypeScript support requires or you want to use syntax that Node's built-in TypeScript support doesn't support.
 {% /hint %}
 
 A context created in this way does not have an implicit `session`, nor is it a `sudo()` context.

--- a/examples/script/README.md
+++ b/examples/script/README.md
@@ -4,6 +4,8 @@ This project demonstrates how to write code to interact with Keystone without us
 
 The `getContext` function does not adhere to the typical Keystone entry-point and requires that your Prisma schema has been previously built by Keystone.
 
+This example requires Node.js 22.18 or newer because it uses Node.js's built-in TypeScript support.
+
 ## Instructions
 
 To run this project, clone the Keystone repository locally, run `pnpm install` at the root of this repository, then navigate to this directory and run:
@@ -16,5 +18,13 @@ This will start the Admin UI at [localhost:3000](http://localhost:3000).
 You can use the Admin UI to create items in your database.
 
 You can also access a GraphQL Playground at [localhost:3000/api/graphql](http://localhost:3000/api/graphql), which allows you to directly run GraphQL queries and mutations.
+
+Once the generated Prisma client and Keystone types exist, run the standalone script in another terminal:
+
+```shell
+pnpm go
+```
+
+You can generate those artifacts without starting the development server by running `pnpm keystone postinstall` first.
 
 Congratulations, you're now up and running with Keystone! 🚀

--- a/examples/script/keystone.ts
+++ b/examples/script/keystone.ts
@@ -2,7 +2,7 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config, list } from '@keystone-6/core'
 import { allowAll } from '@keystone-6/core/access'
 import { text, timestamp } from '@keystone-6/core/fields'
-import type { TypeInfo } from './generated/keystone/types'
+import type { TypeInfo } from './generated/keystone/types.ts'
 
 export default config<TypeInfo>({
   db: {

--- a/examples/script/package.json
+++ b/examples/script/package.json
@@ -2,13 +2,14 @@
   "name": "@keystone-6/example-script",
   "version": null,
   "private": true,
+  "type": "module",
   "license": "MIT",
   "scripts": {
     "dev": "keystone dev",
     "start": "keystone start",
     "build": "keystone build",
     "check": "keystone postinstall",
-    "go": "tsx script.ts"
+    "go": "node script.ts"
   },
   "dependencies": {
     "@keystone-6/core": "workspace:^",
@@ -21,7 +22,6 @@
   },
   "devDependencies": {
     "prisma": "catalog:",
-    "tsx": "^4.0.0",
     "typescript": "catalog:"
   }
 }

--- a/examples/script/script.ts
+++ b/examples/script/script.ts
@@ -1,7 +1,7 @@
 import { getContext } from '@keystone-6/core/context'
-import config from './keystone'
+import config from './keystone.ts'
 
-import * as PrismaModule from './generated/prisma/client'
+import * as PrismaModule from './generated/prisma/client.ts'
 
 async function main() {
   const context = getContext(config, PrismaModule)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2266,9 +2266,6 @@ importers:
       prisma:
         specifier: 'catalog:'
         version: 7.9.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.11.1)(magicast@0.3.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      tsx:
-        specifier: ^4.0.0
-        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3


### PR DESCRIPTION
This replaces `tsx` in `examples/script` with `node` with the built-in type stripping. I'll merge this after a release goes out with #9976.