### PR TITLE
Add explicit `files` to `package.json`s and remove declaration maps

### DIFF
--- a/.changeset/orange-coins-strive.md
+++ b/.changeset/orange-coins-strive.md
@@ -1,0 +1,10 @@
+---
+'@keystone-6/document-renderer': patch
+'@keystone-6/cloudinary': patch
+'@keystone-6/auth': patch
+'@keystone-6/core': patch
+'create-keystone-app': patch
+'@keystone-6/fields-document': patch
+---
+
+Removes declaration maps and `src` from published package

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,6 +9,9 @@
     "./components/Navigation": "./dist/keystone-6-auth-components-Navigation.js",
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.24.7",
     "@keystar/ui": "catalog:",

--- a/packages/cloudinary/package.json
+++ b/packages/cloudinary/package.json
@@ -8,6 +8,9 @@
     "./views": "./dist/keystone-6-cloudinary-views.js",
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist"
+  ],
   "dependencies": {
     "@babel/runtime": "^7.24.7",
     "@keystar/ui": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,6 +57,11 @@
   "bin": {
     "keystone": "bin/cli.js"
   },
+  "files": [
+    "bin",
+    "dist",
+    "static"
+  ],
   "dependencies": {
     "@apollo/cache-control-types": "^1.0.3",
     "@apollo/client": "^4.1.6",

--- a/packages/document-renderer/package.json
+++ b/packages/document-renderer/package.json
@@ -8,6 +8,9 @@
     ".": "./dist/keystone-6-document-renderer.js",
     "./package.json": "./package.json"
   },
+  "files": [
+    "dist"
+  ],
   "peerDependencies": {
     "react": "^16.14.0 || 17 || 18 || 19"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
This is part to reduce the size of the packages and part because for some reason `pkg.pr.new` seems to be using the `.gitignore` to exclude files from the published packages so the `dist` is excluded (even though my understanding is that it just uses `pnpm pack`)