### PR TITLE
Update auth package to allow persisted queries

### DIFF
--- a/.changeset/gold-keys-tell.md
+++ b/.changeset/gold-keys-tell.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Adds `persistedQueries` function to return of `createAuth` and calls GraphQL API with persisted query extension in sign in mutation

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type {
   AdminFileToWrite,
   BaseListTypeInfo,
@@ -6,9 +7,11 @@ import type {
   BaseKeystoneTypeInfo,
   KeystoneConfig,
 } from '@keystone-6/core/types'
+import { print } from 'graphql'
 import type { AuthConfig, AuthGqlNames } from './types.ts'
 
 import { getSchemaExtension } from './schema.ts'
+import { getSigninPageQuery } from './signin-query.ts'
 import configTemplate from './templates/config.ts'
 import signinTemplate from './templates/signin.ts'
 
@@ -42,6 +45,31 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   identityField,
   sessionData = 'id',
 }: AuthConfig<ListTypeInfo>) {
+  function getSigninQuery(authGqlNames: AuthGqlNames) {
+    const query = print(
+      getSigninPageQuery({
+        authGqlNames,
+        identityField,
+        secretField,
+      })
+    )
+
+    return {
+      query,
+      hash: createHash('sha256').update(query).digest('hex'),
+    }
+  }
+
+  function persistedQueries(
+    listConfig: { graphql?: { singular?: string } } = {}
+  ): Record<string, string> {
+    const { query, hash } = getSigninQuery(getAuthGqlNames(listConfig.graphql?.singular ?? listKey))
+
+    return {
+      [hash]: query,
+    }
+  }
+
   /**
    * getAdditionalFiles
    *
@@ -64,10 +92,19 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
             : 'id')
 
     const authGqlNames = getAuthGqlNames(listConfig.graphql?.singular ?? listKey)
+    const persistedQueryHash =
+      config.graphql?.apolloConfig?.persistedQueries === false
+        ? undefined
+        : getSigninQuery(authGqlNames).hash
     const filesToWrite: AdminFileToWrite[] = [
       {
         mode: 'write',
-        src: signinTemplate({ authGqlNames, identityField, secretField }),
+        src: signinTemplate({
+          authGqlNames,
+          identityField,
+          secretField,
+          persistedQueryHash,
+        }),
         outputPath: 'pages/signin.js',
       },
       {
@@ -236,6 +273,7 @@ export function createAuth<ListTypeInfo extends BaseListTypeInfo>({
   }
 
   return {
+    persistedQueries,
     withAuth,
   }
 }

--- a/packages/auth/src/pages/SigninPage.tsx
+++ b/packages/auth/src/pages/SigninPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import { Button } from '@keystar/ui/button'
 import { Grid, HStack, VStack } from '@keystar/ui/layout'
@@ -7,74 +7,120 @@ import { PasswordField } from '@keystar/ui/password-field'
 import { Content } from '@keystar/ui/slots'
 import { TextField } from '@keystar/ui/text-field'
 import { Heading, Text } from '@keystar/ui/typography'
+import { print } from 'graphql'
 
-import { gql, type TypedDocumentNode, useMutation } from '@keystone-6/core/admin-ui/apollo'
+import { useApolloClient } from '@keystone-6/core/admin-ui/apollo'
 import { GraphQLErrorNotice, Logo } from '@keystone-6/core/admin-ui/components'
+import { useKeystone } from '@keystone-6/core/admin-ui/context'
 import { useRouter } from '@keystone-6/core/admin-ui/router'
+import { getSigninPageQuery } from '../signin-query.ts'
 import type { AuthGqlNames } from '../types.ts'
 
 export default (props: Parameters<typeof SigninPage>[0]) => () => <SigninPage {...props} />
+
+type SigninData = {
+  authenticate: { __typename: string; item?: { id: string }; message?: string }
+}
+
+type MutationState =
+  | { status: 'idle' | 'loading' | 'success' }
+  | { status: 'error'; error: Error }
+  | { status: 'failure'; message: string }
 
 function SigninPage({
   identityField,
   secretField,
   authGqlNames,
+  persistedQueryHash,
 }: {
   identityField: string
   secretField: string
   authGqlNames: AuthGqlNames
+  persistedQueryHash?: string
 }) {
   const router = useRouter()
+  const apolloClient = useApolloClient()
+  const { apiPath } = useKeystone()
   const [state, setState] = useState({ identity: '', secret: '' })
+  const [mutationState, setMutationState] = useState<MutationState>({ status: 'idle' })
   const {
-    authenticateItemWithPassword,
     ItemAuthenticationWithPasswordSuccess: successTypename,
     ItemAuthenticationWithPasswordFailure: failureTypename,
   } = authGqlNames
-  const [tryAuthenticate, { error, loading, data }] = useMutation(
-    gql`
-    mutation KsAuthSignin ($identity: String!, $secret: String!) {
-      authenticate: ${authenticateItemWithPassword}(${identityField}: $identity, ${secretField}: $secret) {
-        ... on ${successTypename} {
-          item {
-            id
-          }
-        }
-        ... on ${failureTypename} {
-          message
-        }
-      }
-    }` as TypedDocumentNode<
-      { authenticate: { __typename: string; item?: { id: string }; message?: string } },
-      { identity: string; secret: string }
-    >,
-    {
-      refetchQueries: ['KsFetchAdminMeta'],
-    }
+  const signinQuery = useMemo(
+    () => print(getSigninPageQuery({ authGqlNames, identityField, secretField })),
+    [authGqlNames, identityField, secretField]
   )
 
   const onSubmit = async (event: React.SubmitEvent) => {
     if (event.target !== event.currentTarget) return
     event.preventDefault()
 
-    try {
-      const { data } = await tryAuthenticate({
-        variables: {
-          identity: state.identity,
-          secret: state.secret,
-        },
-      })
+    setMutationState({ status: 'loading' })
 
-      if (data?.authenticate.item) {
+    try {
+      if (!apiPath) throw new Error('The GraphQL API path is unavailable')
+
+      const response = await fetch(apiPath, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          operationName: 'KsAuthSignin',
+          query: signinQuery,
+          variables: {
+            identity: state.identity,
+            secret: state.secret,
+          },
+          ...(persistedQueryHash === undefined
+            ? {}
+            : {
+                extensions: {
+                  persistedQuery: {
+                    version: 1,
+                    sha256Hash: persistedQueryHash,
+                  },
+                },
+              }),
+        }),
+      })
+      const result = (await response.json()) as {
+        data?: SigninData
+        errors?: { message: string }[]
+      }
+
+      if (result.errors?.length) {
+        throw new Error(result.errors.map(error => error.message).join('\n'))
+      }
+      if (!response.ok) throw new Error(`Sign in failed with status ${response.status}`)
+      if (!result.data) throw new Error('The sign-in response contained no data')
+
+      const { authenticate } = result.data
+
+      if (authenticate.__typename === successTypename && authenticate.item) {
+        setMutationState({ status: 'success' })
+        await apolloClient.refetchQueries({ include: ['KsFetchAdminMeta'] })
         router.push('/')
+      } else if (authenticate.__typename === failureTypename) {
+        setMutationState({
+          status: 'failure',
+          message: authenticate.message ?? 'Sign in failed',
+        })
+      } else {
+        throw new Error('The sign-in response was invalid')
       }
     } catch (e) {
       console.error(e)
-      return
+      setMutationState({
+        status: 'error',
+        error: e instanceof Error ? e : new Error('Sign in failed'),
+      })
     }
   }
 
-  const pending = loading || data?.authenticate?.__typename === successTypename
+  const pending = mutationState.status === 'loading' || mutationState.status === 'success'
 
   return (
     <>
@@ -105,12 +151,14 @@ function SigninPage({
             Sign in
           </Heading>
 
-          <GraphQLErrorNotice errors={[error]} />
+          <GraphQLErrorNotice
+            errors={[mutationState.status === 'error' ? mutationState.error : undefined]}
+          />
 
-          {data?.authenticate?.__typename === failureTypename && (
+          {mutationState.status === 'failure' && (
             <Notice tone="critical">
               <Content>
-                <Text>{data?.authenticate.message}</Text>
+                <Text>{mutationState.message}</Text>
               </Content>
             </Notice>
           )}

--- a/packages/auth/src/signin-query.ts
+++ b/packages/auth/src/signin-query.ts
@@ -1,0 +1,34 @@
+import { parse } from 'graphql'
+import type { AuthGqlNames } from './types.ts'
+
+export function getSigninPageQuery({
+  authGqlNames,
+  identityField,
+  secretField,
+}: {
+  authGqlNames: AuthGqlNames
+  identityField: string
+  secretField: string
+}) {
+  const {
+    authenticateItemWithPassword,
+    ItemAuthenticationWithPasswordSuccess: successTypename,
+    ItemAuthenticationWithPasswordFailure: failureTypename,
+  } = authGqlNames
+
+  return parse(`
+      mutation KsAuthSignin($identity: String!, $secret: String!) {
+        authenticate: ${authenticateItemWithPassword}(${identityField}: $identity, ${secretField}: $secret) {
+          ... on ${successTypename} {
+            item {
+              id
+            }
+          }
+          ... on ${failureTypename} {
+            message
+          }
+          __typename
+        }
+      }
+    `)
+}

--- a/packages/auth/src/templates/signin.ts
+++ b/packages/auth/src/templates/signin.ts
@@ -4,10 +4,12 @@ export default function ({
   authGqlNames,
   identityField,
   secretField,
+  persistedQueryHash,
 }: {
   authGqlNames: AuthGqlNames
   identityField: string
   secretField: string
+  persistedQueryHash?: string
 }) {
   return `import makeSigninPage from '@keystone-6/auth/pages/SigninPage'
 
@@ -15,6 +17,7 @@ export default makeSigninPage(${JSON.stringify({
     authGqlNames,
     identityField,
     secretField,
+    persistedQueryHash,
   })})
 `
 }

--- a/tests/api-tests/auth.test.ts
+++ b/tests/api-tests/auth.test.ts
@@ -22,6 +22,58 @@ const auth = createAuth({
   sessionData: 'id name',
 })
 
+describe('persistedQueries', () => {
+  test('uses the list key as the default GraphQL singular', () => {
+    const queries = Object.values(auth.persistedQueries())
+
+    expect(queries).toHaveLength(1)
+    expect(queries[0]).toContain('authenticateUserWithPassword')
+  })
+
+  test('accepts a list config with a custom GraphQL singular', () => {
+    const queries = Object.values(auth.persistedQueries({ graphql: { singular: 'Account' } }))
+
+    expect(queries).toHaveLength(1)
+    expect(queries[0]).toContain('authenticateAccountWithPassword')
+    expect(queries[0]).toContain('AccountAuthenticationWithPasswordSuccess')
+    expect(queries[0]).toContain('AccountAuthenticationWithPasswordFailure')
+  })
+
+  test('passes the precomputed hash to the sign-in page when persisted queries are enabled', async () => {
+    const signinSource = await getSigninPageSource()
+    const [hash] = Object.keys(auth.persistedQueries())
+
+    expect(signinSource).toContain(`"persistedQueryHash":"${hash}"`)
+  })
+
+  test('does not pass a hash when persisted queries are disabled', async () => {
+    const signinSource = await getSigninPageSource(false)
+
+    expect(signinSource).not.toContain('persistedQueryHash')
+  })
+})
+
+async function getSigninPageSource(persistedQueries?: false) {
+  const authConfig = auth.withAuth({
+    lists: {
+      User: list({
+        access: allowAll,
+        fields: {
+          email: text({ isIndexed: 'unique' }),
+          password: password(),
+        },
+      }),
+    },
+    session: statelessSessions(),
+    graphql: persistedQueries === false ? { apolloConfig: { persistedQueries } } : undefined,
+  } as any)
+  const files = await authConfig.ui!.getAdditionalFiles!()
+  const signinPage = files.find(file => file.outputPath === 'pages/signin.js')
+
+  if (signinPage?.mode !== 'write') throw new Error('The sign-in page was not generated')
+  return signinPage.src
+}
+
 const runner = setupTestRunner({
   serve: true,
   config: {


### PR DESCRIPTION
This is to allow a Keystone setup where persisted queries are required for all callers except the Admin UI.

To make that approach work, the mutation that the Admin UI uses for authentication naturally needs to use a persisted query since it's not authenticated yet. This makes two small changes to `@keystone-6/auth` to make it possible to use it:

- `createAuth` returns a `persistedQueries` function that returns a map of a sha256 hash to the exact query the front-end uses so it can be used in where you define 
- Uses a minimal `fetch` call for the sign in mutation that adds the appropriate `extensions.persistedQuery` while still passing the actual query in so this doesn't
  - I went with `fetch` directly rather than getting Apollo Client to send `extensions.persistedQuery` since I don't think we want to this for any other query and it seemed like unnecessary complexity

Note this doesn't use persisted queries for all Admin UI queries, I don't think this would be very practical or helpful since those queries are very dynamic so it would be a massive number of queries that essentially allows anything. 

In a PR stacked on top of this, I've added an example that actually uses persisted queries in the way described above.