### PR TITLE
Ensure storage directories exist before first write in assets-local example

### DIFF
--- a/examples/assets-local/keystone.ts
+++ b/examples/assets-local/keystone.ts
@@ -3,6 +3,7 @@ import { config } from '@keystone-6/core'
 import { lists } from './schema'
 import bytes from 'bytes'
 import express from 'express'
+import fs from 'node:fs/promises'
 
 export default config({
   db: {
@@ -12,6 +13,13 @@ export default config({
         url: process.env.DATABASE_URL ?? 'file:./keystone-example.db',
       }),
     }),
+    async onConnect() {
+      // `public/` is gitignored, so these directories do not exist in a fresh clone.
+      await Promise.all([
+        fs.mkdir('public/images', { recursive: true }),
+        fs.mkdir('public/files', { recursive: true }),
+      ])
+    },
   },
   lists,
   server: {


### PR DESCRIPTION
## Problem

The `assets-local` example stores uploads in `public/images` and `public/files`, but the whole `public/` directory is [gitignored](../tree/main/examples/assets-local/.gitignore). In a fresh clone of the example those directories do not exist, and:

- the first upload crashes with `ENOENT: no such file or directory` from `fs.writeFile`, because the target directory is missing;
- `express.static('public/images', ...)` in `keystone.ts` silently returns 404 for the same reason, which makes the failure hard to diagnose for someone following the example.

Follow-up to #9995, which added `assertStrictStorageKey` to the same `put`/`delete` implementations.

## Solution

Add a small `ensureStorageDir` helper that calls `fs.mkdir(path, { recursive: true })` before the first write in both `put` implementations, with a comment explaining why it is needed (gitignored `public/`, ENOENT on missing directory). `mkdir` with `recursive: true` is idempotent, so no per-upload branching is required.

## Verification

Reproduced against the merged example code: `fs.writeFile('public/images/...', stream)` fails with `ENOENT` when `public/` does not exist. With `ensureStorageDir` added, the same `put` path writes the file successfully (verified with a real stream write, 11 bytes on disk) and subsequent behaviour is unchanged. `delete` and `url` are untouched.

---
Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
