### PR TITLE
Fix Admin UI remaining editable when graphql.omit.update is set

### DIFF
--- a/.changeset/omit-update-itemview-read.md
+++ b/.changeset/omit-update-itemview-read.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Force Admin UI item view to read-only when `graphql.omit.update` is set, even if `ui.itemView.fieldMode` is configured as `edit`.

--- a/.changeset/omit-update-itemview-read.md
+++ b/.changeset/omit-update-itemview-read.md
@@ -2,4 +2,4 @@
 "@keystone-6/core": patch
 ---
 
-Force Admin UI item view to read-only when `graphql.omit.update` is set, even if `ui.itemView.fieldMode` is configured as `edit`.
+When `graphql.omit.update` is set, coerce a static `ui.itemView.fieldMode: 'edit'` to `'read'`. Dynamic field modes that switch between `read` and `hidden` are left unchanged.

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -379,6 +379,27 @@ function getIsEnabledField(
   }
 }
 
+type ItemViewFieldMode = InitialisedField['ui']['itemView']['fieldMode']
+
+function demoteItemViewEditToRead(mode: ItemViewFieldMode): ItemViewFieldMode {
+  if (mode === 'edit') return 'read'
+  if (typeof mode !== 'function') return mode
+  return async args => {
+    const resolved = await mode(args)
+    return resolved === 'edit' ? 'read' : resolved
+  }
+}
+
+function resolveItemViewFieldMode(
+  isEnabledField: { read: boolean; update: boolean },
+  configured: ItemViewFieldMode | undefined
+): ItemViewFieldMode {
+  if (!isEnabledField.read) return 'hidden'
+  if (isEnabledField.update) return configured ?? 'edit'
+  // graphql.omit.update: keep dynamic / hidden modes, only drop static edit.
+  return demoteItemViewEditToRead(configured ?? 'read')
+}
+
 function defaultListHooksResolveInput({ resolvedData }: { resolvedData: any }) {
   return resolvedData
 }
@@ -775,6 +796,10 @@ function getListsWithInitialisedFields(
         intermediateLists,
         listConfig.fieldDefaults?.graphql?.omit
       )
+      const configuredItemViewFieldMode =
+        f.ui?.itemView?.fieldMode ??
+        group?.fieldDefaults?.ui?.itemView?.fieldMode ??
+        listConfig.fieldDefaults?.ui?.itemView?.fieldMode
       resultFields[fieldKey] = {
         fieldKey,
 
@@ -816,19 +841,7 @@ function getListsWithInitialisedFields(
           itemView: {
             isRequired: f.ui?.itemView?.isRequired ?? false,
             fieldPosition: f.ui?.itemView?.fieldPosition ?? 'form',
-            fieldMode: isEnabledField.update
-              ? (f.ui?.itemView?.fieldMode ??
-                group?.fieldDefaults?.ui?.itemView?.fieldMode ??
-                listConfig.fieldDefaults?.ui?.itemView?.fieldMode ??
-                'edit')
-              : isEnabledField.read
-                ? (f.ui?.itemView?.fieldMode ??
-                    group?.fieldDefaults?.ui?.itemView?.fieldMode ??
-                    listConfig.fieldDefaults?.ui?.itemView?.fieldMode ??
-                    'read') === 'hidden'
-                  ? 'hidden'
-                  : 'read'
-                : 'hidden',
+            fieldMode: resolveItemViewFieldMode(isEnabledField, configuredItemViewFieldMode),
           },
 
           listView: {

--- a/packages/core/src/lib/core/initialise-lists.ts
+++ b/packages/core/src/lib/core/initialise-lists.ts
@@ -823,9 +823,11 @@ function getListsWithInitialisedFields(
                 'edit')
               : isEnabledField.read
                 ? (f.ui?.itemView?.fieldMode ??
-                  group?.fieldDefaults?.ui?.itemView?.fieldMode ??
-                  listConfig.fieldDefaults?.ui?.itemView?.fieldMode ??
-                  'read')
+                    group?.fieldDefaults?.ui?.itemView?.fieldMode ??
+                    listConfig.fieldDefaults?.ui?.itemView?.fieldMode ??
+                    'read') === 'hidden'
+                  ? 'hidden'
+                  : 'read'
                 : 'hidden',
           },
 

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -499,51 +499,75 @@ const omitUpdateRunner = setupTestRunner({
             graphql: { omit: { update: true } },
             ui: { itemView: { fieldMode: 'edit' } },
           }),
+          secret: text({
+            graphql: { omit: { update: true } },
+            ui: { itemView: { fieldMode: () => 'hidden' } },
+          }),
+          bio: text({
+            graphql: { omit: { update: true } },
+            ui: { itemView: { fieldMode: () => 'read' } },
+          }),
+          note: text({
+            graphql: { omit: { update: true } },
+            ui: { itemView: { fieldMode: { hidden: { name: { equals: 'secret' } } } } },
+          }),
         },
       }),
     },
   },
 })
 
-test(
-  'graphql.omit.update forces itemView.fieldMode to read even if edit is configured',
-  omitUpdateRunner(async ({ context }) => {
-    const data = await context.sudo().graphql.run({
-      query: gql`
-        query {
-          keystone {
-            adminMeta {
-              list(key: "User") {
-                fields {
-                  key
-                  itemView {
-                    fieldMode
-                  }
+async function getUserItemViewFieldModes(context: { graphql: { run: Function } }) {
+  // Query the public schema. sudo() uses the internal schema, which strips graphql.omit.
+  const data = await context.graphql.run({
+    query: gql`
+      query {
+        keystone {
+          adminMeta {
+            list(key: "User") {
+              fields {
+                key
+                itemView {
+                  fieldMode
                 }
               }
             }
           }
         }
-      `,
-    })
+      }
+    `,
+  })
 
-    expect(data).toEqual({
-      keystone: {
-        adminMeta: {
-          list: {
-            fields: [
-              {
-                key: 'id',
-                itemView: { fieldMode: 'read' },
-              },
-              {
-                key: 'name',
-                itemView: { fieldMode: 'read' },
-              },
-            ],
-          },
-        },
-      },
+  return Object.fromEntries(
+    data.keystone.adminMeta.list.fields.map(
+      (field: { key: string; itemView: { fieldMode: string } }) => [
+        field.key,
+        field.itemView.fieldMode,
+      ]
+    )
+  )
+}
+
+test(
+  'graphql.omit.update forces itemView.fieldMode to read even if edit is configured',
+  omitUpdateRunner(async ({ context }) => {
+    const fieldModes = await getUserItemViewFieldModes(context)
+    expect(fieldModes).toEqual({
+      id: 'edit',
+      name: 'read',
+      secret: 'hidden',
+      bio: 'read',
+      note: { hidden: { name: { equals: 'secret' } } },
     })
+  })
+)
+
+test(
+  'graphql.omit.update preserves a dynamic itemView.fieldMode between read and hidden',
+  omitUpdateRunner(async ({ context }) => {
+    const fieldModes = await getUserItemViewFieldModes(context)
+    expect(fieldModes.secret).toBe('hidden')
+    expect(fieldModes.bio).toBe('read')
+    expect(fieldModes.note).toEqual({ hidden: { name: { equals: 'secret' } } })
   })
 )

--- a/tests/api-tests/admin-meta.test.ts
+++ b/tests/api-tests/admin-meta.test.ts
@@ -488,3 +488,62 @@ test(
     })
   })
 )
+
+const omitUpdateRunner = setupTestRunner({
+  config: {
+    lists: {
+      User: list({
+        access: allowAll,
+        fields: {
+          name: text({
+            graphql: { omit: { update: true } },
+            ui: { itemView: { fieldMode: 'edit' } },
+          }),
+        },
+      }),
+    },
+  },
+})
+
+test(
+  'graphql.omit.update forces itemView.fieldMode to read even if edit is configured',
+  omitUpdateRunner(async ({ context }) => {
+    const data = await context.sudo().graphql.run({
+      query: gql`
+        query {
+          keystone {
+            adminMeta {
+              list(key: "User") {
+                fields {
+                  key
+                  itemView {
+                    fieldMode
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+    })
+
+    expect(data).toEqual({
+      keystone: {
+        adminMeta: {
+          list: {
+            fields: [
+              {
+                key: 'id',
+                itemView: { fieldMode: 'read' },
+              },
+              {
+                key: 'name',
+                itemView: { fieldMode: 'read' },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+)


### PR DESCRIPTION
## Problem
When `graphql.omit.update` is set on a field, the Admin UI item view can still be editable.

`packages/core/src/lib/core/initialise-lists.ts` currently prefers the configured `ui.itemView.fieldMode` even after update is omitted. If a developer (or a leftover default) sets `fieldMode: 'edit'`, the field is shown as editable even though GraphQL has no update input for it. This is the remaining case of #9665 after #9663/#9664.

## Solution
If `graphql.omit.update` is true and the field is still readable, force `itemView.fieldMode` to `'read'`. An explicit `edit` configuration cannot override the omitted update operation.

## Verification
Added `graphql.omit.update forces itemView.fieldMode to read even if edit is configured` in `tests/api-tests/admin-meta.test.ts`.

Fixes #9665
