### PR TITLE
Use Session type augmentation in examples

### DIFF
--- a/examples/auth-magic-link/keystone.ts
+++ b/examples/auth-magic-link/keystone.ts
@@ -2,7 +2,7 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
-import { type Session, lists, extendGraphqlSchema } from './schema'
+import { lists, extendGraphqlSchema } from './schema'
 import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
@@ -29,7 +29,7 @@ const { withAuth } = createAuth({
   secretField: 'password',
 })
 
-export default withAuth<TypeInfo<Session>>(
+export default withAuth<TypeInfo>(
   config<TypeInfo>({
     db: {
       provider: 'sqlite',

--- a/examples/auth-magic-link/schema.ts
+++ b/examples/auth-magic-link/schema.ts
@@ -1,15 +1,18 @@
 import { gWithContext, list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { password, text, timestamp } from '@keystone-6/core/fields'
-import type { Lists, Context } from './generated/keystone/types'
+import type { Lists, Context, Session } from './generated/keystone/types'
 
 import { randomBytes } from 'node:crypto'
 
 const g = gWithContext<Context>()
 type g<T> = gWithContext.infer<T>
 
-export type Session = {
-  itemId: string
+declare module './generated/keystone/types' {
+  interface Session {
+    itemId: string
+    listKey: string
+  }
 }
 
 function hasSession({ session }: { session?: Session }) {
@@ -98,7 +101,7 @@ export const lists = {
       oneTimeTokenCreatedAt: timestamp({ ...hiddenField }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
@@ -191,7 +194,7 @@ export const extendGraphqlSchema = g.extend(base => {
             await context.sessionStrategy.start({
               context,
               data: {
-                listkey: 'User',
+                listKey: 'User',
                 itemId: userId,
               },
             })

--- a/examples/auth/keystone.ts
+++ b/examples/auth/keystone.ts
@@ -2,7 +2,7 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
-import { type Session, lists } from './schema'
+import { lists } from './schema'
 import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
@@ -32,7 +32,7 @@ const { withAuth } = createAuth({
   sessionData: 'isAdmin',
 })
 
-export default withAuth<TypeInfo<Session>>(
+export default withAuth<TypeInfo>(
   config<TypeInfo>({
     db: {
       provider: 'sqlite',

--- a/examples/auth/schema.ts
+++ b/examples/auth/schema.ts
@@ -1,4 +1,4 @@
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll } from '@keystone-6/core/access'
 import { checkbox, password, text } from '@keystone-6/core/fields'
@@ -6,11 +6,12 @@ import { checkbox, password, text } from '@keystone-6/core/fields'
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
-
-export type Session = {
-  itemId: string
-  data: {
-    isAdmin: boolean
+declare module './generated/keystone/types' {
+  interface Session {
+    itemId: string
+    data: {
+      isAdmin: boolean
+    }
   }
 }
 
@@ -166,4 +167,4 @@ export const lists = {
       }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session-invalidation/keystone.ts
+++ b/examples/custom-session-invalidation/keystone.ts
@@ -2,8 +2,8 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
-import { type Session, lists } from './schema'
-import type { Config, Context, TypeInfo } from './generated/keystone/types'
+import { lists } from './schema'
+import type { Config, Context, TypeInfo, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
@@ -23,7 +23,7 @@ const { withAuth } = createAuth({
   sessionData: 'passwordChangedAt',
 })
 
-function withSessionInvalidation(config: Config<Session>): Config<Session> {
+function withSessionInvalidation(config: Config): Config {
   const existingSessionStrategy = config.session!
 
   return {

--- a/examples/custom-session-invalidation/schema.ts
+++ b/examples/custom-session-invalidation/schema.ts
@@ -1,20 +1,22 @@
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { text, password, timestamp } from '@keystone-6/core/fields'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
 // needs to be compatible with withAuth
-export type Session = {
-  listKey: string
-  itemId: string
-  data: {
-    passwordChangedAt: string
+declare module './generated/keystone/types' {
+  interface Session {
+    listKey: string
+    itemId: string
+    data: {
+      passwordChangedAt: string
+    }
+    startedAt: number
   }
-  startedAt: number
 }
 
 function hasSession({ session }: { session?: Session }) {
@@ -88,4 +90,4 @@ export const lists = {
       },
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session-jwt/keystone.ts
+++ b/examples/custom-session-jwt/keystone.ts
@@ -1,8 +1,8 @@
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import jwt from 'jsonwebtoken'
 import { config } from '@keystone-6/core'
-import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from './generated/keystone/types'
+import { lists } from './schema'
+import type { Context, TypeInfo, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted

--- a/examples/custom-session-jwt/schema.ts
+++ b/examples/custom-session-jwt/schema.ts
@@ -1,11 +1,13 @@
 import { list } from '@keystone-6/core'
 import { allowAll, unfiltered, allOperations } from '@keystone-6/core/access'
 import { checkbox, text } from '@keystone-6/core/fields'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
-export type Session = {
-  id: string
-  admin: boolean
+declare module './generated/keystone/types' {
+  interface Session {
+    id: string
+    admin: boolean
+  }
 }
 
 function hasSession({ session }: { session?: Session }) {
@@ -61,4 +63,4 @@ export const lists = {
       admin: checkbox(),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session-next-auth/keystone.ts
+++ b/examples/custom-session-next-auth/keystone.ts
@@ -2,14 +2,14 @@ import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
 import { lists } from './schema'
 
-import { type Session, nextAuthSessionStrategy } from './session'
+import { nextAuthSessionStrategy } from './session'
 import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-export default config<TypeInfo<Session>>({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     prismaClientOptions: () => ({

--- a/examples/custom-session-next-auth/schema.ts
+++ b/examples/custom-session-next-auth/schema.ts
@@ -1,8 +1,7 @@
 import { denyAll, allOperations } from '@keystone-6/core/access'
 import { list } from '@keystone-6/core'
 import { text, relationship } from '@keystone-6/core/fields'
-import type { Session } from './session'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
@@ -43,4 +42,4 @@ export const lists = {
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session-next-auth/session.ts
+++ b/examples/custom-session-next-auth/session.ts
@@ -40,8 +40,10 @@ export const nextAuthOptions = {
   ],
 }
 
-export type Session = {
-  id: string
+declare module './generated/keystone/types' {
+  interface Session {
+    id: string
+  }
 }
 
 export const nextAuthSessionStrategy = {

--- a/examples/custom-session-passport/auth.ts
+++ b/examples/custom-session-passport/auth.ts
@@ -7,10 +7,11 @@ import type { VerifyCallback } from 'passport-oauth2'
 import { Strategy, type StrategyOptions, type Profile } from 'passport-github2'
 
 import type { Author } from './generated/prisma/client'
-import type { TypeInfo } from './generated/keystone/types'
+import type { Session, TypeInfo } from './generated/keystone/types'
 
-export type Session = Author
-
+declare module './generated/keystone/types' {
+  export interface Session extends Author {}
+}
 export const session = statelessSessions<Session>({
   maxAge: 60 * 60 * 24 * 30,
   secret: process.env.SESSION_SECRET!,
@@ -30,7 +31,7 @@ const options: StrategyOptions = {
   callbackURL: 'http://localhost:3000/auth/github/callback',
 }
 
-export function passportMiddleware(commonContext: KeystoneContext<TypeInfo<Session>>): Router {
+export function passportMiddleware(commonContext: KeystoneContext<TypeInfo>): Router {
   const router = Router()
   const instance = new Passport()
   const strategy = new Strategy(

--- a/examples/custom-session-passport/keystone.ts
+++ b/examples/custom-session-passport/keystone.ts
@@ -4,9 +4,9 @@ import 'dotenv/config'
 import { config } from '@keystone-6/core'
 import type { TypeInfo } from './generated/keystone/types'
 import { lists } from './schema'
-import { type Session, session, passportMiddleware } from './auth'
+import { session, passportMiddleware } from './auth'
 
-export default config<TypeInfo<Session>>({
+export default config<TypeInfo>({
   db: {
     provider: 'sqlite',
     prismaClientOptions: () => ({

--- a/examples/custom-session-passport/schema.ts
+++ b/examples/custom-session-passport/schema.ts
@@ -1,9 +1,7 @@
 import { denyAll, allOperations } from '@keystone-6/core/access'
 import { list } from '@keystone-6/core'
 import { text, relationship } from '@keystone-6/core/fields'
-import type { Lists } from './generated/keystone/types'
-
-import type { Session } from './auth'
+import type { Lists, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
@@ -44,4 +42,4 @@ export const lists = {
       posts: relationship({ ref: 'Post.author', many: true }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session-redis/keystone.ts
+++ b/examples/custom-session-redis/keystone.ts
@@ -3,8 +3,8 @@ import { config } from '@keystone-6/core'
 import { storedSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { createClient } from '@redis/client'
-import { lists, type Session } from './schema'
-import type { TypeInfo } from './generated/keystone/types'
+import { lists } from './schema'
+import type { TypeInfo, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
@@ -48,7 +48,7 @@ function redisSessionStrategy() {
 }
 
 export default withAuth(
-  config<TypeInfo<Session>>({
+  config<TypeInfo>({
     db: {
       provider: 'sqlite',
       prismaClientOptions: () => ({

--- a/examples/custom-session-redis/schema.ts
+++ b/examples/custom-session-redis/schema.ts
@@ -1,18 +1,20 @@
 import { list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { text, password } from '@keystone-6/core/fields'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
 // needs to be compatible with withAuth
-export type Session = {
-  listKey: string
-  itemId: string
-  data: {
-    something: string
+declare module './generated/keystone/types' {
+  interface Session {
+    listKey: string
+    itemId: string
+    data: {
+      something: string
+    }
   }
 }
 
@@ -66,4 +68,4 @@ export const lists = {
       }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/custom-session/keystone.ts
+++ b/examples/custom-session/keystone.ts
@@ -1,7 +1,7 @@
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
-import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from './generated/keystone/types'
+import { lists } from './schema'
+import type { Context, TypeInfo, Session } from './generated/keystone/types'
 
 const sillySessionStrategy = {
   async get({ context }: { context: Context }): Promise<Session | undefined> {

--- a/examples/custom-session/schema.ts
+++ b/examples/custom-session/schema.ts
@@ -1,11 +1,13 @@
 import { list } from '@keystone-6/core'
 import { allowAll, unfiltered } from '@keystone-6/core/access'
 import { checkbox, text } from '@keystone-6/core/fields'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
-export type Session = {
-  id: string
-  admin: boolean
+declare module './generated/keystone/types' {
+  interface Session {
+    id: string
+    admin: boolean
+  }
 }
 
 function hasSession({ session }: { session?: Session }) {
@@ -63,4 +65,4 @@ export const lists = {
       admin: checkbox(),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/framework-astro/src/keystone/schema.ts
+++ b/examples/framework-astro/src/keystone/schema.ts
@@ -18,6 +18,13 @@ import { text, select } from '@keystone-6/core/fields'
 // the generated types from '../../generated/keystone/types'
 import type { Lists } from '../../generated/keystone/types'
 
+declare module '../../generated/keystone/types' {
+  interface Session {
+    user: string
+    browser: string
+  }
+}
+
 export const lists = {
   Post: list({
     // WARNING

--- a/examples/testing/keystone.ts
+++ b/examples/testing/keystone.ts
@@ -3,7 +3,6 @@ import { config } from '@keystone-6/core'
 import { statelessSessions } from '@keystone-6/core/session'
 import { createAuth } from '@keystone-6/auth'
 import { lists } from './schema'
-import type { Session } from './schema'
 import type { TypeInfo } from './generated/keystone/types'
 
 // WARNING: this example is for TESTING purposes only
@@ -23,7 +22,7 @@ const { withAuth } = createAuth({
 })
 
 export default withAuth(
-  config<TypeInfo<Session>>({
+  config<TypeInfo>({
     db: {
       provider: 'sqlite',
       prismaClientOptions: () => ({

--- a/examples/testing/schema.ts
+++ b/examples/testing/schema.ts
@@ -2,13 +2,15 @@ import { list } from '@keystone-6/core'
 import { checkbox, password, relationship, text, timestamp } from '@keystone-6/core/fields'
 import { select } from '@keystone-6/core/fields'
 import { allowAll } from '@keystone-6/core/access'
-import type { Lists } from './generated/keystone/types'
+import type { Lists, Session } from './generated/keystone/types'
 
 // needs to be compatible with withAuth
-export type Session = {
-  listKey: string
-  itemId: string
-  data: {}
+declare module './generated/keystone/types' {
+  interface Session {
+    listKey: string
+    itemId: string
+    data: {}
+  }
 }
 
 function isAssignedUserFilter({ session }: { session?: Session }) {
@@ -56,4 +58,4 @@ export const lists = {
       tasks: relationship({ ref: 'Task.assignedTo', many: true }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/usecase-blog-moderated/keystone.ts
+++ b/examples/usecase-blog-moderated/keystone.ts
@@ -1,7 +1,7 @@
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import { config } from '@keystone-6/core'
-import { lists, type Session } from './schema'
-import type { Context, TypeInfo } from './generated/keystone/types'
+import { lists } from './schema'
+import type { Context, TypeInfo, Session } from './generated/keystone/types'
 
 const sillySessionStrategy = {
   async get({ context }: { context: Context }): Promise<Session | undefined> {

--- a/examples/usecase-blog-moderated/schema.ts
+++ b/examples/usecase-blog-moderated/schema.ts
@@ -1,4 +1,4 @@
-import type { Context, Lists } from './generated/keystone/types'
+import type { Context, Lists, Session } from './generated/keystone/types'
 import { action, gWithContext, list } from '@keystone-6/core'
 import { allowAll, denyAll, unfiltered } from '@keystone-6/core/access'
 import { checkbox, relationship, text, timestamp, virtual } from '@keystone-6/core/fields'
@@ -7,11 +7,13 @@ import { checkbox, relationship, text, timestamp, virtual } from '@keystone-6/co
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-export type Session = {
-  id: string
-  admin: boolean
-  moderator: null | { id: string }
-  contributor: null | { id: string }
+declare module './generated/keystone/types' {
+  interface Session {
+    id: string
+    admin: boolean
+    moderator: null | { id: string }
+    contributor: null | { id: string }
+  }
 }
 
 type Has<T, K extends keyof T> = {
@@ -339,4 +341,4 @@ export const lists = {
       }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists

--- a/examples/usecase-roles/access.ts
+++ b/examples/usecase-roles/access.ts
@@ -1,21 +1,25 @@
-export type Session = {
-  itemId: string
-  listKey: string
-  data: {
-    name: string
-    role: {
-      id: string
+declare module './generated/keystone/types' {
+  export interface Session {
+    itemId: string
+    listKey: string
+    data: {
       name: string
-      canCreateTodos: boolean
-      canManageAllTodos: boolean
-      canSeeOtherPeople: boolean
-      canEditOtherPeople: boolean
-      canManagePeople: boolean
-      canManageRoles: boolean
-      canUseAdminUI: boolean
+      role: {
+        id: string
+        name: string
+        canCreateTodos: boolean
+        canManageAllTodos: boolean
+        canSeeOtherPeople: boolean
+        canEditOtherPeople: boolean
+        canManagePeople: boolean
+        canManageRoles: boolean
+        canUseAdminUI: boolean
+      }
     }
   }
 }
+
+import type { Session } from './generated/keystone/types'
 
 type AccessArgs = {
   session?: Session

--- a/examples/usecase-roles/schema.ts
+++ b/examples/usecase-roles/schema.ts
@@ -3,14 +3,13 @@ import { allOperations, denyAll } from '@keystone-6/core/access'
 import { checkbox, password, relationship, text } from '@keystone-6/core/fields'
 
 import type { Lists } from './generated/keystone/types'
-import type { Session } from './access'
 import { isSignedIn as hasSession, permissions, rules } from './access'
 
 // WARNING: this example is for demonstration purposes only
 //   as with each of our examples, it has not been vetted
 //   or tested for any particular usage
 
-export const lists: Lists<Session> = {
+export const lists: Lists = {
   Todo: list({
     access: {
       operation: {
@@ -206,4 +205,4 @@ export const lists: Lists<Session> = {
       }),
     },
   }),
-} satisfies Lists<Session>
+} satisfies Lists


### PR DESCRIPTION
This makes all the examples use Session type augmentation instead of passing the type param, will only merge when #9578 is released.