### PR TITLE
Change height to minHeight in PageContainer

### DIFF
--- a/.changeset/slimy-eggs-play.md
+++ b/.changeset/slimy-eggs-play.md
@@ -1,0 +1,5 @@
+---
+"@keystone-6/core": patch
+---
+
+Changes `height` to `minHeight` in `PageContainer`

--- a/packages/core/src/admin-ui/components/PageContainer.tsx
+++ b/packages/core/src/admin-ui/components/PageContainer.tsx
@@ -54,7 +54,7 @@ const Sidebar = ({
     >
       <aside
         className={css({
-          height: '100%',
+          minHeight: '100%',
           minWidth: 0, // resolves collapsing issues in children
         })}
         {...props}


### PR DESCRIPTION
Allows the side navigation content to determine the height of the `aside` element. This, in turn allows customisations using position sticky to work correctly.

Previously, the sticky element would become unstuck at the bottom of "100%" which might not be the bottom of the view.

Screen capture showing this "sticky" behaviour.

https://github.com/user-attachments/assets/757b444c-8146-4dfb-887c-92b595da5a11

