### PR TITLE
Remove node: imports from @keystone-6/core and @keystone-6/core/context

### DIFF
--- a/.changeset/major-lies-check.md
+++ b/.changeset/major-lies-check.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/core': patch
+---
+
+Removes runtime `node:` imports from `@keystone-6/core` and `@keystone-6/core/context`

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,1 +1,1 @@
-export { getContext } from './lib/system.ts'
+export { getContext } from './lib/getContext.ts'

--- a/packages/core/src/fields/types/file/index.ts
+++ b/packages/core/src/fields/types/file/index.ts
@@ -12,7 +12,7 @@ import { fieldType } from '../../../types/index.ts'
 import { g } from '../../../index.ts'
 import { merge } from '../../resolve-hooks.ts'
 import type { InferValueFromArg, InferValueFromInputType } from '@graphql-ts/schema'
-import { randomBytes } from 'node:crypto'
+import { toBase64Url } from '../../../lib/encoding.ts'
 
 export type FieldTypeInfo = {
   item: undefined
@@ -161,7 +161,7 @@ function defaultTransformName(path: string) {
   // followed by any alphanumerical character before the end of the string
   const [, name, ext] = path.match(/^([^:\n].*?)(\.[A-Za-z0-9]{0,10})?$/) as RegExpMatchArray
 
-  const id = randomBytes(16).toString('base64url')
+  const id = toBase64Url(crypto.getRandomValues(new Uint8Array(16)))
   const urlSafeName = name.replace(/[^A-Za-z0-9]/g, '-')
   if (ext) return `${urlSafeName}-${id}${ext}`
   return `${urlSafeName}-${id}`

--- a/packages/core/src/fields/types/image/index.ts
+++ b/packages/core/src/fields/types/image/index.ts
@@ -13,7 +13,7 @@ import { g } from '../../../index.ts'
 import { SUPPORTED_IMAGE_EXTENSIONS } from './utils.ts'
 import { merge } from '../../resolve-hooks.ts'
 import type { InferValueFromArg, InferValueFromInputType } from '@graphql-ts/schema'
-import { randomBytes } from 'node:crypto'
+import { toBase64Url } from '../../../lib/encoding.ts'
 import type { ImageExtension } from './internal-utils.ts'
 import { getBytesFromStream, getImageMetadata, teeStream } from './internal-utils.ts'
 
@@ -240,5 +240,5 @@ export function image<ListTypeInfo extends BaseListTypeInfo>(
 }
 
 function defaultTransformName(_: string) {
-  return randomBytes(16).toString('base64url')
+  return toBase64Url(crypto.getRandomValues(new Uint8Array(16)))
 }

--- a/packages/core/src/lib/admin-meta.ts
+++ b/packages/core/src/lib/admin-meta.ts
@@ -1,5 +1,3 @@
-import path from 'node:path'
-
 import type {
   BaseFieldTypeInfo,
   BaseItem,
@@ -412,7 +410,7 @@ function assertValidView(view: string, location: string) {
     )
   }
 
-  if (path.isAbsolute(view)) {
+  if (view.startsWith('/') || /^[A-Za-z]:\//.test(view)) {
     throw new Error(
       `${location} is an absolute path, which is invalid. You need to use a module path that is resolved from where 'keystone start' is run (see https://github.com/keystonejs/keystone/pull/7805)`
     )

--- a/packages/core/src/lib/encoding.ts
+++ b/packages/core/src/lib/encoding.ts
@@ -1,0 +1,19 @@
+// delete when we require node 26 or above which has the built-ins
+export const toHex: (bytes: Uint8Array) => string =
+  typeof Uint8Array.prototype.toHex === 'function'
+    ? bytes => bytes.toHex()
+    : bytes => {
+        let str = ''
+        for (const byte of bytes) {
+          str += byte.toString(16).padStart(2, '0')
+        }
+        return str
+      }
+
+export const toBase64Url: (bytes: Uint8Array) => string =
+  typeof Uint8Array.prototype.toBase64 === 'function'
+    ? bytes => bytes.toBase64({ alphabet: 'base64url', omitPadding: true })
+    : bytes => {
+        const binString = Array.from(bytes, byte => String.fromCodePoint(byte)).join('')
+        return btoa(binString).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+      }

--- a/packages/core/src/lib/getContext.ts
+++ b/packages/core/src/lib/getContext.ts
@@ -1,0 +1,130 @@
+import type { BaseKeystoneTypeInfo, KeystoneConfig, KeystoneContext } from '../types/index.ts'
+import { createAdminMeta } from './admin-meta.ts'
+import { createContext } from './context/createContext.ts'
+import { initialiseLists, type InitialisedList } from './core/initialise-lists.ts'
+import { toBase64Url, toHex } from './encoding.ts'
+import { createGraphQLSchema } from './graphql.ts'
+
+function getInternalGraphQLSchema(config: KeystoneConfig) {
+  const withoutOmit: KeystoneConfig = {
+    ...config,
+    lists: Object.fromEntries(
+      Object.entries(config.lists).map(([listKey, list]) => {
+        return [
+          listKey,
+          {
+            ...list,
+            graphql: { ...(list.graphql || {}), omit: false },
+            fields: Object.fromEntries(
+              Object.entries(list.fields).map(([fieldKey, field]) => {
+                if (fieldKey.startsWith('__group')) return [fieldKey, field]
+                return [
+                  fieldKey,
+                  data => {
+                    const f = field(data)
+                    return {
+                      ...f,
+                      graphql: { ...(f.graphql || {}), omit: false },
+                    }
+                  },
+                ]
+              })
+            ),
+          },
+        ]
+      })
+    ),
+  }
+
+  const lists = initialiseLists(withoutOmit)
+  const adminMeta = createAdminMeta(withoutOmit, lists)
+  return createGraphQLSchema(withoutOmit, lists, adminMeta, 'internal')
+}
+
+function injectNewDefaults(prismaClient: unknown, lists: Record<string, InitialisedList>) {
+  for (const listKey in lists) {
+    const list = lists[listKey]
+    const { dbField } = list.fields.id
+
+    if ('default' in dbField && dbField.default?.kind === 'random') {
+      const { bytes, encoding } = dbField.default
+
+      prismaClient = (prismaClient as any).$extends({
+        query: {
+          [list.prisma.listKey]: {
+            async create({ args, query }: any) {
+              return query({
+                ...args,
+                data: {
+                  ...args.data,
+                  id:
+                    args.data.id ??
+                    (encoding === 'hex'
+                      ? toHex(crypto.getRandomValues(new Uint8Array(bytes)))
+                      : toBase64Url(crypto.getRandomValues(new Uint8Array(bytes)))),
+                },
+              })
+            },
+          },
+        },
+      })
+    }
+  }
+
+  return prismaClient
+}
+
+export function createContextSystem(config: KeystoneConfig) {
+  const lists = initialiseLists(config)
+  const adminMeta = createAdminMeta(config, lists)
+  const graphQLSchemas = {
+    public: createGraphQLSchema(config, lists, adminMeta, 'public'),
+    internal: getInternalGraphQLSchema(config),
+  }
+
+  return {
+    config,
+    graphql: {
+      schemas: graphQLSchemas,
+    },
+    adminMeta,
+    lists,
+    getKeystone: (PM: any, existingPrismaClient?: any) => {
+      const prismaClient =
+        existingPrismaClient ??
+        config.db.extendPrismaClient(
+          injectNewDefaults(new PM.PrismaClient(config.db.prismaClientOptions()), lists)
+        )
+      const context = createContext({
+        config,
+        lists,
+        graphQLSchemas,
+        prismaClient,
+        prismaTypes: {
+          DbNull: PM.Prisma.DbNull,
+          JsonNull: PM.Prisma.JsonNull,
+        },
+      })
+
+      return {
+        async connect() {
+          await prismaClient.$connect()
+          await config.db.onConnect?.(context)
+        },
+        async disconnect() {
+          await prismaClient.$disconnect()
+        },
+        context,
+      }
+    },
+  }
+}
+
+export function getContext<TypeInfo extends BaseKeystoneTypeInfo>(
+  config: KeystoneConfig<TypeInfo>,
+  PrismaModule: unknown
+): KeystoneContext<TypeInfo> {
+  const system = createContextSystem(config)
+  const { context } = system.getKeystone(PrismaModule)
+  return context
+}

--- a/packages/core/src/lib/system.ts
+++ b/packages/core/src/lib/system.ts
@@ -1,11 +1,7 @@
-import { randomBytes } from 'node:crypto'
 import path from 'node:path'
 
-import type { BaseKeystoneTypeInfo, KeystoneConfig, KeystoneContext } from '../types/index.ts'
-import { createAdminMeta } from './admin-meta.ts'
-import { createContext } from './context/createContext.ts'
-import { initialiseLists, type InitialisedList } from './core/initialise-lists.ts'
-import { createGraphQLSchema } from './graphql.ts'
+import type { KeystoneConfig } from '../types/index.ts'
+import { createContextSystem } from './getContext.ts'
 
 // TODO: this cannot be changed for now, circular dependency with getSystemPaths, getEsbuildConfig
 export function getBuiltKeystoneConfigurationPath(cwd: string) {
@@ -63,131 +59,13 @@ function getSystemPaths(cwd: string, config: KeystoneConfig) {
   }
 }
 
-function getInternalGraphQLSchema(config: KeystoneConfig) {
-  // omit `graphql.omit`
-  const withoutOmit: KeystoneConfig = {
-    ...config,
-    lists: Object.fromEntries(
-      Object.entries(config.lists).map(([listKey, list]) => {
-        return [
-          listKey,
-          {
-            ...list,
-            graphql: { ...(list.graphql || {}), omit: false },
-            fields: Object.fromEntries(
-              Object.entries(list.fields).map(([fieldKey, field]) => {
-                if (fieldKey.startsWith('__group')) return [fieldKey, field]
-                return [
-                  fieldKey,
-                  data => {
-                    const f = field(data)
-                    return {
-                      ...f,
-                      graphql: { ...(f.graphql || {}), omit: false },
-                    }
-                  },
-                ]
-              })
-            ),
-          },
-        ]
-      })
-    ),
-  }
-
-  const lists = initialiseLists(withoutOmit)
-  const adminMeta = createAdminMeta(withoutOmit, lists)
-  return createGraphQLSchema(withoutOmit, lists, adminMeta, 'internal')
-}
-
-function injectNewDefaults(prismaClient: unknown, lists: Record<string, InitialisedList>) {
-  for (const listKey in lists) {
-    const list = lists[listKey]
-
-    // TODO: other fields might use 'random' too
-    const { dbField } = list.fields.id
-
-    if ('default' in dbField && dbField.default?.kind === 'random') {
-      const { bytes, encoding } = dbField.default
-
-      prismaClient = (prismaClient as any).$extends({
-        query: {
-          [list.prisma.listKey]: {
-            async create({ args, query }: any) {
-              return query({
-                ...args,
-                data: {
-                  ...args.data,
-                  id: args.data.id ?? randomBytes(bytes).toString(encoding),
-                },
-              })
-            },
-          },
-        },
-      })
-    }
-  }
-
-  return prismaClient
-}
-
 export function createSystem(config: KeystoneConfig) {
-  const lists = initialiseLists(config)
-  const adminMeta = createAdminMeta(config, lists)
-  const graphQLSchemas = {
-    public: createGraphQLSchema(config, lists, adminMeta, 'public'),
-    internal: getInternalGraphQLSchema(config),
-  }
+  const system = createContextSystem(config)
 
   return {
-    config,
-    graphql: {
-      schemas: graphQLSchemas,
-    },
-    adminMeta,
-    lists,
+    ...system,
     getPaths: (cwd: string) => getSystemPaths(cwd, config),
-
-    getKeystone: (PM: any, existingPrismaClient?: any) => {
-      const prismaClient =
-        existingPrismaClient ??
-        config.db.extendPrismaClient(
-          injectNewDefaults(new PM.PrismaClient(config.db.prismaClientOptions()), lists)
-        )
-      const context = createContext({
-        config,
-        lists,
-        graphQLSchemas,
-        prismaClient,
-        prismaTypes: {
-          DbNull: PM.Prisma.DbNull,
-          JsonNull: PM.Prisma.JsonNull,
-        },
-      })
-
-      return {
-        // TODO: replace with server.onStart, remove in breaking change
-        async connect() {
-          await (prismaClient as any).$connect()
-          await config.db.onConnect?.(context)
-        },
-        // TODO: only used by tests, remove in breaking change
-        async disconnect() {
-          await (prismaClient as any).$disconnect()
-        },
-        context,
-      }
-    },
   }
 }
 
 export type System = ReturnType<typeof createSystem>
-
-export function getContext<TypeInfo extends BaseKeystoneTypeInfo>(
-  config: KeystoneConfig<TypeInfo>,
-  PrismaModule: unknown
-): KeystoneContext<TypeInfo> {
-  const system = createSystem(config)
-  const { context } = system.getKeystone(PrismaModule)
-  return context
-}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,6 +1,6 @@
-import { randomBytes } from 'node:crypto'
 import * as cookie from 'cookie'
 import Iron from '@hapi/iron'
+import { toBase64Url } from './lib/encoding.ts'
 import type { KeystoneContext, SessionStrategy, SessionStoreFunction } from './types/index.ts'
 
 // TODO: should we also accept httpOnly?
@@ -71,7 +71,7 @@ function getToken(req: NonNullable<KeystoneContext['req']>, cookieName: string) 
 }
 
 export function statelessSessions<Session>({
-  secret = randomBytes(32).toString('base64url'),
+  secret = toBase64Url(crypto.getRandomValues(new Uint8Array(32))),
   maxAge = 60 * 60 * 8, // 8 hours,
   cookieName = 'keystonejs-session',
   path = '/',
@@ -153,7 +153,7 @@ export function storedSessions<Session>({
       return store.get(sessionId)
     },
     async start({ context, data }) {
-      const sessionId = randomBytes(24).toString('base64url') // 192-bit
+      const sessionId = toBase64Url(crypto.getRandomValues(new Uint8Array(24))) // 192-bit
       await store.set(sessionId, data)
       return stateless.start({ context, data: sessionId }) || ''
     },

--- a/packages/core/src/types/schema/scalars.ts
+++ b/packages/core/src/types/schema/scalars.ts
@@ -4,6 +4,7 @@ import GraphQLUpload from 'graphql-upload/GraphQLUpload.js'
 import { GraphQLError, GraphQLScalarType } from 'graphql/index.js'
 import { Decimal as DecimalValue } from 'decimal.js'
 import type { JSONValue } from '../utils.ts'
+import { toHex } from '../../lib/encoding.ts'
 
 export const JSON = new GraphQLScalarType<JSONValue>({
   name: 'JSON',
@@ -32,14 +33,6 @@ function hexToBytes(value: string): Uint8Array {
   return bytes
 }
 
-function bytesToHex(bytes: Uint8Array): string {
-  let str = ''
-  for (const byte of bytes) {
-    str += byte.toString(16).padStart(2, '0')
-  }
-  return str
-}
-
 export const Hex = new GraphQLScalarType({
   name: 'Hex',
   description: 'The `Hex` scalar type represents bytes as a string of hexadecimal characters.',
@@ -65,7 +58,7 @@ export const Hex = new GraphQLScalarType({
     if (!(value instanceof Uint8Array)) {
       throw new GraphQLError(`unexpected value provided to Hex scalar: ${value}`)
     }
-    return bytesToHex(value)
+    return toHex(value)
   },
 })
 


### PR DESCRIPTION
This is to get closer to Keystone running on Cloudflare Workers without nodejs_compat

Notably, this doesn't include:
- `@keystone-6/core/session` because of the `@hapi/iron` import
- The image/file fields/`graphql.Upload`, I was originally hoping to remove the `node:stream` import in the image field so `@keystone-6/core/fields` wouldn't at runtime depend on any `node:` stuff even if the image/file fields wouldn't work but it turned into a hassle so I haven't included that here