### PR TITLE
Fix next being a regular dep of auth instead of a peer dep

### DIFF
--- a/.changeset/ready-ideas-chew.md
+++ b/.changeset/ready-ideas-chew.md
@@ -1,0 +1,5 @@
+---
+'@keystone-6/auth': patch
+---
+
+Moves `next` from `dependencies` to `peerDependencies` in `@keystone-6/auth`, previously you may have had duplicate copies of `next` because of this

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,17 +16,18 @@
     "@babel/runtime": "^7.24.7",
     "@keystar/ui": "catalog:",
     "graphql": "catalog:",
-    "next": "catalog:",
     "react-aria": "catalog:"
   },
   "devDependencies": {
     "@keystone-6/core": "workspace:^",
+    "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"
   },
   "peerDependencies": {
     "@keystone-6/core": "^8.0.0",
     "graphql": "catalog:",
+    "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "@keystar/ui": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2692,9 +2692,6 @@ importers:
       graphql:
         specifier: 'catalog:'
         version: 16.14.2
-      next:
-        specifier: 'catalog:'
-        version: 16.2.10(@babel/core@7.29.0(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-aria:
         specifier: 'catalog:'
         version: 3.50.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -2702,6 +2699,9 @@ importers:
       '@keystone-6/core':
         specifier: workspace:^
         version: link:../core
+      next:
+        specifier: 'catalog:'
+        version: 16.2.10(@babel/core@7.29.0(supports-color@7.2.0))(@opentelemetry/api@1.9.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: 'catalog:'
         version: 19.2.5


### PR DESCRIPTION
I'm doing this just in a patch since @keystone-6/core already has a next peer dep and @keystone-6/core is a peer dep of @keystone-6/auth so all users of this major of @keystone-6/auth must already have next installed themselves. this just fixes duplicate copies.